### PR TITLE
Add terminal font customization options

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import {
   clampTerminalFontSize,
+  DEFAULT_TERMINAL_FONT_FAMILY,
+  DEFAULT_TERMINAL_FONT_SIZE,
+  DEFAULT_TERMINAL_LINE_HEIGHT,
+  MAX_TERMINAL_LINE_HEIGHT,
+  MIN_TERMINAL_LINE_HEIGHT,
   getAppModelOptions,
   getSlashModelOptions,
   normalizeCustomModelSlugs,
   parsePersistedSettings,
+  resolveTerminalLineHeight,
   resolveTerminalFontFamily,
   resolveAppServiceTier,
   shouldShowFastTierIcon,
@@ -20,8 +26,9 @@ function createPersistedSettings(overrides: Record<string, unknown>): string {
     enableAssistantStreaming: false,
     codexServiceTier: "auto",
     customCodexModels: [],
-    terminalFontFamily: '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
-    terminalFontSize: 12,
+    terminalFontFamily: DEFAULT_TERMINAL_FONT_FAMILY,
+    terminalFontSize: DEFAULT_TERMINAL_FONT_SIZE,
+    terminalLineHeight: DEFAULT_TERMINAL_LINE_HEIGHT,
     ...overrides,
   });
 }
@@ -142,6 +149,18 @@ describe("clampTerminalFontSize", () => {
   });
 });
 
