### PR TITLE
Persist chat image previews and migrate web persistence schema to v8

### DIFF
--- a/apps/server/src/bun-sqlite.d.ts
+++ b/apps/server/src/bun-sqlite.d.ts
@@ -1,0 +1,11 @@
+declare module "bun:sqlite" {
+  export class Database {
+    constructor(filename?: string);
+    exec(sql: string): void;
+    run(sql: string, ...params: unknown[]): unknown;
+    query(sql: string): {
+      get(...params: unknown[]): unknown;
+    };
+    close(): void;
+  }
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -118,6 +118,7 @@ async function main() {
     port,
     host: mode === "desktop" ? "127.0.0.1" : undefined,
     cwd,
+    stateDir,
     staticDir,
     devUrl,
     projectRegistry,

--- a/apps/server/src/rendererStateStore.test.ts
+++ b/apps/server/src/rendererStateStore.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { RendererStateStore } from "./rendererStateStore";
+
+function makeTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+describe("RendererStateStore", () => {
+  it("returns null when no renderer state has been saved", async () => {
+    const stateDir = makeTempDir("t3code-renderer-state-empty-");
+    const store = new RendererStateStore(stateDir);
+
+    await expect(store.get()).resolves.toBeNull();
+
+    await store.close();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("persists and reloads renderer state from sqlite", async () => {
+    const stateDir = makeTempDir("t3code-renderer-state-roundtrip-");
+    const firstStore = new RendererStateStore(stateDir);
+    const payload =
+      '{"version":8,"projects":[],"threads":[],"activeThreadId":null,"runtimeMode":"full-access"}';
+
+    await firstStore.set({ stateJson: payload });
+    const firstRead = await firstStore.get();
+    expect(firstRead).toMatchObject({
+      stateJson: payload,
+      updatedAt: expect.any(String),
+    });
+    await firstStore.close();
+
+    const secondStore = new RendererStateStore(stateDir);
+    const secondRead = await secondStore.get();
+    expect(secondRead).toMatchObject({
+      stateJson: payload,
+      updatedAt: expect.any(String),
+    });
+    await secondStore.close();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+});

--- a/apps/server/src/rendererStateStore.ts
+++ b/apps/server/src/rendererStateStore.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  type RendererStateSetInput,
+  type RendererStateSnapshot,
+  rendererStateSetInputSchema,
+  rendererStateSnapshotSchema,
+} from "@t3tools/contracts";
+
+interface RowShape {
+  stateJson: string;
+  updatedAt: string;
+}
+
+interface SqliteAdapter {
+  getState(): RowShape | null;
+  setState(stateJson: string, updatedAt: string): void;
+  close(): void;
+}
+
+interface BunSqliteDatabase {
+  exec(sql: string): void;
+  run(sql: string, ...params: unknown[]): unknown;
+  query(sql: string): {
+    get(...params: unknown[]): unknown;
+  };
+  close(): void;
+}
+
+interface BunSqliteModule {
+  Database: new (filename?: string) => BunSqliteDatabase;
+}
+
+function defaultStateDir(): string {
+  return path.join(os.homedir(), ".t3", "userdata");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseRowShape(row: unknown): RowShape | null {
+  if (!isObject(row)) return null;
+  const stateJson = row.stateJson;
+  const updatedAt = row.updatedAt;
+  if (typeof stateJson !== "string" || typeof updatedAt !== "string") return null;
+  return { stateJson, updatedAt };
+}
+
+async function createNodeSqliteAdapter(dbPath: string): Promise<SqliteAdapter> {
+  const module = await import("node:sqlite");
+  const db = new module.DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS renderer_state (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      state_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  const selectStatement = db.prepare(`
+    SELECT state_json AS stateJson, updated_at AS updatedAt
+    FROM renderer_state
+    WHERE id = 1
+  `);
+  const upsertStatement = db.prepare(`
+    INSERT INTO renderer_state (id, state_json, updated_at)
+    VALUES (1, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      state_json = excluded.state_json,
+      updated_at = excluded.updated_at
+  `);
+
+  return {
+    getState() {
+      return parseRowShape(selectStatement.get());
+    },
+    setState(stateJson: string, updatedAt: string) {
+      upsertStatement.run(stateJson, updatedAt);
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+async function createBunSqliteAdapter(dbPath: string): Promise<SqliteAdapter> {
+  const loadBunSqlite = new Function(
+    "return import('bun:sqlite')",
+  ) as () => Promise<BunSqliteModule>;
+  const module = await loadBunSqlite();
+  const db = new module.Database(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS renderer_state (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      state_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  const selectQuery = db.query(`
+    SELECT state_json AS stateJson, updated_at AS updatedAt
+    FROM renderer_state
+    WHERE id = 1
+  `);
+  const upsertSql = `
+    INSERT INTO renderer_state (id, state_json, updated_at)
+    VALUES (1, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      state_json = excluded.state_json,
+      updated_at = excluded.updated_at
+  `;
+
+  return {
+    getState() {
+      return parseRowShape(selectQuery.get());
+    },
+    setState(stateJson: string, updatedAt: string) {
+      db.run(upsertSql, stateJson, updatedAt);
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+async function createSqliteAdapter(dbPath: string): Promise<SqliteAdapter> {
+  try {
+    return await createNodeSqliteAdapter(dbPath);
+  } catch {
+    return createBunSqliteAdapter(dbPath);
+  }
+}
+
+export class RendererStateStore {
+  private readonly stateDir: string;
+  private readonly dbPath: string;
+  private adapterPromise: Promise<SqliteAdapter> | null = null;
+
+  constructor(stateDir: string = defaultStateDir()) {
+    this.stateDir = stateDir;
+    this.dbPath = path.join(this.stateDir, "renderer-state.sqlite");
+    fs.mkdirSync(this.stateDir, { recursive: true });
+  }
+
+  async get(): Promise<RendererStateSnapshot | null> {
+    const adapter = await this.getAdapter();
+    const row = adapter.getState();
+    if (!row) return null;
+    const parsed = rendererStateSnapshotSchema.safeParse(row);
+    if (!parsed.success) return null;
+    return parsed.data;
+  }
+
+  async set(raw: RendererStateSetInput): Promise<void> {
+    const input = rendererStateSetInputSchema.parse(raw);
+    const adapter = await this.getAdapter();
+    adapter.setState(input.stateJson, new Date().toISOString());
+  }
+
+  async close(): Promise<void> {
+    if (!this.adapterPromise) return;
+    const adapter = await this.adapterPromise;
+    adapter.close();
+    this.adapterPromise = null;
+  }
+
+  private async getAdapter(): Promise<SqliteAdapter> {
+    if (!this.adapterPromise) {
+      this.adapterPromise = createSqliteAdapter(this.dbPath);
+    }
+    return this.adapterPromise;
+  }
+}

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -249,6 +249,7 @@ describe("WebSocket Server", () => {
     return createServer({
       port: 0,
       cwd: options.cwd ?? "/test/project",
+      stateDir,
       ...(options.devUrl ? { devUrl: options.devUrl } : {}),
       ...(options.authToken ? { authToken: options.authToken } : {}),
       projectRegistry: new ProjectRegistry(stateDir),
@@ -339,6 +340,71 @@ describe("WebSocket Server", () => {
     expect(response.result).toEqual({
       cwd: "/my/workspace",
       keybindings: DEFAULT_RESOLVED_KEYBINDINGS,
+    });
+  });
+
+  it("reads and writes renderer state over websocket", async () => {
+    const stateDir = makeTempDir("t3code-ws-renderer-state-");
+    server = createTestServer({ cwd: "/my/workspace", stateDir });
+    await server.start();
+    const addr = server.httpServer.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    const empty = await sendRequest(ws, WS_METHODS.serverGetRendererState);
+    expect(empty.error).toBeUndefined();
+    expect(empty.result).toBeNull();
+
+    const setResponse = await sendRequest(ws, WS_METHODS.serverSetRendererState, {
+      stateJson: '{"version":8,"projects":[],"threads":[],"activeThreadId":null,"runtimeMode":"full-access"}',
+    });
+    expect(setResponse.error).toBeUndefined();
+
+    const loaded = await sendRequest(ws, WS_METHODS.serverGetRendererState);
+    expect(loaded.error).toBeUndefined();
+    expect(loaded.result).toMatchObject({
+      stateJson:
+        '{"version":8,"projects":[],"threads":[],"activeThreadId":null,"runtimeMode":"full-access"}',
+      updatedAt: expect.any(String),
+    });
+  });
+
+  it("persists renderer state across server restarts", async () => {
+    const stateDir = makeTempDir("t3code-ws-renderer-state-restart-");
+    server = createTestServer({ cwd: "/workspace", stateDir });
+    await server.start();
+    const firstAddr = server.httpServer.address();
+    const firstPort = typeof firstAddr === "object" && firstAddr !== null ? firstAddr.port : 0;
+
+    const firstWs = await connectWs(firstPort);
+    connections.push(firstWs);
+    await waitForMessage(firstWs);
+    const setResponse = await sendRequest(firstWs, WS_METHODS.serverSetRendererState, {
+      stateJson:
+        '{"version":8,"projects":[{"id":"project-1","name":"project","cwd":"/workspace","model":"gpt-5.3-codex","expanded":true}],"threads":[],"activeThreadId":null,"runtimeMode":"full-access"}',
+    });
+    expect(setResponse.error).toBeUndefined();
+
+    await server.stop();
+    server = createTestServer({ cwd: "/workspace", stateDir });
+    await server.start();
+    const secondAddr = server.httpServer.address();
+    const secondPort =
+      typeof secondAddr === "object" && secondAddr !== null ? secondAddr.port : 0;
+
+    const secondWs = await connectWs(secondPort);
+    connections.push(secondWs);
+    await waitForMessage(secondWs);
+
+    const loaded = await sendRequest(secondWs, WS_METHODS.serverGetRendererState);
+    expect(loaded.error).toBeUndefined();
+    expect(loaded.result).toMatchObject({
+      stateJson:
+        '{"version":8,"projects":[{"id":"project-1","name":"project","cwd":"/workspace","model":"gpt-5.3-codex","expanded":true}],"threads":[],"activeThreadId":null,"runtimeMode":"full-access"}',
+      updatedAt: expect.any(String),
     });
   });
 

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -32,6 +32,7 @@ import {
 } from "./git";
 import { TerminalManager } from "./terminalManager";
 import { loadResolvedKeybindingsConfig } from "./keybindings";
+import { RendererStateStore } from "./rendererStateStore";
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -52,12 +53,14 @@ export interface ServerOptions {
   port: number;
   host?: string | undefined;
   cwd: string;
+  stateDir?: string | undefined;
   staticDir?: string | undefined;
   devUrl?: string | undefined;
   logWebSocketEvents?: boolean | undefined;
   projectRegistry?: ProjectRegistry | undefined;
   gitManager?: GitManager | undefined;
   terminalManager?: TerminalManager | undefined;
+  rendererStateStore?: RendererStateStore | undefined;
   authToken?: string | undefined;
 }
 
@@ -74,18 +77,21 @@ export function createServer(options: ServerOptions) {
     port,
     host,
     cwd,
+    stateDir,
     staticDir,
     devUrl,
     logWebSocketEvents: explicitLogWsEvents,
     projectRegistry: providedRegistry,
     gitManager: providedGitManager,
     terminalManager: providedTerminalManager,
+    rendererStateStore: providedRendererStateStore,
     authToken,
   } = options;
   const providerManager = new ProviderManager();
   const terminalManager = providedTerminalManager ?? new TerminalManager();
-  const projectRegistry =
-    providedRegistry ?? new ProjectRegistry(path.join(os.homedir(), ".t3", "userdata"));
+  const resolvedStateDir = stateDir ?? path.join(os.homedir(), ".t3", "userdata");
+  const projectRegistry = providedRegistry ?? new ProjectRegistry(resolvedStateDir);
+  const rendererStateStore = providedRendererStateStore ?? new RendererStateStore(resolvedStateDir);
   const gitManager = providedGitManager ?? new GitManager();
   const clients = new Set<WebSocket>();
   const logger = createLogger("ws");
@@ -417,6 +423,13 @@ export function createServer(options: ServerOptions) {
           keybindings: keybindingsConfig,
         };
 
+      case WS_METHODS.serverGetRendererState:
+        return rendererStateStore.get();
+
+      case WS_METHODS.serverSetRendererState:
+        await rendererStateStore.set(request.params as never);
+        return undefined;
+
       default:
         throw new Error(`Unknown method: ${request.method}`);
     }
@@ -446,6 +459,7 @@ export function createServer(options: ServerOptions) {
     providerManager.stopAll();
     providerManager.dispose();
     terminalManager.dispose();
+    await rendererStateStore.close();
 
     for (const client of clients) {
       client.close();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -823,41 +823,48 @@ export default function ChatView() {
     }
 
     setThreadError(activeThread.id, null);
-    const messageAttachments: ChatImageAttachment[] = composerImagesSnapshot.map((image) => ({
-      type: "image",
-      id: image.id,
-      name: image.name,
-      mimeType: image.mimeType,
-      sizeBytes: image.sizeBytes,
-      previewUrl: image.previewUrl,
-    }));
-    dispatch({
-      type: "PUSH_USER_MESSAGE",
-      threadId: activeThread.id,
-      id: crypto.randomUUID(),
-      text: trimmed,
-      ...(messageAttachments.length > 0 ? { attachments: messageAttachments } : {}),
-    });
     const previousMessages = activeThread.messages;
-    setPrompt("");
-    setComposerImages([]);
-
-    const sessionInfo = await ensureSession(sessionCwd);
-    if (!sessionInfo) return;
-
     setIsSending(true);
     try {
-      const turnAttachments = await Promise.all(
-        composerImagesSnapshot.map(
-          async (image): Promise<ProviderSendTurnAttachmentInput> => ({
+      const preparedImages = await Promise.all(
+        composerImagesSnapshot.map(async (image) => {
+          const attachment: ProviderSendTurnAttachmentInput = {
             type: "image",
             name: image.name,
             mimeType: image.mimeType,
             sizeBytes: image.sizeBytes,
             dataUrl: await readFileAsDataUrl(image.file),
-          }),
-        ),
+          };
+          return { image, attachment };
+        }),
       );
+      const turnAttachments = preparedImages.map(({ attachment }) => attachment);
+      const messageAttachments: ChatImageAttachment[] = preparedImages.map(
+        ({ image, attachment }) => ({
+          type: "image",
+          id: image.id,
+          name: image.name,
+          mimeType: image.mimeType,
+          sizeBytes: image.sizeBytes,
+          previewUrl: attachment.dataUrl,
+        }),
+      );
+      dispatch({
+        type: "PUSH_USER_MESSAGE",
+        threadId: activeThread.id,
+        id: crypto.randomUUID(),
+        text: trimmed,
+        ...(messageAttachments.length > 0 ? { attachments: messageAttachments } : {}),
+      });
+      setPrompt("");
+      setComposerImages((existing) => {
+        revokePreviewUrls(existing);
+        return [];
+      });
+
+      const sessionInfo = await ensureSession(sessionCwd);
+      if (!sessionInfo) return;
+
       const shouldBootstrap =
         previousMessages.length > 0 &&
         (sessionInfo.continuityState === "new" || sessionInfo.continuityState === "fallback_new");

--- a/apps/web/src/persistenceSchema.test.ts
+++ b/apps/web/src/persistenceSchema.test.ts
@@ -257,10 +257,65 @@ describe("hydratePersistedState", () => {
     ]);
     expect(hydrated?.threads[0]?.activeTerminalGroupId).toBe(`group-${DEFAULT_THREAD_TERMINAL_ID}`);
   });
+
+  it("hydrates persisted image preview data urls", () => {
+    const payload = JSON.stringify({
+      version: 8,
+      runtimeMode: "full-access",
+      projects: [
+        {
+          id: "p-1",
+          name: "Project",
+          cwd: "/tmp/project",
+          model: "gpt-5.3-codex",
+          expanded: true,
+        },
+      ],
+      threads: [
+        {
+          id: "t-1",
+          codexThreadId: null,
+          projectId: "p-1",
+          title: "Thread",
+          model: "gpt-5.3-codex",
+          terminalOpen: true,
+          terminalHeight: 360,
+          terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+          activeTerminalId: DEFAULT_THREAD_TERMINAL_ID,
+          messages: [
+            {
+              id: "m-1",
+              role: "user",
+              text: "Here",
+              attachments: [
+                {
+                  type: "image",
+                  id: "img-1",
+                  name: "diagram.png",
+                  mimeType: "image/png",
+                  sizeBytes: 4_096,
+                  previewUrl: "data:image/png;base64,AAAA",
+                },
+              ],
+              createdAt: "2026-02-08T10:00:00.000Z",
+              streaming: false,
+            },
+          ],
+          createdAt: "2026-02-08T10:00:00.000Z",
+        },
+      ],
+      activeThreadId: "t-1",
+    });
+
+    const hydrated = hydratePersistedState(payload, false);
+    expect(hydrated?.threads[0]?.messages[0]?.attachments?.[0]?.previewUrl).toBe(
+      "data:image/png;base64,AAAA",
+    );
+  });
 });
 
 describe("toPersistedState", () => {
-  it("writes v7 payload and strips non-persisted thread fields", () => {
+  it("writes v8 payload and strips non-persisted thread fields", () => {
     const thread: Thread = {
       id: "t-1",
       codexThreadId: "thr_1",
@@ -320,7 +375,7 @@ describe("toPersistedState", () => {
       runtimeMode: "full-access",
     });
 
-    expect(persisted.version).toBe(7);
+    expect(persisted.version).toBe(8);
     expect(persisted.runtimeMode).toBe("full-access");
     expect(persisted.threads[0]).toEqual({
       id: "t-1",
@@ -366,5 +421,70 @@ describe("toPersistedState", () => {
 
     expect("error" in persistedThread).toBe(false);
     expect("session" in persistedThread).toBe(false);
+  });
+
+  it("persists preview data urls for image attachments", () => {
+    const thread: Thread = {
+      id: "t-1",
+      codexThreadId: null,
+      projectId: "p-1",
+      title: "Thread",
+      model: "gpt-5.3-codex",
+      terminalOpen: false,
+      terminalHeight: DEFAULT_THREAD_TERMINAL_HEIGHT,
+      terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+      runningTerminalIds: [],
+      activeTerminalId: DEFAULT_THREAD_TERMINAL_ID,
+      terminalGroups: [
+        { id: `group-${DEFAULT_THREAD_TERMINAL_ID}`, terminalIds: [DEFAULT_THREAD_TERMINAL_ID] },
+      ],
+      activeTerminalGroupId: `group-${DEFAULT_THREAD_TERMINAL_ID}`,
+      session: null,
+      messages: [
+        {
+          id: "m-1",
+          role: "user",
+          text: "Image",
+          attachments: [
+            {
+              type: "image",
+              id: "img-1",
+              name: "screenshot.png",
+              mimeType: "image/png",
+              sizeBytes: 1_024,
+              previewUrl: "data:image/png;base64,AAAA",
+            },
+          ],
+          createdAt: "2026-02-08T10:00:00.000Z",
+          streaming: false,
+        },
+      ],
+      events: [],
+      error: null,
+      createdAt: "2026-02-08T10:00:00.000Z",
+      branch: null,
+      worktreePath: null,
+    };
+
+    const persisted = toPersistedState({
+      projects: [
+        {
+          id: "p-1",
+          name: "Project",
+          cwd: "/tmp/project",
+          model: "gpt-5.3-codex",
+          expanded: true,
+        },
+      ],
+      threads: [thread],
+      activeThreadId: "t-1",
+      runtimeMode: "full-access",
+    });
+
+    expect(persisted.threads[0]?.messages[0]?.attachments?.[0]).toMatchObject({
+      type: "image",
+      id: "img-1",
+      previewUrl: "data:image/png;base64,AAAA",
+    });
   });
 });

--- a/apps/web/src/persistenceSchema.ts
+++ b/apps/web/src/persistenceSchema.ts
@@ -33,6 +33,7 @@ const persistedMessageSchema = z.object({
         name: z.string().min(1),
         mimeType: z.string().min(1),
         sizeBytes: z.number().int().min(1),
+        previewUrl: z.string().min(1).optional(),
       }),
     )
     .optional(),
@@ -103,12 +104,18 @@ export const persistedStateV7Schema = persistedStateBodySchema.extend({
   version: z.literal(7).optional(),
 });
 
+export const persistedStateV8Schema = persistedStateBodySchema.extend({
+  runtimeMode: runtimeModeSchema.default(DEFAULT_RUNTIME_MODE),
+  version: z.literal(8).optional(),
+});
+
 export const persistedStateV5Schema = persistedStateBodySchema.extend({
   runtimeMode: runtimeModeSchema.default(DEFAULT_RUNTIME_MODE),
   version: z.literal(5).optional(),
 });
 
 const persistedStateSchema = z.union([
+  persistedStateV8Schema,
   persistedStateV7Schema,
   persistedStateV6Schema,
   persistedStateV5Schema,
@@ -252,7 +259,14 @@ function hydrateThread(
     activeTerminalGroupId,
     session: null,
     messages: thread.messages.map((message) => {
-      const hydratedAttachments = message.attachments?.map((attachment) => ({ ...attachment }));
+      const hydratedAttachments = message.attachments?.map((attachment) => ({
+        type: attachment.type,
+        id: attachment.id,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        sizeBytes: attachment.sizeBytes,
+        ...(attachment.previewUrl ? { previewUrl: attachment.previewUrl } : {}),
+      }));
       return {
         id: message.id,
         role: message.role,
@@ -312,9 +326,9 @@ export function hydratePersistedState(
 
 export function toPersistedState(
   state: PersistedStoreSnapshot,
-): z.infer<typeof persistedStateV7Schema> {
+): z.infer<typeof persistedStateV8Schema> {
   return {
-    version: 7,
+    version: 8,
     projects: state.projects,
     threads: state.threads.map((thread) => ({
       id: thread.id,
@@ -340,6 +354,9 @@ export function toPersistedState(
                 name: attachment.name,
                 mimeType: attachment.mimeType,
                 sizeBytes: attachment.sizeBytes,
+                ...(attachment.previewUrl && /^data:image\//i.test(attachment.previewUrl)
+                  ? { previewUrl: attachment.previewUrl }
+                  : {}),
               })),
             }
           : {}),

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -5,13 +5,19 @@ import {
   createElement,
   useContext,
   useEffect,
+  useRef,
   useReducer,
+  useState,
 } from "react";
 
 import type { ProviderEvent, ProviderSession, TerminalEvent } from "@t3tools/contracts";
 import { resolveModelSlug } from "./model-logic";
-import { hydratePersistedState, toPersistedState } from "./persistenceSchema";
-import { applyEventToMessages, asObject, asString, evolveSession } from "./session-logic";
+import {
+  type PersistedStoreSnapshot,
+  hydratePersistedState,
+  toPersistedState,
+} from "./persistenceSchema";
+import { applyEventToMessages, asObject, asString, evolveSession, readNativeApi } from "./session-logic";
 import {
   type ChatAttachment,
   DEFAULT_THREAD_TERMINAL_ID,
@@ -25,6 +31,7 @@ import {
 // ── Actions ──────────────────────────────────────────────────────────
 
 type Action =
+  | { type: "HYDRATE_PERSISTED_STATE"; snapshot: PersistedStoreSnapshot }
   | { type: "ADD_PROJECT"; project: Project }
   | { type: "SYNC_PROJECTS"; projects: Project[] }
   | { type: "TOGGLE_PROJECT"; projectId: string }
@@ -75,8 +82,9 @@ export interface AppState {
   diffOpen: boolean;
 }
 
-const PERSISTED_STATE_KEY = "t3code:renderer-state:v8";
+const LEGACY_PERSISTED_STATE_PRIMARY_KEY = "t3code:renderer-state:v8";
 const LEGACY_PERSISTED_STATE_KEYS = [
+  LEGACY_PERSISTED_STATE_PRIMARY_KEY,
   "t3code:renderer-state:v7",
   "t3code:renderer-state:v6",
   "t3code:renderer-state:v5",
@@ -98,35 +106,30 @@ const initialState: AppState = {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function readPersistedState(): AppState {
-  if (typeof window === "undefined") return initialState;
+function readLegacyPersistedStateFromLocalStorage(): PersistedStoreSnapshot | null {
+  if (typeof window === "undefined") return null;
 
   try {
-    const rawCurrent = window.localStorage.getItem(PERSISTED_STATE_KEY);
+    const rawCurrent = window.localStorage.getItem(LEGACY_PERSISTED_STATE_PRIMARY_KEY);
     const legacyValues = LEGACY_PERSISTED_STATE_KEYS.map((key) => window.localStorage.getItem(key));
     const rawLegacy = legacyValues.find((value) => value !== null) ?? null;
     const raw = rawCurrent ?? rawLegacy;
-    if (!raw) return initialState;
+    if (!raw) return null;
     const rawCodethingV1 = window.localStorage.getItem("codething:renderer-state:v1");
-    const hydrated = hydratePersistedState(raw, !rawCurrent && raw === rawCodethingV1);
-    if (!hydrated) return initialState;
-
-    return { ...hydrated, diffOpen: false };
+    return hydratePersistedState(raw, !rawCurrent && raw === rawCodethingV1);
   } catch {
-    return initialState;
+    return null;
   }
 }
 
-function persistState(state: AppState): void {
+function clearLegacyPersistedStateFromLocalStorage(): void {
   if (typeof window === "undefined") return;
-
   try {
-    window.localStorage.setItem(PERSISTED_STATE_KEY, JSON.stringify(toPersistedState(state)));
     for (const legacyKey of LEGACY_PERSISTED_STATE_KEYS) {
       window.localStorage.removeItem(legacyKey);
     }
   } catch {
-    // Ignore quota/storage errors to avoid breaking chat UX.
+    // Ignore storage errors.
   }
 }
 
@@ -410,6 +413,16 @@ function updateTurnFields(thread: Thread, event: ProviderEvent): Partial<Thread>
 
 export function reducer(state: AppState, action: Action): AppState {
   switch (action.type) {
+    case "HYDRATE_PERSISTED_STATE":
+      return {
+        ...state,
+        projects: action.snapshot.projects,
+        threads: action.snapshot.threads,
+        activeThreadId: action.snapshot.activeThreadId,
+        runtimeMode: action.snapshot.runtimeMode,
+        diffOpen: false,
+      };
+
     case "ADD_PROJECT":
       if (state.projects.some((project) => project.cwd === action.project.cwd)) {
         return state;
@@ -843,11 +856,88 @@ const StoreContext = createContext<{
 }>({ state: initialState, dispatch: () => {} });
 
 export function StoreProvider({ children }: { children: ReactNode }) {
-  const [state, dispatch] = useReducer(reducer, undefined, readPersistedState);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const [persistenceReady, setPersistenceReady] = useState(false);
+  const bootstrapStartedRef = useRef(false);
+  const lastPersistedStateJsonRef = useRef<string | null>(null);
 
   useEffect(() => {
-    persistState(state);
-  }, [state]);
+    if (bootstrapStartedRef.current) return;
+    bootstrapStartedRef.current = true;
+
+    let disposed = false;
+    const api = readNativeApi();
+    if (!api) {
+      setPersistenceReady(true);
+      return;
+    }
+
+    void (async () => {
+      try {
+        const serverSnapshot = await api.server.getRendererState();
+        if (disposed) return;
+
+        const hydratedFromServer = serverSnapshot
+          ? hydratePersistedState(serverSnapshot.stateJson, false)
+          : null;
+        if (hydratedFromServer) {
+          lastPersistedStateJsonRef.current = serverSnapshot?.stateJson ?? null;
+          dispatch({ type: "HYDRATE_PERSISTED_STATE", snapshot: hydratedFromServer });
+          clearLegacyPersistedStateFromLocalStorage();
+          return;
+        }
+
+        const hydratedLegacy = readLegacyPersistedStateFromLocalStorage();
+        if (!hydratedLegacy) return;
+        const migratedStateJson = JSON.stringify(toPersistedState(hydratedLegacy));
+        dispatch({ type: "HYDRATE_PERSISTED_STATE", snapshot: hydratedLegacy });
+        try {
+          await api.server.setRendererState({ stateJson: migratedStateJson });
+          if (!disposed) {
+            lastPersistedStateJsonRef.current = migratedStateJson;
+            clearLegacyPersistedStateFromLocalStorage();
+          }
+        } catch {
+          // Keep running with hydrated legacy state. Persist effect will retry.
+        }
+      } catch {
+        if (disposed) return;
+        const hydratedLegacy = readLegacyPersistedStateFromLocalStorage();
+        if (hydratedLegacy) {
+          dispatch({ type: "HYDRATE_PERSISTED_STATE", snapshot: hydratedLegacy });
+        }
+      } finally {
+        if (!disposed) {
+          setPersistenceReady(true);
+        }
+      }
+    })();
+
+    return () => {
+      disposed = true;
+    };
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (!persistenceReady) return;
+    const api = readNativeApi();
+    if (!api) return;
+
+    const stateJson = JSON.stringify(toPersistedState(state));
+    if (lastPersistedStateJsonRef.current === stateJson) return;
+    const persistTimer = window.setTimeout(() => {
+      void api.server
+        .setRendererState({ stateJson })
+        .then(() => {
+          lastPersistedStateJsonRef.current = stateJson;
+        })
+        .catch(() => undefined);
+    }, 150);
+
+    return () => {
+      window.clearTimeout(persistTimer);
+    };
+  }, [persistenceReady, state]);
 
   return createElement(StoreContext.Provider, { value: { state, dispatch } }, children);
 }

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -75,8 +75,9 @@ export interface AppState {
   diffOpen: boolean;
 }
 
-const PERSISTED_STATE_KEY = "t3code:renderer-state:v7";
+const PERSISTED_STATE_KEY = "t3code:renderer-state:v8";
 const LEGACY_PERSISTED_STATE_KEYS = [
+  "t3code:renderer-state:v7",
   "t3code:renderer-state:v6",
   "t3code:renderer-state:v5",
   "t3code:renderer-state:v4",

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -141,6 +141,8 @@ export function createWsNativeApi(): NativeApi {
     },
     server: {
       getConfig: () => transport.request(WS_METHODS.serverGetConfig),
+      getRendererState: () => transport.request(WS_METHODS.serverGetRendererState),
+      setRendererState: (input) => transport.request(WS_METHODS.serverSetRendererState, input),
     },
   };
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7,5 +7,6 @@ export * from "./model";
 export * from "./ws";
 export * from "./keybindings";
 export * from "./server";
+export * from "./rendererState";
 export * from "./project";
 export * from "./git";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -32,6 +32,7 @@ import type {
   ProjectRemoveInput,
 } from "./project";
 import type { ServerConfig } from "./server";
+import type { RendererStateSetInput, RendererStateSnapshot } from "./rendererState";
 import type {
   TerminalClearInput,
   TerminalCloseInput,
@@ -116,5 +117,7 @@ export interface NativeApi {
   };
   server: {
     getConfig: () => Promise<ServerConfig>;
+    getRendererState: () => Promise<RendererStateSnapshot | null>;
+    setRendererState: (input: RendererStateSetInput) => Promise<void>;
   };
 }

--- a/packages/contracts/src/rendererState.test.ts
+++ b/packages/contracts/src/rendererState.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { rendererStateSetInputSchema, rendererStateSnapshotSchema } from "./rendererState";
+
+describe("rendererState contracts", () => {
+  it("parses renderer state snapshot", () => {
+    const parsed = rendererStateSnapshotSchema.parse({
+      stateJson: '{"version":8,"projects":[],"threads":[],"activeThreadId":null,"runtimeMode":"full-access"}',
+      updatedAt: "2026-02-18T10:00:00.000Z",
+    });
+
+    expect(parsed.updatedAt).toBe("2026-02-18T10:00:00.000Z");
+  });
+
+  it("requires non-empty stateJson for set input", () => {
+    expect(() => rendererStateSetInputSchema.parse({ stateJson: "" })).toThrow();
+  });
+});

--- a/packages/contracts/src/rendererState.ts
+++ b/packages/contracts/src/rendererState.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const RENDERER_STATE_MAX_JSON_CHARS = 25_000_000;
+
+export const rendererStateSnapshotSchema = z.object({
+  stateJson: z.string().min(1).max(RENDERER_STATE_MAX_JSON_CHARS),
+  updatedAt: z.string().datetime(),
+});
+
+export const rendererStateSetInputSchema = z.object({
+  stateJson: z.string().min(1).max(RENDERER_STATE_MAX_JSON_CHARS),
+});
+
+export type RendererStateSnapshot = z.infer<typeof rendererStateSnapshotSchema>;
+export type RendererStateSetInput = z.input<typeof rendererStateSetInputSchema>;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -40,6 +40,8 @@ export const WS_METHODS = {
 
   // Server meta
   serverGetConfig: "server.getConfig",
+  serverGetRendererState: "server.getRendererState",
+  serverSetRendererState: "server.setRendererState",
 } as const;
 
 // ── Push Event Channels ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- persist user image attachment `previewUrl` values (data URLs) in chat state so previews survive reloads
- move persistence storage key/version from `v7` to `v8` and add `v8` schema support in hydration
- update message attachment hydration/serialization to carry `previewUrl` only when valid image data URLs
- reorder send flow in `ChatView` to prepare image data first, then store message attachments with durable previews
- add coverage for hydrating and persisting image preview data URLs, and update schema version expectations in tests

## Testing
- `apps/web/src/persistenceSchema.test.ts`: verifies v8 payload writing and non-persisted field stripping
- `apps/web/src/persistenceSchema.test.ts`: verifies persisted image `previewUrl` data URLs are serialized
- `apps/web/src/persistenceSchema.test.ts`: verifies persisted image `previewUrl` data URLs are hydrated
- Not run: project lint scripts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch localStorage schema/versioning and message attachment serialization, so mistakes could break state hydration or increase storage usage due to persisted data URLs.
> 
> **Overview**
> Chat image attachments now store a durable `previewUrl` (data URL) so message previews survive reloads, and the persisted state version/storage key is migrated from `v7` to `v8`.
> 
> Persistence is updated to *hydrate and serialize* optional `attachments[].previewUrl`, only writing it when it matches an image data URL, and tests are expanded to cover v8 versioning plus preview URL round-tripping. The chat send flow is reordered to read image files into data URLs before dispatching `PUSH_USER_MESSAGE`, ensuring the message’s stored preview matches what gets persisted, and composer preview object URLs are revoked when clearing images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c50a2d8e1095f169d8137a0e85e0efb749e9586. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renderer state persistence: renderer view state can be saved and restored across server restarts.
  * Server-backed persisted state hydration and sync for more reliable cross-device restoration.

* **Improvements**
  * Image attachments: preview data URLs are preserved in persisted state and restored as previews.
  * Chat sending flow improved to reliably build and clear image attachments and composer input.

* **Tests**
  * Added tests covering renderer state persistence and image preview hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->