### PR TITLE
fix: run fixPath() before provider health check layer construction

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -27,6 +27,12 @@ import { ServerLoggerLive } from "./serverLogger";
 import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
 import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
 
+// Resolve the full interactive-shell PATH early so that provider health checks
+// (which run during layer construction) can locate binaries installed via
+// Homebrew, nvm, fnm, etc.  On macOS, Electron inherits a minimal PATH that
+// typically excludes /opt/homebrew/bin and similar directories.
+fixPath();
+
 export class StartupError extends Data.TaggedError("StartupError")<{
   readonly message: string;
   readonly cause?: unknown;


### PR DESCRIPTION
## Summary

On macOS, Electron apps inherit a minimal `PATH` that typically excludes directories like `/opt/homebrew/bin`. The Codex provider health check (`ProviderHealthLive`) runs during layer construction in `LayerLive`, which happens **before** the existing `fixPath()` call in `makeServerProgram`. This means the health check cannot locate the `codex` binary even when it is properly installed via Homebrew or npm global, causing:

> Codex CLI (`codex`) is not installed or not on PATH.

This PR moves the `fixPath()` call to module-level in `main.ts` so it executes before any layer construction begins. The existing call inside `makeServerProgram` is kept as-is since `fixPath()` is idempotent.

## Reproduction

1. Install Codex CLI via npm global (`npm i -g @openai/codex`)
2. Open T3 Code (Alpha) on macOS — the Electron app does not include `/opt/homebrew/bin` in its PATH
3. Observe "Codex CLI (`codex`) is not installed or not on PATH" error in provider status

## Test plan

- [x] `bun lint` passes (0 errors)
- [x] `bun run test` passes (392 tests, 0 failures)
- [x] Existing `ProviderHealth.test.ts` tests still pass

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `apps/server` bootstrap `fixPath()` before constructing provider health check layers in [main.ts](https://github.com/pingdotgg/t3code/pull/268/files#diff-4b5ca93a818c9edbd84d8a8ea2eb3c82a19d1c39e8cdcef478da4bb14f46b69a)
> Insert an early call to `fixPath()` during module bootstrap in [main.ts](https://github.com/pingdotgg/t3code/pull/268/files#diff-4b5ca93a818c9edbd84d8a8ea2eb3c82a19d1c39e8cdcef478da4bb14f46b69a) before building layers and executing provider health checks.
>
> #### 📍Where to Start
> Begin at the module bootstrap in [main.ts](https://github.com/pingdotgg/t3code/pull/268/files#diff-4b5ca93a818c9edbd84d8a8ea2eb3c82a19d1c39e8cdcef478da4bb14f46b69a), focusing on the early `fixPath()` invocation and the subsequent health check layer construction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15a383b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->