### PR TITLE
Add project deletion from sidebar context menu

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -333,6 +333,52 @@ export default function Sidebar() {
     [api, dispatch, removeWorktreeMutation, state.projects, state.threads],
   );
 
+  const handleProjectContextMenu = useCallback(
+    async (projectId: string, position: { x: number; y: number }) => {
+      if (!api) return;
+      const clicked = await api.contextMenu.show([{ id: "delete", label: "Delete" }], position);
+      if (clicked !== "delete") return;
+
+      const project = state.projects.find((entry) => entry.id === projectId);
+      if (!project) return;
+
+      if (isElectron) {
+        try {
+          await api.projects.remove({ id: projectId });
+        } catch {
+          return;
+        }
+      }
+
+      const projectThreads = state.threads.filter((thread) => thread.projectId === projectId);
+      await Promise.all(
+        projectThreads.map(async (thread) => {
+          if (thread.session?.sessionId) {
+            try {
+              await api.providers.stopSession({
+                sessionId: thread.session.sessionId,
+              });
+            } catch {
+              // Session may already be stopped
+            }
+          }
+
+          try {
+            await api.terminal.close({
+              threadId: thread.id,
+              deleteHistory: true,
+            });
+          } catch {
+            // Terminal may already be closed
+          }
+        }),
+      );
+
+      dispatch({ type: "DELETE_PROJECT", projectId });
+    },
+    [api, dispatch, state.projects, state.threads],
+  );
+
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
       if (!isChatNewShortcut(event, keybindings)) return;
@@ -413,6 +459,13 @@ export default function Sidebar() {
                 type="button"
                 className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-150 hover:bg-accent"
                 onClick={() => dispatch({ type: "TOGGLE_PROJECT", projectId: project.id })}
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  void handleProjectContextMenu(project.id, {
+                    x: e.clientX,
+                    y: e.clientY,
+                  });
+                }}
               >
                 <span className="text-[10px] text-muted-foreground/70">
                   {project.expanded ? "▼" : "▶"}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
 import { useNativeApi } from "../hooks/useNativeApi";
 import { gitRemoveWorktreeMutationOptions } from "../lib/gitReactQuery";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
+import { toastManager } from "./ui/toast";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 
 const THEME_CYCLE = { system: "light", light: "dark", dark: "system" } as const;
