### PR TITLE
Add configurable assistant delivery mode with buffered-by-default ingestion

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@
 - [x] "Response" bar should ONLY appear above the FINAL message in a series
 - [x] Reduce noise of tool calls (combine "command run" and "command completed", make tool calls a "box" with limited # of calls shown at a time, etc)
 - [x] Insta focus input on new thread creation
-- [ ] Disable "streaming" (wait until whole paragraph/step finishes before showing it
+- [x] Disable "streaming" (wait until whole paragraph/step finishes before showing it
 - [x] Making new thread should auto-focus input box
 - [x] Threads should be scrolled to bottom on open (they currently start near top and "scroll down" after rendering, it's jank)
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,4 +22,4 @@
 ## Bigger things
 
 - [ ] Queueing messages
-- [ ] External runners (i.e. running the cli on a mac mini)
+- [x] External runners (i.e. running the cli on a mac mini)

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2,6 +2,7 @@ import type { ProviderRuntimeEvent } from "@t3tools/contracts";
 import {
   CommandId,
   EventId,
+  MessageId,
   ProjectId,
   ProviderItemId,
   ProviderSessionId,
@@ -33,6 +34,7 @@ const asSessionId = (value: string): ProviderSessionId => ProviderSessionId.make
 const asProviderTurnId = (value: string): ProviderTurnId => ProviderTurnId.makeUnsafe(value);
 const asItemId = (value: string): ProviderItemId => ProviderItemId.makeUnsafe(value);
 const asEventId = (value: string): EventId => EventId.makeUnsafe(value);
+const asMessageId = (value: string): MessageId => MessageId.makeUnsafe(value);
 
 function createProviderServiceHarness() {
   const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
@@ -256,6 +258,148 @@ describe("ProviderRuntimeIngestion", () => {
     const message = thread.messages.find((entry) => entry.id === "assistant:item-1");
     expect(message?.text).toBe("hello world");
     expect(message?.streaming).toBe(false);
+  });
+
+  it("buffers assistant deltas by default until completion", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-buffered"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-buffered"),
+    });
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" && thread.session?.activeTurnId === "turn-buffered",
+    );
+
+    harness.emit({
+      type: "message.delta",
+      eventId: asEventId("evt-message-delta-buffered"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-buffered"),
+      itemId: asItemId("item-buffered"),
+      delta: "buffer me",
+    });
+
+    await Effect.runPromise(Effect.sleep("30 millis"));
+    const midReadModel = await Effect.runPromise(harness.engine.getReadModel());
+    const midThread = midReadModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+    expect(midThread?.messages.some((message) => message.id === "assistant:item-buffered")).toBe(
+      false,
+    );
+
+    harness.emit({
+      type: "message.completed",
+      eventId: asEventId("evt-message-completed-buffered"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-buffered"),
+      itemId: asItemId("item-buffered"),
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.messages.some((message) => message.id === "assistant:item-buffered" && !message.streaming),
+    );
+    const message = thread.messages.find((entry) => entry.id === "assistant:item-buffered");
+    expect(message?.text).toBe("buffer me");
+    expect(message?.streaming).toBe(false);
+  });
+
+  it("streams assistant deltas when thread.turn.start requests streaming mode", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-streaming-mode"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("message-streaming-mode"),
+          role: "user",
+          text: "stream please",
+          attachments: [],
+        },
+        assistantDeliveryMode: "streaming",
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(Effect.sleep("30 millis"));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-mode"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-streaming-mode"),
+    });
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" &&
+        thread.session?.activeTurnId === "turn-streaming-mode",
+    );
+
+    harness.emit({
+      type: "message.delta",
+      eventId: asEventId("evt-message-delta-streaming-mode"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-streaming-mode"),
+      itemId: asItemId("item-streaming-mode"),
+      delta: "hello live",
+    });
+
+    const liveThread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.messages.some(
+          (message) =>
+            message.id === "assistant:item-streaming-mode" &&
+            message.streaming &&
+            message.text === "hello live",
+        ),
+    );
+    const liveMessage = liveThread.messages.find(
+      (entry) => entry.id === "assistant:item-streaming-mode",
+    );
+    expect(liveMessage?.streaming).toBe(true);
+
+    harness.emit({
+      type: "message.completed",
+      eventId: asEventId("evt-message-completed-streaming-mode"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-streaming-mode"),
+      itemId: asItemId("item-streaming-mode"),
+    });
+
+    const finalThread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.messages.some(
+          (message) => message.id === "assistant:item-streaming-mode" && !message.streaming,
+        ),
+    );
+    const finalMessage = finalThread.messages.find(
+      (entry) => entry.id === "assistant:item-streaming-mode",
+    );
+    expect(finalMessage?.text).toBe("hello live");
+    expect(finalMessage?.streaming).toBe(false);
   });
 
   it("does not duplicate assistant completion when message.completed is followed by turn.completed", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -402,6 +402,59 @@ describe("ProviderRuntimeIngestion", () => {
     expect(finalMessage?.streaming).toBe(false);
   });
 
+  it("spills oversized buffered deltas and still finalizes full assistant text", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    const oversizedText = "x".repeat(40_000);
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-buffer-spill"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-buffer-spill"),
+    });
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" &&
+        thread.session?.activeTurnId === "turn-buffer-spill",
+    );
+
+    harness.emit({
+      type: "message.delta",
+      eventId: asEventId("evt-message-delta-buffer-spill"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-buffer-spill"),
+      itemId: asItemId("item-buffer-spill"),
+      delta: oversizedText,
+    });
+    harness.emit({
+      type: "message.completed",
+      eventId: asEventId("evt-message-completed-buffer-spill"),
+      provider: "codex",
+      sessionId: asSessionId("sess-1"),
+      createdAt: now,
+      turnId: asProviderTurnId("turn-buffer-spill"),
+      itemId: asItemId("item-buffer-spill"),
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.messages.some(
+          (message) => message.id === "assistant:item-buffer-spill" && !message.streaming,
+        ),
+    );
+    const message = thread.messages.find((entry) => entry.id === "assistant:item-buffer-spill");
+    expect(message?.text.length).toBe(oversizedText.length);
+    expect(message?.text).toBe(oversizedText);
+    expect(message?.streaming).toBe(false);
+  });
+
   it("does not duplicate assistant completion when message.completed is followed by turn.completed", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -288,7 +288,6 @@ const make = Effect.gen(function* () {
         threadId: input.threadId,
         messageId: input.messageId,
         ...(input.turnId ? { turnId: input.turnId } : {}),
-        text: "",
         createdAt: input.createdAt,
       });
       yield* clearAssistantMessageState(input.messageId);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -491,7 +491,7 @@ const make = Effect.gen(function* () {
         const assistantDeliveryMode = yield* resolveAssistantDeliveryModeForMessage({
           threadId: thread.id,
           sessionId: event.sessionId,
-          turnId,
+          ...(turnId ? { turnId } : {}),
           messageId: assistantMessageId,
         });
         yield* rememberAssistantDeliveryModeForMessage(assistantMessageId, assistantDeliveryMode);
@@ -520,7 +520,7 @@ const make = Effect.gen(function* () {
         const assistantDeliveryMode = yield* resolveAssistantDeliveryModeForMessage({
           threadId: thread.id,
           sessionId: event.sessionId,
-          turnId,
+          ...(turnId ? { turnId } : {}),
           messageId: assistantMessageId,
         });
         yield* rememberAssistantDeliveryModeForMessage(assistantMessageId, assistantDeliveryMode);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -237,7 +237,7 @@ const make = Effect.gen(function* () {
             return "";
           }
 
-          // Safety valve: spill full buffered text as a persisted assistant delta to cap memory.
+          // Safety valve: flush full buffered text as an assistant delta to cap memory.
           yield* Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
           return nextText;
         }),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -10,7 +10,7 @@ import {
   type ProviderRuntimeEvent,
   type ProviderSessionId,
 } from "@t3tools/contracts";
-import { Cache, Cause, Duration, Effect, Layer, Option, Queue, Stream } from "effect";
+import { Cache, Cause, Duration, Effect, Layer, Option, Queue, Ref, Stream } from "effect";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
@@ -22,15 +22,10 @@ import {
 const providerTurnKey = (sessionId: ProviderSessionId, turnId: TurnId) => `${sessionId}:${turnId}`;
 const providerCommandId = (event: ProviderRuntimeEvent, tag: string): CommandId =>
   CommandId.makeUnsafe(`provider:${event.eventId}:${tag}:${crypto.randomUUID()}`);
+
 const DEFAULT_ASSISTANT_DELIVERY_MODE: AssistantDeliveryMode = "buffered";
 const TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY = 10_000;
 const TURN_MESSAGE_IDS_BY_TURN_TTL = Duration.minutes(120);
-const TURN_DELIVERY_MODE_BY_TURN_CACHE_CAPACITY = 10_000;
-const TURN_DELIVERY_MODE_BY_TURN_TTL = Duration.minutes(120);
-const PENDING_DELIVERY_MODE_BY_THREAD_CACHE_CAPACITY = 10_000;
-const PENDING_DELIVERY_MODE_BY_THREAD_TTL = Duration.minutes(30);
-const MESSAGE_DELIVERY_MODE_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
-const MESSAGE_DELIVERY_MODE_BY_MESSAGE_ID_TTL = Duration.minutes(120);
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
 
@@ -115,6 +110,7 @@ function runtimeEventToActivities(
         },
       ];
     }
+
     case "tool.completed": {
       return [
         {
@@ -131,6 +127,7 @@ function runtimeEventToActivities(
         },
       ];
     }
+
     case "tool.started": {
       return [
         {
@@ -157,26 +154,16 @@ const make = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const providerService = yield* ProviderService;
 
+  const assistantDeliveryModeRef = yield* Ref.make<AssistantDeliveryMode>(
+    DEFAULT_ASSISTANT_DELIVERY_MODE,
+  );
+
   const turnMessageIdsByTurnKey = yield* Cache.make<string, Set<MessageId>>({
     capacity: TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY,
     timeToLive: TURN_MESSAGE_IDS_BY_TURN_TTL,
     lookup: () => Effect.succeed(new Set<MessageId>()),
   });
-  const assistantDeliveryModeByTurnKey = yield* Cache.make<string, AssistantDeliveryMode>({
-    capacity: TURN_DELIVERY_MODE_BY_TURN_CACHE_CAPACITY,
-    timeToLive: TURN_DELIVERY_MODE_BY_TURN_TTL,
-    lookup: () => Effect.succeed(DEFAULT_ASSISTANT_DELIVERY_MODE),
-  });
-  const pendingAssistantDeliveryModeByThreadId = yield* Cache.make<ThreadId, AssistantDeliveryMode>({
-    capacity: PENDING_DELIVERY_MODE_BY_THREAD_CACHE_CAPACITY,
-    timeToLive: PENDING_DELIVERY_MODE_BY_THREAD_TTL,
-    lookup: () => Effect.succeed(DEFAULT_ASSISTANT_DELIVERY_MODE),
-  });
-  const assistantDeliveryModeByMessageId = yield* Cache.make<MessageId, AssistantDeliveryMode>({
-    capacity: MESSAGE_DELIVERY_MODE_BY_MESSAGE_ID_CACHE_CAPACITY,
-    timeToLive: MESSAGE_DELIVERY_MODE_BY_MESSAGE_ID_TTL,
-    lookup: () => Effect.succeed(DEFAULT_ASSISTANT_DELIVERY_MODE),
-  });
+
   const bufferedAssistantTextByMessageId = yield* Cache.make<MessageId, string>({
     capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
     timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
@@ -236,45 +223,6 @@ const make = Effect.gen(function* () {
   const clearAssistantMessageIdsForTurn = (sessionId: ProviderSessionId, turnId: TurnId) =>
     Cache.invalidate(turnMessageIdsByTurnKey, providerTurnKey(sessionId, turnId));
 
-  const rememberAssistantDeliveryModeForTurn = (
-    sessionId: ProviderSessionId,
-    turnId: TurnId,
-    assistantDeliveryMode: AssistantDeliveryMode,
-  ) =>
-    Cache.set(
-      assistantDeliveryModeByTurnKey,
-      providerTurnKey(sessionId, turnId),
-      assistantDeliveryMode,
-    );
-
-  const clearAssistantDeliveryModeForTurn = (sessionId: ProviderSessionId, turnId: TurnId) =>
-    Cache.invalidate(assistantDeliveryModeByTurnKey, providerTurnKey(sessionId, turnId));
-
-  const rememberPendingAssistantDeliveryModeForThread = (
-    threadId: ThreadId,
-    assistantDeliveryMode: AssistantDeliveryMode,
-  ) => Cache.set(pendingAssistantDeliveryModeByThreadId, threadId, assistantDeliveryMode);
-
-  const takePendingAssistantDeliveryModeForThread = (threadId: ThreadId) =>
-    Cache.getOption(pendingAssistantDeliveryModeByThreadId, threadId).pipe(
-      Effect.flatMap((assistantDeliveryMode) =>
-        Cache.invalidate(pendingAssistantDeliveryModeByThreadId, threadId).pipe(
-          Effect.as(assistantDeliveryMode),
-        ),
-      ),
-    );
-
-  const clearPendingAssistantDeliveryModeForThread = (threadId: ThreadId) =>
-    Cache.invalidate(pendingAssistantDeliveryModeByThreadId, threadId);
-
-  const rememberAssistantDeliveryModeForMessage = (
-    messageId: MessageId,
-    assistantDeliveryMode: AssistantDeliveryMode,
-  ) => Cache.set(assistantDeliveryModeByMessageId, messageId, assistantDeliveryMode);
-
-  const clearAssistantDeliveryModeForMessage = (messageId: MessageId) =>
-    Cache.invalidate(assistantDeliveryModeByMessageId, messageId);
-
   const appendBufferedAssistantText = (messageId: MessageId, delta: string) =>
     Cache.getOption(bufferedAssistantTextByMessageId, messageId).pipe(
       Effect.flatMap((existingText) =>
@@ -301,66 +249,18 @@ const make = Effect.gen(function* () {
   const clearBufferedAssistantText = (messageId: MessageId) =>
     Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
 
-  const clearAssistantMessageState = (messageId: MessageId) =>
-    Effect.all(
-      [
-        clearAssistantDeliveryModeForMessage(messageId),
-        clearBufferedAssistantText(messageId),
-      ],
-      { concurrency: 1 },
-    ).pipe(Effect.asVoid);
-
-  const resolveAssistantDeliveryModeForMessage = (input: {
-    threadId: ThreadId;
-    sessionId: ProviderSessionId;
-    turnId?: TurnId;
-    messageId: MessageId;
-  }) =>
-    Effect.gen(function* () {
-      const messageMode = yield* Cache.getOption(assistantDeliveryModeByMessageId, input.messageId);
-      if (Option.isSome(messageMode)) {
-        return messageMode.value;
-      }
-
-      if (input.turnId) {
-        const turnMode = yield* Cache.getOption(
-          assistantDeliveryModeByTurnKey,
-          providerTurnKey(input.sessionId, input.turnId),
-        );
-        if (Option.isSome(turnMode)) {
-          return turnMode.value;
-        }
-      }
-
-      const pendingMode = yield* Cache.getOption(
-        pendingAssistantDeliveryModeByThreadId,
-        input.threadId,
-      );
-      if (Option.isSome(pendingMode)) {
-        if (input.turnId) {
-          yield* rememberAssistantDeliveryModeForTurn(input.sessionId, input.turnId, pendingMode.value);
-          yield* clearPendingAssistantDeliveryModeForThread(input.threadId);
-        }
-        return pendingMode.value;
-      }
-
-      return DEFAULT_ASSISTANT_DELIVERY_MODE;
-    });
+  const clearAssistantMessageState = (messageId: MessageId) => clearBufferedAssistantText(messageId);
 
   const dispatchAssistantCompletion = (input: {
     event: ProviderRuntimeEvent;
     threadId: ThreadId;
     messageId: MessageId;
     turnId?: TurnId;
-    assistantDeliveryMode: AssistantDeliveryMode;
     createdAt: string;
     commandTag: string;
   }) =>
     Effect.gen(function* () {
-      const text =
-        input.assistantDeliveryMode === "buffered"
-          ? yield* takeBufferedAssistantText(input.messageId)
-          : undefined;
+      const text = yield* takeBufferedAssistantText(input.messageId);
 
       yield* orchestrationEngine.dispatch({
         type: "thread.message.assistant.complete",
@@ -368,7 +268,7 @@ const make = Effect.gen(function* () {
         threadId: input.threadId,
         messageId: input.messageId,
         ...(input.turnId ? { turnId: input.turnId } : {}),
-        ...(text !== undefined ? { text } : {}),
+        text,
         createdAt: input.createdAt,
       });
       yield* clearAssistantMessageState(input.messageId);
@@ -397,16 +297,6 @@ const make = Effect.gen(function* () {
           }),
         { concurrency: 1 },
       ).pipe(Effect.asVoid);
-
-      const deliveryModeKeys = Array.from(yield* Cache.keys(assistantDeliveryModeByTurnKey));
-      yield* Effect.forEach(
-        deliveryModeKeys,
-        (key) =>
-          key.startsWith(prefix)
-            ? Cache.invalidate(assistantDeliveryModeByTurnKey, key)
-            : Effect.void,
-        { concurrency: 1 },
-      ).pipe(Effect.asVoid);
     });
 
   const processRuntimeEvent = (event: ProviderRuntimeEvent) =>
@@ -427,18 +317,6 @@ const make = Effect.gen(function* () {
         event.type === "turn.completed"
       ) {
         const activeTurnId = event.type === "turn.started" ? (toTurnId(event.turnId) ?? null) : null;
-        if (event.type === "turn.started" && activeTurnId) {
-          const pendingAssistantDeliveryMode = yield* takePendingAssistantDeliveryModeForThread(
-            thread.id,
-          );
-          if (Option.isSome(pendingAssistantDeliveryMode)) {
-            yield* rememberAssistantDeliveryModeForTurn(
-              event.sessionId,
-              activeTurnId,
-              pendingAssistantDeliveryMode.value,
-            );
-          }
-        }
         const providerThreadIdFromEvent =
           event.type === "thread.started"
             ? ProviderThreadId.makeUnsafe(event.threadId)
@@ -488,14 +366,8 @@ const make = Effect.gen(function* () {
         if (turnId) {
           yield* rememberAssistantMessageId(event.sessionId, turnId, assistantMessageId);
         }
-        const assistantDeliveryMode = yield* resolveAssistantDeliveryModeForMessage({
-          threadId: thread.id,
-          sessionId: event.sessionId,
-          ...(turnId ? { turnId } : {}),
-          messageId: assistantMessageId,
-        });
-        yield* rememberAssistantDeliveryModeForMessage(assistantMessageId, assistantDeliveryMode);
 
+        const assistantDeliveryMode = yield* Ref.get(assistantDeliveryModeRef);
         if (assistantDeliveryMode === "buffered") {
           yield* appendBufferedAssistantText(assistantMessageId, event.delta);
         } else {
@@ -517,20 +389,12 @@ const make = Effect.gen(function* () {
         if (turnId) {
           yield* rememberAssistantMessageId(event.sessionId, turnId, assistantMessageId);
         }
-        const assistantDeliveryMode = yield* resolveAssistantDeliveryModeForMessage({
-          threadId: thread.id,
-          sessionId: event.sessionId,
-          ...(turnId ? { turnId } : {}),
-          messageId: assistantMessageId,
-        });
-        yield* rememberAssistantDeliveryModeForMessage(assistantMessageId, assistantDeliveryMode);
 
         yield* dispatchAssistantCompletion({
           event,
           threadId: thread.id,
           messageId: assistantMessageId,
           ...(turnId ? { turnId } : {}),
-          assistantDeliveryMode,
           createdAt: now,
           commandTag: "assistant-complete",
         });
@@ -548,19 +412,11 @@ const make = Effect.gen(function* () {
             assistantMessageIds,
             (assistantMessageId) =>
               Effect.gen(function* () {
-                const assistantDeliveryMode =
-                  yield* resolveAssistantDeliveryModeForMessage({
-                    threadId: thread.id,
-                    sessionId: event.sessionId,
-                    turnId,
-                    messageId: assistantMessageId,
-                  });
                 yield* dispatchAssistantCompletion({
                   event,
                   threadId: thread.id,
                   messageId: assistantMessageId,
                   turnId,
-                  assistantDeliveryMode,
                   createdAt: now,
                   commandTag: "assistant-complete-finalize",
                 });
@@ -568,13 +424,11 @@ const make = Effect.gen(function* () {
             { concurrency: 1 },
           ).pipe(Effect.asVoid);
           yield* clearAssistantMessageIdsForTurn(event.sessionId, turnId);
-          yield* clearAssistantDeliveryModeForTurn(event.sessionId, turnId);
         }
       }
 
       if (event.type === "session.exited") {
         yield* clearTurnStateForSession(event.sessionId);
-        yield* clearPendingAssistantDeliveryModeForThread(thread.id);
       }
 
       if (event.type === "runtime.error") {
@@ -614,8 +468,8 @@ const make = Effect.gen(function* () {
     });
 
   const processDomainEvent = (event: TurnStartRequestedDomainEvent) =>
-    rememberPendingAssistantDeliveryModeForThread(
-      event.payload.threadId,
+    Ref.set(
+      assistantDeliveryModeRef,
       event.payload.assistantDeliveryMode ?? DEFAULT_ASSISTANT_DELIVERY_MODE,
     );
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -28,6 +28,10 @@ const TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY = 10_000;
 const TURN_MESSAGE_IDS_BY_TURN_TTL = Duration.minutes(120);
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
+const BUFFERED_ASSISTANT_MESSAGE_SPILLED_CACHE_CAPACITY = 20_000;
+const BUFFERED_ASSISTANT_MESSAGE_SPILLED_TTL = Duration.minutes(120);
+const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
+const BUFFERED_ASSISTANT_KEEP_CHARS = 8_000;
 
 type TurnStartRequestedDomainEvent = Extract<
   OrchestrationEvent,
@@ -169,6 +173,11 @@ const make = Effect.gen(function* () {
     timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
     lookup: () => Effect.succeed(""),
   });
+  const bufferedAssistantMessageSpilledByMessageId = yield* Cache.make<MessageId, true>({
+    capacity: BUFFERED_ASSISTANT_MESSAGE_SPILLED_CACHE_CAPACITY,
+    timeToLive: BUFFERED_ASSISTANT_MESSAGE_SPILLED_TTL,
+    lookup: () => Effect.succeed(true),
+  });
 
   const rememberAssistantMessageId = (
     sessionId: ProviderSessionId,
@@ -226,14 +235,23 @@ const make = Effect.gen(function* () {
   const appendBufferedAssistantText = (messageId: MessageId, delta: string) =>
     Cache.getOption(bufferedAssistantTextByMessageId, messageId).pipe(
       Effect.flatMap((existingText) =>
-        Cache.set(
-          bufferedAssistantTextByMessageId,
-          messageId,
-          Option.match(existingText, {
+        Effect.gen(function* () {
+          const nextText = Option.match(existingText, {
             onNone: () => delta,
             onSome: (text) => `${text}${delta}`,
-          }),
-        ),
+          });
+          if (nextText.length <= MAX_BUFFERED_ASSISTANT_CHARS) {
+            yield* Cache.set(bufferedAssistantTextByMessageId, messageId, nextText);
+            return "";
+          }
+
+          // Safety valve: spill oldest text as a persisted assistant delta to cap memory.
+          const spillChars = Math.max(1, nextText.length - BUFFERED_ASSISTANT_KEEP_CHARS);
+          const spillChunk = nextText.slice(0, spillChars);
+          const retainedTail = nextText.slice(spillChars);
+          yield* Cache.set(bufferedAssistantTextByMessageId, messageId, retainedTail);
+          return spillChunk;
+        }),
       ),
     );
 
@@ -249,18 +267,51 @@ const make = Effect.gen(function* () {
   const clearBufferedAssistantText = (messageId: MessageId) =>
     Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
 
-  const clearAssistantMessageState = (messageId: MessageId) => clearBufferedAssistantText(messageId);
+  const markBufferedAssistantMessageSpilled = (messageId: MessageId) =>
+    Cache.set(bufferedAssistantMessageSpilledByMessageId, messageId, true);
 
-  const dispatchAssistantCompletion = (input: {
+  const takeBufferedAssistantMessageSpilled = (messageId: MessageId) =>
+    Cache.getOption(bufferedAssistantMessageSpilledByMessageId, messageId).pipe(
+      Effect.flatMap((spilled) =>
+        Cache.invalidate(bufferedAssistantMessageSpilledByMessageId, messageId).pipe(
+          Effect.as(Option.isSome(spilled)),
+        ),
+      ),
+    );
+
+  const clearBufferedAssistantMessageSpilled = (messageId: MessageId) =>
+    Cache.invalidate(bufferedAssistantMessageSpilledByMessageId, messageId);
+
+  const clearAssistantMessageState = (messageId: MessageId) =>
+    Effect.all(
+      [clearBufferedAssistantText(messageId), clearBufferedAssistantMessageSpilled(messageId)],
+      { concurrency: 1 },
+    ).pipe(Effect.asVoid);
+
+  const finalizeAssistantMessage = (input: {
     event: ProviderRuntimeEvent;
     threadId: ThreadId;
     messageId: MessageId;
     turnId?: TurnId;
     createdAt: string;
     commandTag: string;
+    spillRemainderCommandTag: string;
   }) =>
     Effect.gen(function* () {
       const text = yield* takeBufferedAssistantText(input.messageId);
+      const spilled = yield* takeBufferedAssistantMessageSpilled(input.messageId);
+
+      if (spilled && text.length > 0) {
+        yield* orchestrationEngine.dispatch({
+          type: "thread.message.assistant.delta",
+          commandId: providerCommandId(input.event, input.spillRemainderCommandTag),
+          threadId: input.threadId,
+          messageId: input.messageId,
+          delta: text,
+          ...(input.turnId ? { turnId: input.turnId } : {}),
+          createdAt: input.createdAt,
+        });
+      }
 
       yield* orchestrationEngine.dispatch({
         type: "thread.message.assistant.complete",
@@ -268,7 +319,7 @@ const make = Effect.gen(function* () {
         threadId: input.threadId,
         messageId: input.messageId,
         ...(input.turnId ? { turnId: input.turnId } : {}),
-        text,
+        text: spilled ? "" : text,
         createdAt: input.createdAt,
       });
       yield* clearAssistantMessageState(input.messageId);
@@ -369,7 +420,19 @@ const make = Effect.gen(function* () {
 
         const assistantDeliveryMode = yield* Ref.get(assistantDeliveryModeRef);
         if (assistantDeliveryMode === "buffered") {
-          yield* appendBufferedAssistantText(assistantMessageId, event.delta);
+          const spillChunk = yield* appendBufferedAssistantText(assistantMessageId, event.delta);
+          if (spillChunk.length > 0) {
+            yield* markBufferedAssistantMessageSpilled(assistantMessageId);
+            yield* orchestrationEngine.dispatch({
+              type: "thread.message.assistant.delta",
+              commandId: providerCommandId(event, "assistant-delta-buffer-spill"),
+              threadId: thread.id,
+              messageId: assistantMessageId,
+              delta: spillChunk,
+              ...(turnId ? { turnId } : {}),
+              createdAt: now,
+            });
+          }
         } else {
           yield* orchestrationEngine.dispatch({
             type: "thread.message.assistant.delta",
@@ -390,13 +453,14 @@ const make = Effect.gen(function* () {
           yield* rememberAssistantMessageId(event.sessionId, turnId, assistantMessageId);
         }
 
-        yield* dispatchAssistantCompletion({
+        yield* finalizeAssistantMessage({
           event,
           threadId: thread.id,
           messageId: assistantMessageId,
           ...(turnId ? { turnId } : {}),
           createdAt: now,
           commandTag: "assistant-complete",
+          spillRemainderCommandTag: "assistant-delta-buffer-remainder",
         });
 
         if (turnId) {
@@ -412,13 +476,14 @@ const make = Effect.gen(function* () {
             assistantMessageIds,
             (assistantMessageId) =>
               Effect.gen(function* () {
-                yield* dispatchAssistantCompletion({
+                yield* finalizeAssistantMessage({
                   event,
                   threadId: thread.id,
                   messageId: assistantMessageId,
                   turnId,
                   createdAt: now,
                   commandTag: "assistant-complete-finalize",
+                  spillRemainderCommandTag: "assistant-delta-buffer-remainder-finalize",
                 });
               }),
             { concurrency: 1 },

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -28,8 +28,6 @@ const TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY = 10_000;
 const TURN_MESSAGE_IDS_BY_TURN_TTL = Duration.minutes(120);
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
-const BUFFERED_ASSISTANT_MESSAGE_SPILLED_CACHE_CAPACITY = 20_000;
-const BUFFERED_ASSISTANT_MESSAGE_SPILLED_TTL = Duration.minutes(120);
 const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
 
 type TurnStartRequestedDomainEvent = Extract<
@@ -172,11 +170,6 @@ const make = Effect.gen(function* () {
     timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
     lookup: () => Effect.succeed(""),
   });
-  const bufferedAssistantMessageSpilledByMessageId = yield* Cache.make<MessageId, true>({
-    capacity: BUFFERED_ASSISTANT_MESSAGE_SPILLED_CACHE_CAPACITY,
-    timeToLive: BUFFERED_ASSISTANT_MESSAGE_SPILLED_TTL,
-    lookup: () => Effect.succeed(true),
-  });
 
   const rememberAssistantMessageId = (
     sessionId: ProviderSessionId,
@@ -263,26 +256,7 @@ const make = Effect.gen(function* () {
   const clearBufferedAssistantText = (messageId: MessageId) =>
     Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
 
-  const markBufferedAssistantMessageSpilled = (messageId: MessageId) =>
-    Cache.set(bufferedAssistantMessageSpilledByMessageId, messageId, true);
-
-  const takeBufferedAssistantMessageSpilled = (messageId: MessageId) =>
-    Cache.getOption(bufferedAssistantMessageSpilledByMessageId, messageId).pipe(
-      Effect.flatMap((spilled) =>
-        Cache.invalidate(bufferedAssistantMessageSpilledByMessageId, messageId).pipe(
-          Effect.as(Option.isSome(spilled)),
-        ),
-      ),
-    );
-
-  const clearBufferedAssistantMessageSpilled = (messageId: MessageId) =>
-    Cache.invalidate(bufferedAssistantMessageSpilledByMessageId, messageId);
-
-  const clearAssistantMessageState = (messageId: MessageId) =>
-    Effect.all(
-      [clearBufferedAssistantText(messageId), clearBufferedAssistantMessageSpilled(messageId)],
-      { concurrency: 1 },
-    ).pipe(Effect.asVoid);
+  const clearAssistantMessageState = (messageId: MessageId) => clearBufferedAssistantText(messageId);
 
   const finalizeAssistantMessage = (input: {
     event: ProviderRuntimeEvent;
@@ -291,16 +265,15 @@ const make = Effect.gen(function* () {
     turnId?: TurnId;
     createdAt: string;
     commandTag: string;
-    spillRemainderCommandTag: string;
+    finalDeltaCommandTag: string;
   }) =>
     Effect.gen(function* () {
       const text = yield* takeBufferedAssistantText(input.messageId);
-      const spilled = yield* takeBufferedAssistantMessageSpilled(input.messageId);
 
-      if (spilled && text.length > 0) {
+      if (text.length > 0) {
         yield* orchestrationEngine.dispatch({
           type: "thread.message.assistant.delta",
-          commandId: providerCommandId(input.event, input.spillRemainderCommandTag),
+          commandId: providerCommandId(input.event, input.finalDeltaCommandTag),
           threadId: input.threadId,
           messageId: input.messageId,
           delta: text,
@@ -315,7 +288,7 @@ const make = Effect.gen(function* () {
         threadId: input.threadId,
         messageId: input.messageId,
         ...(input.turnId ? { turnId: input.turnId } : {}),
-        text: spilled ? "" : text,
+        text: "",
         createdAt: input.createdAt,
       });
       yield* clearAssistantMessageState(input.messageId);
@@ -418,7 +391,6 @@ const make = Effect.gen(function* () {
         if (assistantDeliveryMode === "buffered") {
           const spillChunk = yield* appendBufferedAssistantText(assistantMessageId, event.delta);
           if (spillChunk.length > 0) {
-            yield* markBufferedAssistantMessageSpilled(assistantMessageId);
             yield* orchestrationEngine.dispatch({
               type: "thread.message.assistant.delta",
               commandId: providerCommandId(event, "assistant-delta-buffer-spill"),
@@ -456,7 +428,7 @@ const make = Effect.gen(function* () {
           ...(turnId ? { turnId } : {}),
           createdAt: now,
           commandTag: "assistant-complete",
-          spillRemainderCommandTag: "assistant-delta-buffer-remainder",
+          finalDeltaCommandTag: "assistant-delta-finalize",
         });
 
         if (turnId) {
@@ -479,7 +451,7 @@ const make = Effect.gen(function* () {
                   turnId,
                   createdAt: now,
                   commandTag: "assistant-complete-finalize",
-                  spillRemainderCommandTag: "assistant-delta-buffer-remainder-finalize",
+                  finalDeltaCommandTag: "assistant-delta-finalize-fallback",
                 });
               }),
             { concurrency: 1 },

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1,7 +1,10 @@
 import {
+  type AssistantDeliveryMode,
   CommandId,
   MessageId,
+  type OrchestrationEvent,
   ProviderThreadId,
+  type ThreadId,
   TurnId,
   type OrchestrationThreadActivity,
   type ProviderRuntimeEvent,
@@ -19,8 +22,32 @@ import {
 const providerTurnKey = (sessionId: ProviderSessionId, turnId: TurnId) => `${sessionId}:${turnId}`;
 const providerCommandId = (event: ProviderRuntimeEvent, tag: string): CommandId =>
   CommandId.makeUnsafe(`provider:${event.eventId}:${tag}:${crypto.randomUUID()}`);
+const DEFAULT_ASSISTANT_DELIVERY_MODE: AssistantDeliveryMode = "buffered";
 const TURN_MESSAGE_IDS_BY_TURN_CACHE_CAPACITY = 10_000;
 const TURN_MESSAGE_IDS_BY_TURN_TTL = Duration.minutes(120);
+const TURN_DELIVERY_MODE_BY_TURN_CACHE_CAPACITY = 10_000;
+const TURN_DELIVERY_MODE_BY_TURN_TTL = Duration.minutes(120);
+const PENDING_DELIVERY_MODE_BY_THREAD_CACHE_CAPACITY = 10_000;
+const PENDING_DELIVERY_MODE_BY_THREAD_TTL = Duration.minutes(30);
+const MESSAGE_DELIVERY_MODE_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
+const MESSAGE_DELIVERY_MODE_BY_MESSAGE_ID_TTL = Duration.minutes(120);
+const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
+const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
+
+type TurnStartRequestedDomainEvent = Extract<
+  OrchestrationEvent,
+  { type: "thread.turn-start-requested" }
+>;
+
+type RuntimeIngestionInput =
+  | {
+      source: "runtime";
+      event: ProviderRuntimeEvent;
+    }
+  | {
+      source: "domain";
+      event: TurnStartRequestedDomainEvent;
+    };
 
 function toTurnId(value: string | undefined): TurnId | undefined {
   return value === undefined ? undefined : TurnId.makeUnsafe(value);
@@ -135,6 +162,26 @@ const make = Effect.gen(function* () {
     timeToLive: TURN_MESSAGE_IDS_BY_TURN_TTL,
     lookup: () => Effect.succeed(new Set<MessageId>()),
   });
+  const assistantDeliveryModeByTurnKey = yield* Cache.make<string, AssistantDeliveryMode>({
+    capacity: TURN_DELIVERY_MODE_BY_TURN_CACHE_CAPACITY,
+    timeToLive: TURN_DELIVERY_MODE_BY_TURN_TTL,
+    lookup: () => Effect.succeed(DEFAULT_ASSISTANT_DELIVERY_MODE),
+  });
+  const pendingAssistantDeliveryModeByThreadId = yield* Cache.make<ThreadId, AssistantDeliveryMode>({
+    capacity: PENDING_DELIVERY_MODE_BY_THREAD_CACHE_CAPACITY,
+    timeToLive: PENDING_DELIVERY_MODE_BY_THREAD_TTL,
+    lookup: () => Effect.succeed(DEFAULT_ASSISTANT_DELIVERY_MODE),
+  });
+  const assistantDeliveryModeByMessageId = yield* Cache.make<MessageId, AssistantDeliveryMode>({
+    capacity: MESSAGE_DELIVERY_MODE_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: MESSAGE_DELIVERY_MODE_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(DEFAULT_ASSISTANT_DELIVERY_MODE),
+  });
+  const bufferedAssistantTextByMessageId = yield* Cache.make<MessageId, string>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(""),
+  });
 
   const rememberAssistantMessageId = (
     sessionId: ProviderSessionId,
@@ -189,6 +236,144 @@ const make = Effect.gen(function* () {
   const clearAssistantMessageIdsForTurn = (sessionId: ProviderSessionId, turnId: TurnId) =>
     Cache.invalidate(turnMessageIdsByTurnKey, providerTurnKey(sessionId, turnId));
 
+  const rememberAssistantDeliveryModeForTurn = (
+    sessionId: ProviderSessionId,
+    turnId: TurnId,
+    assistantDeliveryMode: AssistantDeliveryMode,
+  ) =>
+    Cache.set(
+      assistantDeliveryModeByTurnKey,
+      providerTurnKey(sessionId, turnId),
+      assistantDeliveryMode,
+    );
+
+  const clearAssistantDeliveryModeForTurn = (sessionId: ProviderSessionId, turnId: TurnId) =>
+    Cache.invalidate(assistantDeliveryModeByTurnKey, providerTurnKey(sessionId, turnId));
+
+  const rememberPendingAssistantDeliveryModeForThread = (
+    threadId: ThreadId,
+    assistantDeliveryMode: AssistantDeliveryMode,
+  ) => Cache.set(pendingAssistantDeliveryModeByThreadId, threadId, assistantDeliveryMode);
+
+  const takePendingAssistantDeliveryModeForThread = (threadId: ThreadId) =>
+    Cache.getOption(pendingAssistantDeliveryModeByThreadId, threadId).pipe(
+      Effect.flatMap((assistantDeliveryMode) =>
+        Cache.invalidate(pendingAssistantDeliveryModeByThreadId, threadId).pipe(
+          Effect.as(assistantDeliveryMode),
+        ),
+      ),
+    );
+
+  const clearPendingAssistantDeliveryModeForThread = (threadId: ThreadId) =>
+    Cache.invalidate(pendingAssistantDeliveryModeByThreadId, threadId);
+
+  const rememberAssistantDeliveryModeForMessage = (
+    messageId: MessageId,
+    assistantDeliveryMode: AssistantDeliveryMode,
+  ) => Cache.set(assistantDeliveryModeByMessageId, messageId, assistantDeliveryMode);
+
+  const clearAssistantDeliveryModeForMessage = (messageId: MessageId) =>
+    Cache.invalidate(assistantDeliveryModeByMessageId, messageId);
+
+  const appendBufferedAssistantText = (messageId: MessageId, delta: string) =>
+    Cache.getOption(bufferedAssistantTextByMessageId, messageId).pipe(
+      Effect.flatMap((existingText) =>
+        Cache.set(
+          bufferedAssistantTextByMessageId,
+          messageId,
+          Option.match(existingText, {
+            onNone: () => delta,
+            onSome: (text) => `${text}${delta}`,
+          }),
+        ),
+      ),
+    );
+
+  const takeBufferedAssistantText = (messageId: MessageId) =>
+    Cache.getOption(bufferedAssistantTextByMessageId, messageId).pipe(
+      Effect.flatMap((existingText) =>
+        Cache.invalidate(bufferedAssistantTextByMessageId, messageId).pipe(
+          Effect.as(Option.getOrElse(existingText, () => "")),
+        ),
+      ),
+    );
+
+  const clearBufferedAssistantText = (messageId: MessageId) =>
+    Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
+
+  const clearAssistantMessageState = (messageId: MessageId) =>
+    Effect.all(
+      [
+        clearAssistantDeliveryModeForMessage(messageId),
+        clearBufferedAssistantText(messageId),
+      ],
+      { concurrency: 1 },
+    ).pipe(Effect.asVoid);
+
+  const resolveAssistantDeliveryModeForMessage = (input: {
+    threadId: ThreadId;
+    sessionId: ProviderSessionId;
+    turnId?: TurnId;
+    messageId: MessageId;
+  }) =>
+    Effect.gen(function* () {
+      const messageMode = yield* Cache.getOption(assistantDeliveryModeByMessageId, input.messageId);
+      if (Option.isSome(messageMode)) {
+        return messageMode.value;
+      }
+
+      if (input.turnId) {
+        const turnMode = yield* Cache.getOption(
+          assistantDeliveryModeByTurnKey,
+          providerTurnKey(input.sessionId, input.turnId),
+        );
+        if (Option.isSome(turnMode)) {
+          return turnMode.value;
+        }
+      }
+
+      const pendingMode = yield* Cache.getOption(
+        pendingAssistantDeliveryModeByThreadId,
+        input.threadId,
+      );
+      if (Option.isSome(pendingMode)) {
+        if (input.turnId) {
+          yield* rememberAssistantDeliveryModeForTurn(input.sessionId, input.turnId, pendingMode.value);
+          yield* clearPendingAssistantDeliveryModeForThread(input.threadId);
+        }
+        return pendingMode.value;
+      }
+
+      return DEFAULT_ASSISTANT_DELIVERY_MODE;
+    });
+
+  const dispatchAssistantCompletion = (input: {
+    event: ProviderRuntimeEvent;
+    threadId: ThreadId;
+    messageId: MessageId;
+    turnId?: TurnId;
+    assistantDeliveryMode: AssistantDeliveryMode;
+    createdAt: string;
+    commandTag: string;
+  }) =>
+    Effect.gen(function* () {
+      const text =
+        input.assistantDeliveryMode === "buffered"
+          ? yield* takeBufferedAssistantText(input.messageId)
+          : undefined;
+
+      yield* orchestrationEngine.dispatch({
+        type: "thread.message.assistant.complete",
+        commandId: providerCommandId(input.event, input.commandTag),
+        threadId: input.threadId,
+        messageId: input.messageId,
+        ...(input.turnId ? { turnId: input.turnId } : {}),
+        ...(text !== undefined ? { text } : {}),
+        createdAt: input.createdAt,
+      });
+      yield* clearAssistantMessageState(input.messageId);
+    });
+
   const clearTurnStateForSession = (sessionId: ProviderSessionId) =>
     Effect.gen(function* () {
       const prefix = `${sessionId}:`;
@@ -196,12 +381,35 @@ const make = Effect.gen(function* () {
       yield* Effect.forEach(
         turnKeys,
         (key) =>
-          key.startsWith(prefix) ? Cache.invalidate(turnMessageIdsByTurnKey, key) : Effect.void,
+          Effect.gen(function* () {
+            if (!key.startsWith(prefix)) {
+              return;
+            }
+
+            const messageIds = yield* Cache.getOption(turnMessageIdsByTurnKey, key);
+            if (Option.isSome(messageIds)) {
+              yield* Effect.forEach(messageIds.value, clearAssistantMessageState, {
+                concurrency: 1,
+              }).pipe(Effect.asVoid);
+            }
+
+            yield* Cache.invalidate(turnMessageIdsByTurnKey, key);
+          }),
+        { concurrency: 1 },
+      ).pipe(Effect.asVoid);
+
+      const deliveryModeKeys = Array.from(yield* Cache.keys(assistantDeliveryModeByTurnKey));
+      yield* Effect.forEach(
+        deliveryModeKeys,
+        (key) =>
+          key.startsWith(prefix)
+            ? Cache.invalidate(assistantDeliveryModeByTurnKey, key)
+            : Effect.void,
         { concurrency: 1 },
       ).pipe(Effect.asVoid);
     });
 
-  const processEvent = (event: ProviderRuntimeEvent) =>
+  const processRuntimeEvent = (event: ProviderRuntimeEvent) =>
     Effect.gen(function* () {
       const readModel = yield* orchestrationEngine.getReadModel();
       const thread = readModel.threads.find(
@@ -218,8 +426,19 @@ const make = Effect.gen(function* () {
         event.type === "turn.started" ||
         event.type === "turn.completed"
       ) {
-        const activeTurnId =
-          event.type === "turn.started" ? (toTurnId(event.turnId) ?? null) : null;
+        const activeTurnId = event.type === "turn.started" ? (toTurnId(event.turnId) ?? null) : null;
+        if (event.type === "turn.started" && activeTurnId) {
+          const pendingAssistantDeliveryMode = yield* takePendingAssistantDeliveryModeForThread(
+            thread.id,
+          );
+          if (Option.isSome(pendingAssistantDeliveryMode)) {
+            yield* rememberAssistantDeliveryModeForTurn(
+              event.sessionId,
+              activeTurnId,
+              pendingAssistantDeliveryMode.value,
+            );
+          }
+        }
         const providerThreadIdFromEvent =
           event.type === "thread.started"
             ? ProviderThreadId.makeUnsafe(event.threadId)
@@ -269,16 +488,27 @@ const make = Effect.gen(function* () {
         if (turnId) {
           yield* rememberAssistantMessageId(event.sessionId, turnId, assistantMessageId);
         }
-
-        yield* orchestrationEngine.dispatch({
-          type: "thread.message.assistant.delta",
-          commandId: providerCommandId(event, "assistant-delta"),
+        const assistantDeliveryMode = yield* resolveAssistantDeliveryModeForMessage({
           threadId: thread.id,
+          sessionId: event.sessionId,
+          turnId,
           messageId: assistantMessageId,
-          delta: event.delta,
-          ...(turnId ? { turnId } : {}),
-          createdAt: now,
         });
+        yield* rememberAssistantDeliveryModeForMessage(assistantMessageId, assistantDeliveryMode);
+
+        if (assistantDeliveryMode === "buffered") {
+          yield* appendBufferedAssistantText(assistantMessageId, event.delta);
+        } else {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.message.assistant.delta",
+            commandId: providerCommandId(event, "assistant-delta"),
+            threadId: thread.id,
+            messageId: assistantMessageId,
+            delta: event.delta,
+            ...(turnId ? { turnId } : {}),
+            createdAt: now,
+          });
+        }
       }
 
       if (event.type === "message.completed") {
@@ -287,14 +517,22 @@ const make = Effect.gen(function* () {
         if (turnId) {
           yield* rememberAssistantMessageId(event.sessionId, turnId, assistantMessageId);
         }
+        const assistantDeliveryMode = yield* resolveAssistantDeliveryModeForMessage({
+          threadId: thread.id,
+          sessionId: event.sessionId,
+          turnId,
+          messageId: assistantMessageId,
+        });
+        yield* rememberAssistantDeliveryModeForMessage(assistantMessageId, assistantDeliveryMode);
 
-        yield* orchestrationEngine.dispatch({
-          type: "thread.message.assistant.complete",
-          commandId: providerCommandId(event, "assistant-complete"),
+        yield* dispatchAssistantCompletion({
+          event,
           threadId: thread.id,
           messageId: assistantMessageId,
           ...(turnId ? { turnId } : {}),
+          assistantDeliveryMode,
           createdAt: now,
+          commandTag: "assistant-complete",
         });
 
         if (turnId) {
@@ -306,22 +544,37 @@ const make = Effect.gen(function* () {
         const turnId = toTurnId(event.turnId);
         if (turnId) {
           const assistantMessageIds = yield* getAssistantMessageIdsForTurn(event.sessionId, turnId);
-          yield* Effect.forEach(assistantMessageIds, (assistantMessageId) =>
-            orchestrationEngine.dispatch({
-              type: "thread.message.assistant.complete",
-              commandId: providerCommandId(event, "assistant-complete-finalize"),
-              threadId: thread.id,
-              messageId: assistantMessageId,
-              turnId,
-              createdAt: now,
-            }),
+          yield* Effect.forEach(
+            assistantMessageIds,
+            (assistantMessageId) =>
+              Effect.gen(function* () {
+                const assistantDeliveryMode =
+                  yield* resolveAssistantDeliveryModeForMessage({
+                    threadId: thread.id,
+                    sessionId: event.sessionId,
+                    turnId,
+                    messageId: assistantMessageId,
+                  });
+                yield* dispatchAssistantCompletion({
+                  event,
+                  threadId: thread.id,
+                  messageId: assistantMessageId,
+                  turnId,
+                  assistantDeliveryMode,
+                  createdAt: now,
+                  commandTag: "assistant-complete-finalize",
+                });
+              }),
+            { concurrency: 1 },
           ).pipe(Effect.asVoid);
           yield* clearAssistantMessageIdsForTurn(event.sessionId, turnId);
+          yield* clearAssistantDeliveryModeForTurn(event.sessionId, turnId);
         }
       }
 
       if (event.type === "session.exited") {
         yield* clearTurnStateForSession(event.sessionId);
+        yield* clearPendingAssistantDeliveryModeForThread(thread.id);
       }
 
       if (event.type === "runtime.error") {
@@ -360,32 +613,49 @@ const make = Effect.gen(function* () {
       ).pipe(Effect.asVoid);
     });
 
-  const processEventSafely = (event: ProviderRuntimeEvent) =>
-    processEvent(event).pipe(
+  const processDomainEvent = (event: TurnStartRequestedDomainEvent) =>
+    rememberPendingAssistantDeliveryModeForThread(
+      event.payload.threadId,
+      event.payload.assistantDeliveryMode ?? DEFAULT_ASSISTANT_DELIVERY_MODE,
+    );
+
+  const processInput = (input: RuntimeIngestionInput) =>
+    input.source === "runtime" ? processRuntimeEvent(input.event) : processDomainEvent(input.event);
+
+  const processInputSafely = (input: RuntimeIngestionInput) =>
+    processInput(input).pipe(
       Effect.catchCause((cause) => {
         if (Cause.hasInterruptsOnly(cause)) {
           return Effect.failCause(cause);
         }
         return Effect.logWarning("provider runtime ingestion failed to process event", {
-          eventId: event.eventId,
-          eventType: event.type,
+          source: input.source,
+          eventId: input.event.eventId,
+          eventType: input.event.type,
           cause: Cause.pretty(cause),
         });
       }),
     );
 
   const start: ProviderRuntimeIngestionShape["start"] = Effect.gen(function* () {
-    const providerEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
-
-    yield* Effect.addFinalizer(() => Queue.shutdown(providerEventQueue).pipe(Effect.asVoid));
+    const inputQueue = yield* Queue.unbounded<RuntimeIngestionInput>();
+    yield* Effect.addFinalizer(() => Queue.shutdown(inputQueue).pipe(Effect.asVoid));
 
     yield* Effect.forkScoped(
-      Effect.forever(Queue.take(providerEventQueue).pipe(Effect.flatMap(processEventSafely))),
+      Effect.forever(Queue.take(inputQueue).pipe(Effect.flatMap(processInputSafely))),
     );
     yield* Effect.forkScoped(
       Stream.runForEach(providerService.streamEvents, (event) =>
-        Queue.offer(providerEventQueue, event).pipe(Effect.asVoid),
+        Queue.offer(inputQueue, { source: "runtime", event }).pipe(Effect.asVoid),
       ),
+    );
+    yield* Effect.forkScoped(
+      Stream.runForEach(orchestrationEngine.streamDomainEvents, (event) => {
+        if (event.type !== "thread.turn-start-requested") {
+          return Effect.void;
+        }
+        return Queue.offer(inputQueue, { source: "domain", event }).pipe(Effect.asVoid);
+      }),
     );
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -31,7 +31,6 @@ const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
 const BUFFERED_ASSISTANT_MESSAGE_SPILLED_CACHE_CAPACITY = 20_000;
 const BUFFERED_ASSISTANT_MESSAGE_SPILLED_TTL = Duration.minutes(120);
 const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
-const BUFFERED_ASSISTANT_KEEP_CHARS = 8_000;
 
 type TurnStartRequestedDomainEvent = Extract<
   OrchestrationEvent,
@@ -245,12 +244,9 @@ const make = Effect.gen(function* () {
             return "";
           }
 
-          // Safety valve: spill oldest text as a persisted assistant delta to cap memory.
-          const spillChars = Math.max(1, nextText.length - BUFFERED_ASSISTANT_KEEP_CHARS);
-          const spillChunk = nextText.slice(0, spillChars);
-          const retainedTail = nextText.slice(spillChars);
-          yield* Cache.set(bufferedAssistantTextByMessageId, messageId, retainedTail);
-          return spillChunk;
+          // Safety valve: spill full buffered text as a persisted assistant delta to cap memory.
+          yield* Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
+          return nextText;
         }),
       ),
     );

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -256,7 +256,8 @@ const make = Effect.gen(function* () {
   const clearBufferedAssistantText = (messageId: MessageId) =>
     Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
 
-  const clearAssistantMessageState = (messageId: MessageId) => clearBufferedAssistantText(messageId);
+  const clearAssistantMessageState = (messageId: MessageId) =>
+    clearBufferedAssistantText(messageId);
 
   const finalizeAssistantMessage = (input: {
     event: ProviderRuntimeEvent;
@@ -335,7 +336,8 @@ const make = Effect.gen(function* () {
         event.type === "turn.started" ||
         event.type === "turn.completed"
       ) {
-        const activeTurnId = event.type === "turn.started" ? (toTurnId(event.turnId) ?? null) : null;
+        const activeTurnId =
+          event.type === "turn.started" ? (toTurnId(event.turnId) ?? null) : null;
         const providerThreadIdFromEvent =
           event.type === "thread.started"
             ? ProviderThreadId.makeUnsafe(event.threadId)
@@ -442,16 +444,14 @@ const make = Effect.gen(function* () {
           yield* Effect.forEach(
             assistantMessageIds,
             (assistantMessageId) =>
-              Effect.gen(function* () {
-                yield* finalizeAssistantMessage({
-                  event,
-                  threadId: thread.id,
-                  messageId: assistantMessageId,
-                  turnId,
-                  createdAt: now,
-                  commandTag: "assistant-complete-finalize",
-                  finalDeltaCommandTag: "assistant-delta-finalize-fallback",
-                });
+              finalizeAssistantMessage({
+                event,
+                threadId: thread.id,
+                messageId: assistantMessageId,
+                turnId,
+                createdAt: now,
+                commandTag: "assistant-complete-finalize",
+                finalDeltaCommandTag: "assistant-delta-finalize-fallback",
               }),
             { concurrency: 1 },
           ).pipe(Effect.asVoid);

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -164,5 +164,8 @@ describe("decider project scripts", () => {
     expect(events[0]?.type).toBe("thread.message-sent");
     expect(events[1]?.type).toBe("thread.turn-start-requested");
     expect(events[1]?.causationEventId).toBe(events[0]?.eventId ?? null);
+    expect((events[1]?.payload as { assistantDeliveryMode?: string }).assistantDeliveryMode).toBe(
+      "buffered",
+    );
   });
 });

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -162,10 +162,12 @@ describe("decider project scripts", () => {
     const events = Array.isArray(result) ? result : [result];
     expect(events).toHaveLength(2);
     expect(events[0]?.type).toBe("thread.message-sent");
-    expect(events[1]?.type).toBe("thread.turn-start-requested");
-    expect(events[1]?.causationEventId).toBe(events[0]?.eventId ?? null);
-    expect((events[1]?.payload as { assistantDeliveryMode?: string }).assistantDeliveryMode).toBe(
-      "buffered",
-    );
+    const turnStartEvent = events[1];
+    expect(turnStartEvent?.type).toBe("thread.turn-start-requested");
+    expect(turnStartEvent?.causationEventId).toBe(events[0]?.eventId ?? null);
+    if (turnStartEvent?.type !== "thread.turn-start-requested") {
+      return;
+    }
+    expect(turnStartEvent.payload.assistantDeliveryMode).toBe("buffered");
   });
 });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -425,7 +425,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.messageId,
           role: "assistant",
-          text: command.text ?? "",
+          text: "",
           turnId: command.turnId ?? null,
           streaming: false,
           createdAt: command.createdAt,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -14,6 +14,7 @@ import {
 } from "./commandInvariants.ts";
 
 const nowIso = () => new Date().toISOString();
+const DEFAULT_ASSISTANT_DELIVERY_MODE = "buffered" as const;
 
 const defaultMetadata: Omit<OrchestrationEvent, "sequence" | "type" | "payload"> = {
   eventId: crypto.randomUUID() as OrchestrationEvent["eventId"],
@@ -252,6 +253,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           messageId: command.message.messageId,
           ...(command.model !== undefined ? { model: command.model } : {}),
           ...(command.effort !== undefined ? { effort: command.effort } : {}),
+          assistantDeliveryMode: command.assistantDeliveryMode ?? DEFAULT_ASSISTANT_DELIVERY_MODE,
           createdAt: command.createdAt,
         },
       };
@@ -423,7 +425,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           threadId: command.threadId,
           messageId: command.messageId,
           role: "assistant",
-          text: "",
+          text: command.text ?? "",
           turnId: command.turnId ?? null,
           streaming: false,
           createdAt: command.createdAt,

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -959,6 +959,7 @@ describe("WebSocket Server", () => {
         text: "hello",
         attachments: [],
       },
+      assistantDeliveryMode: "streaming",
       createdAt,
     });
     expect(startTurnResponse.error).toBeUndefined();

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -11,6 +11,9 @@ const AppSettingsSchema = Schema.Struct({
     Schema.withConstructorDefault(() => Option.some("")),
   ),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withConstructorDefault(() => Option.some(true))),
+  enableAssistantStreaming: Schema.Boolean.pipe(
+    Schema.withConstructorDefault(() => Option.some(false)),
+  ),
 });
 export type AppSettings = typeof AppSettingsSchema.Type;
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -107,6 +107,7 @@ import { Toggle } from "./ui/toggle";
 import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
+import { useAppSettings } from "../appSettings";
 
 function formatMessageMeta(createdAt: string, duration: string | null): string {
   if (!duration) return formatTimestamp(createdAt);
@@ -332,6 +333,7 @@ interface ChatViewProps {
 
 export default function ChatView({ threadId }: ChatViewProps) {
   const { state, dispatch } = useStore();
+  const { settings } = useAppSettings();
   const navigate = useNavigate();
   const rawSearch = useSearch({
     strict: false,
@@ -1506,6 +1508,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         },
         model: selectedModel || undefined,
         effort: selectedEffort || undefined,
+        assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
         createdAt: messageCreatedAt,
       });
     } catch (err) {

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -239,6 +239,49 @@ function SettingsRouteView() {
 
             <section className="rounded-2xl border border-border bg-card p-5">
               <div className="mb-4">
+                <h2 className="text-sm font-medium text-foreground">Responses</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Control how assistant output is rendered during a turn.
+                </p>
+              </div>
+
+              <div className="flex items-center justify-between rounded-lg border border-border bg-background px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium text-foreground">Stream assistant messages</p>
+                  <p className="text-xs text-muted-foreground">
+                    Show token-by-token output while a response is in progress.
+                  </p>
+                </div>
+                <Switch
+                  checked={settings.enableAssistantStreaming}
+                  onCheckedChange={(checked) =>
+                    updateSettings({
+                      enableAssistantStreaming: Boolean(checked),
+                    })
+                  }
+                  aria-label="Stream assistant messages"
+                />
+              </div>
+
+              {settings.enableAssistantStreaming !== defaults.enableAssistantStreaming ? (
+                <div className="mt-3 flex justify-end">
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={() =>
+                      updateSettings({
+                        enableAssistantStreaming: defaults.enableAssistantStreaming,
+                      })
+                    }
+                  >
+                    Restore default
+                  </Button>
+                </div>
+              ) : null}
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <div className="mb-4">
                 <h2 className="text-sm font-medium text-foreground">Keybindings</h2>
                 <p className="mt-1 text-xs text-muted-foreground">
                   Open the persisted <code>keybindings.json</code> file to edit advanced bindings

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -46,6 +46,8 @@ export const ProviderSandboxMode = Schema.Literals([
 export type ProviderSandboxMode = typeof ProviderSandboxMode.Type;
 export const ProviderRequestKind = Schema.Literals(["command", "file-change"]);
 export type ProviderRequestKind = typeof ProviderRequestKind.Type;
+export const AssistantDeliveryMode = Schema.Literals(["buffered", "streaming"]);
+export type AssistantDeliveryMode = typeof AssistantDeliveryMode.Type;
 export const ProviderApprovalDecision = Schema.Literals([
   "accept",
   "acceptForSession",
@@ -279,6 +281,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
   }),
   model: Schema.optional(TrimmedNonEmptyString),
   effort: Schema.optional(TrimmedNonEmptyString),
+  assistantDeliveryMode: Schema.optional(AssistantDeliveryMode),
   createdAt: IsoDateTime,
 });
 
@@ -353,6 +356,7 @@ export const ThreadMessageAssistantCompleteCommand = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
   turnId: Schema.optional(TurnId),
+  text: Schema.optional(Schema.String),
   createdAt: IsoDateTime,
 });
 
@@ -492,6 +496,7 @@ export const ThreadTurnStartRequestedPayload = Schema.Struct({
   messageId: MessageId,
   model: Schema.optional(TrimmedNonEmptyString),
   effort: Schema.optional(TrimmedNonEmptyString),
+  assistantDeliveryMode: Schema.optional(AssistantDeliveryMode),
   createdAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -356,7 +356,6 @@ export const ThreadMessageAssistantCompleteCommand = Schema.Struct({
   threadId: ThreadId,
   messageId: MessageId,
   turnId: Schema.optional(TurnId),
-  text: Schema.optional(Schema.String),
   createdAt: IsoDateTime,
 });
 


### PR DESCRIPTION
## Summary
- Add `assistantDeliveryMode` support through orchestration contracts and turn-start flow.
- Update provider runtime ingestion to track delivery mode per thread/turn/message and buffer assistant deltas by default.
- Flush buffered assistant text on `message.completed`/turn finalization, while preserving live delta behavior for streaming mode.
- Add server/web wiring for settings and chat UI to request streaming delivery mode when selected.
- Expand tests for ingestion behavior, including buffered default and explicit streaming mode paths.
- Remove obsolete planning doc `.plans/17-claude-code.md`.

## Testing
- Added/updated unit tests:
- `apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts` (buffered default + streaming mode behavior)
- `apps/server/src/orchestration/decider.projectScripts.test.ts`
- `apps/server/src/wsServer.test.ts`
- Lint: Not run
- Full test suite: Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the turn-start contract and runtime ingestion behavior for assistant messages, which can affect message ordering/visibility and memory usage during active turns. Risk is moderated by added test coverage for buffered, streaming, and oversized-spill paths.
> 
> **Overview**
> Introduces `AssistantDeliveryMode` (`buffered`|`streaming`) in orchestration contracts and propagates it through `thread.turn.start` → `thread.turn-start-requested`, defaulting to **buffered**.
> 
> Updates `ProviderRuntimeIngestion` to **buffer assistant `message.delta` text** and only emit it on `message.completed`/`turn.completed`, with a 24k-char safety spill to cap memory; streaming mode continues emitting live deltas. Web UI adds a persisted setting (`enableAssistantStreaming`) and sends `assistantDeliveryMode` when starting a turn; server/websocket tests and ingestion tests are expanded accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 581d5335827cd91673e17254a8b5635660567b17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable assistant delivery mode and buffer assistant deltas by default with a 24,000‑char spill threshold in `ProviderRuntimeIngestion.make` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/98/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7)
> Introduce `AssistantDeliveryMode` ('buffered'|'streaming'), default to buffered, buffer assistant deltas per `MessageId` with spill at 24,000 chars, flush on `message.completed`/`turn.completed`, and set delivery mode from `thread.turn-start-requested` domain events; wire UI setting to send `assistantDeliveryMode` on `thread.turn.start`.
>
> #### 📍Where to Start
> Start at `ProviderRuntimeIngestion.start` and `processRuntimeEvent` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/98/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7), then review `decider.decideOrchestrationCommand` in [decider.ts](https://github.com/pingdotgg/t3code/pull/98/files#diff-6f7345ef9257e77e02acccced5be5251aa0f108aa0620614c5c80cc072949dc6) for how `assistantDeliveryMode` is emitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 581d533.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings: "Responses" toggle to enable assistant streaming (persisted; default off).
  * Chat UI respects the setting and requests streaming (incremental) or buffered (complete) assistant delivery.
  * Backend/protocol now support both delivery modes, defaulting to buffered.

* **Bug Fixes**
  * Settings toggle was inadvertently added in two places on the Settings page.

* **Tests**
  * Added tests covering buffered and streaming assistant response flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->