### PR TITLE
Auto-select next available dev ports by mode and remove favicon fallback

### DIFF
--- a/scripts/dev-runner.mjs
+++ b/scripts/dev-runner.mjs
@@ -260,7 +260,13 @@ export async function findFirstAvailableOffset({
 }) {
   for (let candidate = startOffset; ; candidate += 1) {
     const { serverPort, webPort } = portPairForOffset(candidate);
-    if (serverPort > MAX_PORT || webPort > MAX_PORT) {
+    const serverPortOutOfRange = serverPort > MAX_PORT;
+    const webPortOutOfRange = webPort > MAX_PORT;
+    if (
+      (requireServerPort && serverPortOutOfRange) ||
+      (requireWebPort && webPortOutOfRange) ||
+      (!requireServerPort && !requireWebPort && (serverPortOutOfRange || webPortOutOfRange))
+    ) {
       break;
     }
 

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -149,6 +149,17 @@ describe("findFirstAvailableOffset", () => {
 
     expect(offset).toBe(2);
   });
+
+  it("allows offsets where only non-required ports exceed max", async () => {
+    const offset = await findFirstAvailableOffset({
+      startOffset: 59_803,
+      requireServerPort: true,
+      requireWebPort: false,
+      checkPortAvailability: async () => true,
+    });
+
+    expect(offset).toBe(59_803);
+  });
 });
 
 describe("resolveModePortOffsets", () => {


### PR DESCRIPTION
## Summary
- add dynamic dev-port selection in `scripts/dev-runner.mjs` so `dev`, `dev:web`, and `dev:server` each pick the next available offset based on required ports
- add loopback port-availability checks (IPv4/IPv6), computed-port validation, and clearer startup logging for selected offsets
- add unit coverage for `findFirstAvailableOffset` and `resolveModePortOffsets` in `scripts/dev-runner.test.ts`
- remove project favicon SVG fallback behavior; `/api/project-favicon` now returns `404` when no icon is found, and remove the related fallback test
- simplify a few server/web callsites (schema serialization path, detached upstream refresh, minor sidebar class/formatting adjustments)

## Testing
- `scripts/dev-runner.test.ts`: validates offset scanning, mode-specific offset behavior, and explicit override handling
- `apps/server/src/projectFaviconRoute.test.ts`: fallback favicon test removed to match new `404` behavior
- `bun lint`: Not run
- `bun typecheck`: Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dev startup behavior by introducing async port probing and mode-specific offset selection, which could alter how local environments pick/bind ports (especially across IPv4/IPv6). Test coverage is added, but failures could still surface on unusual network/loopback configurations.
> 
> **Overview**
> The dev runner now **auto-selects the next available port offset** by probing loopback availability and applying *mode-specific* requirements: `dev` finds a shared offset for server+web, `dev:web` shifts only the web port, and `dev:server` shifts only the server port (unless explicit `T3CODE_PORT`/`VITE_DEV_SERVER_URL` overrides are provided).
> 
> It also sets `PORT`/`ELECTRON_RENDERER_PORT`/`VITE_DEV_SERVER_URL` when missing, validates computed ports are within `1..65535`, improves startup logging to show selected offsets, and switches the entrypoint to async error handling. New unit tests cover offset scanning and override/mode behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70248fafe633b5afef6727ae5eeb558c13954aea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-select next available dev ports by mode and validate against 1–65535 in `scripts/dev-runner.mjs`
> Add async port probing on IPv4/IPv6, scan offsets to pick mode-aware server/web ports, and set `PORT`, `ELECTRON_RENDERER_PORT`, and `VITE_DEV_SERVER_URL` when not provided in [dev-runner.mjs](https://github.com/pingdotgg/t3code/pull/140/files#diff-21a8bbf249ea2eaa490438c252f1580a06b000b6d03863636f71986267cb0124).
>
> #### 📍Where to Start
> Start with `resolveModePortOffsets` and `runDevRunner` in [dev-runner.mjs](https://github.com/pingdotgg/t3code/pull/140/files#diff-21a8bbf249ea2eaa490438c252f1580a06b000b6d03863636f71986267cb0124).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70248fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->