### PR TITLE
Filter app runtime env vars from terminal spawn environment

### DIFF
--- a/apps/server/src/terminalManager.test.ts
+++ b/apps/server/src/terminalManager.test.ts
@@ -424,4 +424,49 @@ describe("TerminalManager", () => {
 
     manager.dispose();
   });
+
+  it("filters app runtime env variables from terminal sessions", async () => {
+    const originalValues = new Map<string, string | undefined>();
+    const setEnv = (key: string, value: string | undefined) => {
+      if (!originalValues.has(key)) {
+        originalValues.set(key, process.env[key]);
+      }
+      if (value === undefined) {
+        delete process.env[key];
+        return;
+      }
+      process.env[key] = value;
+    };
+    const restoreEnv = () => {
+      for (const [key, value] of originalValues) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    };
+
+    setEnv("PORT", "5173");
+    setEnv("T3CODE_PORT", "3773");
+    setEnv("VITE_DEV_SERVER_URL", "http://localhost:5173");
+    setEnv("TEST_TERMINAL_KEEP", "keep-me");
+
+    try {
+      const { manager, ptyAdapter } = makeManager();
+      await manager.open(openInput());
+      const spawnInput = ptyAdapter.spawnInputs[0];
+      expect(spawnInput).toBeDefined();
+      if (!spawnInput) return;
+
+      expect(spawnInput.env.PORT).toBeUndefined();
+      expect(spawnInput.env.T3CODE_PORT).toBeUndefined();
+      expect(spawnInput.env.VITE_DEV_SERVER_URL).toBeUndefined();
+      expect(spawnInput.env.TEST_TERMINAL_KEEP).toBe("keep-me");
+
+      manager.dispose();
+    } finally {
+      restoreEnv();
+    }
+  });
 });

--- a/apps/server/src/terminalManager.ts
+++ b/apps/server/src/terminalManager.ts
@@ -26,6 +26,11 @@ import { runProcess } from "./processRunner";
 const DEFAULT_HISTORY_LINE_LIMIT = 5_000;
 const DEFAULT_PERSIST_DEBOUNCE_MS = 40;
 const DEFAULT_SUBPROCESS_POLL_INTERVAL_MS = 1_000;
+const TERMINAL_ENV_BLOCKLIST = new Set([
+  "PORT",
+  "ELECTRON_RENDERER_PORT",
+  "ELECTRON_RUN_AS_NODE",
+]);
 
 type TerminalSubprocessChecker = (terminalPid: number) => Promise<boolean>;
 
@@ -232,6 +237,27 @@ function toSafeTerminalId(terminalId: string): string {
 
 function toSessionKey(threadId: string, terminalId: string): string {
   return `${threadId}\u0000${terminalId}`;
+}
+
+function shouldExcludeTerminalEnvKey(key: string): boolean {
+  const normalizedKey = key.toUpperCase();
+  if (normalizedKey.startsWith("T3CODE_")) {
+    return true;
+  }
+  if (normalizedKey.startsWith("VITE_")) {
+    return true;
+  }
+  return TERMINAL_ENV_BLOCKLIST.has(normalizedKey);
+}
+
+function createTerminalSpawnEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const spawnEnv: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (value === undefined) continue;
+    if (shouldExcludeTerminalEnvKey(key)) continue;
+    spawnEnv[key] = value;
+  }
+  return spawnEnv;
 }
 
 export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
@@ -467,6 +493,7 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
     let startedShell: string | null = null;
     try {
       const shellCandidates = resolveShellCandidates(this.shellResolver);
+      const terminalEnv = createTerminalSpawnEnv(process.env);
       let lastSpawnError: unknown = null;
 
       for (const shell of shellCandidates) {
@@ -476,7 +503,7 @@ export class TerminalManager extends EventEmitter<TerminalManagerEvents> {
             cwd: session.cwd,
             cols: session.cols,
             rows: session.rows,
-            env: process.env,
+            env: terminalEnv,
           });
           startedShell = shell;
           break;


### PR DESCRIPTION
## Summary
- Filter terminal spawn environment variables to exclude app/runtime keys that can interfere with shell sessions.
- Add explicit exclusion logic for `PORT`, `ELECTRON_RENDERER_PORT`, `ELECTRON_RUN_AS_NODE`, and any keys prefixed with `T3CODE_` or `VITE_`.
- Keep unrelated environment variables intact when launching terminal sessions.
- Add a regression test verifying blocked keys are removed and non-blocked keys are preserved.

## Testing
- Not run (not executed in this PR context).
- Added unit test: `apps/server/src/terminalManager.test.ts` (`filters app runtime env variables from terminal sessions`) to verify:
  - `PORT`, `T3CODE_PORT`, and `VITE_DEV_SERVER_URL` are excluded from terminal spawn env.
  - Non-app variable `TEST_TERMINAL_KEEP` is preserved.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal environment isolation by filtering out framework and application-specific environment variables from terminal sessions. This prevents potential conflicts and enhances security when spawning new terminal instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->