### PR TITLE
Fix fish shell PATH bootstrap on macOS

### DIFF
--- a/apps/desktop/src/fixPath.ts
+++ b/apps/desktop/src/fixPath.ts
@@ -5,10 +5,10 @@ export function fixPath(): void {
 
   try {
     const shell = process.env.SHELL ?? "/bin/zsh";
-    const result = ChildProcess.execFileSync(shell, ["-ilc", "echo -n $PATH"], {
+    const result = ChildProcess.execFileSync(shell, ["-ilc", 'printf "%s" "$PATH"'], {
       encoding: "utf8",
       timeout: 5000,
-    });
+    }).trim();
     if (result) {
       process.env.PATH = result;
     }

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -7,10 +7,10 @@ export function fixPath(): void {
 
   try {
     const shell = process.env.SHELL ?? "/bin/zsh";
-    const result = execFileSync(shell, ["-ilc", "echo -n $PATH"], {
+    const result = execFileSync(shell, ["-ilc", 'printf "%s" "$PATH"'], {
       encoding: "utf8",
       timeout: 5000,
-    });
+    }).trim();
     if (result) {
       process.env.PATH = result;
     }


### PR DESCRIPTION
## Summary
- replace `echo -n $PATH` with `printf "%s" "$PATH"` in macOS `fixPath()` bootstraps
- trim shell output before assigning `process.env.PATH`
- apply the fix in both server and desktop startup paths

## Why
`$PATH` is list-typed in fish. The previous unquoted expansion could produce a space-separated value, which breaks command resolution in Node and can surface as `spawn ... ENOENT`.

## Validation
- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fish shell PATH bootstrap on macOS by sourcing `process.env.PATH` via `apps/desktop/src/fixPath.ts:fixPath` and `apps/server/src/os-jank.ts:fixPath` using `printf "%s" "$PATH"` and trimming the result
> Replace `echo -n $PATH` with `printf "%s" "$PATH"` and apply `.trim()` to the `execFileSync` result before assigning to `process.env.PATH`. Changes occur in [fixPath.ts](https://github.com/pingdotgg/t3code/pull/239/files#diff-b5a16ed958b8e407001f062cf0edea569a7adceeb262d35d520692991a3c3a11) and [os-jank.ts](https://github.com/pingdotgg/t3code/pull/239/files#diff-01387cb8f0521a1e152ae377c15805f328384e404ccf93da7a82c02d30cf694c).
>
> #### 📍Where to Start
> Start with the `fixPath` implementation in [fixPath.ts](https://github.com/pingdotgg/t3code/pull/239/files#diff-b5a16ed958b8e407001f062cf0edea569a7adceeb262d35d520692991a3c3a11), then review the parallel change in [os-jank.ts](https://github.com/pingdotgg/t3code/pull/239/files#diff-01387cb8f0521a1e152ae377c15805f328384e404ccf93da7a82c02d30cf694c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20f149a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->