### PR TITLE
Persist provider runtime mode settings

### DIFF
--- a/apps/server/src/persistence/Layers/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/Layers/ProviderSessionRuntime.ts
@@ -50,6 +50,8 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
           adapter_key,
           provider_thread_id,
           status,
+          approval_policy,
+          sandbox_mode,
           last_seen_at,
           resume_cursor_json,
           runtime_payload_json
@@ -61,6 +63,8 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
           ${runtime.adapterKey},
           ${runtime.providerThreadId},
           ${runtime.status},
+          ${runtime.approvalPolicy},
+          ${runtime.sandboxMode},
           ${runtime.lastSeenAt},
           ${runtime.resumeCursor},
           ${runtime.runtimePayload}
@@ -72,6 +76,8 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
           adapter_key = excluded.adapter_key,
           provider_thread_id = excluded.provider_thread_id,
           status = excluded.status,
+          approval_policy = excluded.approval_policy,
+          sandbox_mode = excluded.sandbox_mode,
           last_seen_at = excluded.last_seen_at,
           resume_cursor_json = excluded.resume_cursor_json,
           runtime_payload_json = excluded.runtime_payload_json
@@ -90,6 +96,8 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
           adapter_key AS "adapterKey",
           provider_thread_id AS "providerThreadId",
           status,
+          approval_policy AS "approvalPolicy",
+          sandbox_mode AS "sandboxMode",
           last_seen_at AS "lastSeenAt",
           resume_cursor_json AS "resumeCursor",
           runtime_payload_json AS "runtimePayload"
@@ -110,6 +118,8 @@ const makeProviderSessionRuntimeRepository = Effect.gen(function* () {
           adapter_key AS "adapterKey",
           provider_thread_id AS "providerThreadId",
           status,
+          approval_policy AS "approvalPolicy",
+          sandbox_mode AS "sandboxMode",
           last_seen_at AS "lastSeenAt",
           resume_cursor_json AS "resumeCursor",
           runtime_payload_json AS "runtimePayload"

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -19,6 +19,7 @@ import Migration0004 from "./Migrations/004_ProviderSessionRuntime.ts";
 import Migration0005 from "./Migrations/005_Projections.ts";
 import Migration0006 from "./Migrations/006_ProjectionThreadSessionRuntimeModeColumns.ts";
 import Migration0007 from "./Migrations/007_ProjectionThreadMessageAttachments.ts";
+import Migration0008 from "./Migrations/008_ProviderSessionRuntimeModeColumns.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -38,6 +39,7 @@ const loader = Migrator.fromRecord({
   "5_Projections": Migration0005,
   "6_ProjectionThreadSessionRuntimeModeColumns": Migration0006,
   "7_ProjectionThreadMessageAttachments": Migration0007,
+  "8_ProviderSessionRuntimeModeColumns": Migration0008,
 });
 
 /**

--- a/apps/server/src/persistence/Migrations/008_ProviderSessionRuntimeModeColumns.ts
+++ b/apps/server/src/persistence/Migrations/008_ProviderSessionRuntimeModeColumns.ts
@@ -1,0 +1,31 @@
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as Effect from "effect/Effect";
+
+const DEFAULT_APPROVAL_POLICY = "never";
+const DEFAULT_SANDBOX_MODE = "workspace-write";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    ALTER TABLE provider_session_runtime
+    ADD COLUMN approval_policy TEXT NOT NULL DEFAULT 'never'
+  `;
+
+  yield* sql`
+    ALTER TABLE provider_session_runtime
+    ADD COLUMN sandbox_mode TEXT NOT NULL DEFAULT 'workspace-write'
+  `;
+
+  yield* sql`
+    UPDATE provider_session_runtime
+    SET approval_policy = ${DEFAULT_APPROVAL_POLICY}
+    WHERE approval_policy IS NULL
+  `;
+
+  yield* sql`
+    UPDATE provider_session_runtime
+    SET sandbox_mode = ${DEFAULT_SANDBOX_MODE}
+    WHERE sandbox_mode IS NULL
+  `;
+});

--- a/apps/server/src/persistence/Services/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/Services/ProviderSessionRuntime.ts
@@ -7,6 +7,8 @@
  */
 import {
   IsoDateTime,
+  ProviderApprovalPolicy,
+  ProviderSandboxMode,
   ProviderSessionId,
   ProviderSessionRuntimeStatus,
   ProviderThreadId,
@@ -24,6 +26,8 @@ export const ProviderSessionRuntime = Schema.Struct({
   adapterKey: Schema.String,
   providerThreadId: Schema.NullOr(ProviderThreadId),
   status: ProviderSessionRuntimeStatus,
+  approvalPolicy: ProviderApprovalPolicy,
+  sandboxMode: ProviderSandboxMode,
   lastSeenAt: IsoDateTime,
   resumeCursor: Schema.NullOr(Schema.Unknown),
   runtimePayload: Schema.NullOr(Schema.Unknown),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -327,6 +327,8 @@ it.effect(
         return yield* provider.startSession(asThreadId("thread-1"), {
           provider: "codex",
           cwd: "/tmp/project",
+          approvalPolicy: "never",
+          sandboxMode: "danger-full-access",
         });
       }).pipe(Effect.provide(firstProviderLayer));
 
@@ -380,6 +382,8 @@ it.effect(
             provider: "codex",
             cwd: "/tmp/project",
             resumeThreadId: startedSession.threadId,
+            approvalPolicy: "never",
+            sandboxMode: "danger-full-access",
           },
         ],
       ]);
