### PR TITLE
Fix chat scroll restoration across thread switches

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1284,7 +1284,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
   // Auto-scroll on new messages
   const messageCount = timelineMessages.length;
-  const workLogCount = workLogEntries.length;
   const scrollMessagesToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     const scrollContainer = messagesScrollRef.current;
     if (!scrollContainer) return;
@@ -1354,11 +1353,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (!shouldAutoScrollRef.current) return;
     scheduleStickToBottom();
   }, [messageCount, scheduleStickToBottom]);
-  useEffect(() => {
-    if (phase !== "running") return;
-    if (!shouldAutoScrollRef.current) return;
-    scheduleStickToBottom();
-  }, [phase, scheduleStickToBottom, workLogCount]);
   useEffect(() => {
     if (phase !== "running") return;
     if (!shouldAutoScrollRef.current) return;


### PR DESCRIPTION
## Summary

- Stabilize scroll position when switching between threads by using stable row IDs in the virtualizer, preventing measurement leaks across thread switches
- Always keep tail rows (last 8) unvirtualized to improve scroll stability near the bottom of the chat
- Add attachment preview handoff mechanism to prevent image flicker when optimistic messages transition to server-confirmed messages
- Schedule auto-scroll via `requestAnimationFrame` for smoother behavior
- Track composer form height changes with `ResizeObserver` to maintain scroll position when the textarea grows/shrinks
- Improve timeline message height estimation based on text length and attachments

## Test plan

- [ ] Switch between threads rapidly and verify scroll position stays at the bottom when expected
- [ ] Send messages with image attachments and verify no flicker when the message transitions from optimistic to confirmed
- [ ] Expand/collapse the composer textarea and verify scroll stays pinned to bottom
- [ ] Scroll up mid-conversation, switch threads, then switch back - verify scroll position is reasonable
- [ ] Verify virtualized content still renders correctly with stable row IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core chat scrolling/virtualization behavior and blob URL lifecycle for image previews, which could introduce UI regressions (jumping scroll, incorrect measurements, or leaked/revoked previews) despite being frontend-only.
> 
> **Overview**
> Improves chat *sticky-bottom* behavior when switching threads and during dynamic layout changes by scheduling bottom scroll via `requestAnimationFrame`, re-sticking shortly after thread switches, and reacting to composer height changes via `ResizeObserver`.
> 
> Hardens `MessagesTimeline` virtualization to avoid scroll/measurement leakage across threads by using stable row keys, keeping the last `8` rows unvirtualized, using content-based height estimates, and remeasuring on image load/error. Also adds a TTL-based attachment preview handoff so blob image previews don’t flicker when optimistic user messages are replaced by server-confirmed messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61a8ca2c314275a2908f0e715eed764ed35a2dbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore chat bottom stickiness across thread switches and implement rAF-based auto-scroll with a 96ms fallback, an 8-row unvirtualized tail, and a 5000ms attachment preview handoff in `ChatView` and `MessagesTimeline`
> Add rAF-scheduled bottom scrolling with a timer fallback, transfer `blob:` image previews from optimistic to server messages with TTL, and update virtualization to keep the last 8 rows unvirtualized and measure rows using an estimator; wire image load/error to schedule re-measure and reset `MessagesTimeline` per thread.
>
> #### 📍Where to Start
> Start with the auto-scroll and preview handoff logic in `ChatView` within [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/145/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), then review virtualization changes in `MessagesTimeline` in the same file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61a8ca2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->