### PR TITLE
Fix `bun run dev:desktop` from not terminating properly on SIGINT/SIGTERM/SIGHUP

### DIFF
--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -43,7 +43,6 @@ class DevRunnerError extends Data.TaggedError("DevRunnerError")<{
   readonly cause?: unknown;
 }> {}
 
-
 const optionalStringConfig = (name: string): Config.Config<string | undefined> =>
   Config.string(name).pipe(
     Config.option,


### PR DESCRIPTION
While locally trying out the new t3code with `bun run dev:desktop` I noticed the spawned processes don't cleanup well after Ctrl+C.

Effect's `ChildProcess.make` defaults to `detached: true` on non-Windows, which puts turbo in a separate process group,

so Ctrl+C and other terminal signals only hit the parent processes, so turbo and its children survive after the dev runner exits.

Fix is to add `detached: false` so turbo shares the process group and receives signals directly. `forceKillAfter: "1500 millis"` acts as a safety net — if turbo ignores the signal, Effect sends SIGKILL after 1.5s during scope teardown.

<Incoming>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `scripts/dev-runner.ts` to keep the spawned turbo process in the same process group and enforce shutdown for `bun run dev:desktop` with a 1500ms kill timeout
> Set `detached: false` and `forceKillAfter: 1500ms` on `ChildProcess.make` within `scripts/dev-runner.ts` to ensure signal handling and forced termination.
>
> #### 📍Where to Start
> Start with `runDevRunnerWithInput` in [scripts/dev-runner.ts](https://github.com/pingdotgg/t3code/pull/305/files#diff-8ba446fc13205cee91be4164b3936316a911d90cfc2fb690c99c49ea439542bf).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f8ecb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->