### PR TITLE
fixed thread title icon resizing.

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3950,7 +3950,7 @@ const ChatHeader = memo(function ChatHeader({
           </Badge>
         )}
       </div>
-      <div className="@container/header-actions flex min-w-0 flex-1 items-center justify-end gap-2 @sm/header-actions:gap-3">
+      <div className="@container/header-actions flex shrink-0 items-center justify-end gap-2 @sm/header-actions:gap-3">
         {activeProjectScripts && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}


### PR DESCRIPTION
fixes resizing behaviour in the thread title

issue in-hand:
<img width="442" height="53" alt="image" src="https://github.com/user-attachments/assets/3c0905f6-4b5c-4cc3-af0a-c014fb50d86b" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ChatHeader header actions container sizing in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/252/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to resolve thread title icon resizing
> Update `ChatHeader` header actions `div` classes by replacing `flex-1 min-w-0` with `shrink-0` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/252/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> #### 📍Where to Start
> Begin with the `ChatHeader` component markup in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/252/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), focusing on the header actions container `className` change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53ad7bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->