@@ -342,17 +343,59 @@ export default function Sidebar() {
       const project = state.projects.find((entry) => entry.id === projectId);
       if (!project) return;
 
+      const projectThreads = state.threads.filter((thread) => thread.projectId === projectId);
+      const linkedWorktreeCount = new Set(
+        projectThreads
+          .map((thread) => thread.worktreePath?.trim() ?? "")
+          .filter((worktreePath) => worktreePath.length > 0),
+      ).size;
+      const confirmed = await api.dialogs.confirm(
+        [
+          `Delete project "${project.name}"?`,
+          `This will delete ${projectThreads.length} thread${projectThreads.length === 1 ? "" : "s"}.`,
+          linkedWorktreeCount > 0
+            ? `Linked worktrees to remove: ${linkedWorktreeCount}.`
+            : "No linked worktrees detected.",
+        ].join("\n"),
+      );
+      if (!confirmed) return;
+
       if (isElectron) {
         try {
           await api.projects.remove({ id: projectId });
-        } catch {
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Unknown error deleting project.";
+          console.error("Failed to remove project", { projectId, error });
+          toastManager.add({
+            type: "error",
+            title: `Failed to delete "${project.name}"`,
+            description: message,
+          });
           return;
         }
       }
 
-      const projectThreads = state.threads.filter((thread) => thread.projectId === projectId);
+      const retainedThreads = state.threads.filter((thread) => thread.projectId !== projectId);
+      const removedWorktreePaths = new Set<string>();
       await Promise.all(
         projectThreads.map(async (thread) => {
+          const orphanedWorktreePath = getOrphanedWorktreePathForThread(
+            [thread, ...retainedThreads],
+            thread.id,
+          );
+          if (orphanedWorktreePath && !removedWorktreePaths.has(orphanedWorktreePath)) {
+            removedWorktreePaths.add(orphanedWorktreePath);
+            try {
+              await removeWorktreeMutation.mutateAsync({
+                cwd: project.cwd,
+                path: orphanedWorktreePath,
+              });
+            } catch {
+              // Worktree deletion is best-effort and should not block project deletion.
+            }
+          }
+
           if (thread.session?.sessionId) {
             try {
               await api.providers.stopSession({
@@ -376,7 +419,7 @@ export default function Sidebar() {
 
       dispatch({ type: "DELETE_PROJECT", projectId });
     },
-    [api, dispatch, state.projects, state.threads],
+    [api, dispatch, removeWorktreeMutation, state.projects, state.threads],
   );
 
   useEffect(() => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -344,19 +344,17 @@ export default function Sidebar() {
       if (!project) return;
 
       const projectThreads = state.threads.filter((thread) => thread.projectId === projectId);
-      const linkedWorktreeCount = new Set(
-        projectThreads
-          .map((thread) => thread.worktreePath?.trim() ?? "")
-          .filter((worktreePath) => worktreePath.length > 0),
-      ).size;
+      if (projectThreads.length > 0) {
+        toastManager.add({
+          type: "warning",
+          title: "Project is not empty",
+          description: "Delete all threads in this project before deleting it.",
+        });
+        return;
+      }
+
       const confirmed = await api.dialogs.confirm(
-        [
-          `Delete project "${project.name}"?`,
-          `This will delete ${projectThreads.length} thread${projectThreads.length === 1 ? "" : "s"}.`,
-          linkedWorktreeCount > 0
-            ? `Linked worktrees to remove: ${linkedWorktreeCount}.`
-            : "No linked worktrees detected.",
-        ].join("\n"),
+        [`Delete project "${project.name}"?`, "This action cannot be undone."].join("\n"),
       );
       if (!confirmed) return;
 
@@ -376,50 +374,9 @@ export default function Sidebar() {
         }
       }
 
-      const retainedThreads = state.threads.filter((thread) => thread.projectId !== projectId);
-      const removedWorktreePaths = new Set<string>();
-      await Promise.all(
-        projectThreads.map(async (thread) => {
-          const orphanedWorktreePath = getOrphanedWorktreePathForThread(
-            [thread, ...retainedThreads],
-            thread.id,
-          );
-          if (orphanedWorktreePath && !removedWorktreePaths.has(orphanedWorktreePath)) {
-            removedWorktreePaths.add(orphanedWorktreePath);
-            try {
-              await removeWorktreeMutation.mutateAsync({
-                cwd: project.cwd,
-                path: orphanedWorktreePath,
-              });
-            } catch {
-              // Worktree deletion is best-effort and should not block project deletion.
-            }
-          }
-
-          if (thread.session?.sessionId) {
-            try {
-              await api.providers.stopSession({
-                sessionId: thread.session.sessionId,
-              });
-            } catch {
-              // Session may already be stopped
-            }
-          }
-
-          try {
-            await api.terminal.close({
-              threadId: thread.id,
-              deleteHistory: true,
-            });
-          } catch {
-            // Terminal may already be closed
-          }
-        }),
-      );
-
       dispatch({ type: "DELETE_PROJECT", projectId });
     },
-    [api, dispatch, removeWorktreeMutation, state.projects, state.threads],
+    [api, dispatch, state.projects, state.threads],
   );
 
   useEffect(() => {

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -486,6 +486,51 @@ describe("store reducer thread continuity", () => {
     expect(next.activeThreadId).toBe("thread-a");
   });
 
+  it("deletes a project and all of its threads", () => {
+    const state: AppState = {
+      projects: [
+        {
+          id: "project-1",
+          name: "One",
+          cwd: "/tmp/one",
+          model: "gpt-5.3-codex",
+          expanded: true,
+        },
+        {
+          id: "project-2",
+          name: "Two",
+          cwd: "/tmp/two",
+          model: "gpt-5.3-codex",
+          expanded: true,
+        },
+      ],
+      threads: [
+        makeThread({
+          id: "thread-a",
+          projectId: "project-1",
+        }),
+        makeThread({
+          id: "thread-b",
+          projectId: "project-2",
+        }),
+      ],
+      activeThreadId: "thread-a",
+      runtimeMode: "full-access",
+      diffOpen: false,
+    };
+
+    const next = reducer(state, {
+      type: "DELETE_PROJECT",
+      projectId: "project-1",
+    });
+
+    expect(next.projects).toHaveLength(1);
+    expect(next.projects[0]?.id).toBe("project-2");
+    expect(next.threads).toHaveLength(1);
+    expect(next.threads[0]?.id).toBe("thread-b");
+    expect(next.activeThreadId).toBe("thread-b");
+  });
+
   it("marks the active thread as visited when selected", () => {
     const state = makeState(
       makeThread({

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -28,6 +28,7 @@ type Action =
   | { type: "ADD_PROJECT"; project: Project }
   | { type: "SYNC_PROJECTS"; projects: Project[] }
   | { type: "TOGGLE_PROJECT"; projectId: string }
+  | { type: "DELETE_PROJECT"; projectId: string }
   | { type: "ADD_THREAD"; thread: Thread }
   | { type: "SET_ACTIVE_THREAD"; threadId: string }
   | { type: "TOGGLE_THREAD_TERMINAL"; threadId: string }
@@ -472,6 +473,25 @@ export function reducer(state: AppState, action: Action): AppState {
           p.id === action.projectId ? { ...p, expanded: !p.expanded } : p,
         ),
       };
+
+    case "DELETE_PROJECT": {
+      const projects = state.projects.filter((project) => project.id !== action.projectId);
+      if (projects.length === state.projects.length) {
+        return state;
+      }
+
+      const threads = state.threads.filter((thread) => thread.projectId !== action.projectId);
+      const activeThreadId = threads.some((thread) => thread.id === state.activeThreadId)
+        ? state.activeThreadId
+        : (threads[0]?.id ?? null);
+
+      return {
+        ...state,
+        projects,
+        threads,
+        activeThreadId,
+      };
+    }
 
     case "ADD_THREAD": {
       const nextThread = normalizeThreadTerminals({


### PR DESCRIPTION
## Summary
- Add a project-level right-click context menu action (`Delete`) in the sidebar.
- On delete, remove the project in Electron mode and clean up associated sessions/terminal history for that project's threads.
- Add `DELETE_PROJECT` reducer support to remove the project, prune its threads, and reassign `activeThreadId` safely.
- Add reducer test coverage for deleting a project and all associated threads.

## Testing
- Added unit test: `apps/web/src/store.test.ts` (`deletes a project and all of its threads`).
- Not run: lint/tests were not executed in this context.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-click project context menu to delete a project with confirmation; prevents deletion of non-empty projects and shows warning or error toasts as needed.
  * Removing a project also removes its associated threads and updates the active-thread selection.

* **Tests**
  * Added a test validating project deletion, cleanup of associated threads, and active-thread selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->