### PR TITLE
#221: Fix missing list markers in chat markdown

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -263,9 +263,30 @@ label:has(> select#reasoning-effort) select {
   margin: 0.65rem 0;
 }
 
-.chat-markdown ul,
+.chat-markdown ul {
+  padding-left: 1.25rem;
+  list-style-type: disc;
+}
+
 .chat-markdown ol {
   padding-left: 1.25rem;
+  list-style-type: decimal;
+}
+
+.chat-markdown ul ul {
+  list-style-type: circle;
+}
+
+.chat-markdown ul ul ul {
+  list-style-type: square;
+}
+
+.chat-markdown ol ol {
+  list-style-type: lower-alpha;
+}
+
+.chat-markdown ol ol ol {
+  list-style-type: lower-roman;
 }
 
 .chat-markdown li + li {


### PR DESCRIPTION
Tailwind v4 Preflight resets list-style to none on ul/ol elements. Restore disc/decimal markers and add nested list style variants (circle, square, lower-alpha, lower-roman) for visual distinction.


<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td><img width="932" height="774" alt="image" src="https://github.com/user-attachments/assets/a4934cb1-62d4-4e82-acf2-601647b07ae8" /></td>
        <td><img width="804" height="786" alt="image" src="https://github.com/user-attachments/assets/272b1727-cd22-4c85-9d52-4b96fe0b5538" /></td>
    </tr>
</table>
