### PR TITLE
Add anonymous PostHog telemetry for provider lifecycle events

### DIFF
--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -253,22 +253,12 @@ export const makeOrchestrationIntegrationHarness = (
       ? makeProviderServiceLive().pipe(
           Layer.provide(providerSessionDirectoryLayer),
           Layer.provide(realCodexRegistry),
-          Layer.provide(
-            Layer.succeed(AnalyticsService, {
-              record: () => Effect.void,
-              flush: Effect.void,
-            }),
-          ),
+          Layer.provide(AnalyticsService.layerTest),
         )
       : makeProviderServiceLive().pipe(
           Layer.provide(providerSessionDirectoryLayer),
           Layer.provide(fakeRegistry!),
-          Layer.provide(
-            Layer.succeed(AnalyticsService, {
-              record: () => Effect.void,
-              flush: Effect.void,
-            }),
-          ),
+          Layer.provide(AnalyticsService.layerTest),
         );
 
     const runtimeServicesLayer = Layer.mergeAll(

--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -40,6 +40,7 @@ import { makeProviderServiceLive } from "../src/provider/Layers/ProviderService.
 import { makeCodexAdapterLive } from "../src/provider/Layers/CodexAdapter.ts";
 import { CodexAdapter } from "../src/provider/Services/CodexAdapter.ts";
 import { ProviderService } from "../src/provider/Services/ProviderService.ts";
+import { AnalyticsService } from "../src/telemetry/Services/AnalyticsService.ts";
 import { CheckpointReactorLive } from "../src/orchestration/Layers/CheckpointReactor.ts";
 import { OrchestrationEngineLive } from "../src/orchestration/Layers/OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "../src/orchestration/Layers/ProjectionPipeline.ts";
@@ -252,10 +253,22 @@ export const makeOrchestrationIntegrationHarness = (
       ? makeProviderServiceLive().pipe(
           Layer.provide(providerSessionDirectoryLayer),
           Layer.provide(realCodexRegistry),
+          Layer.provide(
+            Layer.succeed(AnalyticsService, {
+              record: () => Effect.void,
+              flush: Effect.void,
+            }),
+          ),
         )
       : makeProviderServiceLive().pipe(
           Layer.provide(providerSessionDirectoryLayer),
           Layer.provide(fakeRegistry!),
+          Layer.provide(
+            Layer.succeed(AnalyticsService, {
+              record: () => Effect.void,
+              flush: Effect.void,
+            }),
+          ),
         );
 
     const runtimeServicesLayer = Layer.mergeAll(

--- a/apps/server/integration/providerService.integration.test.ts
+++ b/apps/server/integration/providerService.integration.test.ts
@@ -12,6 +12,7 @@ import {
   ProviderService,
   type ProviderServiceShape,
 } from "../src/provider/Services/ProviderService.ts";
+import { AnalyticsService } from "../src/telemetry/Services/AnalyticsService.ts";
 import { SqlitePersistenceMemory } from "../src/persistence/Layers/Sqlite.ts";
 import { ProviderSessionRuntimeRepositoryLive } from "../src/persistence/Layers/ProviderSessionRuntime.ts";
 
@@ -59,6 +60,10 @@ const makeIntegrationFixture = Effect.gen(function* () {
   const shared = Layer.mergeAll(
     directoryLayer,
     Layer.succeed(ProviderAdapterRegistry, registry),
+    Layer.succeed(AnalyticsService, {
+      record: () => Effect.void,
+      flush: Effect.void,
+    }),
   ).pipe(Layer.provide(SqlitePersistenceMemory));
 
   const layer = makeProviderServiceLive().pipe(Layer.provide(shared));

--- a/apps/server/integration/providerService.integration.test.ts
+++ b/apps/server/integration/providerService.integration.test.ts
@@ -60,10 +60,7 @@ const makeIntegrationFixture = Effect.gen(function* () {
   const shared = Layer.mergeAll(
     directoryLayer,
     Layer.succeed(ProviderAdapterRegistry, registry),
-    Layer.succeed(AnalyticsService, {
-      record: () => Effect.void,
-      flush: Effect.void,
-    }),
+    AnalyticsService.layerTest,
   ).pipe(Layer.provide(SqlitePersistenceMemory));
 
   const layer = makeProviderServiceLive().pipe(Layer.provide(shared));

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -10,7 +10,7 @@ import { version } from "../package.json" with { type: "json" };
 import { ServerLive } from "./wsServer";
 import { NetService } from "@t3tools/shared/Net";
 import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
-import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
+import { FetchHttpClient } from "effect/unstable/http";
 
 const RuntimeLayer = Layer.empty.pipe(
   Layer.provideMerge(CliConfig.layer),
@@ -19,7 +19,7 @@ const RuntimeLayer = Layer.empty.pipe(
   Layer.provideMerge(OpenLive),
   Layer.provideMerge(NetService.layer),
   Layer.provideMerge(NodeServices.layer),
-  Layer.provideMerge(NodeHttpClient.layerUndici),
+  Layer.provideMerge(FetchHttpClient.layer),
 );
 
 Command.run(t3Cli, { version }).pipe(Effect.provide(RuntimeLayer), NodeRuntime.runMain);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,12 +9,10 @@ import { Command } from "effect/unstable/cli";
 import { version } from "../package.json" with { type: "json" };
 import { ServerLive } from "./wsServer";
 import { NetService } from "@t3tools/shared/Net";
-import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
 import { FetchHttpClient } from "effect/unstable/http";
 
 const RuntimeLayer = Layer.empty.pipe(
   Layer.provideMerge(CliConfig.layer),
-  Layer.provideMerge(AnalyticsServiceLayerLive),
   Layer.provideMerge(ServerLive),
   Layer.provideMerge(OpenLive),
   Layer.provideMerge(NetService.layer),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,13 +9,17 @@ import { Command } from "effect/unstable/cli";
 import { version } from "../package.json" with { type: "json" };
 import { ServerLive } from "./wsServer";
 import { NetService } from "@t3tools/shared/Net";
+import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
+import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
 
 const RuntimeLayer = Layer.empty.pipe(
   Layer.provideMerge(CliConfig.layer),
+  Layer.provideMerge(AnalyticsServiceLayerLive),
   Layer.provideMerge(ServerLive),
   Layer.provideMerge(OpenLive),
   Layer.provideMerge(NetService.layer),
   Layer.provideMerge(NodeServices.layer),
+  Layer.provideMerge(NodeHttpClient.layerUndici),
 );
 
 Command.run(t3Cli, { version }).pipe(Effect.provide(RuntimeLayer), NodeRuntime.runMain);

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -1,6 +1,7 @@
 import * as Http from "node:http";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it, vi } from "@effect/vitest";
+import type { OrchestrationReadModel } from "@t3tools/contracts";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -9,9 +10,10 @@ import { FetchHttpClient } from "effect/unstable/http";
 import { beforeEach } from "vitest";
 import { NetService } from "@t3tools/shared/Net";
 
-import { CliConfig, t3Cli, type CliConfigShape } from "./main";
+import { CliConfig, recordStartupHeartbeat, t3Cli, type CliConfigShape } from "./main";
 import { ServerConfig, type ServerConfigShape } from "./config";
 import { Open, type OpenShape } from "./open";
+import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
 import { Server, type ServerShape } from "./wsServer";
 
@@ -228,6 +230,43 @@ it.layer(testLayer)("server CLI command", (it) => {
       assert.equal(start.mock.calls.length, 1);
       assert.equal(resolvedConfig?.autoBootstrapProjectFromCwd, true);
       assert.equal(resolvedConfig?.logWebSocketEvents, false);
+    }),
+  );
+
+  it.effect("records a startup heartbeat with thread/project counts", () =>
+    Effect.gen(function* () {
+      const recordTelemetry = vi.fn(
+        (_event: string, _properties?: Readonly<Record<string, unknown>>) => Effect.void,
+      );
+      const getSnapshot = vi.fn(() =>
+        Effect.succeed({
+          snapshotSequence: 2,
+          projects: [{} as OrchestrationReadModel["projects"][number]],
+          threads: [
+            {} as OrchestrationReadModel["threads"][number],
+            {} as OrchestrationReadModel["threads"][number],
+          ],
+          updatedAt: new Date(1).toISOString(),
+        } satisfies OrchestrationReadModel),
+      );
+
+      yield* recordStartupHeartbeat.pipe(
+        Effect.provideService(ProjectionSnapshotQuery, {
+          getSnapshot,
+        }),
+        Effect.provideService(AnalyticsService, {
+          record: recordTelemetry,
+          flush: Effect.void,
+        }),
+      );
+
+      assert.deepEqual(recordTelemetry.mock.calls[0], [
+        "server.boot.heartbeat",
+        {
+          threadCount: 2,
+          projectCount: 1,
+        },
+      ]);
     }),
   );
 

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -49,10 +49,7 @@ const testLayer = Layer.mergeAll(
     openBrowser: (_target: string) => Effect.void,
     openInEditor: () => Effect.void,
   } satisfies OpenShape),
-  Layer.succeed(AnalyticsService, {
-    record: () => Effect.void,
-    flush: Effect.void,
-  }),
+  AnalyticsService.layerTest,
   FetchHttpClient.layer,
   NodeServices.layer,
 );

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -11,6 +11,7 @@ import { NetService } from "@t3tools/shared/Net";
 import { CliConfig, t3Cli, type CliConfigShape } from "./main";
 import { ServerConfig, type ServerConfigShape } from "./config";
 import { Open, type OpenShape } from "./open";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
 import { Server, type ServerShape } from "./wsServer";
 
 const start = vi.fn(() => undefined);
@@ -47,6 +48,10 @@ const testLayer = Layer.mergeAll(
     openBrowser: (_target: string) => Effect.void,
     openInEditor: () => Effect.void,
   } satisfies OpenShape),
+  Layer.succeed(AnalyticsService, {
+    record: () => Effect.void,
+    flush: Effect.void,
+  }),
   NodeServices.layer,
 );
 

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -5,6 +5,7 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Command from "effect/unstable/cli/Command";
+import { FetchHttpClient } from "effect/unstable/http";
 import { beforeEach } from "vitest";
 import { NetService } from "@t3tools/shared/Net";
 
@@ -52,6 +53,7 @@ const testLayer = Layer.mergeAll(
     record: () => Effect.void,
     flush: Effect.void,
   }),
+  FetchHttpClient.layer,
   NodeServices.layer,
 );
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -20,10 +20,12 @@ import { fixPath, resolveStateDir } from "./os-jank";
 import { Open } from "./open";
 import * as SqlitePersistence from "./persistence/Layers/Sqlite";
 import { makeServerProviderLayer, makeServerRuntimeServicesLayer } from "./serverLayers";
+import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ProviderHealthLive } from "./provider/Layers/ProviderHealth";
 import { Server } from "./wsServer";
 import { ServerLoggerLive } from "./serverLogger";
 import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
 
 export class StartupError extends Data.TaggedError("StartupError")<{
   readonly message: string;
@@ -208,6 +210,31 @@ const isWildcardHost = (host: string | undefined): boolean =>
 const formatHostForUrl = (host: string): string =>
   host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 
+export const recordStartupHeartbeat = Effect.gen(function* () {
+  const analytics = yield* AnalyticsService;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+
+  const { threadCount, projectCount } = yield* projectionSnapshotQuery.getSnapshot().pipe(
+    Effect.map((snapshot) => ({
+      threadCount: snapshot.threads.length,
+      projectCount: snapshot.projects.length,
+    })),
+    Effect.catch((cause) =>
+      Effect.logWarning("failed to gather startup snapshot for telemetry", { cause }).pipe(
+        Effect.as({
+          threadCount: 0,
+          projectCount: 0,
+        }),
+      ),
+    ),
+  );
+
+  yield* analytics.record("server.boot.heartbeat", {
+    threadCount,
+    projectCount,
+  });
+});
+
 const makeServerProgram = (input: CliInput) =>
   Effect.gen(function* () {
     const cliConfig = yield* CliConfig;
@@ -227,6 +254,7 @@ const makeServerProgram = (input: CliInput) =>
     }
 
     yield* start;
+    yield* Effect.forkChild(recordStartupHeartbeat);
 
     const localUrl = `http://localhost:${config.port}`;
     const bindUrl =

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -23,6 +23,7 @@ import { makeServerProviderLayer, makeServerRuntimeServicesLayer } from "./serve
 import { ProviderHealthLive } from "./provider/Layers/ProviderHealth";
 import { Server } from "./wsServer";
 import { ServerLoggerLive } from "./serverLogger";
+import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
 
 export class StartupError extends Data.TaggedError("StartupError")<{
   readonly message: string;
@@ -197,6 +198,7 @@ const LayerLive = (input: CliInput) =>
     Layer.provideMerge(ProviderHealthLive),
     Layer.provideMerge(SqlitePersistence.layerConfig),
     Layer.provideMerge(ServerLoggerLive),
+    Layer.provideMerge(AnalyticsServiceLayerLive),
     Layer.provideMerge(ServerConfigLive(input)),
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -42,6 +42,7 @@ import {
   makeSqlitePersistenceLive,
   SqlitePersistenceMemory,
 } from "../../persistence/Layers/Sqlite.ts";
+import { AnalyticsService } from "../../telemetry/Services/AnalyticsService.ts";
 
 const asRequestId = (value: string): ApprovalRequestId => ApprovalRequestId.makeUnsafe(value);
 const asEventId = (value: string): EventId => EventId.makeUnsafe(value);
@@ -214,6 +215,11 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
 const sleep = (ms: number) =>
   Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
+const noopAnalyticsLayer = Layer.succeed(AnalyticsService, {
+  record: () => Effect.void,
+  flush: Effect.void,
+});
+
 function makeProviderServiceLayer() {
   const codex = makeFakeCodexAdapter();
   const registry: typeof ProviderAdapterRegistry.Service = {
@@ -235,8 +241,10 @@ function makeProviderServiceLayer() {
       makeProviderServiceLive().pipe(
         Layer.provide(providerAdapterLayer),
         Layer.provide(directoryLayer),
+        Layer.provideMerge(noopAnalyticsLayer),
       ),
       directoryLayer,
+
       runtimeRepositoryLayer,
       NodeServices.layer,
     ),
@@ -280,6 +288,7 @@ it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", (
     const providerLayer = makeProviderServiceLive().pipe(
       Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
       Layer.provide(directoryLayer),
+      Layer.provide(noopAnalyticsLayer),
     );
 
     yield* Effect.gen(function* () {
@@ -338,6 +347,7 @@ it.effect(
       const firstProviderLayer = makeProviderServiceLive().pipe(
         Layer.provide(Layer.succeed(ProviderAdapterRegistry, firstRegistry)),
         Layer.provide(firstDirectoryLayer),
+        Layer.provide(noopAnalyticsLayer),
       );
 
       const startedSession = yield* Effect.gen(function* () {
@@ -380,6 +390,7 @@ it.effect(
       const secondProviderLayer = makeProviderServiceLive().pipe(
         Layer.provide(Layer.succeed(ProviderAdapterRegistry, secondRegistry)),
         Layer.provide(secondDirectoryLayer),
+        Layer.provide(noopAnalyticsLayer),
       );
 
       secondCodex.startSession.mockClear();

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -215,11 +215,6 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
 const sleep = (ms: number) =>
   Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
-const noopAnalyticsLayer = Layer.succeed(AnalyticsService, {
-  record: () => Effect.void,
-  flush: Effect.void,
-});
-
 function makeProviderServiceLayer() {
   const codex = makeFakeCodexAdapter();
   const registry: typeof ProviderAdapterRegistry.Service = {
@@ -241,7 +236,7 @@ function makeProviderServiceLayer() {
       makeProviderServiceLive().pipe(
         Layer.provide(providerAdapterLayer),
         Layer.provide(directoryLayer),
-        Layer.provideMerge(noopAnalyticsLayer),
+        Layer.provideMerge(AnalyticsService.layerTest),
       ),
       directoryLayer,
 
@@ -288,7 +283,7 @@ it.effect("ProviderServiceLive keeps persisted resumable sessions on startup", (
     const providerLayer = makeProviderServiceLive().pipe(
       Layer.provide(Layer.succeed(ProviderAdapterRegistry, registry)),
       Layer.provide(directoryLayer),
-      Layer.provide(noopAnalyticsLayer),
+      Layer.provide(AnalyticsService.layerTest),
     );
 
     yield* Effect.gen(function* () {
@@ -347,7 +342,7 @@ it.effect(
       const firstProviderLayer = makeProviderServiceLive().pipe(
         Layer.provide(Layer.succeed(ProviderAdapterRegistry, firstRegistry)),
         Layer.provide(firstDirectoryLayer),
-        Layer.provide(noopAnalyticsLayer),
+        Layer.provide(AnalyticsService.layerTest),
       );
 
       const startedSession = yield* Effect.gen(function* () {
@@ -390,7 +385,7 @@ it.effect(
       const secondProviderLayer = makeProviderServiceLive().pipe(
         Layer.provide(Layer.succeed(ProviderAdapterRegistry, secondRegistry)),
         Layer.provide(secondDirectoryLayer),
-        Layer.provide(noopAnalyticsLayer),
+        Layer.provide(AnalyticsService.layerTest),
       );
 
       secondCodex.startSession.mockClear();

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -31,6 +31,7 @@ import {
   type ProviderRuntimeBinding,
 } from "../Services/ProviderSessionDirectory.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import { AnalyticsService } from "../../telemetry/Services/AnalyticsService.ts";
 
 export interface ProviderServiceLiveOptions {
   readonly canonicalEventLogPath?: string;
@@ -108,6 +109,7 @@ function readPersistedCwd(
 
 const makeProviderService = (options?: ProviderServiceLiveOptions) =>
   Effect.gen(function* () {
+    const analytics = yield* Effect.service(AnalyticsService);
     const canonicalEventLogger =
       options?.canonicalEventLogger ??
       (options?.canonicalEventLogPath !== undefined
@@ -178,6 +180,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           const existing = activeSessions.find((session) => session.threadId === input.binding.threadId);
           if (existing) {
             yield* upsertSessionBinding(existing, input.binding.threadId);
+            yield* analytics.record("provider.session.recovered", {
+              provider: existing.provider,
+              strategy: "adopt-existing",
+              hasResumeCursor: existing.resumeCursor !== undefined,
+            });
             return { adapter, session: existing } as const;
           }
         }
@@ -206,6 +213,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         }
 
         yield* upsertSessionBinding(resumed, input.binding.threadId);
+        yield* analytics.record("provider.session.recovered", {
+          provider: resumed.provider,
+          strategy: "resume-thread",
+          hasResumeCursor: resumed.resumeCursor !== undefined,
+        });
         return { adapter, session: resumed } as const;
       });
 
@@ -262,6 +274,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         }
 
         yield* upsertSessionBinding(session, threadId);
+        yield* analytics.record("provider.session.started", {
+          provider: session.provider,
+          hasResumeCursor: session.resumeCursor !== undefined,
+          hasCwd: typeof input.cwd === "string" && input.cwd.trim().length > 0,
+          approvalPolicy: input.approvalPolicy,
+          sandboxMode: input.sandboxMode,
+        });
 
         return session;
       });
@@ -301,6 +320,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             lastRuntimeEventAt: new Date().toISOString(),
           },
         });
+        yield* analytics.record("provider.turn.sent", {
+          provider: routed.adapter.provider,
+          attachmentCount: input.attachments.length,
+          hasInput: typeof input.input === "string" && input.input.trim().length > 0,
+        });
         return turn;
       });
 
@@ -317,6 +341,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           allowRecovery: true,
         });
         yield* routed.adapter.interruptTurn(routed.threadId, input.turnId);
+        yield* analytics.record("provider.turn.interrupted", {
+          provider: routed.adapter.provider,
+          hasTurnId: input.turnId !== undefined,
+        });
       });
 
     const respondToRequest: ProviderServiceShape["respondToRequest"] = (rawInput) =>
@@ -332,6 +360,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           allowRecovery: true,
         });
         yield* routed.adapter.respondToRequest(routed.threadId, input.requestId, input.decision);
+        yield* analytics.record("provider.request.responded", {
+          provider: routed.adapter.provider,
+          decision: input.decision,
+        });
       });
 
     const respondToUserInput: ProviderServiceShape["respondToUserInput"] = (rawInput) =>
@@ -347,6 +379,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           allowRecovery: true,
         });
         yield* routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
+        yield* analytics.record("provider.user_input.responded", {
+          provider: routed.adapter.provider,
+        });
       });
 
     const stopSession: ProviderServiceShape["stopSession"] = (rawInput) =>
@@ -365,6 +400,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           yield* routed.adapter.stopSession(routed.threadId);
         }
         yield* directory.remove(input.threadId);
+        yield* analytics.record("provider.session.stopped", {
+          provider: routed.adapter.provider,
+          wasActive: routed.isActive,
+        });
       });
 
     const listSessions: ProviderServiceShape["listSessions"] = () =>
@@ -429,6 +468,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           allowRecovery: true,
         });
         yield* routed.adapter.rollbackThread(routed.threadId, input.numTurns);
