### PR TITLE
Serve fallback project favicon when no icon file exists

### DIFF
--- a/apps/server/src/projectFaviconRoute.test.ts
+++ b/apps/server/src/projectFaviconRoute.test.ts
@@ -152,4 +152,16 @@ describe("tryHandleProjectFaviconRequest", () => {
       expect(response.body).toBe("<svg>brand-obj-order</svg>");
     });
   });
+
+  it("serves a fallback favicon when no icon exists", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-fallback-");
+
+    await withRouteServer(async (baseUrl) => {
+      const pathname = `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}`;
+      const response = await request(baseUrl, pathname);
+      expect(response.statusCode).toBe(200);
+      expect(response.contentType).toContain("image/svg+xml");
+      expect(response.body).toContain('data-fallback="project-favicon"');
+    });
+  });
 });

--- a/apps/server/src/projectFaviconRoute.ts
+++ b/apps/server/src/projectFaviconRoute.ts
@@ -9,6 +9,8 @@ const FAVICON_MIME_TYPES: Record<string, string> = {
   ".ico": "image/x-icon",
 };
 
+const FALLBACK_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
+
 // Well-known favicon paths checked in order.
 const FAVICON_CANDIDATES = [
   "favicon.svg",
@@ -85,6 +87,14 @@ function serveFaviconFile(filePath: string, res: http.ServerResponse): void {
   });
 }
 
+function serveFallbackFavicon(res: http.ServerResponse): void {
+  res.writeHead(200, {
+    "Content-Type": "image/svg+xml",
+    "Cache-Control": "public, max-age=3600",
+  });
+  res.end(FALLBACK_FAVICON_SVG);
+}
+
 export function tryHandleProjectFaviconRequest(url: URL, res: http.ServerResponse): boolean {
   if (url.pathname !== "/api/project-favicon") {
     return false;
@@ -118,8 +128,7 @@ export function tryHandleProjectFaviconRequest(url: URL, res: http.ServerRespons
 
   const trySourceFiles = (index: number): void => {
     if (index >= ICON_SOURCE_FILES.length) {
-      res.writeHead(404, { "Content-Type": "text/plain" });
-      res.end("No favicon found");
+      serveFallbackFavicon(res);
       return;
     }
     const sourceFile = path.join(projectCwd, ICON_SOURCE_FILES[index]!);


### PR DESCRIPTION
## Summary
- Update `/api/project-favicon` to return a built-in SVG fallback instead of a 404 when no project icon files are found.
- Add a server test that verifies fallback favicon delivery (`200`, `image/svg+xml`, and fallback marker attribute).
- Simplify Codex text-generation schema serialization by removing unused `$defs` conversion logic.
- Tweak sidebar header/wordmark spacing and typography for improved alignment (including Electron-specific header spacing).

## Testing
- `apps/server/src/projectFaviconRoute.test.ts`: added `serves a fallback favicon when no icon exists` covering fallback response status, content type, and body marker.
- Not run: `bun lint`
- Not run: `bun typecheck`
- Not run: full test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to `/api/project-favicon` now returning a static SVG (200) instead of a 404 when no icon is found, with a focused test covering the new response.
> 
> **Overview**
> `/api/project-favicon` now returns a built-in SVG fallback (with `image/svg+xml` and standard cache headers) instead of a `404` when no favicon file or icon link can be found.
> 
> Adds a Vitest case asserting the new fallback behavior (200 response, SVG content type, and a `data-fallback="project-favicon"` marker in the body).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aad5d29fe84285dd01c1b5b97f50a102dc3291f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serve a fallback SVG favicon with Cache-Control max-age=3600 from the `/api/project-favicon` route when no project icon exists
> Add `projectFaviconRoute.FALLBACK_FAVICON_SVG` and `projectFaviconRoute.serveFallbackFavicon`, and update `projectFaviconRoute.tryHandleProjectFaviconRequest` to return a 200 `image/svg+xml` response instead of 404; add a test for the fallback behavior in [projectFaviconRoute.test.ts](https://github.com/pingdotgg/t3code/pull/139/files#diff-68957f01ecbffb00727e48f36cd459c82bb24da2e2c14e0329fe6b28fc1f15e0).
>
> #### 📍Where to Start
> Start with `tryHandleProjectFaviconRequest` in [projectFaviconRoute.ts](https://github.com/pingdotgg/t3code/pull/139/files#diff-58090eadda9b0eba3a1b50ad23f064b79b20538bd4ae4769c7142bdea2efa56b), then review `serveFallbackFavicon` and the test in [projectFaviconRoute.test.ts](https://github.com/pingdotgg/t3code/pull/139/files#diff-68957f01ecbffb00727e48f36cd459c82bb24da2e2c14e0329fe6b28fc1f15e0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aad5d29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->