### PR TITLE
Projects sidebar reordering

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,12 +1,13 @@
 import {
   ChevronRightIcon,
   FolderIcon,
+  GripVerticalIcon,
   GitPullRequestIcon,
   RocketIcon,
   SquarePenIcon,
   TerminalIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type PointerEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DEFAULT_MODEL,
   type DesktopUpdateState,
@@ -20,6 +21,7 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL } from "../branding";
+import { resolveServerHttpOrigin } from "../lib/serverOrigin";
 import { newCommandId, newProjectId, newThreadId } from "../lib/utils";
 import { useStore } from "../store";
 import { isChatNewLocalShortcut, isChatNewShortcut, shortcutLabelForCommand } from "../keybindings";
@@ -78,6 +80,11 @@ function formatRelativeTime(iso: string): string {
   const hours = Math.floor(minutes / 60);
   if (hours < 24) return `${hours}h ago`;
   return `${Math.floor(hours / 24)}d ago`;
+}
+
+function resolveProjectDropPosition(element: HTMLElement, clientY: number) {
+  const { top, height } = element.getBoundingClientRect();
+  return clientY < top + height / 2 ? "before" : "after";
 }
 
 interface ThreadStatusPill {
@@ -212,29 +219,7 @@ function T3Wordmark() {
   );
 }
 
