### PR TITLE
Fix collapsed toast stack height and text wrapping overflow

### DIFF
--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -206,7 +206,10 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
                 "data-[position*=top]:after:top-full",
                 "data-[position*=bottom]:after:bottom-full",
                 // Define some variables
-                "[--toast-calc-height:var(--toast-frontmost-height,var(--toast-height))] [--toast-gap:--spacing(3)] [--toast-peek:--spacing(3)] [--toast-scale:calc(max(0,1-(var(--toast-index)*.1)))] [--toast-shrink:calc(1-var(--toast-scale))]",
+                // Base UI exposes a shared front-most height for the collapsed stack.
+                // If that shared measurement is briefly stale, long content can render
+                // outside the card until hover expands the toast and swaps to its own height.
+                "[--toast-calc-height:max(var(--toast-frontmost-height,var(--toast-height)),var(--toast-height))] [--toast-gap:--spacing(3)] [--toast-peek:--spacing(3)] [--toast-scale:calc(max(0,1-(var(--toast-index)*.1)))] [--toast-shrink:calc(1-var(--toast-scale))]",
                 // Define offset-y variable
                 "data-[position*=top]:[--toast-calc-offset-y:calc(var(--toast-offset-y)+var(--toast-index)*var(--toast-gap)+var(--toast-swipe-movement-y))]",
                 "data-[position*=bottom]:[--toast-calc-offset-y:calc(var(--toast-offset-y)*-1+var(--toast-index)*var(--toast-gap)*-1+var(--toast-swipe-movement-y))]",
@@ -258,7 +261,7 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
                     "not-data-expanded:pointer-events-none not-data-expanded:opacity-0",
                 )}
               >
-                <div className="flex gap-2">
+                <div className="flex min-w-0 flex-1 gap-2">
                   {Icon && (
                     <div
                       className="[&>svg]:h-lh [&>svg]:w-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
@@ -268,16 +271,22 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
                     </div>
                   )}
 
-                  <div className="flex flex-col gap-0.5">
-                    <Toast.Title className="font-medium" data-slot="toast-title" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <Toast.Title
+                      className="min-w-0 break-words font-medium"
+                      data-slot="toast-title"
+                    />
                     <Toast.Description
-                      className="text-muted-foreground"
+                      className="min-w-0 break-words text-muted-foreground"
                       data-slot="toast-description"
                     />
                   </div>
                 </div>
                 {toast.actionProps && (
-                  <Toast.Action className={buttonVariants({ size: "xs" })} data-slot="toast-action">
+                  <Toast.Action
+                    className={cn(buttonVariants({ size: "xs" }), "shrink-0")}
+                    data-slot="toast-action"
+                  >
                     {toast.actionProps.children}
                   </Toast.Action>
                 )}
@@ -341,7 +350,7 @@ function AnchoredToasts() {
                     </Toast.Content>
                   ) : (
                     <Toast.Content className="pointer-events-auto flex items-center justify-between gap-1.5 overflow-hidden px-3.5 py-3 text-sm">
-                      <div className="flex gap-2">
+                      <div className="flex min-w-0 flex-1 gap-2">
                         {Icon && (
                           <div
                             className="[&>svg]:h-lh [&>svg]:w-4 [&_svg]:pointer-events-none [&_svg]:shrink-0"
@@ -351,17 +360,20 @@ function AnchoredToasts() {
                           </div>
                         )}
 
-                        <div className="flex flex-col gap-0.5">
-                          <Toast.Title className="font-medium" data-slot="toast-title" />
+                        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                          <Toast.Title
+                            className="min-w-0 break-words font-medium"
+                            data-slot="toast-title"
+                          />
                           <Toast.Description
-                            className="text-muted-foreground"
+                            className="min-w-0 break-words text-muted-foreground"
                             data-slot="toast-description"
                           />
                         </div>
                       </div>
                       {toast.actionProps && (
                         <Toast.Action
-                          className={buttonVariants({ size: "xs" })}
+                          className={cn(buttonVariants({ size: "xs" }), "shrink-0")}
                           data-slot="toast-action"
                         >
                           {toast.actionProps.children}


### PR DESCRIPTION
## Summary
- prevent collapsed toasts from clipping by computing `--toast-calc-height` as the max of shared front-most height and each toast’s own height
- improve layout resilience for long title/description content by adding `min-w-0`, `flex-1`, and `break-words` in toast content rows
- keep toast action buttons stable in constrained layouts by adding `shrink-0`
- apply the same overflow protections to both standard and anchored toast variants

## Testing
- Not run (no test or lint/typecheck results were provided in this change context)
- Suggested manual check: trigger multiple stacked toasts with long title/description text and verify no content overflows before/after hover-expand
- Suggested manual check: verify action button remains visible and does not compress text unexpectedly in narrow widths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks toast CSS variables and flex layout to avoid clipping/overflow; potential impact is limited to toast rendering and animations.
> 
> **Overview**
> Fixes collapsed toast stack clipping by changing `--toast-calc-height` to use the max of Base UI’s shared front-most height and each toast’s own `--toast-height`.
> 
> Improves resilience to long titles/descriptions by adding `min-w-0`, `flex-1`, and `break-words` to toast content containers, and keeps action buttons visible by applying `shrink-0` (applied to both standard and anchored toast variants).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c1df870233c7baaf6bcb6b9ed4cfdb92e88ca15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix collapsed toast stack height and text wrapping in `Toasts` and `AnchoredToasts` in [toast.tsx](https://github.com/pingdotgg/t3code/pull/171/files#diff-dbb38a4f02a67491223157a9f1aba388365f4cd55652e1f32847ffda53aee7f2) to prevent overflow
> Adjust `--toast-calc-height` to use `max()` of shared front-most height and per-toast height; add `min-w-0`, `flex-1`, and `break-words` to content, title, and description; prevent `Toast.Action` from shrinking with `shrink-0` and wrap `className` with `cn(...)`.
>
> #### 📍Where to Start
> Start with the `Toasts` component height calculation and layout changes in [toast.tsx](https://github.com/pingdotgg/t3code/pull/171/files#diff-dbb38a4f02a67491223157a9f1aba388365f4cd55652e1f32847ffda53aee7f2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c1df87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->