### PR TITLE
Scope git action mutation state by repository cwd

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1,5 +1,5 @@
 import { type GitStatusResult, type GitStackedAction, type ThreadId } from "@t3tools/contracts";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronDownIcon, CloudUploadIcon, GitCommitIcon, InfoIcon } from "lucide-react";
 import { GitHubIcon } from "./Icons";
@@ -33,6 +33,7 @@ import { toastManager } from "~/components/ui/toast";
 import {
   gitBranchesQueryOptions,
   gitInitMutationOptions,
+  gitMutationKeys,
   gitPullMutationOptions,
   gitRunStackedActionMutationOptions,
   gitStatusQueryOptions,
@@ -168,7 +169,10 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
   );
   const pullMutation = useMutation(gitPullMutationOptions({ cwd: gitCwd, queryClient }));
 
-  const isGitActionRunning = runImmediateGitActionMutation.isPending || pullMutation.isPending;
+  const isRunStackedActionRunning =
+    useIsMutating({ mutationKey: gitMutationKeys.runStackedAction(gitCwd) }) > 0;
+  const isPullRunning = useIsMutating({ mutationKey: gitMutationKeys.pull(gitCwd) }) > 0;
+  const isGitActionRunning = isRunStackedActionRunning || isPullRunning;
   const isDefaultBranch = useMemo(() => {
     const branchName = gitStatusForActions?.branch;
     if (!branchName) return false;

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -1,0 +1,33 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import {
+  gitMutationKeys,
+  gitPullMutationOptions,
+  gitRunStackedActionMutationOptions,
+} from "./gitReactQuery";
+
+describe("gitMutationKeys", () => {
+  it("scopes stacked action keys by cwd", () => {
+    expect(gitMutationKeys.runStackedAction("/repo/a")).not.toEqual(
+      gitMutationKeys.runStackedAction("/repo/b"),
+    );
+  });
+
+  it("scopes pull keys by cwd", () => {
+    expect(gitMutationKeys.pull("/repo/a")).not.toEqual(gitMutationKeys.pull("/repo/b"));
+  });
+});
+
+describe("git mutation options", () => {
+  const queryClient = new QueryClient();
+
+  it("attaches cwd-scoped mutation key for runStackedAction", () => {
+    const options = gitRunStackedActionMutationOptions({ cwd: "/repo/a", queryClient });
+    expect(options.mutationKey).toEqual(gitMutationKeys.runStackedAction("/repo/a"));
+  });
+
+  it("attaches cwd-scoped mutation key for pull", () => {
+    const options = gitPullMutationOptions({ cwd: "/repo/a", queryClient });
+    expect(options.mutationKey).toEqual(gitMutationKeys.pull("/repo/a"));
+  });
+});

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -13,6 +13,16 @@ export const gitQueryKeys = {
   branches: (cwd: string | null) => ["git", "branches", cwd] as const,
 };
 
+export const gitMutationKeys = {
+  init: (cwd: string | null) => ["git", "mutation", "init", cwd] as const,
+  checkout: (cwd: string | null) => ["git", "mutation", "checkout", cwd] as const,
+  createBranchAndCheckout: (cwd: string | null) =>
+    ["git", "mutation", "create-branch-and-checkout", cwd] as const,
+  runStackedAction: (cwd: string | null) =>
+    ["git", "mutation", "run-stacked-action", cwd] as const,
+  pull: (cwd: string | null) => ["git", "mutation", "pull", cwd] as const,
+};
+
 export function invalidateGitQueries(queryClient: QueryClient) {
   return queryClient.invalidateQueries({ queryKey: gitQueryKeys.all });
 }
@@ -51,6 +61,7 @@ export function gitBranchesQueryOptions(cwd: string | null) {
 
 export function gitInitMutationOptions(input: { cwd: string | null; queryClient: QueryClient }) {
   return mutationOptions({
+    mutationKey: gitMutationKeys.init(input.cwd),
     mutationFn: async () => {
       const api = ensureNativeApi();
       if (!input.cwd) throw new Error("Git init is unavailable.");
@@ -67,6 +78,7 @@ export function gitCheckoutMutationOptions(input: {
   queryClient: QueryClient;
 }) {
   return mutationOptions({
+    mutationKey: gitMutationKeys.checkout(input.cwd),
     mutationFn: async (branch: string) => {
       const api = ensureNativeApi();
       if (!input.cwd) throw new Error("Git checkout is unavailable.");
@@ -83,6 +95,7 @@ export function gitCreateBranchAndCheckoutMutationOptions(input: {
   queryClient: QueryClient;
 }) {
   return mutationOptions({
+    mutationKey: gitMutationKeys.createBranchAndCheckout(input.cwd),
     mutationFn: async (branch: string) => {
       const api = ensureNativeApi();
       if (!input.cwd) throw new Error("Git branch creation is unavailable.");
@@ -100,6 +113,7 @@ export function gitRunStackedActionMutationOptions(input: {
   queryClient: QueryClient;
 }) {
   return mutationOptions({
+    mutationKey: gitMutationKeys.runStackedAction(input.cwd),
     mutationFn: async ({
       action,
       commitMessage,
@@ -123,6 +137,7 @@ export function gitRunStackedActionMutationOptions(input: {
 
 export function gitPullMutationOptions(input: { cwd: string | null; queryClient: QueryClient }) {
   return mutationOptions({
+    mutationKey: gitMutationKeys.pull(input.cwd),
     mutationFn: async () => {
       const api = ensureNativeApi();
       if (!input.cwd) throw new Error("Git pull is unavailable.");
@@ -151,6 +166,7 @@ export function gitCreateWorktreeMutationOptions(input: { queryClient: QueryClie
       if (!cwd) throw new Error("Git worktree creation is unavailable.");
       return api.git.createWorktree({ cwd, branch, newBranch, path: path ?? null });
     },
+    mutationKey: ["git", "mutation", "create-worktree"] as const,
     onSettled: async () => {
       await invalidateGitQueries(input.queryClient);
     },
@@ -164,6 +180,7 @@ export function gitRemoveWorktreeMutationOptions(input: { queryClient: QueryClie
       if (!cwd) throw new Error("Git worktree removal is unavailable.");
       return api.git.removeWorktree({ cwd, path, force });
     },
+    mutationKey: ["git", "mutation", "remove-worktree"] as const,
     onSettled: async () => {
       await invalidateGitQueries(input.queryClient);
     },


### PR DESCRIPTION
## Summary
- Scope React Query git mutation keys by `cwd` and switch `GitActionsControl` pending-state checks to `useIsMutating` with cwd-scoped keys, preventing cross-repo action loading bleed.
- Add web tests covering cwd-scoped mutation keys and mutation option wiring in `gitReactQuery`.
- Simplify diff patch caching usage by removing theme-based cache scope from `DiffPanel` and dropping the related cache-scope test.
- Revert dev/desktop state-dir override behavior: desktop now always uses `~/.t3/userdata`, and `dev-runner` removes forwarded CLI flag/env-override plumbing and related tests.
- Simplify orchestration harness dispose flow and remove the integration test that asserted temp-dir cleanup on shutdown failure.
- Minor sidebar active-row style adjustments and README cleanup to match updated dev-runner behavior.

## Testing
- `apps/web/src/lib/gitReactQuery.test.ts`: verifies mutation keys differ by cwd and that `runStackedAction`/`pull` mutation options attach cwd-scoped keys.
- `apps/web/src/lib/diffRendering.test.ts`: updated by removing the cache-scope-specific assertion.
- `scripts/dev-runner.test.ts`: removed (no replacement in this change set).
- Project lint scripts: Not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how git mutation in-flight state is tracked and used to disable UI actions; if keys are incorrect it could leave actions enabled/disabled incorrectly, though coverage was added.
> 
> **Overview**
> Prevents cross-repo “git action running” state bleed by introducing cwd-scoped `gitMutationKeys`, wiring them into git mutation option builders (`init`, `checkout`, `createBranchAndCheckout`, `runStackedAction`, `pull`), and updating `GitActionsControl` to derive busy state via `useIsMutating` with those keys.
> 
> Adds Vitest coverage to ensure mutation keys differ by `cwd` and that `runStackedAction`/`pull` options attach the expected cwd-scoped `mutationKey`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a479e8a1e9f1b48dae2de64005b9405cc266fd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope mutation state by repository cwd and update `GitActionsControl` to read `@tanstack/react-query` mutation keys from [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/102/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f)
> Introduce cwd-scoped `gitMutationKeys` and set `mutationKey` on git mutation options; `GitActionsControl` uses `useIsMutating` with these keys to compute running state.
>
> #### 📍Where to Start
> Start with `gitMutationKeys` and mutation option changes in [gitReactQuery.ts](https://github.com/pingdotgg/t3code/pull/102/files#diff-e457916ff52a952330bbc053522398bcf88467e595c5a9c4ec10f7681c65f250), then review `GitActionsControl` usage in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/102/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3a479e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->