### PR TITLE
fix build?

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
             target: dmg
             arch: arm64
           - label: macOS x64
-            runner: macos-13
+            runner: macos-15-intel
             platform: mac
             target: dmg
             arch: x64
@@ -150,7 +150,7 @@ jobs:
             echo "Signing disabled for ${{ matrix.platform }}."
           fi
 
-          bun run dist:desktop:artifact -- "${args[@]}" --verbose
+          bun run dist:desktop:artifact -- "${args[@]}"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -140,7 +140,7 @@ const BuildEnvConfig = Config.all({
 
 const resolveBooleanFlag = (flag: Option.Option<boolean>, envValue: boolean) =>
   Option.getOrElse(Option.filter(flag, Boolean), () => envValue);
-const mergeOptions = <A,>(a: Option.Option<A>, b: Option.Option<A>, defaultValue: A) =>
+const mergeOptions = <A>(a: Option.Option<A>, b: Option.Option<A>, defaultValue: A) =>
   Option.getOrElse(a, () => Option.getOrElse(b, () => defaultValue));
 
 const resolveBuildOptions = Effect.fn(function* (input: BuildCliInput) {
@@ -195,7 +195,6 @@ const runCommand = Effect.fn(function* (command: ChildProcess.Command) {
   if (exitCode !== 0) {
     return yield* new BuildScriptError({
       message: "Command exited with non-zero exit code",
-      cause: command,
     });
   }
 });
@@ -521,8 +520,18 @@ const buildDesktopArtifact = Effect.fn(function* (options: ResolvedBuildOptions)
   const buildEnv: NodeJS.ProcessEnv = {
     ...process.env,
   };
+  for (const [key, value] of Object.entries(buildEnv)) {
+    if (value === "") {
+      delete buildEnv[key];
+    }
+  }
   if (!options.signed) {
     buildEnv.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+    delete buildEnv.CSC_LINK;
+    delete buildEnv.CSC_KEY_PASSWORD;
+    delete buildEnv.APPLE_API_KEY;
+    delete buildEnv.APPLE_API_KEY_ID;
+    delete buildEnv.APPLE_API_ISSUER;
   }
 
   yield* Effect.log(
@@ -533,7 +542,7 @@ const buildDesktopArtifact = Effect.fn(function* (options: ResolvedBuildOptions)
       cwd: stageAppDir,
       env: buildEnv,
       ...commandOutputOptions(options.verbose),
-    })`bunx --bun electron-builder ${platformConfig.cliFlag} ${options.target} --${options.arch} --publish never`,
+    })`bunx electron-builder ${platformConfig.cliFlag} ${options.target} --${options.arch} --publish never`,
   );
 
   const stageDistDir = path.join(stageAppDir, "dist");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the release workflow runner selection and modifies the desktop artifact build script’s environment and `electron-builder` invocation, which can affect cross-platform release packaging/signing behavior. Risk is moderate because failures would surface at build/release time rather than runtime, but could block publishing artifacts.
> 
> **Overview**
> Improves reliability of desktop release builds by updating the macOS x64 GitHub Actions runner to `macos-15-intel` and simplifying the release workflow’s artifact build invocation (removes `--verbose`).
> 
> Updates `build-desktop-artifact.ts` to better control the build environment: strips empty-string env vars, explicitly removes signing-related variables when `--signed` is not enabled, and adjusts the `electron-builder` launch from `bunx --bun electron-builder` to `bunx electron-builder` to avoid Bun-specific invocation issues. Error reporting for failed subprocesses is also simplified (drops the command as the error cause).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9da3b7f0440b4da80808824b2147cd73f233670. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix build by switching macOS x64 release job to runner 'macos-15-intel' and disabling signing in unsigned desktop builds
> Update release workflow to use 'macos-15-intel' and remove '--verbose'. In `build-desktop-artifact`, clear empty env vars, set `CSC_IDENTITY_AUTO_DISCOVERY=false` when unsigned, remove signing env vars, and call `electron-builder` without `--bun`.
>
> #### 📍Where to Start
> Start with the unsigned build handling in `buildDesktopArtifact` in [scripts/build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/136/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 50c5d17. 1 file reviewed, 12 issues evaluated, 0 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->