### PR TITLE
Fix desktop/server PATH resolution and startup check for codex

### DIFF
--- a/apps/desktop/src/fixPath.ts
+++ b/apps/desktop/src/fixPath.ts
@@ -1,14 +1,11 @@
-import * as ChildProcess from "node:child_process";
+import { resolveLoginShellPath } from "@t3tools/shared/shellPath";
 
 export function fixPath(): void {
-  if (process.platform !== "darwin") return;
+  if (process.platform === "win32") return;
 
   try {
-    const shell = process.env.SHELL ?? "/bin/zsh";
-    const result = ChildProcess.execFileSync(shell, ["-ilc", "echo -n $PATH"], {
-      encoding: "utf8",
-      timeout: 5000,
-    });
+    const shell = process.env.SHELL ?? (process.platform === "darwin" ? "/bin/zsh" : "/bin/sh");
+    const result = resolveLoginShellPath(shell, process.env);
     if (result) {
       process.env.PATH = result;
     }

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -235,12 +235,10 @@ export const recordStartupHeartbeat = Effect.gen(function* () {
   });
 });
 
-const makeServerProgram = (input: CliInput) =>
+const makeServerProgram = () =>
   Effect.gen(function* () {
-    const cliConfig = yield* CliConfig;
     const { start, stopSignal } = yield* Server;
     const openDeps = yield* Open;
-    yield* cliConfig.fixPath;
 
     const config = yield* ServerConfig;
 
@@ -280,7 +278,7 @@ const makeServerProgram = (input: CliInput) =>
     }
 
     return yield* stopSignal;
-  }).pipe(Effect.provide(LayerLive(input)));
+  });
 
 /**
  * These flags mirrors the environment variables and the config shape.
@@ -343,5 +341,12 @@ export const t3Cli = Command.make("t3", {
   logWebSocketEvents: logWebSocketEventsFlag,
 }).pipe(
   Command.withDescription("Run the T3 Code server."),
-  Command.withHandler((input) => Effect.scoped(makeServerProgram(input))),
+  Command.withHandler((input) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* Effect.sync(fixPath);
+        return yield* makeServerProgram().pipe(Effect.provide(LayerLive(input)));
+      }),
+    ),
+  ),
 );

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -1,16 +1,14 @@
 import * as OS from "node:os";
 import { Effect, Path } from "effect";
-import { execFileSync } from "node:child_process";
+
+import { resolveLoginShellPath } from "@t3tools/shared/shellPath";
 
 export function fixPath(): void {
-  if (process.platform !== "darwin") return;
+  if (process.platform === "win32") return;
 
   try {
-    const shell = process.env.SHELL ?? "/bin/zsh";
-    const result = execFileSync(shell, ["-ilc", "echo -n $PATH"], {
-      encoding: "utf8",
-      timeout: 5000,
-    });
+    const shell = process.env.SHELL ?? (process.platform === "darwin" ? "/bin/zsh" : "/bin/sh");
+    const result = resolveLoginShellPath(shell, process.env);
     if (result) {
       process.env.PATH = result;
     }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,10 @@
       "types": "./src/logging.ts",
       "import": "./src/logging.ts"
     },
+    "./shellPath": {
+      "types": "./src/shellPath.ts",
+      "import": "./src/shellPath.ts"
+    },
     "./Net": {
       "types": "./src/Net.ts",
       "import": "./src/Net.ts"

--- a/packages/shared/src/shellPath.test.ts
+++ b/packages/shared/src/shellPath.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+
+import { it } from "@effect/vitest";
+
+import { normalizeShellPathOutput } from "./shellPath";
+
+it("normalizes colon-delimited shell PATH output", () => {
+  assert.strictEqual(
+    normalizeShellPathOutput("/usr/local/bin:/opt/homebrew/bin:/usr/bin"),
+    "/usr/local/bin:/opt/homebrew/bin:/usr/bin",
+  );
+});
+
+it("normalizes fish-style whitespace-delimited PATH output", () => {
+  assert.strictEqual(
+    normalizeShellPathOutput("/usr/local/bin /opt/homebrew/bin /usr/bin"),
+    "/usr/local/bin:/opt/homebrew/bin:/usr/bin",
+  );
+});
+
+it("strips ANSI control sequences from shell PATH output", () => {
+  assert.strictEqual(
+    normalizeShellPathOutput("\u001b[6 q/usr/local/bin:/opt/homebrew/bin\u001b[2 q"),
+    "/usr/local/bin:/opt/homebrew/bin",
+  );
+});

--- a/packages/shared/src/shellPath.ts
+++ b/packages/shared/src/shellPath.ts
@@ -1,0 +1,42 @@
+import { delimiter, basename } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const ESCAPE_CHARACTER = String.fromCharCode(27);
+const ANSI_ESCAPE_SEQUENCE = new RegExp(`${ESCAPE_CHARACTER}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+function getShellProbe(shellPath: string): ReadonlyArray<string> {
+  const shellName = basename(shellPath).toLowerCase();
+  if (shellName === "fish") {
+    return ["-ilc", "string join : $PATH"];
+  }
+  return ["-ilc", 'printf "%s" "$PATH"'];
+}
+
+export function normalizeShellPathOutput(raw: string): string | undefined {
+  const stripped = raw.replace(ANSI_ESCAPE_SEQUENCE, "").trim();
+  if (stripped.length === 0) return undefined;
+
+  const separator = stripped.includes(":") ? ":" : stripped.includes(";") ? ";" : undefined;
+  if (!separator) return undefined;
+
+  const segments = stripped
+    .split(separator)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+  if (segments.length === 0) return undefined;
+  return segments.join(delimiter);
+}
+
+export function resolveLoginShellPath(shellPath: string, env: NodeJS.ProcessEnv = process.env) {
+  const result = execFileSync(shellPath, [...getShellProbe(shellPath)], {
+    encoding: "utf8",
+    timeout: 5000,
+    env: {
+      ...env,
+      TERM: "dumb",
+    },
+  });
+
+  return normalizeShellPathOutput(result);
+}


### PR DESCRIPTION
> [!note]
> only saw theo mentioned as of right now this repo won't take external contribution after making this PR
https://www.youtube.com/watch?v=hDn8-fK3XaU
>
> sad to know but i hope the PR's description is detailed enough, and still helps with addressing this issue!

---

## Bug (related to #234):
- codex availability checks can fail at startup because the app/server process gets an incorrect or incomplete PATH, causing startup spawn failures and false “codex not installed/on PATH” errors.
	- in my case, the PATH was " \x1B[6 q/Users/ydai/.zerobrew/bin /opt/homebrew/bin " with  ANSI control sequences at both ends, and Space-delimited entries instead of colon-delimited 
- Server health probes could run before PATH repair during layer initialization.
- crash loop observed:
```
@t3tools/desktop:start: [10:59:35.373] INFO (#10): Migrations ran successfully
@t3tools/desktop:start: [10:59:35.375] ERROR (#10): RangeError: The value of "err" is out of range. It must be a negative integer. Received 1
@t3tools/desktop:start:     at Object.getSystemErrorName (node:util:331:11)
@t3tools/desktop:start:     at new ErrnoException (node:internal/errors:733:23)
@t3tools/desktop:start:     at ChildProcess.spawn (node:internal/child_process:421:11)
@t3tools/desktop:start:     at Module.spawn (node:child_process:810:9)
@t3tools/desktop:start:     at MixedScheduler.<anonymous> (file://personal/t3code/node_modules/.bun/@effect+platform-node-shared@https+++pkg.pr.new+Effect-TS+effect-smol+@effect+platform-node-shared@8881a9b606d84a6f5eb6615279138322984f5368+eecd35a1726d7096/node_modules/@effect/platform-node-shared/dist/NodeChildProcessSpawner.js:228:37)
@t3tools/desktop:start: [desktop] backend exited unexpectedly (code=1 signal=null); restarting in 500ms
```

## Cause:
- PATH normalization assumed shell output shape and did not robustly sanitize interactive shell artifacts.
- Non-Windows handling was inconsistent across desktop/server startup paths.
- Provider health check (`codex --version`) executed before PATH was reliably normalized.

## Fix:
- Add shared shell PATH resolver (`@t3tools/shared/shellPath`) with:
  - fish-aware probing
  - ANSI/control-sequence stripping
  - delimiter normalization
- Use shared resolver in desktop and server `fixPath` logic.
- Expand PATH repair to non-Windows startup paths (macOS + Linux).
- Ensure server `fixPath` executes before provider layer startup/health probing.
- Add focused tests for shell PATH normalization behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve PATH from login shells on macOS and Linux for desktop and server startup using `@t3tools/shared/shellPath` and run PATH normalization at CLI entry
> Move PATH resolution to a shared helper, update desktop and server `fixPath` to use it with OS-specific shells, and call PATH normalization in the CLI handler before server provisioning. Add shared exports and tests for PATH normalization.
>
> #### 📍Where to Start
> Start with the CLI handler in `t3Cli` to see PATH normalization and provisioning order in [main.ts](https://github.com/pingdotgg/t3code/pull/248/files#diff-4b5ca93a818c9edbd84d8a8ea2eb3c82a19d1c39e8cdcef478da4bb14f46b69a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eaf9336.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->