+        yield* analytics.record("provider.conversation.rolled_back", {
+          provider: routed.adapter.provider,
+          turns: input.numTurns,
+        });
       });
 
     const stopAll: ProviderServiceShape["stopAll"] = () =>
@@ -451,6 +494,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
             ),
           ),
         ).pipe(Effect.asVoid);
+        yield* analytics.record("provider.sessions.stopped_all", {
+          sessionCount: threadIds.length,
+        });
+        yield* analytics.flush;
       });
 
     return {

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -276,8 +276,6 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* upsertSessionBinding(session, threadId);
         yield* analytics.record("provider.session.started", {
           provider: session.provider,
-          hasResumeCursor: session.resumeCursor !== undefined,
-          hasCwd: typeof input.cwd === "string" && input.cwd.trim().length > 0,
           approvalPolicy: input.approvalPolicy,
           sandboxMode: input.sandboxMode,
         });
@@ -322,8 +320,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         });
         yield* analytics.record("provider.turn.sent", {
           provider: routed.adapter.provider,
-          attachmentCount: input.attachments.length,
-          hasInput: typeof input.input === "string" && input.input.trim().length > 0,
+          model: input.model,
+          effort: input.effort,
         });
         return turn;
       });
@@ -343,7 +341,6 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* routed.adapter.interruptTurn(routed.threadId, input.turnId);
         yield* analytics.record("provider.turn.interrupted", {
           provider: routed.adapter.provider,
-          hasTurnId: input.turnId !== undefined,
         });
       });
 
