### PR TITLE
Terminal exit error handling

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -25,6 +25,7 @@ import {
   MAX_THREAD_TERMINAL_COUNT,
   type ThreadTerminalGroup,
 } from "../types";
+import { isIgnorableTerminalWriteError } from "../terminal-errors";
 import { readNativeApi } from "~/nativeApi";
 
 const MIN_DRAWER_HEIGHT = 180;
@@ -112,6 +113,7 @@ interface TerminalViewportProps {
   terminalId: string;
   cwd: string;
   runtimeEnv?: Record<string, string>;
+  onCloseTerminal: (terminalId: string) => void;
   focusRequestId: number;
   autoFocus: boolean;
   resizeEpoch: number;
@@ -123,6 +125,7 @@ function TerminalViewport({
   terminalId,
   cwd,
   runtimeEnv,
+  onCloseTerminal,
   focusRequestId,
   autoFocus,
   resizeEpoch,
@@ -156,6 +159,12 @@ function TerminalViewport({
 
     const api = readNativeApi();
     if (!api) return;
+    let closeRequested = false;
+    const requestTerminalClose = () => {
+      if (closeRequested) return;
+      closeRequested = true;
+      onCloseTerminal(terminalId);
+    };
 
     const sendTerminalInput = async (data: string, fallbackError: string) => {
       const activeTerminal = terminalRef.current;
@@ -163,6 +172,10 @@ function TerminalViewport({
       try {
         await api.terminal.write({ threadId, terminalId, data });
       } catch (error) {
+        if (isIgnorableTerminalWriteError(error)) {
+          requestTerminalClose();
+          return;
+        }
         writeSystemMessage(activeTerminal, error instanceof Error ? error.message : fallbackError);
       }
     };
@@ -243,12 +256,13 @@ function TerminalViewport({
     const inputDisposable = terminal.onData((data) => {
       void api.terminal
         .write({ threadId, terminalId, data })
-        .catch((err) =>
-          writeSystemMessage(
-            terminal,
-            err instanceof Error ? err.message : "Terminal write failed",
-          ),
-        );
+        .catch((err) => {
+          if (isIgnorableTerminalWriteError(err)) {
+            requestTerminalClose();
+            return;
+          }
+          writeSystemMessage(terminal, err instanceof Error ? err.message : "Terminal write failed");
+        });
     });
 
     const themeObserver = new MutationObserver(() => {
@@ -325,16 +339,7 @@ function TerminalViewport({
       }
 
       if (event.type === "exited") {
-        const details = [
-          typeof event.exitCode === "number" ? `code ${event.exitCode}` : null,
-          typeof event.exitSignal === "number" ? `signal ${event.exitSignal}` : null,
-        ]
-          .filter((value): value is string => value !== null)
-          .join(", ");
-        writeSystemMessage(
-          activeTerminal,
-          details.length > 0 ? `Process exited (${details})` : "Process exited",
-        );
+        requestTerminalClose();
       }
     });
 
@@ -370,7 +375,7 @@ function TerminalViewport({
       fitAddonRef.current = null;
       terminal.dispose();
     };
-  }, [cwd, runtimeEnv, terminalId, threadId]);
+  }, [cwd, onCloseTerminal, runtimeEnv, terminalId, threadId]);
 
   useEffect(() => {
     if (!autoFocus) return;
@@ -783,6 +788,7 @@ export default function ThreadTerminalDrawer({
                         terminalId={terminalId}
                         cwd={cwd}
                         {...(runtimeEnv ? { runtimeEnv } : {})}
+                        onCloseTerminal={onCloseTerminal}
                         focusRequestId={focusRequestId}
                         autoFocus={terminalId === resolvedActiveTerminalId}
                         resizeEpoch={resizeEpoch}
@@ -800,6 +806,7 @@ export default function ThreadTerminalDrawer({
                   terminalId={resolvedActiveTerminalId}
                   cwd={cwd}
                   {...(runtimeEnv ? { runtimeEnv } : {})}
+                  onCloseTerminal={onCloseTerminal}
                   focusRequestId={focusRequestId}
                   autoFocus
                   resizeEpoch={resizeEpoch}

--- a/apps/web/src/terminal-errors.test.ts
+++ b/apps/web/src/terminal-errors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { isIgnorableTerminalWriteError } from "./terminal-errors";
+
+describe("isIgnorableTerminalWriteError", () => {
+  it("treats not-running terminal errors as ignorable", () => {
+    expect(
+      isIgnorableTerminalWriteError(
+        new Error("Terminal is not running for thread: thread-1, terminal: default"),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats unknown terminal thread errors as ignorable", () => {
+    expect(
+      isIgnorableTerminalWriteError(
+        `TerminalError: Failed to write to terminal
+├─ cause: Error: Unknown terminal thread: thread-1, terminal: default`,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not ignore unrelated terminal write failures", () => {
+    expect(isIgnorableTerminalWriteError(new Error("Request timed out: terminal.write"))).toBe(
+      false,
+    );
+    expect(isIgnorableTerminalWriteError(null)).toBe(false);
+  });
+});

--- a/apps/web/src/terminal-errors.ts
+++ b/apps/web/src/terminal-errors.ts
@@ -1,0 +1,20 @@
+const BENIGN_TERMINAL_WRITE_ERROR_MARKERS = [
+  "terminal is not running",
+  "unknown terminal thread",
+] as const;
+
+function errorMessage(error: unknown): string | null {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return null;
+}
+
+export function isIgnorableTerminalWriteError(error: unknown): boolean {
+  const message = errorMessage(error)?.toLowerCase();
+  if (!message) return false;
+  return BENIGN_TERMINAL_WRITE_ERROR_MARKERS.some((marker) => message.includes(marker));
+}


### PR DESCRIPTION
Auto-close the terminal on exit and suppress benign write errors that occur during shutdown.

Commands like `exit` should gracefully close the terminal without displaying error messages, treating such "failures" as normal terminal behavior rather than hard errors.

---
<p><a href="https://cursor.com/agents/bc-b6971ff3-62dd-471e-8343-0b8cdd426572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6971ff3-62dd-471e-8343-0b8cdd426572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle terminal exit errors by invoking `components.TerminalViewportProps.onCloseTerminal` from `components.TerminalViewport` and remove system messages in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/116/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636)
> Add `onCloseTerminal` to `components.TerminalViewportProps` and call it when write errors match `terminal-errors.isIgnorableTerminalWriteError` or on `exited`; update `ThreadTerminalDrawer` to pass the callback; add tests for `isIgnorableTerminalWriteError` and implement the utility in [terminal-errors.ts](https://github.com/pingdotgg/t3code/pull/116/files#diff-b3a49bfab2f8e78412fcb0accadb4afbb19c512e9e2af66ee884c5bcf2e2e651).
>
> #### 📍Where to Start
> Start with the `TerminalViewport` component changes in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/116/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636), then review `isIgnorableTerminalWriteError` in [terminal-errors.ts](https://github.com/pingdotgg/t3code/pull/116/files#diff-b3a49bfab2f8e78412fcb0accadb4afbb19c512e9e2af66ee884c5bcf2e2e651).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7dc0ff1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->