### PR TITLE
Require base branch selection before first send in worktree mode

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -368,6 +368,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const composerCommandInputRef = useRef<HTMLInputElement>(null);
   const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
+  const sendInFlightRef = useRef(false);
   const dragDepthRef = useRef(0);
   const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
 
@@ -1391,7 +1392,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const onSend = async (e: React.SubmitEvent | React.KeyboardEvent) => {
     e.preventDefault();
     const api = readNativeApi();
-    if (!api || !activeThread || isSendBusy || isConnecting) return;
+    if (!api || !activeThread || isSendBusy || isConnecting || sendInFlightRef.current) return;
     const trimmed = prompt.trim();
     if (!trimmed && composerImages.length === 0) return;
     if (!activeProject) return;
@@ -1414,6 +1415,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
       });
       return;
     }
+
+    sendInFlightRef.current = true;
+    setSendPhase(baseBranchForWorktree ? "preparing-worktree" : "sending-turn");
 
     const composerImagesSnapshot = [...composerImages];
     const messageIdForSend = newMessageId();
@@ -1463,9 +1467,17 @@ export default function ChatView({ threadId }: ChatViewProps) {
           branch: result.worktree.branch,
           worktreePath: result.worktree.path,
         });
+        // Keep local thread state in sync immediately so terminal drawer opens
+        // with the worktree cwd/env instead of briefly using the project root.
+        dispatch({
+          type: "SET_THREAD_BRANCH",
+          threadId: threadIdForSend,
+          branch: result.worktree.branch,
+          worktreePath: result.worktree.path,
+        });
         const setupScript = setupProjectScript(activeProject.scripts);
         if (setupScript) {
-          void runProjectScript(setupScript, {
+          await runProjectScript(setupScript, {
             cwd: result.worktree.path,
             worktreePath: result.worktree.path,
             rememberAsLastInvoked: false,
@@ -1544,6 +1556,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         err instanceof Error ? err.message : "Failed to send message.",
       );
     } finally {
+      sendInFlightRef.current = false;
       setSendPhase("idle");
     }
   };


### PR DESCRIPTION
## Summary
- enforce base branch selection before the first message when running in `worktree` mode
- show a clear composer error instead of silently falling back when branch is missing
- reuse a `shouldCreateWorktree` guard to simplify first-send worktree creation flow
- immediately sync local thread branch/worktree state after creation so terminal context is correct
- await setup script execution in the new worktree and prefer opening a new terminal
- remove obsolete planning doc `.plans/17-claude-code.md`

## Testing
- Not run (tests not provided in this change set)
- Manual check: first send in `worktree` mode without a selected base branch shows `Select a base branch before sending in New worktree mode.` and aborts send
- Manual check: first send with a selected base branch creates worktree, updates thread state, and runs setup script in worktree cwd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core send/worktree-creation path in `ChatView`, which can block sending and alters sequencing around worktree setup and terminal context. Risk is moderate due to potential regressions in first-message and double-submit behavior.
> 
> **Overview**
> Prevents the first message in *New worktree* mode from sending unless a base branch is selected, surfacing a clear `SET_ERROR` message instead of implicitly falling back.
> 
> Tightens the send lifecycle by adding a `sendInFlightRef` guard, setting send phase earlier, immediately syncing local thread `branch`/`worktreePath` after worktree creation, and awaiting the project setup script so terminal/worktree context is consistent before starting the turn.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b0ae4313956ab430fbcf196479cf598bfca39b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require base branch selection before the first send in worktree mode and block concurrent sends in `ChatView.onSend` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/99/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Add `sendInFlightRef` to gate concurrent sends, enforce base branch presence on the first worktree send with a thread error on missing branch, immediately dispatch `SET_THREAD_BRANCH` after worktree creation, await `runProjectScript`, and reset send phase and in-flight flag in `finally`.
>
> #### 📍Where to Start
> Start with the `onSend` handler in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/99/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b0ae43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when creating new worktrees: requires a base branch in New worktree mode and shows precise error messages if missing or creation fails.
  * Ensured local thread state syncs immediately after worktree creation so branch, path, and titles update reliably.
  * Consistent error clearing and thread-context updates to prevent mismatched or stale thread state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->