### PR TITLE
Sync diff renderer and worker theme with resolved app theme

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -16,7 +16,11 @@ import { useStore } from "../store";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
 type DiffRenderMode = "stacked" | "split";
-type DiffThemeType = "light" | "dark" | "system";
+type DiffThemeType = "light" | "dark";
+
+function resolveDiffThemeName(theme: "light" | "dark") {
+  return theme === "dark" ? "pierre-dark" : "pierre-light";
+}
 
 type RenderablePatch =
   | {
@@ -472,13 +476,15 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                 {renderableFiles.map((fileDiff) => {
                   const filePath = resolveFileDiffPath(fileDiff);
                   const fileKey = buildFileDiffRenderKey(fileDiff);
+                  const themedFileKey = `${fileKey}:${resolvedTheme}`;
                   return (
-                    <div key={fileKey} data-diff-file-path={filePath} className="rounded-md">
+                    <div key={themedFileKey} data-diff-file-path={filePath} className="rounded-md">
                       <FileDiff
                         fileDiff={fileDiff}
                         options={{
                           diffStyle: diffRenderMode === "split" ? "split" : "unified",
                           lineDiffType: "none",
+                          theme: resolveDiffThemeName(resolvedTheme),
                           themeType: resolvedTheme as DiffThemeType,
                         }}
                       />

--- a/apps/web/src/components/DiffWorkerPoolProvider.tsx
+++ b/apps/web/src/components/DiffWorkerPoolProvider.tsx
@@ -1,8 +1,39 @@
-import { WorkerPoolContextProvider } from "@pierre/diffs/react";
+import { WorkerPoolContextProvider, useWorkerPool } from "@pierre/diffs/react";
 import DiffsWorker from "@pierre/diffs/worker/worker.js?worker";
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
+import { useTheme } from "../hooks/useTheme";
+
+function resolveDiffThemeName(theme: "light" | "dark") {
+  return theme === "dark" ? "pierre-dark" : "pierre-light";
+}
+
+function DiffWorkerThemeSync({ themeName }: { themeName: "pierre-light" | "pierre-dark" }) {
+  const workerPool = useWorkerPool();
+
+  useEffect(() => {
+    if (!workerPool) {
+      return;
+    }
+
+    const current = workerPool.getDiffRenderOptions();
+    if (current.theme === themeName) {
+      return;
+    }
+
+    void workerPool
+      .setRenderOptions({
+        ...current,
+        theme: themeName,
+      })
+      .catch(() => undefined);
+  }, [themeName, workerPool]);
+
+  return null;
+}
 
 export function DiffWorkerPoolProvider({ children }: { children?: ReactNode }) {
+  const { resolvedTheme } = useTheme();
+  const diffThemeName = resolveDiffThemeName(resolvedTheme);
   const workerPoolSize = useMemo(() => {
     const cores =
       typeof navigator === "undefined" ? 4 : Math.max(1, navigator.hardwareConcurrency || 4);
@@ -17,9 +48,11 @@ export function DiffWorkerPoolProvider({ children }: { children?: ReactNode }) {
         totalASTLRUCacheSize: 240,
       }}
       highlighterOptions={{
+        theme: diffThemeName,
         tokenizeMaxLineLength: 1_000,
       }}
     >
+      <DiffWorkerThemeSync themeName={diffThemeName} />
       {children}
     </WorkerPoolContextProvider>
   );

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 
 type Theme = "light" | "dark" | "system";
+type ThemeSnapshot = {
+  theme: Theme;
+  systemDark: boolean;
+};
 
 const STORAGE_KEY = "t3code:theme";
 const MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
 let listeners: Array<() => void> = [];
+let lastSnapshot: ThemeSnapshot | null = null;
 function emitChange() {
   for (const listener of listeners) listener();
 }
@@ -39,8 +44,16 @@ function applyTheme(theme: Theme, suppressTransitions = false) {
 // Apply immediately on module load to prevent flash
 applyTheme(getStored());
 
-function getSnapshot(): Theme {
-  return getStored();
+function getSnapshot(): ThemeSnapshot {
+  const theme = getStored();
+  const systemDark = theme === "system" ? getSystemDark() : false;
+
+  if (lastSnapshot && lastSnapshot.theme === theme && lastSnapshot.systemDark === systemDark) {
+    return lastSnapshot;
+  }
+
+  lastSnapshot = { theme, systemDark };
+  return lastSnapshot;
 }
 
 function subscribe(listener: () => void): () => void {
@@ -71,10 +84,11 @@ function subscribe(listener: () => void): () => void {
 }
 
 export function useTheme() {
-  const theme = useSyncExternalStore(subscribe, getSnapshot);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot);
+  const theme = snapshot.theme;
 
   const resolvedTheme: "light" | "dark" =
-    theme === "system" ? (getSystemDark() ? "dark" : "light") : theme;
+    theme === "system" ? (snapshot.systemDark ? "dark" : "light") : theme;
 
   const setTheme = useCallback((next: Theme) => {
     localStorage.setItem(STORAGE_KEY, next);


### PR DESCRIPTION
## Summary
- update diff panel rendering to use explicit Pierre theme names (`pierre-light`/`pierre-dark`) derived from the resolved app theme
- include resolved theme in file diff React keys so diff views remount cleanly on theme switches
- sync worker pool highlighter/render options with current theme via `DiffWorkerThemeSync`
- improve `useTheme` snapshot stability by tracking both stored theme and system dark-mode state for consistent `useSyncExternalStore` updates

## Testing
- Not run (not provided in patch context)
- Suggested check: toggle app theme between `light`, `dark`, and `system` and verify diff colors update immediately without stale highlighting
- Suggested check: with `system` theme selected, change OS color scheme and verify diff panel/worker rendering follows the new resolved theme

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches diff rendering and worker pool configuration; regressions could cause stale or incorrect syntax highlighting when toggling themes, but changes are UI-only and not security/data-critical.
> 
> **Overview**
> Ensures diff rendering updates cleanly on theme changes by mapping the app’s resolved theme to explicit Pierre themes (`pierre-light`/`pierre-dark`) and passing them into `FileDiff` options.
> 
> Updates the diff worker pool to initialize and *continuously sync* highlighter/render options to the current theme via a new `DiffWorkerThemeSync`, and adjusts `useTheme`’s `useSyncExternalStore` snapshot to include cached system dark-mode state for more consistent updates (especially when `theme=system`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df323f859052f450a4bfaf48db4ed67468d9e999. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync diff renderer and worker theme with resolved app theme in `apps/web/src/components/DiffPanel.tsx` and `apps/web/src/components/DiffWorkerPoolProvider.tsx`
> Restrict `DiffThemeType` to `"light" | "dark"`, add `resolveDiffThemeName` to map resolved themes to `"pierre-light"` or `"pierre-dark"`, remount `FileDiff` items on theme change via keyed `resolvedTheme`, and propagate theme names to the worker pool render and highlighter options. Core changes are in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/108/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3), [DiffWorkerPoolProvider.tsx](https://github.com/pingdotgg/t3code/pull/108/files#diff-1c5fc15aaf7dcbcc7292252895549343191a1e1af28c7be3c2c656c32da58032), and [useTheme.ts](https://github.com/pingdotgg/t3code/pull/108/files#diff-57ecb397fe0e1618fa00c5e68da8f87d74b28fa80bbe3278328f195bc91505c4).
>
> #### 📍Where to Start
> Start with `resolveDiffThemeName` and its usage in `DiffPanel` in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/108/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3), then review `DiffWorkerPoolProvider` and `DiffWorkerThemeSync` in [DiffWorkerPoolProvider.tsx](https://github.com/pingdotgg/t3code/pull/108/files#diff-1c5fc15aaf7dcbcc7292252895549343191a1e1af28c7be3c2c656c32da58032).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df323f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed "system" theme option from diff panel; now supports "light" and "dark" only.

* **Improvements**
  * Improved theme synchronization for diff rendering to ensure consistency across the UI.
  * Enhanced performance of theme handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->