### PR TITLE
Current turn virtualization

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2446,11 +2446,31 @@ const MessagesTimeline = memo(function MessagesTimeline({
     return nextRows;
   }, [timelineEntries, completionDividerBeforeEntryId, isWorking]);
 
+  // Split rows: completed turns are virtualized, current in-progress turn is not.
+  // The current turn starts at the last user message when actively working.
+  const currentTurnStartIndex = useMemo(() => {
+    if (!isWorking) return rows.length;
+    for (let i = rows.length - 1; i >= 0; i--) {
+      const row = rows[i];
+      if (row?.kind === "message" && row.message.role === "user") return i;
+    }
+    return rows.length;
+  }, [rows, isWorking]);
+
+  const virtualizedRows = useMemo(
+    () => rows.slice(0, currentTurnStartIndex),
+    [rows, currentTurnStartIndex],
+  );
+  const currentTurnRows = useMemo(
+    () => rows.slice(currentTurnStartIndex),
+    [rows, currentTurnStartIndex],
+  );
+
   const rowVirtualizer = useVirtualizer({
-    count: rows.length,
+    count: virtualizedRows.length,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: (index: number) => {
-      const row = rows[index];
+      const row = virtualizedRows[index];
       if (!row) return 96;
       if (row.kind === "work") return 112;
       if (row.kind === "working") return 40;
@@ -2472,292 +2492,306 @@ const MessagesTimeline = memo(function MessagesTimeline({
     );
   }
 
-  return (
-    <div
-      className="relative mx-auto w-full min-w-0 max-w-3xl overflow-x-hidden"
-      style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
-    >
-      {virtualRows.map((virtualRow: VirtualItem) => {
-        const row = rows[virtualRow.index];
-        if (!row) return null;
+  const renderRowContent = (row: TimelineRow) => (
+    <div className="pb-4">
+      {row.kind === "work" &&
+        (() => {
+          const groupId = row.id;
+          const groupedEntries = row.groupedEntries;
+          const isExpanded = expandedWorkGroups[groupId] ?? false;
+          const hasOverflow = groupedEntries.length > MAX_VISIBLE_WORK_LOG_ENTRIES;
+          const visibleEntries =
+            hasOverflow && !isExpanded
+              ? groupedEntries.slice(-MAX_VISIBLE_WORK_LOG_ENTRIES)
+              : groupedEntries;
+          const hiddenCount = groupedEntries.length - visibleEntries.length;
+          const onlyToolEntries = groupedEntries.every((entry) => entry.tone === "tool");
+          const groupLabel = onlyToolEntries
+            ? groupedEntries.length === 1
+              ? "Tool call"
+              : `Tool calls (${groupedEntries.length})`
+            : groupedEntries.length === 1
+              ? "Work event"
+              : `Work log (${groupedEntries.length})`;
 
-        return (
-          <div
-            key={row.id}
-            data-index={virtualRow.index}
-            ref={rowVirtualizer.measureElement}
-            className="absolute left-0 top-0 w-full"
-            style={{ transform: `translateY(${virtualRow.start}px)` }}
-          >
-            <div className="pb-4">
-              {row.kind === "work" &&
-                (() => {
-                  const groupId = row.id;
-                  const groupedEntries = row.groupedEntries;
-                  const isExpanded = expandedWorkGroups[groupId] ?? false;
-                  const hasOverflow = groupedEntries.length > MAX_VISIBLE_WORK_LOG_ENTRIES;
-                  const visibleEntries =
-                    hasOverflow && !isExpanded
-                      ? groupedEntries.slice(-MAX_VISIBLE_WORK_LOG_ENTRIES)
-                      : groupedEntries;
-                  const hiddenCount = groupedEntries.length - visibleEntries.length;
-                  const onlyToolEntries = groupedEntries.every((entry) => entry.tone === "tool");
-                  const groupLabel = onlyToolEntries
-                    ? groupedEntries.length === 1
-                      ? "Tool call"
-                      : `Tool calls (${groupedEntries.length})`
-                    : groupedEntries.length === 1
-                      ? "Work event"
-                      : `Work log (${groupedEntries.length})`;
+          return (
+            <div className="rounded-lg border border-border/80 bg-card/45 px-3 py-2">
+              <div className="mb-1.5 flex items-center justify-between gap-3">
+                <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
+                  {groupLabel}
+                </p>
+                {hasOverflow && (
+                  <button
+                    type="button"
+                    className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/55 transition-colors duration-150 hover:text-muted-foreground/80"
+                    onClick={() => onToggleWorkGroup(groupId)}
+                  >
+                    {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
+                  </button>
+                )}
+              </div>
+              <div className="space-y-1">
+                {visibleEntries.map((workEntry) => (
+                  <div
+                    key={`work-row:${workEntry.id}`}
+                    className="flex items-start gap-2 py-0.5"
+                  >
+                    <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
+                    <p
+                      className={`py-[2px] text-[11px] leading-relaxed ${workToneClass(workEntry.tone)}`}
+                    >
+                      {workEntry.detail ? (
+                        <>
+                          {workEntry.label}
+                          <span
+                            className="ml-1.5 inline-block max-w-[70ch] truncate align-bottom font-mono text-[11px] opacity-60"
+                            title={workEntry.detail}
+                          >
+                            {workEntry.detail}
+                          </span>
+                        </>
+                      ) : (
+                        workEntry.label
+                      )}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })()}
 
+      {row.kind === "message" &&
+        row.message.role === "user" &&
+        (() => {
+          const userImages = row.message.attachments ?? [];
+          const canRevertAgentWork = revertTurnCountByUserMessageId.has(row.message.id);
+          return (
+            <div className="flex justify-end">
+              <div className="group relative max-w-[80%] rounded-2xl rounded-br-sm border border-border bg-secondary px-4 py-3">
+                {userImages.length > 0 && (
+                  <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
+                    {userImages.map(
+                      (image: NonNullable<TimelineMessage["attachments"]>[number]) => (
+                        <div
+                          key={image.id}
+                          className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
+                        >
+                          {image.previewUrl ? (
+                            <img
+                              src={image.previewUrl}
+                              alt={image.name}
+                              className="h-full max-h-[220px] w-full cursor-zoom-in object-cover"
+                              onClick={() =>
+                                onImageExpand({ src: image.previewUrl!, name: image.name })
+                              }
+                            />
+                          ) : (
+                            <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
+                              {image.name}
+                            </div>
+                          )}
+                        </div>
+                      ),
+                    )}
+                  </div>
+                )}
+                {row.message.text && (
+                  <pre className="whitespace-pre-wrap wrap-break-word font-mono text-sm leading-relaxed text-foreground">
+                    {row.message.text}
+                  </pre>
+                )}
+                <div className="mt-1.5 flex items-center justify-end gap-2">
+                  <div className="flex items-center gap-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+                    {row.message.text && <MessageCopyButton text={row.message.text} />}
+                    {canRevertAgentWork && (
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="outline"
+                        disabled={isRevertingCheckpoint || isWorking}
+                        onClick={() => onRevertUserMessage(row.message.id)}
+                        title="Revert to this message"
+                      >
+                        <Undo2Icon className="size-3" />
+                      </Button>
+                    )}
+                  </div>
+                  <p className="text-right text-[10px] text-muted-foreground/30">
+                    {formatTimestamp(row.message.createdAt)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          );
+        })()}
+
+      {row.kind === "message" &&
+        row.message.role === "assistant" &&
+        (() => {
+          const messageText =
+            row.message.text || (row.message.streaming ? "" : "(empty response)");
+          return (
+            <>
+              {row.showCompletionDivider && (
+                <div className="my-3 flex items-center gap-3">
+                  <span className="h-px flex-1 bg-border" />
+                  <span className="rounded-full border border-border bg-background px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
+                    {completionSummary ? `Response • ${completionSummary}` : "Response"}
+                  </span>
+                  <span className="h-px flex-1 bg-border" />
+                </div>
+              )}
+              <div className="min-w-0 px-1 py-0.5">
+                <ChatMarkdown text={messageText} cwd={markdownCwd} />
+                {(() => {
+                  const turnSummary = turnDiffSummaryByAssistantMessageId.get(
+                    row.message.id,
+                  );
+                  if (!turnSummary) return null;
+                  const checkpointFiles = turnSummary.files;
+                  if (checkpointFiles.length === 0) return null;
+                  const summaryStat = checkpointFiles.reduce(
+                    (acc, file) => {
+                      if (
+                        typeof file.additions !== "number" ||
+                        typeof file.deletions !== "number"
+                      ) {
+                        return acc;
+                      }
+                      return {
+                        additions: acc.additions + file.additions,
+                        deletions: acc.deletions + file.deletions,
+                      };
+                    },
+                    { additions: 0, deletions: 0 },
+                  );
+                  const changedFileCountLabel = String(checkpointFiles.length);
                   return (
-                    <div className="rounded-lg border border-border/80 bg-card/45 px-3 py-2">
-                      <div className="mb-1.5 flex items-center justify-between gap-3">
+                    <div className="mt-2 rounded-lg border border-border/80 bg-card/45 p-2.5">
+                      <div className="mb-1.5 flex items-center justify-between gap-2">
                         <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
-                          {groupLabel}
+                          <span>Changed files ({changedFileCountLabel})</span>
+                          {(summaryStat.additions > 0 || summaryStat.deletions > 0) && (
+                            <>
+                              <span className="mx-1">•</span>
+                              <span className="text-success">+{summaryStat.additions}</span>
+                              <span className="mx-0.5 text-muted-foreground/70">/</span>
+                              <span className="text-destructive">
+                                -{summaryStat.deletions}
+                              </span>
+                            </>
+                          )}
                         </p>
-                        {hasOverflow && (
-                          <button
-                            type="button"
-                            className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/55 transition-colors duration-150 hover:text-muted-foreground/80"
-                            onClick={() => onToggleWorkGroup(groupId)}
-                          >
-                            {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
-                          </button>
-                        )}
+                        <Button
+                          type="button"
+                          size="xs"
+                          variant="outline"
+                          onClick={() =>
+                            onOpenTurnDiff(turnSummary.turnId, checkpointFiles[0]?.path)
+                          }
+                        >
+                          View diff
+                        </Button>
                       </div>
-                      <div className="space-y-1">
-                        {visibleEntries.map((workEntry) => (
-                          <div
-                            key={`work-row:${workEntry.id}`}
-                            className="flex items-start gap-2 py-0.5"
+                      <div className="flex flex-wrap gap-1.5">
+                        {checkpointFiles.map((file) => (
+                          <button
+                            key={`${turnSummary.turnId}:${file.path}`}
+                            type="button"
+                            className="rounded-md border border-border/70 bg-background/70 px-2 py-1 font-mono text-[11px] text-muted-foreground/80 transition-colors hover:border-border hover:text-foreground/90"
+                            onClick={() => onOpenTurnDiff(turnSummary.turnId, file.path)}
                           >
-                            <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
-                            <p
-                              className={`py-[2px] text-[11px] leading-relaxed ${workToneClass(workEntry.tone)}`}
-                            >
-                              {workEntry.detail ? (
+                            {(() => {
+                              const stat =
+                                typeof file.additions === "number" &&
+                                typeof file.deletions === "number"
+                                  ? {
+                                      additions: file.additions,
+                                      deletions: file.deletions,
+                                    }
+                                  : null;
+                              if (!stat) {
+                                return file.path;
+                              }
+                              return (
                                 <>
-                                  {workEntry.label}
-                                  <span
-                                    className="ml-1.5 inline-block max-w-[70ch] truncate align-bottom font-mono text-[11px] opacity-60"
-                                    title={workEntry.detail}
-                                  >
-                                    {workEntry.detail}
+                                  <span>{file.path}</span>
+                                  <span className="ml-1 text-muted-foreground/70">(</span>
+                                  <span className="text-success">+{stat.additions}</span>
+                                  <span className="mx-0.5 text-muted-foreground/70">/</span>
+                                  <span className="text-destructive">
+                                    -{stat.deletions}
                                   </span>
+                                  <span className="text-muted-foreground/70">)</span>
                                 </>
-                              ) : (
-                                workEntry.label
-                              )}
-                            </p>
-                          </div>
+                              );
+                            })()}
+                          </button>
                         ))}
                       </div>
                     </div>
                   );
                 })()}
+                <p className="mt-1.5 text-[10px] text-muted-foreground/30">
+                  {formatMessageMeta(
+                    row.message.createdAt,
+                    row.message.streaming
+                      ? formatElapsed(row.message.createdAt, nowIso)
+                      : formatElapsed(row.message.createdAt, row.message.completedAt),
+                  )}
+                </p>
+              </div>
+            </>
+          );
+        })()}
 
-              {row.kind === "message" &&
-                row.message.role === "user" &&
-                (() => {
-                  const userImages = row.message.attachments ?? [];
-                  const canRevertAgentWork = revertTurnCountByUserMessageId.has(row.message.id);
-                  return (
-                    <div className="flex justify-end">
-                      <div className="group relative max-w-[80%] rounded-2xl rounded-br-sm border border-border bg-secondary px-4 py-3">
-                        {userImages.length > 0 && (
-                          <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
-                            {userImages.map(
-                              (image: NonNullable<TimelineMessage["attachments"]>[number]) => (
-                                <div
-                                  key={image.id}
-                                  className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
-                                >
-                                  {image.previewUrl ? (
-                                    <img
-                                      src={image.previewUrl}
-                                      alt={image.name}
-                                      className="h-full max-h-[220px] w-full cursor-zoom-in object-cover"
-                                      onClick={() =>
-                                        onImageExpand({ src: image.previewUrl!, name: image.name })
-                                      }
-                                    />
-                                  ) : (
-                                    <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
-                                      {image.name}
-                                    </div>
-                                  )}
-                                </div>
-                              ),
-                            )}
-                          </div>
-                        )}
-                        {row.message.text && (
-                          <pre className="whitespace-pre-wrap wrap-break-word font-mono text-sm leading-relaxed text-foreground">
-                            {row.message.text}
-                          </pre>
-                        )}
-                        <div className="mt-1.5 flex items-center justify-end gap-2">
-                          <div className="flex items-center gap-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
-                            {row.message.text && <MessageCopyButton text={row.message.text} />}
-                            {canRevertAgentWork && (
-                              <Button
-                                type="button"
-                                size="xs"
-                                variant="outline"
-                                disabled={isRevertingCheckpoint || isWorking}
-                                onClick={() => onRevertUserMessage(row.message.id)}
-                                title="Revert to this message"
-                              >
-                                <Undo2Icon className="size-3" />
-                              </Button>
-                            )}
-                          </div>
-                          <p className="text-right text-[10px] text-muted-foreground/30">
-                            {formatTimestamp(row.message.createdAt)}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })()}
-
-              {row.kind === "message" &&
-                row.message.role === "assistant" &&
-                (() => {
-                  const messageText =
-                    row.message.text || (row.message.streaming ? "" : "(empty response)");
-                  return (
-                    <>
-                      {row.showCompletionDivider && (
-                        <div className="my-3 flex items-center gap-3">
-                          <span className="h-px flex-1 bg-border" />
-                          <span className="rounded-full border border-border bg-background px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
-                            {completionSummary ? `Response • ${completionSummary}` : "Response"}
-                          </span>
-                          <span className="h-px flex-1 bg-border" />
-                        </div>
-                      )}
-                      <div className="min-w-0 px-1 py-0.5">
-                        <ChatMarkdown text={messageText} cwd={markdownCwd} />
-                        {(() => {
-                          const turnSummary = turnDiffSummaryByAssistantMessageId.get(
-                            row.message.id,
-                          );
-                          if (!turnSummary) return null;
-                          const checkpointFiles = turnSummary.files;
-                          if (checkpointFiles.length === 0) return null;
-                          const summaryStat = checkpointFiles.reduce(
-                            (acc, file) => {
-                              if (
-                                typeof file.additions !== "number" ||
-                                typeof file.deletions !== "number"
-                              ) {
-                                return acc;
-                              }
-                              return {
-                                additions: acc.additions + file.additions,
-                                deletions: acc.deletions + file.deletions,
-                              };
-                            },
-                            { additions: 0, deletions: 0 },
-                          );
-                          const changedFileCountLabel = String(checkpointFiles.length);
-                          return (
-                            <div className="mt-2 rounded-lg border border-border/80 bg-card/45 p-2.5">
-                              <div className="mb-1.5 flex items-center justify-between gap-2">
-                                <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
-                                  <span>Changed files ({changedFileCountLabel})</span>
-                                  {(summaryStat.additions > 0 || summaryStat.deletions > 0) && (
-                                    <>
-                                      <span className="mx-1">•</span>
-                                      <span className="text-success">+{summaryStat.additions}</span>
-                                      <span className="mx-0.5 text-muted-foreground/70">/</span>
-                                      <span className="text-destructive">
-                                        -{summaryStat.deletions}
-                                      </span>
-                                    </>
-                                  )}
-                                </p>
-                                <Button
-                                  type="button"
-                                  size="xs"
-                                  variant="outline"
-                                  onClick={() =>
-                                    onOpenTurnDiff(turnSummary.turnId, checkpointFiles[0]?.path)
-                                  }
-                                >
-                                  View diff
-                                </Button>
-                              </div>
-                              <div className="flex flex-wrap gap-1.5">
-                                {checkpointFiles.map((file) => (
-                                  <button
-                                    key={`${turnSummary.turnId}:${file.path}`}
-                                    type="button"
-                                    className="rounded-md border border-border/70 bg-background/70 px-2 py-1 font-mono text-[11px] text-muted-foreground/80 transition-colors hover:border-border hover:text-foreground/90"
-                                    onClick={() => onOpenTurnDiff(turnSummary.turnId, file.path)}
-                                  >
-                                    {(() => {
-                                      const stat =
-                                        typeof file.additions === "number" &&
-                                        typeof file.deletions === "number"
-                                          ? {
-                                              additions: file.additions,
-                                              deletions: file.deletions,
-                                            }
-                                          : null;
-                                      if (!stat) {
-                                        return file.path;
-                                      }
-                                      return (
-                                        <>
-                                          <span>{file.path}</span>
-                                          <span className="ml-1 text-muted-foreground/70">(</span>
-                                          <span className="text-success">+{stat.additions}</span>
-                                          <span className="mx-0.5 text-muted-foreground/70">/</span>
-                                          <span className="text-destructive">
-                                            -{stat.deletions}
-                                          </span>
-                                          <span className="text-muted-foreground/70">)</span>
-                                        </>
-                                      );
-                                    })()}
-                                  </button>
-                                ))}
-                              </div>
-                            </div>
-                          );
-                        })()}
-                        <p className="mt-1.5 text-[10px] text-muted-foreground/30">
-                          {formatMessageMeta(
-                            row.message.createdAt,
-                            row.message.streaming
-                              ? formatElapsed(row.message.createdAt, nowIso)
-                              : formatElapsed(row.message.createdAt, row.message.completedAt),
-                          )}
-                        </p>
-                      </div>
-                    </>
-                  );
-                })()}
-
-              {row.kind === "working" && (
-                <div className="flex items-center gap-2 py-0.5 pl-1.5">
-                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
-                  <div className="flex items-center pt-1">
-                    <span className="inline-flex items-center gap-[3px]">
-                      <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse" />
-                      <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:200ms]" />
-                      <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:400ms]" />
-                    </span>
-                  </div>
-                </div>
-              )}
-            </div>
+      {row.kind === "working" && (
+        <div className="flex items-center gap-2 py-0.5 pl-1.5">
+          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
+          <div className="flex items-center pt-1">
+            <span className="inline-flex items-center gap-[3px]">
+              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse" />
+              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:200ms]" />
+              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:400ms]" />
+            </span>
           </div>
-        );
-      })}
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="mx-auto w-full min-w-0 max-w-3xl overflow-x-hidden">
+      {/* Virtualized completed turns */}
+      {virtualizedRows.length > 0 && (
+        <div
+          className="relative"
+          style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+        >
+          {virtualRows.map((virtualRow: VirtualItem) => {
+            const row = virtualizedRows[virtualRow.index];
+            if (!row) return null;
+
+            return (
+              <div
+                key={row.id}
+                data-index={virtualRow.index}
+                ref={rowVirtualizer.measureElement}
+                className="absolute left-0 top-0 w-full"
+                style={{ transform: `translateY(${virtualRow.start}px)` }}
+              >
+                {renderRowContent(row)}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Current in-progress turn rendered in normal flow (no virtualization) */}
+      {currentTurnRows.map((row) => (
+        <div key={row.id}>{renderRowContent(row)}</div>
+      ))}
     </div>
   );
 });


### PR DESCRIPTION
Disable virtualization for the active turn in `MessagesTimeline` to prevent height calculation issues during streaming.

---
<p><a href="https://cursor.com/agents/bc-7fcd60d7-5d68-4471-954c-cdb66336f8a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fcd60d7-5d68-4471-954c-cdb66336f8a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Virtualize completed chat turns and render the current in-progress turn without virtualization in `ChatView.MessagesTimeline` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/117/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Split rows into `virtualizedRows` and `currentTurnRows` when `isWorking=true`, compute `currentTurnStartIndex`, scope the virtualizer to completed rows, replace the single absolute container with two sections, and centralize per-row JSX in `renderRowContent` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/117/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> #### 📍Where to Start
> Start in `ChatView.MessagesTimeline` within [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/117/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), focusing on `currentTurnStartIndex`, the `rowVirtualizer` `count`/`estimateSize` changes, and the new `renderRowContent` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87cfb96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->