### PR TITLE
Tighten chat auto-tail to true bottom position

### DIFF
--- a/apps/web/src/chat-scroll.test.ts
+++ b/apps/web/src/chat-scroll.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { AUTO_SCROLL_BOTTOM_THRESHOLD_PX, isScrollContainerNearBottom } from "./chat-scroll";
+import { AUTO_SCROLL_BOTTOM_EPSILON_PX, isScrollContainerAtBottom } from "./chat-scroll";
 
-describe("isScrollContainerNearBottom", () => {
+describe("isScrollContainerAtBottom", () => {
   it("returns true when already at bottom", () => {
     expect(
-      isScrollContainerNearBottom({
+      isScrollContainerAtBottom({
         scrollTop: 600,
         clientHeight: 400,
         scrollHeight: 1_000,
@@ -13,31 +13,31 @@ describe("isScrollContainerNearBottom", () => {
     ).toBe(true);
   });
 
-  it("returns true when within the auto-scroll threshold", () => {
+  it("returns true when within the bottom epsilon", () => {
     expect(
-      isScrollContainerNearBottom({
-        scrollTop: 540,
+      isScrollContainerAtBottom({
+        scrollTop: 599,
         clientHeight: 400,
         scrollHeight: 1_000,
       }),
     ).toBe(true);
   });
 
-  it("returns false when the user is meaningfully above the bottom", () => {
+  it("returns false when the user is above the epsilon", () => {
     expect(
-      isScrollContainerNearBottom({
-        scrollTop: 520,
+      isScrollContainerAtBottom({
+        scrollTop: 597,
         clientHeight: 400,
         scrollHeight: 1_000,
       }),
     ).toBe(false);
   });
 
-  it("clamps negative thresholds to zero", () => {
+  it("clamps negative epsilons to zero", () => {
     expect(
-      isScrollContainerNearBottom(
+      isScrollContainerAtBottom(
         {
-          scrollTop: 539,
+          scrollTop: 599,
           clientHeight: 400,
           scrollHeight: 1_000,
         },
@@ -46,17 +46,27 @@ describe("isScrollContainerNearBottom", () => {
     ).toBe(false);
   });
 
-  it("falls back to the default threshold for non-finite values", () => {
+  it("falls back to the default epsilon for non-finite values", () => {
     expect(
-      isScrollContainerNearBottom(
+      isScrollContainerAtBottom(
         {
-          scrollTop: 540,
+          scrollTop: 599,
           clientHeight: 400,
           scrollHeight: 1_000,
         },
         Number.NaN,
       ),
     ).toBe(true);
-    expect(AUTO_SCROLL_BOTTOM_THRESHOLD_PX).toBe(64);
+    expect(AUTO_SCROLL_BOTTOM_EPSILON_PX).toBe(2);
+  });
+
+  it("treats overscrolled values as bottom", () => {
+    expect(
+      isScrollContainerAtBottom({
+        scrollTop: 610,
+        clientHeight: 400,
+        scrollHeight: 1_000,
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/chat-scroll.ts
+++ b/apps/web/src/chat-scroll.ts
@@ -1,4 +1,4 @@
-export const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 64;
+export const AUTO_SCROLL_BOTTOM_EPSILON_PX = 2;
 
 interface ScrollPosition {
   scrollTop: number;
@@ -6,19 +6,19 @@ interface ScrollPosition {
   scrollHeight: number;
 }
 
-export function isScrollContainerNearBottom(
+export function isScrollContainerAtBottom(
   position: ScrollPosition,
-  thresholdPx = AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
+  epsilonPx = AUTO_SCROLL_BOTTOM_EPSILON_PX,
 ): boolean {
-  const threshold = Number.isFinite(thresholdPx)
-    ? Math.max(0, thresholdPx)
-    : AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
+  const epsilon = Number.isFinite(epsilonPx)
+    ? Math.max(0, epsilonPx)
+    : AUTO_SCROLL_BOTTOM_EPSILON_PX;
 
   const { scrollTop, clientHeight, scrollHeight } = position;
   if (![scrollTop, clientHeight, scrollHeight].every(Number.isFinite)) {
     return true;
   }
 
-  const distanceFromBottom = scrollHeight - clientHeight - scrollTop;
-  return distanceFromBottom <= threshold;
+  const distanceFromBottom = Math.max(0, scrollHeight - clientHeight - scrollTop);
+  return distanceFromBottom <= epsilon;
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -17,6 +17,8 @@ import {
   type DragEvent,
   type FormEvent,
   type KeyboardEvent,
+  type PointerEvent,
+  type TouchEvent,
   type WheelEvent,
   memo,
   type RefObject,
@@ -404,7 +406,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const messagesScrollRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
   const lastKnownScrollTopRef = useRef(0);
-  const lastKnownScrollHeightRef = useRef(0);
+  const isPointerScrollActiveRef = useRef(false);
+  const lastTouchClientYRef = useRef<number | null>(null);
+  const pendingUserScrollUpIntentRef = useRef(false);
   const pendingAutoScrollFrameRef = useRef<number | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const composerCommandInputRef = useRef<HTMLInputElement>(null);
@@ -1105,7 +1109,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (!scrollContainer) return;
     scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior });
     lastKnownScrollTopRef.current = scrollContainer.scrollTop;
-    lastKnownScrollHeightRef.current = scrollContainer.scrollHeight;
     shouldAutoScrollRef.current = true;
   }, []);
   const requestAutoTailToBottom = useCallback(() => {
@@ -1120,28 +1123,59 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const scrollContainer = messagesScrollRef.current;
     if (!scrollContainer) return;
     const currentScrollTop = scrollContainer.scrollTop;
-    const currentScrollHeight = scrollContainer.scrollHeight;
     const atBottom = isScrollContainerAtBottom(scrollContainer);
 
-    if (atBottom) {
+    if (!shouldAutoScrollRef.current && atBottom) {
       shouldAutoScrollRef.current = true;
-    } else if (shouldAutoScrollRef.current) {
-      // While tailing, only relinquish control when the user scrolls upward.
+      pendingUserScrollUpIntentRef.current = false;
+    } else if (shouldAutoScrollRef.current && pendingUserScrollUpIntentRef.current) {
       const scrolledUp = currentScrollTop < lastKnownScrollTopRef.current - 1;
-      const contentHeightChanged =
-        Math.abs(currentScrollHeight - lastKnownScrollHeightRef.current) > 1;
-      if (scrolledUp && !contentHeightChanged) {
+      if (scrolledUp) {
+        shouldAutoScrollRef.current = false;
+      }
+      pendingUserScrollUpIntentRef.current = false;
+    } else if (shouldAutoScrollRef.current && isPointerScrollActiveRef.current) {
+      // Pointer-driven upward scroll means user takes control.
+      const scrolledUp = currentScrollTop < lastKnownScrollTopRef.current - 1;
+      if (scrolledUp) {
         shouldAutoScrollRef.current = false;
       }
     }
 
     lastKnownScrollTopRef.current = currentScrollTop;
-    lastKnownScrollHeightRef.current = currentScrollHeight;
   }, []);
   const onMessagesWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
+    // Wheel-up indicates user intent to move away from bottom.
     if (event.deltaY < 0) {
-      shouldAutoScrollRef.current = false;
+      pendingUserScrollUpIntentRef.current = true;
     }
+  }, []);
+  const onMessagesPointerDown = useCallback((_event: PointerEvent<HTMLDivElement>) => {
+    isPointerScrollActiveRef.current = true;
+  }, []);
+  const onMessagesPointerUp = useCallback((_event: PointerEvent<HTMLDivElement>) => {
+    isPointerScrollActiveRef.current = false;
+  }, []);
+  const onMessagesPointerCancel = useCallback((_event: PointerEvent<HTMLDivElement>) => {
+    isPointerScrollActiveRef.current = false;
+  }, []);
+  const onMessagesTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    const touch = event.touches[0];
+    if (!touch) return;
+    lastTouchClientYRef.current = touch.clientY;
+  }, []);
+  const onMessagesTouchMove = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    const touch = event.touches[0];
+    if (!touch) return;
+    const previousTouchY = lastTouchClientYRef.current;
+    if (previousTouchY !== null && touch.clientY > previousTouchY + 1) {
+      // Finger moved downward => user intends to scroll content upward.
+      pendingUserScrollUpIntentRef.current = true;
+    }
+    lastTouchClientYRef.current = touch.clientY;
+  }, []);
+  const onMessagesTouchEnd = useCallback((_event: TouchEvent<HTMLDivElement>) => {
+    lastTouchClientYRef.current = null;
   }, []);
   useLayoutEffect(() => {
     if (!activeThread?.id) return;
@@ -2089,6 +2123,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
         className="min-h-0 flex-1 overflow-y-auto px-5 py-4"
         onScroll={onMessagesScroll}
         onWheel={onMessagesWheel}
+        onPointerDown={onMessagesPointerDown}
+        onPointerUp={onMessagesPointerUp}
+        onPointerCancel={onMessagesPointerCancel}
+        onTouchStart={onMessagesTouchStart}
+        onTouchMove={onMessagesTouchMove}
+        onTouchEnd={onMessagesTouchEnd}
+        onTouchCancel={onMessagesTouchEnd}
       >
         <MessagesTimeline
           hasMessages={activeThread.messages.length > 0}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -17,6 +17,7 @@ import {
   type DragEvent,
   type FormEvent,
   type KeyboardEvent,
+  type WheelEvent,
   memo,
   type RefObject,
   useCallback,
@@ -402,6 +403,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   >(() => readLastInvokedScriptByProjectFromStorage());
   const messagesScrollRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
+  const lastKnownScrollTopRef = useRef(0);
+  const lastKnownScrollHeightRef = useRef(0);
   const pendingAutoScrollFrameRef = useRef<number | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const composerCommandInputRef = useRef<HTMLInputElement>(null);
@@ -1101,6 +1104,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const scrollContainer = messagesScrollRef.current;
     if (!scrollContainer) return;
     scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior });
+    lastKnownScrollTopRef.current = scrollContainer.scrollTop;
+    lastKnownScrollHeightRef.current = scrollContainer.scrollHeight;
     shouldAutoScrollRef.current = true;
   }, []);
   const requestAutoTailToBottom = useCallback(() => {
@@ -1114,7 +1119,29 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const onMessagesScroll = useCallback(() => {
     const scrollContainer = messagesScrollRef.current;
     if (!scrollContainer) return;
-    shouldAutoScrollRef.current = isScrollContainerAtBottom(scrollContainer);
+    const currentScrollTop = scrollContainer.scrollTop;
+    const currentScrollHeight = scrollContainer.scrollHeight;
+    const atBottom = isScrollContainerAtBottom(scrollContainer);
+
+    if (atBottom) {
+      shouldAutoScrollRef.current = true;
+    } else if (shouldAutoScrollRef.current) {
+      // While tailing, only relinquish control when the user scrolls upward.
+      const scrolledUp = currentScrollTop < lastKnownScrollTopRef.current - 1;
+      const contentHeightChanged =
+        Math.abs(currentScrollHeight - lastKnownScrollHeightRef.current) > 1;
+      if (scrolledUp && !contentHeightChanged) {
+        shouldAutoScrollRef.current = false;
+      }
+    }
+
+    lastKnownScrollTopRef.current = currentScrollTop;
+    lastKnownScrollHeightRef.current = currentScrollHeight;
+  }, []);
+  const onMessagesWheel = useCallback((event: WheelEvent<HTMLDivElement>) => {
+    if (event.deltaY < 0) {
+      shouldAutoScrollRef.current = false;
+    }
   }, []);
   useLayoutEffect(() => {
     if (!activeThread?.id) return;
@@ -2061,6 +2088,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         ref={messagesScrollRef}
         className="min-h-0 flex-1 overflow-y-auto px-5 py-4"
         onScroll={onMessagesScroll}
+        onWheel={onMessagesWheel}
       >
         <MessagesTimeline
           hasMessages={activeThread.messages.length > 0}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -402,6 +402,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   >(() => readLastInvokedScriptByProjectFromStorage());
   const messagesScrollRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
+  const pendingAutoScrollFrameRef = useRef<number | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const composerCommandInputRef = useRef<HTMLInputElement>(null);
   const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
@@ -1102,6 +1103,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
     scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior });
     shouldAutoScrollRef.current = true;
   }, []);
+  const requestAutoTailToBottom = useCallback(() => {
+    if (pendingAutoScrollFrameRef.current !== null) return;
+    pendingAutoScrollFrameRef.current = window.requestAnimationFrame(() => {
+      pendingAutoScrollFrameRef.current = null;
+      if (!shouldAutoScrollRef.current) return;
+      scrollMessagesToBottom();
+    });
+  }, [scrollMessagesToBottom]);
   const onMessagesScroll = useCallback(() => {
     const scrollContainer = messagesScrollRef.current;
     if (!scrollContainer) return;
@@ -1113,8 +1122,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
   }, [activeThread?.id, scrollMessagesToBottom]);
   useLayoutEffect(() => {
     if (!shouldAutoScrollRef.current) return;
-    scrollMessagesToBottom();
-  }, [activeThread?.messages, workLogCount, scrollMessagesToBottom]);
+    requestAutoTailToBottom();
+  }, [activeThread?.messages, workLogCount, requestAutoTailToBottom]);
+  useEffect(
+    () => () => {
+      if (pendingAutoScrollFrameRef.current === null) return;
+      window.cancelAnimationFrame(pendingAutoScrollFrameRef.current);
+      pendingAutoScrollFrameRef.current = null;
+    },
+    [],
+  );
 
   useEffect(() => {
     setExpandedWorkGroups({});

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -61,7 +61,7 @@ import {
   formatElapsed,
   formatTimestamp,
 } from "../session-logic";
-import { isScrollContainerNearBottom } from "../chat-scroll";
+import { isScrollContainerAtBottom } from "../chat-scroll";
 import { useStore } from "../store";
 import { truncateTitle } from "../truncateTitle";
 import {
@@ -1094,8 +1094,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
   }, [lastInvokedScriptByProjectId]);
 
-  // Auto-scroll on new messages
-  const messageCount = activeThread?.messages.length ?? 0;
+  // Auto-tail while the user stays at the bottom.
   const workLogCount = workLogEntries.length;
   const scrollMessagesToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const scrollContainer = messagesScrollRef.current;
@@ -1106,21 +1105,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const onMessagesScroll = useCallback(() => {
     const scrollContainer = messagesScrollRef.current;
     if (!scrollContainer) return;
-    shouldAutoScrollRef.current = isScrollContainerNearBottom(scrollContainer);
+    shouldAutoScrollRef.current = isScrollContainerAtBottom(scrollContainer);
   }, []);
   useLayoutEffect(() => {
     if (!activeThread?.id) return;
     scrollMessagesToBottom();
   }, [activeThread?.id, scrollMessagesToBottom]);
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!shouldAutoScrollRef.current) return;
-    scrollMessagesToBottom("smooth");
-  }, [messageCount, scrollMessagesToBottom]);
-  useEffect(() => {
-    if (phase !== "running") return;
-    if (!shouldAutoScrollRef.current) return;
-    scrollMessagesToBottom("smooth");
-  }, [phase, workLogCount, scrollMessagesToBottom]);
+    scrollMessagesToBottom();
+  }, [activeThread?.messages, workLogCount, scrollMessagesToBottom]);
 
   useEffect(() => {
     setExpandedWorkGroups({});


### PR DESCRIPTION
## Summary
- Replace `isScrollContainerNearBottom` with `isScrollContainerAtBottom` to require true bottom alignment semantics.
- Reduce auto-tail tolerance from `64px` to a `2px` epsilon and clamp overscroll distance to `0`.
- Update `ChatView` scrolling behavior to auto-tail only while the user is at bottom, using layout-timed updates tied to message/worklog changes.
- Refresh chat scroll unit tests to match new naming/behavior, including overscroll and epsilon edge cases.

## Testing
- Updated unit tests in `apps/web/src/chat-scroll.test.ts` cover: exact bottom, within epsilon, above epsilon, negative epsilon clamp, non-finite fallback, and overscroll handling.
- Not run: `pnpm --filter web test`
- Not run: project lint scripts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/codething-mvp/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavioral change in the core chat scrolling UX; risk is mainly regressions across input types (wheel/touch/pointer) and timing-related auto-scroll edge cases.
> 
> **Overview**
> Chat auto-tail is tightened from a “near bottom” threshold to a true-bottom check via `isScrollContainerAtBottom`, reducing tolerance to a `2px` epsilon and clamping overscroll distance to `0`.
> 
> `ChatView` now tails using a `requestAnimationFrame`-debounced layout effect tied to message/worklog changes, and disables auto-tail when wheel/touch/pointer input indicates the user is scrolling up (re-enabling when returning to bottom). Tests are updated/renamed to cover epsilon edge cases and overscroll behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3031dfd122686f67e34fa6a2b9ce69b3eee6ccdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-scroll detection with finer bottom sensitivity; overscrolled positions are treated as at-bottom and non-finite values handled correctly.

* **New Features**
  * Staged "auto-tail" auto-scroll using requestAnimationFrame to debounce scrolling.
  * Auto-scroll now respects user intent across wheel/pointer/touch (disabled when user scrolls up) and pending auto-scrolls are cancelled on unmount.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->