### PR TITLE
Mark selected thread as visited in web store

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -68,6 +68,15 @@ function EventRouter() {
   }, [activeThreadId, api, dispatch, queryClient]);
 
   useEffect(() => {
+    if (!activeThreadId) return;
+    dispatch({
+      type: "MARK_THREAD_VISITED",
+      threadId: activeThreadId,
+      visitedAt: new Date().toISOString(),
+    });
+  }, [activeThreadId, dispatch]);
+
+  useEffect(() => {
     if (!api) return;
     return api.terminal.onEvent((event) => {
       dispatch({

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -815,6 +815,24 @@ describe("store reducer thread continuity", () => {
     expect(next.threads[0]?.lastVisitedAt).toBe(completedAt);
   });
 
+  it("marks a thread as visited when selected", () => {
+    const state = makeState(
+      makeThread({
+        latestTurnCompletedAt: "2026-02-08T10:00:10.000Z",
+        lastVisitedAt: "2026-02-08T10:00:00.000Z",
+      }),
+    );
+
+    const nextVisitedAt = "2026-02-08T10:00:20.000Z";
+    const next = reducer(state, {
+      type: "MARK_THREAD_VISITED",
+      threadId: "thread-local-1",
+      visitedAt: nextVisitedAt,
+    });
+
+    expect(next.threads[0]?.lastVisitedAt).toBe(nextVisitedAt);
+  });
+
   it("reverts thread state to a checkpoint snapshot", () => {
     const state = makeState(
       makeThread({

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -105,6 +105,7 @@ type Action =
       branch: string | null;
       worktreePath: string | null;
     }
+  | { type: "MARK_THREAD_VISITED"; threadId: string; visitedAt?: string }
   | { type: "SET_RUNTIME_MODE"; mode: RuntimeMode }
   | { type: "DELETE_THREAD"; threadId: string };
 
@@ -1138,6 +1139,17 @@ export function reducer(state: AppState, action: Action): AppState {
             ...(cwdChanged ? { session: null } : {}),
           };
         }),
+      };
+    }
+
+    case "MARK_THREAD_VISITED": {
+      const visitedAt = action.visitedAt ?? new Date().toISOString();
+      return {
+        ...state,
+        threads: updateThread(state.threads, action.threadId, (t) => ({
+          ...t,
+          lastVisitedAt: visitedAt,
+        })),
       };
     }
 


### PR DESCRIPTION
## Summary
- dispatch `MARK_THREAD_VISITED` whenever `activeThreadId` changes in `apps/web/src/routes/__root.tsx`
- add reducer support for `MARK_THREAD_VISITED` in `apps/web/src/store.ts`, defaulting `visitedAt` to current ISO time when omitted
- add a reducer test in `apps/web/src/store.test.ts` to verify selecting a thread updates `lastVisitedAt`

## Testing
- `apps/web/src/store.test.ts`: added `marks a thread as visited when selected` to assert `lastVisitedAt` is updated to the provided timestamp
- Lint: Not run
- Full test suite: Not run
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized state-update change affecting only thread metadata (`lastVisitedAt`) plus a new reducer test; no auth/security or data persistence format changes.
> 
> **Overview**
> Updates the web UI to **record thread visit time on selection** by dispatching `MARK_THREAD_VISITED` whenever `activeThreadId` changes.
> 
> Adds reducer support for `MARK_THREAD_VISITED` to update a thread’s `lastVisitedAt` (defaulting to the current ISO timestamp when omitted), and introduces a unit test ensuring selecting a thread updates `lastVisitedAt` as expected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd9ef00636c70e630c711619b7745796518d5254. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Threads now automatically record when they are last visited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->