### PR TITLE
test: fix CheckpointReactor rollback assertions for threadId

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -845,7 +845,7 @@ describe("CheckpointReactor", () => {
     expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
     expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
     expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
-      
+      threadId: ThreadId.makeUnsafe("thread-1"),
       numTurns: 1,
     });
     expect(fs.readFileSync(path.join(harness.cwd, "README.md"), "utf8")).toBe("v2\n");
@@ -918,7 +918,7 @@ describe("CheckpointReactor", () => {
     await waitForEvent(harness.engine, (event) => event.type === "thread.reverted");
     expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(1);
     expect(harness.provider.rollbackConversation).toHaveBeenCalledWith({
-      
+      threadId: ThreadId.makeUnsafe("thread-1"),
       numTurns: 1,
     });
   });
@@ -1008,11 +1008,11 @@ describe("CheckpointReactor", () => {
 
     expect(harness.provider.rollbackConversation).toHaveBeenCalledTimes(2);
     expect(harness.provider.rollbackConversation.mock.calls[0]?.[0]).toEqual({
-      
+      threadId: ThreadId.makeUnsafe("thread-1"),
       numTurns: 1,
     });
     expect(harness.provider.rollbackConversation.mock.calls[1]?.[0]).toEqual({
-      
+      threadId: ThreadId.makeUnsafe("thread-1"),
       numTurns: 1,
     });
   });


### PR DESCRIPTION
Fixes the failing CI assertions in CheckpointReactor.test.ts for PR #178.

The rollback call payload now includes threadId; this updates expectations to match the current provider contract.

Validated locally:
- bun run test src/orchestration/Layers/CheckpointReactor.test.ts
- bun lint
- bun typecheck

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CheckpointReactor tests to assert `provider.rollbackConversation` receives `threadId: ThreadId.makeUnsafe("thread-1")` and `numTurns: 1` in [CheckpointReactor.test.ts](https://github.com/pingdotgg/t3code/pull/242/files#diff-80f47e48c3258a501e94a5ba8b5ee0e8871faf64acfe837965b6ca6caf324279)
> Update three assertions to include `threadId` alongside `numTurns` when verifying `provider.rollbackConversation` calls in [CheckpointReactor.test.ts](https://github.com/pingdotgg/t3code/pull/242/files#diff-80f47e48c3258a501e94a5ba8b5ee0e8871faf64acfe837965b6ca6caf324279).
>
> #### 📍Where to Start
> Start with the modified assertions around `provider.rollbackConversation` in [CheckpointReactor.test.ts](https://github.com/pingdotgg/t3code/pull/242/files#diff-80f47e48c3258a501e94a5ba8b5ee0e8871faf64acfe837965b6ca6caf324279).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d273ce7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->