### PR TITLE
Preserve draft thread terminal state during snapshot cleanup

### DIFF
--- a/apps/web/src/lib/terminalStateCleanup.test.ts
+++ b/apps/web/src/lib/terminalStateCleanup.test.ts
@@ -1,0 +1,32 @@
+import { ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import { collectActiveTerminalThreadIds } from "./terminalStateCleanup";
+
+const threadId = (id: string): ThreadId => ThreadId.makeUnsafe(id);
+
+describe("collectActiveTerminalThreadIds", () => {
+  it("retains non-deleted server threads", () => {
+    const activeThreadIds = collectActiveTerminalThreadIds({
+      snapshotThreads: [
+        { id: threadId("server-1"), deletedAt: null },
+        { id: threadId("server-2"), deletedAt: null },
+      ],
+      draftThreadIds: [],
+    });
+
+    expect(activeThreadIds).toEqual(new Set([threadId("server-1"), threadId("server-2")]));
+  });
+
+  it("ignores deleted server threads and keeps local draft threads", () => {
+    const activeThreadIds = collectActiveTerminalThreadIds({
+      snapshotThreads: [
+        { id: threadId("server-active"), deletedAt: null },
+        { id: threadId("server-deleted"), deletedAt: "2026-03-05T08:00:00.000Z" },
+      ],
+      draftThreadIds: [threadId("local-draft")],
+    });
+
+    expect(activeThreadIds).toEqual(new Set([threadId("server-active"), threadId("local-draft")]));
+  });
+});

--- a/apps/web/src/lib/terminalStateCleanup.ts
+++ b/apps/web/src/lib/terminalStateCleanup.ts
@@ -1,0 +1,25 @@
+import type { ThreadId } from "@t3tools/contracts";
+
+interface TerminalRetentionThread {
+  id: ThreadId;
+  deletedAt: string | null;
+}
+
+interface CollectActiveTerminalThreadIdsInput {
+  snapshotThreads: readonly TerminalRetentionThread[];
+  draftThreadIds: Iterable<ThreadId>;
+}
+
+export function collectActiveTerminalThreadIds(
+  input: CollectActiveTerminalThreadIdsInput,
+): Set<ThreadId> {
+  const activeThreadIds = new Set<ThreadId>();
+  for (const thread of input.snapshotThreads) {
+    if (thread.deletedAt !== null) continue;
+    activeThreadIds.add(thread.id);
+  }
+  for (const draftThreadId of input.draftThreadIds) {
+    activeThreadIds.add(draftThreadId);
+  }
+  return activeThreadIds;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -14,12 +14,14 @@ import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
 import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
+import { useComposerDraftStore } from "../composerDraftStore";
 import { useStore } from "../store";
 import { useTerminalStateStore } from "../terminalStateStore";
 import { preferredTerminalEditor } from "../terminal-links";
 import { terminalRunningSubprocessFromEvent } from "../terminalActivity";
 import { onServerConfigUpdated, onServerWelcome } from "../wsNativeApi";
 import { providerQueryKeys } from "../lib/providerReactQuery";
+import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -154,9 +156,13 @@ function EventRouter() {
       if (disposed) return;
       latestSequence = Math.max(latestSequence, snapshot.snapshotSequence);
       syncServerReadModel(snapshot);
-      const activeThreadIds = new Set(
-        snapshot.threads.filter((t) => t.deletedAt === null).map((t) => t.id),
-      );
+      const draftThreadIds = Object.keys(
+        useComposerDraftStore.getState().draftThreadsByThreadId,
+      ) as ThreadId[];
+      const activeThreadIds = collectActiveTerminalThreadIds({
+        snapshotThreads: snapshot.threads,
+        draftThreadIds,
+      });
       removeOrphanedTerminalStates(activeThreadIds);
       if (pending) {
         pending = false;


### PR DESCRIPTION
## Summary
- keep terminal state for local draft threads when processing server snapshots
- add `collectActiveTerminalThreadIds` to merge active server thread IDs with draft thread IDs before orphan cleanup
- update root event routing to source draft thread IDs from `useComposerDraftStore`
- add focused tests covering retained server threads, deleted server threads, and local draft thread retention

## Testing
- Not run (tests not executed in this context)
- Added unit tests in `apps/web/src/lib/terminalStateCleanup.test.ts` for:
  - retaining non-deleted server threads
  - excluding deleted server threads while preserving local draft threads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 5dc3c89b59517638805c47c88c595bea471fe6fa. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve terminal states for local draft threads by passing active thread IDs from `routes.__root.EventRouter.flushSnapshotSync` using `lib.terminalStateCleanup.collectActiveTerminalThreadIds`
> Add `collectActiveTerminalThreadIds` to merge non-deleted snapshot thread IDs with draft thread IDs and use it in `flushSnapshotSync` so `removeOrphanedTerminalStates` receives the combined set; add tests in [terminalStateCleanup.test.ts](https://github.com/pingdotgg/t3code/pull/182/files#diff-4fb3f50ea369c96aed232e1f782423f643de587c0d31e4c9b5485ad8d12e1bae).
>
> #### 📍Where to Start
> Start with `flushSnapshotSync` in [apps/web/src/routes/__root.tsx](https://github.com/pingdotgg/t3code/pull/182/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100), then review `collectActiveTerminalThreadIds` in [apps/web/src/lib/terminalStateCleanup.ts](https://github.com/pingdotgg/t3code/pull/182/files#diff-54e0af3d5c97930f7f079f0f95138532150061712710f9d5595cbafbb8ddb902).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5dc3c89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->