### PR TITLE
feat: Terminal

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "node-pty": "^1.1.0",
     "open": "^10.1.0",
     "ws": "^8.18.0"
   },

--- a/apps/server/src/git.test.ts
+++ b/apps/server/src/git.test.ts
@@ -53,6 +53,21 @@ async function initRepoWithCommit(cwd: string): Promise<void> {
 // ── Tests ──
 
 describe("git integration", () => {
+  describe("runTerminalCommand", () => {
+    it("caps captured output when maxOutputBytes is exceeded", async () => {
+      const result = await runTerminalCommand({
+        command: `node -e "process.stdout.write('x'.repeat(2000))"`,
+        cwd: process.cwd(),
+        timeoutMs: 10_000,
+        maxOutputBytes: 128,
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.stdout.length).toBeLessThanOrEqual(128);
+      expect(result.stderr).toContain("output truncated");
+    });
+  });
+
   // ── initGitRepo ──
 
   describe("initGitRepo", () => {

--- a/apps/server/src/git.ts
+++ b/apps/server/src/git.ts
@@ -12,9 +12,21 @@ import type {
   GitListBranchesInput,
   GitListBranchesResult,
   GitRemoveWorktreeInput,
-  TerminalCommandInput,
-  TerminalCommandResult,
 } from "@t3tools/contracts";
+
+export interface TerminalCommandInput {
+  command: string;
+  cwd: string;
+  timeoutMs?: number;
+}
+
+export interface TerminalCommandResult {
+  stdout: string;
+  stderr: string;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+}
 
 /** Spawn git directly with an argv array — no shell, no quoting needed. */
 function runGit(args: string[], cwd: string, timeoutMs = 30_000): Promise<TerminalCommandResult> {
@@ -138,8 +150,8 @@ export async function listGitBranches(input: GitListBranchesInput): Promise<GitL
     let currentPath: string | null = null;
     for (const line of worktreeList.stdout.split("\n")) {
       if (line.startsWith("worktree ")) {
-        currentPath = line.slice("worktree ".length);
-        if (!fs.existsSync(currentPath)) currentPath = null;
+        const candidatePath = line.slice("worktree ".length);
+        currentPath = fs.existsSync(candidatePath) ? candidatePath : null;
       } else if (line.startsWith("branch refs/heads/") && currentPath) {
         worktreeMap.set(line.slice("branch refs/heads/".length), currentPath);
       } else if (line === "") {

--- a/apps/server/src/git.ts
+++ b/apps/server/src/git.ts
@@ -18,6 +18,7 @@ export interface TerminalCommandInput {
   command: string;
   cwd: string;
   timeoutMs?: number;
+  maxOutputBytes?: number;
 }
 
 export interface TerminalCommandResult {
@@ -26,6 +27,36 @@ export interface TerminalCommandResult {
   code: number | null;
   signal: NodeJS.Signals | null;
   timedOut: boolean;
+}
+
+const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+
+function appendChunkWithinLimit(
+  target: string,
+  currentBytes: number,
+  chunk: Buffer,
+  maxBytes: number,
+): {
+  next: string;
+  nextBytes: number;
+  truncated: boolean;
+} {
+  const remaining = maxBytes - currentBytes;
+  if (remaining <= 0) {
+    return { next: target, nextBytes: currentBytes, truncated: true };
+  }
+  if (chunk.length <= remaining) {
+    return {
+      next: `${target}${chunk.toString()}`,
+      nextBytes: currentBytes + chunk.length,
+      truncated: false,
+    };
+  }
+  return {
+    next: `${target}${chunk.subarray(0, remaining).toString()}`,
+    nextBytes: currentBytes + remaining,
+    truncated: true,
+  };
 }
 
 /** Spawn git directly with an argv array — no shell, no quoting needed. */
@@ -37,9 +68,13 @@ function runGit(args: string[], cwd: string, timeoutMs = 30_000): Promise<Termin
       stdio: ["ignore", "pipe", "pipe"],
     });
 
+    const maxOutputBytes = DEFAULT_MAX_OUTPUT_BYTES;
     let stdout = "";
     let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
     let timedOut = false;
+    let outputTruncated = false;
 
     const timeout = setTimeout(() => {
       timedOut = true;
@@ -50,10 +85,16 @@ function runGit(args: string[], cwd: string, timeoutMs = 30_000): Promise<Termin
     }, timeoutMs);
 
     child.stdout?.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
+      const appended = appendChunkWithinLimit(stdout, stdoutBytes, chunk, maxOutputBytes);
+      stdout = appended.next;
+      stdoutBytes = appended.nextBytes;
+      outputTruncated = outputTruncated || appended.truncated;
     });
     child.stderr?.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
+      const appended = appendChunkWithinLimit(stderr, stderrBytes, chunk, maxOutputBytes);
+      stderr = appended.next;
+      stderrBytes = appended.nextBytes;
+      outputTruncated = outputTruncated || appended.truncated;
     });
     child.on("error", (error) => {
       clearTimeout(timeout);
@@ -61,6 +102,9 @@ function runGit(args: string[], cwd: string, timeoutMs = 30_000): Promise<Termin
     });
     child.on("close", (code, signal) => {
       clearTimeout(timeout);
+      if (outputTruncated) {
+        stderr = `${stderr}\n[output truncated at ${maxOutputBytes} bytes]`;
+      }
       resolve({ stdout, stderr, code: code ?? null, signal: signal ?? null, timedOut });
     });
   });
@@ -69,6 +113,7 @@ function runGit(args: string[], cwd: string, timeoutMs = 30_000): Promise<Termin
 export async function runTerminalCommand(
   input: TerminalCommandInput,
 ): Promise<TerminalCommandResult> {
+  const maxOutputBytes = input.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
   const shellPath =
     process.platform === "win32"
       ? (process.env.ComSpec ?? "cmd.exe")
@@ -86,7 +131,10 @@ export async function runTerminalCommand(
 
     let stdout = "";
     let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
     let timedOut = false;
+    let outputTruncated = false;
 
     const timeout = setTimeout(() => {
       timedOut = true;
@@ -99,11 +147,17 @@ export async function runTerminalCommand(
     }, input.timeoutMs ?? 30_000);
 
     child.stdout?.on("data", (chunk: Buffer) => {
-      stdout += chunk.toString();
+      const appended = appendChunkWithinLimit(stdout, stdoutBytes, chunk, maxOutputBytes);
+      stdout = appended.next;
+      stdoutBytes = appended.nextBytes;
+      outputTruncated = outputTruncated || appended.truncated;
     });
 
     child.stderr?.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
+      const appended = appendChunkWithinLimit(stderr, stderrBytes, chunk, maxOutputBytes);
+      stderr = appended.next;
+      stderrBytes = appended.nextBytes;
+      outputTruncated = outputTruncated || appended.truncated;
     });
 
     child.on("error", (error) => {
@@ -113,6 +167,9 @@ export async function runTerminalCommand(
 
     child.on("close", (code, signal) => {
       clearTimeout(timeout);
+      if (outputTruncated) {
+        stderr = `${stderr}\n[output truncated at ${maxOutputBytes} bytes]`;
+      }
       resolve({
         stdout,
         stderr,

--- a/apps/server/src/ptyAdapter.ts
+++ b/apps/server/src/ptyAdapter.ts
@@ -1,0 +1,79 @@
+import * as nodePty from "node-pty";
+
+export interface PtyExitEvent {
+  exitCode: number;
+  signal: number | null;
+}
+
+export interface PtyProcess {
+  readonly pid: number;
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(signal?: string): void;
+  onData(callback: (data: string) => void): () => void;
+  onExit(callback: (event: PtyExitEvent) => void): () => void;
+}
+
+export interface PtySpawnInput {
+  shell: string;
+  cwd: string;
+  cols: number;
+  rows: number;
+  env: NodeJS.ProcessEnv;
+}
+
+export interface PtyAdapter {
+  spawn(input: PtySpawnInput): PtyProcess;
+}
+
+class NodePtyProcess implements PtyProcess {
+  constructor(private readonly process: nodePty.IPty) {}
+
+  get pid(): number {
+    return this.process.pid;
+  }
+
+  write(data: string): void {
+    this.process.write(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.process.resize(cols, rows);
+  }
+
+  kill(signal?: string): void {
+    this.process.kill(signal);
+  }
+
+  onData(callback: (data: string) => void): () => void {
+    const disposable = this.process.onData(callback);
+    return () => {
+      disposable.dispose();
+    };
+  }
+
+  onExit(callback: (event: PtyExitEvent) => void): () => void {
+    const disposable = this.process.onExit((event) => {
+      callback({
+        exitCode: event.exitCode,
+        signal: event.signal ?? null,
+      });
+    });
+    return () => {
+      disposable.dispose();
+    };
+  }
+}
+
+export class NodePtyAdapter implements PtyAdapter {
+  spawn(input: PtySpawnInput): PtyProcess {
+    const ptyProcess = nodePty.spawn(input.shell, [], {
+      cwd: input.cwd,
+      cols: input.cols,
+      rows: input.rows,
+      env: input.env,
+      name: globalThis.process.platform === "win32" ? "xterm-color" : "xterm-256color",
+    });
+    return new NodePtyProcess(ptyProcess);
+  }
+}

--- a/apps/server/src/terminalManager.test.ts
+++ b/apps/server/src/terminalManager.test.ts
@@ -100,6 +100,14 @@ function openInput(overrides: Partial<TerminalOpenInput> = {}): TerminalOpenInpu
   };
 }
 
+function historyLogName(threadId: string): string {
+  return `terminal_${Buffer.from(threadId, "utf8").toString("base64url")}.log`;
+}
+
+function historyLogPath(logsDir: string, threadId = "thread-1"): string {
+  return path.join(logsDir, historyLogName(threadId));
+}
+
 describe("TerminalManager", () => {
   const tempDirs: string[] = [];
 
@@ -124,11 +132,12 @@ describe("TerminalManager", () => {
 
   it("spawns lazily and reuses running terminal per thread", async () => {
     const { manager, ptyAdapter } = makeManager();
-    const first = await manager.open(openInput());
-    const second = await manager.open(openInput());
+    const [first, second] = await Promise.all([manager.open(openInput()), manager.open(openInput())]);
+    const third = await manager.open(openInput());
 
     expect(first.threadId).toBe("thread-1");
     expect(second.threadId).toBe("thread-1");
+    expect(third.threadId).toBe("thread-1");
     expect(ptyAdapter.spawnInputs).toHaveLength(1);
 
     manager.dispose();
@@ -162,9 +171,9 @@ describe("TerminalManager", () => {
     if (!process) return;
 
     process.emitData("hello\n");
-    await waitFor(() => fs.existsSync(path.join(logsDir, "thread-1.log")));
+    await waitFor(() => fs.existsSync(historyLogPath(logsDir)));
     await manager.clear({ threadId: "thread-1" });
-    await waitFor(() => fs.readFileSync(path.join(logsDir, "thread-1.log"), "utf8") === "");
+    await waitFor(() => fs.readFileSync(historyLogPath(logsDir), "utf8") === "");
 
     expect(events.some((event) => event.type === "cleared")).toBe(true);
 
@@ -178,13 +187,13 @@ describe("TerminalManager", () => {
     expect(firstProcess).toBeDefined();
     if (!firstProcess) return;
     firstProcess.emitData("before restart\n");
-    await waitFor(() => fs.existsSync(path.join(logsDir, "thread-1.log")));
+    await waitFor(() => fs.existsSync(historyLogPath(logsDir)));
 
     const snapshot = await manager.restart(openInput());
     expect(snapshot.history).toBe("");
     expect(snapshot.status).toBe("running");
     expect(ptyAdapter.spawnInputs).toHaveLength(2);
-    await waitFor(() => fs.readFileSync(path.join(logsDir, "thread-1.log"), "utf8") === "");
+    await waitFor(() => fs.readFileSync(historyLogPath(logsDir), "utf8") === "");
 
     manager.dispose();
   });
@@ -200,7 +209,7 @@ describe("TerminalManager", () => {
     expect(process).toBeDefined();
     if (!process) return;
     process.emitData("old data\n");
-    await waitFor(() => fs.existsSync(path.join(logsDir, "thread-1.log")));
+    await waitFor(() => fs.existsSync(historyLogPath(logsDir)));
     process.emitExit({ exitCode: 0, signal: 0 });
 
     await waitFor(() => events.some((event) => event.type === "exited"));
@@ -208,7 +217,7 @@ describe("TerminalManager", () => {
 
     expect(reopened.history).toBe("");
     expect(ptyAdapter.spawnInputs).toHaveLength(2);
-    expect(fs.readFileSync(path.join(logsDir, "thread-1.log"), "utf8")).toBe("");
+    expect(fs.readFileSync(historyLogPath(logsDir), "utf8")).toBe("");
 
     manager.dispose();
   });
@@ -237,10 +246,23 @@ describe("TerminalManager", () => {
     expect(process).toBeDefined();
     if (!process) return;
     process.emitData("bye\n");
-    await waitFor(() => fs.existsSync(path.join(logsDir, "thread-1.log")));
+    await waitFor(() => fs.existsSync(historyLogPath(logsDir)));
 
     await manager.close({ threadId: "thread-1", deleteHistory: true });
-    expect(fs.existsSync(path.join(logsDir, "thread-1.log"))).toBe(false);
+    expect(fs.existsSync(historyLogPath(logsDir))).toBe(false);
+
+    manager.dispose();
+  });
+
+  it("loads existing legacy transcript filenames and keeps new naming for writes", async () => {
+    const { manager, logsDir } = makeManager();
+    const legacyPath = path.join(logsDir, "thread-1.log");
+    fs.writeFileSync(legacyPath, "legacy-line\n", "utf8");
+
+    const snapshot = await manager.open(openInput());
+
+    expect(snapshot.history).toBe("legacy-line\n");
+    expect(fs.existsSync(legacyPath)).toBe(true);
 
     manager.dispose();
   });

--- a/apps/server/src/terminalManager.test.ts
+++ b/apps/server/src/terminalManager.test.ts
@@ -1,0 +1,247 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+  TerminalEvent,
+  TerminalOpenInput,
+} from "@t3tools/contracts";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { PtyAdapter, PtyExitEvent, PtyProcess, PtySpawnInput } from "./ptyAdapter";
+import { TerminalManager } from "./terminalManager";
+
+class FakePtyProcess implements PtyProcess {
+  readonly writes: string[] = [];
+  readonly resizeCalls: Array<{ cols: number; rows: number }> = [];
+  private readonly dataListeners = new Set<(data: string) => void>();
+  private readonly exitListeners = new Set<(event: PtyExitEvent) => void>();
+  killed = false;
+
+  constructor(readonly pid: number) {}
+
+  write(data: string): void {
+    this.writes.push(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.resizeCalls.push({ cols, rows });
+  }
+
+  kill(): void {
+    this.killed = true;
+  }
+
+  onData(callback: (data: string) => void): () => void {
+    this.dataListeners.add(callback);
+    return () => {
+      this.dataListeners.delete(callback);
+    };
+  }
+
+  onExit(callback: (event: PtyExitEvent) => void): () => void {
+    this.exitListeners.add(callback);
+    return () => {
+      this.exitListeners.delete(callback);
+    };
+  }
+
+  emitData(data: string): void {
+    for (const listener of this.dataListeners) {
+      listener(data);
+    }
+  }
+
+  emitExit(event: PtyExitEvent): void {
+    for (const listener of this.exitListeners) {
+      listener(event);
+    }
+  }
+}
+
+class FakePtyAdapter implements PtyAdapter {
+  readonly spawnInputs: PtySpawnInput[] = [];
+  readonly processes: FakePtyProcess[] = [];
+  private nextPid = 9000;
+
+  spawn(input: PtySpawnInput): PtyProcess {
+    this.spawnInputs.push(input);
+    const process = new FakePtyProcess(this.nextPid++);
+    this.processes.push(process);
+    return process;
+  }
+}
+
+function waitFor(predicate: () => boolean, timeoutMs = 800): Promise<void> {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    const poll = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error("Timed out waiting for condition"));
+        return;
+      }
+      setTimeout(poll, 15);
+    };
+    poll();
+  });
+}
+
+function openInput(overrides: Partial<TerminalOpenInput> = {}): TerminalOpenInput {
+  return {
+    threadId: "thread-1",
+    cwd: process.cwd(),
+    cols: 100,
+    rows: 24,
+    ...overrides,
+  };
+}
+
+describe("TerminalManager", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0, tempDirs.length)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeManager(historyLineLimit = 5) {
+    const logsDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-terminal-"));
+    tempDirs.push(logsDir);
+    const ptyAdapter = new FakePtyAdapter();
+    const manager = new TerminalManager({
+      logsDir,
+      ptyAdapter,
+      historyLineLimit,
+      shellResolver: () => "/bin/bash",
+    });
+    return { logsDir, ptyAdapter, manager };
+  }
+
+  it("spawns lazily and reuses running terminal per thread", async () => {
+    const { manager, ptyAdapter } = makeManager();
+    const first = await manager.open(openInput());
+    const second = await manager.open(openInput());
+
+    expect(first.threadId).toBe("thread-1");
+    expect(second.threadId).toBe("thread-1");
+    expect(ptyAdapter.spawnInputs).toHaveLength(1);
+
+    manager.dispose();
+  });
+
+  it("forwards write and resize to active pty process", async () => {
+    const { manager, ptyAdapter } = makeManager();
+    await manager.open(openInput());
+    const process = ptyAdapter.processes[0];
+    expect(process).toBeDefined();
+    if (!process) return;
+
+    await manager.write({ threadId: "thread-1", data: "ls\n" });
+    await manager.resize({ threadId: "thread-1", cols: 120, rows: 30 });
+
+    expect(process.writes).toEqual(["ls\n"]);
+    expect(process.resizeCalls).toEqual([{ cols: 120, rows: 30 }]);
+
+    manager.dispose();
+  });
+
+  it("clears transcript and emits cleared event", async () => {
+    const { manager, ptyAdapter, logsDir } = makeManager();
+    const events: TerminalEvent[] = [];
+    manager.on("event", (event) => {
+      events.push(event);
+    });
+    await manager.open(openInput());
+    const process = ptyAdapter.processes[0];
+    expect(process).toBeDefined();
+    if (!process) return;
+
+    process.emitData("hello\n");
+    await waitFor(() => fs.existsSync(path.join(logsDir, "thread-1.log")));
+    await manager.clear({ threadId: "thread-1" });
+    await waitFor(() => fs.readFileSync(path.join(logsDir, "thread-1.log"), "utf8") === "");
+
+    expect(events.some((event) => event.type === "cleared")).toBe(true);
+
+    manager.dispose();
+  });
+
+  it("restarts terminal with empty transcript and respawns pty", async () => {
+    const { manager, ptyAdapter, logsDir } = makeManager();
+    await manager.open(openInput());
+    const firstProcess = ptyAdapter.processes[0];
+    expect(firstProcess).toBeDefined();
+    if (!firstProcess) return;
+    firstProcess.emitData("before restart\n");
+    await waitFor(() => fs.existsSync(path.join(logsDir, "thread-1.log")));
+
+    const snapshot = await manager.restart(openInput());
+    expect(snapshot.history).toBe("");
+    expect(snapshot.status).toBe("running");
+    expect(ptyAdapter.spawnInputs).toHaveLength(2);
+    await waitFor(() => fs.readFileSync(path.join(logsDir, "thread-1.log"), "utf8") === "");
+
+    manager.dispose();
+  });
+
+  it("emits exited event and reopens with clean transcript after exit", async () => {
+    const { manager, ptyAdapter, logsDir } = makeManager();
+    const events: TerminalEvent[] = [];
+    manager.on("event", (event) => {
+      events.push(event);
+    });
+    await manager.open(openInput());
+    const process = ptyAdapter.processes[0];
+    expect(process).toBeDefined();
+    if (!process) return;
+    process.emitData("old data\n");
+    await waitFor(() => fs.existsSync(path.join(logsDir, "thread-1.log")));
+    process.emitExit({ exitCode: 0, signal: 0 });
+
+    await waitFor(() => events.some((event) => event.type === "exited"));
+    const reopened = await manager.open(openInput());
+
+    expect(reopened.history).toBe("");
+    expect(ptyAdapter.spawnInputs).toHaveLength(2);
+    expect(fs.readFileSync(path.join(logsDir, "thread-1.log"), "utf8")).toBe("");
+
+    manager.dispose();
+  });
+
+  it("caps persisted history to configured line limit", async () => {
+    const { manager, ptyAdapter } = makeManager(3);
+    await manager.open(openInput());
+    const process = ptyAdapter.processes[0];
+    expect(process).toBeDefined();
+    if (!process) return;
+
+    process.emitData("line1\nline2\nline3\nline4\n");
+    await manager.close({ threadId: "thread-1" });
+
+    const reopened = await manager.open(openInput());
+    const nonEmptyLines = reopened.history.split("\n").filter((line) => line.length > 0);
+    expect(nonEmptyLines).toEqual(["line2", "line3", "line4"]);
+
+    manager.dispose();
+  });
+
+  it("deletes history file when close(deleteHistory=true)", async () => {
+    const { manager, ptyAdapter, logsDir } = makeManager();
+    await manager.open(openInput());
+    const process = ptyAdapter.processes[0];
+    expect(process).toBeDefined();
+    if (!process) return;
+    process.emitData("bye\n");
+    await waitFor(() => fs.existsSync(path.join(logsDir, "thread-1.log")));
+
+    await manager.close({ threadId: "thread-1", deleteHistory: true });
+    expect(fs.existsSync(path.join(logsDir, "thread-1.log"))).toBe(false);
+
+    manager.dispose();
+  });
+});

--- a/apps/server/src/terminalManager.ts
+++ b/apps/server/src/terminalManager.ts
@@ -21,6 +21,7 @@ import { createLogger } from "./logger";
 import { NodePtyAdapter, type PtyAdapter, type PtyExitEvent, type PtyProcess } from "./ptyAdapter";
 
 const DEFAULT_HISTORY_LINE_LIMIT = 5_000;
+const DEFAULT_PERSIST_DEBOUNCE_MS = 40;
 
 export interface TerminalManagerEvents {
   event: [event: TerminalEvent];
@@ -68,8 +69,12 @@ function capHistory(history: string, maxLines: number): string {
   return hasTrailingNewline ? `${capped}\n` : capped;
 }
 
-function toSafeThreadId(threadId: string): string {
+function legacySafeThreadId(threadId: string): string {
   return threadId.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+function toSafeThreadId(threadId: string): string {
+  return `terminal_${Buffer.from(threadId, "utf8").toString("base64url")}`;
 }
 
 export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
@@ -79,6 +84,10 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
   private readonly ptyAdapter: PtyAdapter;
   private readonly shellResolver: () => string;
   private readonly persistQueues = new Map<string, Promise<void>>();
+  private readonly persistTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly pendingPersistHistory = new Map<string, string>();
+  private readonly threadLocks = new Map<string, Promise<void>>();
+  private readonly persistDebounceMs: number;
   private readonly logger = createLogger("terminal");
 
   constructor(options: TerminalManagerOptions = {}) {
@@ -87,60 +96,63 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
     this.historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
     this.ptyAdapter = options.ptyAdapter ?? new NodePtyAdapter();
     this.shellResolver = options.shellResolver ?? defaultShellResolver;
+    this.persistDebounceMs = DEFAULT_PERSIST_DEBOUNCE_MS;
     fs.mkdirSync(this.logsDir, { recursive: true });
   }
 
   async open(raw: TerminalOpenInput): Promise<TerminalSessionSnapshot> {
     const input = terminalOpenInputSchema.parse(raw);
-    await this.assertValidCwd(input.cwd);
-    await this.flushPersistQueue(input.threadId);
+    return this.runWithThreadLock(input.threadId, async () => {
+      await this.assertValidCwd(input.cwd);
 
-    const existing = this.sessions.get(input.threadId);
-    if (!existing) {
-      const history = await this.readHistory(input.threadId);
-      const session: TerminalSessionState = {
-        threadId: input.threadId,
-        cwd: input.cwd,
-        status: "starting",
-        pid: null,
-        history,
-        exitCode: null,
-        exitSignal: null,
-        updatedAt: new Date().toISOString(),
-        cols: input.cols,
-        rows: input.rows,
-        process: null,
-        unsubscribeData: null,
-        unsubscribeExit: null,
-      };
-      this.sessions.set(input.threadId, session);
-      this.startSession(session, input, "started");
-      return this.snapshot(session);
-    }
+      const existing = this.sessions.get(input.threadId);
+      if (!existing) {
+        await this.flushPersistQueue(input.threadId);
+        const history = await this.readHistory(input.threadId);
+        const session: TerminalSessionState = {
+          threadId: input.threadId,
+          cwd: input.cwd,
+          status: "starting",
+          pid: null,
+          history,
+          exitCode: null,
+          exitSignal: null,
+          updatedAt: new Date().toISOString(),
+          cols: input.cols,
+          rows: input.rows,
+          process: null,
+          unsubscribeData: null,
+          unsubscribeExit: null,
+        };
+        this.sessions.set(input.threadId, session);
+        this.startSession(session, input, "started");
+        return this.snapshot(session);
+      }
 
-    if (existing.cwd !== input.cwd) {
-      this.stopProcess(existing);
-      existing.cwd = input.cwd;
-      existing.history = "";
-      await this.persistHistory(existing.threadId, existing.history);
-    } else if (existing.status === "exited" || existing.status === "error") {
-      existing.history = "";
-      await this.persistHistory(existing.threadId, existing.history);
-    }
+      if (existing.cwd !== input.cwd) {
+        this.stopProcess(existing);
+        existing.cwd = input.cwd;
+        existing.history = "";
+        await this.persistHistory(existing.threadId, existing.history);
+      } else if (existing.status === "exited" || existing.status === "error") {
+        existing.history = "";
+        await this.persistHistory(existing.threadId, existing.history);
+      }
 
-    if (!existing.process) {
-      this.startSession(existing, input, "started");
+      if (!existing.process) {
+        this.startSession(existing, input, "started");
+        return this.snapshot(existing);
+      }
+
+      if (existing.cols !== input.cols || existing.rows !== input.rows) {
+        existing.cols = input.cols;
+        existing.rows = input.rows;
+        existing.process.resize(input.cols, input.rows);
+        existing.updatedAt = new Date().toISOString();
+      }
+
       return this.snapshot(existing);
-    }
-
-    if (existing.cols !== input.cols || existing.rows !== input.rows) {
-      existing.cols = input.cols;
-      existing.rows = input.rows;
-      existing.process.resize(input.cols, input.rows);
-      existing.updatedAt = new Date().toISOString();
-    }
-
-    return this.snapshot(existing);
+    });
   }
 
   async write(raw: TerminalWriteInput): Promise<void> {
@@ -166,61 +178,67 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
 
   async clear(raw: TerminalThreadInput): Promise<void> {
     const input = terminalThreadInputSchema.parse(raw);
-    const session = this.requireSession(input.threadId);
-    session.history = "";
-    session.updatedAt = new Date().toISOString();
-    await this.persistHistory(input.threadId, session.history);
-    this.emitEvent({
-      type: "cleared",
-      threadId: input.threadId,
-      createdAt: new Date().toISOString(),
+    await this.runWithThreadLock(input.threadId, async () => {
+      const session = this.requireSession(input.threadId);
+      session.history = "";
+      session.updatedAt = new Date().toISOString();
+      await this.persistHistory(input.threadId, session.history);
+      this.emitEvent({
+        type: "cleared",
+        threadId: input.threadId,
+        createdAt: new Date().toISOString(),
+      });
     });
   }
 
   async restart(raw: TerminalOpenInput): Promise<TerminalSessionSnapshot> {
     const input = terminalOpenInputSchema.parse(raw);
-    await this.assertValidCwd(input.cwd);
+    return this.runWithThreadLock(input.threadId, async () => {
+      await this.assertValidCwd(input.cwd);
 
-    let session = this.sessions.get(input.threadId);
-    if (!session) {
-      session = {
-        threadId: input.threadId,
-        cwd: input.cwd,
-        status: "starting",
-        pid: null,
-        history: "",
-        exitCode: null,
-        exitSignal: null,
-        updatedAt: new Date().toISOString(),
-        cols: input.cols,
-        rows: input.rows,
-        process: null,
-        unsubscribeData: null,
-        unsubscribeExit: null,
-      };
-      this.sessions.set(input.threadId, session);
-    } else {
-      this.stopProcess(session);
-      session.cwd = input.cwd;
-    }
+      let session = this.sessions.get(input.threadId);
+      if (!session) {
+        session = {
+          threadId: input.threadId,
+          cwd: input.cwd,
+          status: "starting",
+          pid: null,
+          history: "",
+          exitCode: null,
+          exitSignal: null,
+          updatedAt: new Date().toISOString(),
+          cols: input.cols,
+          rows: input.rows,
+          process: null,
+          unsubscribeData: null,
+          unsubscribeExit: null,
+        };
+        this.sessions.set(input.threadId, session);
+      } else {
+        this.stopProcess(session);
+        session.cwd = input.cwd;
+      }
 
-    session.history = "";
-    await this.persistHistory(input.threadId, session.history);
-    this.startSession(session, input, "restarted");
-    return this.snapshot(session);
+      session.history = "";
+      await this.persistHistory(input.threadId, session.history);
+      this.startSession(session, input, "restarted");
+      return this.snapshot(session);
+    });
   }
 
   async close(raw: TerminalCloseInput): Promise<void> {
     const input = terminalCloseInputSchema.parse(raw);
-    await this.flushPersistQueue(input.threadId);
-    const session = this.sessions.get(input.threadId);
-    if (session) {
-      this.stopProcess(session);
-      this.sessions.delete(input.threadId);
-    }
-    if (input.deleteHistory) {
-      await this.deleteHistory(input.threadId);
-    }
+    await this.runWithThreadLock(input.threadId, async () => {
+      const session = this.sessions.get(input.threadId);
+      if (session) {
+        this.stopProcess(session);
+        this.sessions.delete(input.threadId);
+      }
+      await this.flushPersistQueue(input.threadId);
+      if (input.deleteHistory) {
+        await this.deleteHistory(input.threadId);
+      }
+    });
   }
 
   dispose(): void {
@@ -228,6 +246,12 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
       this.stopProcess(session);
     }
     this.sessions.clear();
+    for (const timer of this.persistTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.persistTimers.clear();
+    this.pendingPersistHistory.clear();
+    this.threadLocks.clear();
     this.persistQueues.clear();
   }
 
@@ -247,8 +271,9 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
     session.updatedAt = new Date().toISOString();
 
     const shell = this.shellResolver();
+    let ptyProcess: PtyProcess | null = null;
     try {
-      const ptyProcess = this.ptyAdapter.spawn({
+      ptyProcess = this.ptyAdapter.spawn({
         shell,
         cwd: session.cwd,
         cols: session.cols,
@@ -272,6 +297,13 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
         snapshot: this.snapshot(session),
       });
     } catch (error) {
+      if (ptyProcess) {
+        try {
+          ptyProcess.kill();
+        } catch {
+          // Ignore kill errors during failed startup cleanup.
+        }
+      }
       session.status = "error";
       session.pid = null;
       session.process = null;
@@ -346,31 +378,60 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
   }
 
   private queuePersist(threadId: string, history: string): void {
-    const task = async () => {
-      await fs.promises.writeFile(this.historyPath(threadId), history, "utf8");
-    };
-    const previous = this.persistQueues.get(threadId) ?? Promise.resolve();
-    const next = previous.catch(() => undefined).then(task);
-    this.persistQueues.set(threadId, next);
-    void next.finally(() => {
-      if (this.persistQueues.get(threadId) === next) {
-        this.persistQueues.delete(threadId);
-      }
-    });
+    this.pendingPersistHistory.set(threadId, history);
+    this.schedulePersist(threadId);
   }
 
   private async persistHistory(threadId: string, history: string): Promise<void> {
+    this.clearPersistTimer(threadId);
+    this.pendingPersistHistory.delete(threadId);
+    await this.enqueuePersistWrite(threadId, history);
+  }
+
+  private enqueuePersistWrite(threadId: string, history: string): Promise<void> {
     const task = async () => {
       await fs.promises.writeFile(this.historyPath(threadId), history, "utf8");
     };
     const previous = this.persistQueues.get(threadId) ?? Promise.resolve();
-    const next = previous.catch(() => undefined).then(task);
+    const next = previous
+      .catch(() => undefined)
+      .then(task)
+      .catch((error) => {
+        this.logger.warn("failed to persist terminal history", {
+          threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     this.persistQueues.set(threadId, next);
-    await next.finally(() => {
+    const finalized = next.finally(() => {
       if (this.persistQueues.get(threadId) === next) {
         this.persistQueues.delete(threadId);
       }
+      if (this.pendingPersistHistory.has(threadId) && !this.persistTimers.has(threadId)) {
+        this.schedulePersist(threadId);
+      }
     });
+    void finalized.catch(() => undefined);
+    return finalized;
+  }
+
+  private schedulePersist(threadId: string): void {
+    if (this.persistTimers.has(threadId)) return;
+    const timer = setTimeout(() => {
+      this.persistTimers.delete(threadId);
+      const pendingHistory = this.pendingPersistHistory.get(threadId);
+      if (pendingHistory === undefined) return;
+      this.pendingPersistHistory.delete(threadId);
+      void this.enqueuePersistWrite(threadId, pendingHistory);
+    }, this.persistDebounceMs);
+    this.persistTimers.set(threadId, timer);
+  }
+
+  private clearPersistTimer(threadId: string): void {
+    const timer = this.persistTimers.get(threadId);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.persistTimers.delete(threadId);
   }
 
   private async readHistory(threadId: string): Promise<string> {
@@ -379,6 +440,19 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
       const capped = capHistory(raw, this.historyLineLimit);
       if (capped !== raw) {
         await fs.promises.writeFile(this.historyPath(threadId), capped, "utf8");
+      }
+      return capped;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+
+    try {
+      const raw = await fs.promises.readFile(this.legacyHistoryPath(threadId), "utf8");
+      const capped = capHistory(raw, this.historyLineLimit);
+      if (capped !== raw) {
+        await fs.promises.writeFile(this.legacyHistoryPath(threadId), capped, "utf8");
       }
       return capped;
     } catch (error) {
@@ -391,7 +465,10 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
 
   private async deleteHistory(threadId: string): Promise<void> {
     try {
-      await fs.promises.rm(this.historyPath(threadId), { force: true });
+      await Promise.all([
+        fs.promises.rm(this.historyPath(threadId), { force: true }),
+        fs.promises.rm(this.legacyHistoryPath(threadId), { force: true }),
+      ]);
     } catch (error) {
       this.logger.warn("failed to delete terminal history", {
         threadId,
@@ -401,9 +478,21 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
   }
 
   private async flushPersistQueue(threadId: string): Promise<void> {
-    const pending = this.persistQueues.get(threadId);
-    if (!pending) return;
-    await pending.catch(() => undefined);
+    this.clearPersistTimer(threadId);
+
+    while (true) {
+      const pendingHistory = this.pendingPersistHistory.get(threadId);
+      if (pendingHistory !== undefined) {
+        this.pendingPersistHistory.delete(threadId);
+        await this.enqueuePersistWrite(threadId, pendingHistory);
+      }
+
+      const pending = this.persistQueues.get(threadId);
+      if (!pending) {
+        return;
+      }
+      await pending.catch(() => undefined);
+    }
   }
 
   private async assertValidCwd(cwd: string): Promise<void> {
@@ -448,5 +537,30 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
 
   private historyPath(threadId: string): string {
     return path.join(this.logsDir, `${toSafeThreadId(threadId)}.log`);
+  }
+
+  private legacyHistoryPath(threadId: string): string {
+    return path.join(this.logsDir, `${legacySafeThreadId(threadId)}.log`);
+  }
+
+  private async runWithThreadLock<T>(
+    threadId: string,
+    task: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.threadLocks.get(threadId) ?? Promise.resolve();
+    let release: () => void = () => {};
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.threadLocks.set(threadId, current);
+    await previous.catch(() => undefined);
+    try {
+      return await task();
+    } finally {
+      release();
+      if (this.threadLocks.get(threadId) === current) {
+        this.threadLocks.delete(threadId);
+      }
+    }
   }
 }

--- a/apps/server/src/terminalManager.ts
+++ b/apps/server/src/terminalManager.ts
@@ -1,0 +1,452 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  type TerminalCloseInput,
+  type TerminalEvent,
+  type TerminalOpenInput,
+  type TerminalSessionSnapshot,
+  type TerminalSessionStatus,
+  type TerminalThreadInput,
+  type TerminalWriteInput,
+  terminalCloseInputSchema,
+  terminalOpenInputSchema,
+  terminalResizeInputSchema,
+  terminalThreadInputSchema,
+  terminalWriteInputSchema,
+} from "@t3tools/contracts";
+
+import { createLogger } from "./logger";
+import { NodePtyAdapter, type PtyAdapter, type PtyExitEvent, type PtyProcess } from "./ptyAdapter";
+
+const DEFAULT_HISTORY_LINE_LIMIT = 5_000;
+
+export interface TerminalManagerEvents {
+  event: [event: TerminalEvent];
+}
+
+export interface TerminalManagerOptions {
+  logsDir?: string;
+  historyLineLimit?: number;
+  ptyAdapter?: PtyAdapter;
+  shellResolver?: () => string;
+}
+
+interface TerminalSessionState {
+  threadId: string;
+  cwd: string;
+  status: TerminalSessionStatus;
+  pid: number | null;
+  history: string;
+  exitCode: number | null;
+  exitSignal: number | null;
+  updatedAt: string;
+  cols: number;
+  rows: number;
+  process: PtyProcess | null;
+  unsubscribeData: (() => void) | null;
+  unsubscribeExit: (() => void) | null;
+}
+
+function defaultShellResolver(): string {
+  if (process.platform === "win32") {
+    return process.env.ComSpec ?? "cmd.exe";
+  }
+  return process.env.SHELL ?? "bash";
+}
+
+function capHistory(history: string, maxLines: number): string {
+  if (history.length === 0) return history;
+  const hasTrailingNewline = history.endsWith("\n");
+  const lines = history.split("\n");
+  if (hasTrailingNewline) {
+    lines.pop();
+  }
+  if (lines.length <= maxLines) return history;
+  const capped = lines.slice(lines.length - maxLines).join("\n");
+  return hasTrailingNewline ? `${capped}\n` : capped;
+}
+
+function toSafeThreadId(threadId: string): string {
+  return threadId.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
+  private readonly sessions = new Map<string, TerminalSessionState>();
+  private readonly logsDir: string;
+  private readonly historyLineLimit: number;
+  private readonly ptyAdapter: PtyAdapter;
+  private readonly shellResolver: () => string;
+  private readonly persistQueues = new Map<string, Promise<void>>();
+  private readonly logger = createLogger("terminal");
+
+  constructor(options: TerminalManagerOptions = {}) {
+    super();
+    this.logsDir = options.logsDir ?? path.resolve(process.cwd(), ".logs", "terminals");
+    this.historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
+    this.ptyAdapter = options.ptyAdapter ?? new NodePtyAdapter();
+    this.shellResolver = options.shellResolver ?? defaultShellResolver;
+    fs.mkdirSync(this.logsDir, { recursive: true });
+  }
+
+  async open(raw: TerminalOpenInput): Promise<TerminalSessionSnapshot> {
+    const input = terminalOpenInputSchema.parse(raw);
+    await this.assertValidCwd(input.cwd);
+    await this.flushPersistQueue(input.threadId);
+
+    const existing = this.sessions.get(input.threadId);
+    if (!existing) {
+      const history = await this.readHistory(input.threadId);
+      const session: TerminalSessionState = {
+        threadId: input.threadId,
+        cwd: input.cwd,
+        status: "starting",
+        pid: null,
+        history,
+        exitCode: null,
+        exitSignal: null,
+        updatedAt: new Date().toISOString(),
+        cols: input.cols,
+        rows: input.rows,
+        process: null,
+        unsubscribeData: null,
+        unsubscribeExit: null,
+      };
+      this.sessions.set(input.threadId, session);
+      this.startSession(session, input, "started");
+      return this.snapshot(session);
+    }
+
+    if (existing.cwd !== input.cwd) {
+      this.stopProcess(existing);
+      existing.cwd = input.cwd;
+      existing.history = "";
+      await this.persistHistory(existing.threadId, existing.history);
+    } else if (existing.status === "exited" || existing.status === "error") {
+      existing.history = "";
+      await this.persistHistory(existing.threadId, existing.history);
+    }
+
+    if (!existing.process) {
+      this.startSession(existing, input, "started");
+      return this.snapshot(existing);
+    }
+
+    if (existing.cols !== input.cols || existing.rows !== input.rows) {
+      existing.cols = input.cols;
+      existing.rows = input.rows;
+      existing.process.resize(input.cols, input.rows);
+      existing.updatedAt = new Date().toISOString();
+    }
+
+    return this.snapshot(existing);
+  }
+
+  async write(raw: TerminalWriteInput): Promise<void> {
+    const input = terminalWriteInputSchema.parse(raw);
+    const session = this.requireSession(input.threadId);
+    if (!session.process || session.status !== "running") {
+      throw new Error(`Terminal is not running for thread: ${input.threadId}`);
+    }
+    session.process.write(input.data);
+  }
+
+  async resize(raw: TerminalThreadInput & { cols: number; rows: number }): Promise<void> {
+    const input = terminalResizeInputSchema.parse(raw);
+    const session = this.requireSession(input.threadId);
+    if (!session.process || session.status !== "running") {
+      throw new Error(`Terminal is not running for thread: ${input.threadId}`);
+    }
+    session.cols = input.cols;
+    session.rows = input.rows;
+    session.updatedAt = new Date().toISOString();
+    session.process.resize(input.cols, input.rows);
+  }
+
+  async clear(raw: TerminalThreadInput): Promise<void> {
+    const input = terminalThreadInputSchema.parse(raw);
+    const session = this.requireSession(input.threadId);
+    session.history = "";
+    session.updatedAt = new Date().toISOString();
+    await this.persistHistory(input.threadId, session.history);
+    this.emitEvent({
+      type: "cleared",
+      threadId: input.threadId,
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  async restart(raw: TerminalOpenInput): Promise<TerminalSessionSnapshot> {
+    const input = terminalOpenInputSchema.parse(raw);
+    await this.assertValidCwd(input.cwd);
+
+    let session = this.sessions.get(input.threadId);
+    if (!session) {
+      session = {
+        threadId: input.threadId,
+        cwd: input.cwd,
+        status: "starting",
+        pid: null,
+        history: "",
+        exitCode: null,
+        exitSignal: null,
+        updatedAt: new Date().toISOString(),
+        cols: input.cols,
+        rows: input.rows,
+        process: null,
+        unsubscribeData: null,
+        unsubscribeExit: null,
+      };
+      this.sessions.set(input.threadId, session);
+    } else {
+      this.stopProcess(session);
+      session.cwd = input.cwd;
+    }
+
+    session.history = "";
+    await this.persistHistory(input.threadId, session.history);
+    this.startSession(session, input, "restarted");
+    return this.snapshot(session);
+  }
+
+  async close(raw: TerminalCloseInput): Promise<void> {
+    const input = terminalCloseInputSchema.parse(raw);
+    await this.flushPersistQueue(input.threadId);
+    const session = this.sessions.get(input.threadId);
+    if (session) {
+      this.stopProcess(session);
+      this.sessions.delete(input.threadId);
+    }
+    if (input.deleteHistory) {
+      await this.deleteHistory(input.threadId);
+    }
+  }
+
+  dispose(): void {
+    for (const session of this.sessions.values()) {
+      this.stopProcess(session);
+    }
+    this.sessions.clear();
+    this.persistQueues.clear();
+  }
+
+  private startSession(
+    session: TerminalSessionState,
+    input: TerminalOpenInput,
+    eventType: "started" | "restarted",
+  ): void {
+    this.stopProcess(session);
+
+    session.status = "starting";
+    session.cwd = input.cwd;
+    session.cols = input.cols;
+    session.rows = input.rows;
+    session.exitCode = null;
+    session.exitSignal = null;
+    session.updatedAt = new Date().toISOString();
+
+    const shell = this.shellResolver();
+    try {
+      const ptyProcess = this.ptyAdapter.spawn({
+        shell,
+        cwd: session.cwd,
+        cols: session.cols,
+        rows: session.rows,
+        env: process.env,
+      });
+      session.process = ptyProcess;
+      session.pid = ptyProcess.pid;
+      session.status = "running";
+      session.updatedAt = new Date().toISOString();
+      session.unsubscribeData = ptyProcess.onData((data) => {
+        this.onProcessData(session, data);
+      });
+      session.unsubscribeExit = ptyProcess.onExit((event) => {
+        this.onProcessExit(session, event);
+      });
+      this.emitEvent({
+        type: eventType,
+        threadId: session.threadId,
+        createdAt: new Date().toISOString(),
+        snapshot: this.snapshot(session),
+      });
+    } catch (error) {
+      session.status = "error";
+      session.pid = null;
+      session.process = null;
+      session.updatedAt = new Date().toISOString();
+      const message = error instanceof Error ? error.message : "Terminal start failed";
+      this.emitEvent({
+        type: "error",
+        threadId: session.threadId,
+        createdAt: new Date().toISOString(),
+        message,
+      });
+      this.logger.error("failed to start terminal", {
+        threadId: session.threadId,
+        error: message,
+      });
+    }
+  }
+
+  private onProcessData(session: TerminalSessionState, data: string): void {
+    session.history = capHistory(`${session.history}${data}`, this.historyLineLimit);
+    session.updatedAt = new Date().toISOString();
+    this.queuePersist(session.threadId, session.history);
+    this.emitEvent({
+      type: "output",
+      threadId: session.threadId,
+      createdAt: new Date().toISOString(),
+      data,
+    });
+  }
+
+  private onProcessExit(session: TerminalSessionState, event: PtyExitEvent): void {
+    this.cleanupProcessHandles(session);
+    session.process = null;
+    session.pid = null;
+    session.status = "exited";
+    session.exitCode = Number.isInteger(event.exitCode) ? event.exitCode : null;
+    session.exitSignal = Number.isInteger(event.signal) ? event.signal : null;
+    session.updatedAt = new Date().toISOString();
+    this.emitEvent({
+      type: "exited",
+      threadId: session.threadId,
+      createdAt: new Date().toISOString(),
+      exitCode: session.exitCode,
+      exitSignal: session.exitSignal,
+    });
+  }
+
+  private stopProcess(session: TerminalSessionState): void {
+    const process = session.process;
+    if (!process) return;
+    this.cleanupProcessHandles(session);
+    session.process = null;
+    session.pid = null;
+    session.status = "exited";
+    session.updatedAt = new Date().toISOString();
+    try {
+      process.kill();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn("failed to kill terminal process", {
+        threadId: session.threadId,
+        error: message,
+      });
+    }
+  }
+
+  private cleanupProcessHandles(session: TerminalSessionState): void {
+    session.unsubscribeData?.();
+    session.unsubscribeData = null;
+    session.unsubscribeExit?.();
+    session.unsubscribeExit = null;
+  }
+
+  private queuePersist(threadId: string, history: string): void {
+    const task = async () => {
+      await fs.promises.writeFile(this.historyPath(threadId), history, "utf8");
+    };
+    const previous = this.persistQueues.get(threadId) ?? Promise.resolve();
+    const next = previous.catch(() => undefined).then(task);
+    this.persistQueues.set(threadId, next);
+    void next.finally(() => {
+      if (this.persistQueues.get(threadId) === next) {
+        this.persistQueues.delete(threadId);
+      }
+    });
+  }
+
+  private async persistHistory(threadId: string, history: string): Promise<void> {
+    const task = async () => {
+      await fs.promises.writeFile(this.historyPath(threadId), history, "utf8");
+    };
+    const previous = this.persistQueues.get(threadId) ?? Promise.resolve();
+    const next = previous.catch(() => undefined).then(task);
+    this.persistQueues.set(threadId, next);
+    await next.finally(() => {
+      if (this.persistQueues.get(threadId) === next) {
+        this.persistQueues.delete(threadId);
+      }
+    });
+  }
+
+  private async readHistory(threadId: string): Promise<string> {
+    try {
+      const raw = await fs.promises.readFile(this.historyPath(threadId), "utf8");
+      const capped = capHistory(raw, this.historyLineLimit);
+      if (capped !== raw) {
+        await fs.promises.writeFile(this.historyPath(threadId), capped, "utf8");
+      }
+      return capped;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return "";
+      }
+      throw error;
+    }
+  }
+
+  private async deleteHistory(threadId: string): Promise<void> {
+    try {
+      await fs.promises.rm(this.historyPath(threadId), { force: true });
+    } catch (error) {
+      this.logger.warn("failed to delete terminal history", {
+        threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async flushPersistQueue(threadId: string): Promise<void> {
+    const pending = this.persistQueues.get(threadId);
+    if (!pending) return;
+    await pending.catch(() => undefined);
+  }
+
+  private async assertValidCwd(cwd: string): Promise<void> {
+    let stats: fs.Stats;
+    try {
+      stats = await fs.promises.stat(cwd);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new Error(`Terminal cwd does not exist: ${cwd}`, { cause: error });
+      }
+      throw error;
+    }
+    if (!stats.isDirectory()) {
+      throw new Error(`Terminal cwd is not a directory: ${cwd}`);
+    }
+  }
+
+  private requireSession(threadId: string): TerminalSessionState {
+    const session = this.sessions.get(threadId);
+    if (!session) {
+      throw new Error(`Unknown terminal thread: ${threadId}`);
+    }
+    return session;
+  }
+
+  private snapshot(session: TerminalSessionState): TerminalSessionSnapshot {
+    return {
+      threadId: session.threadId,
+      cwd: session.cwd,
+      status: session.status,
+      pid: session.pid,
+      history: session.history,
+      exitCode: session.exitCode,
+      exitSignal: session.exitSignal,
+      updatedAt: session.updatedAt,
+    };
+  }
+
+  private emitEvent(event: TerminalEvent): void {
+    this.emit("event", event);
+  }
+
+  private historyPath(threadId: string): string {
+    return path.join(this.logsDir, `${toSafeThreadId(threadId)}.log`);
+  }
+}

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { EventEmitter } from "node:events";
 
 import { describe, expect, it, afterEach, vi } from "vitest";
 import { createServer } from "./wsServer";
@@ -8,6 +9,15 @@ import WebSocket from "ws";
 
 import { WS_CHANNELS, WS_METHODS, type WsPush, type WsResponse } from "@t3tools/contracts";
 import { ProjectRegistry } from "./projectRegistry";
+import type {
+  TerminalCloseInput,
+  TerminalEvent,
+  TerminalOpenInput,
+  TerminalSessionSnapshot,
+  TerminalThreadInput,
+  TerminalWriteInput,
+} from "@t3tools/contracts";
+import type { TerminalManager } from "./terminalManager";
 
 interface PendingMessages {
   queue: unknown[];
@@ -15,6 +25,91 @@ interface PendingMessages {
 }
 
 const pendingBySocket = new WeakMap<WebSocket, PendingMessages>();
+
+class MockTerminalManager extends EventEmitter<{ event: [event: TerminalEvent] }> {
+  private readonly sessions = new Map<string, TerminalSessionSnapshot>();
+
+  async open(input: TerminalOpenInput): Promise<TerminalSessionSnapshot> {
+    const now = new Date().toISOString();
+    const snapshot: TerminalSessionSnapshot = {
+      threadId: input.threadId,
+      cwd: input.cwd,
+      status: "running",
+      pid: 4242,
+      history: "",
+      exitCode: null,
+      exitSignal: null,
+      updatedAt: now,
+    };
+    this.sessions.set(input.threadId, snapshot);
+    queueMicrotask(() => {
+      this.emit("event", {
+        type: "started",
+        threadId: input.threadId,
+        createdAt: now,
+        snapshot,
+      });
+    });
+    return snapshot;
+  }
+
+  async write(input: TerminalWriteInput): Promise<void> {
+    const existing = this.sessions.get(input.threadId);
+    if (!existing) {
+      throw new Error(`Unknown terminal thread: ${input.threadId}`);
+    }
+    queueMicrotask(() => {
+      this.emit("event", {
+        type: "output",
+        threadId: input.threadId,
+        createdAt: new Date().toISOString(),
+        data: input.data,
+      });
+    });
+  }
+
+  async resize(_input: TerminalThreadInput & { cols: number; rows: number }): Promise<void> {}
+
+  async clear(input: TerminalThreadInput): Promise<void> {
+    queueMicrotask(() => {
+      this.emit("event", {
+        type: "cleared",
+        threadId: input.threadId,
+        createdAt: new Date().toISOString(),
+      });
+    });
+  }
+
+  async restart(input: TerminalOpenInput): Promise<TerminalSessionSnapshot> {
+    const now = new Date().toISOString();
+    const snapshot: TerminalSessionSnapshot = {
+      threadId: input.threadId,
+      cwd: input.cwd,
+      status: "running",
+      pid: 5252,
+      history: "",
+      exitCode: null,
+      exitSignal: null,
+      updatedAt: now,
+    };
+    this.sessions.set(input.threadId, snapshot);
+    queueMicrotask(() => {
+      this.emit("event", {
+        type: "restarted",
+        threadId: input.threadId,
+        createdAt: now,
+        snapshot,
+      });
+    });
+    return snapshot;
+  }
+
+  async close(input: TerminalCloseInput): Promise<void> {
+    this.sessions.delete(input.threadId);
+  }
+
+  dispose(): void {}
+}
 
 function connectWs(port: number, token?: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
@@ -85,6 +180,7 @@ describe("WebSocket Server", () => {
       devUrl?: string;
       authToken?: string;
       stateDir?: string;
+      terminalManager?: TerminalManager;
     } = {},
   ): ReturnType<typeof createServer> {
     const stateDir = options.stateDir ?? makeTempDir("t3code-ws-state-");
@@ -94,6 +190,9 @@ describe("WebSocket Server", () => {
       ...(options.devUrl ? { devUrl: options.devUrl } : {}),
       ...(options.authToken ? { authToken: options.authToken } : {}),
       projectRegistry: new ProjectRegistry(stateDir),
+      ...(options.terminalManager
+        ? { terminalManager: options.terminalManager }
+        : {}),
     });
   }
 
@@ -211,6 +310,95 @@ describe("WebSocket Server", () => {
     const response = await sendRequest(ws, WS_METHODS.providersListSessions);
     expect(response.error).toBeUndefined();
     expect(response.result).toEqual([]);
+  });
+
+  it("routes terminal RPC methods and broadcasts terminal events", async () => {
+    const cwd = makeTempDir("t3code-ws-terminal-cwd-");
+    const terminalManager = new MockTerminalManager();
+    server = createTestServer({
+      cwd: "/test",
+      terminalManager: terminalManager as unknown as TerminalManager,
+    });
+    await server.start();
+    const addr = server.httpServer.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    const open = await sendRequest(ws, WS_METHODS.terminalOpen, {
+      threadId: "thread-1",
+      cwd,
+      cols: 100,
+      rows: 24,
+    });
+    expect(open.error).toBeUndefined();
+    expect((open.result as TerminalSessionSnapshot).threadId).toBe("thread-1");
+
+    const write = await sendRequest(ws, WS_METHODS.terminalWrite, {
+      threadId: "thread-1",
+      data: "echo hello\n",
+    });
+    expect(write.error).toBeUndefined();
+
+    const resize = await sendRequest(ws, WS_METHODS.terminalResize, {
+      threadId: "thread-1",
+      cols: 120,
+      rows: 30,
+    });
+    expect(resize.error).toBeUndefined();
+
+    const clear = await sendRequest(ws, WS_METHODS.terminalClear, {
+      threadId: "thread-1",
+    });
+    expect(clear.error).toBeUndefined();
+
+    const restart = await sendRequest(ws, WS_METHODS.terminalRestart, {
+      threadId: "thread-1",
+      cwd,
+      cols: 120,
+      rows: 30,
+    });
+    expect(restart.error).toBeUndefined();
+
+    const close = await sendRequest(ws, WS_METHODS.terminalClose, {
+      threadId: "thread-1",
+      deleteHistory: true,
+    });
+    expect(close.error).toBeUndefined();
+
+    const manualEvent: TerminalEvent = {
+      type: "output",
+      threadId: "thread-1",
+      createdAt: new Date().toISOString(),
+      data: "manual test output\n",
+    };
+    terminalManager.emit("event", manualEvent);
+
+    const push = (await waitForMessage(ws)) as WsPush;
+    expect(push.type).toBe("push");
+    expect(push.channel).toBe(WS_CHANNELS.terminalEvent);
+    expect((push.data as TerminalEvent).type).toBe("output");
+  });
+
+  it("returns validation errors for invalid terminal open params", async () => {
+    server = createTestServer({ cwd: "/test" });
+    await server.start();
+    const addr = server.httpServer.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.terminalOpen, {
+      threadId: "",
+      cwd: "",
+      cols: 1,
+      rows: 1,
+    });
+    expect(response.error).toBeDefined();
   });
 
   it("handles invalid JSON gracefully", async () => {

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -382,6 +382,22 @@ describe("WebSocket Server", () => {
     expect((push.data as TerminalEvent).type).toBe("output");
   });
 
+  it("detaches terminal event listener on stop for injected manager", async () => {
+    const terminalManager = new MockTerminalManager();
+    server = createTestServer({
+      cwd: "/test",
+      terminalManager: terminalManager as unknown as TerminalManager,
+    });
+    await server.start();
+
+    expect(terminalManager.listenerCount("event")).toBe(1);
+
+    await server.stop();
+    server = null;
+
+    expect(terminalManager.listenerCount("event")).toBe(0);
+  });
+
   it("returns validation errors for invalid terminal open params", async () => {
     server = createTestServer({ cwd: "/test" });
     await server.start();

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -27,6 +27,7 @@ import {
   listGitBranches,
   removeGitWorktree,
 } from "./git";
+import { TerminalManager } from "./terminalManager";
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -51,6 +52,7 @@ export interface ServerOptions {
   devUrl?: string | undefined;
   logWebSocketEvents?: boolean | undefined;
   projectRegistry?: ProjectRegistry | undefined;
+  terminalManager?: TerminalManager | undefined;
   authToken?: string | undefined;
 }
 
@@ -71,9 +73,11 @@ export function createServer(options: ServerOptions) {
     devUrl,
     logWebSocketEvents: explicitLogWsEvents,
     projectRegistry: providedRegistry,
+    terminalManager: providedTerminalManager,
     authToken,
   } = options;
   const providerManager = new ProviderManager();
+  const terminalManager = providedTerminalManager ?? new TerminalManager();
   const projectRegistry =
     providedRegistry ?? new ProjectRegistry(path.join(os.homedir(), ".t3", "userdata"));
   const clients = new Set<WebSocket>();
@@ -95,6 +99,23 @@ export function createServer(options: ServerOptions) {
     const push: WsPush = {
       type: "push",
       channel: WS_CHANNELS.providerEvent,
+      data: event,
+    };
+    const message = JSON.stringify(push);
+    let recipients = 0;
+    for (const client of clients) {
+      if (client.readyState === client.OPEN) {
+        client.send(message);
+        recipients += 1;
+      }
+    }
+    logOutgoingPush(push, recipients);
+  });
+
+  terminalManager.on("event", (event) => {
+    const push: WsPush = {
+      type: "push",
+      channel: WS_CHANNELS.terminalEvent,
       data: event,
     };
     const message = JSON.stringify(push);
@@ -330,6 +351,28 @@ export function createServer(options: ServerOptions) {
       case WS_METHODS.gitInit:
         return initGitRepo(request.params as never);
 
+      case WS_METHODS.terminalOpen:
+        return terminalManager.open(request.params as never);
+
+      case WS_METHODS.terminalWrite:
+        await terminalManager.write(request.params as never);
+        return undefined;
+
+      case WS_METHODS.terminalResize:
+        await terminalManager.resize(request.params as never);
+        return undefined;
+
+      case WS_METHODS.terminalClear:
+        await terminalManager.clear(request.params as never);
+        return undefined;
+
+      case WS_METHODS.terminalRestart:
+        return terminalManager.restart(request.params as never);
+
+      case WS_METHODS.terminalClose:
+        await terminalManager.close(request.params as never);
+        return undefined;
+
       case WS_METHODS.serverGetConfig:
         return { cwd };
 
@@ -360,6 +403,7 @@ export function createServer(options: ServerOptions) {
   async function stop(): Promise<void> {
     providerManager.stopAll();
     providerManager.dispose();
+    terminalManager.dispose();
 
     for (const client of clients) {
       client.close();

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -9,6 +9,7 @@ import {
   EDITORS,
   WS_CHANNELS,
   WS_METHODS,
+  type TerminalEvent,
   type WsPush,
   type WsRequest,
   type WsResponse,
@@ -112,7 +113,7 @@ export function createServer(options: ServerOptions) {
     logOutgoingPush(push, recipients);
   });
 
-  terminalManager.on("event", (event) => {
+  const onTerminalEvent = (event: TerminalEvent) => {
     const push: WsPush = {
       type: "push",
       channel: WS_CHANNELS.terminalEvent,
@@ -127,7 +128,8 @@ export function createServer(options: ServerOptions) {
       }
     }
     logOutgoingPush(push, recipients);
-  });
+  };
+  terminalManager.on("event", onTerminalEvent);
 
   // HTTP server — serves static files or redirects to Vite dev server
   const httpServer = http.createServer((req, res) => {
@@ -401,6 +403,7 @@ export function createServer(options: ServerOptions) {
   }
 
   async function stop(): Promise<void> {
+    terminalManager.off("event", onTerminalEvent);
     providerManager.stopAll();
     providerManager.dispose();
     terminalManager.dispose();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "@t3tools/contracts": "workspace:*",
     "@tanstack/react-query": "^5.90.0",
     "highlight.js": "^11.11.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import { isElectron } from "./env";
 import { DEFAULT_MODEL } from "./model-logic";
 import { readNativeApi } from "./session-logic";
 import { StoreProvider, useStore } from "./store";
+import { DEFAULT_THREAD_TERMINAL_HEIGHT } from "./types";
 import { onServerWelcome } from "./wsNativeApi";
 
 function EventRouter() {
@@ -22,6 +23,18 @@ function EventRouter() {
         type: "APPLY_EVENT",
         event,
         activeAssistantItemRef,
+      });
+    });
+  }, [api, dispatch]);
+
+  useEffect(() => {
+    if (!api) return;
+    return api.terminal.onEvent((event) => {
+      if (event.type !== "exited") return;
+      dispatch({
+        type: "SET_THREAD_TERMINAL_OPEN",
+        threadId: event.threadId,
+        open: false,
       });
     });
   }, [api, dispatch]);
@@ -78,6 +91,8 @@ function AutoProjectBootstrap() {
           projectId,
           title: "New thread",
           model: DEFAULT_MODEL,
+          terminalOpen: false,
+          terminalHeight: DEFAULT_THREAD_TERMINAL_HEIGHT,
           session: null,
           messages: [],
           events: [],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -628,7 +628,7 @@ export default function ChatView() {
   // Empty state: no active thread
   if (!activeThread) {
     return (
-      <div className="flex flex-1 flex-col bg-background text-muted-foreground/40">
+      <div className="flex min-h-0 flex-1 flex-col bg-background text-muted-foreground/40">
         {isElectron && <div className="drag-region h-[52px] shrink-0" />}
         <div className="flex flex-1 items-center justify-center">
           <div className="text-center">
@@ -640,7 +640,7 @@ export default function ChatView() {
   }
 
   return (
-    <div className="flex flex-1 flex-col bg-background">
+    <div className="flex min-h-0 flex-1 flex-col bg-background">
       {/* Top bar */}
       <header
         className={`flex items-center justify-between border-b border-border px-5 pb-3 ${isElectron ? "drag-region pt-[28px]" : "pt-3"}`}
@@ -787,7 +787,7 @@ export default function ChatView() {
       )}
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-5 py-4">
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
         {activeThread.messages.length === 0 && !isWorking ? (
           <div className="flex h-full items-center justify-center">
             <p className="text-sm text-muted-foreground/30">

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -7,6 +7,7 @@ import {
   type FormEvent,
   Fragment,
   type KeyboardEvent,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -34,7 +35,9 @@ import {
 } from "../session-logic";
 import { useStore } from "../store";
 import BranchToolbar from "./BranchToolbar";
+import { isTerminalToggleShortcut } from "../terminal-shortcuts";
 import ChatMarkdown from "./ChatMarkdown";
+import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
 
 function formatMessageMeta(createdAt: string, duration: string | null): string {
   if (!duration) return formatTimestamp(createdAt);
@@ -145,12 +148,15 @@ export default function ChatView() {
   const [respondingRequestIds, setRespondingRequestIds] = useState<string[]>([]);
   const [expandedWorkGroups, setExpandedWorkGroups] = useState<Record<string, boolean>>({});
   const [nowTick, setNowTick] = useState(() => Date.now());
+  const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const modelMenuRef = useRef<HTMLDivElement>(null);
   const editorMenuRef = useRef<HTMLDivElement>(null);
+  const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
 
   const activeThread = state.threads.find((t) => t.id === state.activeThreadId);
+  const activeThreadId = activeThread?.id ?? null;
   const activeProject = state.projects.find((p) => p.id === activeThread?.projectId);
   const selectedModel = resolveModelSlug(
     activeThread?.model ?? activeProject?.model ?? DEFAULT_MODEL,
@@ -255,6 +261,25 @@ export default function ChatView() {
     (activeThread.messages.length > 0 ||
       (activeThread.session !== null && activeThread.session.status !== "closed")),
   );
+  const terminalShortcutHint = navigator.platform.includes("Mac")
+    ? "\u2318J"
+    : "Ctrl+J";
+  const focusComposer = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.focus();
+    const cursor = textarea.value.length;
+    textarea.setSelectionRange(cursor, cursor);
+  }, []);
+  const toggleTerminalVisibility = useCallback(() => {
+    if (!activeThreadId) return;
+    const isOpen = Boolean(activeThread?.terminalOpen);
+    dispatch({
+      type: "SET_THREAD_TERMINAL_OPEN",
+      threadId: activeThreadId,
+      open: !isOpen,
+    });
+  }, [activeThread?.terminalOpen, activeThreadId, dispatch]);
 
   const handleRuntimeModeChange = async (mode: "approval-required" | "full-access") => {
     if (mode === state.runtimeMode) return;
@@ -363,6 +388,37 @@ export default function ChatView() {
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
   }, [api, activeProject, activeThread, lastEditor]);
+
+  useEffect(() => {
+    if (!activeThreadId) return;
+    const previous = terminalOpenByThreadRef.current[activeThreadId] ?? false;
+    const current = Boolean(activeThread?.terminalOpen);
+
+    if (!previous && current) {
+      setTerminalFocusRequestId((value) => value + 1);
+    } else if (previous && !current) {
+      terminalOpenByThreadRef.current[activeThreadId] = current;
+      const frame = window.requestAnimationFrame(() => {
+        focusComposer();
+      });
+      return () => {
+        window.cancelAnimationFrame(frame);
+      };
+    }
+
+    terminalOpenByThreadRef.current[activeThreadId] = current;
+  }, [activeThread?.terminalOpen, activeThreadId, focusComposer]);
+
+  useEffect(() => {
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (!activeThreadId) return;
+      if (!isTerminalToggleShortcut(event)) return;
+      event.preventDefault();
+      toggleTerminalVisibility();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [activeThreadId, toggleTerminalVisibility]);
 
   const openInEditor = (editorId: EditorId) => {
     if (!api || !activeProject) return;
@@ -636,6 +692,17 @@ export default function ChatView() {
             </div>
           )}
           {/* Diff toggle */}
+          <button
+            type="button"
+            className={`rounded-md px-2 py-1 text-[10px] transition-colors duration-150 ${
+              activeThread.terminalOpen
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground/40 hover:text-muted-foreground/60"
+            }`}
+            onClick={toggleTerminalVisibility}
+          >
+            Terminal <span className="text-muted-foreground/50">{terminalShortcutHint}</span>
+          </button>
           <button
             type="button"
             className={`rounded-md px-2 py-1 text-[10px] transition-colors duration-150 ${
@@ -1141,6 +1208,32 @@ export default function ChatView() {
       </div>
 
       <BranchToolbar envMode={envMode} onEnvModeChange={setEnvMode} envLocked={envLocked} />
+      <BranchToolbar envMode={envMode} onEnvModeChange={setEnvMode} envLocked={envLocked} />
+
+      {activeThread.terminalOpen && api && activeProject && (
+        <ThreadTerminalDrawer
+          key={activeThread.id}
+          api={api}
+          threadId={activeThread.id}
+          cwd={activeProject.cwd}
+          height={activeThread.terminalHeight}
+          focusRequestId={terminalFocusRequestId}
+          onHeightChange={(height) =>
+            dispatch({
+              type: "SET_THREAD_TERMINAL_HEIGHT",
+              threadId: activeThread.id,
+              height,
+            })
+          }
+          onThreadExited={() =>
+            dispatch({
+              type: "SET_THREAD_TERMINAL_OPEN",
+              threadId: activeThread.id,
+              open: false,
+            })
+          }
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1208,7 +1208,6 @@ export default function ChatView() {
       </div>
 
       <BranchToolbar envMode={envMode} onEnvModeChange={setEnvMode} envLocked={envLocked} />
-      <BranchToolbar envMode={envMode} onEnvModeChange={setEnvMode} envLocked={envLocked} />
 
       {activeThread.terminalOpen && api && activeProject && (
         <ThreadTerminalDrawer

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "../hooks/useTheme";
 import { DEFAULT_MODEL } from "../model-logic";
 import { readNativeApi } from "../session-logic";
 import { useStore } from "../store";
-import type { Project } from "../types";
+import { DEFAULT_THREAD_TERMINAL_HEIGHT, type Project } from "../types";
 
 const THEME_CYCLE = { system: "light", light: "dark", dark: "system" } as const;
 function formatRelativeTime(iso: string): string {
@@ -52,6 +52,8 @@ export default function Sidebar() {
           projectId,
           title: "New thread",
           model: state.projects.find((p) => p.id === projectId)?.model ?? DEFAULT_MODEL,
+          terminalOpen: false,
+          terminalHeight: DEFAULT_THREAD_TERMINAL_HEIGHT,
           session: null,
           messages: [],
           events: [],
@@ -180,6 +182,15 @@ export default function Sidebar() {
         } catch {
           // Session may already be stopped
         }
+      }
+
+      try {
+        await api.terminal.close({
+          threadId,
+          deleteHistory: true,
+        });
+      } catch {
+        // Terminal may already be closed
       }
 
       dispatch({ type: "DELETE_THREAD", threadId });

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -129,6 +129,7 @@ export default function ThreadTerminalDrawer({
     startY: number;
     startHeight: number;
   } | null>(null);
+  const didResizeDuringDragRef = useRef(false);
 
   useEffect(() => {
     onHeightChangeRef.current = onHeightChange;
@@ -152,11 +153,17 @@ export default function ThreadTerminalDrawer({
     [],
   );
 
-  const fitAndResizeTerminal = useCallback(() => {
+  const fitAndResizeTerminal = useCallback((preserveBottom = false) => {
     const activeTerminal = terminalRef.current;
     const activeFitAddon = fitAddonRef.current;
     if (!activeTerminal || !activeFitAddon) return;
+    const wasAtBottom =
+      preserveBottom &&
+      activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
     activeFitAddon.fit();
+    if (wasAtBottom) {
+      activeTerminal.scrollToBottom();
+    }
     void api.terminal
       .resize({
         threadId,
@@ -177,13 +184,14 @@ export default function ThreadTerminalDrawer({
       if (event.button !== 0) return;
       event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
+      didResizeDuringDragRef.current = false;
       resizeStateRef.current = {
         pointerId: event.pointerId,
         startY: event.clientY,
-        startHeight: drawerHeight,
+        startHeight: drawerHeightRef.current,
       };
     },
-    [drawerHeight],
+    [],
   );
 
   const handleResizePointerMove = useCallback(
@@ -194,6 +202,11 @@ export default function ThreadTerminalDrawer({
       const clampedHeight = clampDrawerHeight(
         resizeState.startHeight + (resizeState.startY - event.clientY),
       );
+      if (clampedHeight === drawerHeightRef.current) {
+        return;
+      }
+      didResizeDuringDragRef.current = true;
+      drawerHeightRef.current = clampedHeight;
       setDrawerHeight(clampedHeight);
     },
     [],
@@ -207,9 +220,13 @@ export default function ThreadTerminalDrawer({
       if (event.currentTarget.hasPointerCapture(event.pointerId)) {
         event.currentTarget.releasePointerCapture(event.pointerId);
       }
+      if (!didResizeDuringDragRef.current) {
+        return;
+      }
       syncHeight(drawerHeightRef.current);
+      fitAndResizeTerminal(true);
     },
-    [syncHeight],
+    [fitAndResizeTerminal, syncHeight],
   );
 
   useEffect(() => {
@@ -219,7 +236,7 @@ export default function ThreadTerminalDrawer({
       if (changed) {
         setDrawerHeight(clampedHeight);
       } else {
-        fitAndResizeTerminal();
+        fitAndResizeTerminal(true);
       }
       if (!resizeStateRef.current) {
         syncHeight(clampedHeight);
@@ -366,7 +383,9 @@ export default function ThreadTerminalDrawer({
       }
     });
 
-    const fitTimer = window.setTimeout(fitAndResizeTerminal, 30);
+    const fitTimer = window.setTimeout(() => {
+      fitAndResizeTerminal(true);
+    }, 30);
     void openTerminal();
 
     return () => {
@@ -396,8 +415,12 @@ export default function ThreadTerminalDrawer({
     const terminal = terminalRef.current;
     const fitAddon = fitAddonRef.current;
     if (!terminal || !fitAddon) return;
+    const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
     const frame = window.requestAnimationFrame(() => {
       fitAddon.fit();
+      if (wasAtBottom) {
+        terminal.scrollToBottom();
+      }
       void api.terminal
         .resize({
           threadId,

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1,0 +1,435 @@
+import { FitAddon } from "@xterm/addon-fit";
+import { type NativeApi } from "@t3tools/contracts";
+import { Terminal, type ITheme } from "@xterm/xterm";
+import {
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { isTerminalClearShortcut } from "../terminal-shortcuts";
+import { DEFAULT_THREAD_TERMINAL_HEIGHT } from "../types";
+
+const MIN_DRAWER_HEIGHT = 180;
+const MAX_DRAWER_HEIGHT_RATIO = 0.75;
+
+function maxDrawerHeight(): number {
+  if (typeof window === "undefined") return DEFAULT_THREAD_TERMINAL_HEIGHT;
+  return Math.max(
+    MIN_DRAWER_HEIGHT,
+    Math.floor(window.innerHeight * MAX_DRAWER_HEIGHT_RATIO),
+  );
+}
+
+function clampDrawerHeight(height: number): number {
+  const safeHeight = Number.isFinite(height)
+    ? height
+    : DEFAULT_THREAD_TERMINAL_HEIGHT;
+  const maxHeight = maxDrawerHeight();
+  return Math.min(Math.max(Math.round(safeHeight), MIN_DRAWER_HEIGHT), maxHeight);
+}
+
+function writeSystemMessage(terminal: Terminal, message: string): void {
+  terminal.write(`\r\n[terminal] ${message}\r\n`);
+}
+
+function terminalThemeFromApp(): ITheme {
+  const isDark = document.documentElement.classList.contains("dark");
+  const bodyStyles = getComputedStyle(document.body);
+  const background =
+    bodyStyles.backgroundColor || (isDark ? "rgb(14, 18, 24)" : "rgb(255, 255, 255)");
+  const foreground =
+    bodyStyles.color || (isDark ? "rgb(237, 241, 247)" : "rgb(28, 33, 41)");
+
+  if (isDark) {
+    return {
+      background,
+      foreground,
+      cursor: "rgb(180, 203, 255)",
+      selectionBackground: "rgba(180, 203, 255, 0.25)",
+      scrollbarSliderBackground: "rgba(255, 255, 255, 0.1)",
+      scrollbarSliderHoverBackground: "rgba(255, 255, 255, 0.18)",
+      scrollbarSliderActiveBackground: "rgba(255, 255, 255, 0.22)",
+      black: "rgb(24, 30, 38)",
+      red: "rgb(255, 122, 142)",
+      green: "rgb(134, 231, 149)",
+      yellow: "rgb(244, 205, 114)",
+      blue: "rgb(137, 190, 255)",
+      magenta: "rgb(208, 176, 255)",
+      cyan: "rgb(124, 232, 237)",
+      white: "rgb(210, 218, 230)",
+      brightBlack: "rgb(110, 120, 136)",
+      brightRed: "rgb(255, 168, 180)",
+      brightGreen: "rgb(176, 245, 186)",
+      brightYellow: "rgb(255, 224, 149)",
+      brightBlue: "rgb(174, 210, 255)",
+      brightMagenta: "rgb(229, 203, 255)",
+      brightCyan: "rgb(167, 244, 247)",
+      brightWhite: "rgb(244, 247, 252)",
+    };
+  }
+
+  return {
+    background,
+    foreground,
+    cursor: "rgb(38, 56, 78)",
+    selectionBackground: "rgba(37, 63, 99, 0.2)",
+    scrollbarSliderBackground: "rgba(0, 0, 0, 0.15)",
+    scrollbarSliderHoverBackground: "rgba(0, 0, 0, 0.25)",
+    scrollbarSliderActiveBackground: "rgba(0, 0, 0, 0.3)",
+    black: "rgb(44, 53, 66)",
+    red: "rgb(191, 70, 87)",
+    green: "rgb(60, 126, 86)",
+    yellow: "rgb(146, 112, 35)",
+    blue: "rgb(72, 102, 163)",
+    magenta: "rgb(132, 86, 149)",
+    cyan: "rgb(53, 127, 141)",
+    white: "rgb(210, 215, 223)",
+    brightBlack: "rgb(112, 123, 140)",
+    brightRed: "rgb(212, 95, 112)",
+    brightGreen: "rgb(85, 148, 111)",
+    brightYellow: "rgb(173, 133, 45)",
+    brightBlue: "rgb(91, 124, 194)",
+    brightMagenta: "rgb(153, 107, 172)",
+    brightCyan: "rgb(70, 149, 164)",
+    brightWhite: "rgb(236, 240, 246)",
+  };
+}
+
+interface ThreadTerminalDrawerProps {
+  api: NativeApi;
+  threadId: string;
+  cwd: string;
+  height: number;
+  focusRequestId: number;
+  onHeightChange: (height: number) => void;
+  onThreadExited: () => void;
+}
+
+export default function ThreadTerminalDrawer({
+  api,
+  threadId,
+  cwd,
+  height,
+  focusRequestId,
+  onHeightChange,
+  onThreadExited,
+}: ThreadTerminalDrawerProps) {
+  const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height));
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const drawerHeightRef = useRef(drawerHeight);
+  const lastSyncedHeightRef = useRef(clampDrawerHeight(height));
+  const onHeightChangeRef = useRef(onHeightChange);
+  const onThreadExitedRef = useRef(onThreadExited);
+  const resizeStateRef = useRef<{
+    pointerId: number;
+    startY: number;
+    startHeight: number;
+  } | null>(null);
+
+  useEffect(() => {
+    onHeightChangeRef.current = onHeightChange;
+  }, [onHeightChange]);
+
+  useEffect(() => {
+    onThreadExitedRef.current = onThreadExited;
+  }, [onThreadExited]);
+
+  useEffect(() => {
+    drawerHeightRef.current = drawerHeight;
+  }, [drawerHeight]);
+
+  const syncHeight = useCallback(
+    (nextHeight: number) => {
+      const clampedHeight = clampDrawerHeight(nextHeight);
+      if (lastSyncedHeightRef.current === clampedHeight) return;
+      lastSyncedHeightRef.current = clampedHeight;
+      onHeightChangeRef.current(clampedHeight);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const clampedHeight = clampDrawerHeight(height);
+    setDrawerHeight(clampedHeight);
+    lastSyncedHeightRef.current = clampedHeight;
+  }, [height, threadId]);
+
+  const handleResizePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      resizeStateRef.current = {
+        pointerId: event.pointerId,
+        startY: event.clientY,
+        startHeight: drawerHeight,
+      };
+    },
+    [drawerHeight],
+  );
+
+  const handleResizePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const resizeState = resizeStateRef.current;
+      if (!resizeState || resizeState.pointerId !== event.pointerId) return;
+      event.preventDefault();
+      const clampedHeight = clampDrawerHeight(
+        resizeState.startHeight + (resizeState.startY - event.clientY),
+      );
+      setDrawerHeight(clampedHeight);
+    },
+    [],
+  );
+
+  const handleResizePointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const resizeState = resizeStateRef.current;
+      if (!resizeState || resizeState.pointerId !== event.pointerId) return;
+      resizeStateRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      syncHeight(drawerHeightRef.current);
+    },
+    [syncHeight],
+  );
+
+  useEffect(() => {
+    const onWindowResize = () => {
+      const clampedHeight = clampDrawerHeight(drawerHeightRef.current);
+      if (clampedHeight !== drawerHeightRef.current) {
+        setDrawerHeight(clampedHeight);
+      }
+      if (!resizeStateRef.current) {
+        syncHeight(clampedHeight);
+      }
+    };
+    window.addEventListener("resize", onWindowResize);
+    return () => {
+      window.removeEventListener("resize", onWindowResize);
+    };
+  }, [syncHeight]);
+
+  useEffect(() => {
+    return () => {
+      syncHeight(drawerHeightRef.current);
+    };
+  }, [syncHeight]);
+
+  useEffect(() => {
+    const mount = containerRef.current;
+    if (!mount) return;
+
+    let disposed = false;
+
+    const fitAddon = new FitAddon();
+    const terminal = new Terminal({
+      cursorBlink: true,
+      lineHeight: 1.2,
+      fontSize: 12,
+      scrollback: 5_000,
+      fontFamily:
+        '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+      theme: terminalThemeFromApp(),
+    });
+    terminal.loadAddon(fitAddon);
+    terminal.open(mount);
+    fitAddon.fit();
+
+    terminalRef.current = terminal;
+    fitAddonRef.current = fitAddon;
+
+    const sendClearShortcut = async () => {
+      const activeTerminal = terminalRef.current;
+      if (!activeTerminal) return;
+      try {
+        await api.terminal.write({ threadId, data: "\u000c" });
+      } catch (error) {
+        writeSystemMessage(
+          activeTerminal,
+          error instanceof Error ? error.message : "Failed to clear terminal",
+        );
+      }
+    };
+
+    terminal.attachCustomKeyEventHandler((event) => {
+      if (!isTerminalClearShortcut(event)) return true;
+      event.preventDefault();
+      event.stopPropagation();
+      void sendClearShortcut();
+      return false;
+    });
+
+    const resizeAndSync = () => {
+      const activeTerminal = terminalRef.current;
+      const activeFitAddon = fitAddonRef.current;
+      if (!activeTerminal || !activeFitAddon) return;
+      activeFitAddon.fit();
+      void api.terminal
+        .resize({
+          threadId,
+          cols: activeTerminal.cols,
+          rows: activeTerminal.rows,
+        })
+        .catch(() => undefined);
+    };
+
+    const inputDisposable = terminal.onData((data) => {
+      void api.terminal
+        .write({ threadId, data })
+        .catch((err) =>
+          writeSystemMessage(
+            terminal,
+            err instanceof Error ? err.message : "Terminal write failed",
+          ),
+        );
+    });
+
+    const themeObserver = new MutationObserver(() => {
+      const activeTerminal = terminalRef.current;
+      if (!activeTerminal) return;
+      activeTerminal.options.theme = terminalThemeFromApp();
+      activeTerminal.refresh(0, activeTerminal.rows - 1);
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style"],
+    });
+
+    const openTerminal = async () => {
+      try {
+        const activeTerminal = terminalRef.current;
+        const activeFitAddon = fitAddonRef.current;
+        if (!activeTerminal || !activeFitAddon) return;
+        activeFitAddon.fit();
+        const snapshot = await api.terminal.open({
+          threadId,
+          cwd,
+          cols: activeTerminal.cols,
+          rows: activeTerminal.rows,
+        });
+        if (disposed) return;
+        activeTerminal.write("\u001bc");
+        if (snapshot.history.length > 0) {
+          activeTerminal.write(snapshot.history);
+        }
+        window.requestAnimationFrame(() => {
+          activeTerminal.focus();
+        });
+      } catch (err) {
+        if (disposed) return;
+        writeSystemMessage(
+          terminal,
+          err instanceof Error ? err.message : "Failed to open terminal",
+        );
+      }
+    };
+
+    const unsubscribe = api.terminal.onEvent((event) => {
+      if (event.threadId !== threadId) return;
+      const activeTerminal = terminalRef.current;
+      if (!activeTerminal) return;
+
+      if (event.type === "output") {
+        activeTerminal.write(event.data);
+        return;
+      }
+
+      if (event.type === "started" || event.type === "restarted") {
+        activeTerminal.write("\u001bc");
+        if (event.snapshot.history.length > 0) {
+          activeTerminal.write(event.snapshot.history);
+        }
+        return;
+      }
+
+      if (event.type === "cleared") {
+        activeTerminal.clear();
+        activeTerminal.write("\u001bc");
+        return;
+      }
+
+      if (event.type === "error") {
+        writeSystemMessage(activeTerminal, event.message);
+        return;
+      }
+
+      if (event.type === "exited") {
+        onThreadExitedRef.current();
+      }
+    });
+
+    window.addEventListener("resize", resizeAndSync);
+    const fitTimer = window.setTimeout(resizeAndSync, 30);
+    void openTerminal();
+
+    return () => {
+      disposed = true;
+      window.clearTimeout(fitTimer);
+      window.removeEventListener("resize", resizeAndSync);
+      unsubscribe();
+      inputDisposable.dispose();
+      themeObserver.disconnect();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+      terminal.dispose();
+    };
+  }, [api, cwd, threadId]);
+
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    if (!terminal) return;
+    const frame = window.requestAnimationFrame(() => {
+      terminal.focus();
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [focusRequestId]);
+
+  useEffect(() => {
+    const terminal = terminalRef.current;
+    const fitAddon = fitAddonRef.current;
+    if (!terminal || !fitAddon) return;
+    const frame = window.requestAnimationFrame(() => {
+      fitAddon.fit();
+      void api.terminal
+        .resize({
+          threadId,
+          cols: terminal.cols,
+          rows: terminal.rows,
+        })
+        .catch(() => undefined);
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [api, drawerHeight, threadId]);
+
+  return (
+    <aside
+      className="thread-terminal-drawer flex shrink-0 flex-col border-t border-border/80 bg-background"
+      style={{ height: `${drawerHeight}px` }}
+    >
+      <div
+        className="flex h-2 cursor-row-resize items-center justify-center"
+        onPointerDown={handleResizePointerDown}
+        onPointerMove={handleResizePointerMove}
+        onPointerUp={handleResizePointerEnd}
+        onPointerCancel={handleResizePointerEnd}
+      >
+        <div className="h-px w-10 rounded-full bg-border/80" />
+      </div>
+      <div className="min-h-0 w-full flex-1 px-1.5 pb-1">
+        <div
+          ref={containerRef}
+          className="h-full w-full overflow-hidden rounded-[4px]"
+        />
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -152,6 +152,20 @@ export default function ThreadTerminalDrawer({
     [],
   );
 
+  const fitAndResizeTerminal = useCallback(() => {
+    const activeTerminal = terminalRef.current;
+    const activeFitAddon = fitAddonRef.current;
+    if (!activeTerminal || !activeFitAddon) return;
+    activeFitAddon.fit();
+    void api.terminal
+      .resize({
+        threadId,
+        cols: activeTerminal.cols,
+        rows: activeTerminal.rows,
+      })
+      .catch(() => undefined);
+  }, [api, threadId]);
+
   useEffect(() => {
     const clampedHeight = clampDrawerHeight(height);
     setDrawerHeight(clampedHeight);
@@ -201,8 +215,11 @@ export default function ThreadTerminalDrawer({
   useEffect(() => {
     const onWindowResize = () => {
       const clampedHeight = clampDrawerHeight(drawerHeightRef.current);
-      if (clampedHeight !== drawerHeightRef.current) {
+      const changed = clampedHeight !== drawerHeightRef.current;
+      if (changed) {
         setDrawerHeight(clampedHeight);
+      } else {
+        fitAndResizeTerminal();
       }
       if (!resizeStateRef.current) {
         syncHeight(clampedHeight);
@@ -212,7 +229,7 @@ export default function ThreadTerminalDrawer({
     return () => {
       window.removeEventListener("resize", onWindowResize);
     };
-  }, [syncHeight]);
+  }, [fitAndResizeTerminal, syncHeight]);
 
   useEffect(() => {
     return () => {
@@ -263,20 +280,6 @@ export default function ThreadTerminalDrawer({
       void sendClearShortcut();
       return false;
     });
-
-    const resizeAndSync = () => {
-      const activeTerminal = terminalRef.current;
-      const activeFitAddon = fitAddonRef.current;
-      if (!activeTerminal || !activeFitAddon) return;
-      activeFitAddon.fit();
-      void api.terminal
-        .resize({
-          threadId,
-          cols: activeTerminal.cols,
-          rows: activeTerminal.rows,
-        })
-        .catch(() => undefined);
-    };
 
     const inputDisposable = terminal.onData((data) => {
       void api.terminal
@@ -363,14 +366,12 @@ export default function ThreadTerminalDrawer({
       }
     });
 
-    window.addEventListener("resize", resizeAndSync);
-    const fitTimer = window.setTimeout(resizeAndSync, 30);
+    const fitTimer = window.setTimeout(fitAndResizeTerminal, 30);
     void openTerminal();
 
     return () => {
       disposed = true;
       window.clearTimeout(fitTimer);
-      window.removeEventListener("resize", resizeAndSync);
       unsubscribe();
       inputDisposable.dispose();
       themeObserver.disconnect();
@@ -378,7 +379,7 @@ export default function ThreadTerminalDrawer({
       fitAddonRef.current = null;
       terminal.dispose();
     };
-  }, [api, cwd, threadId]);
+  }, [api, cwd, fitAndResizeTerminal, threadId]);
 
   useEffect(() => {
     const terminal = terminalRef.current;
@@ -408,7 +409,7 @@ export default function ThreadTerminalDrawer({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [api, drawerHeight, threadId]);
+  }, [api, cwd, drawerHeight, threadId]);
 
   return (
     <aside

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -229,6 +229,20 @@ input {
   background: rgba(255, 255, 255, 0.18);
 }
 
+/* Terminal drawer scrollbar parity with chat */
+.thread-terminal-drawer .xterm .xterm-scrollable-element > .scrollbar.vertical {
+  width: 6px !important;
+}
+
+.thread-terminal-drawer .xterm .xterm-scrollable-element > .scrollbar > .slider {
+  border-radius: 3px;
+}
+
+.thread-terminal-drawer .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider {
+  width: 6px !important;
+  left: 0 !important;
+}
+
 /* Reasoning select -- clickable label surface */
 label:has(> select#reasoning-effort) {
   position: relative;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "@xterm/xterm/css/xterm.css";
 import "highlight.js/styles/github-dark.css";
 
 import App from "./App";

--- a/apps/web/src/persistenceSchema.test.ts
+++ b/apps/web/src/persistenceSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_MODEL } from "./model-logic";
 import { hydratePersistedState, toPersistedState } from "./persistenceSchema";
+import { DEFAULT_THREAD_TERMINAL_HEIGHT } from "./types";
 import type { Thread } from "./types";
 
 describe("hydratePersistedState", () => {
@@ -47,6 +48,8 @@ describe("hydratePersistedState", () => {
     expect(hydrated?.projects[0]?.model).toBe(DEFAULT_MODEL);
     expect(hydrated?.threads[0]?.model).toBe(DEFAULT_MODEL);
     expect(hydrated?.threads[0]?.codexThreadId).toBeNull();
+    expect(hydrated?.threads[0]?.terminalOpen).toBe(false);
+    expect(hydrated?.threads[0]?.terminalHeight).toBe(DEFAULT_THREAD_TERMINAL_HEIGHT);
     expect(hydrated?.threads[0]?.messages[0]?.streaming).toBe(false);
     expect(hydrated?.runtimeMode).toBe("full-access");
   });
@@ -87,6 +90,8 @@ describe("hydratePersistedState", () => {
     expect(hydrated).not.toBeNull();
     expect(hydrated?.threads.map((thread) => thread.id)).toEqual(["t-1"]);
     expect(hydrated?.threads[0]?.codexThreadId).toBeNull();
+    expect(hydrated?.threads[0]?.terminalOpen).toBe(false);
+    expect(hydrated?.threads[0]?.terminalHeight).toBe(DEFAULT_THREAD_TERMINAL_HEIGHT);
     expect(hydrated?.activeThreadId).toBe("t-1");
     expect(hydrated?.runtimeMode).toBe("full-access");
   });
@@ -111,16 +116,84 @@ describe("hydratePersistedState", () => {
     const hydrated = hydratePersistedState(payload, false);
     expect(hydrated?.runtimeMode).toBe("approval-required");
   });
+
+  it("hydrates terminal fields from v6 payload", () => {
+    const payload = JSON.stringify({
+      version: 6,
+      runtimeMode: "full-access",
+      projects: [
+        {
+          id: "p-1",
+          name: "Project",
+          cwd: "/tmp/project",
+          model: "gpt-5.3-codex",
+          expanded: true,
+        },
+      ],
+      threads: [
+        {
+          id: "t-1",
+          codexThreadId: null,
+          projectId: "p-1",
+          title: "Thread",
+          model: "gpt-5.3-codex",
+          terminalOpen: true,
+          terminalHeight: 360,
+          messages: [],
+          createdAt: "2026-02-08T10:00:00.000Z",
+        },
+      ],
+      activeThreadId: "t-1",
+    });
+
+    const hydrated = hydratePersistedState(payload, false);
+    expect(hydrated?.threads[0]?.terminalOpen).toBe(true);
+    expect(hydrated?.threads[0]?.terminalHeight).toBe(360);
+  });
+
+  it("defaults terminalHeight when hydrating v5 payloads", () => {
+    const payload = JSON.stringify({
+      version: 5,
+      runtimeMode: "full-access",
+      projects: [
+        {
+          id: "p-1",
+          name: "Project",
+          cwd: "/tmp/project",
+          model: "gpt-5.3-codex",
+          expanded: true,
+        },
+      ],
+      threads: [
+        {
+          id: "t-1",
+          codexThreadId: null,
+          projectId: "p-1",
+          title: "Thread",
+          model: "gpt-5.3-codex",
+          terminalOpen: true,
+          messages: [],
+          createdAt: "2026-02-08T10:00:00.000Z",
+        },
+      ],
+      activeThreadId: "t-1",
+    });
+
+    const hydrated = hydratePersistedState(payload, false);
+    expect(hydrated?.threads[0]?.terminalHeight).toBe(DEFAULT_THREAD_TERMINAL_HEIGHT);
+  });
 });
 
 describe("toPersistedState", () => {
-  it("writes v4 payload and strips non-persisted thread fields", () => {
+  it("writes v6 payload and strips non-persisted thread fields", () => {
     const thread: Thread = {
       id: "t-1",
       codexThreadId: "thr_1",
       projectId: "p-1",
       title: "Thread",
       model: "gpt-5.3-codex",
+      terminalOpen: true,
+      terminalHeight: 320,
       session: null,
       messages: [
         {
@@ -153,7 +226,7 @@ describe("toPersistedState", () => {
       runtimeMode: "full-access",
     });
 
-    expect(persisted.version).toBe(4);
+    expect(persisted.version).toBe(6);
     expect(persisted.runtimeMode).toBe("full-access");
     expect(persisted.threads[0]).toEqual({
       id: "t-1",
@@ -161,6 +234,8 @@ describe("toPersistedState", () => {
       projectId: "p-1",
       title: "Thread",
       model: "gpt-5.3-codex",
+      terminalOpen: true,
+      terminalHeight: 320,
       messages: thread.messages,
       createdAt: thread.createdAt,
       branch: null,

--- a/apps/web/src/persistenceSchema.ts
+++ b/apps/web/src/persistenceSchema.ts
@@ -1,7 +1,13 @@
 import { z } from "zod";
 
 import { DEFAULT_MODEL, resolveModelSlug } from "./model-logic";
-import { DEFAULT_RUNTIME_MODE, type Project, type RuntimeMode, type Thread } from "./types";
+import {
+  DEFAULT_THREAD_TERMINAL_HEIGHT,
+  DEFAULT_RUNTIME_MODE,
+  type Project,
+  type RuntimeMode,
+  type Thread,
+} from "./types";
 
 const LEGACY_DEFAULT_MODEL = "gpt-5.2-codex";
 
@@ -27,6 +33,10 @@ const persistedThreadSchema = z.object({
   projectId: z.string().min(1),
   title: z.string().min(1),
   model: z.string().min(1),
+  terminalOpen: z.boolean().default(false),
+  terminalHeight: z.number().int().min(120).max(4_096).default(
+    DEFAULT_THREAD_TERMINAL_HEIGHT,
+  ),
   messages: z.array(persistedMessageSchema),
   createdAt: z.string().min(1),
   branch: z.string().min(1).nullable().optional(),
@@ -59,7 +69,19 @@ export const persistedStateV4Schema = persistedStateBodySchema.extend({
   version: z.literal(4).optional(),
 });
 
+export const persistedStateV6Schema = persistedStateBodySchema.extend({
+  runtimeMode: runtimeModeSchema.default(DEFAULT_RUNTIME_MODE),
+  version: z.literal(6).optional(),
+});
+
+export const persistedStateV5Schema = persistedStateBodySchema.extend({
+  runtimeMode: runtimeModeSchema.default(DEFAULT_RUNTIME_MODE),
+  version: z.literal(5).optional(),
+});
+
 const persistedStateSchema = z.union([
+  persistedStateV6Schema,
+  persistedStateV5Schema,
   persistedStateV4Schema,
   persistedStateV3Schema,
   persistedStateV2Schema,
@@ -101,6 +123,8 @@ function hydrateThread(
     projectId: thread.projectId,
     title: thread.title,
     model: resolveModelSlug(maybeMigrateLegacyModel(thread.model, isLegacyPayload)),
+    terminalOpen: thread.terminalOpen ?? false,
+    terminalHeight: thread.terminalHeight ?? DEFAULT_THREAD_TERMINAL_HEIGHT,
     session: null,
     messages: thread.messages.map((message) => ({
       ...message,
@@ -153,9 +177,9 @@ export function hydratePersistedState(
 
 export function toPersistedState(
   state: PersistedStoreSnapshot,
-): z.infer<typeof persistedStateV4Schema> {
+): z.infer<typeof persistedStateV6Schema> {
   return {
-    version: 4,
+    version: 6,
     projects: state.projects,
     threads: state.threads.map((thread) => ({
       id: thread.id,
@@ -163,6 +187,8 @@ export function toPersistedState(
       projectId: thread.projectId,
       title: thread.title,
       model: thread.model,
+      terminalOpen: thread.terminalOpen,
+      terminalHeight: thread.terminalHeight,
       messages: thread.messages,
       createdAt: thread.createdAt,
       branch: thread.branch,

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -2,6 +2,7 @@ import type { ProviderEvent, ProviderSession } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
 import { type AppState, reducer } from "./store";
+import { DEFAULT_THREAD_TERMINAL_HEIGHT } from "./types";
 import type { Thread } from "./types";
 
 function makeSession(overrides: Partial<ProviderSession> = {}): ProviderSession {
@@ -34,6 +35,8 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     projectId: "project-1",
     title: "Thread",
     model: "gpt-5.3-codex",
+    terminalOpen: false,
+    terminalHeight: DEFAULT_THREAD_TERMINAL_HEIGHT,
     session: makeSession(),
     messages: [],
     events: [],
@@ -77,6 +80,35 @@ describe("store reducer thread continuity", () => {
     });
 
     expect(next.threads[0]?.codexThreadId).toBe("thr_123");
+  });
+
+  it("toggles terminal open state per thread", () => {
+    const state = makeState(makeThread({ terminalOpen: false }));
+    const next = reducer(state, {
+      type: "TOGGLE_THREAD_TERMINAL",
+      threadId: "thread-local-1",
+    });
+    expect(next.threads[0]?.terminalOpen).toBe(true);
+  });
+
+  it("sets terminal open state per thread", () => {
+    const state = makeState(makeThread({ terminalOpen: true }));
+    const next = reducer(state, {
+      type: "SET_THREAD_TERMINAL_OPEN",
+      threadId: "thread-local-1",
+      open: false,
+    });
+    expect(next.threads[0]?.terminalOpen).toBe(false);
+  });
+
+  it("sets terminal height per thread", () => {
+    const state = makeState(makeThread({ terminalHeight: 280 }));
+    const next = reducer(state, {
+      type: "SET_THREAD_TERMINAL_HEIGHT",
+      threadId: "thread-local-1",
+      height: 360,
+    });
+    expect(next.threads[0]?.terminalHeight).toBe(360);
   });
 
   it("backfills codexThreadId from routed provider events", () => {

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -12,7 +12,12 @@ import type { ProviderEvent, ProviderSession } from "@t3tools/contracts";
 import { resolveModelSlug } from "./model-logic";
 import { hydratePersistedState, toPersistedState } from "./persistenceSchema";
 import { applyEventToMessages, asObject, asString, evolveSession } from "./session-logic";
-import { DEFAULT_RUNTIME_MODE, type Project, type RuntimeMode, type Thread } from "./types";
+import {
+  DEFAULT_RUNTIME_MODE,
+  type Project,
+  type RuntimeMode,
+  type Thread,
+} from "./types";
 
 // ── Actions ──────────────────────────────────────────────────────────
 
@@ -22,6 +27,9 @@ type Action =
   | { type: "TOGGLE_PROJECT"; projectId: string }
   | { type: "ADD_THREAD"; thread: Thread }
   | { type: "SET_ACTIVE_THREAD"; threadId: string }
+  | { type: "TOGGLE_THREAD_TERMINAL"; threadId: string }
+  | { type: "SET_THREAD_TERMINAL_OPEN"; threadId: string; open: boolean }
+  | { type: "SET_THREAD_TERMINAL_HEIGHT"; threadId: string; height: number }
   | { type: "TOGGLE_DIFF" }
   | {
       type: "APPLY_EVENT";
@@ -52,8 +60,10 @@ export interface AppState {
   diffOpen: boolean;
 }
 
-const PERSISTED_STATE_KEY = "t3code:renderer-state:v4";
+const PERSISTED_STATE_KEY = "t3code:renderer-state:v6";
 const LEGACY_PERSISTED_STATE_KEYS = [
+  "t3code:renderer-state:v5",
+  "t3code:renderer-state:v4",
   "t3code:renderer-state:v3",
   "codething:renderer-state:v4",
   "codething:renderer-state:v3",
@@ -76,15 +86,16 @@ function readPersistedState(): AppState {
 
   try {
     const rawCurrent = window.localStorage.getItem(PERSISTED_STATE_KEY);
-    const [legacyV3Key, legacyV2Key, legacyV1Key] = LEGACY_PERSISTED_STATE_KEYS;
-    const rawLegacyV3 = window.localStorage.getItem(legacyV3Key);
-    const rawLegacyV2 = window.localStorage.getItem(legacyV2Key);
-    const rawLegacyV1 = window.localStorage.getItem(legacyV1Key);
-    const raw = rawCurrent ?? rawLegacyV3 ?? rawLegacyV2 ?? rawLegacyV1;
+    const legacyValues = LEGACY_PERSISTED_STATE_KEYS.map((key) =>
+      window.localStorage.getItem(key),
+    );
+    const rawLegacy = legacyValues.find((value) => value !== null) ?? null;
+    const raw = rawCurrent ?? rawLegacy;
     if (!raw) return initialState;
+    const rawCodethingV1 = window.localStorage.getItem("codething:renderer-state:v1");
     const hydrated = hydratePersistedState(
       raw,
-      !rawCurrent && !rawLegacyV3 && !rawLegacyV2 && Boolean(rawLegacyV1),
+      !rawCurrent && raw === rawCodethingV1,
     );
     if (!hydrated) return initialState;
 
@@ -282,6 +293,33 @@ export function reducer(state: AppState, action: Action): AppState {
 
     case "SET_ACTIVE_THREAD":
       return { ...state, activeThreadId: action.threadId };
+
+    case "TOGGLE_THREAD_TERMINAL":
+      return {
+        ...state,
+        threads: updateThread(state.threads, action.threadId, (t) => ({
+          ...t,
+          terminalOpen: !t.terminalOpen,
+        })),
+      };
+
+    case "SET_THREAD_TERMINAL_OPEN":
+      return {
+        ...state,
+        threads: updateThread(state.threads, action.threadId, (t) => ({
+          ...t,
+          terminalOpen: action.open,
+        })),
+      };
+
+    case "SET_THREAD_TERMINAL_HEIGHT":
+      return {
+        ...state,
+        threads: updateThread(state.threads, action.threadId, (t) => ({
+          ...t,
+          terminalHeight: action.height,
+        })),
+      };
 
     case "TOGGLE_DIFF":
       return { ...state, diffOpen: !state.diffOpen };

--- a/apps/web/src/terminal-shortcuts.test.ts
+++ b/apps/web/src/terminal-shortcuts.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isTerminalClearShortcut,
+  isTerminalToggleShortcut,
+  type ShortcutEventLike,
+} from "./terminal-shortcuts";
+
+function event(overrides: Partial<ShortcutEventLike> = {}): ShortcutEventLike {
+  return {
+    key: "j",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides,
+  };
+}
+
+describe("isTerminalToggleShortcut", () => {
+  it("matches Cmd+J on macOS", () => {
+    expect(
+      isTerminalToggleShortcut(event({ metaKey: true }), "MacIntel"),
+    ).toBe(true);
+  });
+
+  it("matches Ctrl+J on non-macOS", () => {
+    expect(
+      isTerminalToggleShortcut(event({ ctrlKey: true }), "Win32"),
+    ).toBe(true);
+  });
+
+  it("rejects wrong modifiers", () => {
+    expect(
+      isTerminalToggleShortcut(
+        event({ ctrlKey: true, shiftKey: true }),
+        "Win32",
+      ),
+    ).toBe(false);
+    expect(
+      isTerminalToggleShortcut(event({ metaKey: true, altKey: true }), "MacIntel"),
+    ).toBe(false);
+  });
+
+  it("rejects non-j keys", () => {
+    expect(
+      isTerminalToggleShortcut(event({ key: "k", ctrlKey: true }), "Linux"),
+    ).toBe(false);
+  });
+});
+
+describe("isTerminalClearShortcut", () => {
+  it("matches Ctrl+L on all platforms", () => {
+    expect(
+      isTerminalClearShortcut(event({ key: "l", ctrlKey: true }), "Linux"),
+    ).toBe(true);
+    expect(
+      isTerminalClearShortcut(event({ key: "l", ctrlKey: true }), "MacIntel"),
+    ).toBe(true);
+  });
+
+  it("matches Cmd+K on macOS", () => {
+    expect(
+      isTerminalClearShortcut(event({ key: "k", metaKey: true }), "MacIntel"),
+    ).toBe(true);
+  });
+
+  it("rejects Cmd+K on non-macOS", () => {
+    expect(
+      isTerminalClearShortcut(event({ key: "k", metaKey: true }), "Win32"),
+    ).toBe(false);
+  });
+
+  it("rejects wrong modifiers", () => {
+    expect(
+      isTerminalClearShortcut(
+        event({ key: "l", ctrlKey: true, shiftKey: true }),
+        "Linux",
+      ),
+    ).toBe(false);
+    expect(
+      isTerminalClearShortcut(
+        event({ key: "k", metaKey: true, altKey: true }),
+        "MacIntel",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/terminal-shortcuts.ts
+++ b/apps/web/src/terminal-shortcuts.ts
@@ -1,0 +1,52 @@
+export interface ShortcutEventLike {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+function isMacPlatform(platform: string): boolean {
+  return /mac|iphone|ipad|ipod/i.test(platform);
+}
+
+export function isTerminalToggleShortcut(
+  event: ShortcutEventLike,
+  platform = navigator.platform,
+): boolean {
+  const key = event.key.toLowerCase();
+  if (key !== "j") return false;
+  if (event.shiftKey || event.altKey) return false;
+
+  if (isMacPlatform(platform)) {
+    return event.metaKey && !event.ctrlKey;
+  }
+
+  return event.ctrlKey && !event.metaKey;
+}
+
+export function isTerminalClearShortcut(
+  event: ShortcutEventLike,
+  platform = navigator.platform,
+): boolean {
+  const key = event.key.toLowerCase();
+
+  if (
+    key === "l" &&
+    event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey
+  ) {
+    return true;
+  }
+
+  return (
+    isMacPlatform(platform) &&
+    key === "k" &&
+    event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey
+  );
+}

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -3,6 +3,7 @@ import type { ProviderEvent, ProviderSession } from "@t3tools/contracts";
 export type SessionPhase = "disconnected" | "connecting" | "ready" | "running";
 export type RuntimeMode = "approval-required" | "full-access";
 export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
+export const DEFAULT_THREAD_TERMINAL_HEIGHT = 280;
 
 export interface ChatMessage {
   id: string;
@@ -26,6 +27,8 @@ export interface Thread {
   projectId: string;
   title: string;
   model: string;
+  terminalOpen: boolean;
+  terminalHeight: number;
   session: ProviderSession | null;
   messages: ChatMessage[];
   events: ProviderEvent[];

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -62,13 +62,14 @@ export function createWsNativeApi(): NativeApi {
       },
     },
     terminal: {
-      run: async () => ({
-        stdout: "",
-        stderr: "Terminal not available in web mode",
-        code: 1,
-        signal: null,
-        timedOut: false,
-      }),
+      open: (input) => transport.request(WS_METHODS.terminalOpen, input),
+      write: (input) => transport.request(WS_METHODS.terminalWrite, input),
+      resize: (input) => transport.request(WS_METHODS.terminalResize, input),
+      clear: (input) => transport.request(WS_METHODS.terminalClear, input),
+      restart: (input) => transport.request(WS_METHODS.terminalRestart, input),
+      close: (input) => transport.request(WS_METHODS.terminalClose, input),
+      onEvent: (callback) =>
+        transport.subscribe(WS_CHANNELS.terminalEvent, callback as (data: unknown) => void),
     },
     agent: {
       spawn: async () => "",

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "ct-round-5",
+      "name": "@t3tools/monorepo",
       "devDependencies": {
         "oxfmt": "^0.28.0",
         "oxlint": "^1.43.0",
@@ -31,9 +31,10 @@
       "name": "t3",
       "version": "0.1.0",
       "bin": {
-        "t3": "./dist/index.js",
+        "t3": "./dist/index.mjs",
       },
       "dependencies": {
+        "node-pty": "^1.1.0",
         "open": "^10.1.0",
         "ws": "^8.18.0",
       },
@@ -52,6 +53,8 @@
       "dependencies": {
         "@t3tools/contracts": "workspace:*",
         "@tanstack/react-query": "^5.90.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.563.0",
         "react": "^19.0.0",
@@ -191,7 +194,7 @@
 
     "@hapi/pinpoint": ["@hapi/pinpoint@2.0.1", "", {}, "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q=="],
 
-    "@hapi/tlds": ["@hapi/tlds@1.1.4", "", {}, "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA=="],
+    "@hapi/tlds": ["@hapi/tlds@1.1.5", "", {}, "sha512-Vq/1gnIIsvFUpKlDdfrPd/ssHDpAyBP/baVukh3u2KSG2xoNjsnRNjQiPmuyPPGqsn1cqVWWhtZHfOBaLizFRQ=="],
 
     "@hapi/topo": ["@hapi/topo@6.0.2", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg=="],
 
@@ -227,21 +230,43 @@
 
     "@oxfmt/win32-x64": ["@oxfmt/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-4+S2j4OxOIyo8dz5osm5dZuL0yVmxXvtmNdHB5xyGwAWVvyWNvf7tCaQD7w2fdSsAXQLOvK7KFQrHFe33nJUCA=="],
 
-    "@oxlint/darwin-arm64": ["@oxlint/darwin-arm64@1.43.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C/GhObv/pQZg34NOzB6Mk8x0wc9AKj8fXzJF8ZRKTsBPyHusC6AZ6bba0QG0TUufw1KWuD0j++oebQfWeiFXNw=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.46.0", "", { "os": "android", "cpu": "arm" }, "sha512-vLPcE+HcZ/W/0cVA1KLuAnoUSejGougDH/fDjBFf0Q+rbBIyBNLevOhgx3AnBNAt3hcIGY7U05ISbJCKZeVa3w=="],
 
-    "@oxlint/darwin-x64": ["@oxlint/darwin-x64@1.43.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-4NjfUtEEH8ewRQ2KlZGmm6DyrvypMdHwBnQT92vD0dLScNOQzr0V9O8Ua4IWXdeCNl/XMVhAV3h4/3YEYern5A=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.46.0", "", { "os": "android", "cpu": "arm64" }, "sha512-b8IqCczUsirdtJ3R/be4cRm64I5pMPafMO/9xyTAZvc+R/FxZHMQuhw0iNT9hQwRn+Uo5rNAoA8QS7QurG2QeA=="],
 
-    "@oxlint/linux-arm64-gnu": ["@oxlint/linux-arm64-gnu@1.43.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-75tf1HvwdZ3ebk83yMbSB+moAEWK98mYqpXiaFAi6Zshie7r+Cx5PLXZFUEqkscenoZ+fcNXakHxfn94V6nf1g=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.46.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CfC/KGnNMhI01dkfCMjquKnW4zby3kqD5o/9XA7+pgo9I4b+Nipm+JVFyZPWMNwKqLXNmi35GTLWjs9svPxlew=="],
 
-    "@oxlint/linux-arm64-musl": ["@oxlint/linux-arm64-musl@1.43.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-BHV4fb36T2p/7bpA9fiJ5ayt7oJbiYX10nklW5arYp4l9/9yG/FQC5J4G1evzbJ/YbipF9UH0vYBAm5xbqGrvw=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.46.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-m38mKPsV3rBdWOJ4TAGZiUjWU8RGrBxsmdSeMQ0bPr/8O6CUOm/RJkPBf0GAfPms2WRVcbkfEXvIiPshAeFkeA=="],
 
-    "@oxlint/linux-x64-gnu": ["@oxlint/linux-x64-gnu@1.43.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1l3nvnzWWse1YHibzZ4HQXdF/ibfbKZhp9IguElni3bBqEyPEyurzZ0ikWynDxKGXqZa+UNXTFuU1NRVX1RJ3g=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.46.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-YaFRKslSAfuMwn7ejS1/wo9jENqQigpGBjjThX+mrpmEROLYGky+zIC5xSVGRng28U92VEDVbSNJ/sguz3dUAA=="],
 
-    "@oxlint/linux-x64-musl": ["@oxlint/linux-x64-musl@1.43.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+jNYgLGRFTJxJuaSOZJBwlYo5M0TWRw0+3y5MHOL4ArrIdHyCthg6r4RbVWrsR1qUfUE1VSSHQ2bfbC99RXqMg=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.46.0", "", { "os": "linux", "cpu": "arm" }, "sha512-Nlw+5mSZQtkg1Oj0N8ulxzG8ATpmSDz5V2DNaGhaYAVlcdR8NYSm/xTOnweOXc/UOOv3LwkPPYzqcfPhu2lEkA=="],
 
-    "@oxlint/win32-arm64": ["@oxlint/win32-arm64@1.43.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-dvs1C/HCjCyGTURMagiHprsOvVTT3omDiSzi5Qw0D4QFJ1pEaNlfBhVnOUYgUfS6O7Mcmj4+G+sidRsQcWQ/kA=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.46.0", "", { "os": "linux", "cpu": "arm" }, "sha512-d3Y5y4ukMqAGnWLMKpwqj8ftNUaac7pA0NrId4AZ77JvHzezmxEcm2gswaBw2HW8y1pnq6KDB0vEPPvpTfDLrA=="],
 
-    "@oxlint/win32-x64": ["@oxlint/win32-x64@1.43.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.46.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jkjx+XSOPuFR+C458prQmehO+v0VK19/3Hj2mOYDF4hHUf3CzmtA4fTmQUtkITZiGHnky7Oao6JeJX24mrX7WQ=="],
+
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.46.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-X/aPB1rpJUdykjWSeeGIbjk6qbD8VDulgLuTSMWgr/t6m1ljcAjqHb1g49pVG9bZl55zjECgzvlpPLWnfb4FMQ=="],
+
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.46.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AymyOxGWwKY2KJa8b+h8iLrYJZbWKYCjqctSc2q6uIAkYPrCsxcWlge1JP6XZ14Sa80DVMwI/QvktbytSV+xVw=="],
+
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.46.0", "", { "os": "linux", "cpu": "none" }, "sha512-PkeVdPKCDA59rlMuucsel2LjlNEpslQN5AhkMMorIJZItbbqi/0JSuACCzaiIcXYv0oNfbeQ8rbOBikv+aT6cg=="],
+
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.46.0", "", { "os": "linux", "cpu": "none" }, "sha512-snQaRLO/X+Ry/CxX1px1g8GUbmXzymdRs+/RkP2bySHWZFhFDtbLm2hA1ujX/jKlTLMJDZn4hYzFGLDwG/Rh2w=="],
+
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.46.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-kZhDMwUe/sgDTluGao9c0Dqc1JzV6wPzfGo0l/FLQdh5Zmp39Yg1FbBsCgsJfVKmKl1fNqsHyFLTShWMOlOEhA=="],
+
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.46.0", "", { "os": "linux", "cpu": "x64" }, "sha512-n5a7VtQTxHZ13cNAKQc3ziARv5bE1Fx868v/tnhZNVUjaRNYe5uiUrRJ/LZghdAzOxVuQGarjjq/q4QM2+9OPA=="],
+
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.46.0", "", { "os": "linux", "cpu": "x64" }, "sha512-KpsDU/BhdVn3iKCLxMXAOZIpO8fS0jEA5iluRoK1rhHPwKtpzEm/OCwERsu/vboMSZm66qnoTUVXRPJ8M+iKVQ=="],
+
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.46.0", "", { "os": "none", "cpu": "arm64" }, "sha512-jtbqUyEXlsDlRmMtTZqNbw49+1V/WxqNAR5l0S3OEkdat9diI5I+eqq9IT+jb5cSDdszTGcXpn7S3+gUYSydxQ=="],
+
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.46.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-EE8NjpqEZPwHQVigNvdyJ11dZwWIfsfn4VeBAuiJeAdrnY4HFX27mIjJINJgP5ZdBYEFV1OWH/eb9fURCYel8w=="],
+
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.46.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-BHyk3H/HRdXs+uImGZ/2+qCET+B8lwGHOm7m54JiJEEUWf3zYCFX/Df1SPqtozWWmnBvioxoTG1J3mPRAr8KUA=="],
+
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.46.0", "", { "os": "win32", "cpu": "x64" }, "sha512-DJbQsSJUr4KSi9uU0QqOgI7PX2C+fKGZX+YDprt3vM2sC0dWZsgVTLoN2vtkNyEWJSY2mnvRFUshWXT3bmo0Ug=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
@@ -403,9 +428,9 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@22.19.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw=="],
+    "@types/node": ["@types/node@22.19.11", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w=="],
 
-    "@types/react": ["@types/react@19.2.13", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ=="],
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
@@ -434,6 +459,10 @@
     "@vitest/spy": ["@vitest/spy@4.0.18", "", {}, "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw=="],
 
     "@vitest/utils": ["@vitest/utils@4.0.18", "", { "dependencies": { "@vitest/pretty-format": "4.0.18", "tinyrainbow": "^3.0.3" } }, "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -667,7 +696,7 @@
 
     "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
-    "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "joi": ["joi@18.0.2", "", { "dependencies": { "@hapi/address": "^5.1.1", "@hapi/formula": "^3.0.2", "@hapi/hoek": "^11.0.7", "@hapi/pinpoint": "^2.0.1", "@hapi/tlds": "^1.1.1", "@hapi/topo": "^6.0.2", "@standard-schema/spec": "^1.0.0" } }, "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA=="],
 
@@ -831,6 +860,10 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
+
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
     "normalize-path": ["normalize-path@2.1.1", "", { "dependencies": { "remove-trailing-separator": "^1.0.1" } }, "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w=="],
@@ -847,7 +880,7 @@
 
     "oxfmt": ["oxfmt@0.28.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/darwin-arm64": "0.28.0", "@oxfmt/darwin-x64": "0.28.0", "@oxfmt/linux-arm64-gnu": "0.28.0", "@oxfmt/linux-arm64-musl": "0.28.0", "@oxfmt/linux-x64-gnu": "0.28.0", "@oxfmt/linux-x64-musl": "0.28.0", "@oxfmt/win32-arm64": "0.28.0", "@oxfmt/win32-x64": "0.28.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-3+hhBqPE6Kp22KfJmnstrZbl+KdOVSEu1V0ABaFIg1rYLtrMgrupx9znnHgHLqKxAVHebjTdiCJDk30CXOt6cw=="],
 
-    "oxlint": ["oxlint@1.43.0", "", { "optionalDependencies": { "@oxlint/darwin-arm64": "1.43.0", "@oxlint/darwin-x64": "1.43.0", "@oxlint/linux-arm64-gnu": "1.43.0", "@oxlint/linux-arm64-musl": "1.43.0", "@oxlint/linux-x64-gnu": "1.43.0", "@oxlint/linux-x64-musl": "1.43.0", "@oxlint/win32-arm64": "1.43.0", "@oxlint/win32-x64": "1.43.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.11.2" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-xiqTCsKZch+R61DPCjyqUVP2MhkQlRRYxLRBeBDi+dtQJ90MOgdcjIktvDCgXz0bgtx94EQzHEndsizZjMX2OA=="],
+    "oxlint": ["oxlint@1.46.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.46.0", "@oxlint/binding-android-arm64": "1.46.0", "@oxlint/binding-darwin-arm64": "1.46.0", "@oxlint/binding-darwin-x64": "1.46.0", "@oxlint/binding-freebsd-x64": "1.46.0", "@oxlint/binding-linux-arm-gnueabihf": "1.46.0", "@oxlint/binding-linux-arm-musleabihf": "1.46.0", "@oxlint/binding-linux-arm64-gnu": "1.46.0", "@oxlint/binding-linux-arm64-musl": "1.46.0", "@oxlint/binding-linux-ppc64-gnu": "1.46.0", "@oxlint/binding-linux-riscv64-gnu": "1.46.0", "@oxlint/binding-linux-riscv64-musl": "1.46.0", "@oxlint/binding-linux-s390x-gnu": "1.46.0", "@oxlint/binding-linux-x64-gnu": "1.46.0", "@oxlint/binding-linux-x64-musl": "1.46.0", "@oxlint/binding-openharmony-arm64": "1.46.0", "@oxlint/binding-win32-arm64-msvc": "1.46.0", "@oxlint/binding-win32-ia32-msvc": "1.46.0", "@oxlint/binding-win32-x64-msvc": "1.46.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.11.2" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-I9h42QDtAVsRwoueJ4PL/7qN5jFzIUXvbO4Z5ddtII92ZCiD7uiS/JW2V4viBSfGLsbZkQp3YEs6Ls4I8q+8tA=="],
 
     "p-cancelable": ["p-cancelable@2.1.1", "", {}, "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg=="],
 
@@ -977,21 +1010,19 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+    "turbo": ["turbo@2.8.7", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.7", "turbo-darwin-arm64": "2.8.7", "turbo-linux-64": "2.8.7", "turbo-linux-arm64": "2.8.7", "turbo-windows-64": "2.8.7", "turbo-windows-arm64": "2.8.7" }, "bin": { "turbo": "bin/turbo" } }, "sha512-RBLh5caMAu1kFdTK1jgH2gH/z+jFsvX5rGbhgJ9nlIAWXSvxlzwId05uDlBA1+pBd3wO/UaKYzaQZQBXDd7kcA=="],
 
-    "turbo": ["turbo@2.8.3", "", { "optionalDependencies": { "turbo-darwin-64": "2.8.3", "turbo-darwin-arm64": "2.8.3", "turbo-linux-64": "2.8.3", "turbo-linux-arm64": "2.8.3", "turbo-windows-64": "2.8.3", "turbo-windows-arm64": "2.8.3" }, "bin": { "turbo": "bin/turbo" } }, "sha512-8Osxz5Tu/Dw2kb31EAY+nhq/YZ3wzmQSmYa1nIArqxgCAldxv9TPlrAiaBUDVnKA4aiPn0OFBD1ACcpc5VFOAQ=="],
+    "turbo-darwin-64": ["turbo-darwin-64@2.8.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-Xr4TO/oDDwoozbDtBvunb66g//WK8uHRygl72vUthuwzmiw48pil4IuoG/QbMHd9RE8aBnVmzC0WZEWk/WWt3A=="],
 
-    "turbo-darwin-64": ["turbo-darwin-64@2.8.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kXRLfcygLOeNcP6JquqRLmGB/ATjjfehiojL2dJkL7GFm3SPSXbq7oNj8UbD8XriYQ5hPaSuz59iF1ijPHkTw=="],
+    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.8.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-p8Xbmb9kZEY/NoshQUcFmQdO80s2PCGoLYj5DbpxjZr3diknipXxzOK7pcmT7l2gNHaMCpFVWLkiFY9nO3EU5w=="],
 
-    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.8.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-xF7uCeC0UY0Hrv/tqax0BMbFlVP1J/aRyeGQPZT4NjvIPj8gSPDgFhfkfz06DhUwDg5NgMo04uiSkAWE8WB/QQ=="],
+    "turbo-linux-64": ["turbo-linux-64@2.8.7", "", { "os": "linux", "cpu": "x64" }, "sha512-nwfEPAH3m5y/nJeYly3j1YJNYU2EG5+2ysZUxvBNM+VBV2LjQaLxB9CsEIpIOKuWKCjnFHKIADTSDPZ3D12J5Q=="],
 
-    "turbo-linux-64": ["turbo-linux-64@2.8.3", "", { "os": "linux", "cpu": "x64" }, "sha512-vxMDXwaOjweW/4etY7BxrXCSkvtwh0PbwVafyfT1Ww659SedUxd5rM3V2ZCmbwG8NiCfY7d6VtxyHx3Wh1GoZA=="],
+    "turbo-linux-arm64": ["turbo-linux-arm64@2.8.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-mgA/M6xiJzyxtXV70TtWGDPh+I6acOKmeQGtOzbFQZYEf794pu5jax26bCk5skAp1gqZu3vacPr6jhYHoHU9IQ=="],
 
-    "turbo-linux-arm64": ["turbo-linux-arm64@2.8.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-mQX7uYBZFkuPLLlKaNe9IjR1JIef4YvY8f21xFocvttXvdPebnq3PK1Zjzl9A1zun2BEuWNUwQIL8lgvN9Pm3Q=="],
+    "turbo-windows-64": ["turbo-windows-64@2.8.7", "", { "os": "win32", "cpu": "x64" }, "sha512-sHTYMaXuCcyHnGUQgfUUt7S8407TWoP14zc/4N2tsM0wZNK6V9h4H2t5jQPtqKEb6Fg8313kygdDgEwuM4vsHg=="],
 
-    "turbo-windows-64": ["turbo-windows-64@2.8.3", "", { "os": "win32", "cpu": "x64" }, "sha512-YLGEfppGxZj3VWcNOVa08h6ISsVKiG85aCAWosOKNUjb6yErWEuydv6/qImRJUI+tDLvDvW7BxopAkujRnWCrw=="],
-
-    "turbo-windows-arm64": ["turbo-windows-arm64@2.8.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-afTUGKBRmOJU1smQSBnFGcbq0iabAPwh1uXu2BVk7BREg30/1gMnJh9DFEQTah+UD3n3ru8V55J83RQNFfqoyw=="],
+    "turbo-windows-arm64": ["turbo-windows-arm64@2.8.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-WyGiOI2Zp3AhuzVagzQN+T+iq0fWx0oGxDfAWT3ZiLEd4U0cDUkwUZDKVGb3rKqPjDL6lWnuxKKu73ge5xtovQ=="],
 
     "type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
@@ -1077,8 +1108,6 @@
 
     "@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
-
     "@tailwindcss/node/lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
@@ -1093,13 +1122,13 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@tailwindcss/vite/vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+    "@tailwindcss/vite/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "@types/babel__core/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 
     "@types/babel__template/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 
-    "@vitejs/plugin-react/vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+    "@vitejs/plugin-react/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "clone-response/mimic-response": ["mimic-response@1.0.1", "", {}, "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="],
 
@@ -1113,7 +1142,7 @@
 
     "rolldown-plugin-dts/@babel/types": ["@babel/types@8.0.0-rc.1", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.1", "@babel/helper-validator-identifier": "^8.0.0-rc.1" } }, "sha512-ubmJ6TShyaD69VE9DQrlXcdkvJbmwWPB8qYj0H2kaJi29O7vJT9ajSdBd2W8CG34pwL9pYA74fi7RHC1qbLoVQ=="],
 
-    "vitest/vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+    "vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.1", "", {}, "sha512-vi/pfmbrOtQmqgfboaBhaCU50G7mcySVu69VU8z+lYoPPB6WzI9VgV7WQfL908M4oeSH5fDkmoupIqoE0SdApw=="],
 
@@ -1141,168 +1170,6 @@
 
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
-    "@tailwindcss/vite/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
-
-    "@vitejs/plugin-react/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
-
     "rolldown-plugin-dts/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.1", "", {}, "sha512-vi/pfmbrOtQmqgfboaBhaCU50G7mcySVu69VU8z+lYoPPB6WzI9VgV7WQfL908M4oeSH5fDkmoupIqoE0SdApw=="],
-
-    "vitest/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
-
-    "@tailwindcss/vite/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
-
-    "@vitejs/plugin-react/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
-
-    "vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
-
-    "vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
-
-    "vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
-
-    "vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
-
-    "vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
-
-    "vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
-
-    "vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
-
-    "vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
-
-    "vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
-
-    "vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
-
-    "vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
-
-    "vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
-
-    "vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
-
-    "vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
-
-    "vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
-
-    "vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
-
-    "vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
-
-    "vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
   }
 }

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -25,7 +25,15 @@ import type {
   ProjectListResult,
   ProjectRemoveInput,
 } from "./project";
-import type { TerminalCommandInput, TerminalCommandResult } from "./terminal";
+import type {
+  TerminalCloseInput,
+  TerminalEvent,
+  TerminalOpenInput,
+  TerminalResizeInput,
+  TerminalSessionSnapshot,
+  TerminalThreadInput,
+  TerminalWriteInput,
+} from "./terminal";
 import type { NewTodoInput, Todo } from "./todo";
 
 export const EDITORS = [
@@ -46,7 +54,13 @@ export interface NativeApi {
     pickFolder: () => Promise<string | null>;
   };
   terminal: {
-    run: (input: TerminalCommandInput) => Promise<TerminalCommandResult>;
+    open: (input: TerminalOpenInput) => Promise<TerminalSessionSnapshot>;
+    write: (input: TerminalWriteInput) => Promise<void>;
+    resize: (input: TerminalResizeInput) => Promise<void>;
+    clear: (input: TerminalThreadInput) => Promise<void>;
+    restart: (input: TerminalOpenInput) => Promise<TerminalSessionSnapshot>;
+    close: (input: TerminalCloseInput) => Promise<void>;
+    onEvent: (callback: (event: TerminalEvent) => void) => () => void;
   };
   agent: {
     spawn: (config: AgentConfig) => Promise<string>;

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -1,24 +1,118 @@
 import { describe, expect, it } from "vitest";
 
-import { terminalCommandInputSchema } from "./terminal";
+import {
+  terminalCloseInputSchema,
+  terminalEventSchema,
+  terminalOpenInputSchema,
+  terminalResizeInputSchema,
+  terminalSessionSnapshotSchema,
+  terminalThreadInputSchema,
+  terminalWriteInputSchema,
+} from "./terminal";
 
-describe("terminalCommandInputSchema", () => {
-  it("accepts a valid command", () => {
-    const result = terminalCommandInputSchema.safeParse({
-      command: "echo hello",
+describe("terminalOpenInputSchema", () => {
+  it("accepts valid open input", () => {
+    const result = terminalOpenInputSchema.safeParse({
+      threadId: "thread-1",
+      cwd: "/tmp/project",
+      cols: 120,
+      rows: 40,
     });
     expect(result.success).toBe(true);
   });
 
-  it("trims whitespace", () => {
-    const result = terminalCommandInputSchema.parse({
-      command: "  echo hello  ",
+  it("rejects invalid bounds", () => {
+    const result = terminalOpenInputSchema.safeParse({
+      threadId: "thread-1",
+      cwd: "/tmp/project",
+      cols: 10,
+      rows: 2,
     });
-    expect(result.command).toBe("echo hello");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("terminalWriteInputSchema", () => {
+  it("accepts non-empty data", () => {
+    const result = terminalWriteInputSchema.safeParse({
+      threadId: "thread-1",
+      data: "echo hello\n",
+    });
+    expect(result.success).toBe(true);
   });
 
-  it("rejects an empty command", () => {
-    const result = terminalCommandInputSchema.safeParse({ command: "   " });
+  it("rejects empty data", () => {
+    const result = terminalWriteInputSchema.safeParse({
+      threadId: "thread-1",
+      data: "",
+    });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("terminalThreadInputSchema", () => {
+  it("trims thread ids", () => {
+    const parsed = terminalThreadInputSchema.parse({ threadId: " thread-1 " });
+    expect(parsed.threadId).toBe("thread-1");
+  });
+});
+
+describe("terminalResizeInputSchema", () => {
+  it("accepts valid size", () => {
+    const result = terminalResizeInputSchema.safeParse({
+      threadId: "thread-1",
+      cols: 80,
+      rows: 24,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("terminalCloseInputSchema", () => {
+  it("accepts optional deleteHistory", () => {
+    const result = terminalCloseInputSchema.safeParse({
+      threadId: "thread-1",
+      deleteHistory: true,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("terminalSessionSnapshotSchema", () => {
+  it("accepts running snapshots", () => {
+    const result = terminalSessionSnapshotSchema.safeParse({
+      threadId: "thread-1",
+      cwd: "/tmp/project",
+      status: "running",
+      pid: 1234,
+      history: "hello\n",
+      exitCode: null,
+      exitSignal: null,
+      updatedAt: new Date().toISOString(),
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("terminalEventSchema", () => {
+  it("accepts output events", () => {
+    const result = terminalEventSchema.safeParse({
+      type: "output",
+      threadId: "thread-1",
+      createdAt: new Date().toISOString(),
+      data: "line\n",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts exited events", () => {
+    const result = terminalEventSchema.safeParse({
+      type: "exited",
+      threadId: "thread-1",
+      createdAt: new Date().toISOString(),
+      exitCode: 0,
+      exitSignal: null,
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -1,18 +1,98 @@
 import { z } from "zod";
 
-export const terminalCommandInputSchema = z.object({
-  command: z.string().trim().min(1).max(4000),
-  cwd: z.string().min(1).optional(),
-  timeoutMs: z.number().int().positive().max(120_000).optional(),
+const terminalColsSchema = z.number().int().min(20).max(400);
+const terminalRowsSchema = z.number().int().min(5).max(200);
+
+export const terminalThreadInputSchema = z.object({
+  threadId: z.string().trim().min(1),
 });
 
-export const terminalCommandResultSchema = z.object({
-  stdout: z.string(),
-  stderr: z.string(),
-  code: z.number().nullable(),
-  signal: z.string().nullable(),
-  timedOut: z.boolean(),
+export const terminalOpenInputSchema = terminalThreadInputSchema.extend({
+  cwd: z.string().trim().min(1),
+  cols: terminalColsSchema,
+  rows: terminalRowsSchema,
 });
 
-export type TerminalCommandInput = z.infer<typeof terminalCommandInputSchema>;
-export type TerminalCommandResult = z.infer<typeof terminalCommandResultSchema>;
+export const terminalWriteInputSchema = terminalThreadInputSchema.extend({
+  data: z.string().min(1).max(65_536),
+});
+
+export const terminalResizeInputSchema = terminalThreadInputSchema.extend({
+  cols: terminalColsSchema,
+  rows: terminalRowsSchema,
+});
+
+export const terminalCloseInputSchema = terminalThreadInputSchema.extend({
+  deleteHistory: z.boolean().optional(),
+});
+
+export const terminalSessionStatusSchema = z.enum([
+  "starting",
+  "running",
+  "exited",
+  "error",
+]);
+
+export const terminalSessionSnapshotSchema = z.object({
+  threadId: z.string().min(1),
+  cwd: z.string().min(1),
+  status: terminalSessionStatusSchema,
+  pid: z.number().int().positive().nullable(),
+  history: z.string(),
+  exitCode: z.number().int().nullable(),
+  exitSignal: z.number().int().nullable(),
+  updatedAt: z.string().datetime(),
+});
+
+const terminalEventBaseSchema = z.object({
+  threadId: z.string().min(1),
+  createdAt: z.string().datetime(),
+});
+
+export const terminalStartedEventSchema = terminalEventBaseSchema.extend({
+  type: z.literal("started"),
+  snapshot: terminalSessionSnapshotSchema,
+});
+
+export const terminalOutputEventSchema = terminalEventBaseSchema.extend({
+  type: z.literal("output"),
+  data: z.string(),
+});
+
+export const terminalExitedEventSchema = terminalEventBaseSchema.extend({
+  type: z.literal("exited"),
+  exitCode: z.number().int().nullable(),
+  exitSignal: z.number().int().nullable(),
+});
+
+export const terminalErrorEventSchema = terminalEventBaseSchema.extend({
+  type: z.literal("error"),
+  message: z.string().min(1),
+});
+
+export const terminalClearedEventSchema = terminalEventBaseSchema.extend({
+  type: z.literal("cleared"),
+});
+
+export const terminalRestartedEventSchema = terminalEventBaseSchema.extend({
+  type: z.literal("restarted"),
+  snapshot: terminalSessionSnapshotSchema,
+});
+
+export const terminalEventSchema = z.discriminatedUnion("type", [
+  terminalStartedEventSchema,
+  terminalOutputEventSchema,
+  terminalExitedEventSchema,
+  terminalErrorEventSchema,
+  terminalClearedEventSchema,
+  terminalRestartedEventSchema,
+]);
+
+export type TerminalThreadInput = z.input<typeof terminalThreadInputSchema>;
+export type TerminalOpenInput = z.input<typeof terminalOpenInputSchema>;
+export type TerminalWriteInput = z.input<typeof terminalWriteInputSchema>;
+export type TerminalResizeInput = z.input<typeof terminalResizeInputSchema>;
+export type TerminalCloseInput = z.input<typeof terminalCloseInputSchema>;
+export type TerminalSessionStatus = z.infer<typeof terminalSessionStatusSchema>;
+export type TerminalSessionSnapshot = z.infer<typeof terminalSessionSnapshotSchema>;
+export type TerminalEvent = z.infer<typeof terminalEventSchema>;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -27,6 +27,14 @@ export const WS_METHODS = {
   gitCheckout: "git.checkout",
   gitInit: "git.init",
 
+  // Terminal methods
+  terminalOpen: "terminal.open",
+  terminalWrite: "terminal.write",
+  terminalResize: "terminal.resize",
+  terminalClear: "terminal.clear",
+  terminalRestart: "terminal.restart",
+  terminalClose: "terminal.close",
+
   // Server meta
   serverGetConfig: "server.getConfig",
 } as const;
@@ -35,6 +43,7 @@ export const WS_METHODS = {
 
 export const WS_CHANNELS = {
   providerEvent: "providers.event",
+  terminalEvent: "terminal.event",
   serverWelcome: "server.welcome",
 } as const;
 


### PR DESCRIPTION
Adds a terminal

- CMD+J to toggle visibility (persisted per thread)
- Resizable (height persisted per thread)
- CMD+K (Mac), CTRL+L (others) to clear the buffer
-

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated per-thread terminal with open/write/resize/clear/restart/close operations and live I/O/events (output, exited, restarted, cleared).
  * Real-time terminal event streaming to clients via WebSocket.
  * Terminal drawer UI: resizable, theme-aware, height sync, focus management, and keyboard shortcuts (Cmd/Ctrl+J to toggle; Ctrl+L/Cmd+K to clear).
  * Per-thread terminal state and height persisted with a default height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->