+describe("resolveTerminalLineHeight", () => {
+  it("falls back to the default option for invalid values", () => {
+    expect(resolveTerminalLineHeight(undefined)).toBe(DEFAULT_TERMINAL_LINE_HEIGHT);
+  });
+
+  it("clamps and rounds persisted values to the supported range", () => {
+    expect(resolveTerminalLineHeight(0.8)).toBe(MIN_TERMINAL_LINE_HEIGHT);
+    expect(resolveTerminalLineHeight(2.4)).toBe(MAX_TERMINAL_LINE_HEIGHT);
+    expect(resolveTerminalLineHeight(1.236)).toBe(1.24);
+  });
+});
+
 describe("parsePersistedSettings", () => {
   it("clamps persisted terminal font sizes instead of discarding the settings payload", () => {
     expect(
@@ -150,12 +169,14 @@ describe("parsePersistedSettings", () => {
           confirmThreadDelete: false,
           terminalFontFamily: "Fira Code, monospace",
           terminalFontSize: 99,
+          terminalLineHeight: 2.4,
         }),
       ),
     ).toMatchObject({
       confirmThreadDelete: false,
       terminalFontFamily: "Fira Code, monospace",
       terminalFontSize: 32,
+      terminalLineHeight: 2,
     });
   });
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -12,6 +12,9 @@ export const DEFAULT_TERMINAL_FONT_FAMILY =
 export const DEFAULT_TERMINAL_FONT_SIZE = 12;
 export const MIN_TERMINAL_FONT_SIZE = 8;
 export const MAX_TERMINAL_FONT_SIZE = 32;
+export const DEFAULT_TERMINAL_LINE_HEIGHT = 1.2;
+export const MIN_TERMINAL_LINE_HEIGHT = 1;
+export const MAX_TERMINAL_LINE_HEIGHT = 2;
 export const APP_SERVICE_TIER_OPTIONS = [
   {
     value: "auto",
@@ -56,6 +59,9 @@ const AppSettingsSchema = Schema.Struct({
   ),
   terminalFontSize: Schema.Number.pipe(
     Schema.withConstructorDefault(() => Option.some(DEFAULT_TERMINAL_FONT_SIZE)),
+  ),
+  terminalLineHeight: Schema.Number.pipe(
+    Schema.withConstructorDefault(() => Option.some(DEFAULT_TERMINAL_LINE_HEIGHT)),
   ),
 });
 export type AppSettings = typeof AppSettingsSchema.Type;
@@ -132,12 +138,21 @@ export function clampTerminalFontSize(fontSize: number | null | undefined): numb
   return Math.min(Math.max(rounded, MIN_TERMINAL_FONT_SIZE), MAX_TERMINAL_FONT_SIZE);
 }
 
+export function resolveTerminalLineHeight(lineHeight: number | null | undefined): number {
+  if (typeof lineHeight !== "number" || !Number.isFinite(lineHeight)) {
+    return DEFAULT_TERMINAL_LINE_HEIGHT;
+  }
+  const rounded = Math.round(lineHeight * 100) / 100;
+  return Math.min(Math.max(rounded, MIN_TERMINAL_LINE_HEIGHT), MAX_TERMINAL_LINE_HEIGHT);
+}
+
 function normalizeAppSettings(settings: AppSettings): AppSettings {
   return {
     ...settings,
     customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
     terminalFontFamily: resolveTerminalFontFamily(settings.terminalFontFamily),
     terminalFontSize: clampTerminalFontSize(settings.terminalFontSize),
+    terminalLineHeight: resolveTerminalLineHeight(settings.terminalLineHeight),
   };
 }
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -115,6 +115,7 @@ interface TerminalViewportProps {
   runtimeEnv?: Record<string, string>;
   terminalFontFamily: string;
   terminalFontSize: number;
+  terminalLineHeight: number;
   onSessionExited: () => void;
   focusRequestId: number;
   autoFocus: boolean;
@@ -129,6 +130,7 @@ function TerminalViewport({
   runtimeEnv,
   terminalFontFamily,
   terminalFontSize,
+  terminalLineHeight,
   onSessionExited,
   focusRequestId,
   autoFocus,
@@ -154,7 +156,7 @@ function TerminalViewport({
     const fitAddon = new FitAddon();
     const terminal = new Terminal({
       cursorBlink: true,
-      lineHeight: 1.2,
+      lineHeight: terminalLineHeight,
       fontSize: terminalFontSize,
       scrollback: 5_000,
       fontFamily: terminalFontFamily,
@@ -419,12 +421,14 @@ function TerminalViewport({
 
     const fontFamilyChanged = terminal.options.fontFamily !== terminalFontFamily;
     const fontSizeChanged = terminal.options.fontSize !== terminalFontSize;
-    if (!fontFamilyChanged && !fontSizeChanged) {
+    const lineHeightChanged = terminal.options.lineHeight !== terminalLineHeight;
+    if (!fontFamilyChanged && !fontSizeChanged && !lineHeightChanged) {
       return;
     }
 
     terminal.options.fontFamily = terminalFontFamily;
     terminal.options.fontSize = terminalFontSize;
+    terminal.options.lineHeight = terminalLineHeight;
 
     const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
     const frame = window.requestAnimationFrame(() => {
@@ -448,7 +452,7 @@ function TerminalViewport({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [terminalFontFamily, terminalFontSize, terminalId, threadId]);
+  }, [terminalFontFamily, terminalFontSize, terminalLineHeight, terminalId, threadId]);
 
   useEffect(() => {
     const api = readNativeApi();
@@ -673,6 +677,7 @@ export default function ThreadTerminalDrawer({
     : "Close Terminal";
   const terminalFontFamily = appSettings.terminalFontFamily;
   const terminalFontSize = appSettings.terminalFontSize;
+  const terminalLineHeight = appSettings.terminalLineHeight;
   const onSplitTerminalAction = useCallback(() => {
     if (hasReachedTerminalLimit) return;
     onSplitTerminal();
@@ -790,11 +795,10 @@ export default function ThreadTerminalDrawer({
         <div className="pointer-events-none absolute right-2 top-2 z-20">
           <div className="pointer-events-auto inline-flex items-center overflow-hidden rounded-md border border-border/80 bg-background/70">
             <TerminalActionButton
-              className={`p-1 text-foreground/90 transition-colors ${
-                hasReachedTerminalLimit
-                  ? "cursor-not-allowed opacity-45 hover:bg-transparent"
-                  : "hover:bg-accent"
-              }`}
+              className={`p-1 text-foreground/90 transition-colors ${hasReachedTerminalLimit
+                ? "cursor-not-allowed opacity-45 hover:bg-transparent"
+                : "hover:bg-accent"
+                }`}
               onClick={onSplitTerminalAction}
               label={splitTerminalActionLabel}
             >
@@ -802,11 +806,10 @@ export default function ThreadTerminalDrawer({
             </TerminalActionButton>
             <div className="h-4 w-px bg-border/80" />
             <TerminalActionButton
-              className={`p-1 text-foreground/90 transition-colors ${
-                hasReachedTerminalLimit
-                  ? "cursor-not-allowed opacity-45 hover:bg-transparent"
-                  : "hover:bg-accent"
-              }`}
+              className={`p-1 text-foreground/90 transition-colors ${hasReachedTerminalLimit
+                ? "cursor-not-allowed opacity-45 hover:bg-transparent"
+                : "hover:bg-accent"
+                }`}
               onClick={onNewTerminalAction}
               label={newTerminalActionLabel}
             >
@@ -837,9 +840,8 @@ export default function ThreadTerminalDrawer({
                 {visibleTerminalIds.map((terminalId) => (
                   <div
                     key={terminalId}
-                    className={`min-h-0 min-w-0 border-l first:border-l-0 ${
-                      terminalId === resolvedActiveTerminalId ? "border-border" : "border-border/70"
-                    }`}
+                    className={`min-h-0 min-w-0 border-l first:border-l-0 ${terminalId === resolvedActiveTerminalId ? "border-border" : "border-border/70"
+                      }`}
                     onMouseDown={() => {
                       if (terminalId !== resolvedActiveTerminalId) {
                         onActiveTerminalChange(terminalId);
@@ -854,6 +856,7 @@ export default function ThreadTerminalDrawer({
                         {...(runtimeEnv ? { runtimeEnv } : {})}
                         terminalFontFamily={terminalFontFamily}
                         terminalFontSize={terminalFontSize}
+                        terminalLineHeight={terminalLineHeight}
                         onSessionExited={() => onCloseTerminal(terminalId)}
                         focusRequestId={focusRequestId}
                         autoFocus={terminalId === resolvedActiveTerminalId}
@@ -874,6 +877,7 @@ export default function ThreadTerminalDrawer({
                   {...(runtimeEnv ? { runtimeEnv } : {})}
                   terminalFontFamily={terminalFontFamily}
                   terminalFontSize={terminalFontSize}
+                  terminalLineHeight={terminalLineHeight}
                   onSessionExited={() => onCloseTerminal(resolvedActiveTerminalId)}
                   focusRequestId={focusRequestId}
                   autoFocus
@@ -889,22 +893,20 @@ export default function ThreadTerminalDrawer({
               <div className="flex h-[22px] items-stretch justify-end border-b border-border/70">
                 <div className="inline-flex h-full items-stretch">
                   <TerminalActionButton
-                    className={`inline-flex h-full items-center px-1 text-foreground/90 transition-colors ${
-                      hasReachedTerminalLimit
-                        ? "cursor-not-allowed opacity-45 hover:bg-transparent"
-                        : "hover:bg-accent/70"
-                    }`}
+                    className={`inline-flex h-full items-center px-1 text-foreground/90 transition-colors ${hasReachedTerminalLimit
+                      ? "cursor-not-allowed opacity-45 hover:bg-transparent"
+                      : "hover:bg-accent/70"
+                      }`}
                     onClick={onSplitTerminalAction}
                     label={splitTerminalActionLabel}
                   >
                     <SquareSplitHorizontal className="size-3.25" />
                   </TerminalActionButton>
                   <TerminalActionButton
-                    className={`inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors ${
-                      hasReachedTerminalLimit
-                        ? "cursor-not-allowed opacity-45 hover:bg-transparent"
-                        : "hover:bg-accent/70"
-                    }`}
+                    className={`inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors ${hasReachedTerminalLimit
+                      ? "cursor-not-allowed opacity-45 hover:bg-transparent"
+                      : "hover:bg-accent/70"
+                      }`}
                     onClick={onNewTerminalAction}
                     label={newTerminalActionLabel}
                   >
@@ -933,11 +935,10 @@ export default function ThreadTerminalDrawer({
                       {showGroupHeaders && (
                         <button
                           type="button"
-                          className={`flex w-full items-center rounded px-1 py-0.5 text-[10px] uppercase tracking-[0.08em] ${
-                            isGroupActive
-                              ? "bg-accent/70 text-foreground"
-                              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                          }`}
+                          className={`flex w-full items-center rounded px-1 py-0.5 text-[10px] uppercase tracking-[0.08em] ${isGroupActive
+                            ? "bg-accent/70 text-foreground"
+                            : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                            }`}
                           onClick={() => onActiveTerminalChange(groupActiveTerminalId)}
                         >
                           {terminalGroup.terminalIds.length > 1
@@ -951,17 +952,15 @@ export default function ThreadTerminalDrawer({
                       >
                         {terminalGroup.terminalIds.map((terminalId) => {
                           const isActive = terminalId === resolvedActiveTerminalId;
-                          const closeTerminalLabel = `Close ${
-                            terminalLabelById.get(terminalId) ?? "terminal"
-                          }${isActive && closeShortcutLabel ? ` (${closeShortcutLabel})` : ""}`;
+                          const closeTerminalLabel = `Close ${terminalLabelById.get(terminalId) ?? "terminal"
+                            }${isActive && closeShortcutLabel ? ` (${closeShortcutLabel})` : ""}`;
                           return (
                             <div
                               key={terminalId}
-                              className={`group flex items-center gap-1 rounded px-1 py-0.5 text-[11px] ${
-                                isActive
-                                  ? "bg-accent text-foreground"
-                                  : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                              }`}
+                              className={`group flex items-center gap-1 rounded px-1 py-0.5 text-[11px] ${isActive
+                                ? "bg-accent text-foreground"
+                                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                                }`}
                             >
                               {showGroupHeaders && (
                                 <span className="text-[10px] text-muted-foreground/80">└</span>

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { type ProviderKind } from "@t3tools/contracts";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 import { ZapIcon } from "lucide-react";
@@ -8,9 +8,12 @@ import { ZapIcon } from "lucide-react";
 import {
   APP_SERVICE_TIER_OPTIONS,
   MAX_TERMINAL_FONT_SIZE,
+  MAX_TERMINAL_LINE_HEIGHT,
   MIN_TERMINAL_FONT_SIZE,
+  MIN_TERMINAL_LINE_HEIGHT,
   MAX_CUSTOM_MODEL_LENGTH,
   clampTerminalFontSize,
+  resolveTerminalLineHeight,
   shouldShowFastTierIcon,
   useAppSettings,
 } from "../appSettings";
@@ -109,36 +112,53 @@ function SettingsRouteView() {
   const codexServiceTier = settings.codexServiceTier;
   const terminalFontFamily = settings.terminalFontFamily;
   const terminalFontSize = settings.terminalFontSize;
+  const terminalLineHeight = settings.terminalLineHeight;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
-  const [terminalFontSizeInput, setTerminalFontSizeInput] = useState(() =>
-    String(terminalFontSize),
-  );
-
-  useEffect(() => {
-    setTerminalFontSizeInput(String(terminalFontSize));
-  }, [terminalFontSize]);
 
   const commitTerminalFontSize = useCallback(
-    (rawValue: string) => {
-      const trimmed = rawValue.trim();
+    (input: HTMLInputElement): void => {
+      const trimmed = input.value.trim();
       if (!trimmed) {
-        setTerminalFontSizeInput(String(terminalFontSize));
+        input.value = String(terminalFontSize);
         return;
       }
 
       const next = Number(trimmed);
       if (!Number.isFinite(next)) {
-        setTerminalFontSizeInput(String(terminalFontSize));
+        input.value = String(terminalFontSize);
         return;
       }
 
       const normalized = clampTerminalFontSize(next);
-      setTerminalFontSizeInput(String(normalized));
+      input.value = String(normalized);
       if (normalized !== terminalFontSize) {
         updateSettings({ terminalFontSize: normalized });
       }
     },
     [terminalFontSize, updateSettings],
+  );
+
+  const commitTerminalLineHeight = useCallback(
+    (input: HTMLInputElement): void => {
+      const trimmed = input.value.trim();
+      if (!trimmed) {
+        input.value = String(terminalLineHeight);
+        return;
+      }
+
+      const next = Number(trimmed);
+      if (!Number.isFinite(next)) {
+        input.value = String(terminalLineHeight);
+        return;
+      }
+
+      const normalized = resolveTerminalLineHeight(next);
+      input.value = String(normalized);
+      if (normalized !== terminalLineHeight) {
+        updateSettings({ terminalLineHeight: normalized });
+      }
+    },
+    [terminalLineHeight, updateSettings],
   );
 
   const openKeybindingsFile = useCallback(() => {
@@ -361,19 +381,17 @@ function SettingsRouteView() {
                 <label htmlFor="terminal-font-size" className="block space-y-1">
                   <span className="text-xs font-medium text-foreground">Terminal font size</span>
                   <Input
+                    key={terminalFontSize}
                     id="terminal-font-size"
                     type="number"
                     nativeInput
-                    value={terminalFontSizeInput}
+                    defaultValue={String(terminalFontSize)}
                     min={MIN_TERMINAL_FONT_SIZE}
                     max={MAX_TERMINAL_FONT_SIZE}
                     step={1}
                     inputMode="numeric"
-                    onChange={(event) => {
-                      setTerminalFontSizeInput(event.target.value);
-                    }}
                     onBlur={(event) => {
-                      commitTerminalFontSize(event.target.value);
+                      commitTerminalFontSize(event.currentTarget);
                     }}
                     onKeyDown={(event) => {
                       if (event.key === "Enter") {
@@ -386,8 +404,35 @@ function SettingsRouteView() {
                   </span>
                 </label>
 
+                <label htmlFor="terminal-line-height" className="block space-y-1">
+                  <span className="text-xs font-medium text-foreground">Terminal line height</span>
+                  <Input
+                    key={terminalLineHeight}
+                    id="terminal-line-height"
+                    type="number"
+                    nativeInput
+                    defaultValue={String(terminalLineHeight)}
+                    min={MIN_TERMINAL_LINE_HEIGHT}
+                    max={MAX_TERMINAL_LINE_HEIGHT}
+                    step={0.05}
+                    inputMode="decimal"
+                    onBlur={(event) => {
+                      commitTerminalLineHeight(event.currentTarget);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.currentTarget.blur();
+                      }
+                    }}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    Allowed range: {MIN_TERMINAL_LINE_HEIGHT} - {MAX_TERMINAL_LINE_HEIGHT}x.
+                  </span>
+                </label>
+
                 {terminalFontFamily !== defaults.terminalFontFamily ||
-                terminalFontSize !== defaults.terminalFontSize ? (
+                terminalFontSize !== defaults.terminalFontSize ||
+                terminalLineHeight !== defaults.terminalLineHeight ? (
                   <div className="flex justify-end">
                     <Button
                       size="xs"
@@ -396,6 +441,7 @@ function SettingsRouteView() {
                         updateSettings({
                           terminalFontFamily: defaults.terminalFontFamily,
                           terminalFontSize: defaults.terminalFontSize,
+                          terminalLineHeight: defaults.terminalLineHeight,
                         })
                       }
                     >


### PR DESCRIPTION
## Summary

- add terminal font family and font size preferences to app settings
- apply terminal typography changes live in the terminal drawer, including refit and resize handling
- add validation and tests for terminal font family fallback and font size clamping

## Why

This makes terminal panes easier to read and lets users match the terminal to their preferred coding setup without requiring any manual app configuration.
I just want to use my Nerd Fonts from my system.

## Screenshots
# Default Fonts
<img width="1248" height="813" alt="image" src="https://github.com/user-attachments/assets/62a22a32-0381-4898-b218-027a739539fb" />
<img width="1423" height="874" alt="image" src="https://github.com/user-attachments/assets/325d646e-9567-4dc8-bddf-f2d20046dac9" />
# After Adding Nerd Font
<img width="1248" height="813" alt="image" src="https://github.com/user-attachments/assets/7665c026-cfb2-4195-bca5-5d14c0d69412" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add terminal font customization by persisting `AppSettingsSchema` fields and wiring them to `ThreadTerminalDrawer` and `TerminalViewport`
> Add `terminalFontFamily`, `terminalFontSize` (clamped to min/max and rounded), and `terminalLineHeight` (clamped and rounded to 2 decimals) to settings; normalize via `resolveTerminalFontFamily`, `clampTerminalFontSize`, and `resolveTerminalLineHeight`; export `parsePersistedSettings`; pass settings into the terminal and update live; expose inputs in the chat settings UI.
>
> #### 📍Where to Start
> Start with `normalizeAppSettings` and new terminal typography utils in [apps/web/src/appSettings.ts](https://github.com/pingdotgg/t3code/pull/300/files#diff-4f500b80c5f743d5b39d3f07498169da0c26f4bf9b5a2127453a90c04a4c49cc), then review their use in `ThreadTerminalDrawer` and `TerminalViewport` in [apps/web/src/components/ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/300/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db68d11.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->