@@ -452,6 +456,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const initial = yield* provider.startSession(asThreadId("thread-1"), {
         provider: "codex",
         cwd: "/tmp/project",
+        approvalPolicy: "never",
+        sandboxMode: "danger-full-access",
       });
       yield* routing.codex.stopSession(initial.sessionId);
       routing.codex.startSession.mockClear();
@@ -468,6 +474,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
             provider: "codex",
             cwd: "/tmp/project",
             resumeThreadId: initial.threadId,
+            approvalPolicy: "never",
+            sandboxMode: "danger-full-access",
           },
         ],
       ]);
@@ -484,6 +492,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
       const initial = yield* provider.startSession(asThreadId("thread-1"), {
         provider: "codex",
         cwd: "/tmp/project-send-turn",
+        approvalPolicy: "never",
+        sandboxMode: "danger-full-access",
       });
 
       yield* provider.stopAll();
@@ -502,6 +512,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
             provider: "codex",
             cwd: "/tmp/project-send-turn",
             resumeThreadId: initial.threadId,
+            approvalPolicy: "never",
+            sandboxMode: "danger-full-access",
           },
         ],
       ]);

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -18,6 +18,8 @@ import {
   ProviderSendTurnInput,
   ProviderSessionStartInput,
   ProviderStopSessionInput,
+  type ProviderApprovalPolicy,
+  type ProviderSandboxMode,
   type ProviderRuntimeEvent,
   type ProviderSession,
 } from "@t3tools/contracts";
@@ -155,6 +157,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       session: ProviderSession,
       operation: string,
       threadId: ThreadId,
+      options?: {
+        readonly approvalPolicy?: ProviderApprovalPolicy;
+        readonly sandboxMode?: ProviderSandboxMode;
+      },
     ) =>
       Effect.gen(function* () {
         const providerThreadId = session.threadId;
@@ -171,6 +177,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           threadId,
           providerThreadId,
           status: toRuntimeStatus(session),
+          ...(options?.approvalPolicy !== undefined
+            ? { approvalPolicy: options.approvalPolicy }
+            : {}),
+          ...(options?.sandboxMode !== undefined ? { sandboxMode: options.sandboxMode } : {}),
           ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
           runtimePayload: toRuntimePayloadFromSession(session),
         });
@@ -243,6 +253,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const resumeThreadId = input.binding.providerThreadId ?? undefined;
         const hasResumeCursor =
           input.binding.resumeCursor !== null && input.binding.resumeCursor !== undefined;
