### PR TITLE
Add “Mark unread” thread action in sidebar context menu

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -281,7 +281,17 @@ export default function Sidebar() {
     async (threadId: ThreadId, position: { x: number; y: number }) => {
       const api = readNativeApi();
       if (!api) return;
-      const clicked = await api.contextMenu.show([{ id: "delete", label: "Delete" }], position);
+      const clicked = await api.contextMenu.show(
+        [
+          { id: "mark-unread", label: "Mark unread" },
+          { id: "delete", label: "Delete" },
+        ],
+        position,
+      );
+      if (clicked === "mark-unread") {
+        dispatch({ type: "MARK_THREAD_UNREAD", threadId });
+        return;
+      }
       if (clicked !== "delete") return;
 
       const thread = state.threads.find((t) => t.id === threadId);
@@ -380,6 +390,7 @@ export default function Sidebar() {
     },
     [
       appSettings.confirmThreadDelete,
+      dispatch,
       navigate,
       removeWorktreeMutation,
       routeThreadId,

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -41,8 +41,10 @@ export function showContextMenuFallback<T extends string>(
       const btn = document.createElement("button");
       btn.type = "button";
       btn.textContent = item.label;
-      btn.className =
-        "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-destructive hover:bg-accent cursor-default";
+      const isDeleteAction = item.id === "delete";
+      btn.className = isDeleteAction
+        ? "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-destructive hover:bg-accent cursor-default"
+        : "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] text-popover-foreground hover:bg-accent cursor-default";
       btn.addEventListener("click", () => cleanup(item.id));
       menu.appendChild(btn);
     }

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -1,0 +1,94 @@
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import { reducer, type AppState } from "./store";
+import { DEFAULT_THREAD_TERMINAL_HEIGHT, DEFAULT_THREAD_TERMINAL_ID, type Thread } from "./types";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread",
+    model: "gpt-5-codex",
+    terminalOpen: false,
+    terminalHeight: DEFAULT_THREAD_TERMINAL_HEIGHT,
+    terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+    runningTerminalIds: [],
+    activeTerminalId: DEFAULT_THREAD_TERMINAL_ID,
+    terminalGroups: [
+      {
+        id: `group-${DEFAULT_THREAD_TERMINAL_ID}`,
+        terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+      },
+    ],
+    activeTerminalGroupId: `group-${DEFAULT_THREAD_TERMINAL_ID}`,
+    session: null,
+    messages: [],
+    turnDiffSummaries: [],
+    activities: [],
+    error: null,
+    createdAt: "2026-02-13T00:00:00.000Z",
+    branch: null,
+    worktreePath: null,
+    ...overrides,
+  };
+}
+
+function makeState(thread: Thread): AppState {
+  return {
+    projects: [
+      {
+        id: ProjectId.makeUnsafe("project-1"),
+        name: "Project",
+        cwd: "/tmp/project",
+        model: "gpt-5-codex",
+        expanded: true,
+        scripts: [],
+      },
+    ],
+    threads: [thread],
+    threadsHydrated: true,
+    runtimeMode: "full-access",
+  };
+}
+
+describe("store reducer", () => {
+  it("marks a completed thread as unread by moving lastVisitedAt before completion", () => {
+    const latestTurnCompletedAt = "2026-02-25T12:30:00.000Z";
+    const initialState = makeState(
+      makeThread({
+        latestTurnCompletedAt,
+        lastVisitedAt: "2026-02-25T12:35:00.000Z",
+      }),
+    );
+
+    const next = reducer(initialState, {
+      type: "MARK_THREAD_UNREAD",
+      threadId: ThreadId.makeUnsafe("thread-1"),
+    });
+
+    const updatedThread = next.threads[0];
+    expect(updatedThread).toBeDefined();
+    expect(updatedThread?.lastVisitedAt).toBe("2026-02-25T12:29:59.999Z");
+    expect(Date.parse(updatedThread?.lastVisitedAt ?? "")).toBeLessThan(
+      Date.parse(latestTurnCompletedAt),
+    );
+  });
+
+  it("does not change a thread without a completed turn", () => {
+    const initialState = makeState(
+      makeThread({
+        latestTurnCompletedAt: undefined,
+        lastVisitedAt: "2026-02-25T12:35:00.000Z",
+      }),
+    );
+
+    const next = reducer(initialState, {
+      type: "MARK_THREAD_UNREAD",
+      threadId: ThreadId.makeUnsafe("thread-1"),
+    });
+
+    expect(next).toEqual(initialState);
+  });
+});

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -33,6 +33,7 @@ import {
 type Action =
   | { type: "SYNC_SERVER_READ_MODEL"; readModel: OrchestrationReadModel }
   | { type: "MARK_THREAD_VISITED"; threadId: ThreadId; visitedAt?: string }
+  | { type: "MARK_THREAD_UNREAD"; threadId: ThreadId }
   | { type: "TOGGLE_PROJECT"; projectId: Project["id"] }
   | { type: "TOGGLE_THREAD_TERMINAL"; threadId: ThreadId }
   | { type: "SET_THREAD_TERMINAL_OPEN"; threadId: ThreadId; open: boolean }
@@ -499,6 +500,29 @@ export function reducer(state: AppState, action: Action): AppState {
           return {
             ...thread,
             lastVisitedAt: visitedAt,
+          };
+        }),
+      };
+    }
+
+    case "MARK_THREAD_UNREAD": {
+      return {
+        ...state,
+        threads: updateThread(state.threads, action.threadId, (thread) => {
+          if (!thread.latestTurnCompletedAt) {
+            return thread;
+          }
+          const latestTurnCompletedAtMs = Date.parse(thread.latestTurnCompletedAt);
+          if (Number.isNaN(latestTurnCompletedAtMs)) {
+            return thread;
+          }
+          const unreadVisitedAt = new Date(latestTurnCompletedAtMs - 1).toISOString();
+          if (thread.lastVisitedAt === unreadVisitedAt) {
+            return thread;
+          }
+          return {
+            ...thread,
+            lastVisitedAt: unreadVisitedAt,
           };
         }),
       };


### PR DESCRIPTION
## Summary
- Add a new `mark-unread` option to the thread context menu in the sidebar before `Delete`.
- Wire `mark-unread` to dispatch `MARK_THREAD_UNREAD`, updating thread read state without triggering delete flow.
- Implement `MARK_THREAD_UNREAD` in the store reducer by setting `lastVisitedAt` to 1ms before `latestTurnCompletedAt`.
- Keep the fallback context menu styling neutral for non-destructive actions and destructive styling for `Delete` only.
- Add reducer unit tests covering:
  - completed-thread case (marks unread)
  - no-completed-turn case (no state change)

## Testing
- Added unit tests in `apps/web/src/store.test.ts` for `MARK_THREAD_UNREAD` behavior.
- Concrete check: verifies `lastVisitedAt` becomes `latestTurnCompletedAt - 1ms` and is strictly earlier than completion time.
- Concrete check: verifies reducer returns unchanged state when `latestTurnCompletedAt` is absent.
- Run status: Not run (execution results were not provided in the patch context).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state update: adds a new reducer action to tweak `lastVisitedAt` and a context-menu entry to trigger it; minimal surface area with unit coverage.
> 
> **Overview**
> Adds a **“Mark unread”** entry to the sidebar thread context menu (ahead of *Delete*) that dispatches `MARK_THREAD_UNREAD` and exits before the delete flow.
> 
> Implements `MARK_THREAD_UNREAD` in the store reducer by setting a thread’s `lastVisitedAt` to 1ms before `latestTurnCompletedAt` (no-op if missing/invalid), updates the non-Electron context-menu fallback styling so only `delete` is destructive-colored, and adds `vitest` coverage for the new reducer behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0e3c1a93ac8f89f33dd40ffc1a05fcb5264dc29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a 'Mark unread' action to the sidebar thread context menu and dispatch `MARK_THREAD_UNREAD` to set `lastVisitedAt` to `latestTurnCompletedAt` minus 1 ms
> Introduce `MARK_THREAD_UNREAD` in the store reducer and wire it to the sidebar context menu; adjust non-destructive context menu item styling in [contextMenuFallback.ts](https://github.com/pingdotgg/t3code/pull/104/files#diff-032cd4155f179490fdc876b54fb96f2609ab2552587ed8b42b9963c1d250a3be); add reducer tests in [store.test.ts](https://github.com/pingdotgg/t3code/pull/104/files#diff-da5bb58321c36f9d05fab4094aeab97a54cb8eb30f13d85a80ab85bbbd7f3405).
>
> #### 📍Where to Start
> Start with the `handleThreadContextMenu` callback in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/104/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), then review the `reducer` case for `MARK_THREAD_UNREAD` in [store.ts](https://github.com/pingdotgg/t3code/pull/104/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0e3c1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->