### PR TITLE
Current turn virtualization

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -111,6 +111,7 @@ import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import { useAppSettings } from "../appSettings";
+import { clamp } from "effect/Number";
 
 function formatMessageMeta(createdAt: string, duration: string | null): string {
   if (!duration) return formatTimestamp(createdAt);
@@ -2338,13 +2339,7 @@ const MessageCopyButton = memo(function MessageCopyButton({ text }: { text: stri
   }, [text]);
 
   return (
-    <Button
-      type="button"
-      size="xs"
-      variant="outline"
-      onClick={handleCopy}
-      title="Copy message"
-    >
+    <Button type="button" size="xs" variant="outline" onClick={handleCopy} title="Copy message">
       {copied ? <CheckIcon className="size-3 text-success" /> : <CopyIcon className="size-3" />}
     </Button>
   );
@@ -2499,7 +2494,10 @@ const MessagesTimeline = memo(function MessagesTimeline({
     return firstCurrentTurnRowIndex;
   }, [activeTurnInProgress, activeTurnStartedAt, rows]);
 
-  const virtualizedRowCount = Math.max(0, Math.min(rows.length, firstUnvirtualizedRowIndex));
+  const virtualizedRowCount = clamp(firstUnvirtualizedRowIndex, {
+    minimum: 0,
+    maximum: rows.length,
+  });
 
   const rowVirtualizer = useVirtualizer({
     count: virtualizedRowCount,
@@ -2594,25 +2592,29 @@ const MessagesTimeline = memo(function MessagesTimeline({
               <div className="group relative max-w-[80%] rounded-2xl rounded-br-sm border border-border bg-secondary px-4 py-3">
                 {userImages.length > 0 && (
                   <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
-                    {userImages.map((image: NonNullable<TimelineMessage["attachments"]>[number]) => (
-                      <div
-                        key={image.id}
-                        className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
-                      >
-                        {image.previewUrl ? (
-                          <img
-                            src={image.previewUrl}
-                            alt={image.name}
-                            className="h-full max-h-[220px] w-full cursor-zoom-in object-cover"
-                            onClick={() => onImageExpand({ src: image.previewUrl!, name: image.name })}
-                          />
-                        ) : (
-                          <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
-                            {image.name}
-                          </div>
-                        )}
-                      </div>
-                    ))}
+                    {userImages.map(
+                      (image: NonNullable<TimelineMessage["attachments"]>[number]) => (
+                        <div
+                          key={image.id}
+                          className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
+                        >
+                          {image.previewUrl ? (
+                            <img
+                              src={image.previewUrl}
+                              alt={image.name}
+                              className="h-full max-h-[220px] w-full cursor-zoom-in object-cover"
+                              onClick={() =>
+                                onImageExpand({ src: image.previewUrl!, name: image.name })
+                              }
+                            />
+                          ) : (
+                            <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
+                              {image.name}
+                            </div>
+                          )}
+                        </div>
+                      ),
+                    )}
                   </div>
                 )}
                 {row.message.text && (


### PR DESCRIPTION
Disable virtualization for the currently in-progress turn to prevent height calculation issues and collisions during streaming.

---
<p><a href="https://cursor.com/agents/bc-c2cc5fa2-fa06-4e28-9f3e-7a2de1478564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2cc5fa2-fa06-4e28-9f3e-7a2de1478564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Virtualize only pre-turn rows in `MessagesTimeline` and pass active turn state from `ChatView` to support current turn virtualization
> Add `activeTurnInProgress` and `activeTurnStartedAt` props to `MessagesTimeline`; compute `firstUnvirtualizedRowIndex` and use `virtualizedRowCount` to split rendering between virtualized past rows and non-virtualized current turn, with a timestamped `working` row. Minor JSX formatting update in `MessageCopyButton`. See [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/118/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/118/files#diff-8390b041a98e8f24de2e0cf9abb2ca54eb87eef76d7229ac0896de2b4c2d7c42).
>
> #### 📍Where to Start
> Start with the virtualization split and `firstUnvirtualizedRowIndex` logic in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/118/files#diff-8390b041a98e8f24de2e0cf9abb2ca54eb87eef76d7229ac0896de2b4c2d7c42).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88ab776.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chat timeline virtualization and row rendering during in-progress turns, which can affect scrolling behavior and message/work log layout while streaming. Risk is limited to UI/UX but could introduce regressions in virtual list sizing or auto-scroll.
> 
> **Overview**
> **Prevents virtualized rendering for the currently in-progress turn** in `ChatView` to avoid height/measurement issues during streaming.
> 
> `MessagesTimeline` now receives `activeTurnInProgress`/`activeTurnStartedAt`, stamps rows with `createdAt`, computes a split index for the active turn, virtualizes only the earlier rows, and renders the remainder (including the working indicator/current turn) non-virtualized. Minor refactor extracts shared row rendering (`renderRowContent`) and adds `clamp` to bound the virtualized row count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88ab776bd31806b97e5e09d3d6aab5f0cd847b8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->