### PR TITLE
Fix ChatView header overflow for long thread titles

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -51,7 +51,7 @@ import {
 } from "../session-logic";
 import { isScrollContainerNearBottom } from "../chat-scroll";
 import { useStore } from "../store";
-import type { ChatImageAttachment } from "../types";
+import { MAX_THREAD_TERMINAL_COUNT, type ChatImageAttachment } from "../types";
 import BranchToolbar from "./BranchToolbar";
 import GitActionsControl from "./GitActionsControl";
 import {
@@ -294,6 +294,8 @@ export default function ChatView() {
     (activeThread.messages.length > 0 ||
       (activeThread.session !== null && activeThread.session.status !== "closed")),
   );
+  const hasReachedTerminalLimit =
+    (activeThread?.terminalIds.length ?? 0) >= MAX_THREAD_TERMINAL_COUNT;
 
   const revokePreviewUrls = useCallback((images: Array<{ previewUrl?: string }>) => {
     for (const image of images) {
@@ -322,23 +324,23 @@ export default function ChatView() {
     });
   }, [activeThread?.terminalOpen, activeThreadId, dispatch]);
   const splitTerminal = useCallback(() => {
-    if (!activeThreadId) return;
+    if (!activeThreadId || hasReachedTerminalLimit) return;
     dispatch({
       type: "SPLIT_THREAD_TERMINAL",
       threadId: activeThreadId,
       terminalId: `terminal-${crypto.randomUUID()}`,
     });
     setTerminalFocusRequestId((value) => value + 1);
-  }, [activeThreadId, dispatch]);
+  }, [activeThreadId, dispatch, hasReachedTerminalLimit]);
   const createNewTerminal = useCallback(() => {
-    if (!activeThreadId) return;
+    if (!activeThreadId || hasReachedTerminalLimit) return;
     dispatch({
       type: "NEW_THREAD_TERMINAL",
       threadId: activeThreadId,
       terminalId: `terminal-${crypto.randomUUID()}`,
     });
     setTerminalFocusRequestId((value) => value + 1);
-  }, [activeThreadId, dispatch]);
+  }, [activeThreadId, dispatch, hasReachedTerminalLimit]);
   const activateTerminal = useCallback(
     (terminalId: string) => {
       if (!activeThreadId) return;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -22,6 +22,7 @@ import { isTerminalClearShortcut, terminalNavigationShortcutData } from "../keyb
 import {
   DEFAULT_THREAD_TERMINAL_HEIGHT,
   DEFAULT_THREAD_TERMINAL_ID,
+  MAX_THREAD_TERMINAL_COUNT,
   type ThreadTerminalGroup,
 } from "../types";
 
@@ -581,6 +582,7 @@ export default function ThreadTerminalDrawer({
   const showGroupHeaders =
     resolvedTerminalGroups.length > 1 ||
     resolvedTerminalGroups.some((terminalGroup) => terminalGroup.terminalIds.length > 1);
+  const hasReachedTerminalLimit = normalizedTerminalIds.length >= MAX_THREAD_TERMINAL_COUNT;
   const terminalLabelById = useMemo(
     () =>
       new Map(
@@ -588,9 +590,23 @@ export default function ThreadTerminalDrawer({
       ),
     [normalizedTerminalIds],
   );
+  const splitTerminalActionLabel = hasReachedTerminalLimit
+    ? `Split Terminal (max ${MAX_THREAD_TERMINAL_COUNT})`
+    : (splitShortcutLabel ? `Split Terminal (${splitShortcutLabel})` : "Split Terminal");
+  const newTerminalActionLabel = hasReachedTerminalLimit
+    ? `New Terminal (max ${MAX_THREAD_TERMINAL_COUNT})`
+    : (newShortcutLabel ? `New Terminal (${newShortcutLabel})` : "New Terminal");
   const closeTerminalActionLabel = closeShortcutLabel
     ? `Close Terminal (${closeShortcutLabel})`
     : "Close Terminal";
+  const onSplitTerminalAction = useCallback(() => {
+    if (hasReachedTerminalLimit) return;
+    onSplitTerminal();
+  }, [hasReachedTerminalLimit, onSplitTerminal]);
+  const onNewTerminalAction = useCallback(() => {
+    if (hasReachedTerminalLimit) return;
+    onNewTerminal();
+  }, [hasReachedTerminalLimit, onNewTerminal]);
 
   useEffect(() => {
     onHeightChangeRef.current = onHeightChange;
@@ -685,7 +701,7 @@ export default function ThreadTerminalDrawer({
 
   return (
     <aside
-      className="thread-terminal-drawer relative flex shrink-0 flex-col border-t border-border/80 bg-background"
+      className="thread-terminal-drawer relative flex min-w-0 shrink-0 flex-col overflow-hidden border-t border-border/80 bg-background"
       style={{ height: `${drawerHeight}px` }}
     >
       <div
@@ -700,19 +716,25 @@ export default function ThreadTerminalDrawer({
         <div className="pointer-events-none absolute right-2 top-2 z-20">
           <div className="pointer-events-auto inline-flex items-center overflow-hidden rounded-md border border-border/80 bg-background/70">
             <TerminalActionButton
-              className="p-1 text-foreground/90 transition-colors hover:bg-accent"
-              onClick={onSplitTerminal}
-              label={
-                splitShortcutLabel ? `Split Terminal (${splitShortcutLabel})` : "Split Terminal"
-              }
+              className={`p-1 text-foreground/90 transition-colors ${
+                hasReachedTerminalLimit
+                  ? "cursor-not-allowed opacity-45 hover:bg-transparent"
+                  : "hover:bg-accent"
+              }`}
+              onClick={onSplitTerminalAction}
+              label={splitTerminalActionLabel}
             >
               <SquareSplitHorizontal className="size-3.25" />
             </TerminalActionButton>
             <div className="h-4 w-px bg-border/80" />
             <TerminalActionButton
-              className="p-1 text-foreground/90 transition-colors hover:bg-accent"
-              onClick={onNewTerminal}
-              label={newShortcutLabel ? `New Terminal (${newShortcutLabel})` : "New Terminal"}
+              className={`p-1 text-foreground/90 transition-colors ${
+                hasReachedTerminalLimit
+                  ? "cursor-not-allowed opacity-45 hover:bg-transparent"
+                  : "hover:bg-accent"
+              }`}
+              onClick={onNewTerminalAction}
+              label={newTerminalActionLabel}
             >
               <Plus className="size-3.25" />
             </TerminalActionButton>
@@ -733,9 +755,9 @@ export default function ThreadTerminalDrawer({
           <div className="min-w-0 flex-1">
             {isSplitView ? (
               <div
-                className="grid h-full w-full gap-0 overflow-x-auto"
+                className="grid h-full w-full min-w-0 gap-0 overflow-hidden"
                 style={{
-                  gridTemplateColumns: `repeat(${visibleTerminalIds.length}, minmax(260px, 1fr))`,
+                  gridTemplateColumns: `repeat(${visibleTerminalIds.length}, minmax(0, 1fr))`,
                 }}
               >
                 {visibleTerminalIds.map((terminalId) => (
@@ -787,20 +809,24 @@ export default function ThreadTerminalDrawer({
               <div className="flex h-[22px] items-stretch justify-end border-b border-border/70">
                 <div className="inline-flex h-full items-stretch">
                   <TerminalActionButton
-                    className="inline-flex h-full items-center px-1 text-foreground/90 transition-colors hover:bg-accent/70"
-                    onClick={onSplitTerminal}
-                    label={
-                      splitShortcutLabel
-                        ? `Split Terminal (${splitShortcutLabel})`
-                        : "Split Terminal"
-                    }
+                    className={`inline-flex h-full items-center px-1 text-foreground/90 transition-colors ${
+                      hasReachedTerminalLimit
+                        ? "cursor-not-allowed opacity-45 hover:bg-transparent"
+                        : "hover:bg-accent/70"
+                    }`}
+                    onClick={onSplitTerminalAction}
+                    label={splitTerminalActionLabel}
                   >
                     <SquareSplitHorizontal className="size-3.25" />
                   </TerminalActionButton>
                   <TerminalActionButton
-                    className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
-                    onClick={onNewTerminal}
-                    label={newShortcutLabel ? `New Terminal (${newShortcutLabel})` : "New Terminal"}
+                    className={`inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors ${
+                      hasReachedTerminalLimit
+                        ? "cursor-not-allowed opacity-45 hover:bg-transparent"
+                        : "hover:bg-accent/70"
+                    }`}
+                    onClick={onNewTerminalAction}
+                    label={newTerminalActionLabel}
                   >
                     <Plus className="size-3.25" />
                   </TerminalActionButton>

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -2,7 +2,11 @@ import type { ProviderEvent, ProviderSession, TerminalEvent } from "@t3tools/con
 import { describe, expect, it } from "vitest";
 
 import { type AppState, reducer } from "./store";
-import { DEFAULT_THREAD_TERMINAL_HEIGHT, DEFAULT_THREAD_TERMINAL_ID } from "./types";
+import {
+  DEFAULT_THREAD_TERMINAL_HEIGHT,
+  DEFAULT_THREAD_TERMINAL_ID,
+  MAX_THREAD_TERMINAL_COUNT,
+} from "./types";
 import type { Thread } from "./types";
 
 type TerminalStartedEvent = Extract<TerminalEvent, { type: "started" }>;
@@ -253,6 +257,70 @@ describe("store reducer thread continuity", () => {
     ]);
     expect(next.threads[0]?.activeTerminalId).toBe("term-3");
     expect(next.threads[0]?.activeTerminalGroupId).toBe(`group-${DEFAULT_THREAD_TERMINAL_ID}`);
+  });
+
+  it("caps split terminals at four per thread", () => {
+    const state = makeState(
+      makeThread({
+        terminalIds: [DEFAULT_THREAD_TERMINAL_ID, "term-2", "term-3", "term-4"],
+        activeTerminalId: "term-4",
+        terminalGroups: [
+          {
+            id: `group-${DEFAULT_THREAD_TERMINAL_ID}`,
+            terminalIds: [DEFAULT_THREAD_TERMINAL_ID, "term-2", "term-3", "term-4"],
+          },
+        ],
+        activeTerminalGroupId: `group-${DEFAULT_THREAD_TERMINAL_ID}`,
+      }),
+    );
+    const next = reducer(state, {
+      type: "SPLIT_THREAD_TERMINAL",
+      threadId: "thread-local-1",
+      terminalId: "term-5",
+    });
+
+    expect(next.threads[0]?.terminalIds).toHaveLength(MAX_THREAD_TERMINAL_COUNT);
+    expect(next.threads[0]?.terminalIds).toEqual([
+      DEFAULT_THREAD_TERMINAL_ID,
+      "term-2",
+      "term-3",
+      "term-4",
+    ]);
+    expect(next.threads[0]?.activeTerminalId).toBe("term-4");
+  });
+
+  it("caps new terminals at four per thread", () => {
+    const state = makeState(
+      makeThread({
+        terminalIds: [DEFAULT_THREAD_TERMINAL_ID, "term-2", "term-3", "term-4"],
+        activeTerminalId: "term-4",
+        terminalGroups: [
+          {
+            id: `group-${DEFAULT_THREAD_TERMINAL_ID}`,
+            terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+          },
+          { id: "group-term-2", terminalIds: ["term-2"] },
+          { id: "group-term-3", terminalIds: ["term-3"] },
+          { id: "group-term-4", terminalIds: ["term-4"] },
+        ],
+        activeTerminalGroupId: "group-term-4",
+      }),
+    );
+    const next = reducer(state, {
+      type: "NEW_THREAD_TERMINAL",
+      threadId: "thread-local-1",
+      terminalId: "term-5",
+    });
+
+    expect(next.threads[0]?.terminalIds).toHaveLength(MAX_THREAD_TERMINAL_COUNT);
+    expect(next.threads[0]?.terminalIds).toEqual([
+      DEFAULT_THREAD_TERMINAL_ID,
+      "term-2",
+      "term-3",
+      "term-4",
+    ]);
+    expect(next.threads[0]?.activeTerminalId).toBe("term-4");
+    expect(next.threads[0]?.activeTerminalGroupId).toBe("group-term-4");
   });
 
   it("closes a terminal and keeps grouped layout coherent", () => {

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -16,6 +16,7 @@ import {
   type ChatAttachment,
   DEFAULT_THREAD_TERMINAL_ID,
   DEFAULT_RUNTIME_MODE,
+  MAX_THREAD_TERMINAL_COUNT,
   type Project,
   type RuntimeMode,
   type Thread,
@@ -110,7 +111,12 @@ function readPersistedState(): AppState {
     const hydrated = hydratePersistedState(raw, !rawCurrent && raw === rawCodethingV1);
     if (!hydrated) return initialState;
 
-    return { ...hydrated, diffOpen: false };
+    const threads = hydrated.threads.map((thread) => normalizeThreadTerminals(thread));
+    const activeThreadId = threads.some((thread) => thread.id === hydrated.activeThreadId)
+      ? hydrated.activeThreadId
+      : (threads[0]?.id ?? null);
+
+    return { ...hydrated, threads, activeThreadId, diffOpen: false };
   } catch {
     return initialState;
   }
@@ -139,7 +145,7 @@ function updateThread(
 
 function normalizeTerminalIds(terminalIds: string[]): string[] {
   const ids = terminalIds.map((id) => id.trim()).filter((id) => id.length > 0);
-  const unique = [...new Set(ids)];
+  const unique = [...new Set(ids)].slice(0, MAX_THREAD_TERMINAL_COUNT);
   if (unique.length > 0) {
     return unique;
   }
@@ -550,6 +556,13 @@ export function reducer(state: AppState, action: Action): AppState {
         ...state,
         threads: updateThread(state.threads, action.threadId, (thread) => {
           const normalizedThread = normalizeThreadTerminals(thread);
+          const isNewTerminal = !normalizedThread.terminalIds.includes(action.terminalId);
+          if (
+            isNewTerminal &&
+            normalizedThread.terminalIds.length >= MAX_THREAD_TERMINAL_COUNT
+          ) {
+            return normalizedThread;
+          }
           const terminalIds = normalizedThread.terminalIds.includes(action.terminalId)
             ? normalizedThread.terminalIds
             : [...normalizedThread.terminalIds, action.terminalId];
@@ -616,6 +629,13 @@ export function reducer(state: AppState, action: Action): AppState {
         ...state,
         threads: updateThread(state.threads, action.threadId, (thread) => {
           const normalizedThread = normalizeThreadTerminals(thread);
+          const isNewTerminal = !normalizedThread.terminalIds.includes(action.terminalId);
+          if (
+            isNewTerminal &&
+            normalizedThread.terminalIds.length >= MAX_THREAD_TERMINAL_COUNT
+          ) {
+            return normalizedThread;
+          }
           const terminalIds = normalizedThread.terminalIds.includes(action.terminalId)
             ? normalizedThread.terminalIds
             : [...normalizedThread.terminalIds, action.terminalId];

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -5,6 +5,7 @@ export type RuntimeMode = "approval-required" | "full-access";
 export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
 export const DEFAULT_THREAD_TERMINAL_HEIGHT = 280;
 export const DEFAULT_THREAD_TERMINAL_ID = "default";
+export const MAX_THREAD_TERMINAL_COUNT = 4;
 
 export interface ThreadTerminalGroup {
   id: string;


### PR DESCRIPTION
## Summary
- add `min-w-0` to ChatView container wrappers so header content can shrink within flex layouts
- update header title container to `flex-1 min-w-0` and apply `truncate` to the thread title
- add a `title` tooltip on the truncated thread name to preserve full-title visibility
- mark the header action group as `shrink-0` so controls remain stable when titles are long

## Testing
- Not run (no test output provided)
- Visual check: long thread titles should truncate with ellipsis instead of overflowing header controls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced a 4-terminal-per-thread limit; creating or splitting terminals is blocked at the cap and action labels reflect the max.
  * Terminal action buttons are disabled and visually dimmed when the limit is reached.

* **Improvements**
  * Chat header shows long titles with truncation and tooltip; layout tweaks prevent overflow and unwanted shrinking.

* **Tests**
  * Added tests verifying the terminal cap and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI/layout tweaks plus a straightforward terminal-count cap with added reducer guards and tests; limited blast radius to thread terminal management and display.
> 
> **Overview**
> Fixes chat header layout issues with long thread titles by adding `min-w-0`/`truncate` and a hover `title` tooltip, and by marking the actions area as `shrink-0` so controls don’t get pushed off-screen.
> 
> Introduces a shared `MAX_THREAD_TERMINAL_COUNT` (set to 4) and enforces it end-to-end: UI actions for split/new terminals are disabled with updated tooltips when at the cap, the reducer ignores attempts to add beyond the limit (including on hydration/normalization), and new tests cover both split and new terminal capping behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcc6d9d9ae51b50762d553b475cbced36f1c0e98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->