@@ -379,8 +376,6 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           allowRecovery: true,
         });
         yield* routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
-        yield* analytics.record("provider.user_input.responded", {
-          provider: routed.adapter.provider,
         });
       });
 
@@ -402,7 +397,6 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* directory.remove(input.threadId);
         yield* analytics.record("provider.session.stopped", {
           provider: routed.adapter.provider,
-          wasActive: routed.isActive,
         });
       });
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -276,8 +276,10 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* upsertSessionBinding(session, threadId);
         yield* analytics.record("provider.session.started", {
           provider: session.provider,
-          approvalPolicy: input.approvalPolicy,
-          sandboxMode: input.sandboxMode,
+          runtimeMode: input.runtimeMode,
+          hasResumeCursor: session.resumeCursor !== undefined,
+          hasCwd: typeof input.cwd === "string" && input.cwd.trim().length > 0,
+          hasModel: typeof input.model === "string" && input.model.trim().length > 0,
         });
 
         return session;
@@ -321,7 +323,9 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         yield* analytics.record("provider.turn.sent", {
           provider: routed.adapter.provider,
           model: input.model,
-          effort: input.effort,
+          interactionMode: input.interactionMode,
+          attachmentCount: input.attachments.length,
+          hasInput: typeof input.input === "string" && input.input.trim().length > 0,
         });
         return turn;
       });
