### PR TITLE
Add manual GitHub Actions workflow for macOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,18 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Git tag to create/use for this release (example: v0.1.0)"
+      bump:
+        description: "Semantic version bump to apply before release"
         required: true
-        type: string
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
       release_name:
         description: "Display name for the GitHub release"
         required: false
-        type: string
-      version:
-        description: "Semver version injected into packaged artifacts (example: 0.1.0)"
-        required: true
         type: string
       draft:
         description: "Create release as draft"
@@ -30,7 +31,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: release-${{ inputs.tag }}
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -38,8 +39,8 @@ jobs:
     name: Bump versions, commit, and tag
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.meta.outputs.tag }}
-      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.bump-version.outputs.tag }}
+      version: ${{ steps.bump-version.outputs.version }}
     steps:
       - name: Ensure workflow runs from a branch
         run: |
@@ -59,43 +60,93 @@ jobs:
         with:
           node-version-file: package.json
 
-      - name: Set release metadata outputs
-        id: meta
-        run: |
-          echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-          echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-
-      - name: Validate tag does not already exist
-        run: |
-          if git rev-parse --verify --quiet "refs/tags/${{ inputs.tag }}"; then
-            echo "Tag ${{ inputs.tag }} already exists locally."
-            exit 1
-          fi
-          if git ls-remote --tags origin "${{ inputs.tag }}" | grep -q .; then
-            echo "Tag ${{ inputs.tag }} already exists on origin."
-            exit 1
-          fi
-
-      - name: Bump app versions
+      - name: Bump app versions and infer release tag
+        id: bump-version
         run: |
           node --input-type=module <<'EOF'
           import fs from "node:fs";
 
-          const version = process.env.RELEASE_VERSION;
+          const bump = process.env.RELEASE_BUMP;
           const files = [
             "apps/server/package.json",
             "apps/desktop/package.json",
             "apps/web/package.json",
           ];
+          const sourceVersionFile = "apps/server/package.json";
+
+          const semverRegex = /^(\d+)\.(\d+)\.(\d+)$/;
+          const versions = files.map((file) => {
+            const json = JSON.parse(fs.readFileSync(file, "utf8"));
+            return { file, version: json.version };
+          });
+
+          const source = versions.find((entry) => entry.file === sourceVersionFile);
+          if (!source) {
+            throw new Error(`Could not find source version file '${sourceVersionFile}'.`);
+          }
+          const outOfSync = versions.filter((entry) => entry.version !== source.version);
+          if (outOfSync.length > 0) {
+            const details = outOfSync.map((entry) => `${entry.file}=${entry.version}`).join(", ");
+            console.warn(
+              `Detected out-of-sync app versions. Using ${sourceVersionFile}=${source.version} as source of truth. Others: ${details}`,
+            );
+          }
+
+          const currentVersion = source.version;
+          const match = semverRegex.exec(currentVersion);
+          if (!match) {
+            throw new Error(
+              `Version '${currentVersion}' is not a supported plain semver (x.y.z).`,
+            );
+          }
+
+          let major = Number.parseInt(match[1], 10);
+          let minor = Number.parseInt(match[2], 10);
+          let patch = Number.parseInt(match[3], 10);
+
+          if (bump === "patch") {
+            patch += 1;
+          } else if (bump === "minor") {
+            minor += 1;
+            patch = 0;
+          } else if (bump === "major") {
+            major += 1;
+            minor = 0;
+            patch = 0;
+          } else {
+            throw new Error(`Unsupported bump type '${bump}'.`);
+          }
+
+          const version = `${major}.${minor}.${patch}`;
+          const tag = `v${version}`;
 
           for (const file of files) {
             const json = JSON.parse(fs.readFileSync(file, "utf8"));
             json.version = version;
             fs.writeFileSync(file, `${JSON.stringify(json, null, 2)}\n`, "utf8");
           }
+
+          const outputPath = process.env.GITHUB_OUTPUT;
+          fs.appendFileSync(outputPath, `version=${version}\n`);
+          fs.appendFileSync(outputPath, `tag=${tag}\n`);
+
+          console.log(`Bumped version ${currentVersion} -> ${version}`);
+          console.log(`Inferred release tag: ${tag}`);
           EOF
         env:
