### PR TITLE
Add scroll-to-bottom CTA in chat

### DIFF
--- a/apps/web/src/chat-scroll.test.ts
+++ b/apps/web/src/chat-scroll.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { AUTO_SCROLL_BOTTOM_THRESHOLD_PX, isScrollContainerNearBottom } from "./chat-scroll";
+import {
+  AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
+  isScrollContainerNearBottom,
+  shouldShowScrollToBottomButton,
+} from "./chat-scroll";
 
 describe("isScrollContainerNearBottom", () => {
   it("returns true when already at bottom", () => {
@@ -58,5 +62,37 @@ describe("isScrollContainerNearBottom", () => {
       ),
     ).toBe(true);
     expect(AUTO_SCROLL_BOTTOM_THRESHOLD_PX).toBe(64);
+  });
+});
+
+describe("shouldShowScrollToBottomButton", () => {
+  it("returns false when the viewport is already near the bottom", () => {
+    expect(
+      shouldShowScrollToBottomButton({
+        scrollTop: 540,
+        clientHeight: 400,
+        scrollHeight: 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when the viewport is meaningfully above the bottom", () => {
+    expect(
+      shouldShowScrollToBottomButton({
+        scrollTop: 520,
+        clientHeight: 400,
+        scrollHeight: 1_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for invalid positions to avoid flashing the CTA during setup", () => {
+    expect(
+      shouldShowScrollToBottomButton({
+        scrollTop: Number.NaN,
+        clientHeight: 400,
+        scrollHeight: 1_000,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/chat-scroll.ts
+++ b/apps/web/src/chat-scroll.ts
@@ -22,3 +22,10 @@ export function isScrollContainerNearBottom(
   const distanceFromBottom = scrollHeight - clientHeight - scrollTop;
   return distanceFromBottom <= threshold;
 }
+
+export function shouldShowScrollToBottomButton(
+  position: ScrollPosition,
+  thresholdPx = AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
+): boolean {
+  return !isScrollContainerNearBottom(position, thresholdPx);
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -79,7 +79,11 @@ import {
   formatElapsed,
   formatTimestamp,
 } from "../session-logic";
-import { AUTO_SCROLL_BOTTOM_THRESHOLD_PX, isScrollContainerNearBottom } from "../chat-scroll";
+import {
+  AUTO_SCROLL_BOTTOM_THRESHOLD_PX,
+  isScrollContainerNearBottom,
+  shouldShowScrollToBottomButton,
+} from "../chat-scroll";
 import {
   buildPendingUserInputAnswers,
   derivePendingUserInputProgress,
@@ -124,6 +128,7 @@ import ChatMarkdown from "./ChatMarkdown";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
 import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
 import {
+  ArrowDownIcon,
   BotIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -638,6 +643,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     Record<string, string[]>
   >({});
   const [composerCursor, setComposerCursor] = useState(() => prompt.length);
+  const [showScrollToBottomButton, setShowScrollToBottomButton] = useState(false);
   const [composerTrigger, setComposerTrigger] = useState<ComposerTrigger | null>(() =>
     detectComposerTrigger(prompt, prompt.length),
   );
@@ -670,10 +676,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const sendInFlightRef = useRef(false);
   const dragDepthRef = useRef(0);
   const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
+  const syncScrollToBottomButtonVisibility = useCallback((scrollContainer: HTMLDivElement | null) => {
+    const nextVisible = scrollContainer ? shouldShowScrollToBottomButton(scrollContainer) : false;
+    setShowScrollToBottomButton((current) => (current === nextVisible ? current : nextVisible));
+  }, []);
   const setMessagesScrollContainerRef = useCallback((element: HTMLDivElement | null) => {
     messagesScrollRef.current = element;
     setMessagesScrollElement(element);
-  }, []);
+    syncScrollToBottomButtonVisibility(element);
+  }, [syncScrollToBottomButtonVisibility]);
 
   const terminalState = useTerminalStateStore((state) =>
     selectThreadTerminalState(state.terminalStateByThreadId, threadId),
@@ -1693,7 +1704,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
     scrollContainer.scrollTo({ top: scrollContainer.scrollHeight, behavior });
     lastKnownScrollTopRef.current = scrollContainer.scrollTop;
     shouldAutoScrollRef.current = true;
-  }, []);
+    syncScrollToBottomButtonVisibility(scrollContainer);
+  }, [syncScrollToBottomButtonVisibility]);
   const cancelPendingStickToBottom = useCallback(() => {
     const pendingFrame = pendingAutoScrollFrameRef.current;
     if (pendingFrame === null) return;
@@ -1747,9 +1759,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
     },
     [cancelPendingInteractionAnchorAdjustment],
   );
-  const forceStickToBottom = useCallback(() => {
+  const forceStickToBottom = useCallback((behavior: ScrollBehavior = "auto") => {
     cancelPendingStickToBottom();
-    scrollMessagesToBottom();
+    scrollMessagesToBottom(behavior);
     scheduleStickToBottom();
   }, [cancelPendingStickToBottom, scheduleStickToBottom, scrollMessagesToBottom]);
   const onMessagesScroll = useCallback(() => {
@@ -1781,7 +1793,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
 
     lastKnownScrollTopRef.current = currentScrollTop;
-  }, []);
+    syncScrollToBottomButtonVisibility(scrollContainer);
+  }, [syncScrollToBottomButtonVisibility]);
   const onMessagesWheel = useCallback((event: React.WheelEvent<HTMLDivElement>) => {
     if (event.deltaY < 0) {
       pendingUserScrollUpIntentRef.current = true;
@@ -1813,6 +1826,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const onMessagesTouchEnd = useCallback((_event: React.TouchEvent<HTMLDivElement>) => {
     lastTouchClientYRef.current = null;
   }, []);
+  const onScrollToBottomButtonClick = useCallback(() => {
+    setShowScrollToBottomButton(false);
+    forceStickToBottom("smooth");
+  }, [forceStickToBottom]);
   useEffect(() => {
     return () => {
       cancelPendingStickToBottom();
@@ -1820,8 +1837,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
     };
   }, [cancelPendingInteractionAnchorAdjustment, cancelPendingStickToBottom]);
   useLayoutEffect(() => {
-    if (!activeThread?.id) return;
+    if (!activeThread?.id) {
+      setShowScrollToBottomButton(false);
+      return;
+    }
     shouldAutoScrollRef.current = true;
+    setShowScrollToBottomButton(false);
     scheduleStickToBottom();
     const timeout = window.setTimeout(() => {
       const scrollContainer = messagesScrollRef.current;
@@ -3348,43 +3369,61 @@ export default function ChatView({ threadId }: ChatViewProps) {
       <PlanModePanel activePlan={activePlan} />
 
       {/* Messages */}
-      <div
-        ref={setMessagesScrollContainerRef}
-        className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-y-contain px-3 py-3 sm:px-5 sm:py-4"
-        onScroll={onMessagesScroll}
-        onClickCapture={onMessagesClickCapture}
-        onWheel={onMessagesWheel}
-        onPointerDown={onMessagesPointerDown}
-        onPointerUp={onMessagesPointerUp}
-        onPointerCancel={onMessagesPointerCancel}
-        onTouchStart={onMessagesTouchStart}
-        onTouchMove={onMessagesTouchMove}
-        onTouchEnd={onMessagesTouchEnd}
-        onTouchCancel={onMessagesTouchEnd}
-      >
-        <MessagesTimeline
-          key={activeThread.id}
-          hasMessages={timelineEntries.length > 0}
-          isWorking={isWorking}
-          activeTurnInProgress={!latestTurnSettled}
-          activeTurnStartedAt={activeLatestTurn?.startedAt ?? null}
-          scrollContainer={messagesScrollElement}
-          timelineEntries={timelineEntries}
-          completionDividerBeforeEntryId={completionDividerBeforeEntryId}
-          completionSummary={completionSummary}
-          turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
-          nowIso={nowIso}
-          expandedWorkGroups={expandedWorkGroups}
-          onToggleWorkGroup={onToggleWorkGroup}
-          onOpenTurnDiff={onOpenTurnDiff}
-          revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
-          onRevertUserMessage={onRevertUserMessage}
-          isRevertingCheckpoint={isRevertingCheckpoint}
-          onImageExpand={onExpandTimelineImage}
-          markdownCwd={gitCwd ?? undefined}
-          resolvedTheme={resolvedTheme}
-          workspaceRoot={activeProject?.cwd ?? undefined}
-        />
+      <div className="relative min-h-0 flex-1">
+        <div
+          ref={setMessagesScrollContainerRef}
+          className="h-full min-h-0 overflow-x-hidden overflow-y-auto overscroll-y-contain px-3 py-3 sm:px-5 sm:py-4"
+          onScroll={onMessagesScroll}
+          onClickCapture={onMessagesClickCapture}
+          onWheel={onMessagesWheel}
+          onPointerDown={onMessagesPointerDown}
+          onPointerUp={onMessagesPointerUp}
+          onPointerCancel={onMessagesPointerCancel}
+          onTouchStart={onMessagesTouchStart}
+          onTouchMove={onMessagesTouchMove}
+          onTouchEnd={onMessagesTouchEnd}
+          onTouchCancel={onMessagesTouchEnd}
+        >
+          <MessagesTimeline
+            key={activeThread.id}
+            hasMessages={timelineEntries.length > 0}
+            isWorking={isWorking}
+            activeTurnInProgress={!latestTurnSettled}
+            activeTurnStartedAt={activeLatestTurn?.startedAt ?? null}
+            scrollContainer={messagesScrollElement}
+            timelineEntries={timelineEntries}
+            completionDividerBeforeEntryId={completionDividerBeforeEntryId}
+            completionSummary={completionSummary}
+            turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
+            nowIso={nowIso}
+            expandedWorkGroups={expandedWorkGroups}
+            onToggleWorkGroup={onToggleWorkGroup}
+            onOpenTurnDiff={onOpenTurnDiff}
+            revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
+            onRevertUserMessage={onRevertUserMessage}
+            isRevertingCheckpoint={isRevertingCheckpoint}
+            onImageExpand={onExpandTimelineImage}
+            markdownCwd={gitCwd ?? undefined}
+            resolvedTheme={resolvedTheme}
+            workspaceRoot={activeProject?.cwd ?? undefined}
+          />
+        </div>
+        {showScrollToBottomButton ? (
+          <div className="pointer-events-none absolute inset-x-0 bottom-3 z-10 px-3 sm:bottom-4 sm:px-5">
+            <div className="mx-auto flex max-w-3xl justify-center">
+              <Button
+                variant="default"
+                size="sm"
+                className="pointer-events-auto h-auto min-h-10 rounded-full border-primary px-4 py-2 shadow-lg shadow-primary/25 hover:!bg-primary hover:brightness-95 focus-visible:!bg-primary focus-visible:brightness-95 active:!bg-primary active:brightness-90"
+                onClick={onScrollToBottomButtonClick}
+                aria-label="Scroll to bottom"
+              >
+                <ArrowDownIcon aria-hidden="true" className="size-4" />
+                <span>Scroll to bottom</span>
+              </Button>
+            </div>
+          </div>
+        ) : null}
       </div>
 
       {/* Input bar */}


### PR DESCRIPTION
## Summary
- add a floating scroll-to-bottom CTA when the chat viewport is away from the latest messages
- reuse the existing bottom-threshold logic for CTA visibility and smooth-scroll back to the latest messages on click
- keep the CTA fully opaque and darken it on hover instead of using the default translucent primary hover treatment

## Validation
- `bun lint`
- `bun typecheck`
- Manual: verified the CTA in the local web app
- Manual: verified the CTA in the local desktop app


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will a


https://github.com/user-attachments/assets/7aaa7985-5e2d-4143-9591-271d83adffef



> [!NOTE]
> ### Add a scroll-to-bottom CTA in the ChatView and expose visibility logic via `apps/web/src/chat-scroll.ts::shouldShowScrollToBottomButton`
> Introduce `shouldShowScrollToBottomButton` and wire a conditional CTA in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/326/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) that updates on scroll, programmatic scrolls, and thread changes, with tests in [chat-scroll.test.ts](https://github.com/pingdotgg/t3code/pull/326/files#diff-5c167b89b4ddf5b0c8203bde37a93ac5d736bca7b647a03d2af76e9a55b044a9).
>
> #### 📍Where to Start
> Start with the CTA visibility logic in `shouldShowScrollToBottomButton` in [chat-scroll.ts](https://github.com/pingdotgg/t3code/pull/326/files#diff-2dbaaa9fc35eb50983b6790c6b894f1594ca817474f5cda7d60e50086be94df9), then review its integration in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/326/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c41424c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->