### PR TITLE
Add open-in-editor feature with Cmd+O shortcut

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -130,15 +130,20 @@ function registerIpcHandlers(): void {
   ipcMain.handle(
     IPC_CHANNELS.shellOpenInEditor,
     async (_event, cwd: string, editor: string) => {
+      if (!cwd) throw new Error("cwd is required");
       const editorDef = EDITORS.find((e) => e.id === editor);
       if (!editorDef) throw new Error(`Unknown editor: ${editor}`);
       if (!editorDef.command) {
-        await shell.openPath(cwd);
+        const error = await shell.openPath(cwd);
+        if (error) throw new Error(error);
         return;
       }
       const child = spawn(editorDef.command, [cwd], {
         detached: true,
         stdio: "ignore",
+      });
+      child.on("error", () => {
+        /* ignore spawn failures for detached editors */
       });
       child.unref();
     },

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3,14 +3,7 @@ fixPath();
 
 import { spawn } from "node:child_process";
 import path from "node:path";
-import {
-  BrowserWindow,
-  app,
-  dialog,
-  ipcMain,
-  session,
-  shell,
-} from "electron";
+import { BrowserWindow, app, dialog, ipcMain, session, shell } from "electron";
 
 import {
   EDITORS,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -13,6 +13,7 @@ import {
 } from "electron";
 
 import {
+  EDITORS,
   IPC_CHANNELS,
   type TerminalCommandInput,
   type TerminalCommandResult,
@@ -136,16 +137,13 @@ function registerIpcHandlers(): void {
   ipcMain.handle(
     IPC_CHANNELS.shellOpenInEditor,
     async (_event, cwd: string, editor: string) => {
-      if (editor === "file-manager") {
+      const editorDef = EDITORS.find((e) => e.id === editor);
+      if (!editorDef) throw new Error(`Unknown editor: ${editor}`);
+      if (!editorDef.command) {
         await shell.openPath(cwd);
         return;
       }
-      const EDITOR_COMMANDS: Record<string, { command: string; args: (cwd: string) => string[] }> = {
-        cursor: { command: "cursor", args: (p) => [p] },
-      };
-      const entry = EDITOR_COMMANDS[editor];
-      if (!entry) throw new Error(`Unknown editor: ${editor}`);
-      const child = spawn(entry.command, entry.args(cwd), {
+      const child = spawn(editorDef.command, [cwd], {
         detached: true,
         stdio: "ignore",
       });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3,7 +3,14 @@ fixPath();
 
 import { spawn } from "node:child_process";
 import path from "node:path";
-import { BrowserWindow, app, dialog, ipcMain, session } from "electron";
+import {
+  BrowserWindow,
+  app,
+  dialog,
+  ipcMain,
+  session,
+  shell,
+} from "electron";
 
 import {
   IPC_CHANNELS,
@@ -123,6 +130,27 @@ function registerIpcHandlers(): void {
     withParsedPayload(terminalCommandInputSchema, async (_event, payload) => {
       return runTerminalCommand(payload);
     }),
+  );
+
+  // Shell handlers
+  ipcMain.handle(
+    IPC_CHANNELS.shellOpenInEditor,
+    async (_event, cwd: string, editor: string) => {
+      if (editor === "file-manager") {
+        await shell.openPath(cwd);
+        return;
+      }
+      const EDITOR_COMMANDS: Record<string, { command: string; args: (cwd: string) => string[] }> = {
+        cursor: { command: "cursor", args: (p) => [p] },
+      };
+      const entry = EDITOR_COMMANDS[editor];
+      if (!entry) throw new Error(`Unknown editor: ${editor}`);
+      const child = spawn(entry.command, entry.args(cwd), {
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+    },
   );
 
   // Agent handlers

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -52,6 +52,10 @@ const nativeApi: NativeApi = {
         ipcRenderer.removeListener(IPC_CHANNELS.providerEvent, listener);
     },
   },
+  shell: {
+    openInEditor: (cwd: string, editor: string) =>
+      ipcRenderer.invoke(IPC_CHANNELS.shellOpenInEditor, cwd, editor),
+  },
 };
 
 contextBridge.exposeInMainWorld("nativeApi", nativeApi);

--- a/apps/renderer/src/components/ChatView.tsx
+++ b/apps/renderer/src/components/ChatView.tsx
@@ -65,9 +65,12 @@ export default function ChatView() {
   const [isConnecting, setIsConnecting] = useState(false);
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
   const [isEditorMenuOpen, setIsEditorMenuOpen] = useState(false);
-  const [lastEditor, setLastEditor] = useState<EditorId>(
-    () => (localStorage.getItem(LAST_EDITOR_KEY) as EditorId) ?? EDITORS[0].id,
-  );
+  const [lastEditor, setLastEditor] = useState<EditorId>(() => {
+    const stored = localStorage.getItem(LAST_EDITOR_KEY);
+    return EDITORS.some((e) => e.id === stored)
+      ? (stored as EditorId)
+      : EDITORS[0].id;
+  });
   const [selectedEffort, setSelectedEffort] =
     useState<string>(DEFAULT_REASONING);
   const [nowTick, setNowTick] = useState(() => Date.now());
@@ -185,8 +188,8 @@ export default function ChatView() {
   useEffect(() => {
     const handler = (e: globalThis.KeyboardEvent) => {
       if (e.key === "o" && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
-        e.preventDefault();
         if (api && activeProject) {
+          e.preventDefault();
           void api.shell.openInEditor(activeProject.cwd, lastEditor);
         }
       }

--- a/apps/renderer/src/components/ChatView.tsx
+++ b/apps/renderer/src/components/ChatView.tsx
@@ -398,7 +398,9 @@ export default function ChatView() {
                       {editorLabel(editor)}
                       {editor.id === lastEditor && (
                         <kbd className="ml-auto text-[9px] text-[#a0a0a0]/40">
-                          {navigator.platform.includes("Mac") ? "\u2318" : "Ctrl+"}O
+                          {navigator.platform.includes("Mac")
+                            ? "\u2318O"
+                            : "Ctrl+O"}
                         </kbd>
                       )}
                     </button>

--- a/apps/renderer/src/components/ChatView.tsx
+++ b/apps/renderer/src/components/ChatView.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 
+import { EDITORS, type EditorId } from "@acme/contracts";
 import {
   DEFAULT_MODEL,
   DEFAULT_REASONING,
@@ -36,10 +37,10 @@ const FILE_MANAGER_LABEL = navigator.platform.includes("Mac")
     ? "Explorer"
     : "Files";
 
-const EDITORS = [
-  { id: "cursor", label: "Cursor" },
-  { id: "file-manager", label: FILE_MANAGER_LABEL },
-] as const;
+function editorLabel(editor: (typeof EDITORS)[number]): string {
+  return editor.command ? editor.label : FILE_MANAGER_LABEL;
+}
+
 const LAST_EDITOR_KEY = "codething:last-editor";
 
 function statusLabel(phase: string): string {
@@ -64,8 +65,8 @@ export default function ChatView() {
   const [isConnecting, setIsConnecting] = useState(false);
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
   const [isEditorMenuOpen, setIsEditorMenuOpen] = useState(false);
-  const [lastEditor, setLastEditor] = useState(
-    () => localStorage.getItem(LAST_EDITOR_KEY) ?? EDITORS[0].id,
+  const [lastEditor, setLastEditor] = useState<EditorId>(
+    () => (localStorage.getItem(LAST_EDITOR_KEY) as EditorId) ?? EDITORS[0].id,
   );
   const [selectedEffort, setSelectedEffort] =
     useState<string>(DEFAULT_REASONING);
@@ -194,7 +195,7 @@ export default function ChatView() {
     return () => window.removeEventListener("keydown", handler);
   }, [api, activeProject, lastEditor]);
 
-  const openInEditor = (editorId: string) => {
+  const openInEditor = (editorId: EditorId) => {
     if (!api || !activeProject) return;
     void api.shell.openInEditor(activeProject.cwd, editorId);
     setLastEditor(editorId);
@@ -394,7 +395,7 @@ export default function ChatView() {
                       className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-[#e0e0e0] hover:bg-white/[0.06]"
                       onClick={() => openInEditor(editor.id)}
                     >
-                      {editor.label}
+                      {editorLabel(editor)}
                       {editor.id === lastEditor && (
                         <kbd className="ml-auto text-[9px] text-[#a0a0a0]/40">
                           {navigator.platform.includes("Mac") ? "\u2318" : "Ctrl+"}O

--- a/apps/renderer/src/components/ChatView.tsx
+++ b/apps/renderer/src/components/ChatView.tsx
@@ -30,6 +30,18 @@ function formatMessageMeta(createdAt: string, duration: string | null): string {
   return `${formatTimestamp(createdAt)} • ${duration}`;
 }
 
+const FILE_MANAGER_LABEL = navigator.platform.includes("Mac")
+  ? "Finder"
+  : navigator.platform.includes("Win")
+    ? "Explorer"
+    : "Files";
+
+const EDITORS = [
+  { id: "cursor", label: "Cursor" },
+  { id: "file-manager", label: FILE_MANAGER_LABEL },
+] as const;
+const LAST_EDITOR_KEY = "codething:last-editor";
+
 function statusLabel(phase: string): string {
   if (phase === "running") return "Thinking / working";
   if (phase === "connecting") return "Connecting";
@@ -51,12 +63,17 @@ export default function ChatView() {
   const [isSending, setIsSending] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
+  const [isEditorMenuOpen, setIsEditorMenuOpen] = useState(false);
+  const [lastEditor, setLastEditor] = useState(
+    () => localStorage.getItem(LAST_EDITOR_KEY) ?? EDITORS[0].id,
+  );
   const [selectedEffort, setSelectedEffort] =
     useState<string>(DEFAULT_REASONING);
   const [nowTick, setNowTick] = useState(() => Date.now());
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const modelMenuRef = useRef<HTMLDivElement>(null);
+  const editorMenuRef = useRef<HTMLDivElement>(null);
 
   const activeThread = state.threads.find((t) => t.id === state.activeThreadId);
   const activeProject = state.projects.find(
@@ -143,6 +160,47 @@ export default function ChatView() {
       window.removeEventListener("mousedown", handleClickOutside);
     };
   }, [isModelMenuOpen]);
+
+  useEffect(() => {
+    if (!isEditorMenuOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!editorMenuRef.current) return;
+      if (
+        event.target instanceof Node &&
+        !editorMenuRef.current.contains(event.target)
+      ) {
+        setIsEditorMenuOpen(false);
+      }
+    };
+
+    window.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      window.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isEditorMenuOpen]);
+
+  // Cmd+O / Ctrl+O to open in last-used editor
+  useEffect(() => {
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "o" && (e.metaKey || e.ctrlKey) && !e.shiftKey) {
+        e.preventDefault();
+        if (api && activeProject) {
+          void api.shell.openInEditor(activeProject.cwd, lastEditor);
+        }
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [api, activeProject, lastEditor]);
+
+  const openInEditor = (editorId: string) => {
+    if (!api || !activeProject) return;
+    void api.shell.openInEditor(activeProject.cwd, editorId);
+    setLastEditor(editorId);
+    localStorage.setItem(LAST_EDITOR_KEY, editorId);
+    setIsEditorMenuOpen(false);
+  };
 
   const ensureSession = async (): Promise<string | null> => {
     if (!api || !activeThread || !activeProject) return null;
@@ -317,6 +375,37 @@ export default function ChatView() {
             </span>
             <span>{statusLabel(phase)}</span>
           </div>
+          {/* Open in editor */}
+          {activeProject && (
+            <div className="relative" ref={editorMenuRef}>
+              <button
+                type="button"
+                className="rounded-md px-2 py-1 text-[10px] text-[#a0a0a0]/40 transition-colors duration-150 hover:text-[#a0a0a0]/60"
+                onClick={() => setIsEditorMenuOpen((v) => !v)}
+              >
+                Open in&hellip;
+              </button>
+              {isEditorMenuOpen && (
+                <div className="absolute right-0 top-full z-50 mt-1 min-w-[120px] rounded-md border border-white/[0.08] bg-[#1b1b1d] py-1 shadow-xl">
+                  {EDITORS.map((editor) => (
+                    <button
+                      key={editor.id}
+                      type="button"
+                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-[#e0e0e0] hover:bg-white/[0.06]"
+                      onClick={() => openInEditor(editor.id)}
+                    >
+                      {editor.label}
+                      {editor.id === lastEditor && (
+                        <kbd className="ml-auto text-[9px] text-[#a0a0a0]/40">
+                          {navigator.platform.includes("Mac") ? "\u2318" : "Ctrl+"}O
+                        </kbd>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
           {/* Diff toggle */}
           <button
             type="button"

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -29,6 +29,7 @@ export const IPC_CHANNELS = {
   providerSessionStop: "provider:session:stop",
   providerSessionList: "provider:session:list",
   providerEvent: "provider:event",
+  shellOpenInEditor: "shell:open-in-editor",
 } as const;
 
 export interface NativeApi {
@@ -62,5 +63,8 @@ export interface NativeApi {
     stopSession: (input: ProviderStopSessionInput) => Promise<void>;
     listSessions: () => Promise<ProviderSession[]>;
     onEvent: (callback: (event: ProviderEvent) => void) => () => void;
+  };
+  shell: {
+    openInEditor: (cwd: string, editor: string) => Promise<void>;
   };
 }

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -11,6 +11,13 @@ import type {
 import type { TerminalCommandInput, TerminalCommandResult } from "./terminal";
 import type { NewTodoInput, Todo } from "./todo";
 
+export const EDITORS = [
+  { id: "cursor", label: "Cursor", command: "cursor" },
+  { id: "file-manager", label: "File Manager", command: null },
+] as const;
+
+export type EditorId = (typeof EDITORS)[number]["id"];
+
 export const IPC_CHANNELS = {
   todosList: "todos:list",
   todosAdd: "todos:add",
@@ -65,6 +72,6 @@ export interface NativeApi {
     onEvent: (callback: (event: ProviderEvent) => void) => () => void;
   };
   shell: {
-    openInEditor: (cwd: string, editor: string) => Promise<void>;
+    openInEditor: (cwd: string, editor: EditorId) => Promise<void>;
   };
 }


### PR DESCRIPTION

<img width="2200" height="1560" alt="CleanShot 2026-02-08 at 20 49 41@2x" src="https://github.com/user-attachments/assets/7330ce43-2066-4858-afee-05ea8e66e1a3" />


## Summary
Add a header dropdown to open the workspace in Cursor or the system file manager (Finder on macOS, Explorer on Windows, Files on Linux). Includes a global `Cmd+O` / `Ctrl+O` keyboard shortcut that opens in the last-used editor, with persistence via localStorage.

## Changes
- Add IPC channel `shell:open-in-editor` in contracts
- Main process handler that spawns editor CLI or uses `shell.openPath()` for cross-platform file manager support
- Header dropdown with editor options between status indicator and Diff button
- Global keyboard shortcut listener for `Cmd+O` / `Ctrl+O`
- Last-used editor tracked in localStorage with intelligent platform-aware naming (Finder/Explorer/Files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open in…" dropdown in the top bar to open the active project in a chosen editor or the file manager.
  * Added Cmd/Ctrl+O shortcut to open the project with your last-selected editor; selection is persisted across sessions.
  * Editor menu closes on outside clicks and after choosing an editor.

* **Platform Integration**
  * Desktop app now launches external editors or the file manager to open project folders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->