### PR TITLE
Extract slash model suggestion filtering into app settings helper

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getAppModelOptions, normalizeCustomModelSlugs } from "./appSettings";
+import { getAppModelOptions, getSlashModelOptions, normalizeCustomModelSlugs } from "./appSettings";
 
 describe("normalizeCustomModelSlugs", () => {
   it("normalizes aliases, removes built-ins, and deduplicates values", () => {
@@ -38,5 +38,19 @@ describe("getAppModelOptions", () => {
       name: "custom/selected-model",
       isCustom: true,
     });
+  });
+});
+
+describe("getSlashModelOptions", () => {
+  it("includes saved custom model slugs for /model command suggestions", () => {
+    const options = getSlashModelOptions(["custom/internal-model"], "", "gpt-5.3-codex");
+
+    expect(options.some((option) => option.slug === "custom/internal-model")).toBe(true);
+  });
+
+  it("filters slash-model suggestions across built-in and custom model names", () => {
+    const options = getSlashModelOptions(["openai/gpt-oss-120b"], "oss", "gpt-5.3-codex");
+
+    expect(options.map((option) => option.slug)).toEqual(["openai/gpt-oss-120b"]);
   });
 });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -105,6 +105,24 @@ export function getAppModelOptions(
   return options;
 }
 
+export function getSlashModelOptions(
+  customModels: readonly string[],
+  query: string,
+  selectedModel?: string | null,
+): AppModelOption[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const options = getAppModelOptions(customModels, selectedModel);
+  if (!normalizedQuery) {
+    return options;
+  }
+
+  return options.filter((option) => {
+    const searchSlug = option.slug.toLowerCase();
+    const searchName = option.name.toLowerCase();
+    return searchSlug.includes(normalizedQuery) || searchName.includes(normalizedQuery);
+  });
+}
+
 function emitChange(): void {
   for (const listener of listeners) {
     listener();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -118,7 +118,7 @@ import { Toggle } from "./ui/toggle";
 import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
-import { getAppModelOptions, useAppSettings } from "../appSettings";
+import { getAppModelOptions, getSlashModelOptions, useAppSettings } from "../appSettings";
 import {
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
@@ -632,6 +632,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
     () => getAppModelOptions(settings.customCodexModels, selectedModel),
     [selectedModel, settings.customCodexModels],
   );
+  const slashModelOptions = useMemo(
+    () => getSlashModelOptions(settings.customCodexModels, composerTrigger?.query ?? "", selectedModel),
+    [composerTrigger?.query, selectedModel, settings.customCodexModels],
+  );
   const phase = derivePhase(activeThread?.session ?? null);
   const isSendBusy = sendPhase !== "idle";
   const isPreparingWorktree = sendPhase === "preparing-worktree";
@@ -907,26 +911,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
       ];
     }
 
-    return modelOptions
-      .map(({ slug, name }) => ({
-        slug,
-        name,
-        searchSlug: slug.toLowerCase(),
-        searchName: name.toLowerCase(),
-      }))
-      .filter(({ searchSlug, searchName }) => {
-        const query = composerTrigger.query.trim().toLowerCase();
-        if (!query) return true;
-        return searchSlug.includes(query) || searchName.includes(query);
-      })
-      .map(({ slug, name }) => ({
+    return slashModelOptions.map(({ slug, name }) => ({
         id: `model:${slug}`,
         type: "model" as const,
         model: slug,
         label: name,
         description: slug,
       }));
-  }, [composerTrigger, modelOptions, workspaceEntries]);
+  }, [composerTrigger, slashModelOptions, workspaceEntries]);
   const composerMenuOpen = Boolean(composerTrigger);
   const activeComposerMenuItem = useMemo(
     () =>


### PR DESCRIPTION
## Summary
- Move `/model` suggestion filtering logic into a shared `getSlashModelOptions` helper in `appSettings`.
- Update `ChatView` to consume pre-filtered slash model options instead of in-component filtering.
- Add tests covering slash model option inclusion for custom models and query-based filtering across built-in/custom entries.

## Testing
- Added unit tests in `apps/web/src/appSettings.test.ts` for `getSlashModelOptions`:
- Confirms saved custom model slugs appear in `/model` suggestions.
- Confirms query filtering matches by slug/name and returns expected model(s).
- Not run: `bun lint`
- Not run: `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes `/model` suggestion filtering logic and adds unit coverage; behavior should remain the same aside from any subtle query-matching differences.
> 
> **Overview**
> Moves `/model` slash-command model suggestion generation/filtering out of `ChatView` into a new `getSlashModelOptions` helper in `appSettings`, reusing `getAppModelOptions` and applying query-based filtering there.
> 
> Updates `ChatView` to memoize and consume these pre-filtered options instead of performing inline slug/name filtering, and adds `vitest` coverage ensuring saved custom models appear in suggestions and that query filtering works across built-in and custom entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdc856fca5b2f6b65003a9f3964fd67885452c02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract filtering for /model composer suggestions into `apps/web/src/appSettings.ts:getSlashModelOptions` to include custom slugs and query matching
> Add `getSlashModelOptions` that returns query-filtered model options, and update `ChatView` to use it for `/model` suggestions; add tests for custom model inclusion and filtering in [appSettings.test.ts](https://github.com/pingdotgg/t3code/pull/160/files#diff-8845ab49a83a8d2db22196997e04cf35571b4188b2e86b090559bb50ca0e8c1e).
>
> #### 📍Where to Start
> Start with `getSlashModelOptions` in [appSettings.ts](https://github.com/pingdotgg/t3code/pull/160/files#diff-4f500b80c5f743d5b39d3f07498169da0c26f4bf9b5a2127453a90c04a4c49cc), then review its use in `ChatView` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/160/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), and finally the tests in [appSettings.test.ts](https://github.com/pingdotgg/t3code/pull/160/files#diff-8845ab49a83a8d2db22196997e04cf35571b4188b2e86b090559bb50ca0e8c1e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdc856f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->