### PR TITLE
Auto-dismiss thread toasts after 10s of visible time

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -312,7 +312,10 @@ export default function GitActionsControl({ api, gitCwd }: GitActionsControlProp
           title: resultToast.title,
           description: resultToast.description,
           timeout: 0,
-          data: threadToastData,
+          data: {
+            ...threadToastData,
+            dismissAfterVisibleMs: 10_000,
+          },
           ...(shouldOfferPushCta
             ? {
                 actionProps: {

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Toast } from "@base-ui/react/toast";
+import { useEffect } from "react";
 import {
   CircleAlertIcon,
   CircleCheckIcon,
@@ -16,10 +17,13 @@ import { useStore } from "~/store";
 type ThreadToastData = {
   threadId?: string | null;
   tooltipStyle?: boolean;
+  dismissAfterVisibleMs?: number;
 };
 
 const toastManager = Toast.createToastManager<ThreadToastData>();
 const anchoredToastManager = Toast.createToastManager<ThreadToastData>();
+type ToastId = ReturnType<typeof toastManager.add>;
+const threadToastVisibleTimeoutRemainingMs = new Map<ToastId, number>();
 
 const TOAST_ICONS = {
   error: CircleAlertIcon,
@@ -50,6 +54,84 @@ function shouldRenderForActiveThread(
   return toastThreadId === activeThreadId;
 }
 
+function ThreadToastVisibleAutoDismiss({
+  toastId,
+  dismissAfterVisibleMs,
+}: {
+  toastId: ToastId;
+  dismissAfterVisibleMs: number | undefined;
+}) {
+  useEffect(() => {
+    if (!dismissAfterVisibleMs || dismissAfterVisibleMs <= 0) return;
+    if (typeof window === "undefined" || typeof document === "undefined") return;
+
+    let remainingMs = threadToastVisibleTimeoutRemainingMs.get(toastId) ?? dismissAfterVisibleMs;
+    let startedAtMs: number | null = null;
+    let timeoutId: number | null = null;
+    let closed = false;
+
+    const clearTimer = () => {
+      if (timeoutId === null) return;
+      window.clearTimeout(timeoutId);
+      timeoutId = null;
+    };
+
+    const closeToast = () => {
+      if (closed) return;
+      closed = true;
+      threadToastVisibleTimeoutRemainingMs.delete(toastId);
+      toastManager.close(toastId);
+    };
+
+    const pause = () => {
+      if (startedAtMs === null) return;
+      remainingMs = Math.max(0, remainingMs - (Date.now() - startedAtMs));
+      startedAtMs = null;
+      clearTimer();
+      threadToastVisibleTimeoutRemainingMs.set(toastId, remainingMs);
+    };
+
+    const start = () => {
+      if (closed || startedAtMs !== null) return;
+      if (remainingMs <= 0) {
+        closeToast();
+        return;
+      }
+      startedAtMs = Date.now();
+      clearTimer();
+      timeoutId = window.setTimeout(() => {
+        remainingMs = 0;
+        startedAtMs = null;
+        closeToast();
+      }, remainingMs);
+    };
+
+    const syncTimer = () => {
+      const shouldRun = document.visibilityState === "visible" && document.hasFocus();
+      if (shouldRun) {
+        start();
+        return;
+      }
+      pause();
+    };
+
+    syncTimer();
+    document.addEventListener("visibilitychange", syncTimer);
+    window.addEventListener("focus", syncTimer);
+    window.addEventListener("blur", syncTimer);
+
+    return () => {
+      document.removeEventListener("visibilitychange", syncTimer);
+      window.removeEventListener("focus", syncTimer);
+      window.removeEventListener("blur", syncTimer);
+      pause();
+      clearTimer();
+    };
+  }, [dismissAfterVisibleMs, toastId]);
+
+  return null;
+}
+
 function ToastProvider({ children, position = "top-right", ...props }: ToastProviderProps) {
   return (
     <Toast.Provider toastManager={toastManager} {...props}>
@@ -64,6 +146,15 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
   const { toasts } = Toast.useToastManager<ThreadToastData>();
   const activeThreadId = state.activeThreadId;
   const isTop = position.startsWith("top");
+
+  useEffect(() => {
+    const activeToastIds = new Set(toasts.map((toast) => toast.id));
+    for (const toastId of threadToastVisibleTimeoutRemainingMs.keys()) {
+      if (!activeToastIds.has(toastId)) {
+        threadToastVisibleTimeoutRemainingMs.delete(toastId);
+      }
+    }
+  }, [toasts]);
 
   return (
     <Toast.Portal data-slot="toast-portal">
@@ -140,6 +231,10 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
                 }
                 toast={toast}
               >
+                <ThreadToastVisibleAutoDismiss
+                  dismissAfterVisibleMs={toast.data?.dismissAfterVisibleMs}
+                  toastId={toast.id}
+                />
                 <Toast.Content className="pointer-events-auto flex items-center justify-between gap-1.5 overflow-hidden px-3.5 py-3 text-sm transition-opacity duration-250 data-behind:not-data-expanded:pointer-events-none data-behind:opacity-0 data-expanded:opacity-100">
                   <div className="flex gap-2">
                     {Icon && (


### PR DESCRIPTION
## Summary
- Add support for `dismissAfterVisibleMs` in thread toast metadata.
- Set Git action thread toasts to auto-dismiss after 10,000ms of visible/focused time.
- Implement visibility-aware auto-dismiss logic that pauses on tab blur/hidden and resumes when visible.
- Clean up stored per-toast remaining timeout state when toasts are removed.

## Testing
- Not run (no test execution details were provided with the commit/diff).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toast notifications now automatically dismiss after 10 seconds when visible, with awareness of page visibility and browser focus states for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->