### PR TITLE
docs: add contributing guide for fork PR workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing
+
+Thanks for taking the time to contribute to T3 Code.
+
+This project is moving quickly, and the contribution process is still fairly lightweight. This document is meant to make the current workflow explicit so outside contributors know what to expect when opening issues or pull requests.
+
+## Before You Open a PR
+
+- Check for an existing issue or PR that already covers the same work.
+- Prefer small, focused changes over broad refactors unless the change clearly needs broader scope.
+- If the change affects behavior, include or update tests where possible.
+
+## Local Setup
+
+T3 Code uses Bun and a monorepo workspace.
+
+Typical setup:
+
+```bash
+bun install
+bun run lint
+bun run typecheck
+bun run test
+```
+
+Useful development commands are documented in [README.md](./README.md).
+
+## Pull Request Expectations
+
+When opening a PR, keep the description concrete:
+
+- what changed
+- why it changed
+- how you validated it locally
+
+For validation, prefer including exact commands, for example:
+
+```text
+- bun run lint
+- bun run typecheck
+- bun run test
+```
+
+## Fork PR Behavior
+
+If you are contributing from a fork, the current PR experience may look unusual even when your code is correct.
+
+### GitHub Actions
+
+The repository CI workflow lives in `.github/workflows/ci.yml` and runs:
+
+- `bun run lint`
+- `bun run typecheck`
+- `bun run test`
+
+For fork-based PRs, GitHub Actions may require maintainer approval before jobs actually start. In that case, the workflow can show `action_required` and no job logs will appear yet.
+
+If that happens, your PR is not necessarily failing because of code. It may simply be waiting for a maintainer to approve the workflow run.
+
+### Vercel Preview Checks
+
+Fork PRs may also show a red `Vercel` status with a message similar to:
+
+```text
+Authorization required to deploy.
+```
+
+That status is managed outside this repository. It does not come from `.github/workflows/ci.yml`, and it may fail even when the code and repository CI are otherwise fine.
+
+If your PR is red only because of Vercel authorization, call that out clearly in the PR discussion so maintainers can evaluate the code separately from deploy authorization.
+
+## What To Do If Checks Are Stuck
+
+If your PR is from a fork and checks are not green:
+
+1. Run `bun run lint`, `bun run typecheck`, and `bun run test` locally.
+2. Include those results in your PR description or a comment.
+3. If GitHub Actions shows `action_required`, ask a maintainer to approve the workflow run.
+4. If Vercel is the only red check, note that it may be a fork authorization issue rather than a code failure.
+
+## Issues
+
+Bug reports and contribution-quality issues are useful. Good issues usually include:
+
+- what happened
+- what you expected
+- clear reproduction steps
+- screenshots or logs when relevant
+- exact environment details when the problem may be platform-specific
+
+## Questions
+
+If you are unsure whether a contribution is a good fit, opening an issue first is a good default.


### PR DESCRIPTION
Adds a `CONTRIBUTING.md` that documents the current outside-contributor workflow.

This is intended to make fork-based PR behavior easier to understand, especially when:
- GitHub Actions `CI` is waiting in `action_required`
- `Vercel` is red due to deploy authorization on fork PRs

The goal is not to change policy in this PR, only to document the current behavior clearly so contributors know what to expect and how to validate changes locally.

Closes #249.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CONTRIBUTING.md documenting fork pull request workflow for GitHub Actions and Vercel in [CONTRIBUTING.md](https://github.com/pingdotgg/t3code/pull/250/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055)
> Add a new [CONTRIBUTING.md](https://github.com/pingdotgg/t3code/pull/250/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) with Bun setup commands, pull request expectations, fork PR behavior notes for GitHub Actions and Vercel, steps for stuck checks, and guidance for filing issues and questions.
>
> #### 📍Where to Start
> Start with the guidelines in [CONTRIBUTING.md](https://github.com/pingdotgg/t3code/pull/250/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f6a946.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->