### PR TITLE
add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+node_modules
+.turbo
+dist
+*.log
+.env
+.env.*
+!.env.example
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM oven/bun:debian@sha256:b86c67b531d87b4db11470d9b2bd0c519b1976eee6fcd71634e73abfa6230d2e
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    make \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN bun install -g @openai/codex
+
+WORKDIR /app
+
+COPY package.json bun.lockb* turbo.json ./
+COPY apps/ ./apps/
+COPY packages/ ./packages/
+COPY scripts/ ./scripts/
+
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+RUN bun run build
+
+ENV NODE_ENV=production
+
+EXPOSE 3773
+
+CMD ["bun", "run", "start"]


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add a Dockerfile to build and run the Bun app in production on TCP port 3773
Introduce a Bun-based container image using `oven/bun:debian` (pinned by sha256), install build tools via `apt`, run `bun install --frozen-lockfile`, execute `bun run build`, set `NODE_ENV=production`, expose `3773`, and start with `bun run start`. Add [.dockerignore](https://github.com/pingdotgg/t3code/pull/215/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5) to exclude common build context files while re-including `.env.example`. Include [Dockerfile](https://github.com/pingdotgg/t3code/pull/215/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557).

#### 📍Where to Start
Start with the container setup and build steps in [Dockerfile](https://github.com/pingdotgg/t3code/pull/215/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557).

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e44d53.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->