### PR TITLE
Refresh upstream before git status and tune query polling intervals

### DIFF
--- a/apps/server/src/git.test.ts
+++ b/apps/server/src/git.test.ts
@@ -760,6 +760,35 @@ describe("git integration", () => {
       expect(dirty.hasWorkingTreeChanges).toBe(true);
     });
 
+    it("refreshes upstream before statusDetails so behind count reflects remote updates", async () => {
+      await using remote = await makeTmpDir();
+      await using source = await makeTmpDir();
+      await using clone = await makeTmpDir();
+      await git(remote.path, "init --bare");
+
+      await initRepoWithCommit(source.path);
+      const initialBranch = (await listGitBranches({ cwd: source.path })).branches.find(
+        (branch) => branch.current,
+      )!.name;
+      await git(source.path, `remote add origin ${JSON.stringify(remote.path)}`);
+      await git(source.path, `push -u origin ${initialBranch}`);
+
+      await git(clone.path, `clone ${JSON.stringify(remote.path)} .`);
+      await git(clone.path, "config user.email 'test@test.com'");
+      await git(clone.path, "config user.name 'Test'");
+      await git(clone.path, `checkout -B ${initialBranch} --track origin/${initialBranch}`);
+      await writeFile(path.join(clone.path, "CHANGELOG.md"), "remote change\n");
+      await git(clone.path, "add CHANGELOG.md");
+      await git(clone.path, "commit -m 'remote update'");
+      await git(clone.path, `push origin ${initialBranch}`);
+
+      const core = new GitCoreService();
+      const details = await core.statusDetails(source.path);
+      expect(details.branch).toBe(initialBranch);
+      expect(details.aheadCount).toBe(0);
+      expect(details.behindCount).toBe(1);
+    });
+
     it("prepares commit context by auto-staging and creates commit", async () => {
       await using tmp = await makeTmpDir();
       await initRepoWithCommit(tmp.path);

--- a/apps/server/src/git.ts
+++ b/apps/server/src/git.ts
@@ -65,6 +65,8 @@ interface ExecuteGitOptions {
 }
 
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+const STATUS_UPSTREAM_REFRESH_INTERVAL_MS = 15_000;
+const STATUS_UPSTREAM_REFRESH_TIMEOUT_MS = 5_000;
 
 /** Spawn git directly with an argv array — no shell, no quoting needed. */
 function runGit(
@@ -216,6 +218,8 @@ async function executeGit(
 }
 
 export class GitCoreService {
+  private readonly lastUpstreamRefreshAt = new Map<string, number>();
+
   async status(raw: GitStatusInput): Promise<GitStatusResult> {
     const input = gitStatusInputSchema.parse(raw);
     const details = await this.statusDetails(input.cwd);
@@ -231,6 +235,8 @@ export class GitCoreService {
   }
 
   async statusDetails(cwd: string): Promise<GitStatusDetails> {
+    await this.refreshStatusUpstreamIfStale(cwd).catch(() => undefined);
+
     const [statusStdout, unstagedNumstatStdout, stagedNumstatStdout] = await Promise.all([
       this.gitStdout(cwd, ["status", "--porcelain=2", "--branch"]),
       this.gitStdout(cwd, ["diff", "--numstat"]),
@@ -553,7 +559,9 @@ export class GitCoreService {
     });
   }
 
-  private async refreshCheckedOutBranchUpstream(cwd: string): Promise<void> {
+  private async resolveCurrentUpstream(
+    cwd: string,
+  ): Promise<{ upstreamRef: string; remoteName: string; upstreamBranch: string } | null> {
     const upstreamRef = trimStdout(
       await this.gitStdout(
         cwd,
@@ -562,24 +570,72 @@ export class GitCoreService {
       ),
     );
     if (upstreamRef.length === 0 || upstreamRef === "@{upstream}") {
-      return;
+      return null;
     }
 
     const separatorIndex = upstreamRef.indexOf("/");
     if (separatorIndex <= 0) {
-      return;
+      return null;
     }
     const remoteName = upstreamRef.slice(0, separatorIndex);
     const upstreamBranch = upstreamRef.slice(separatorIndex + 1);
     if (remoteName.length === 0) {
-      return;
+      return null;
     }
     if (upstreamBranch.length === 0) {
+      return null;
+    }
+
+    return {
+      upstreamRef,
+      remoteName,
+      upstreamBranch,
+    };
+  }
+
+  private async fetchUpstreamRef(
+    cwd: string,
+    upstream: { upstreamRef: string; remoteName: string; upstreamBranch: string },
+  ): Promise<void> {
+    const refspec = `+refs/heads/${upstream.upstreamBranch}:refs/remotes/${upstream.upstreamRef}`;
+    await this.git(cwd, ["fetch", "--quiet", "--no-tags", upstream.remoteName, refspec], true);
+  }
+
+  private async fetchUpstreamRefForStatus(
+    cwd: string,
+    upstream: { upstreamRef: string; remoteName: string; upstreamBranch: string },
+  ): Promise<void> {
+    const refspec = `+refs/heads/${upstream.upstreamBranch}:refs/remotes/${upstream.upstreamRef}`;
+    await executeGit(cwd, ["fetch", "--quiet", "--no-tags", upstream.remoteName, refspec], {
+      allowNonZeroExit: true,
+      timeoutMs: STATUS_UPSTREAM_REFRESH_TIMEOUT_MS,
+    });
+  }
+
+  private async refreshStatusUpstreamIfStale(cwd: string): Promise<void> {
+    const upstream = await this.resolveCurrentUpstream(cwd);
+    if (!upstream) {
       return;
     }
 
-    const refspec = `+refs/heads/${upstreamBranch}:refs/remotes/${upstreamRef}`;
-    await this.git(cwd, ["fetch", "--quiet", "--no-tags", remoteName, refspec], true);
+    const cacheKey = `${cwd}\u0000${upstream.upstreamRef}`;
+    const now = Date.now();
+    const lastRefreshAt = this.lastUpstreamRefreshAt.get(cacheKey) ?? 0;
+    if (now - lastRefreshAt < STATUS_UPSTREAM_REFRESH_INTERVAL_MS) {
+      return;
+    }
+
+    // Record attempt time first to avoid repeated fetch spikes when status is polled often.
+    this.lastUpstreamRefreshAt.set(cacheKey, now);
+    await this.fetchUpstreamRefForStatus(cwd, upstream);
+  }
+
+  private async refreshCheckedOutBranchUpstream(cwd: string): Promise<void> {
+    const upstream = await this.resolveCurrentUpstream(cwd);
+    if (!upstream) {
+      return;
+    }
+    await this.fetchUpstreamRef(cwd, upstream);
   }
 
   async checkoutBranch(input: GitCheckoutInput): Promise<void> {

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -1,6 +1,11 @@
 import type { GitStackedAction, NativeApi } from "@t3tools/contracts";
 import { mutationOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
 
+const GIT_STATUS_STALE_TIME_MS = 5_000;
+const GIT_STATUS_REFETCH_INTERVAL_MS = 15_000;
+const GIT_BRANCHES_STALE_TIME_MS = 15_000;
+const GIT_BRANCHES_REFETCH_INTERVAL_MS = 60_000;
+
 export const gitQueryKeys = {
   all: ["git"] as const,
   status: (cwd: string | null) => ["git", "status", cwd] as const,
@@ -21,6 +26,10 @@ export function gitStatusQueryOptions(api: NativeApi | undefined, cwd: string | 
       return api.git.status({ cwd });
     },
     enabled: !!api && !!cwd,
+    staleTime: GIT_STATUS_STALE_TIME_MS,
+    refetchOnWindowFocus: "always",
+    refetchOnReconnect: "always",
+    refetchInterval: GIT_STATUS_REFETCH_INTERVAL_MS,
   });
 }
 
@@ -34,6 +43,10 @@ export function gitBranchesQueryOptions(api: NativeApi | undefined, cwd: string 
       return api.git.listBranches({ cwd });
     },
     enabled: !!api && !!cwd,
+    staleTime: GIT_BRANCHES_STALE_TIME_MS,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: GIT_BRANCHES_REFETCH_INTERVAL_MS,
   });
 }
 


### PR DESCRIPTION
## Summary
- Refreshes branch upstream before computing `statusDetails` so `behindCount` reflects remote updates.
- Adds a throttled upstream refresh path for status checks (15s interval, 5s timeout) to avoid fetch spikes during frequent polling.
- Refactors upstream resolution/fetch logic into reusable helpers used by both status refresh and checkout flows.
- Adds an integration test covering the stale-remote scenario to verify `behindCount` updates after a remote commit.
- Tunes web React Query behavior for git status/branches with explicit stale times and periodic/background refetch settings.

## Testing
- Added integration test: `apps/server/src/git.test.ts` (`refreshes upstream before statusDetails so behind count reflects remote updates`).
- Not run: full project lint script.
- Not run: full test suite.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/67" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces additional `git fetch` calls during status polling (albeit throttled/timeout-limited), which could affect responsiveness or network load and has behavior implications for branch status accuracy.
> 
> **Overview**
> `GitCoreService.statusDetails()` now proactively fetches the current branch’s upstream (with a **15s throttle** and **5s timeout**) so `behindCount` reflects remote updates, and refactors upstream parsing/fetching into reusable helpers shared with the checkout background refresh.
> 
> Adds an integration test covering the stale-remote `behindCount` scenario, and tunes the web React Query configuration to use explicit `staleTime` plus periodic/background refetch intervals for git status (15s) and branches (60s).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15959097e559838416a034c503eb17be4fd05932. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Git status now accurately reflects upstream changes with intelligent refresh mechanisms
  * Enhanced automatic refetch behavior for branch information—refreshes when the app regains focus, reconnects to the network, or on configured intervals
  * Better real-time upstream tracking to keep commit ahead/behind counts current

<!-- end of auto-generated comment: release notes by coderabbit.ai -->