### PR TITLE
Keep DiffPanel header sticky during diff scroll

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -547,7 +547,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
               </div>
             ) : renderablePatch.kind === "files" ? (
               <Virtualizer
-                className="diff-render-surface h-full min-h-0 overflow-auto p-2 "
+                className="diff-render-surface h-full min-h-0 overflow-auto px-2 pb-2"
                 config={{
                   overscrollSize: 600,
                   intersectionObserverMargin: 1200,
@@ -561,7 +561,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                     <div
                       key={themedFileKey}
                       data-diff-file-path={filePath}
-                      className="diff-render-file mb-2 rounded-md last:mb-0"
+                      className="diff-render-file mb-2 rounded-md first:mt-2 last:mb-0"
                       onClickCapture={(event) => {
                         const nativeEvent = event.nativeEvent as MouseEvent;
                         const composedPath = nativeEvent.composedPath?.() ?? [];


### PR DESCRIPTION
## Summary
- make the diff header (`[data-diffs-header]`) sticky so it remains visible while scrolling
- pin header to the top with `top: 0` and ensure layering with `z-index: 4`
- improve readability by adding a blended background and bottom border to the sticky header

## Testing
- Not run (changes provided as patch context only)
- Visual check: open a large diff in the web app and confirm the header stays visible while scrolling
- Visual check: verify header background/border render correctly and do not overlap diff content unexpectedly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts CSS and spacing within the diff virtualizer; main risk is minor layout/overlap regressions in the diff header rendering.
> 
> **Overview**
> Keeps the diff renderer header (`[data-diffs-header]`) visible during scroll by making it `position: sticky` with `top: 0`, a higher `z-index`, and an explicit background/bottom border to prevent content bleed.
> 
> Tweaks diff list spacing in `DiffPanel` by adjusting `Virtualizer` padding and adding a top margin to the first rendered file container to account for the sticky header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3aa5ae0aae697218926955031fc77a225f74a61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make diff panel headers sticky during scroll in `apps/web/src/components/DiffPanel.tsx` to keep context visible
> Add `[data-diffs-header]` CSS with `position: sticky; top: 0; z-index: 4` and a bottom border, and adjust container padding/margins by changing Virtualizer className to `px-2 pb-2` and per-file to `first:mt-2` in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/132/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3).
>
> #### 📍Where to Start
> Start with the render logic in `DiffPanel` in [apps/web/src/components/DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/132/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) and the `[data-diffs-header]` block in the associated stylesheet.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3aa5ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->