### PR TITLE
feat: sort sidebar projects by latest thread update

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -312,6 +312,24 @@ export default function Sidebar() {
     () => new Map(projects.map((project) => [project.id, project.cwd] as const)),
     [projects],
   );
+  const sortedProjects = useMemo(() => {
+    const latestUpdateByProjectId = new Map<ProjectId, number>();
+    for (const thread of threads) {
+      const threadTimestamp = Math.max(
+        new Date(thread.session?.updatedAt ?? thread.createdAt).getTime(),
+        new Date(thread.createdAt).getTime(),
+      );
+      const existing = latestUpdateByProjectId.get(thread.projectId) ?? 0;
+      if (threadTimestamp > existing) {
+        latestUpdateByProjectId.set(thread.projectId, threadTimestamp);
+      }
+    }
+    return [...projects].toSorted((a, b) => {
+      const aTime = latestUpdateByProjectId.get(a.id) ?? 0;
+      const bTime = latestUpdateByProjectId.get(b.id) ?? 0;
+      return bTime - aTime;
+    });
+  }, [projects, threads]);
   const threadGitTargets = useMemo(
     () =>
       threads.map((thread) => ({
@@ -1026,7 +1044,7 @@ export default function Sidebar() {
       <SidebarContent className="gap-0">
         <SidebarGroup className="px-2 py-2">
           <SidebarMenu>
-            {projects.map((project) => {
+            {sortedProjects.map((project) => {
               const projectThreads = threads
                 .filter((thread) => thread.projectId === project.id)
                 .toSorted((a, b) => {


### PR DESCRIPTION
Projects with the most recent thread activity now appear first in the sidebar, making it easier to find actively-used projects.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort Sidebar projects by most recent thread activity in `Sidebar` component to reflect latest updates
> Add a memoized `sortedProjects` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/341/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that orders projects by the latest timestamp from associated threads using `session.updatedAt` or `thread.createdAt`, and render the list from this sorted array.
>
> #### 📍Where to Start
> Start with the `sortedProjects` computation and its usage in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/341/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9898798.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects in the sidebar are now automatically sorted by their most recent activity, with recently updated projects appearing first for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->