-/**
- * Derives the server's HTTP origin (scheme + host + port) from the same
- * sources WsTransport uses, converting ws(s) to http(s).
- */
-function getServerHttpOrigin(): string {
-  const bridgeUrl = window.desktopBridge?.getWsUrl();
-  const envUrl = import.meta.env.VITE_WS_URL as string | undefined;
-  const wsUrl =
-    bridgeUrl && bridgeUrl.length > 0
-      ? bridgeUrl
-      : envUrl && envUrl.length > 0
-        ? envUrl
-        : `ws://${window.location.hostname}:${window.location.port}`;
-  // Parse to extract just the origin, dropping path/query (e.g. ?token=…)
-  const httpUrl = wsUrl.replace(/^wss:/, "https:").replace(/^ws:/, "http:");
-  try {
-    return new URL(httpUrl).origin;
-  } catch {
-    return httpUrl;
-  }
-}
-
-const serverHttpOrigin = getServerHttpOrigin();
+const serverHttpOrigin = resolveServerHttpOrigin();
 
 function ProjectFavicon({ cwd }: { cwd: string }) {
   const [status, setStatus] = useState<"loading" | "loaded" | "error">("loading");
@@ -260,6 +245,7 @@ export default function Sidebar() {
   const projects = useStore((store) => store.projects);
   const threads = useStore((store) => store.threads);
   const markThreadUnread = useStore((store) => store.markThreadUnread);
+  const moveProject = useStore((store) => store.moveProject);
   const toggleProject = useStore((store) => store.toggleProject);
   const clearComposerDraftForThread = useComposerDraftStore((store) => store.clearThreadDraft);
   const getDraftThreadByProjectId = useComposerDraftStore(
@@ -294,6 +280,11 @@ export default function Sidebar() {
   const [isAddingProject, setIsAddingProject] = useState(false);
   const [renamingThreadId, setRenamingThreadId] = useState<ThreadId | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
+  const [draggedProjectId, setDraggedProjectId] = useState<ProjectId | null>(null);
+  const [projectDropTarget, setProjectDropTarget] = useState<{
+    projectId: ProjectId;
+    position: "before" | "after";
+  } | null>(null);
   const [expandedThreadListsByProject, setExpandedThreadListsByProject] = useState<
     ReadonlySet<ProjectId>
   >(() => new Set());
@@ -967,6 +958,65 @@ export default function Sidebar() {
     });
   }, []);
 
+  useEffect(() => {
+    if (!draggedProjectId) return;
+
+    const previousUserSelect = document.body.style.userSelect;
+    const previousCursor = document.body.style.cursor;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "grabbing";
+
+    const handlePointerRelease = () => {
+      setDraggedProjectId(null);
+      setProjectDropTarget(null);
+    };
+
+    window.addEventListener("pointerup", handlePointerRelease);
+    window.addEventListener("pointercancel", handlePointerRelease);
+    return () => {
+      document.body.style.userSelect = previousUserSelect;
+      document.body.style.cursor = previousCursor;
+      window.removeEventListener("pointerup", handlePointerRelease);
+      window.removeEventListener("pointercancel", handlePointerRelease);
+    };
+  }, [draggedProjectId]);
+
+  function resetProjectDragState() {
+    setDraggedProjectId(null);
+    setProjectDropTarget(null);
+  }
+
+  function handleProjectDragStart(event: PointerEvent<HTMLButtonElement>, projectId: ProjectId) {
+    if (event.button !== 0) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    setDraggedProjectId(projectId);
+    setProjectDropTarget(null);
+  }
+
+  function handleProjectDragOver(event: PointerEvent<HTMLElement>, projectId: ProjectId) {
+    if (!draggedProjectId) return;
+
+    const position = resolveProjectDropPosition(event.currentTarget, event.clientY);
+    setProjectDropTarget((current) => {
+      if (current?.projectId === projectId && current.position === position) {
+        return current;
+      }
+      return { projectId, position };
+    });
+  }
+
+  function handleProjectDrop(event: PointerEvent<HTMLElement>, projectId: ProjectId) {
+    if (!draggedProjectId) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    const position = resolveProjectDropPosition(event.currentTarget, event.clientY);
+    moveProject(draggedProjectId, projectId, position);
+    resetProjectDragState();
+  }
+
   const wordmark = (
     <div className="flex items-center gap-2">
       <SidebarTrigger className="shrink-0 md:hidden" />
@@ -1032,6 +1082,12 @@ export default function Sidebar() {
                 hasHiddenThreads && !isThreadListExpanded
                   ? projectThreads.slice(0, THREAD_PREVIEW_LIMIT)
                   : projectThreads;
+              const dropIndicator =
+                draggedProjectId !== null &&
+                draggedProjectId !== project.id &&
+                projectDropTarget?.projectId === project.id
+                  ? projectDropTarget.position
+                  : null;
 
               return (
                 <Collapsible
@@ -1043,13 +1099,39 @@ export default function Sidebar() {
                     toggleProject(project.id);
                   }}
                 >
-                  <SidebarMenuItem>
-                    <div className="group/project-header relative">
+                  <SidebarMenuItem className={draggedProjectId === project.id ? "opacity-60" : ""}>
+                    {dropIndicator === "before" && (
+                      <div className="pointer-events-none absolute inset-x-2 top-0 h-0.5 rounded-full bg-primary" />
+                    )}
+                    {dropIndicator === "after" && (
+                      <div className="pointer-events-none absolute inset-x-2 bottom-0 h-0.5 rounded-full bg-primary" />
+                    )}
+                    <div
+                      className="group/project-header relative"
+                      onPointerEnter={(event) => handleProjectDragOver(event, project.id)}
+                      onPointerMove={(event) => handleProjectDragOver(event, project.id)}
+                      onPointerUp={(event) => handleProjectDrop(event, project.id)}
+                    >
+                      <button
+                        type="button"
+                        aria-label={`Reorder ${project.name}`}
+                        aria-grabbed={draggedProjectId === project.id}
+                        className={`absolute top-1/2 left-1 z-10 inline-flex size-5 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground/45 transition-colors hover:bg-accent hover:text-foreground ${
+                          draggedProjectId === project.id ? "cursor-grabbing" : "cursor-grab"
+                        }`}
+                        onClick={(event) => {
+                          event.preventDefault();
+                          event.stopPropagation();
+                        }}
+                        onPointerDown={(event) => handleProjectDragStart(event, project.id)}
+                      >
+                        <GripVerticalIcon className="size-3.5" />
+                      </button>
                       <CollapsibleTrigger
                         render={
                           <SidebarMenuButton
                             size="sm"
-                            className="gap-2 px-2 py-1.5 text-left hover:bg-accent group-hover/project-header:bg-accent group-hover/project-header:text-sidebar-accent-foreground"
+                            className="gap-2 py-1.5 pr-2 pl-7 text-left hover:bg-accent group-hover/project-header:bg-accent group-hover/project-header:text-sidebar-accent-foreground"
                           />
                         }
                         onContextMenu={(event) => {

--- a/apps/web/src/lib/serverOrigin.ts
+++ b/apps/web/src/lib/serverOrigin.ts
@@ -1,0 +1,19 @@
+export function resolveServerHttpOrigin(): string {
+  if (typeof window === "undefined") return "";
+
+  const bridgeWsUrl = window.desktopBridge?.getWsUrl?.();
+  const envWsUrl = import.meta.env.VITE_WS_URL as string | undefined;
+  const wsUrl =
+    typeof bridgeWsUrl === "string" && bridgeWsUrl.length > 0
+      ? bridgeWsUrl
+      : typeof envWsUrl === "string" && envWsUrl.length > 0
+        ? envWsUrl
+        : `ws://${window.location.hostname}:${window.location.port}`;
+  const httpUrl = wsUrl.replace(/^wss:/, "https:").replace(/^ws:/, "http:");
+
+  try {
+    return new URL(httpUrl).origin;
+  } catch {
+    return httpUrl;
+  }
+}

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -1,7 +1,9 @@
+import type { OrchestrationReadModel } from "@t3tools/contracts";
 import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { markThreadUnread, type AppState } from "./store";
+import { markThreadUnread, moveProject, syncServerReadModel, type AppState } from "./store";
+import type { Project } from "./types";
 import type { Thread } from "./types";
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
@@ -24,18 +26,22 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
   };
 }
 
-function makeState(thread: Thread): AppState {
+function makeProject(overrides: Partial<Project> = {}): Project {
   return {
-    projects: [
-      {
-        id: ProjectId.makeUnsafe("project-1"),
-        name: "Project",
-        cwd: "/tmp/project",
-        model: "gpt-5-codex",
-        expanded: true,
-        scripts: [],
-      },
-    ],
+    id: ProjectId.makeUnsafe("project-1"),
+    name: "Project",
+    cwd: "/tmp/project",
+    model: "gpt-5-codex",
+    expanded: true,
+    scripts: [],
+    ...overrides,
+  };
+}
+
+function makeState(thread: Thread, projects: Project[] = [makeProject()]): AppState {
+  return {
+    projects,
+    projectOrder: projects.map((project) => project.id),
     threads: [thread],
     threadsHydrated: true,
     runtimeMode: "full-access",
@@ -80,5 +86,77 @@ describe("store pure functions", () => {
     const next = markThreadUnread(initialState, ThreadId.makeUnsafe("thread-1"));
 
     expect(next).toEqual(initialState);
+  });
+
+  it("moveProject reorders projects and persists the new order", () => {
+    const firstProject = makeProject({
+      id: ProjectId.makeUnsafe("project-1"),
+      name: "First",
+      cwd: "/tmp/first",
+    });
+    const secondProject = makeProject({
+      id: ProjectId.makeUnsafe("project-2"),
+      name: "Second",
+      cwd: "/tmp/second",
+    });
+    const thirdProject = makeProject({
+      id: ProjectId.makeUnsafe("project-3"),
+      name: "Third",
+      cwd: "/tmp/third",
+    });
+    const initialState = makeState(makeThread(), [firstProject, secondProject, thirdProject]);
+
+    const next = moveProject(
+      initialState,
+      ProjectId.makeUnsafe("project-3"),
+      ProjectId.makeUnsafe("project-1"),
+      "before",
+    );
+
+    expect(next.projects.map((project) => project.id)).toEqual([
+      ProjectId.makeUnsafe("project-3"),
+      ProjectId.makeUnsafe("project-1"),
+      ProjectId.makeUnsafe("project-2"),
+    ]);
+    expect(next.projectOrder).toEqual(next.projects.map((project) => project.id));
+  });
+
+  it("syncServerReadModel reapplies a persisted project order to fresh snapshots", () => {
+    const initialState = {
+      ...makeState(makeThread(), []),
+      projectOrder: [
+        ProjectId.makeUnsafe("project-2"),
+        ProjectId.makeUnsafe("project-1"),
+      ],
+    };
+    const readModel = {
+      projects: [
+        {
+          id: ProjectId.makeUnsafe("project-1"),
+          title: "First",
+          workspaceRoot: "/tmp/first",
+          defaultModel: null,
+          scripts: [],
+          deletedAt: null,
+        },
+        {
+          id: ProjectId.makeUnsafe("project-2"),
+          title: "Second",
+          workspaceRoot: "/tmp/second",
+          defaultModel: null,
+          scripts: [],
+          deletedAt: null,
+        },
+      ],
+      threads: [],
+    } as unknown as OrchestrationReadModel;
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.projects.map((project) => project.id)).toEqual([
+      ProjectId.makeUnsafe("project-2"),
+      ProjectId.makeUnsafe("project-1"),
+    ]);
+    expect(next.projectOrder).toEqual(next.projects.map((project) => project.id));
   });
 });

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -1,6 +1,7 @@
 import { Fragment, type ReactNode, createElement, useEffect } from "react";
 import {
   DEFAULT_MODEL,
+  ProjectId,
   ProviderSessionId,
   ThreadId,
   type OrchestrationReadModel,
@@ -15,11 +16,13 @@ import {
   type RuntimeMode,
   type Thread,
 } from "./types";
+import { resolveServerHttpOrigin } from "./lib/serverOrigin";
 
 // ── State ────────────────────────────────────────────────────────────
 
 export interface AppState {
   projects: Project[];
+  projectOrder: Project["id"][];
   threads: Thread[];
   threadsHydrated: boolean;
   runtimeMode: RuntimeMode;
@@ -39,15 +42,19 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 
 const initialState: AppState = {
   projects: [],
+  projectOrder: [],
   threads: [],
   threadsHydrated: false,
   runtimeMode: DEFAULT_RUNTIME_MODE,
 };
 const persistedExpandedProjectCwds = new Set<string>();
+const persistedProjectOrder: Project["id"][] = [];
 
 // ── Persist helpers ──────────────────────────────────────────────────
 
 function readPersistedState(): AppState {
+  persistedExpandedProjectCwds.clear();
+  persistedProjectOrder.length = 0;
   if (typeof window === "undefined") return initialState;
   try {
     const raw = window.localStorage.getItem(PERSISTED_STATE_KEY);
@@ -55,15 +62,21 @@ function readPersistedState(): AppState {
     const parsed = JSON.parse(raw) as {
       runtimeMode?: RuntimeMode;
       expandedProjectCwds?: string[];
+      projectOrder?: string[];
     };
-    persistedExpandedProjectCwds.clear();
     for (const cwd of parsed.expandedProjectCwds ?? []) {
       if (typeof cwd === "string" && cwd.length > 0) {
         persistedExpandedProjectCwds.add(cwd);
       }
     }
+    for (const projectId of parsed.projectOrder ?? []) {
+      if (typeof projectId === "string" && projectId.length > 0) {
+        persistedProjectOrder.push(ProjectId.makeUnsafe(projectId));
+      }
+    }
     return {
       ...initialState,
+      projectOrder: [...persistedProjectOrder],
       runtimeMode:
         parsed.runtimeMode === "approval-required" || parsed.runtimeMode === "full-access"
           ? parsed.runtimeMode
@@ -84,6 +97,7 @@ function persistState(state: AppState): void {
         expandedProjectCwds: state.projects
           .filter((project) => project.expanded)
           .map((project) => project.cwd),
+        projectOrder: state.projects.map((project) => project.id),
       }),
     );
     for (const legacyKey of LEGACY_PERSISTED_STATE_KEYS) {
@@ -134,6 +148,28 @@ function mapProjectsFromReadModel(
   });
 }
 
+function applyProjectOrder(projects: Project[], projectOrder: Project["id"][]): Project[] {
+  if (projects.length < 2 || projectOrder.length === 0) {
+    return projects;
+  }
+
+  const remainingProjects = new Map(projects.map((project) => [project.id, project] as const));
+  const orderedProjects: Project[] = [];
+  for (const projectId of projectOrder) {
+    const project = remainingProjects.get(projectId);
+    if (!project) continue;
+    orderedProjects.push(project);
+    remainingProjects.delete(projectId);
+  }
+
+  const nextProjects = [
+    ...orderedProjects,
+    ...projects.filter((project) => remainingProjects.has(project.id)),
+  ];
+  const orderChanged = nextProjects.some((project, index) => project !== projects[index]);
+  return orderChanged ? nextProjects : projects;
+}
+
 function toLegacySessionStatus(
   status: OrchestrationSessionStatus,
 ): "connecting" | "ready" | "running" | "error" | "closed" {
@@ -157,34 +193,9 @@ function toLegacyProvider(providerName: string | null): "codex" | "claudeCode" {
   return providerName === "claudeCode" ? "claudeCode" : "codex";
 }
 
-function resolveWsHttpOrigin(): string {
-  if (typeof window === "undefined") return "";
-  const bridgeWsUrl = window.desktopBridge?.getWsUrl?.();
-  const envWsUrl = import.meta.env.VITE_WS_URL as string | undefined;
-  const wsCandidate =
-    typeof bridgeWsUrl === "string" && bridgeWsUrl.length > 0
-      ? bridgeWsUrl
-      : typeof envWsUrl === "string" && envWsUrl.length > 0
-        ? envWsUrl
-        : null;
-  if (!wsCandidate) return window.location.origin;
-  try {
-    const wsUrl = new URL(wsCandidate);
-    const protocol =
-      wsUrl.protocol === "wss:"
-        ? "https:"
-        : wsUrl.protocol === "ws:"
-          ? "http:"
-          : wsUrl.protocol;
-    return `${protocol}//${wsUrl.host}`;
-  } catch {
-    return window.location.origin;
-  }
-}
-
 function toAttachmentPreviewUrl(rawUrl: string): string {
   if (rawUrl.startsWith("/")) {
-    return `${resolveWsHttpOrigin()}${rawUrl}`;
+    return `${resolveServerHttpOrigin()}${rawUrl}`;
   }
   return rawUrl;
 }
@@ -199,9 +210,10 @@ export function syncServerReadModel(
   state: AppState,
   readModel: OrchestrationReadModel,
 ): AppState {
-  const projects = mapProjectsFromReadModel(
-    readModel.projects.filter((project) => project.deletedAt === null),
-    state.projects,
+  const activeReadModelProjects = readModel.projects.filter((project) => project.deletedAt === null);
+  const projects = applyProjectOrder(
+    mapProjectsFromReadModel(activeReadModelProjects, state.projects),
+    state.projectOrder,
   );
   const existingThreadById = new Map(
     state.threads.map((thread) => [thread.id, thread] as const),
@@ -272,6 +284,7 @@ export function syncServerReadModel(
   return {
     ...state,
     projects,
+    projectOrder: projects.map((project) => project.id),
     threads,
     threadsHydrated: true,
   };
@@ -333,6 +346,38 @@ export function setProjectExpanded(
   return changed ? { ...state, projects } : state;
 }
 
+export function moveProject(
+  state: AppState,
+  projectId: Project["id"],
+  targetProjectId: Project["id"],
+  position: "before" | "after",
+): AppState {
+  if (projectId === targetProjectId) return state;
+
+  const currentIndex = state.projects.findIndex((project) => project.id === projectId);
+  const targetIndex = state.projects.findIndex((project) => project.id === targetProjectId);
+  if (currentIndex < 0 || targetIndex < 0) return state;
+
+  const projects = [...state.projects];
+  const [project] = projects.splice(currentIndex, 1);
+  if (!project) return state;
+
+  const adjustedTargetIndex = projects.findIndex((entry) => entry.id === targetProjectId);
+  if (adjustedTargetIndex < 0) return state;
+
+  const insertionIndex = position === "before" ? adjustedTargetIndex : adjustedTargetIndex + 1;
+  projects.splice(insertionIndex, 0, project);
+
+  const orderChanged = projects.some((entry, index) => entry !== state.projects[index]);
+  if (!orderChanged) return state;
+
+  return {
+    ...state,
+    projects,
+    projectOrder: projects.map((entry) => entry.id),
+  };
+}
+
 export function setError(state: AppState, threadId: ThreadId, error: string | null): AppState {
   const threads = updateThread(state.threads, threadId, (t) => {
     if (t.error === error) return t;
@@ -372,6 +417,11 @@ interface AppStore extends AppState {
   markThreadVisited: (threadId: ThreadId, visitedAt?: string) => void;
   markThreadUnread: (threadId: ThreadId) => void;
   toggleProject: (projectId: Project["id"]) => void;
+  moveProject: (
+    projectId: Project["id"],
+    targetProjectId: Project["id"],
+    position: "before" | "after",
+  ) => void;
   setProjectExpanded: (projectId: Project["id"], expanded: boolean) => void;
   setError: (threadId: ThreadId, error: string | null) => void;
   setThreadBranch: (
@@ -392,6 +442,8 @@ export const useStore = create<AppStore>((set) => ({
     set((state) => markThreadUnread(state, threadId)),
   toggleProject: (projectId) =>
     set((state) => toggleProject(state, projectId)),
+  moveProject: (projectId, targetProjectId, position) =>
+    set((state) => moveProject(state, projectId, targetProjectId, position)),
   setProjectExpanded: (projectId, expanded) =>
     set((state) => setProjectExpanded(state, projectId, expanded)),
   setError: (threadId, error) =>
@@ -402,7 +454,7 @@ export const useStore = create<AppStore>((set) => ({
     set((state) => setRuntimeMode(state, mode)),
 }));
 
-// Persist on every state change (only runtimeMode + expandedProjectCwds)
+// Persist on every state change (runtimeMode + expanded projects + project order)
 useStore.subscribe((state) => persistState(state));
 
 export function StoreProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add drag and drop reordering for projects in the sidebar with local persistence.

The initial attempt to use HTML5 drag and drop events encountered environment-specific issues where the drag lifecycle events did not fire. This PR pivots to a pointer-driven drag model to ensure reliable reordering functionality.

---
<p><a href="https://cursor.com/agents/bc-d39d1014-3bea-42fa-9b7e-c6e427405a8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d39d1014-3bea-42fa-9b7e-c6e427405a8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-and-drop reordering to the projects sidebar and persist order via `store.moveProject` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/176/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1)
> Introduce pointer-driven drag handles and drop indicators in the sidebar, wire `store.moveProject` to update `projectOrder`, and delegate HTTP origin resolution to `lib/serverOrigin.resolveServerHttpOrigin`.
>
> #### 📍Where to Start
> Start with the drag handlers and drop logic in the `Sidebar` component in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/176/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1); then review `store.moveProject` and `applyProjectOrder` in [store.ts](https://github.com/pingdotgg/t3code/pull/176/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02739bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->