### PR TITLE
Correct installation command for T3 Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ T3 Code is a minimal web GUI for coding agents. Currently Codex-first, with Clau
 > You need to have [Codex CLI](https://github.com/openai/codex) installed and authorized for T3 Code to work.
 
 ```bash
-npx t3
+npx t3@alpha
 ```
 
 You can also just install the desktop app. It's cooler.


### PR DESCRIPTION
Fixes #232 

I don't like to just make readme fixing PRs, but I think I should for this. because some people are facing problems because of this like #202. I am assuming this PR will be allowed as I am not making any change to the app. Hoping I will be allowed to do that soon

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README usage snippet to use the installation command `npx t3@alpha` in [README.md](https://github.com/pingdotgg/t3code/pull/235/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to correct T3 Code installation instructions
> Replace the CLI example `npx t3` with `npx t3@alpha` in [README.md](https://github.com/pingdotgg/t3code/pull/235/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).
>
> #### 📍Where to Start
> Start with the README usage section in [README.md](https://github.com/pingdotgg/t3code/pull/235/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f982a5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->