### PR TITLE
Command failure tolerance

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.test.ts
+++ b/apps/server/src/terminal/Layers/Manager.test.ts
@@ -639,6 +639,38 @@ describe("TerminalManager", () => {
     manager.dispose();
   });
 
+  it("silently drops write to exited terminal instead of throwing", async () => {
+    const { manager, ptyAdapter } = makeManager();
+    await manager.open(openInput());
+    const process = ptyAdapter.processes[0];
+    expect(process).toBeDefined();
+    if (!process) return;
+
+    process.emitExit({ exitCode: 0, signal: 0 });
+
+    await expect(
+      manager.write({ threadId: "thread-1", data: "hello\n" }),
+    ).resolves.toBeUndefined();
+
+    manager.dispose();
+  });
+
+  it("silently drops resize to exited terminal instead of throwing", async () => {
+    const { manager, ptyAdapter } = makeManager();
+    await manager.open(openInput());
+    const process = ptyAdapter.processes[0];
+    expect(process).toBeDefined();
+    if (!process) return;
+
+    process.emitExit({ exitCode: 0, signal: 0 });
+
+    await expect(
+      manager.resize({ threadId: "thread-1", cols: 200, rows: 50 }),
+    ).resolves.toBeUndefined();
+
+    manager.dispose();
+  });
+
   it("starts zsh with prompt spacer disabled to avoid `%` end markers", async () => {
     if (process.platform === "win32") return;
     const { manager, ptyAdapter } = makeManager(5, {

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -438,25 +438,29 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     const input = decodeTerminalWriteInput(raw);
     const session = this.requireSession(input.threadId, input.terminalId);
     if (!session.process || session.status !== "running") {
-      throw new Error(
-        `Terminal is not running for thread: ${input.threadId}, terminal: ${input.terminalId}`,
-      );
+      return;
     }
-    session.process.write(input.data);
+    try {
+      session.process.write(input.data);
+    } catch {
+      // Process may have exited between the status check and the write call.
+    }
   }
 
   async resize(raw: TerminalResizeInput): Promise<void> {
     const input = decodeTerminalResizeInput(raw);
     const session = this.requireSession(input.threadId, input.terminalId);
     if (!session.process || session.status !== "running") {
-      throw new Error(
-        `Terminal is not running for thread: ${input.threadId}, terminal: ${input.terminalId}`,
-      );
+      return;
     }
     session.cols = input.cols;
     session.rows = input.rows;
     session.updatedAt = new Date().toISOString();
-    session.process.resize(input.cols, input.rows);
+    try {
+      session.process.resize(input.cols, input.rows);
+    } catch {
+      // Process may have exited between the status check and the resize call.
+    }
   }
 
   async clear(raw: TerminalClearInput): Promise<void> {


### PR DESCRIPTION
Make terminal `write` and `resize` tolerant of exited processes to prevent errors when a terminal closes.

The terminal's `write` and `resize` methods were throwing errors when called on a process that had already exited (e.g., after an `exit` command), causing error messages to appear in the UI. This change makes these operations silently return or catch errors, allowing the terminal to close gracefully without user-facing errors.

---
<p><a href="https://cursor.com/agents/bc-832cfc3a-7e32-43c3-a379-00b46873aad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-832cfc3a-7e32-43c3-a379-00b46873aad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `TerminalManagerRuntime.write` and `TerminalManagerRuntime.resize` tolerate command failures in [Manager.ts](https://github.com/pingdotgg/t3code/pull/114/files#diff-51f9668a4493e7cf6ec7c836a4af9946110091ee50cd822c9c4a4d5bdcedf496) by returning early when the terminal is missing or exited
> Update terminal runtime methods to return without throwing when the session is absent or exited and wrap process calls in try/catch; add tests asserting resolved promises on exited sessions in [Manager.test.ts](https://github.com/pingdotgg/t3code/pull/114/files#diff-3b6f9b0b99b80efb744cdc5062565dd1ac1a4d4f551e3054c3d85b32dbddbaef).
>
> #### 📍Where to Start
> Start with the `TerminalManagerRuntime.write` and `TerminalManagerRuntime.resize` implementations in [Manager.ts](https://github.com/pingdotgg/t3code/pull/114/files#diff-51f9668a4493e7cf6ec7c836a4af9946110091ee50cd822c9c4a4d5bdcedf496).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 25ea66c. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->