### PR TITLE
Open diff files in editor from clickable diff headers

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -7,6 +7,8 @@ import { ChevronLeftIcon, ChevronRightIcon, Columns2Icon, Rows3Icon } from "luci
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
 import { cn } from "~/lib/utils";
+import { readNativeApi } from "../nativeApi";
+import { preferredTerminalEditor, resolvePathLinkTarget } from "../terminal-links";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
@@ -57,6 +59,21 @@ const DIFF_PANEL_UNSAFE_CSS = `
   background-color: color-mix(in srgb, var(--card) 94%, var(--foreground)) !important;
   border-block-color: var(--border) !important;
   color: var(--foreground) !important;
+}
+
+[data-title] {
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    text-decoration-color 120ms ease;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 2px;
+}
+
+[data-title]:hover {
+  color: color-mix(in srgb, var(--foreground) 84%, var(--primary)) !important;
+  text-decoration-color: currentColor;
 }
 `;
 
@@ -144,6 +161,8 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const diffSearch = useSearch({ strict: false, select: (search) => parseDiffRouteSearch(search) });
   const activeThreadId = routeThreadId;
   const activeThread = state.threads.find((thread) => thread.id === activeThreadId);
+  const activeProject = state.projects.find((project) => project.id === activeThread?.projectId);
+  const activeCwd = activeThread?.worktreePath ?? activeProject?.cwd;
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
   const orderedTurnDiffSummaries = useMemo(
@@ -263,6 +282,18 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     ).find((element) => element.dataset.diffFilePath === selectedFilePath);
     target?.scrollIntoView({ block: "nearest" });
   }, [selectedFilePath, renderableFiles]);
+
+  const openDiffFileInEditor = useCallback(
+    (filePath: string) => {
+      const api = readNativeApi();
+      if (!api) return;
+      const targetPath = activeCwd ? resolvePathLinkTarget(filePath, activeCwd) : filePath;
+      void api.shell.openInEditor(targetPath, preferredTerminalEditor()).catch((error) => {
+        console.warn("Failed to open diff file in editor.", error);
+      });
+    },
+    [activeCwd],
+  );
 
   const selectTurn = (turnId: TurnId) => {
     if (!activeThread) return;
@@ -508,7 +539,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
               </div>
             ) : renderablePatch.kind === "files" ? (
               <Virtualizer
-                className="diff-render-surface h-full min-h-0 overflow-auto px-3 py-2"
+                className="diff-render-surface h-full min-h-0 overflow-auto p-2 "
                 config={{
                   overscrollSize: 600,
                   intersectionObserverMargin: 1200,
@@ -522,7 +553,17 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                     <div
                       key={themedFileKey}
                       data-diff-file-path={filePath}
-                      className="diff-render-file rounded-md"
+                      className="diff-render-file mb-2 rounded-md last:mb-0"
+                      onClickCapture={(event) => {
+                        const nativeEvent = event.nativeEvent as MouseEvent;
+                        const composedPath = nativeEvent.composedPath?.() ?? [];
+                        const clickedHeader = composedPath.some((node) => {
+                          if (!(node instanceof Element)) return false;
+                          return node.hasAttribute("data-title");
+                        });
+                        if (!clickedHeader) return;
+                        openDiffFileInEditor(filePath);
+                      }}
                     >
                       <FileDiff
                         fileDiff={fileDiff}
@@ -539,7 +580,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                 })}
               </Virtualizer>
             ) : (
-              <div className="h-full overflow-auto px-3 py-2">
+              <div className="h-full overflow-auto p-2">
                 <div className="space-y-2">
                   <p className="text-[11px] text-muted-foreground/75">{renderablePatch.reason}</p>
                   <pre className="max-h-[72vh] overflow-auto rounded-md border border-border/70 bg-background/70 p-3 font-mono text-[11px] leading-relaxed text-muted-foreground/90">


### PR DESCRIPTION
## Summary
- Make diff file headers interactive and open the corresponding file in the configured terminal editor when clicked.
- Resolve file paths against the active thread/project working directory before invoking `openInEditor`.
- Add header hover/click styling and tighten diff panel spacing for file and fallback views.
- Handle editor-open failures safely with a console warning.

## Testing
- Not run (no test execution details provided in this change set).
- Manual check: click a file header in the Diff Panel and verify the file opens in the preferred editor.
- Manual check: verify no open action occurs when clicking non-header regions of a diff file.
- Manual check: verify relative paths resolve correctly when the active thread has a worktree path and when falling back to project cwd.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new click-to-open behavior that invokes the native `shell.openInEditor` bridge and resolves paths against thread/project working directories, which could affect Electron/desktop integrations and path handling.
> 
> **Overview**
> Makes diff file headers clickable in `DiffPanel` so selecting a header opens that file in the user’s preferred terminal editor via the native API.
> 
> Paths are resolved relative to the active thread worktree or project `cwd`, failures are handled with a warning, and the diff UI gets small spacing/hover-style tweaks (header underline/hover, tighter padding, per-file margins).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a30a50807bd2a187c8dcda2f03d7943f7b031d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add clickable diff file headers that open the file in the preferred terminal editor from [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/127/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3)
> Add `onClickCapture` to detect clicks on `[data-title]` elements and call `readNativeApi().shell.openInEditor` with a path from `resolvePathLinkTarget` using `preferredTerminalEditor`; update styles via `DIFF_PANEL_UNSAFE_CSS` and adjust container padding/margins.
>
> #### 📍Where to Start
> Start with the `openDiffFileInEditor` callback and the `onClickCapture` handler in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/127/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a30a50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->