### PR TITLE
feat: delete actions

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -341,6 +341,27 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
+  it.effect("deletes custom keybindings from configured path", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+j", command: "terminal.toggle" },
+        { key: "mod+shift+r", command: "script.run-tests.run" },
+      ]);
+
+      const resolved = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.deleteKeybindingRule("script.run-tests.run");
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command }) => ({ key, command }));
+      assert.deepEqual(persistedView, [{ key: "mod+j", command: "terminal.toggle" }]);
+      assert.isFalse(resolved.some((entry) => entry.command === "script.run-tests.run"));
+      assert.isTrue(resolved.some((entry) => entry.command === "terminal.toggle"));
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
   it.effect("refuses to overwrite malformed keybindings config", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -455,6 +476,26 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
 
       assert.isTrue(loadedAfterUpsert.some((entry) => entry.command === "script.run-tests.run"));
       assert.isTrue(loadedAfterUpsert.some((entry) => entry.command === "terminal.toggle"));
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("updates cached resolved config after delete", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+j", command: "terminal.toggle" },
+        { key: "mod+shift+r", command: "script.run-tests.run" },
+      ]);
+
+      const loadedAfterDelete = yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        yield* keybindings.loadConfigState;
+        yield* keybindings.deleteKeybindingRule("script.run-tests.run");
+        return (yield* keybindings.loadConfigState).keybindings;
+      });
+
+      assert.isFalse(loadedAfterDelete.some((entry) => entry.command === "script.run-tests.run"));
+      assert.isTrue(loadedAfterDelete.some((entry) => entry.command === "terminal.toggle"));
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -7,6 +7,7 @@
  * @module Keybindings
  */
 import {
+  type KeybindingCommand,
   KeybindingRule,
   KeybindingsConfig,
   KeybindingShortcut,
@@ -493,6 +494,14 @@ export interface KeybindingsShape {
   readonly upsertKeybindingRule: (
     rule: KeybindingRule,
   ) => Effect.Effect<ResolvedKeybindingsConfig, KeybindingsConfigError>;
+
+  /**
+   * Remove a custom keybinding rule for the given command and persist the
+   * resulting configuration.
+   */
+  readonly deleteKeybindingRule: (
+    command: KeybindingCommand,
+  ) => Effect.Effect<ResolvedKeybindingsConfig, KeybindingsConfigError>;
 }
 
 /**
@@ -653,6 +662,18 @@ const makeKeybindings = Effect.gen(function* () {
       ),
     );
   };
+
+  const persistCustomConfigAndCache = (rules: readonly KeybindingRule[]) =>
+    Effect.gen(function* () {
+      yield* writeConfigAtomically(rules);
+      const nextResolved = mergeWithDefaultKeybindings(compileResolvedKeybindingsConfig(rules));
+      yield* Cache.set(resolvedConfigCache, resolvedConfigCacheKey, {
+        keybindings: nextResolved,
+        issues: [],
+      });
+      yield* emitChange([]);
+      return nextResolved;
+    });
 
   const loadConfigStateFromDisk = loadRuntimeCustomKeybindingsConfig().pipe(
     Effect.map(({ keybindings, issues }) => ({
@@ -825,16 +846,18 @@ const makeKeybindings = Effect.gen(function* () {
               maxEntries: MAX_KEYBINDINGS_COUNT,
             });
           }
-          yield* writeConfigAtomically(cappedConfig);
-          const nextResolved = mergeWithDefaultKeybindings(
-            compileResolvedKeybindingsConfig(cappedConfig),
-          );
-          yield* Cache.set(resolvedConfigCache, resolvedConfigCacheKey, {
-            keybindings: nextResolved,
-            issues: [],
-          });
-          yield* emitChange([]);
-          return nextResolved;
+          return yield* persistCustomConfigAndCache(cappedConfig);
+        }),
+      ),
+    deleteKeybindingRule: (command) =>
+      upsertSemaphore.withPermits(1)(
+        Effect.gen(function* () {
+          const customConfig = yield* loadWritableCustomKeybindingsConfig();
+          const nextConfig = customConfig.filter((entry) => entry.command !== command);
+          if (nextConfig.length === customConfig.length) {
+            return yield* loadConfigStateFromCacheOrDisk.pipe(Effect.map((state) => state.keybindings));
+          }
+          return yield* persistCustomConfigAndCache(nextConfig);
         }),
       ),
   } satisfies KeybindingsShape;

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -1028,6 +1028,59 @@ describe("WebSocket Server", () => {
     );
   });
 
+  it("deletes keybinding rules and updates cached server config", async () => {
+    const stateDir = makeTempDir("t3code-state-delete-keybinding-");
+    const keybindingsPath = path.join(stateDir, "keybindings.json");
+    fs.writeFileSync(
+      keybindingsPath,
+      JSON.stringify([
+        { key: "mod+j", command: "terminal.toggle" },
+        { key: "mod+shift+r", command: "script.run-tests.run" },
+      ]),
+      "utf8",
+    );
+
+    server = await createTestServer({ cwd: "/my/workspace", stateDir });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    const deleteResponse = await sendRequest(ws, WS_METHODS.serverDeleteKeybinding, {
+      command: "script.run-tests.run",
+    });
+    expect(deleteResponse.error).toBeUndefined();
+
+    const persistedConfig = JSON.parse(
+      fs.readFileSync(keybindingsPath, "utf8"),
+    ) as KeybindingsConfig;
+    expect(persistedConfig.some((entry) => entry.command === "script.run-tests.run")).toBe(false);
+    expect(persistedConfig.some((entry) => entry.command === "terminal.toggle")).toBe(true);
+    for (const defaultRule of DEFAULT_KEYBINDINGS) {
+      expect(persistedConfig.some((entry) => entry.command === defaultRule.command)).toBe(true);
+    }
+    expect(deleteResponse.result).toEqual({
+      keybindings: compileKeybindings(persistedConfig),
+      issues: [],
+    });
+
+    const configResponse = await sendRequest(ws, WS_METHODS.serverGetConfig);
+    expect(configResponse.error).toBeUndefined();
+    expect(configResponse.result).toEqual({
+      cwd: "/my/workspace",
+      keybindingsConfigPath: keybindingsPath,
+      keybindings: compileKeybindings(persistedConfig),
+      issues: [],
+      providers: defaultProviderStatuses,
+      availableEditors: expect.any(Array),
+    });
+    expectAvailableEditors(
+      (configResponse.result as { availableEditors: unknown }).availableEditors,
+    );
+  });
+
   it("returns error for unknown methods", async () => {
     server = await createTestServer({ cwd: "/test" });
     const addr = server.address();

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -847,6 +847,12 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         return { keybindings: keybindingsConfig, issues: [] };
       }
 
+      case WS_METHODS.serverDeleteKeybinding: {
+        const body = stripRequestTag(request.body);
+        const keybindingsConfig = yield* keybindingsManager.deleteKeybindingRule(body.command);
+        return { keybindings: keybindingsConfig, issues: [] };
+      }
+
       default: {
         const _exhaustiveCheck: never = request.body;
         return yield* new RouteRequestError({

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1484,11 +1484,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const persistProjectScripts = useCallback(
     async (input: {
       projectId: ProjectId;
-      projectCwd: string;
-      previousScripts: ProjectScript[];
       nextScripts: ProjectScript[];
+      keybindingCommandsToDelete?: KeybindingCommand[];
       keybinding?: string | null;
-      keybindingCommand: KeybindingCommand;
+      keybindingCommand?: KeybindingCommand;
     }) => {
       const api = readNativeApi();
       if (!api) return;
@@ -1500,13 +1499,26 @@ export default function ChatView({ threadId }: ChatViewProps) {
         scripts: input.nextScripts,
       });
 
-      const keybindingRule = decodeProjectScriptKeybindingRule({
-        keybinding: input.keybinding,
-        command: input.keybindingCommand,
-      });
+      if (isElectron) {
+        const keybindingRule = input.keybindingCommand
+          ? decodeProjectScriptKeybindingRule({
+              keybinding: input.keybinding,
+              command: input.keybindingCommand,
+            })
+          : null;
+        const keybindingCommandsToDelete = new Set(input.keybindingCommandsToDelete ?? []);
+        if (keybindingRule) {
+          keybindingCommandsToDelete.delete(keybindingRule.command);
+        } else if (input.keybindingCommand) {
+          keybindingCommandsToDelete.add(input.keybindingCommand);
+        }
 
-      if (isElectron && keybindingRule) {
-        await api.server.upsertKeybinding(keybindingRule);
+        for (const command of keybindingCommandsToDelete) {
+          await api.server.deleteKeybinding({ command });
+        }
+        if (keybindingRule) {
+          await api.server.upsertKeybinding(keybindingRule);
+        }
         await queryClient.invalidateQueries({ queryKey: serverQueryKeys.all });
       }
     },
@@ -1537,8 +1549,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
       await persistProjectScripts({
         projectId: activeProject.id,
-        projectCwd: activeProject.cwd,
-        previousScripts: activeProject.scripts,
         nextScripts,
         keybinding: input.keybinding,
         keybindingCommand: commandForProjectScript(nextId),
@@ -1571,11 +1581,25 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
       await persistProjectScripts({
         projectId: activeProject.id,
-        projectCwd: activeProject.cwd,
-        previousScripts: activeProject.scripts,
         nextScripts,
         keybinding: input.keybinding,
         keybindingCommand: commandForProjectScript(scriptId),
+      });
+    },
+    [activeProject, persistProjectScripts],
+  );
+  const deleteProjectScript = useCallback(
+    async (scriptId: string) => {
+      if (!activeProject) return;
+      const nextScripts = activeProject.scripts.filter((script) => script.id !== scriptId);
+      if (nextScripts.length === activeProject.scripts.length) {
+        throw new Error("Script not found.");
+      }
+
+      await persistProjectScripts({
+        projectId: activeProject.id,
+        nextScripts,
+        keybindingCommandsToDelete: [commandForProjectScript(scriptId)],
       });
     },
     [activeProject, persistProjectScripts],
@@ -3338,6 +3362,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           }}
           onAddProjectScript={saveProjectScript}
           onUpdateProjectScript={updateProjectScript}
+          onDeleteProjectScript={deleteProjectScript}
           onToggleDiff={onToggleDiff}
         />
       </header>
@@ -3914,6 +3939,7 @@ interface ChatHeaderProps {
   onRunProjectScript: (script: ProjectScript) => void;
   onAddProjectScript: (input: NewProjectScriptInput) => Promise<void>;
   onUpdateProjectScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void>;
+  onDeleteProjectScript: (scriptId: string) => Promise<void>;
   onToggleDiff: () => void;
 }
 
@@ -3932,6 +3958,7 @@ const ChatHeader = memo(function ChatHeader({
   onRunProjectScript,
   onAddProjectScript,
   onUpdateProjectScript,
+  onDeleteProjectScript,
   onToggleDiff,
 }: ChatHeaderProps) {
   return (
@@ -3959,6 +3986,7 @@ const ChatHeader = memo(function ChatHeader({
             onRunScript={onRunProjectScript}
             onAddScript={onAddProjectScript}
             onUpdateScript={onUpdateProjectScript}
+            onDeleteScript={onDeleteProjectScript}
           />
         )}
         {activeProjectName && (

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -12,6 +12,7 @@ import {
   PlayIcon,
   PlusIcon,
   SettingsIcon,
+  Trash2Icon,
   WrenchIcon,
 } from "lucide-react";
 import React, { type FormEvent, type KeyboardEvent, useMemo, useState } from "react";
@@ -84,6 +85,7 @@ interface ProjectScriptsControlProps {
   onRunScript: (script: ProjectScript) => void;
   onAddScript: (input: NewProjectScriptInput) => Promise<void> | void;
   onUpdateScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void> | void;
+  onDeleteScript: (scriptId: string) => Promise<void> | void;
 }
 
 function normalizeShortcutKeyToken(key: string): string | null {
@@ -144,6 +146,7 @@ export default function ProjectScriptsControl({
   onRunScript,
   onAddScript,
   onUpdateScript,
+  onDeleteScript,
 }: ProjectScriptsControlProps) {
   const addScriptFormId = React.useId();
   const [editingScriptId, setEditingScriptId] = useState<string | null>(null);
@@ -155,6 +158,7 @@ export default function ProjectScriptsControl({
   const [runOnWorktreeCreate, setRunOnWorktreeCreate] = useState(false);
   const [keybinding, setKeybinding] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<"save" | "delete" | null>(null);
 
   const primaryScript = useMemo(() => {
     if (preferredScriptId) {
@@ -164,8 +168,21 @@ export default function ProjectScriptsControl({
     return primaryProjectScript(scripts);
   }, [preferredScriptId, scripts]);
   const isEditing = editingScriptId !== null;
+  const isBusy = pendingAction !== null;
   const dropdownItemClassName =
     "data-highlighted:bg-transparent data-highlighted:text-foreground hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground data-highlighted:hover:bg-accent data-highlighted:hover:text-accent-foreground data-highlighted:focus-visible:bg-accent data-highlighted:focus-visible:text-accent-foreground";
+
+  const resetDialogState = () => {
+    setEditingScriptId(null);
+    setName("");
+    setCommand("");
+    setIcon("play");
+    setIconPickerOpen(false);
+    setRunOnWorktreeCreate(false);
+    setKeybinding("");
+    setValidationError(null);
+    setPendingAction(null);
+  };
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Tab") return;
@@ -181,6 +198,7 @@ export default function ProjectScriptsControl({
 
   const submitAddScript = async (event: FormEvent) => {
     event.preventDefault();
+    if (isBusy) return;
     const trimmedName = name.trim();
     const trimmedCommand = command.trim();
     if (trimmedName.length === 0) {
@@ -193,6 +211,7 @@ export default function ProjectScriptsControl({
     }
 
     setValidationError(null);
+    setPendingAction("save");
     try {
       const scriptIdForValidation =
         editingScriptId ??
@@ -220,22 +239,31 @@ export default function ProjectScriptsControl({
       setIconPickerOpen(false);
     } catch (error) {
       setValidationError(error instanceof Error ? error.message : "Failed to save action.");
+      setPendingAction(null);
+    }
+  };
+
+  const deleteScript = async () => {
+    if (!editingScriptId || isBusy) return;
+    setValidationError(null);
+    setPendingAction("delete");
+    try {
+      await onDeleteScript(editingScriptId);
+      setDialogOpen(false);
+      setIconPickerOpen(false);
+    } catch (error) {
+      setValidationError(error instanceof Error ? error.message : "Failed to delete action.");
+      setPendingAction(null);
     }
   };
 
   const openAddDialog = () => {
-    setEditingScriptId(null);
-    setName("");
-    setCommand("");
-    setIcon("play");
-    setIconPickerOpen(false);
-    setRunOnWorktreeCreate(false);
-    setKeybinding("");
-    setValidationError(null);
+    resetDialogState();
     setDialogOpen(true);
   };
 
   const openEditDialog = (script: ProjectScript) => {
+    setPendingAction(null);
     setEditingScriptId(script.id);
     setName(script.name);
     setCommand(script.command);
@@ -297,6 +325,7 @@ export default function ProjectScriptsControl({
                         size="icon-xs"
                         className="absolute right-0 top-1/2 size-6 -translate-y-1/2 opacity-0 pointer-events-none transition-opacity group-hover:opacity-100 group-hover:pointer-events-auto group-focus-visible:opacity-100 group-focus-visible:pointer-events-auto"
                         aria-label={`Edit ${script.name}`}
+                        disabled={isBusy}
                         onPointerDown={(event) => {
                           event.preventDefault();
                           event.stopPropagation();
@@ -331,6 +360,9 @@ export default function ProjectScriptsControl({
 
       <Dialog
         onOpenChange={(open) => {
+          if (!open && isBusy) {
+            return;
+          }
           setDialogOpen(open);
           if (!open) {
             setIconPickerOpen(false);
@@ -338,13 +370,7 @@ export default function ProjectScriptsControl({
         }}
         onOpenChangeComplete={(open) => {
           if (open) return;
-          setEditingScriptId(null);
-          setName("");
-          setCommand("");
-          setIcon("play");
-          setRunOnWorktreeCreate(false);
-          setKeybinding("");
-          setValidationError(null);
+          resetDialogState();
         }}
         open={dialogOpen}
       >
@@ -368,6 +394,7 @@ export default function ProjectScriptsControl({
                           variant="outline"
                           className="size-9 shrink-0 hover:bg-popover active:bg-popover data-pressed:bg-popover data-pressed:shadow-xs/5 data-pressed:before:shadow-[0_1px_--theme(--color-black/4%)] dark:data-pressed:before:shadow-[0_-1px_--theme(--color-white/6%)]"
                           aria-label="Choose icon"
+                          disabled={isBusy}
                         />
                       }
                     >
@@ -386,6 +413,7 @@ export default function ProjectScriptsControl({
                                   ? "border-primary/70 bg-primary/10"
                                   : "border-border/70 hover:bg-accent/60"
                               }`}
+                              disabled={isBusy}
                               onClick={() => {
                                 setIcon(entry.id);
                                 setIconPickerOpen(false);
@@ -403,6 +431,7 @@ export default function ProjectScriptsControl({
                     id="script-name"
                     placeholder="Test"
                     value={name}
+                    disabled={isBusy}
                     onChange={(event) => setName(event.target.value)}
                   />
                 </div>
@@ -413,6 +442,7 @@ export default function ProjectScriptsControl({
                   id="script-keybinding"
                   placeholder="Press shortcut"
                   value={keybinding}
+                  disabled={isBusy}
                   readOnly
                   onKeyDown={captureKeybinding}
                 />
@@ -426,6 +456,7 @@ export default function ProjectScriptsControl({
                   id="script-command"
                   placeholder="bun test"
                   value={command}
+                  disabled={isBusy}
                   onChange={(event) => setCommand(event.target.value)}
                 />
               </div>
@@ -433,25 +464,46 @@ export default function ProjectScriptsControl({
                 <span>Run automatically on worktree creation</span>
                 <Switch
                   checked={runOnWorktreeCreate}
+                  disabled={isBusy}
                   onCheckedChange={(checked) => setRunOnWorktreeCreate(Boolean(checked))}
                 />
               </label>
               {validationError && <p className="text-sm text-destructive">{validationError}</p>}
             </form>
           </DialogPanel>
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => {
-                setDialogOpen(false);
-              }}
-            >
-              Cancel
-            </Button>
-            <Button form={addScriptFormId} type="submit">
-              {isEditing ? "Save changes" : "Save action"}
-            </Button>
+          <DialogFooter className={isEditing ? "sm:justify-between" : undefined}>
+            {isEditing ? (
+              <Button
+                type="button"
+                variant="destructive-outline"
+                disabled={isBusy}
+                onClick={() => {
+                  void deleteScript();
+                }}
+              >
+                <Trash2Icon className="size-3.5" />
+                {pendingAction === "delete" ? "Deleting..." : "Delete action"}
+              </Button>
+            ) : null}
+            <div className="flex flex-col-reverse gap-2 sm:flex-row">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isBusy}
+                onClick={() => {
+                  setDialogOpen(false);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button form={addScriptFormId} type="submit" disabled={isBusy}>
+                {pendingAction === "save"
+                  ? "Saving..."
+                  : isEditing
+                    ? "Save changes"
+                    : "Save action"}
+              </Button>
+            </div>
           </DialogFooter>
         </DialogPopup>
       </Dialog>

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -349,6 +349,18 @@ describe("wsNativeApi", () => {
     });
   });
 
+  it("forwards keybinding deletions to the websocket server method", async () => {
+    requestMock.mockResolvedValue({ keybindings: [], issues: [] });
+    const { createWsNativeApi } = await import("./wsNativeApi");
+
+    const api = createWsNativeApi();
+    await api.server.deleteKeybinding({ command: "script.run-tests.run" });
+
+    expect(requestMock).toHaveBeenCalledWith(WS_METHODS.serverDeleteKeybinding, {
+      command: "script.run-tests.run",
+    });
+  });
+
   it("forwards full-thread diff requests to the orchestration websocket method", async () => {
     requestMock.mockResolvedValue({ diff: "patch" });
     const { createWsNativeApi } = await import("./wsNativeApi");

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -185,6 +185,7 @@ export function createWsNativeApi(): NativeApi {
     server: {
       getConfig: () => transport.request(WS_METHODS.serverGetConfig),
       upsertKeybinding: (input) => transport.request(WS_METHODS.serverUpsertKeybinding, input),
+      deleteKeybinding: (input) => transport.request(WS_METHODS.serverDeleteKeybinding, input),
     },
     orchestration: {
       getSnapshot: () => transport.request(ORCHESTRATION_WS_METHODS.getSnapshot),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -30,7 +30,12 @@ import type {
   TerminalSessionSnapshot,
   TerminalWriteInput,
 } from "./terminal";
-import type { ServerUpsertKeybindingInput, ServerUpsertKeybindingResult } from "./server";
+import type {
+  ServerDeleteKeybindingInput,
+  ServerDeleteKeybindingResult,
+  ServerUpsertKeybindingInput,
+  ServerUpsertKeybindingResult,
+} from "./server";
 import type {
   ClientOrchestrationCommand,
   OrchestrationGetFullThreadDiffInput,
@@ -137,6 +142,7 @@ export interface NativeApi {
   server: {
     getConfig: () => Promise<ServerConfig>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;
+    deleteKeybinding: (input: ServerDeleteKeybindingInput) => Promise<ServerDeleteKeybindingResult>;
   };
   orchestration: {
     getSnapshot: () => Promise<OrchestrationReadModel>;

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 import { IsoDateTime, TrimmedNonEmptyString } from "./baseSchemas";
-import { KeybindingRule, ResolvedKeybindingsConfig } from "./keybindings";
+import { KeybindingCommand, KeybindingRule, ResolvedKeybindingsConfig } from "./keybindings";
 import { EditorId } from "./editor";
 import { ProviderKind } from "./orchestration";
 
@@ -63,6 +63,17 @@ export const ServerUpsertKeybindingResult = Schema.Struct({
   issues: ServerConfigIssues,
 });
 export type ServerUpsertKeybindingResult = typeof ServerUpsertKeybindingResult.Type;
+
+export const ServerDeleteKeybindingInput = Schema.Struct({
+  command: KeybindingCommand,
+});
+export type ServerDeleteKeybindingInput = typeof ServerDeleteKeybindingInput.Type;
+
+export const ServerDeleteKeybindingResult = Schema.Struct({
+  keybindings: ResolvedKeybindingsConfig,
+  issues: ServerConfigIssues,
+});
+export type ServerDeleteKeybindingResult = typeof ServerDeleteKeybindingResult.Type;
 
 export const ServerConfigUpdatedPayload = Schema.Struct({
   issues: ServerConfigIssues,

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -29,6 +29,7 @@ import {
   TerminalWriteInput,
 } from "./terminal";
 import { KeybindingRule } from "./keybindings";
+import { ServerDeleteKeybindingInput } from "./server";
 import { ProjectSearchEntriesInput, ProjectWriteFileInput } from "./project";
 import { OpenInEditorInput } from "./editor";
 
@@ -67,6 +68,7 @@ export const WS_METHODS = {
   // Server meta
   serverGetConfig: "server.getConfig",
   serverUpsertKeybinding: "server.upsertKeybinding",
+  serverDeleteKeybinding: "server.deleteKeybinding",
 } as const;
 
 // ── Push Event Channels ──────────────────────────────────────────────
@@ -129,6 +131,7 @@ const WebSocketRequestBody = Schema.Union([
   // Server meta
   tagRequestBody(WS_METHODS.serverGetConfig, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverUpsertKeybinding, KeybindingRule),
+  tagRequestBody(WS_METHODS.serverDeleteKeybinding, ServerDeleteKeybindingInput),
 ]);
 
 export const WebSocketRequest = Schema.Struct({


### PR DESCRIPTION
**Add delete support for project actions and fix stale keybinding cleanup**

- Add destructive Delete button to the project action edit dialog
- Disable dialog controls while save or delete operations are in flight
- Persist action removal through ChatView
- Clean up stale shortcuts when a keybinding is cleared during editing
- Add explicit keybinding deletion through shared contracts and server path
- Add websocket/native API and server-side test coverage

bun lint passed and bun typecheck passed. Running apps/server/src/keybindings.test.ts still surfaces an existing Windows-specific permission test failure unrelated to this feature.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add delete actions by implementing `KeybindingsShape.deleteKeybindingRule` and wiring `WS_METHODS.serverDeleteKeybinding` through server and web clients
> Introduce keybinding deletion across server and web: add `deleteKeybindingRule` with atomic persist-and-cache updates in [apps/server/src/keybindings.ts](https://github.com/pingdotgg/t3code/pull/222/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e), route `serverDeleteKeybinding` in [apps/server/src/wsServer.ts](https://github.com/pingdotgg/t3code/pull/222/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679), expose `deleteKeybinding` in [apps/web/src/wsNativeApi.ts](https://github.com/pingdotgg/t3code/pull/222/files#diff-eae2e1e3878c14b7af9318605dd9eed50d08123751d3748fb1feadf12daa30f4), and call it from script delete flows in [apps/web/src/components/ChatView.tsx](https://github.com/pingdotgg/t3code/pull/222/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [apps/web/src/components/ProjectScriptsControl.tsx](https://github.com/pingdotgg/t3code/pull/222/files#diff-e891caffa18ba1b7506cceb8fe52ad48887e3161ef59bee56d37cd57b61c511b). Add tests for server and websocket behavior.
>
> #### 📍Where to Start
> Start with the `makeKeybindings` factory and `deleteKeybindingRule` implementation in [apps/server/src/keybindings.ts](https://github.com/pingdotgg/t3code/pull/222/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb0a47a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->