### PR TITLE
docs: add dummy marker note to task completion requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 - Both `bun lint` and `bun typecheck` must pass before considering tasks completed.
 - Dummy marker: touched for a no-op documentation update.
+- Dummy marker: touched on 2026-03-03 for a no-op documentation update.
 
 ## Project Snapshot
 


### PR DESCRIPTION
## Summary
- Add a no-op documentation marker under **Task Completion Requirements** in `AGENTS.md`.
- Keep existing completion requirements (`bun lint` and `bun typecheck`) unchanged.

## Testing
- Not run (documentation-only change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds two no-op bullets; no runtime or build behavior is affected.
> 
> **Overview**
> Adds two *no-op* “dummy marker” bullets under **Task Completion Requirements** in `AGENTS.md`, leaving the existing `bun lint`/`bun typecheck` completion requirements unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c246e727f0f916526187cd699817c32afcbca16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dummy marker notes to AGENTS.md Task Completion Requirements to record a no-op update dated 2026-03-03
> Add two bullet points to the Task Completion Requirements section in [AGENTS.md](https://github.com/pingdotgg/t3code/pull/155/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9): a no-op documentation marker and the date 2026-03-03.
>
> #### 📍Where to Start
> Start with the Task Completion Requirements section in [AGENTS.md](https://github.com/pingdotgg/t3code/pull/155/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c246e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->