### PR TITLE
docs(agents): clarify contracts use effect/Schema schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ If a tradeoff is required, choose correctness and robustness over short-term con
 
 - `apps/server`: Node.js WebSocket server. Wraps Codex app-server (JSON-RPC over stdio), serves the React web app, and manages provider sessions.
 - `apps/web`: React/Vite UI. Owns session UX, conversation/event rendering, and client-side state. Connects to the server via WebSocket.
-- `packages/contracts`: Shared Zod schemas and TypeScript contracts for provider events, WebSocket protocol, and model/session types.
+- `packages/contracts`: Shared effect/Schema schemas and TypeScript contracts for provider events, WebSocket protocol, and model/session types.
 
 ## Codex App Server (Important)
 


### PR DESCRIPTION
## Summary
- Update `AGENTS.md` package role description for `packages/contracts`.
- Replace "Shared Zod schemas" with "Shared effect/Schema schemas" to match current contract implementation wording.

## Testing
- Not run (documentation-only change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates wording in `AGENTS.md` with no runtime impact.
> 
> **Overview**
> Updates `AGENTS.md` to clarify that `packages/contracts` provides shared *effect/Schema* schemas (instead of Zod) alongside TypeScript contracts for events, the WebSocket protocol, and model/session types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acfeb0617d3e085124bdfec37aaae12dee6a4890. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify `packages/contracts` in AGENTS.md to state contracts use `effect/Schema` schemas
> Update the Package Roles section in [AGENTS.md](https://github.com/pingdotgg/t3code/pull/137/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to replace the reference to shared Zod schemas with shared `effect/Schema` schemas for `packages/contracts`.
>
> #### 📍Where to Start
> Start with the Package Roles section in [AGENTS.md](https://github.com/pingdotgg/t3code/pull/137/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acfeb06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->