### PR TITLE
Simplify terminal visibility toggle in ChatView

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -262,24 +262,12 @@ export default function ChatView() {
   }, []);
   const toggleTerminalVisibility = useCallback(() => {
     if (!activeThreadId) return;
-    const isOpen = Boolean(activeThread?.terminalOpen);
-
-    if (isOpen && api) {
-      if (typeof api.terminal.close === "function") {
-        void api.terminal.close({ threadId: activeThreadId }).catch(() => {
-          void api.terminal.write({ threadId: activeThreadId, data: "exit\n" }).catch(() => undefined);
-        });
-      } else {
-        void api.terminal.write({ threadId: activeThreadId, data: "exit\n" }).catch(() => undefined);
-      }
-    }
-
     dispatch({
       type: "SET_THREAD_TERMINAL_OPEN",
       threadId: activeThreadId,
-      open: !isOpen,
+      open: !activeThread?.terminalOpen,
     });
-  }, [activeThread?.terminalOpen, activeThreadId, api, dispatch]);
+  }, [activeThread?.terminalOpen, activeThreadId, dispatch]);
   const splitTerminal = useCallback(() => {
     if (!activeThreadId) return;
     dispatch({


### PR DESCRIPTION
## Summary
- remove terminal close/exit side effects from `toggleTerminalVisibility`
- keep toggle behavior focused on updating `SET_THREAD_TERMINAL_OPEN` state only
- drop unused `api` dependency from the callback

## Testing
- Not run (not requested)
- Verified from diff that toggling now only flips `activeThread.terminalOpen` state without terminal API calls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Terminal visibility toggle simplified to reduce unnecessary API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->