### PR TITLE
test: align Claude adapter thread identity assertions

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCodeAdapter.test.ts
@@ -546,14 +546,14 @@ describe("ClaudeCodeAdapterLive", () => {
         provider: "claudeCode",
         runtimeMode: "full-access",
       });
-      assert.equal(session.threadId, undefined);
+      assert.equal(String(session.threadId), String(THREAD_ID));
 
       const turn = yield* adapter.sendTurn({
         threadId: session.threadId,
         input: "hello",
         attachments: [],
       });
-      assert.equal(turn.threadId, undefined);
+      assert.equal(String(turn.threadId), String(THREAD_ID));
 
       harness.query.emit({
         type: "stream_event",
@@ -592,13 +592,14 @@ describe("ClaudeCodeAdapterLive", () => {
       const sessionStarted = runtimeEvents[0];
       assert.equal(sessionStarted?.type, "session.started");
       if (sessionStarted?.type === "session.started") {
-        assert.equal("threadId" in sessionStarted, false);
+        assert.equal(String(sessionStarted.threadId), String(THREAD_ID));
       }
 
       const threadStarted = runtimeEvents[4];
       assert.equal(threadStarted?.type, "thread.started");
       if (threadStarted?.type === "thread.started") {
-        assert.equal(threadStarted.threadId, "sdk-thread-real");
+        assert.equal(String(threadStarted.threadId), String(THREAD_ID));
+        assert.equal(threadStarted.payload.providerThreadId, "sdk-thread-real");
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
@@ -700,9 +701,9 @@ describe("ClaudeCodeAdapterLive", () => {
         runtimeMode: "full-access",
       });
 
-      assert.equal(session.threadId, "resume-thread-1");
+      assert.equal(String(session.threadId), String(RESUME_THREAD_ID));
       assert.deepEqual(session.resumeCursor, {
-        threadId: "resume-thread-1",
+        threadId: String(RESUME_THREAD_ID),
         resume: "550e8400-e29b-41d4-a716-446655440000",
         resumeSessionAt: "assistant-99",
         turnCount: 3,
@@ -849,7 +850,7 @@ describe("ClaudeCodeAdapterLive", () => {
       event?: {
         provider?: string;
         method?: string;
-        threadId?: string;
+        providerThreadId?: string;
         turnId?: string;
       };
     }> = [];
@@ -911,7 +912,10 @@ describe("ClaudeCodeAdapterLive", () => {
 
       assert.equal(nativeEvents.length > 0, true);
       assert.equal(nativeEvents.some((record) => record.event?.provider === "claudeCode"), true);
-      assert.equal(nativeEvents.some((record) => String(record.event?.threadId) === String(session.threadId)), true);
+      assert.equal(
+        nativeEvents.some((record) => record.event?.providerThreadId === "sdk-session-native-log"),
+        true,
+      );
       assert.equal(
         nativeEvents.some((record) => String(record.event?.turnId) === String(turn.turnId)),
         true,


### PR DESCRIPTION
Fixes the failing CI assertions in ClaudeCodeAdapter.test.ts for PR #179.

Updates stale expectations to match current adapter behavior:
- Session/turn IDs remain on the orchestrator thread ID
- thread.started carries providerThreadId in payload
- native observability records assert providerThreadId instead of threadId
- resume cursor threadId reflects the active orchestrator thread ID

Validated locally:
- bun run test src/provider/Layers/ClaudeCodeAdapter.test.ts
- bun lint
- bun typecheck

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align Claude adapter tests to assert external thread IDs and provider-native identifiers in [ClaudeCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/243/files#diff-57eb2a330ee37568abf6f0d15aad4a9fa1fe4578f5814db0214af7691fa7511f)
> Updates tests to assert `session.threadId` and `turn.threadId` as external IDs via `String(...)`, expect `thread.started` to include `payload.providerThreadId`, and switch native observability checks from `event.event.threadId` to `event.event.providerThreadId` in [ClaudeCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/243/files#diff-57eb2a330ee37568abf6f0d15aad4a9fa1fe4578f5814db0214af7691fa7511f).
>
> #### 📍Where to Start
> Start with the test cases in [ClaudeCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/243/files#diff-57eb2a330ee37568abf6f0d15aad4a9fa1fe4578f5814db0214af7691fa7511f), focusing on expectations for `session.threadId`, `turn.threadId`, `thread.started` payloads, and observability event assertions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47ddb15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->