### PR TITLE
Surface orphaned worktree removal failures after thread deletion

### DIFF
--- a/apps/server/src/git.test.ts
+++ b/apps/server/src/git.test.ts
@@ -760,6 +760,24 @@ describe("git integration", () => {
       expect(dirty.hasWorkingTreeChanges).toBe(true);
     });
 
+    it("includes command context when worktree removal fails", async () => {
+      await using tmp = await makeTmpDir();
+      await initRepoWithCommit(tmp.path);
+      const core = new GitCoreService();
+      const missingWorktreePath = path.join(tmp.path, "missing-worktree");
+
+      const error = await core
+        .removeWorktree({ cwd: tmp.path, path: missingWorktreePath })
+        .then(() => null)
+        .catch((err: unknown) => err);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toContain("git worktree remove");
+      expect(message).toContain(`cwd: ${tmp.path}`);
+      expect(message).toContain(missingWorktreePath);
+    });
+
     it("refreshes upstream before statusDetails so behind count reflects remote updates", async () => {
       await using remote = await makeTmpDir();
       await using source = await makeTmpDir();

--- a/apps/server/src/git.ts
+++ b/apps/server/src/git.ts
@@ -546,10 +546,18 @@ export class GitCoreService {
   }
 
   async removeWorktree(input: GitRemoveWorktreeInput): Promise<void> {
-    await executeGit(input.cwd, ["worktree", "remove", input.path], {
-      timeoutMs: 15_000,
-      fallbackErrorMessage: "git worktree remove failed",
-    });
+    const args = ["worktree", "remove", input.path] as const;
+    try {
+      await executeGit(input.cwd, args, {
+        timeoutMs: 15_000,
+        fallbackErrorMessage: "git worktree remove failed",
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`${commandLabel(args)} failed (cwd: ${input.cwd}): ${detail}`, {
+        cause: error,
+      });
+    }
   }
 
   async createBranch(input: GitCreateBranchInput): Promise<void> {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -336,8 +336,19 @@ export default function Sidebar() {
           cwd: threadProject.cwd,
           path: orphanedWorktreePath,
         });
-      } catch {
-        // Worktree deletion is best-effort and should not block thread deletion.
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error removing worktree.";
+        console.error("Failed to remove orphaned worktree after thread deletion", {
+          threadId,
+          projectCwd: threadProject.cwd,
+          worktreePath: orphanedWorktreePath,
+          error,
+        });
+        toastManager.add({
+          type: "error",
+          title: "Thread deleted, but worktree removal failed",
+          description: `Could not remove ${displayWorktreePath ?? orphanedWorktreePath}. ${message}`,
+        });
       }
     },
     [api, dispatch, removeWorktreeMutation, state.projects, state.threads],


### PR DESCRIPTION
## Summary
- add error wrapping in `GitCoreService.removeWorktree` to include command context (`git worktree remove`), `cwd`, and original failure details
- add a server integration test verifying worktree removal failures include command and path context in the thrown error message
- update sidebar thread-deletion flow to surface best-effort worktree cleanup failures via console error logging and a user-facing error toast

## Testing
- `apps/server/src/git.test.ts`: added `includes command context when worktree removal fails` to verify error message contains command label, cwd, and missing worktree path
- Not run: full project lint/test suite
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to error handling and user-facing notifications around best-effort cleanup, with no changes to core git command behavior beyond improved error messages.
> 
> **Overview**
> Worktree removal failures are now wrapped in `GitCoreService.removeWorktree` to include the attempted `git worktree remove` command, `cwd`, and underlying error details (with `cause`).
> 
> Adds a server integration test asserting this richer error context, and updates the sidebar thread-deletion flow to log details and show an error toast when best-effort orphaned worktree cleanup fails (without blocking thread deletion).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 077de88885477c694098079fba3f5bc4bdf2f94e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when removing worktrees, providing clearer context and surfaced messages.
  * Added a user-facing notification when automatic worktree removal fails after thread deletion, showing the affected path and error.

* **Tests**
  * Added a test verifying error context is included when worktree removal fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->