### PR TITLE
Scope DiffPanel patch cache keys by theme

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -29,13 +29,19 @@ type RenderablePatch =
       reason: string;
     };
 
-function getRenderablePatch(patch: string | undefined): RenderablePatch | null {
+function getRenderablePatch(
+  patch: string | undefined,
+  cacheScope = "diff-panel",
+): RenderablePatch | null {
   if (!patch) return null;
   const normalizedPatch = patch.trim();
   if (normalizedPatch.length === 0) return null;
 
   try {
-    const parsedPatches = parsePatchFiles(normalizedPatch, buildPatchCacheKey(normalizedPatch));
+    const parsedPatches = parsePatchFiles(
+      normalizedPatch,
+      buildPatchCacheKey(normalizedPatch, cacheScope),
+    );
     const files = parsedPatches.flatMap((parsedPatch) => parsedPatch.files);
     if (files.length > 0) {
       return { kind: "files", files };
@@ -190,7 +196,10 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const selectedPatch = selectedTurn ? selectedTurnCheckpointDiff : conversationCheckpointDiff;
   const hasResolvedPatch = typeof selectedPatch === "string";
   const hasNoNetChanges = hasResolvedPatch && selectedPatch.trim().length === 0;
-  const renderablePatch = useMemo(() => getRenderablePatch(selectedPatch), [selectedPatch]);
+  const renderablePatch = useMemo(
+    () => getRenderablePatch(selectedPatch, `diff-panel:${resolvedTheme}`),
+    [resolvedTheme, selectedPatch],
+  );
   const renderableFiles = useMemo(() => {
     if (!renderablePatch || renderablePatch.kind !== "files") {
       return [];

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -20,4 +20,12 @@ describe("buildPatchCacheKey", () => {
 
     expect(buildPatchCacheKey(before)).not.toBe(buildPatchCacheKey(after));
   });
+
+  it("changes when cache scope changes", () => {
+    const patch = "diff --git a/a.ts b/a.ts\n+console.log('hello')";
+
+    expect(buildPatchCacheKey(patch, "diff-panel:light")).not.toBe(
+      buildPatchCacheKey(patch, "diff-panel:dark"),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- update `DiffPanel` patch parsing to pass a cache scope into `buildPatchCacheKey`
- scope cache keys by resolved theme (`diff-panel:light` / `diff-panel:dark`) to avoid cross-theme reuse
- keep `getRenderablePatch` behavior unchanged aside from configurable cache scoping
- add a unit test confirming `buildPatchCacheKey` changes when cache scope changes

## Testing
- added test: `apps/web/src/lib/diffRendering.test.ts` verifies different cache scopes produce different keys
- Not run: full lint/test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust diff parsing cache-key scoping to avoid cross-theme reuse, plus a small unit test; no data/auth flows affected.
> 
> **Overview**
> `DiffPanel` now scopes patch parsing cache keys by the resolved theme (e.g. `diff-panel:light` vs `diff-panel:dark`) by threading a `cacheScope` into `getRenderablePatch()` and `buildPatchCacheKey()` usage, preventing cached diff artifacts from being reused across themes.
> 
> Adds a unit test ensuring `buildPatchCacheKey()` output changes when the provided scope changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a567ba3d59c58819133b30b38e268ef72d1f543. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope DiffPanel patch cache keys by theme and modify `apps/web/src/components/DiffPanel.tsx` to pass `cacheScope` to `getRenderablePatch`
> Add `cacheScope` to `getRenderablePatch` and include `resolvedTheme` in the DiffPanel memo to derive theme-scoped patch cache keys; add a test for `buildPatchCacheKey` scope variance in [diffRendering.test.ts](https://github.com/pingdotgg/t3code/pull/94/files#diff-8c55a200646c0ef6b427f477edc4512c06248c93c6f94265a86af423201468d6).
>
> #### 📍Where to Start
> Start with the `DiffPanel` `useMemo` for `renderablePatch` in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/94/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) and then review `getRenderablePatch` usage of `cacheScope`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a567ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced diff panel rendering to properly account for theme changes, improving display consistency when switching between light and dark themes.

* **Tests**
  * Added test coverage for theme-scoped caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->