### PR TITLE
Sort local branches by latest commit timestamp

### DIFF
--- a/apps/server/src/git.test.ts
+++ b/apps/server/src/git.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   GitCoreService,
@@ -602,6 +602,22 @@ describe("git integration", () => {
 
       const skipped = await core.pushCurrentBranch(tmp.path, null);
       expect(skipped.status).toBe("skipped_up_to_date");
+    });
+
+    it("lists branches when recency lookup fails", async () => {
+      await using tmp = await makeTmpDir();
+      await initRepoWithCommit(tmp.path);
+      const core = new GitCoreService();
+      const recencySpy = vi
+        .spyOn(core as any, "readBranchRecency")
+        .mockRejectedValueOnce(new Error("timeout"));
+
+      const result = await core.listBranches({ cwd: tmp.path });
+
+      expect(result.isRepo).toBe(true);
+      expect(result.branches.length).toBeGreaterThan(0);
+      expect(result.branches[0]?.current).toBe(true);
+      recencySpy.mockRestore();
     });
   });
 });

--- a/apps/server/src/git.ts
+++ b/apps/server/src/git.ts
@@ -312,7 +312,40 @@ export class GitCoreService {
     return value.length > 0 ? value : null;
   }
 
+  private async readBranchRecency(cwd: string): Promise<Map<string, number>> {
+    const branchRecency = await executeGit(
+      cwd,
+      ["for-each-ref", "--format=%(refname:short)%09%(committerdate:unix)", "refs/heads"],
+      {
+        timeoutMs: 15_000,
+        allowNonZeroExit: true,
+      },
+    );
+
+    const branchLastCommit = new Map<string, number>();
+    if (branchRecency.code !== 0) {
+      return branchLastCommit;
+    }
+
+    for (const line of branchRecency.stdout.split("\n")) {
+      if (line.length === 0) {
+        continue;
+      }
+      const [name, lastCommitRaw] = line.split("\t");
+      if (!name) {
+        continue;
+      }
+      const lastCommit = Number.parseInt(lastCommitRaw ?? "0", 10);
+      branchLastCommit.set(name, Number.isFinite(lastCommit) ? lastCommit : 0);
+    }
+
+    return branchLastCommit;
+  }
+
   async listBranches(input: GitListBranchesInput): Promise<GitListBranchesResult> {
+    const branchRecencyPromise = this.readBranchRecency(input.cwd).catch(
+      () => new Map<string, number>(),
+    );
     const result = await executeGit(input.cwd, ["branch", "--no-color"], {
       timeoutMs: 10_000,
       allowNonZeroExit: true,
@@ -326,7 +359,7 @@ export class GitCoreService {
       throw new Error(stderr || "git branch failed");
     }
 
-    const [defaultRef, worktreeList, branchRecency] = await Promise.all([
+    const [defaultRef, worktreeList, branchLastCommit] = await Promise.all([
       executeGit(input.cwd, ["symbolic-ref", "refs/remotes/origin/HEAD"], {
         timeoutMs: 5_000,
         allowNonZeroExit: true,
@@ -335,14 +368,7 @@ export class GitCoreService {
         timeoutMs: 5_000,
         allowNonZeroExit: true,
       }),
-      executeGit(
-        input.cwd,
-        ["for-each-ref", "--format=%(refname:short)%09%(committerdate:unix)", "refs/heads"],
-        {
-          timeoutMs: 5_000,
-          allowNonZeroExit: true,
-        },
-      ),
+      branchRecencyPromise,
     ]);
     const defaultBranch =
       defaultRef.code === 0
@@ -361,21 +387,6 @@ export class GitCoreService {
         } else if (line === "") {
           currentPath = null;
         }
-      }
-    }
-
-    const branchLastCommit = new Map<string, number>();
-    if (branchRecency.code === 0) {
-      for (const line of branchRecency.stdout.split("\n")) {
-        if (line.length === 0) {
-          continue;
-        }
-        const [name, lastCommitRaw] = line.split("\t");
-        if (!name) {
-          continue;
-        }
-        const lastCommit = Number.parseInt(lastCommitRaw ?? "0", 10);
-        branchLastCommit.set(name, Number.isFinite(lastCommit) ? lastCommit : 0);
       }
     }
 


### PR DESCRIPTION
## Summary
- update `listGitBranches` sorting to prioritize branches with the most recent commit timestamp
- collect per-branch recency via `git for-each-ref --format=%(refname:short)%09%(committerdate:unix) refs/heads`
- retain existing tie-breakers for current branch, default branch, and branch name when timestamps are equal or unavailable
- replace the prior ordering test with a deterministic recency-based integration test using explicit commit dates
- add a test helper to create dated commits for stable branch ordering assertions

## Testing
- Added integration coverage in `apps/server/src/git.test.ts` to verify branch list order is based on most recent commit (`newer-branch` before `older-branch` even when not current)
- Existing branch listing integration checks remain in place for current/default/worktree semantics
- Not run: project lint/test commands were not executed in this PR write-up context
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Branch listing now places the current branch first, the default branch second, then other branches sorted by most recent commit timestamp, with a safe fallback when recency data is unavailable.
* **Tests**
  * Updated branch-ordering tests for deterministic, recency-based ordering using dated commits and added a test covering failure of recency lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->