-          RELEASE_VERSION: ${{ inputs.version }}
+          RELEASE_BUMP: ${{ inputs.bump }}
+
+      - name: Validate inferred tag does not already exist
+        run: |
+          tag="${{ steps.bump-version.outputs.tag }}"
+          if git rev-parse --verify --quiet "refs/tags/${tag}"; then
+            echo "Tag ${tag} already exists locally."
+            exit 1
+          fi
+          if git ls-remote --tags origin "${tag}" | grep -q .; then
+            echo "Tag ${tag} already exists on origin."
+            exit 1
+          fi
 
       - name: Commit version bump
         run: |
@@ -106,15 +157,15 @@ jobs:
             echo "No version change detected; refusing to create empty release commit."
             exit 1
           fi
-          git commit -m "chore(release): bump app versions to ${{ inputs.version }}
+          git commit -m "chore(release): bump app versions to ${{ steps.bump-version.outputs.version }}
 
           Co-authored-by: codex <codex@users.noreply.github.com>"
 
       - name: Create and push release tag
         run: |
-          git tag -a "${{ inputs.tag }}" -m "Release ${{ inputs.tag }}"
+          git tag -a "${{ steps.bump-version.outputs.tag }}" -m "Release ${{ steps.bump-version.outputs.tag }}"
           git push origin "${{ github.ref_name }}"
-          git push origin "refs/tags/${{ inputs.tag }}"
+          git push origin "refs/tags/${{ steps.bump-version.outputs.tag }}"
 
   build-macos:
     name: Build and package macOS (${{ matrix.arch }})


### PR DESCRIPTION
## Summary
- Add a new `.github/workflows/release.yml` workflow triggered via `workflow_dispatch`.
- Support release inputs for `tag`, `release_name`, `version`, `arch` (`arm64`/`x64`/`universal`), `draft`, and `prerelease`.
- Build macOS artifacts on `macos-14`, generate `SHA256SUMS.txt`, upload workflow artifacts, and publish assets to a GitHub release.
- Configure release concurrency by tag and include TODO notes for future signing/notarization and multi-platform release expansion.

## Testing
- Not run (content-only workflow addition).
- Verified workflow structure includes checkout, Bun/Node setup, dependency install, packaging, checksum generation, artifact upload, and release publication steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates version bumping, tagging, and release publishing with `contents: write` permissions; mistakes could create unintended commits/tags or publish incorrect artifacts.
> 
> **Overview**
> Adds a new manually triggered `Release` GitHub Actions workflow that bumps semver across `apps/server`, `apps/desktop`, and `apps/web`, commits the change, and creates/pushes an annotated `vX.Y.Z` tag.
> 
> The workflow then builds macOS DMG artifacts on `macos-14` for `arm64` and `x64`, generates per-arch SHA256 checksum files, uploads the build outputs, and publishes a GitHub Release (draft/prerelease configurable) with the packaged assets and autogenerated release notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54f8aef6a2904d9117cb7fbd4b938aac64b21428. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a manually triggered GitHub Actions Release workflow to build and publish macOS arm64 and x64 DMG releases with version bumping across `apps/server`, `apps/desktop`, and `apps/web`
> Introduce `.github/workflows/release.yml` with `workflow_dispatch` inputs, a `prepare-release` job that bumps and tags versions, a `build-macos` matrix job that packages DMGs and SHA256SUMS for arm64 and x64, and a `publish-release` job that creates a GitHub release with uploaded artifacts.
>
> #### 📍Where to Start
> Start with the workflow definition in [release.yml](https://github.com/pingdotgg/t3code/pull/112/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34), focusing on the `prepare-release` job and its version bump script and outputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54f8aef.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual "Release" workflow to automate version bumping, tagging and publishing with inputs for bump, release name, draft and prerelease.
  * Automated macOS builds for arm64 and x64, producing per-architecture artifacts and SHA256 checksums.
  * Automated release creation that uploads artifacts and supports draft/prerelease releases; placeholders remain for signing/notarization and multi-platform support.
  * Added safeguards: branch-only execution, duplicate-tag prevention, and empty-commit detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->