### PR TITLE
Track per-terminal subprocess activity in thread state

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,8 +1,5 @@
-import {
-  Outlet,
-  createRootRouteWithContext,
-  type ErrorComponentProps,
-} from "@tanstack/react-router";
+import { ThreadId } from "@t3tools/contracts";
+import { Outlet, createRootRouteWithContext, type ErrorComponentProps } from "@tanstack/react-router";
 import { useEffect, useRef } from "react";
 import { QueryClient, useQueryClient } from "@tanstack/react-query";
 
@@ -13,6 +10,7 @@ import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQue
 import { readNativeApi } from "../nativeApi";
 import { useStore } from "../store";
 import { preferredTerminalEditor } from "../terminal-links";
+import { terminalRunningSubprocessFromEvent } from "../terminalActivity";
 import { onServerConfigUpdated, onServerWelcome } from "../wsNativeApi";
 import { providerQueryKeys } from "../lib/providerReactQuery";
 
@@ -170,6 +168,18 @@ function EventRouter() {
       }
       void syncSnapshot();
     });
+    const unsubTerminalEvent = api.terminal.onEvent((event) => {
+      const hasRunningSubprocess = terminalRunningSubprocessFromEvent(event);
+      if (hasRunningSubprocess === null) {
+        return;
+      }
+      dispatch({
+        type: "SET_THREAD_TERMINAL_ACTIVITY",
+        threadId: ThreadId.makeUnsafe(event.threadId),
+        terminalId: event.terminalId,
+        hasRunningSubprocess,
+      });
+    });
     const unsubWelcome = onServerWelcome(() => {
       void syncSnapshot();
     });
@@ -218,6 +228,7 @@ function EventRouter() {
     return () => {
       disposed = true;
       unsubDomainEvent();
+      unsubTerminalEvent();
       unsubWelcome();
       unsubServerConfigUpdated();
     };

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -92,3 +92,62 @@ describe("store reducer", () => {
     expect(next).toEqual(initialState);
   });
 });
+
+describe("store terminal activity reducer", () => {
+  it("adds a terminal to runningTerminalIds when subprocess activity starts", () => {
+    const state = makeState(
+      makeThread({
+        terminalIds: [DEFAULT_THREAD_TERMINAL_ID, "alt"],
+        terminalGroups: [
+          {
+            id: `group-${DEFAULT_THREAD_TERMINAL_ID}`,
+            terminalIds: [DEFAULT_THREAD_TERMINAL_ID, "alt"],
+          },
+        ],
+      }),
+    );
+    const next = reducer(state, {
+      type: "SET_THREAD_TERMINAL_ACTIVITY",
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      terminalId: "alt",
+      hasRunningSubprocess: true,
+    });
+
+    expect(next.threads[0]?.runningTerminalIds).toEqual(["alt"]);
+  });
+
+  it("removes a terminal from runningTerminalIds when subprocess activity stops", () => {
+    const state = makeState(
+      makeThread({
+        terminalIds: [DEFAULT_THREAD_TERMINAL_ID, "alt"],
+        terminalGroups: [
+          {
+            id: `group-${DEFAULT_THREAD_TERMINAL_ID}`,
+            terminalIds: [DEFAULT_THREAD_TERMINAL_ID, "alt"],
+          },
+        ],
+        runningTerminalIds: ["alt"],
+      }),
+    );
+    const next = reducer(state, {
+      type: "SET_THREAD_TERMINAL_ACTIVITY",
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      terminalId: "alt",
+      hasRunningSubprocess: false,
+    });
+
+    expect(next.threads[0]?.runningTerminalIds).toEqual([]);
+  });
+
+  it("ignores activity events for unknown terminal ids", () => {
+    const state = makeState(makeThread());
+    const next = reducer(state, {
+      type: "SET_THREAD_TERMINAL_ACTIVITY",
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      terminalId: "missing",
+      hasRunningSubprocess: true,
+    });
+
+    expect(next.threads[0]?.runningTerminalIds).toEqual([]);
+  });
+});

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -35,6 +35,12 @@ type Action =
   | { type: "MARK_THREAD_VISITED"; threadId: ThreadId; visitedAt?: string }
   | { type: "MARK_THREAD_UNREAD"; threadId: ThreadId }
   | { type: "TOGGLE_PROJECT"; projectId: Project["id"] }
