### PR TITLE
Fix crash when rendering code blocks with unsupported languages (#266 & #210)

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -4,7 +4,7 @@ import {
   type SupportedLanguages,
 } from "@pierre/diffs";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import {
+import React, {
   Children,
   Suspense,
   isValidElement,
@@ -27,6 +27,27 @@ import { useTheme } from "../hooks/useTheme";
 import { resolveMarkdownFileLinkTarget } from "../markdown-links";
 import { readNativeApi } from "../nativeApi";
 import { preferredTerminalEditor } from "../terminal-links";
+
+class CodeHighlightErrorBoundary extends React.Component<
+  { fallback: ReactNode; children: ReactNode },
+  { hasError: boolean }
+> {
+  constructor(props: { fallback: ReactNode; children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
 
 interface ChatMarkdownProps {
   text: string;
@@ -99,6 +120,14 @@ function getHighlighterPromise(language: string): Promise<DiffsHighlighter> {
     themes: [resolveDiffThemeName("dark"), resolveDiffThemeName("light")],
     langs: [language as SupportedLanguages],
     preferredHighlighter: "shiki-js",
+  }).catch((err) => {
+    highlighterPromiseCache.delete(language);
+    if (language === "text") {
+      // "text" itself failed — Shiki cannot initialize at all, surface the error
+      throw err;
+    }
+    // Language not supported by Shiki — fall back to "text"
+    return getHighlighterPromise("text");
   });
   highlighterPromiseCache.set(language, promise);
   return promise;
@@ -179,10 +208,14 @@ function SuspenseShikiCodeBlock({
   }
 
   const highlighter = use(getHighlighterPromise(language));
-  const highlightedHtml = useMemo(
-    () => highlighter.codeToHtml(code, { lang: language, theme: themeName }),
-    [code, highlighter, language, themeName],
-  );
+  const highlightedHtml = useMemo(() => {
+    try {
+      return highlighter.codeToHtml(code, { lang: language, theme: themeName });
+    } catch {
+      // If highlighting fails for this language, render as plain text
+      return highlighter.codeToHtml(code, { lang: "text", theme: themeName });
+    }
+  }, [code, highlighter, language, themeName]);
 
   useEffect(() => {
     if (!isStreaming) {
@@ -235,14 +268,16 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
 
         return (
           <MarkdownCodeBlock code={codeBlock.code}>
-            <Suspense fallback={<pre {...props}>{children}</pre>}>
-              <SuspenseShikiCodeBlock
-                className={codeBlock.className}
-                code={codeBlock.code}
-                themeName={diffThemeName}
-                isStreaming={isStreaming}
-              />
-            </Suspense>
+            <CodeHighlightErrorBoundary fallback={<pre {...props}>{children}</pre>}>
+              <Suspense fallback={<pre {...props}>{children}</pre>}>
+                <SuspenseShikiCodeBlock
+                  className={codeBlock.className}
+                  code={codeBlock.code}
+                  themeName={diffThemeName}
+                  isStreaming={isStreaming}
+                />
+              </Suspense>
+            </CodeHighlightErrorBoundary>
           </MarkdownCodeBlock>
         );
       },


### PR DESCRIPTION
## Summary
- Fix app crash when the agent edits `.env` files or any file whose language identifier is not bundled in Shiki
- Add graceful fallback to plain text highlighting when `getSharedHighlighter` rejects for an unsupported language (e.g. `"env"`)
- Wrap `codeToHtml` in a try/catch so render-time language errors also fall back to `"text"` instead of throwing
- Add a `CodeHighlightErrorBoundary` around the Shiki `Suspense` block to prevent unhandled highlighting errors from crashing the entire chat thread

## Context
The root cause is in `ChatMarkdown.tsx` — the language extracted from a markdown code fence (e.g. ` ```env `) was cast directly to `SupportedLanguages` and passed to Shiki without validation. When Shiki didn't recognize the language, `resolveLanguage` threw an unhandled error that propagated through React and killed the thread.

## Testing
- `bun run lint` — 0 errors (4 pre-existing warnings, none from this change)
- `bun run typecheck` — 7/7 packages pass
- `bun run test` — 33/33 web test files pass, 281/281 tests pass (2 pre-existing test files `composerDraftStore.test.ts` and `terminalStateStore.test.ts` excluded — they fail on main due to missing `localStorage` in the test environment, unrelated to this change)

Closes #266
Closes #210 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent ChatMarkdown code block crashes by falling back to plain text when Shiki highlighter fails or language is unsupported in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/279/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05)
> Add `CodeHighlightErrorBoundary` to contain renderer errors, make `getHighlighterPromise` delete failed cache entries and retry with `text`, and update `SuspenseShikiCodeBlock` to catch `codeToHtml` errors and render as `text`.
>
> #### 📍Where to Start
> Start with the `CodeHighlightErrorBoundary` and its integration in the `pre` renderer within `markdownComponents` in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/279/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c487cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->