### PR TITLE
feat: copy button on user messages, hover on message for buttons

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -83,6 +83,8 @@ import {
   LockOpenIcon,
   Undo2Icon,
   XIcon,
+  CopyIcon,
+  CheckIcon,
 } from "lucide-react";
 import { Button } from "./ui/button";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "./ui/select";
@@ -2333,6 +2335,28 @@ const PendingApprovalsPanel = memo(function PendingApprovalsPanel({
   );
 });
 
+const MessageCopyButton = memo(function MessageCopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+
+  return (
+    <Button
+      type="button"
+      size="xs"
+      variant="outline"
+      onClick={handleCopy}
+      title="Copy message"
+    >
+      {copied ? <CheckIcon className="size-3 text-success" /> : <CopyIcon className="size-3" />}
+    </Button>
+  );
+});
+
 interface MessagesTimelineProps {
   hasMessages: boolean;
   isWorking: boolean;
@@ -2549,7 +2573,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
                   const canRevertAgentWork = revertTurnCountByUserMessageId.has(row.message.id);
                   return (
                     <div className="flex justify-end">
-                      <div className="max-w-[80%] rounded-2xl rounded-br-sm border border-border bg-secondary px-4 py-3">
+                      <div className="group relative max-w-[80%] rounded-2xl rounded-br-sm border border-border bg-secondary px-4 py-3">
                         {userImages.length > 0 && (
                           <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
                             {userImages.map(
@@ -2583,17 +2607,21 @@ const MessagesTimeline = memo(function MessagesTimeline({
                           </pre>
                         )}
                         <div className="mt-1.5 flex items-center justify-end gap-2">
-                          {canRevertAgentWork && (
-                            <Button
-                              type="button"
-                              size="xs"
-                              variant="outline"
-                              disabled={isRevertingCheckpoint || isWorking}
-                              onClick={() => onRevertUserMessage(row.message.id)}
-                            >
-                              <Undo2Icon className="size-3" />
-                            </Button>
-                          )}
+                          <div className="flex items-center gap-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+                            {row.message.text && <MessageCopyButton text={row.message.text} />}
+                            {canRevertAgentWork && (
+                              <Button
+                                type="button"
+                                size="xs"
+                                variant="outline"
+                                disabled={isRevertingCheckpoint || isWorking}
+                                onClick={() => onRevertUserMessage(row.message.id)}
+                                title="Revert to this message"
+                              >
+                                <Undo2Icon className="size-3" />
+                              </Button>
+                            )}
+                          </div>
                           <p className="text-right text-[10px] text-muted-foreground/30">
                             {formatTimestamp(row.message.createdAt)}
                           </p>


### PR DESCRIPTION
<img width="913" height="348" alt="image" src="https://github.com/user-attachments/assets/286667f3-5574-4347-a333-9f33165f1bb6" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a copy button to user message bubbles and show message controls on hover in `apps/web/src/components/ChatView.tsx`
> Introduce a memoized `MessageCopyButton` that writes text to the clipboard and toggles `CopyIcon`/`CheckIcon` for 2000ms, and update user message bubbles to reveal copy and revert controls on hover/focus with opacity transitions in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/110/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> #### 📍Where to Start
> Start with the `MessageCopyButton` component and its usage within `MessagesTimeline` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/110/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e09f859.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard functionality for user messages in the chat timeline. A copy button appears when hovering over messages with visual confirmation when text is successfully copied.
  * Enhanced message action button interactions and layout for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->