+  | {
+      type: "SET_THREAD_TERMINAL_ACTIVITY";
+      threadId: ThreadId;
+      terminalId: string;
+      hasRunningSubprocess: boolean;
+    }
   | { type: "TOGGLE_THREAD_TERMINAL"; threadId: ThreadId }
   | { type: "SET_THREAD_TERMINAL_OPEN"; threadId: ThreadId; open: boolean }
   | { type: "SET_THREAD_TERMINAL_HEIGHT"; threadId: ThreadId; height: number }
@@ -370,6 +376,27 @@ function closeThreadTerminal(thread: Thread, terminalId: string): Thread {
   });
 }
 
+function setThreadTerminalActivity(
+  thread: Thread,
+  terminalId: string,
+  hasRunningSubprocess: boolean,
+): Thread {
+  const normalizedThread = normalizeThreadTerminals(thread);
+  if (!normalizedThread.terminalIds.includes(terminalId)) {
+    return normalizedThread;
+  }
+  const runningTerminalIds = new Set(normalizedThread.runningTerminalIds);
+  if (hasRunningSubprocess) {
+    runningTerminalIds.add(terminalId);
+  } else {
+    runningTerminalIds.delete(terminalId);
+  }
+  return normalizeThreadTerminals({
+    ...normalizedThread,
+    runningTerminalIds: [...runningTerminalIds],
+  });
+}
+
 // ── Reducer ──────────────────────────────────────────────────────────
 
 export function reducer(state: AppState, action: Action): AppState {
@@ -533,6 +560,14 @@ export function reducer(state: AppState, action: Action): AppState {
         ...state,
         projects: state.projects.map((p) =>
           p.id === action.projectId ? { ...p, expanded: !p.expanded } : p,
+        ),
+      };
+
+    case "SET_THREAD_TERMINAL_ACTIVITY":
+      return {
+        ...state,
+        threads: updateThread(state.threads, action.threadId, (thread) =>
+          setThreadTerminalActivity(thread, action.terminalId, action.hasRunningSubprocess),
         ),
       };
 

--- a/apps/web/src/terminalActivity.test.ts
+++ b/apps/web/src/terminalActivity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import type { TerminalEvent, TerminalSessionSnapshot } from "@t3tools/contracts";
+import { terminalRunningSubprocessFromEvent } from "./terminalActivity";
+
+const snapshot: TerminalSessionSnapshot = {
+  threadId: "thread-1",
+  terminalId: "default",
+  cwd: "/tmp",
+  status: "running",
+  pid: 1234,
+  history: "",
+  exitCode: null,
+  exitSignal: null,
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function eventBase() {
+  return {
+    threadId: "thread-1",
+    terminalId: "default",
+    createdAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+describe("terminalRunningSubprocessFromEvent", () => {
+  it("returns the subprocess flag for terminal activity events", () => {
+    const active = terminalRunningSubprocessFromEvent({
+      ...eventBase(),
+      type: "activity",
+      hasRunningSubprocess: true,
+    });
+    const idle = terminalRunningSubprocessFromEvent({
+      ...eventBase(),
+      type: "activity",
+      hasRunningSubprocess: false,
+    });
+
+    expect(active).toBe(true);
+    expect(idle).toBe(false);
+  });
+
+  it("clears running state when a terminal session starts/restarts/exits", () => {
+    const events: TerminalEvent[] = [
+      { ...eventBase(), type: "started", snapshot },
+      { ...eventBase(), type: "restarted", snapshot },
+      { ...eventBase(), type: "exited", exitCode: 0, exitSignal: null },
+    ];
+
+    for (const event of events) {
+      expect(terminalRunningSubprocessFromEvent(event)).toBe(false);
+    }
+  });
+
+  it("ignores non-activity terminal events", () => {
+    expect(
+      terminalRunningSubprocessFromEvent({
+        ...eventBase(),
+        type: "output",
+        data: "hello",
+      }),
+    ).toBeNull();
+    expect(
+      terminalRunningSubprocessFromEvent({
+        ...eventBase(),
+        type: "error",
+        message: "oops",
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/terminalActivity.ts
+++ b/apps/web/src/terminalActivity.ts
@@ -1,0 +1,14 @@
+import type { TerminalEvent } from "@t3tools/contracts";
+
+export function terminalRunningSubprocessFromEvent(event: TerminalEvent): boolean | null {
+  switch (event.type) {
+    case "activity":
+      return event.hasRunningSubprocess;
+    case "started":
+    case "restarted":
+    case "exited":
+      return false;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Summary
- wire terminal event subscription in the root route to track per-terminal subprocess activity in client state
- add `SET_THREAD_TERMINAL_ACTIVITY` reducer action to maintain `runningTerminalIds` per thread
- ignore activity updates for unknown terminal IDs and normalize terminal state updates
- add `terminalRunningSubprocessFromEvent` helper to map terminal events to running/idle/no-op activity signals
- add focused Vitest coverage for reducer behavior and terminal event mapping

## Testing
- `apps/web/src/store.test.ts`: verifies add/remove/ignore behavior for `runningTerminalIds`
- `apps/web/src/terminalActivity.test.ts`: verifies activity parsing for `activity`, `started`/`restarted`/`exited`, and ignored event types
- Lint: Not run
- Full test suite: Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new terminal event subscription and reducer path that continuously mutates per-thread `runningTerminalIds`, which can affect UI behavior that depends on terminal busy/idle state. Risk is moderate due to new event-driven state updates, but it’s scoped to client-side state and covered by focused tests.
> 
> **Overview**
> **Tracks per-terminal subprocess activity in client state.** The root `EventRouter` now subscribes to `api.terminal.onEvent`, maps terminal events to a running/idle signal, and dispatches a new `SET_THREAD_TERMINAL_ACTIVITY` action.
> 
> The store reducer adds `setThreadTerminalActivity` to maintain each thread’s `runningTerminalIds` (ignoring unknown terminal IDs and normalizing terminal state). Adds `terminalRunningSubprocessFromEvent` plus Vitest coverage for both the event mapping and reducer add/remove/ignore behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9017090e504e0fe0d96070d654fa367c3d8a5c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Track per-thread terminal subprocess activity and dispatch `SET_THREAD_TERMINAL_ACTIVITY` from `EventRouter` in [__root.tsx](https://github.com/pingdotgg/t3code/pull/105/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100)
> Add terminal event subscription that derives subprocess activity via `terminalActivity.terminalRunningSubprocessFromEvent` and updates thread state through the reducer, with tests covering event mapping and store updates.
>
> #### 📍Where to Start
> Start with `EventRouter` in [apps/web/src/routes/__root.tsx](https://github.com/pingdotgg/t3code/pull/105/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100), then review `terminalActivity.terminalRunningSubprocessFromEvent` in [apps/web/src/terminalActivity.ts](https://github.com/pingdotgg/t3code/pull/105/files#diff-8395243d55ee3ed0ac440a83067406eb6651d8cef22d925ccd0ff106fd4965b1) and the `SET_THREAD_TERMINAL_ACTIVITY` case in [apps/web/src/store.ts](https://github.com/pingdotgg/t3code/pull/105/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c901709.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced terminal subprocess activity monitoring to accurately track when subprocesses are running across terminals, providing real-time visibility into terminal operations.

* **Tests**
  * Added comprehensive test coverage for terminal activity state management, including subprocess start, stop, and activity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->