+        const persistedApprovalPolicy = input.binding.approvalPolicy;
+        const persistedSandboxMode = input.binding.sandboxMode;
         const existing =
           resumeThreadId === undefined
             ? undefined
@@ -252,6 +264,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             existing,
             `${input.operation}:upsertExistingSession`,
             input.binding.threadId,
+            {
+              ...(persistedApprovalPolicy ? { approvalPolicy: persistedApprovalPolicy } : {}),
+              ...(persistedSandboxMode ? { sandboxMode: persistedSandboxMode } : {}),
+            },
           );
           yield* directory.upsert({
             sessionId: input.staleSessionId,
@@ -285,6 +301,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           ...(persistedCwd ? { cwd: persistedCwd } : {}),
           ...(resumeThreadId ? { resumeThreadId } : {}),
           ...(hasResumeCursor ? { resumeCursor: input.binding.resumeCursor } : {}),
+          ...(persistedApprovalPolicy ? { approvalPolicy: persistedApprovalPolicy } : {}),
+          ...(persistedSandboxMode ? { sandboxMode: persistedSandboxMode } : {}),
         });
         if (resumed.provider !== adapter.provider) {
           return yield* toValidationError(
@@ -297,6 +315,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           resumed,
           `${input.operation}:upsertRecoveredSession`,
           input.binding.threadId,
+          {
+            ...(persistedApprovalPolicy ? { approvalPolicy: persistedApprovalPolicy } : {}),
+            ...(persistedSandboxMode ? { sandboxMode: persistedSandboxMode } : {}),
+          },
         );
 
         yield* directory.upsert({
@@ -416,7 +438,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           );
         }
 
-        yield* upsertSessionBinding(session, "ProviderService.startSession", threadId);
+        yield* upsertSessionBinding(session, "ProviderService.startSession", threadId, {
+          approvalPolicy: input.approvalPolicy,
+          sandboxMode: input.sandboxMode,
+        });
 
         return session;
       });

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
@@ -118,6 +118,8 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         threadId,
         providerThreadId,
         status: "starting",
+        approvalPolicy: "never",
+        sandboxMode: "danger-full-access",
         resumeCursor: {
           resumeThreadId: "provider-thread-runtime",
         },
@@ -131,6 +133,8 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         sessionId,
         provider: "codex",
         status: "running",
+        approvalPolicy: "on-request",
+        sandboxMode: "workspace-write",
         runtimePayload: {
           activeTurnId: "turn-1",
         },
@@ -144,6 +148,8 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
         assert.equal(runtime.value.threadId, threadId);
         assert.equal(runtime.value.providerThreadId, providerThreadId);
         assert.equal(runtime.value.status, "running");
+        assert.equal(runtime.value.approvalPolicy, "on-request");
+        assert.equal(runtime.value.sandboxMode, "workspace-write");
         assert.deepEqual(runtime.value.resumeCursor, {
           resumeThreadId: providerThreadId,
         });

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -1,4 +1,9 @@
-import { ProviderSessionId, type ProviderKind } from "@t3tools/contracts";
+import {
+  ProviderSessionId,
+  type ProviderApprovalPolicy,
+  type ProviderKind,
+  type ProviderSandboxMode,
+} from "@t3tools/contracts";
 import { Effect, Layer, Option } from "effect";
 
 import { ProviderSessionRuntimeRepository } from "../../persistence/Services/ProviderSessionRuntime.ts";
@@ -12,6 +17,9 @@ import {
   type ProviderSessionBinding,
   type ProviderSessionDirectoryShape,
 } from "../Services/ProviderSessionDirectory.ts";
