### PR TITLE
feat: resizable sidebar

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -339,6 +339,7 @@ function SidebarRail({
   const sidebarInstance = React.useContext(SidebarInstanceContext);
   const railRef = React.useRef<HTMLButtonElement | null>(null);
   const suppressClickRef = React.useRef(false);
+  const cleanupResizeListenersRef = React.useRef<(() => void) | null>(null);
   const resizeStateRef = React.useRef<{
     moved: boolean;
     pointerId: number;
@@ -367,6 +368,8 @@ function SidebarRail({
       if (resizeState.rafId !== null) {
         window.cancelAnimationFrame(resizeState.rafId);
       }
+      cleanupResizeListenersRef.current?.();
+      cleanupResizeListenersRef.current = null;
       resizeState.transitionTargets.forEach((element) => {
         element.style.removeProperty("transition-duration");
       });
@@ -429,12 +432,46 @@ function SidebarRail({
         width: initialWidth,
         wrapper,
       };
+      const stopResizeFromWindowEvent = (nativeEvent: PointerEvent) => {
+        const activeResizeState = resizeStateRef.current;
+        if (!activeResizeState || nativeEvent.pointerId !== activeResizeState.pointerId) {
+          return;
+        }
+        suppressClickRef.current = activeResizeState.moved;
+        stopResize(nativeEvent.pointerId);
+      };
+      const stopResizeFromVisibilityChange = () => {
+        const activeResizeState = resizeStateRef.current;
+        if (!activeResizeState || document.visibilityState === "visible") {
+          return;
+        }
+        suppressClickRef.current = activeResizeState.moved;
+        stopResize(activeResizeState.pointerId);
+      };
+      const stopResizeFromBlur = () => {
+        const activeResizeState = resizeStateRef.current;
+        if (!activeResizeState) {
+          return;
+        }
+        suppressClickRef.current = activeResizeState.moved;
+        stopResize(activeResizeState.pointerId);
+      };
+      window.addEventListener("pointerup", stopResizeFromWindowEvent, true);
+      window.addEventListener("pointercancel", stopResizeFromWindowEvent, true);
+      window.addEventListener("blur", stopResizeFromBlur);
+      document.addEventListener("visibilitychange", stopResizeFromVisibilityChange);
+      cleanupResizeListenersRef.current = () => {
+        window.removeEventListener("pointerup", stopResizeFromWindowEvent, true);
+        window.removeEventListener("pointercancel", stopResizeFromWindowEvent, true);
+        window.removeEventListener("blur", stopResizeFromBlur);
+        document.removeEventListener("visibilitychange", stopResizeFromVisibilityChange);
+      };
       wrapper.style.setProperty("--sidebar-width", `${initialWidth}px`);
       event.currentTarget.setPointerCapture(event.pointerId);
       document.body.style.cursor = "col-resize";
       document.body.style.userSelect = "none";
     },
-    [onPointerDown, open, resolvedResizable, sidebarInstance?.side],
+    [onPointerDown, open, resolvedResizable, sidebarInstance?.side, stopResize],
   );
 
   const handlePointerMove = React.useCallback(
@@ -516,6 +553,13 @@ function SidebarRail({
     [endResizeInteraction, onPointerCancel],
   );
 
+  const handleLostPointerCapture = React.useCallback(() => {
+    const resizeState = resizeStateRef.current;
+    if (!resizeState) return;
+    suppressClickRef.current = resizeState.moved;
+    stopResize(resizeState.pointerId);
+  }, [stopResize]);
+
   const handleClick = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       onClick?.(event);
@@ -579,6 +623,7 @@ function SidebarRail({
       onClick={handleClick}
       onPointerCancel={handlePointerCancel}
       onPointerDown={handlePointerDown}
+      onLostPointerCapture={handleLostPointerCapture}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
       ref={railRef}

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -3,7 +3,11 @@ import { useEffect } from "react";
 
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
 import ThreadSidebar from "../components/Sidebar";
-import { Sidebar, SidebarProvider } from "~/components/ui/sidebar";
+import { Sidebar, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
+
+const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
+const THREAD_SIDEBAR_MIN_WIDTH = 16 * 16;
+const THREAD_SIDEBAR_MAX_WIDTH = 40 * 16;
 
 function ChatRouteLayout() {
   const navigate = useNavigate();
@@ -30,8 +34,14 @@ function ChatRouteLayout() {
         side="left"
         collapsible="offcanvas"
         className="border-r border-border bg-card text-foreground"
+        resizable={{
+          maxWidth: THREAD_SIDEBAR_MAX_WIDTH,
+          minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+          storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
+        }}
       >
         <ThreadSidebar />
+        <SidebarRail />
       </Sidebar>
       <DiffWorkerPoolProvider>
         <Outlet />

--- a/apps/web/src/truncateTitle.ts
+++ b/apps/web/src/truncateTitle.ts
@@ -1,4 +1,4 @@
-export function truncateTitle(text: string, maxLength = 50): string {
+export function truncateTitle(text: string, maxLength = 300): string {
   const trimmed = text.trim();
   if (trimmed.length <= maxLength) {
     return trimmed;


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add a resizable left sidebar in the chat route with a visible rail and width persisted between 256px and 640px under localStorage key "chat_thread_sidebar_width"
Implement a resizable `Sidebar` in the chat layout, add `SidebarRail` with global pointer termination and cleanup logic, and update `truncateTitle` default max length to 300 in [apps/web/src/truncateTitle.ts](https://github.com/pingdotgg/t3code/pull/177/files#diff-98ba8f8678c1970340e34afda2d930c036a375ae48923ec66613f074a149cd41).

#### 📍Where to Start
Start with the `SidebarRail` logic and resize handlers in [apps/web/src/components/ui/sidebar.tsx](https://github.com/pingdotgg/t3code/pull/177/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd), then review how `ChatRouteLayout` wires the component in [apps/web/src/routes/_chat.tsx](https://github.com/pingdotgg/t3code/pull/177/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59d508e.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->