### PR TITLE
Update cached branch list immediately after checkout

### DIFF
--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { projectGitBranchesToCurrent } from "./gitReactQuery";
+
+describe("projectGitBranchesToCurrent", () => {
+  it("moves the checked out branch to the top and marks it current", () => {
+    const result = projectGitBranchesToCurrent(
+      {
+        isRepo: true,
+        branches: [
+          { name: "main", current: true, isDefault: true, worktreePath: null },
+          { name: "feature/a", current: false, isDefault: false, worktreePath: null },
+          { name: "feature/b", current: false, isDefault: false, worktreePath: null },
+        ],
+      },
+      "feature/a",
+    );
+
+    expect(result).toEqual({
+      isRepo: true,
+      branches: [
+        { name: "feature/a", current: true, isDefault: false, worktreePath: null },
+        { name: "main", current: false, isDefault: true, worktreePath: null },
+        { name: "feature/b", current: false, isDefault: false, worktreePath: null },
+      ],
+    });
+  });
+
+  it("inserts a missing branch as current", () => {
+    const result = projectGitBranchesToCurrent(
+      {
+        isRepo: true,
+        branches: [{ name: "main", current: true, isDefault: true, worktreePath: null }],
+      },
+      "feature/new",
+    );
+
+    expect(result).toEqual({
+      isRepo: true,
+      branches: [
+        { name: "feature/new", current: true, isDefault: false, worktreePath: null },
+        { name: "main", current: false, isDefault: true, worktreePath: null },
+      ],
+    });
+  });
+
+  it("returns undefined when no cached branch list exists yet", () => {
+    expect(projectGitBranchesToCurrent(undefined, "feature/new")).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -1,4 +1,4 @@
-import type { GitStackedAction, NativeApi } from "@t3tools/contracts";
+import type { GitListBranchesResult, GitStackedAction, NativeApi } from "@t3tools/contracts";
 import { mutationOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
 
 export const gitQueryKeys = {
@@ -9,6 +9,50 @@ export const gitQueryKeys = {
 
 export function invalidateGitQueries(queryClient: QueryClient) {
   return queryClient.invalidateQueries({ queryKey: gitQueryKeys.all });
+}
+
+export function projectGitBranchesToCurrent(
+  existing: GitListBranchesResult | undefined,
+  currentBranch: string,
+): GitListBranchesResult | undefined {
+  if (!existing) return existing;
+
+  let nextCurrent: GitListBranchesResult["branches"][number] | null = null;
+  const remaining: GitListBranchesResult["branches"] = [];
+
+  for (const branch of existing.branches) {
+    if (branch.name === currentBranch) {
+      nextCurrent = branch.current ? branch : { ...branch, current: true };
+      continue;
+    }
+    remaining.push(branch.current ? { ...branch, current: false } : branch);
+  }
+
+  if (!nextCurrent) {
+    nextCurrent = {
+      name: currentBranch,
+      current: true,
+      isDefault: false,
+      worktreePath: null,
+    };
+  }
+
+  return {
+    ...existing,
+    branches: [nextCurrent, ...remaining],
+  };
+}
+
+export function setGitBranchesCurrentBranch(
+  queryClient: QueryClient,
+  cwd: string | null,
+  currentBranch: string,
+) {
+  if (!cwd) return;
+
+  queryClient.setQueryData<GitListBranchesResult>(gitQueryKeys.branches(cwd), (existing) =>
+    projectGitBranchesToCurrent(existing, currentBranch),
+  );
 }
 
 export function gitStatusQueryOptions(api: NativeApi | undefined, cwd: string | null) {
@@ -63,7 +107,8 @@ export function gitCheckoutMutationOptions(input: {
       if (!input.api || !input.cwd) throw new Error("Git checkout is unavailable.");
       return input.api.git.checkout({ cwd: input.cwd, branch });
     },
-    onSuccess: async () => {
+    onSuccess: async (_result, branch) => {
+      setGitBranchesCurrentBranch(input.queryClient, input.cwd, branch);
       await invalidateGitQueries(input.queryClient);
     },
   });
@@ -80,7 +125,8 @@ export function gitCreateBranchAndCheckoutMutationOptions(input: {
       await input.api.git.createBranch({ cwd: input.cwd, branch });
       return input.api.git.checkout({ cwd: input.cwd, branch });
     },
-    onSuccess: async () => {
+    onSuccess: async (_result, branch) => {
+      setGitBranchesCurrentBranch(input.queryClient, input.cwd, branch);
       await invalidateGitQueries(input.queryClient);
     },
   });


### PR DESCRIPTION
## Summary
- add `projectGitBranchesToCurrent` to project cached branch data to the newly checked-out branch
- add `setGitBranchesCurrentBranch` to update React Query cache for `git.listBranches` before invalidation
- wire checkout mutation success handlers to optimistically set the current branch in cache
- add unit tests for branch reordering, missing-branch insertion, and undefined-cache handling

## Testing
- `apps/web/src/lib/gitReactQuery.test.ts`: verifies checked-out branch is moved to top and marked current
- `apps/web/src/lib/gitReactQuery.test.ts`: verifies missing checked-out branch is inserted as current
- `apps/web/src/lib/gitReactQuery.test.ts`: verifies undefined cache input returns `undefined`
- Not run: project lint/test scripts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**: Added comprehensive unit tests for Git branch management, covering proper reordering of the current branch to the top of the list, preservation of branch metadata, and handling of new branches.
* **Improvements**: Git operations (branch checkout and creation) now properly synchronize cached branch information in real-time, ensuring the currently active branch is immediately visible in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->