+
+const DEFAULT_APPROVAL_POLICY: ProviderApprovalPolicy = "never";
+const DEFAULT_SANDBOX_MODE: ProviderSandboxMode = "workspace-write";
 
 function toPersistenceError(operation: string) {
   return (cause: unknown) =>
@@ -76,6 +84,8 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
                   adapterKey: value.adapterKey,
                   providerThreadId: value.providerThreadId,
                   status: value.status,
+                  approvalPolicy: value.approvalPolicy,
+                  sandboxMode: value.sandboxMode,
                   resumeCursor: value.resumeCursor,
                   runtimePayload: value.runtimePayload,
                 }),
@@ -113,6 +123,11 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
             ? binding.providerThreadId
             : (existingRuntime?.providerThreadId ?? null),
         status: binding.status ?? existingRuntime?.status ?? "running",
+        approvalPolicy:
+          binding.approvalPolicy ??
+          existingRuntime?.approvalPolicy ??
+          DEFAULT_APPROVAL_POLICY,
+        sandboxMode: binding.sandboxMode ?? existingRuntime?.sandboxMode ?? DEFAULT_SANDBOX_MODE,
         lastSeenAt: now,
         resumeCursor:
           binding.resumeCursor !== undefined

--- a/apps/server/src/provider/Services/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Services/ProviderSessionDirectory.ts
@@ -8,7 +8,9 @@
  * @module ProviderSessionDirectory
  */
 import type {
+  ProviderApprovalPolicy,
   ProviderKind,
+  ProviderSandboxMode,
   ProviderSessionId,
   ProviderSessionRuntimeStatus,
   ProviderThreadId,
@@ -30,6 +32,8 @@ export interface ProviderSessionBinding {
   readonly adapterKey?: string;
   readonly providerThreadId?: ProviderThreadId | null;
   readonly status?: ProviderSessionRuntimeStatus;
+  readonly approvalPolicy?: ProviderApprovalPolicy;
+  readonly sandboxMode?: ProviderSandboxMode;
   readonly resumeCursor?: unknown | null;
   readonly runtimePayload?: unknown | null;
 }


### PR DESCRIPTION
Store approval policy and sandbox mode in provider session runtime records, carry them through session recovery, and cover the behavior with provider layer tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new NOT NULL columns to `provider_session_runtime` and threads them through session start/recovery, which can affect migrations and resumable-session behavior if defaults/backfills are wrong.
> 
> **Overview**
> Persists provider runtime mode settings by adding `approval_policy` and `sandbox_mode` to the `provider_session_runtime` table (new migration `008_ProviderSessionRuntimeModeColumns`) and extending the runtime repository schema/queries to read/write them.
> 
> Plumbs these fields through `ProviderSessionDirectory` and `ProviderService` so they are stored on `startSession`, defaulted when missing, and reapplied when recovering stale sessions (resume by thread/cursor). Tests are updated to assert the values are persisted and passed back into adapter `startSession` during recovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de5270e2d7fc602d769fb0cbb729b76105c0976a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist provider session approval policy and sandbox mode in `persistence.makeProviderSessionRuntimeRepository` and propagate them through `provider.ProviderServiceLive.makeProviderService` and `provider.ProviderSessionDirectoryLive.makeProviderSessionDirectory`
> Add `approvalPolicy` and `sandboxMode` columns via migration, extend runtime repository CRUD to read/write them, and pass these fields through session directory and service lifecycles with defaults `never` and `workspace-write`.
>
> #### 📍Where to Start
> Start with the migration defining new columns in [008_ProviderSessionRuntimeModeColumns.ts](https://github.com/pingdotgg/t3code/pull/119/files#diff-5ecc3a5d83ece098db416676ff7ca3e4d96e8d485d5343fa5465759708991793), then review repository changes in [ProviderSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/119/files#diff-21ca18f720dcb9b3964eb8646257bcb571b77cbe9a4aa288c22f0886da712888) before tracing usage in [ProviderSessionDirectory.ts](https://github.com/pingdotgg/t3code/pull/119/files#diff-0ca581a6030196f89d4a3b84a4699e4eb24dd0d70432ebcd642b6b1ca88851ab) and [ProviderService.ts](https://github.com/pingdotgg/t3code/pull/119/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de5270e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->