### PR TITLE
Fix chat composer overflow by allowing form to shrink

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2471,7 +2471,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         <form
           ref={composerFormRef}
           onSubmit={onSend}
-          className="mx-auto w-full min-w-fit max-w-3xl"
+          className="mx-auto w-full min-w-0 max-w-3xl"
           data-chat-composer-form="true"
         >
           <div


### PR DESCRIPTION
## Summary
- Replace `min-w-fit` with `min-w-0` on the chat composer form in `ChatView`.
- Allows the composer to shrink correctly in constrained layouts instead of forcing horizontal overflow.

## Testing
- Not run (content generated from provided diff/commit metadata).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that adjusts the chat composer form’s minimum width to avoid overflow in constrained layouts.
> 
> **Overview**
> Prevents horizontal overflow in `ChatView`’s chat composer by changing the form’s Tailwind min-width from `min-w-fit` to `min-w-0`, allowing it to shrink properly in narrow/constrained layouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31b515cd6c1e42838cb05eeef88edfccee1e0efa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat composer overflow by set the ChatView form min-width to `0` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/147/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Update the input bar form class from `min-w-fit` to `min-w-0` in `ChatView` to allow shrinking within its container.
>
> #### 📍Where to Start
> Start with the form element inside `ChatView` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/147/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31b515c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->