### PR TITLE
Force orphan worktree cleanup to remove dirty worktrees

### DIFF
--- a/apps/server/src/git.test.ts
+++ b/apps/server/src/git.test.ts
@@ -617,6 +617,32 @@ describe("git integration", () => {
       await removeGitWorktree({ cwd: tmp.path, path: wtPath });
       expect(existsSync(wtPath)).toBe(false);
     });
+
+    it("removeGitWorktree force removes a dirty worktree", async () => {
+      await using tmp = await makeTmpDir();
+      await initRepoWithCommit(tmp.path);
+
+      const wtPath = path.join(tmp.path, "wt-dirty-dir");
+      const currentBranch = (await listGitBranches({ cwd: tmp.path })).branches.find(
+        (b) => b.current,
+      )!.name;
+
+      await createGitWorktree({
+        cwd: tmp.path,
+        branch: currentBranch,
+        newBranch: "wt-dirty",
+        path: wtPath,
+      });
+      expect(existsSync(wtPath)).toBe(true);
+
+      await writeFile(path.join(wtPath, "README.md"), "dirty change\n");
+
+      await expect(removeGitWorktree({ cwd: tmp.path, path: wtPath })).rejects.toThrow();
+      expect(existsSync(wtPath)).toBe(true);
+
+      await removeGitWorktree({ cwd: tmp.path, path: wtPath, force: true });
+      expect(existsSync(wtPath)).toBe(false);
+    });
   });
 
   // ── Full flow: local branch checkout ──

--- a/apps/server/src/git.ts
+++ b/apps/server/src/git.ts
@@ -546,7 +546,11 @@ export class GitCoreService {
   }
 
   async removeWorktree(input: GitRemoveWorktreeInput): Promise<void> {
-    const args = ["worktree", "remove", input.path] as const;
+    const args = ["worktree", "remove"];
+    if (input.force) {
+      args.push("--force");
+    }
+    args.push(input.path);
     try {
       await executeGit(input.cwd, args, {
         timeoutMs: 15_000,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -331,6 +331,7 @@ export default function Sidebar() {
         await removeWorktreeMutation.mutateAsync({
           cwd: threadProject.cwd,
           path: orphanedWorktreePath,
+          force: true,
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : "Unknown error removing worktree.";

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -173,11 +173,11 @@ export function gitRemoveWorktreeMutationOptions(input: {
   queryClient: QueryClient;
 }) {
   return mutationOptions({
-    mutationFn: async ({ cwd, path }: { cwd: string; path: string }) => {
+    mutationFn: async ({ cwd, path, force }: { cwd: string; path: string; force?: boolean }) => {
       if (!input.api) {
         throw new Error("Git worktree removal is unavailable.");
       }
-      return input.api.git.removeWorktree({ cwd, path });
+      return input.api.git.removeWorktree({ cwd, path, force });
     },
     onSettled: async () => {
       await invalidateGitQueries(input.queryClient);

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -16,6 +16,7 @@ export const gitCreateWorktreeInputSchema = z.object({
 export const gitRemoveWorktreeInputSchema = z.object({
   cwd: z.string().min(1),
   path: z.string().min(1),
+  force: z.boolean().optional(),
 });
 
 export const gitCreateBranchInputSchema = z.object({


### PR DESCRIPTION
## Summary
- Add optional `force` support to git worktree removal in shared contracts and server git execution.
- Update orphaned worktree cleanup in the sidebar flow to call remove with `force: true`.
- Extend server git integration tests to cover dirty worktree behavior:
- verify non-forced removal fails when the worktree has uncommitted changes.
- verify forced removal succeeds and deletes the worktree directory.
- Thread the optional `force` flag through the web React Query mutation to the API call.

## Testing
- Added integration test: `removeGitWorktree force removes a dirty worktree` in `apps/server/src/git.test.ts`.
- Check included in test:
- dirty worktree removal without force throws.
- dirty worktree removal with force succeeds and directory no longer exists.
- Lint: Not run.
- Full test suite: Not run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses `git worktree remove --force`, which can discard uncommitted changes in the worktree; impact is limited to explicit cleanup paths and is covered by an integration test.
> 
> **Overview**
> Enables optional forced git worktree cleanup by threading a `force` flag through the shared contract, web mutation, and server execution so callers can pass `--force` to `git worktree remove`.
> 
> Updates the thread deletion/orphaned worktree cleanup flow in `Sidebar` to always attempt removal with `force: true`, and adds a server integration test covering the dirty-worktree behavior (non-forced removal fails; forced removal succeeds and deletes the directory).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d3263d69d1c534009f268aa34b86c07b2c78461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented forced worktree removal capability, allowing cleanup of worktrees with uncommitted changes when deleting threads.

* **Tests**
  * Added comprehensive test coverage for forced worktree removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->