### PR TITLE
Use project cwd when opening draft threads without a worktree path

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -19,6 +19,7 @@ import { page } from "vitest/browser";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
+import { useComposerDraftStore } from "../composerDraftStore";
 import { getRouter } from "../router";
 import { useStore } from "../store";
 import { estimateTimelineMessageHeight } from "./timelineHeight";
@@ -44,6 +45,7 @@ interface TestFixture {
 }
 
 let fixture: TestFixture;
+const wsRequests: WsRequestEnvelope["body"][] = [];
 const wsLink = ws.link(/ws(s)?:\/\/.*/);
 
 interface ViewportSpec {
@@ -243,6 +245,17 @@ function buildFixture(snapshot: OrchestrationReadModel): TestFixture {
   };
 }
 
+function createDraftOnlySnapshot(): OrchestrationReadModel {
+  const snapshot = createSnapshotForTargetUser({
+    targetMessageId: "msg-user-draft-target" as MessageId,
+    targetText: "draft thread",
+  });
+  return {
+    ...snapshot,
+    threads: [],
+  };
+}
+
 function resolveWsRpc(tag: string): unknown {
   if (tag === ORCHESTRATION_WS_METHODS.getSnapshot) {
     return fixture.snapshot;
@@ -307,6 +320,7 @@ const worker = setupWorker(
       }
       const method = request.body?._tag;
       if (typeof method !== "string") return;
+      wsRequests.push(request.body);
       client.send(
         JSON.stringify({
           id: request.id,
@@ -466,8 +480,10 @@ async function measureUserRow(options: {
 async function mountChatView(options: {
   viewport: ViewportSpec;
   snapshot: OrchestrationReadModel;
+  configureFixture?: (fixture: TestFixture) => void;
 }): Promise<MountedChatView> {
   fixture = buildFixture(options.snapshot);
+  options.configureFixture?.(fixture);
   await setViewport(options.viewport);
   await waitForProductionStyles();
 
@@ -547,6 +563,12 @@ describe("ChatView timeline estimator parity (full app)", () => {
     await setViewport(DEFAULT_VIEWPORT);
     localStorage.clear();
     document.body.innerHTML = "";
+    wsRequests.length = 0;
+    useComposerDraftStore.setState({
+      draftsByThreadId: {},
+      draftThreadsByThreadId: {},
+      projectDraftThreadIdByProjectId: {},
+    });
     useStore.setState({
       projects: [],
       threads: [],
@@ -708,4 +730,59 @@ describe("ChatView timeline estimator parity (full app)", () => {
       }
     },
   );
+
+  it("opens the project cwd for draft threads without a worktree path", async () => {
+    useComposerDraftStore.setState({
+      draftThreadsByThreadId: {
+        [THREAD_ID]: {
+          projectId: PROJECT_ID,
+          createdAt: NOW_ISO,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          envMode: "local",
+        },
+      },
+      projectDraftThreadIdByProjectId: {
+        [PROJECT_ID]: THREAD_ID,
+      },
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["vscode"],
+        };
+      },
+    });
+
+    try {
+      const openButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Open",
+          ) as HTMLButtonElement | null,
+        "Unable to find Open button.",
+      );
+      openButton.click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find((request) => request._tag === WS_METHODS.shellOpenInEditor);
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenInEditor,
+            cwd: "/repo/project",
+            editor: "vscode",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
 });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3293,6 +3293,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           activeThreadId={activeThread.id}
           activeThreadTitle={activeThread.title}
           activeProjectName={activeProject?.name}
+          openInCwd={activeThread.worktreePath ?? activeProject?.cwd ?? null}
           activeProjectScripts={activeProject?.scripts}
           preferredScriptId={
             activeProject ? (lastInvokedScriptByProjectId[activeProject.id] ?? null) : null
@@ -3855,6 +3856,7 @@ interface ChatHeaderProps {
   activeThreadId: ThreadId;
   activeThreadTitle: string;
   activeProjectName: string | undefined;
+  openInCwd: string | null;
   activeProjectScripts: ProjectScript[] | undefined;
   preferredScriptId: string | null;
   keybindings: ResolvedKeybindingsConfig;
@@ -3872,6 +3874,7 @@ const ChatHeader = memo(function ChatHeader({
   activeThreadId,
   activeThreadTitle,
   activeProjectName,
+  openInCwd,
   activeProjectScripts,
   preferredScriptId,
   keybindings,
@@ -3915,7 +3918,7 @@ const ChatHeader = memo(function ChatHeader({
           <OpenInPicker
             keybindings={keybindings}
             availableEditors={availableEditors}
-            activeThreadId={activeThreadId}
+            openInCwd={openInCwd}
           />
         )}
         {activeProjectName && <GitActionsControl gitCwd={gitCwd} activeThreadId={activeThreadId} />}
@@ -5392,11 +5395,11 @@ const CodexTraitsPicker = memo(function CodexTraitsPicker(props: {
 const OpenInPicker = memo(function OpenInPicker({
   keybindings,
   availableEditors,
-  activeThreadId,
+  openInCwd,
 }: {
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
-  activeThreadId: ThreadId | null;
+  openInCwd: string | null;
 }) {
   const [lastEditor, setLastEditor] = useState<EditorId>(() => {
     const stored = localStorage.getItem(LAST_EDITOR_KEY);
@@ -5442,26 +5445,17 @@ const OpenInPicker = memo(function OpenInPicker({
     : (options[0]?.value ?? null);
   const primaryOption = options.find(({ value }) => value === effectiveEditor) ?? null;
 
-  const activeThread = useStore((store) =>
-    activeThreadId ? store.threads.find((thread) => thread.id === activeThreadId) : undefined,
-  );
-  const activeProjectId = activeThread?.projectId ?? null;
-  const activeProject = useStore((store) =>
-    activeProjectId ? store.projects.find((project) => project.id === activeProjectId) : undefined,
-  );
-
   const openInEditor = useCallback(
     (editorId: EditorId | null) => {
       const api = readNativeApi();
-      if (!api || !activeProject) return;
+      if (!api || !openInCwd) return;
       const editor = editorId ?? effectiveEditor;
       if (!editor) return;
-      const cwd = activeThread?.worktreePath ?? activeProject.cwd;
-      void api.shell.openInEditor(cwd, editor);
+      void api.shell.openInEditor(openInCwd, editor);
       localStorage.setItem(LAST_EDITOR_KEY, editor);
       setLastEditor(editor);
     },
-    [activeProject, activeThread, effectiveEditor, setLastEditor],
+    [effectiveEditor, openInCwd, setLastEditor],
   );
 
   const openFavoriteEditorShortcutLabel = useMemo(
@@ -5473,23 +5467,22 @@ const OpenInPicker = memo(function OpenInPicker({
     const handler = (e: globalThis.KeyboardEvent) => {
       const api = readNativeApi();
       if (!isOpenFavoriteEditorShortcut(e, keybindings)) return;
-      if (!api || !activeProject) return;
+      if (!api || !openInCwd) return;
       if (!effectiveEditor) return;
 
       e.preventDefault();
-      const cwd = activeThread?.worktreePath ?? activeProject.cwd;
-      void api.shell.openInEditor(cwd, effectiveEditor);
+      void api.shell.openInEditor(openInCwd, effectiveEditor);
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [activeProject, activeThread, keybindings, effectiveEditor]);
+  }, [effectiveEditor, keybindings, openInCwd]);
 
   return (
     <Group aria-label="Subscription actions">
       <Button
         size="xs"
         variant="outline"
-        disabled={!effectiveEditor || !activeProject}
+        disabled={!effectiveEditor || !openInCwd}
         onClick={() => openInEditor(effectiveEditor)}
       >
         {primaryOption?.Icon && <primaryOption.Icon aria-hidden="true" className="size-3.5" />}


### PR DESCRIPTION
## Summary
- Pass `openInCwd` from `ChatView` into `ChatHeader`/`OpenInPicker` so editor open actions no longer depend on thread/project lookups inside the picker.
- Prefer `activeThread.worktreePath` and fall back to `activeProject.cwd` when computing the open path.
- Update `OpenInPicker` click/shortcut handlers and button disabled state to use `openInCwd` directly.
- Add a browser test covering draft-only threads to verify `shellOpenInEditor` is sent with project cwd when no worktree path exists.

## Testing
- Added test: `opens the project cwd for draft threads without a worktree path` in `apps/web/src/components/ChatView.browser.tsx`.
- Not run: `bun lint`.
- Not run: `bun typecheck`.
- Not run: `bun run test`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the path used for native `shell.openInEditor` actions (button + shortcut) and could change behavior for some thread/project edge cases, though the change is small and covered by a new browser test.
> 
> **Overview**
> Ensures the **Open in editor** action works for local draft threads that don’t yet have a `worktreePath` by computing an `openInCwd` in `ChatView` (`worktreePath` fallback to project `cwd`) and passing it down to `ChatHeader`/`OpenInPicker`.
> 
> `OpenInPicker` no longer does its own thread/project store lookups; its click handler, keyboard shortcut handler, and disabled state now rely solely on `openInCwd`.
> 
> Adds a browser test that mounts a draft-only thread (no server threads in snapshot), clicks **Open**, and asserts a `shellOpenInEditor` WS request is sent with the project `cwd` (including test harness support to capture WS requests and reset draft store state between tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19d5853148aee27c0cbf94e194e6fa948b574f83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route Chat header Open control to use the draft thread worktree path or fall back to the project cwd when calling `api.shell.openInEditor` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/183/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Introduce `openInCwd` in `ChatView` and pass it through `ChatHeader` to `OpenInPicker`, which now calls `api.shell.openInEditor` with that cwd and disables the control when null; add tests that capture WebSocket RPCs and verify the cwd fallback behavior.
>
> #### 📍Where to Start
> Start with `ChatView` computing `openInCwd` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/183/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), then follow its propagation through `ChatHeader` to `OpenInPicker`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19d5853.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->