### PR TITLE
Soften chat composer focus border in ChatView

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3388,7 +3388,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           data-chat-composer-form="true"
         >
           <div
-            className={`group rounded-[20px] border bg-card transition-colors duration-200 focus-within:border-ring ${
+            className={`group rounded-[20px] border bg-card transition-colors duration-200 focus-within:border-ring/45 ${
               isDragOverComposer ? "border-primary/70 bg-accent/30" : "border-border"
             }`}
             onDragEnter={onComposerDragEnter}


### PR DESCRIPTION
## Summary
- Reduce the chat composer focus border intensity in `ChatView`.
- Change `focus-within:border-ring` to `focus-within:border-ring/45` for a subtler focus state.
- No functional behavior changes; visual styling update only.

## Testing
- Not run (provided diff includes a single Tailwind class change in `apps/web/src/components/ChatView.tsx`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Soften the ChatView composer focus border to 45% opacity in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/188/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Change the composer container class from `focus-within:border-ring` to `focus-within:border-ring/45` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/188/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> #### 📍Where to Start
> Start with the composer container styles in the `ChatView` component in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/188/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38511e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->