### PR TITLE
Add Shift+Tab shortcut to toggle composer plan mode

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -392,6 +392,23 @@ async function waitForElement<T extends Element>(
   return element;
 }
 
+async function waitForComposerEditor(): Promise<HTMLElement> {
+  return waitForElement(
+    () => document.querySelector<HTMLElement>('[contenteditable="true"]'),
+    "Unable to find composer editor.",
+  );
+}
+
+async function waitForInteractionModeButton(expectedLabel: "Chat" | "Plan"): Promise<HTMLButtonElement> {
+  return waitForElement(
+    () =>
+      Array.from(document.querySelectorAll("button")).find(
+        (button) => button.textContent?.trim() === expectedLabel,
+      ) as HTMLButtonElement | null,
+    `Unable to find ${expectedLabel} interaction mode button.`,
+  );
+}
+
 async function waitForImagesToLoad(scope: ParentNode): Promise<void> {
   const images = Array.from(scope.querySelectorAll("img"));
   if (images.length === 0) {
@@ -778,6 +795,71 @@ describe("ChatView timeline estimator parity (full app)", () => {
             cwd: "/repo/project",
             editor: "vscode",
           });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("toggles plan mode with Shift+Tab only while the composer is focused", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-target-hotkey" as MessageId,
+        targetText: "hotkey target",
+      }),
+    });
+
+    try {
+      const initialModeButton = await waitForInteractionModeButton("Chat");
+      expect(initialModeButton.title).toContain("enter plan mode");
+
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await waitForLayout();
+
+      expect((await waitForInteractionModeButton("Chat")).title).toContain("enter plan mode");
+
+      const composerEditor = await waitForComposerEditor();
+      composerEditor.focus();
+      composerEditor.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      await vi.waitFor(
+        async () => {
+          expect((await waitForInteractionModeButton("Plan")).title).toContain(
+            "return to normal chat mode",
+          );
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      composerEditor.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      await vi.waitFor(
+        async () => {
+          expect((await waitForInteractionModeButton("Chat")).title).toContain("enter plan mode");
         },
         { timeout: 8_000, interval: 16 },
       );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1600,6 +1600,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
       threadId,
     ],
   );
+  const toggleInteractionMode = useCallback(() => {
+    handleInteractionModeChange(interactionMode === "plan" ? "default" : "plan");
+  }, [handleInteractionModeChange, interactionMode]);
 
   const persistThreadSettingsForNextTurn = useCallback(
     async (input: {
@@ -3196,6 +3199,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
     event: KeyboardEvent,
   ) => {
+    if (key === "Tab" && event.shiftKey) {
+      toggleInteractionMode();
+      return true;
+    }
+
     const { trigger } = resolveActiveComposerTrigger();
     const menuIsActive = composerMenuOpenRef.current || trigger !== null;
 
@@ -3559,11 +3567,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                     className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
                     size="sm"
                     type="button"
-                    onClick={() =>
-                      void handleInteractionModeChange(
-                        interactionMode === "plan" ? "default" : "plan",
-                      )
-                    }
+                    onClick={toggleInteractionMode}
                     title={
                       interactionMode === "plan"
                         ? "Plan mode — click to return to normal chat mode"


### PR DESCRIPTION
## Summary
- add a `Shift+Tab` keyboard shortcut to toggle between Chat and Plan interaction modes
- scope the shortcut to composer key handling so it only applies while the composer is focused
- extract mode switching into a shared `toggleInteractionMode` callback and reuse it for the mode button
- add browser-level coverage to verify no toggle when unfocused and correct toggling when focused

## Testing
- `apps/web/src/components/ChatView.browser.tsx`: added test `toggles plan mode with Shift+Tab only while the composer is focused`
- Verified in test flow that `Shift+Tab` on `window` does not toggle mode
- Verified in test flow that `Shift+Tab` on focused composer toggles `Chat -> Plan -> Chat`
- Not run: `bun lint`
- Not run: `bun typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Shift+Tab keyboard shortcut in ChatView to toggle composer interaction mode for plan drafting
> Implement a `toggleInteractionMode` callback in `ChatView` and handle `Shift+Tab` in the composer keyboard handler to switch between "Chat" and "Plan"; add utilities to wait for the composer editor and interaction mode button; add an integration test covering focus-gated toggling in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/186/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) and logic changes in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/186/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> #### 📍Where to Start
> Start with the `toggleInteractionMode` callback and `onComposerCommandKey` handling in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/186/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3392a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shift+Tab keyboard shortcut to toggle between Chat and Plan modes when the composer is focused, enabling faster mode switching without using the mouse.

* **Tests**
  * Added test coverage for keyboard navigation mode transitions and UI state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->