### PR TITLE
Fix Linux Codex PATH resolution and tagged desktop artifact version

### DIFF
--- a/apps/desktop/src/fixPath.ts
+++ b/apps/desktop/src/fixPath.ts
@@ -1,18 +1,28 @@
 import * as ChildProcess from "node:child_process";
 
 export function fixPath(): void {
-  if (process.platform !== "darwin") return;
+  if (process.platform === "win32") return;
 
-  try {
-    const shell = process.env.SHELL ?? "/bin/zsh";
-    const result = ChildProcess.execFileSync(shell, ["-ilc", "echo -n $PATH"], {
-      encoding: "utf8",
-      timeout: 5000,
-    });
-    if (result) {
-      process.env.PATH = result;
+  const shell = process.env.SHELL ?? (process.platform === "darwin" ? "/bin/zsh" : "/bin/sh");
+  const commandArgSets = [
+    ["-ilc", "echo -n $PATH"],
+    ["-lc", "echo -n $PATH"],
+  ] as const;
+
+  for (const args of commandArgSets) {
+    try {
+      const result = ChildProcess.execFileSync(shell, args, {
+        encoding: "utf8",
+        timeout: 5000,
+      });
+      if (result) {
+        process.env.PATH = result;
+        return;
+      }
+    } catch {
+      // Try the next shell invocation mode.
     }
-  } catch {
-    // Keep inherited PATH if shell lookup fails.
   }
+
+  // Keep inherited PATH if shell lookup fails.
 }

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -3,20 +3,30 @@ import { Effect, Path } from "effect";
 import { execFileSync } from "node:child_process";
 
 export function fixPath(): void {
-  if (process.platform !== "darwin") return;
+  if (process.platform === "win32") return;
 
-  try {
-    const shell = process.env.SHELL ?? "/bin/zsh";
-    const result = execFileSync(shell, ["-ilc", "echo -n $PATH"], {
-      encoding: "utf8",
-      timeout: 5000,
-    });
-    if (result) {
-      process.env.PATH = result;
+  const shell = process.env.SHELL ?? (process.platform === "darwin" ? "/bin/zsh" : "/bin/sh");
+  const commandArgSets = [
+    ["-ilc", "echo -n $PATH"],
+    ["-lc", "echo -n $PATH"],
+  ] as const;
+
+  for (const args of commandArgSets) {
+    try {
+      const result = execFileSync(shell, args, {
+        encoding: "utf8",
+        timeout: 5000,
+      });
+      if (result) {
+        process.env.PATH = result;
+        return;
+      }
+    } catch {
+      // Try the next shell invocation mode.
     }
-  } catch {
-    // Silently ignore — keep default PATH
   }
+
+  // Silently ignore and keep default PATH.
 }
 
 export const expandHomePath = Effect.fn(function* (input: string) {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -117,6 +117,30 @@ function resolveGitCommitHash(repoRoot: string): string {
   return hash.toLowerCase();
 }
 
+function resolveGitTaggedVersion(repoRoot: string): string | undefined {
+  const result = spawnSync("git", ["tag", "--points-at", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    return undefined;
+  }
+
+  const tags = result.stdout
+    .split("\n")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  for (const tag of tags) {
+    const match = tag.match(/^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return undefined;
+}
+
 function resolvePythonForNodeGyp(): string | undefined {
   const configured = process.env.npm_config_python ?? process.env.PYTHON;
   if (configured && existsSync(configured)) {
@@ -558,7 +582,8 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       }),
   });
 
-  const appVersion = options.version ?? serverPackageJson.version;
+  const tagVersion = resolveGitTaggedVersion(repoRoot);
+  const appVersion = options.version ?? tagVersion ?? serverPackageJson.version;
   const commitHash = resolveGitCommitHash(repoRoot);
   const mkdir = options.keepStage ? fs.makeTempDirectory : fs.makeTempDirectoryScoped;
   const stageRoot = yield* mkdir({


### PR DESCRIPTION
## What this PR changes
This PR fixes two practical issues discovered while testing the Linux AppImage build:

1. The desktop app could fail to find `codex` on Linux even when `codex` works in terminal.
2. Local desktop artifact builds from a tagged commit could still resolve to an older version number.

## Implementation notes
- Extended PATH bootstrap logic for desktop/server startup on Linux (while keeping Windows behavior unchanged).
- PATH is now resolved from shell startup context with safe fallback behavior.
- Updated desktop artifact version resolution order to prefer:
  1. explicit `--build-version`
  2. exact semver git tag on `HEAD` (`vX.Y.Z`)
  3. package fallback version

## How this was done
- Implemented with GPT-5.3 + Codex CLI.
- Vibecoded, codex cli run some tests and said it was correct.

## Validation performed
- Linux AppImage builds were tested and are working on Ubuntu 24.04.
- Type checks run for touched areas (`apps/desktop`, `apps/server`, `scripts`).
- Built AppImage after fixes and confirmed expected behavior.

## Context
This is focused on improving real-world release usability for Linux users launching AppImage from GUI environments.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update non-Windows PATH resolution in `apps/desktop/src/fixPath.ts` and `apps/server/src/os-jank.ts`, and set desktop artifact `appVersion` from a Git tag in `scripts/build-desktop-artifact.ts`
> Extend `fixPath` to run on all non-Windows platforms, try `['-ilc', 'echo -n $PATH']` then `['-lc', 'echo -n $PATH']` using `$SHELL` or platform defaults, and set `process.env.PATH` on first success; prefer a HEAD-pointing semver Git tag (without `v`) for desktop build `appVersion`.
>
> #### 📍Where to Start
> Start with `fixPath` in [fixPath.ts](https://github.com/pingdotgg/t3code/pull/337/files#diff-b5a16ed958b8e407001f062cf0edea569a7adceeb262d35d520692991a3c3a11), then review the mirrored changes in [os-jank.ts](https://github.com/pingdotgg/t3code/pull/337/files#diff-01387cb8f0521a1e152ae377c15805f328384e404ccf93da7a82c02d30cf694c); finally check `resolveGitTaggedVersion` and its use in [scripts/build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/337/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1bd0817.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->