@@ -376,7 +380,6 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           allowRecovery: true,
         });
         yield* routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
-        });
       });
 
     const stopSession: ProviderServiceShape["stopSession"] = (rawInput) =>

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -34,11 +34,12 @@ import { CodexTextGenerationLive } from "./git/Layers/CodexTextGeneration";
 import { GitServiceLive } from "./git/Layers/GitService";
 import { BunPtyAdapterLive } from "./terminal/Layers/BunPTY";
 import { NodePtyAdapterLive } from "./terminal/Layers/NodePTY";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
 
 export function makeServerProviderLayer(): Layer.Layer<
   ProviderService,
   ProviderUnsupportedError,
-  SqlClient.SqlClient | ServerConfig | FileSystem.FileSystem
+  SqlClient.SqlClient | ServerConfig | FileSystem.FileSystem | AnalyticsService
 > {
   return Effect.gen(function* () {
     const { stateDir } = yield* ServerConfig;

--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -60,14 +60,14 @@ const upsertAnonymousId = Effect.gen(function* () {
  * 2. ~/.t3/telemetry/anonymous-id
  */
 export const getTelemetryIdentifier = Effect.gen(function* () {
-  const codexAccountId = yield* getCodexAccountId;
-  if (codexAccountId) {
-    return yield* hash(codexAccountId);
+  const codexAccountId = yield* Effect.result(getCodexAccountId);
+  if (codexAccountId._tag === "Success") {
+    return yield* hash(codexAccountId.success);
   }
 
-  const anonymousId = yield* upsertAnonymousId;
-  if (anonymousId) {
-    return yield* hash(anonymousId);
+  const anonymousId = yield* Effect.result(upsertAnonymousId);
+  if (anonymousId._tag === "Success") {
+    return yield* hash(anonymousId.success);
   }
 
   return null;

--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -1,0 +1,77 @@
+import { Effect, FileSystem, Path, Random, Schema } from "effect";
+import * as Crypto from "node:crypto";
+import { homedir } from "node:os";
+
+const CodexAuthJsonSchema = Schema.Struct({
+  tokens: Schema.Struct({
+    account_id: Schema.String,
+  }),
+});
+
+class IdentifyUserError extends Schema.TaggedErrorClass<IdentifyUserError>()("IdentifyUserError", {
+  message: Schema.String,
+  cause: Schema.optional(Schema.Defect),
+}) {}
+
+const hash = (value: string) =>
+  Effect.try({
+    try: () => Crypto.createHash("sha256").update(value).digest("hex"),
+    catch: (error) =>
+      new IdentifyUserError({
+        message: "Failed to hash identifier",
+        cause: error,
+      }),
+  });
+
+const getCodexAccountId = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const authJsonPath = path.join(homedir(), ".codex", "auth.json");
+  const authJson = yield* Effect.flatMap(
+    fileSystem.readFileString(authJsonPath),
+    Schema.decodeEffect(Schema.fromJsonString(CodexAuthJsonSchema)),
+  );
+
+  return authJson.tokens.account_id;
+});
+
+const upsertAnonymousId = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const anonymousIdPath = path.join(homedir(), ".t3", "telemetry", "anonymous-id");
+  const anonymousId = yield* fileSystem.readFileString(anonymousIdPath).pipe(
+    Effect.catch(() =>
+      Effect.gen(function* () {
+        const randomId = yield* Random.nextUUIDv4;
+        yield* fileSystem.writeFileString(anonymousIdPath, randomId);
+        return randomId;
+      }),
+    ),
+  );
+
+  return anonymousId;
+});
+
+/**
+ * getTelemetryIdentifier - Users are "identified" by finding the first match of the following, then hashing the value.
+ * 1. ~/.codex/auth.json tokens.account_id
+ * 2. ~/.t3/telemetry/anonymous-id
+ */
+export const getTelemetryIdentifier = Effect.gen(function* () {
+  const codexAccountId = yield* getCodexAccountId;
+  if (codexAccountId) {
+    return yield* hash(codexAccountId);
+  }
+
+  const anonymousId = yield* upsertAnonymousId;
+  if (anonymousId) {
+    return yield* hash(anonymousId);
+  }
+
+  return null;
+}).pipe(
+  Effect.tapError((error) => Effect.logWarning("Failed to get identifier", { cause: error })),
+  Effect.orElseSucceed(() => null),
+);

--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -1,6 +1,7 @@
 import { Effect, FileSystem, Path, Random, Schema } from "effect";
 import * as Crypto from "node:crypto";
 import { homedir } from "node:os";
+import { ServerConfig } from "../config";
 
 const CodexAuthJsonSchema = Schema.Struct({
   tokens: Schema.Struct({
@@ -39,8 +40,9 @@ const getCodexAccountId = Effect.gen(function* () {
 const upsertAnonymousId = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+  const serverConfig = yield* ServerConfig;
 
-  const anonymousIdPath = path.join(homedir(), ".t3", "telemetry", "anonymous-id");
+  const anonymousIdPath = path.join(serverConfig.stateDir, "anonymous-id");
   const anonymousId = yield* fileSystem.readFileString(anonymousIdPath).pipe(
     Effect.catch(() =>
       Effect.gen(function* () {

--- a/apps/server/src/telemetry/Layers/AnalyticsService.test.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.test.ts
@@ -63,9 +63,8 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
             Effect.map((body) => body as RecordedBatchRequest["body"]),
             Effect.catch(() => Effect.succeed(null)),
           );
-          yield* Effect.sync(() => {
-            capturedRequests.push({ path: request.url, body: payload });
-          });
+
+          capturedRequests.push({ path: request.url, body: payload });
 
           return HttpServerResponse.jsonUnsafe({});
         }),

--- a/apps/server/src/telemetry/Layers/AnalyticsService.test.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.test.ts
@@ -18,6 +18,7 @@ interface RecordedBatchRequest {
       readonly event?: string;
       readonly properties?: {
         readonly index?: number;
+        readonly clientType?: string;
       };
     }>;
   } | null;
@@ -28,6 +29,7 @@ interface RecordedBatchBody {
     readonly event?: string;
     readonly properties?: {
       readonly index?: number;
+      readonly clientType?: string;
     };
   }>;
 }
@@ -108,6 +110,12 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
       assert.deepEqual(
         sorted,
         Array.from({ length: 45 }, (_, index) => index),
+      );
+      assert.equal(
+        batchRequests.every((request) =>
+          request.body.batch.every((event) => event.properties?.clientType === "cli-web-client"),
+        ),
+        true,
       );
     }),
   );

--- a/apps/server/src/telemetry/Layers/AnalyticsService.test.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.test.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import { assert, it } from "@effect/vitest";
+import { ConfigProvider, Effect, Layer } from "effect";
+import * as HttpServer from "effect/unstable/http/HttpServer";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+import { ServerConfig } from "../../config.ts";
+import { getTelemetryIdentifier } from "../Identify.ts";
+import { AnalyticsService } from "../Services/AnalyticsService.ts";
+import { AnalyticsServiceLayerLive } from "./AnalyticsService.ts";
+
+interface RecordedBatchRequest {
+  readonly path: string;
+  readonly body:
+    | {
+        readonly batch?: ReadonlyArray<{
+          readonly event?: string;
+          readonly properties?: {
+            readonly index?: number;
+          };
+        }>;
+      }
+    | null;
+}
+
+interface RecordedBatchBody {
+  readonly batch: ReadonlyArray<{
+    readonly event?: string;
+    readonly properties?: {
+      readonly index?: number;
+    };
+  }>;
+}
+
+it.effect("flush drains all buffered events across multiple batches", () =>
+  Effect.gen(function* () {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-telemetry-flush-"));
+    const capturedRequests: Array<RecordedBatchRequest> = [];
+    const telemetryLayer = AnalyticsServiceLayerLive.pipe(
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), tempDir)),
+    );
+    const configLayer = ConfigProvider.layer(
+      ConfigProvider.fromUnknown({
+        T3CODE_TELEMETRY_ENABLED: true,
+        T3CODE_POSTHOG_KEY: "phc_test_key",
+        T3CODE_POSTHOG_HOST: "",
+        T3CODE_TELEMETRY_FLUSH_BATCH_SIZE: 20,
+      }),
+    );
+    const batchServerLayer = HttpServer.serve(
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        if (request.method !== "POST") {
+          return HttpServerResponse.empty({ status: 404 });
+        }
+
+        const payload = yield* request.json.pipe(
+          Effect.map((body) => body as RecordedBatchRequest["body"]),
+          Effect.catch(() => Effect.succeed(null)),
+        );
+        yield* Effect.sync(() => {
+          capturedRequests.push({ path: request.url, body: payload });
+        });
+
+        return HttpServerResponse.jsonUnsafe({});
+      }),
+    );
+    const runtimeLayer = telemetryLayer.pipe(
+      Layer.provide(configLayer),
+      Layer.provideMerge(NodeHttpServer.layerTest),
+    );
+
+    yield* Effect.gen(function* () {
+      yield* Layer.launch(batchServerLayer).pipe(Effect.forkScoped);
+      const telemetryIdentifier = yield* getTelemetryIdentifier;
+      assert.equal(telemetryIdentifier !== null, true);
+      const analytics = yield* AnalyticsService;
+
+      for (let index = 0; index < 45; index += 1) {
+        yield* analytics.record("test.flush.drain", { index });
+      }
+
+      yield* analytics.flush;
+    }).pipe(
+      Effect.provide(runtimeLayer),
+      Effect.ensuring(
+        Effect.sync(() => {
+          fs.rmSync(tempDir, { recursive: true, force: true });
+        }),
+      ),
+    );
+
+    const batchRequests = capturedRequests.filter(
+      (request): request is RecordedBatchRequest & { readonly body: RecordedBatchBody } =>
+        Array.isArray(request.body?.batch),
+    );
+    assert.equal(batchRequests.length, 3);
+    assert.equal(
+      batchRequests.every((request) => request.path === "/batch/" || request.path === "/batch"),
+      true,
+    );
+    const deliveredIndexes = batchRequests.flatMap((request) =>
+      request.body.batch
+        .filter((event) => event.event === "test.flush.drain")
+        .map((event) => event.properties?.index)
+        .filter((index): index is number => typeof index === "number"),
+    );
+
+    const sorted = deliveredIndexes.toSorted((a, b) => a - b);
+    assert.equal(sorted.length, 45);
+    assert.deepEqual(
+      sorted,
+      Array.from({ length: 45 }, (_, index) => index),
+    );
+  }),
+);

--- a/apps/server/src/telemetry/Layers/AnalyticsService.test.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.test.ts
@@ -1,10 +1,7 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
-
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
-import { ConfigProvider, Effect, Layer } from "effect";
+import { ConfigProvider, Effect, FileSystem, Layer } from "effect";
 import * as HttpServer from "effect/unstable/http/HttpServer";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
@@ -16,16 +13,14 @@ import { AnalyticsServiceLayerLive } from "./AnalyticsService.ts";
 
 interface RecordedBatchRequest {
   readonly path: string;
-  readonly body:
-    | {
-        readonly batch?: ReadonlyArray<{
-          readonly event?: string;
-          readonly properties?: {
-            readonly index?: number;
-          };
-        }>;
-      }
-    | null;
+  readonly body: {
+    readonly batch?: ReadonlyArray<{
+      readonly event?: string;
+      readonly properties?: {
+        readonly index?: number;
+      };
+    }>;
+  } | null;
 }
 
 interface RecordedBatchBody {
@@ -37,85 +32,84 @@ interface RecordedBatchBody {
   }>;
 }
 
-it.effect("flush drains all buffered events across multiple batches", () =>
-  Effect.gen(function* () {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-telemetry-flush-"));
-    const capturedRequests: Array<RecordedBatchRequest> = [];
-    const telemetryLayer = AnalyticsServiceLayerLive.pipe(
-      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), tempDir)),
-    );
-    const configLayer = ConfigProvider.layer(
-      ConfigProvider.fromUnknown({
-        T3CODE_TELEMETRY_ENABLED: true,
-        T3CODE_POSTHOG_KEY: "phc_test_key",
-        T3CODE_POSTHOG_HOST: "",
-        T3CODE_TELEMETRY_FLUSH_BATCH_SIZE: 20,
-      }),
-    );
-    const batchServerLayer = HttpServer.serve(
-      Effect.gen(function* () {
-        const request = yield* HttpServerRequest.HttpServerRequest;
-        if (request.method !== "POST") {
-          return HttpServerResponse.empty({ status: 404 });
+it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
+  it.effect("flush drains all buffered events across multiple batches", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const stateDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-telemetry-flush-",
+      });
+
+      const capturedRequests: Array<RecordedBatchRequest> = [];
+      const serverConfigLayer = ServerConfig.layerTest(process.cwd(), stateDir);
+
+      const telemetryLayer = AnalyticsServiceLayerLive.pipe(Layer.provideMerge(serverConfigLayer));
+      const configLayer = ConfigProvider.layer(
+        ConfigProvider.fromUnknown({
+          T3CODE_TELEMETRY_ENABLED: true,
+          T3CODE_POSTHOG_KEY: "phc_test_key",
+          T3CODE_POSTHOG_HOST: "",
+          T3CODE_TELEMETRY_FLUSH_BATCH_SIZE: 20,
+        }),
+      );
+      const batchServerLayer = HttpServer.serve(
+        Effect.gen(function* () {
+          const request = yield* HttpServerRequest.HttpServerRequest;
+          if (request.method !== "POST") {
+            return HttpServerResponse.empty({ status: 404 });
+          }
+
+          const payload = yield* request.json.pipe(
+            Effect.map((body) => body as RecordedBatchRequest["body"]),
+            Effect.catch(() => Effect.succeed(null)),
+          );
+          yield* Effect.sync(() => {
+            capturedRequests.push({ path: request.url, body: payload });
+          });
+
+          return HttpServerResponse.jsonUnsafe({});
+        }),
+      );
+      const runtimeLayer = telemetryLayer.pipe(
+        Layer.provide(configLayer),
+        Layer.provideMerge(NodeHttpServer.layerTest),
+      );
+
+      yield* Effect.gen(function* () {
+        yield* Layer.launch(batchServerLayer).pipe(Effect.forkScoped);
+        const telemetryIdentifier = yield* getTelemetryIdentifier;
+        assert.equal(telemetryIdentifier !== null, true);
+        const analytics = yield* AnalyticsService;
+
+        for (let index = 0; index < 45; index += 1) {
+          yield* analytics.record("test.flush.drain", { index });
         }
 
-        const payload = yield* request.json.pipe(
-          Effect.map((body) => body as RecordedBatchRequest["body"]),
-          Effect.catch(() => Effect.succeed(null)),
-        );
-        yield* Effect.sync(() => {
-          capturedRequests.push({ path: request.url, body: payload });
-        });
+        yield* analytics.flush;
+      }).pipe(Effect.provide(runtimeLayer));
 
-        return HttpServerResponse.jsonUnsafe({});
-      }),
-    );
-    const runtimeLayer = telemetryLayer.pipe(
-      Layer.provide(configLayer),
-      Layer.provideMerge(NodeHttpServer.layerTest),
-    );
+      const batchRequests = capturedRequests.filter(
+        (request): request is RecordedBatchRequest & { readonly body: RecordedBatchBody } =>
+          Array.isArray(request.body?.batch),
+      );
+      assert.equal(batchRequests.length, 3);
+      assert.equal(
+        batchRequests.every((request) => request.path === "/batch/" || request.path === "/batch"),
+        true,
+      );
+      const deliveredIndexes = batchRequests.flatMap((request) =>
+        request.body.batch
+          .filter((event) => event.event === "test.flush.drain")
+          .map((event) => event.properties?.index)
+          .filter((index): index is number => typeof index === "number"),
+      );
 
-    yield* Effect.gen(function* () {
-      yield* Layer.launch(batchServerLayer).pipe(Effect.forkScoped);
-      const telemetryIdentifier = yield* getTelemetryIdentifier;
-      assert.equal(telemetryIdentifier !== null, true);
-      const analytics = yield* AnalyticsService;
-
-      for (let index = 0; index < 45; index += 1) {
-        yield* analytics.record("test.flush.drain", { index });
-      }
-
-      yield* analytics.flush;
-    }).pipe(
-      Effect.provide(runtimeLayer),
-      Effect.ensuring(
-        Effect.sync(() => {
-          fs.rmSync(tempDir, { recursive: true, force: true });
-        }),
-      ),
-    );
-
-    const batchRequests = capturedRequests.filter(
-      (request): request is RecordedBatchRequest & { readonly body: RecordedBatchBody } =>
-        Array.isArray(request.body?.batch),
-    );
-    assert.equal(batchRequests.length, 3);
-    assert.equal(
-      batchRequests.every((request) => request.path === "/batch/" || request.path === "/batch"),
-      true,
-    );
-    const deliveredIndexes = batchRequests.flatMap((request) =>
-      request.body.batch
-        .filter((event) => event.event === "test.flush.drain")
-        .map((event) => event.properties?.index)
-        .filter((index): index is number => typeof index === "number"),
-    );
-
-    const sorted = deliveredIndexes.toSorted((a, b) => a - b);
-    assert.equal(sorted.length, 45);
-    assert.deepEqual(
-      sorted,
-      Array.from({ length: 45 }, (_, index) => index),
-    );
-  }),
-);
+      const sorted = deliveredIndexes.toSorted((a, b) => a - b);
+      assert.equal(sorted.length, 45);
+      assert.deepEqual(
+        sorted,
+        Array.from({ length: 45 }, (_, index) => index),
+      );
+    }),
+  );
+});

--- a/apps/server/src/telemetry/Layers/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.ts
@@ -126,7 +126,11 @@ const makeAnalyticsService = Effect.gen(function* () {
     }
   });
 
-  yield* Effect.forever(flush, { disableYield: true }).pipe(Effect.forkDetach);
+  yield* Effect.forever(Effect.sleep(1000).pipe(Effect.flatMap(() => flush)), {
+    disableYield: true,
+  }).pipe(Effect.forkDetach);
+
+  yield* Effect.addFinalizer(() => flush);
 
   return {
     record,

--- a/apps/server/src/telemetry/Layers/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.ts
@@ -134,7 +134,7 @@ const makeAnalyticsService = Effect.gen(function* () {
 
   yield* Effect.forever(Effect.sleep(1000).pipe(Effect.flatMap(() => flush)), {
     disableYield: true,
-  }).pipe(Effect.forkDetach);
+  }).pipe(Effect.forkScoped);
 
   yield* Effect.addFinalizer(() => flush);
 

--- a/apps/server/src/telemetry/Layers/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.ts
@@ -96,26 +96,28 @@ const makeAnalyticsService = Effect.gen(function* () {
     });
 
   const flush: AnalyticsServiceShape["flush"] = Effect.gen(function* () {
-    const batch = yield* Ref.modify(bufferRef, (current) => {
-      if (current.length === 0) {
-        return [[] as ReadonlyArray<BufferedAnalyticsEvent>, current] as const;
+    while (true) {
+      const batch = yield* Ref.modify(bufferRef, (current) => {
+        if (current.length === 0) {
+          return [[] as ReadonlyArray<BufferedAnalyticsEvent>, current] as const;
+        }
+        const nextBatch = current.slice(0, telemetryConfig.flushBatchSize);
+        const remaining = current.slice(nextBatch.length);
+        return [nextBatch, remaining] as const;
+      });
+
+      if (batch.length === 0) {
+        return;
       }
-      const nextBatch = current.slice(0, telemetryConfig.flushBatchSize);
-      const remaining = current.slice(nextBatch.length);
-      return [nextBatch, remaining] as const;
-    });
 
-    if (batch.length === 0) {
-      return;
-    }
-
-    yield* sendBatch(batch).pipe(
-      Effect.catch((error) =>
-        Ref.update(bufferRef, (current) => [...batch, ...current]).pipe(
-          Effect.flatMap(() => Effect.fail(error)),
+      yield* sendBatch(batch).pipe(
+        Effect.catch((error) =>
+          Ref.update(bufferRef, (current) => [...batch, ...current]).pipe(
+            Effect.flatMap(() => Effect.fail(error)),
+          ),
         ),
-      ),
-    );
+      );
+    }
   }).pipe(Effect.catch((cause) => Effect.logError("Failed to flush telemetry", { cause })));
 
   const record: AnalyticsServiceShape["record"] = Effect.fnUntraced(function* (event, properties) {

--- a/apps/server/src/telemetry/Layers/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.ts
@@ -10,6 +10,7 @@
 import { Config, DateTime, Effect, Layer, Ref } from "effect";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 
+import { ServerConfig } from "../../config.ts";
 import { AnalyticsService, type AnalyticsServiceShape } from "../Services/AnalyticsService.ts";
 import { getTelemetryIdentifier } from "../Identify.ts";
 import { version } from "../../../package.json" with { type: "json" };
@@ -37,8 +38,10 @@ const TelemetryEnvConfig = Config.all({
 const makeAnalyticsService = Effect.gen(function* () {
   const telemetryConfig = yield* TelemetryEnvConfig.asEffect();
   const httpClient = yield* HttpClient.HttpClient;
+  const serverConfig = yield* ServerConfig;
   const identifier = yield* getTelemetryIdentifier;
   const bufferRef = yield* Ref.make<ReadonlyArray<BufferedAnalyticsEvent>>([]);
+  const clientType = serverConfig.mode === "desktop" ? "desktop-app" : "cli-web-client";
 
   const enqueueBufferedEvent = (event: string, properties?: Readonly<Record<string, unknown>>) =>
     Effect.flatMap(DateTime.now, (now) =>
@@ -83,6 +86,7 @@ const makeAnalyticsService = Effect.gen(function* () {
             wsl: process.env.WSL_DISTRO_NAME,
             arch: process.arch,
             t3CodeVersion: version,
+            clientType,
           },
           timestamp: event.capturedAt,
         })),

--- a/apps/server/src/telemetry/Layers/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.ts
@@ -12,6 +12,7 @@ import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstab
 
 import { AnalyticsService, type AnalyticsServiceShape } from "../Services/AnalyticsService.ts";
 import { getTelemetryIdentifier } from "../Identify.ts";
+import { version } from "../../../package.json" with { type: "json" };
 
 interface BufferedAnalyticsEvent {
   readonly event: string;
@@ -78,7 +79,10 @@ const makeAnalyticsService = Effect.gen(function* () {
           properties: {
             ...event.properties,
             $process_person_profile: false,
-            $lib: "t3code-server",
+            platform: process.platform,
+            wsl: process.env.WSL_DISTRO_NAME,
+            arch: process.arch,
+            t3CodeVersion: version,
           },
           timestamp: event.capturedAt,
         })),

--- a/apps/server/src/telemetry/Layers/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.ts
@@ -1,0 +1,137 @@
+/**
+ * AnalyticsServiceLive - Anonymous PostHog telemetry layer.
+ *
+ * Persists a random installation-scoped anonymous id to state dir, buffers
+ * events in memory, and flushes batches to PostHog over Effect HttpClient.
+ *
+ * @module AnalyticsServiceLive
+ */
+
+import { Config, DateTime, Effect, Layer, Ref } from "effect";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import { AnalyticsService, type AnalyticsServiceShape } from "../Services/AnalyticsService.ts";
+import { getTelemetryIdentifier } from "../Identify.ts";
+
+interface BufferedAnalyticsEvent {
+  readonly event: string;
+  readonly properties?: Readonly<Record<string, unknown>>;
+  readonly capturedAt: string;
+}
+
+const TelemetryEnvConfig = Config.all({
+  posthogKey: Config.string("T3CODE_POSTHOG_KEY").pipe(
+    Config.withDefault("phc_XOWci4oZP4VvLiEyrFqkFjP4CZn55mjYYBMREK5Wd6m"),
+  ),
+  posthogHost: Config.string("T3CODE_POSTHOG_HOST").pipe(
+    Config.withDefault("https://us.i.posthog.com"),
+  ),
+  enabled: Config.boolean("T3CODE_TELEMETRY_ENABLED").pipe(Config.withDefault(true)),
+  flushBatchSize: Config.number("T3CODE_TELEMETRY_FLUSH_BATCH_SIZE").pipe(Config.withDefault(20)),
+  maxBufferedEvents: Config.number("T3CODE_TELEMETRY_MAX_BUFFERED_EVENTS").pipe(
+    Config.withDefault(1_000),
+  ),
+});
+
+const makeAnalyticsService = Effect.gen(function* () {
+  const telemetryConfig = yield* TelemetryEnvConfig.asEffect();
+  const httpClient = yield* HttpClient.HttpClient;
+  const identifier = yield* getTelemetryIdentifier;
+  const bufferRef = yield* Ref.make<ReadonlyArray<BufferedAnalyticsEvent>>([]);
+
+  const enqueueBufferedEvent = (event: string, properties?: Readonly<Record<string, unknown>>) =>
+    Effect.flatMap(DateTime.now, (now) =>
+      Ref.modify(bufferRef, (current) => {
+        const appended = [
+          ...current,
+          {
+            event,
+            ...(properties ? { properties } : {}),
+            capturedAt: DateTime.formatIso(now),
+          } satisfies BufferedAnalyticsEvent,
+        ];
+
+        const next =
+          appended.length > telemetryConfig.maxBufferedEvents
+            ? appended.slice(appended.length - telemetryConfig.maxBufferedEvents)
+            : appended;
+
+        return [
+          {
+            size: next.length,
+            dropped: next.length !== appended.length,
+          } as const,
+          next,
+        ] as const;
+      }),
+    );
+
+  const sendBatch = (events: ReadonlyArray<BufferedAnalyticsEvent>) =>
+    Effect.gen(function* () {
+      if (!telemetryConfig.enabled || !identifier) return;
+
+      const payload = {
+        api_key: telemetryConfig.posthogKey,
+        batch: events.map((event) => ({
+          event: event.event,
+          distinct_id: identifier,
+          properties: {
+            ...event.properties,
+            $process_person_profile: false,
+            $lib: "t3code-server",
+          },
+          timestamp: event.capturedAt,
+        })),
+      };
+
+      yield* HttpClientRequest.post(`${telemetryConfig.posthogHost}/batch/`).pipe(
+        HttpClientRequest.bodyJson(payload),
+        Effect.flatMap(httpClient.execute),
+        Effect.flatMap(HttpClientResponse.filterStatusOk),
+      );
+    });
+
+  const flush: AnalyticsServiceShape["flush"] = Effect.gen(function* () {
+    const batch = yield* Ref.modify(bufferRef, (current) => {
+      if (current.length === 0) {
+        return [[] as ReadonlyArray<BufferedAnalyticsEvent>, current] as const;
+      }
+      const nextBatch = current.slice(0, telemetryConfig.flushBatchSize);
+      const remaining = current.slice(nextBatch.length);
+      return [nextBatch, remaining] as const;
+    });
+
+    if (batch.length === 0) {
+      return;
+    }
+
+    yield* sendBatch(batch).pipe(
+      Effect.catch((error) =>
+        Ref.update(bufferRef, (current) => [...batch, ...current]).pipe(
+          Effect.flatMap(() => Effect.fail(error)),
+        ),
+      ),
+    );
+  }).pipe(Effect.catch((cause) => Effect.logError("Failed to flush telemetry", { cause })));
+
+  const record: AnalyticsServiceShape["record"] = Effect.fnUntraced(function* (event, properties) {
+    if (!telemetryConfig.enabled || !identifier) return;
+
+    const enqueueResult = yield* enqueueBufferedEvent(event, properties);
+    if (enqueueResult.dropped) {
+      yield* Effect.logDebug("analytics buffer full; dropping oldest event", {
+        size: enqueueResult.size,
+        event,
+      });
+    }
+  });
+
+  yield* Effect.forever(flush, { disableYield: true }).pipe(Effect.forkDetach);
+
+  return {
+    record,
+    flush,
+  } satisfies AnalyticsServiceShape;
+});
+
+export const AnalyticsServiceLayerLive = Layer.effect(AnalyticsService, makeAnalyticsService);

--- a/apps/server/src/telemetry/Services/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Services/AnalyticsService.ts
@@ -6,7 +6,7 @@
  *
  * @module AnalyticsService
  */
-import { Effect, ServiceMap } from "effect";
+import { Effect, Layer, ServiceMap } from "effect";
 
 export interface AnalyticsServiceShape {
   /**
@@ -25,4 +25,9 @@ export interface AnalyticsServiceShape {
 
 export class AnalyticsService extends ServiceMap.Service<AnalyticsService, AnalyticsServiceShape>()(
   "t3/telemetry/Services/AnalyticsService",
-) {}
+) {
+  static readonly layerTest = Layer.succeed(AnalyticsService, {
+    record: () => Effect.void,
+    flush: Effect.void,
+  });
+}

--- a/apps/server/src/telemetry/Services/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Services/AnalyticsService.ts
@@ -1,0 +1,28 @@
+/**
+ * AnalyticsService - Anonymous telemetry capture contract.
+ *
+ * Provides a best-effort event API for runtime telemetry and a strict
+ * `captureImmediate` method for call sites that need explicit error handling.
+ *
+ * @module AnalyticsService
+ */
+import { Effect, ServiceMap } from "effect";
+
+export interface AnalyticsServiceShape {
+  /**
+   * Capture an event immediately; returns typed failure when capture fails.
+   */
+  readonly record: (
+    event: string,
+    properties?: Readonly<Record<string, unknown>>,
+  ) => Effect.Effect<void, never>;
+
+  /**
+   * Flush queued telemetry.
+   */
+  readonly flush: Effect.Effect<void, never>;
+}
+
+export class AnalyticsService extends ServiceMap.Service<AnalyticsService, AnalyticsServiceShape>()(
+  "t3/telemetry/Services/AnalyticsService",
+) {}

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -50,8 +50,7 @@ import type { GitCoreShape } from "./git/Services/GitCore.ts";
 import { GitCore } from "./git/Services/GitCore.ts";
 import { GitCommandError, GitManagerError } from "./git/Errors.ts";
 import { MigrationError } from "@effect/sql-sqlite-bun/SqliteMigrator";
-import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService.ts";
-import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService.ts";
 
 interface PendingMessages {
   queue: unknown[];
@@ -436,6 +435,7 @@ describe("WebSocket Server", () => {
         ? Layer.succeed(TerminalManager, options.terminalManager)
         : Layer.empty,
     );
+
     const runtimeLayer = Layer.merge(
       Layer.merge(
         makeServerRuntimeServicesLayer().pipe(Layer.provide(infrastructureLayer)),
@@ -448,9 +448,8 @@ describe("WebSocket Server", () => {
       Layer.provideMerge(providerHealthLayer),
       Layer.provideMerge(openLayer),
       Layer.provideMerge(serverConfigLayer),
-      Layer.provideMerge(AnalyticsServiceLayerLive),
+      Layer.provideMerge(AnalyticsService.layerTest),
       Layer.provideMerge(NodeServices.layer),
-      Layer.provideMerge(NodeHttpClient.layerUndici),
     );
     const runtimeServices = await Effect.runPromise(
       Layer.build(dependenciesLayer).pipe(Scope.provide(scope)),

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -50,6 +50,8 @@ import type { GitCoreShape } from "./git/Services/GitCore.ts";
 import { GitCore } from "./git/Services/GitCore.ts";
 import { GitCommandError, GitManagerError } from "./git/Errors.ts";
 import { MigrationError } from "@effect/sql-sqlite-bun/SqliteMigrator";
+import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService.ts";
+import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
 
 interface PendingMessages {
   queue: unknown[];
@@ -393,10 +395,7 @@ describe("WebSocket Server", () => {
       providerHealth?: ProviderHealthShape;
       open?: OpenShape;
       gitManager?: GitManagerShape;
-      gitCore?: Pick<
-        GitCoreShape,
-        "listBranches" | "initRepo" | "pullCurrentBranch"
-      >;
+      gitCore?: Pick<GitCoreShape, "listBranches" | "initRepo" | "pullCurrentBranch">;
       terminalManager?: TerminalManagerShape;
     } = {},
   ): Promise<Http.Server> {
@@ -449,7 +448,9 @@ describe("WebSocket Server", () => {
       Layer.provideMerge(providerHealthLayer),
       Layer.provideMerge(openLayer),
       Layer.provideMerge(serverConfigLayer),
+      Layer.provideMerge(AnalyticsServiceLayerLive),
       Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(NodeHttpClient.layerUndici),
     );
     const runtimeServices = await Effect.runPromise(
       Layer.build(dependenciesLayer).pipe(Scope.provide(scope)),
@@ -1620,7 +1621,6 @@ describe("WebSocket Server", () => {
     expect(pullResponse.result).toBeUndefined();
     expect(pullResponse.error?.message).toContain("No upstream configured");
     expect(pullCurrentBranch).toHaveBeenCalledWith("/repo/path");
-
   });
 
   it("supports git.status over websocket", async () => {

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -71,6 +71,7 @@ import {
   resolveAttachmentPathById,
 } from "./attachmentStore.ts";
 import { parseBase64DataUrl } from "./imageMime.ts";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService.ts";
 
 /**
  * ServerShape - Service API for server lifecycle control.
@@ -207,7 +208,8 @@ export type ServerRuntimeServices =
   | GitCore
   | TerminalManager
   | Keybindings
-  | Open;
+  | Open
+  | AnalyticsService;
 
 export class ServerLifecycleError extends Schema.TaggedErrorClass<ServerLifecycleError>()(
   "ServerLifecycleError",


### PR DESCRIPTION
## Summary
- add a new server-side `AnalyticsService` layer that buffers and flushes anonymous telemetry events to PostHog
- introduce telemetry identity resolution with hashed identifiers (Codex account id when available, otherwise a persisted anonymous id)
- instrument provider lifecycle actions (`session started/recovered/stopped`, `turn sent/interrupted`, `request responded`, `rollback`, `stop all`) with structured analytics events
- wire telemetry dependencies into runtime/server layers and update tests/integration harnesses with no-op analytics service where needed
- simplify release workflow by moving version/lockfile updates, tagging, and push logic into preflight for `workflow_dispatch`, and remove the separate finalize job
- remove unused web turn diff tree logic and related tests, reducing `ChatView` complexity

## Testing
- updated backend tests to provide `AnalyticsService` in unit/integration test layers (`ProviderService`, `main`, websocket, orchestration harness)
- concrete checks in code paths: telemetry calls are now exercised alongside provider lifecycle flows in existing provider/integration tests
- `bun lint` Not run
- `bun typecheck` Not run
- full test suite (`bun run test`) Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new telemetry pipeline (file-based identifier + background HTTP batching) and wires it into core server/provider startup paths, which could impact runtime behavior/performance or introduce unexpected network/file I/O in production.
> 
> **Overview**
> Adds an anonymous `AnalyticsService` with a live layer that buffers events and periodically flushes PostHog `/batch/` requests using an installation-scoped hashed identifier (preferring Codex `account_id`, otherwise a persisted anonymous id in `stateDir`).
> 
> Instruments `ProviderServiceLive` to emit structured analytics for session recovery/start/stop, turn send/interrupt, approval decisions, rollback, and `stopAll` (including a final `flush`). Also records a background `server.boot.heartbeat` on startup with projected thread/project counts.
> 
> Wires the new service and required `FetchHttpClient` into the server runtime, and updates unit/integration/websocket tests and harness layers to provide `AnalyticsService.layerTest`; adds coverage for telemetry batching/flush and the startup heartbeat.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 701f5dfb3fb7758bdcf852dc8f604368f36ef63f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add anonymous PostHog telemetry by providing `AnalyticsService` across server runtime and emitting provider lifecycle events in `ProviderService`
> Introduce a live `AnalyticsService` that batches and posts events to PostHog, wire it into server layers and runtime, and record `server.boot.heartbeat` plus provider session/turn/request lifecycle events; add `FetchHttpClient` to the runtime and update tests and layers accordingly. Core implementations are in [apps/server/src/telemetry/Layers/AnalyticsService.ts](https://github.com/pingdotgg/t3code/pull/174/files#diff-160d0b6c89e522c818baa7f2970b03b123e43fbf79fa8139ac1a58028f66259c), [apps/server/src/telemetry/Services/AnalyticsService.ts](https://github.com/pingdotgg/t3code/pull/174/files#diff-9a019a197fe670028f8852e3f4b4b7496a61317f69d9a13d127260324428fc46), [apps/server/src/telemetry/Identify.ts](https://github.com/pingdotgg/t3code/pull/174/files#diff-a50c9348071512e0bea296dca3a49a3f8fe4e903cf32378d3d94c5341161b174), [apps/server/src/main.ts](https://github.com/pingdotgg/t3code/pull/174/files#diff-4b5ca93a818c9edbd84d8a8ea2eb3c82a19d1c39e8cdcef478da4bb14f46b69a), and [apps/server/src/provider/Layers/ProviderService.ts](https://github.com/pingdotgg/t3code/pull/174/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775).
>
> #### 📍Where to Start
> Start with `AnalyticsServiceLayerLive` in [apps/server/src/telemetry/Layers/AnalyticsService.ts](https://github.com/pingdotgg/t3code/pull/174/files#diff-160d0b6c89e522c818baa7f2970b03b123e43fbf79fa8139ac1a58028f66259c), then follow wiring in [apps/server/src/main.ts](https://github.com/pingdotgg/t3code/pull/174/files#diff-4b5ca93a818c9edbd84d8a8ea2eb3c82a19d1c39e8cdcef478da4bb14f46b69a) and event emissions in `ProviderService` at [apps/server/src/provider/Layers/ProviderService.ts](https://github.com/pingdotgg/t3code/pull/174/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 701f5df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->