### PR TITLE
Adding Horizontal View & Utilizing Space Better

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -45,6 +45,7 @@ const AppSettingsSchema = Schema.Struct({
   customCodexModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
   ),
+  horizontalTabs: Schema.Boolean.pipe(Schema.withConstructorDefault(() => Option.some(false))),
 });
 export type AppSettings = typeof AppSettingsSchema.Type;
 export interface AppModelOption {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3413,54 +3413,61 @@ export default function ChatView({ threadId }: ChatViewProps) {
       {/* Error banner */}
       <ProviderHealthBanner status={activeProviderStatus} />
       <ThreadErrorBanner error={activeThread.error} />
-      <PlanModePanel activePlan={activePlan} />
+      {!settings.horizontalTabs && <PlanModePanel activePlan={activePlan} />}
 
-      {/* Messages */}
-      <div
-        ref={setMessagesScrollContainerRef}
-        className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-y-contain px-3 py-3 sm:px-5 sm:py-4"
-        onScroll={onMessagesScroll}
-        onClickCapture={onMessagesClickCapture}
-        onWheel={onMessagesWheel}
-        onPointerDown={onMessagesPointerDown}
-        onPointerUp={onMessagesPointerUp}
-        onPointerCancel={onMessagesPointerCancel}
-        onTouchStart={onMessagesTouchStart}
-        onTouchMove={onMessagesTouchMove}
-        onTouchEnd={onMessagesTouchEnd}
-        onTouchCancel={onMessagesTouchEnd}
-      >
-        <MessagesTimeline
-          key={activeThread.id}
-          hasMessages={timelineEntries.length > 0}
-          isWorking={isWorking}
-          activeTurnInProgress={isWorking || !latestTurnSettled}
-          activeTurnStartedAt={activeWorkStartedAt}
-          scrollContainer={messagesScrollElement}
-          timelineEntries={timelineEntries}
-          completionDividerBeforeEntryId={completionDividerBeforeEntryId}
-          completionSummary={completionSummary}
-          turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
-          nowIso={nowIso}
-          expandedWorkGroups={expandedWorkGroups}
-          onToggleWorkGroup={onToggleWorkGroup}
-          onOpenTurnDiff={onOpenTurnDiff}
-          revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
-          onRevertUserMessage={onRevertUserMessage}
-          isRevertingCheckpoint={isRevertingCheckpoint}
-          onImageExpand={onExpandTimelineImage}
-          markdownCwd={gitCwd ?? undefined}
-          resolvedTheme={resolvedTheme}
-          workspaceRoot={activeProject?.cwd ?? undefined}
-        />
-      </div>
+      <div className={settings.horizontalTabs ? "flex min-h-0 flex-1" : "contents"}>
+        <div className={cn("flex min-h-0 flex-1 flex-col", settings.horizontalTabs && "relative")}>
+          {/* Messages */}
+          <div
+            ref={setMessagesScrollContainerRef}
+            className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-y-contain px-3 py-3 sm:px-5 sm:py-4"
+            onScroll={onMessagesScroll}
+            onClickCapture={onMessagesClickCapture}
+            onWheel={onMessagesWheel}
+            onPointerDown={onMessagesPointerDown}
+            onPointerUp={onMessagesPointerUp}
+            onPointerCancel={onMessagesPointerCancel}
+            onTouchStart={onMessagesTouchStart}
+            onTouchMove={onMessagesTouchMove}
+            onTouchEnd={onMessagesTouchEnd}
+            onTouchCancel={onMessagesTouchEnd}
+          >
+            <MessagesTimeline
+              key={activeThread.id}
+              hasMessages={timelineEntries.length > 0}
+              isWorking={isWorking}
+              activeTurnInProgress={isWorking || !latestTurnSettled}
+              activeTurnStartedAt={activeWorkStartedAt}
+              scrollContainer={messagesScrollElement}
+              timelineEntries={timelineEntries}
+              completionDividerBeforeEntryId={completionDividerBeforeEntryId}
+              completionSummary={completionSummary}
+              turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
+              nowIso={nowIso}
+              expandedWorkGroups={expandedWorkGroups}
+              onToggleWorkGroup={onToggleWorkGroup}
+              onOpenTurnDiff={onOpenTurnDiff}
+              revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
+              onRevertUserMessage={onRevertUserMessage}
+              isRevertingCheckpoint={isRevertingCheckpoint}
+              onImageExpand={onExpandTimelineImage}
+              markdownCwd={gitCwd ?? undefined}
+              resolvedTheme={resolvedTheme}
+              workspaceRoot={activeProject?.cwd ?? undefined}
+            />
+            {settings.horizontalTabs && <div className="h-28 shrink-0" aria-hidden="true" />}
+          </div>
 
-      {/* Input bar */}
-      <div className={cn("px-3 pt-1.5 sm:px-5 sm:pt-2", isGitRepo ? "pb-1" : "pb-3 sm:pb-4")}>
+          {/* Input bar */}
+          <div className={cn(
+            settings.horizontalTabs
+              ? "pointer-events-none absolute inset-x-0 bottom-0 z-10 px-3 pb-3 pt-1.5 sm:px-5 sm:pb-4 sm:pt-2"
+              : cn("px-3 pt-1.5 sm:px-5 sm:pt-2", isGitRepo ? "pb-1" : "pb-3 sm:pb-4"),
+          )}>
         <form
           ref={composerFormRef}
           onSubmit={onSend}
-          className="mx-auto w-full min-w-0 max-w-3xl"
+          className={cn("mx-auto w-full min-w-0 max-w-3xl", settings.horizontalTabs && "pointer-events-auto")}
           data-chat-composer-form="true"
         >
           <div
@@ -3895,6 +3902,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
           />
         );
       })()}
+
+        </div>
+        {settings.horizontalTabs && activePlan && (
+          <aside className="w-[clamp(20rem,30vw,28rem)] shrink-0 overflow-y-auto border-l border-border bg-card/50 p-4">
+            <PlanModePanel activePlan={activePlan} />
+          </aside>
+        )}
+      </div>
 
       {expandedImage && expandedImageItem && (
         <div
@@ -5128,6 +5143,30 @@ const MessagesTimeline = memo(function MessagesTimeline({
                   <span className="rounded-full border border-border bg-background px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
                     {completionSummary ? `Response • ${completionSummary}` : "Response"}
                   </span>
+                  {(() => {
+                    const diffSummary = turnDiffSummaryByAssistantMessageId.get(row.message.id);
+                    if (!diffSummary || diffSummary.files.length === 0) return null;
+                    const count = diffSummary.files.length;
+                    return (
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <span className="cursor-default rounded-full border border-border bg-background px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
+                              {count} {count === 1 ? "file" : "files"} changed
+                            </span>
+                          }
+                        />
+                        <TooltipPopup side="bottom" className="max-w-xs">
+                          <p className="mb-1 text-xs font-medium">{count} {count === 1 ? "file" : "files"} changed</p>
+                          <div className="space-y-0.5">
+                            {diffSummary.files.map((f) => (
+                              <p key={f.path} className="font-mono text-[11px] text-muted-foreground">{f.path}</p>
+                            ))}
+                          </div>
+                        </TooltipPopup>
+                      </Tooltip>
+                    );
+                  })()}
                   <span className="h-px flex-1 bg-border" />
                 </div>
               )}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3455,19 +3455,22 @@ export default function ChatView({ threadId }: ChatViewProps) {
               resolvedTheme={resolvedTheme}
               workspaceRoot={activeProject?.cwd ?? undefined}
             />
-            {settings.horizontalTabs && <div className="h-28 shrink-0" aria-hidden="true" />}
+            {settings.horizontalTabs && <div className="h-44 shrink-0" aria-hidden="true" />}
           </div>
 
           {/* Input bar */}
           <div className={cn(
             settings.horizontalTabs
-              ? "pointer-events-none absolute inset-x-0 bottom-0 z-10 px-3 pb-3 pt-1.5 sm:px-5 sm:pb-4 sm:pt-2"
+              ? "absolute inset-x-0 bottom-0 z-10 px-3 pb-3 sm:px-5 sm:pb-4"
               : cn("px-3 pt-1.5 sm:px-5 sm:pt-2", isGitRepo ? "pb-1" : "pb-3 sm:pb-4"),
           )}>
+            {settings.horizontalTabs && (
+              <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-background/80 to-background" aria-hidden="true" />
+            )}
         <form
           ref={composerFormRef}
           onSubmit={onSend}
-          className={cn("mx-auto w-full min-w-0 max-w-3xl", settings.horizontalTabs && "pointer-events-auto")}
+          className={cn("mx-auto w-full min-w-0 max-w-3xl", settings.horizontalTabs && "relative")}
           data-chat-composer-form="true"
         >
           <div
@@ -3864,9 +3867,19 @@ export default function ChatView({ threadId }: ChatViewProps) {
             )}
           </div>
         </form>
+        {settings.horizontalTabs && isGitRepo && (
+          <div className="relative">
+            <BranchToolbar
+              threadId={activeThread.id}
+              onEnvModeChange={onEnvModeChange}
+              envLocked={envLocked}
+              onComposerFocusRequest={scheduleComposerFocus}
+            />
+          </div>
+        )}
       </div>
 
-      {isGitRepo && (
+      {!settings.horizontalTabs && isGitRepo && (
         <BranchToolbar
           threadId={activeThread.id}
           onEnvModeChange={onEnvModeChange}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3454,8 +3454,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
               markdownCwd={gitCwd ?? undefined}
               resolvedTheme={resolvedTheme}
               workspaceRoot={activeProject?.cwd ?? undefined}
+              hideProposedPlans={settings.horizontalTabs && activeProposedPlan !== null}
             />
-            {settings.horizontalTabs && <div className="h-44 shrink-0" aria-hidden="true" />}
+            {settings.horizontalTabs && <div className="h-56 shrink-0" aria-hidden="true" />}
           </div>
 
           {/* Input bar */}
@@ -3917,10 +3918,19 @@ export default function ChatView({ threadId }: ChatViewProps) {
       })()}
 
         </div>
-        {settings.horizontalTabs && activePlan && (
-          <aside className="w-[clamp(20rem,30vw,28rem)] shrink-0 overflow-y-auto border-l border-border bg-card/50 p-4">
-            <PlanModePanel activePlan={activePlan} />
-          </aside>
+        {settings.horizontalTabs && (activePlan || activeProposedPlan) && (
+          <ResizablePlanPanel>
+            {activePlan && <PlanModePanel activePlan={activePlan} />}
+            {activeProposedPlan && (
+              <div className={activePlan ? "mt-4" : ""}>
+                <ProposedPlanCard
+                  planMarkdown={activeProposedPlan.planMarkdown}
+                  cwd={gitCwd ?? undefined}
+                  workspaceRoot={activeProject?.cwd ?? undefined}
+                />
+              </div>
+            )}
+          </ResizablePlanPanel>
         )}
       </div>
 
@@ -4222,6 +4232,65 @@ const ComposerPendingApprovalActions = memo(function ComposerPendingApprovalActi
         Approve once
       </Button>
     </>
+  );
+});
+
+const PLAN_PANEL_WIDTH_KEY = "t3code:plan-panel-width";
+const PLAN_PANEL_MIN_WIDTH = 280;
+const PLAN_PANEL_MAX_WIDTH = 700;
+const PLAN_PANEL_DEFAULT_WIDTH = 380;
+
+function readPersistedPlanWidth(): number {
+  try {
+    const stored = localStorage.getItem(PLAN_PANEL_WIDTH_KEY);
+    if (stored) {
+      const val = Number(stored);
+      if (val >= PLAN_PANEL_MIN_WIDTH && val <= PLAN_PANEL_MAX_WIDTH) return val;
+    }
+  } catch {}
+  return PLAN_PANEL_DEFAULT_WIDTH;
+}
+
+const ResizablePlanPanel = memo(function ResizablePlanPanel({ children }: { children: React.ReactNode }) {
+  const [width, setWidth] = useState(readPersistedPlanWidth);
+  const dragging = useRef(false);
+  const startX = useRef(0);
+  const startWidth = useRef(0);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    dragging.current = true;
+    startX.current = e.clientX;
+    startWidth.current = width;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, [width]);
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    if (!dragging.current) return;
+    const delta = startX.current - e.clientX;
+    const next = Math.min(PLAN_PANEL_MAX_WIDTH, Math.max(PLAN_PANEL_MIN_WIDTH, startWidth.current + delta));
+    setWidth(next);
+  }, []);
+
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    if (!dragging.current) return;
+    dragging.current = false;
+    (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    const delta = startX.current - e.clientX;
+    const final = Math.min(PLAN_PANEL_MAX_WIDTH, Math.max(PLAN_PANEL_MIN_WIDTH, startWidth.current + delta));
+    try { localStorage.setItem(PLAN_PANEL_WIDTH_KEY, String(final)); } catch {}
+  }, []);
+
+  return (
+    <aside className="relative shrink-0 overflow-y-auto border-l border-border bg-card/50" style={{ width }}>
+      <div
+        className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+      />
+      <div className="p-4">{children}</div>
+    </aside>
   );
 });
 
@@ -4731,6 +4800,7 @@ interface MessagesTimelineProps {
   markdownCwd: string | undefined;
   resolvedTheme: "light" | "dark";
   workspaceRoot: string | undefined;
+  hideProposedPlans?: boolean;
 }
 
 type TimelineEntry = ReturnType<typeof deriveTimelineEntries>[number];
@@ -4785,6 +4855,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
   markdownCwd,
   resolvedTheme,
   workspaceRoot,
+  hideProposedPlans,
 }: MessagesTimelineProps) {
   const timelineRootRef = useRef<HTMLDivElement | null>(null);
   const [timelineWidthPx, setTimelineWidthPx] = useState<number | null>(null);
@@ -5258,7 +5329,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
           );
         })()}
 
-      {row.kind === "proposed-plan" && (
+      {row.kind === "proposed-plan" && !hideProposedPlans && (
         <div className="min-w-0 px-1 py-0.5">
           <ProposedPlanCard
             planMarkdown={row.proposedPlan.planMarkdown}

--- a/apps/web/src/components/HorizontalTabBar.tsx
+++ b/apps/web/src/components/HorizontalTabBar.tsx
@@ -1,15 +1,18 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { ChevronDownIcon, PlusIcon } from "lucide-react";
-import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { ChevronDownIcon, FolderPlusIcon, PlusIcon } from "lucide-react";
+import { DEFAULT_MODEL_BY_PROVIDER, ProjectId, ThreadId } from "@t3tools/contracts";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { useStore } from "../store";
 import { useComposerDraftStore } from "../composerDraftStore";
-import { newThreadId } from "../lib/utils";
+import { newCommandId, newProjectId, newThreadId } from "../lib/utils";
 import { DEFAULT_RUNTIME_MODE } from "../types";
 import { isElectron } from "../env";
 import type { Thread, Project } from "../types";
 import { derivePendingApprovals } from "../session-logic";
+import { readNativeApi } from "../nativeApi";
+import { isNonEmpty as isNonEmptyString } from "effect/String";
+import { toastManager } from "./ui/toast";
 
 interface TabThread {
   id: ThreadId;
@@ -64,10 +67,12 @@ const ProjectDropdown = memo(function ProjectDropdown({
   projects,
   activeProjectId,
   onSelect,
+  onAddProject,
 }: {
   projects: Project[];
   activeProjectId: ProjectId | null;
   onSelect: (id: ProjectId) => void;
+  onAddProject: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -143,6 +148,18 @@ const ProjectDropdown = memo(function ProjectDropdown({
                 )}
               </button>
             ))}
+            <div className="mx-2 my-1 h-px bg-border" />
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              onClick={() => {
+                onAddProject();
+                setOpen(false);
+              }}
+            >
+              <FolderPlusIcon className="size-3" />
+              <span>Add project</span>
+            </button>
           </div>,
           document.body,
         )}
@@ -243,6 +260,54 @@ export default function HorizontalTabBar() {
     void navigate({ to: "/$threadId", params: { threadId } });
   }, [activeProjectId, navigate, setProjectDraftThreadId]);
 
+  const addProject = useCallback(async () => {
+    const api = readNativeApi();
+    if (!api) return;
+    let pickedPath: string | null = null;
+    try {
+      pickedPath = await api.dialogs.pickFolder();
+    } catch {}
+    if (!pickedPath) return;
+
+    const cwd = pickedPath.trim();
+    if (!cwd) return;
+
+    const existing = projects.find((p) => p.cwd === cwd);
+    if (existing) {
+      switchProject(existing.id);
+      return;
+    }
+
+    const projectId = newProjectId();
+    const title = cwd.split(/[/\\]/).findLast(isNonEmptyString) ?? cwd;
+    try {
+      await api.orchestration.dispatchCommand({
+        type: "project.create",
+        commandId: newCommandId(),
+        projectId,
+        title,
+        workspaceRoot: cwd,
+        defaultModel: DEFAULT_MODEL_BY_PROVIDER.codex,
+        createdAt: new Date().toISOString(),
+      });
+      const threadId = newThreadId();
+      setProjectDraftThreadId(projectId, threadId, {
+        createdAt: new Date().toISOString(),
+        branch: null,
+        worktreePath: null,
+        envMode: "local",
+        runtimeMode: DEFAULT_RUNTIME_MODE,
+      });
+      void navigate({ to: "/$threadId", params: { threadId } });
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Unable to add project",
+        description: error instanceof Error ? error.message : "An error occurred.",
+      });
+    }
+  }, [projects, switchProject, navigate, setProjectDraftThreadId]);
+
   return (
     <div
       className={`relative z-10 flex h-9 shrink-0 items-stretch border-b border-border bg-card ${
@@ -255,6 +320,7 @@ export default function HorizontalTabBar() {
         projects={projects}
         activeProjectId={activeProjectId}
         onSelect={switchProject}
+        onAddProject={addProject}
       />
 
       <div

--- a/apps/web/src/components/HorizontalTabBar.tsx
+++ b/apps/web/src/components/HorizontalTabBar.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { ChevronDownIcon, PlusIcon, XIcon } from "lucide-react";
+import { ChevronDownIcon, PlusIcon } from "lucide-react";
 import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { useStore } from "../store";
@@ -32,13 +32,11 @@ const Tab = memo(function Tab({
   isActive,
   hasPendingApproval,
   onSelect,
-  onClose,
 }: {
   thread: TabThread;
   isActive: boolean;
   hasPendingApproval: boolean;
   onSelect: (id: ThreadId) => void;
-  onClose: (id: ThreadId) => void;
 }) {
   const dot = statusDot(thread, hasPendingApproval);
 
@@ -55,24 +53,6 @@ const Tab = memo(function Tab({
     >
       {dot && <span className={`size-1.5 shrink-0 rounded-full ${dot}`} />}
       <span className="min-w-0 flex-1 truncate text-xs">{thread.title}</span>
-      <span
-        role="button"
-        tabIndex={0}
-        aria-label="Close tab"
-        className="ml-auto shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-secondary group-hover:opacity-100"
-        onClick={(e) => {
-          e.stopPropagation();
-          onClose(thread.id);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.stopPropagation();
-            onClose(thread.id);
-          }
-        }}
-      >
-        <XIcon className="size-3" />
-      </span>
       {isActive && (
         <span className="absolute inset-x-0 bottom-0 h-0.5 bg-primary" />
       )}
@@ -237,27 +217,6 @@ export default function HorizontalTabBar() {
     [navigate],
   );
 
-  const clearThreadDraft = useComposerDraftStore((s) => s.clearThreadDraft);
-
-  const closeTab = useCallback(
-    (threadId: ThreadId) => {
-      const tab = projectThreads.find((t) => t.id === threadId);
-      if (tab?.isDraft) {
-        clearThreadDraft(threadId);
-      }
-      if (routeThreadId === threadId) {
-        const idx = projectThreads.findIndex((t) => t.id === threadId);
-        const next = projectThreads[idx + 1] ?? projectThreads[idx - 1];
-        if (next) {
-          void navigate({ to: "/$threadId", params: { threadId: next.id } });
-        } else {
-          void navigate({ to: "/" });
-        }
-      }
-    },
-    [routeThreadId, projectThreads, navigate, clearThreadDraft],
-  );
-
   const switchProject = useCallback(
     (projectId: ProjectId) => {
       const firstThread = threads
@@ -309,7 +268,6 @@ export default function HorizontalTabBar() {
             isActive={routeThreadId === thread.id}
             hasPendingApproval={pendingApprovalByThreadId.get(thread.id) === true}
             onSelect={selectThread}
-            onClose={closeTab}
           />
         ))}
         <button

--- a/apps/web/src/components/HorizontalTabBar.tsx
+++ b/apps/web/src/components/HorizontalTabBar.tsx
@@ -11,7 +11,16 @@ import { isElectron } from "../env";
 import type { Thread, Project } from "../types";
 import { derivePendingApprovals } from "../session-logic";
 
-function statusDot(thread: Thread, hasPendingApproval: boolean): string | null {
+interface TabThread {
+  id: ThreadId;
+  title: string;
+  session: Thread["session"] | null;
+  activities: Thread["activities"];
+  createdAt: string;
+  isDraft: boolean;
+}
+
+function statusDot(thread: TabThread, hasPendingApproval: boolean): string | null {
   if (hasPendingApproval) return "bg-amber-500";
   if (thread.session?.status === "running" || thread.session?.status === "connecting")
     return "bg-sky-500 animate-pulse";
@@ -25,7 +34,7 @@ const Tab = memo(function Tab({
   onSelect,
   onClose,
 }: {
-  thread: Thread;
+  thread: TabThread;
   isActive: boolean;
   hasPendingApproval: boolean;
   onSelect: (id: ThreadId) => void;
@@ -171,26 +180,52 @@ export default function HorizontalTabBar() {
   });
   const setProjectDraftThreadId = useComposerDraftStore((s) => s.setProjectDraftThreadId);
   const getDraftThread = useComposerDraftStore((s) => s.getDraftThread);
+  const draftThreadsByThreadId = useComposerDraftStore((s) => s.draftThreadsByThreadId);
 
   const activeThread = threads.find((t) => t.id === routeThreadId);
   const draftThread = routeThreadId ? getDraftThread(routeThreadId) : null;
   const activeProjectId = activeThread?.projectId ?? draftThread?.projectId ?? projects[0]?.id ?? null;
 
-  const projectThreads = useMemo(
-    () =>
-      threads
-        .filter((t) => t.projectId === activeProjectId)
-        .toSorted((a, b) => {
-          const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-          return byDate !== 0 ? byDate : b.id.localeCompare(a.id);
-        }),
-    [threads, activeProjectId],
-  );
+  const projectThreads = useMemo(() => {
+    const persistedThreadIds = new Set<ThreadId>();
+    const tabThreads: TabThread[] = threads
+      .filter((t) => t.projectId === activeProjectId)
+      .map((t) => {
+        persistedThreadIds.add(t.id);
+        return {
+          id: t.id,
+          title: t.title,
+          session: t.session,
+          activities: t.activities,
+          createdAt: t.createdAt,
+          isDraft: false,
+        };
+      });
+
+    for (const [threadId, draft] of Object.entries(draftThreadsByThreadId)) {
+      const tid = ThreadId.makeUnsafe(threadId);
+      if (draft.projectId === activeProjectId && !persistedThreadIds.has(tid)) {
+        tabThreads.push({
+          id: tid,
+          title: "New thread",
+          session: null,
+          activities: [],
+          createdAt: draft.createdAt,
+          isDraft: true,
+        });
+      }
+    }
+
+    return tabThreads.toSorted((a, b) => {
+      const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+      return byDate !== 0 ? byDate : b.id.localeCompare(a.id);
+    });
+  }, [threads, activeProjectId, draftThreadsByThreadId]);
 
   const pendingApprovalByThreadId = useMemo(() => {
     const map = new Map<ThreadId, boolean>();
     for (const thread of projectThreads) {
-      map.set(thread.id, derivePendingApprovals(thread.activities).length > 0);
+      map.set(thread.id, thread.isDraft ? false : derivePendingApprovals(thread.activities).length > 0);
     }
     return map;
   }, [projectThreads]);
@@ -202,8 +237,14 @@ export default function HorizontalTabBar() {
     [navigate],
   );
 
+  const clearThreadDraft = useComposerDraftStore((s) => s.clearThreadDraft);
+
   const closeTab = useCallback(
     (threadId: ThreadId) => {
+      const tab = projectThreads.find((t) => t.id === threadId);
+      if (tab?.isDraft) {
+        clearThreadDraft(threadId);
+      }
       if (routeThreadId === threadId) {
         const idx = projectThreads.findIndex((t) => t.id === threadId);
         const next = projectThreads[idx + 1] ?? projectThreads[idx - 1];
@@ -214,7 +255,7 @@ export default function HorizontalTabBar() {
         }
       }
     },
-    [routeThreadId, projectThreads, navigate],
+    [routeThreadId, projectThreads, navigate, clearThreadDraft],
   );
 
   const switchProject = useCallback(

--- a/apps/web/src/components/HorizontalTabBar.tsx
+++ b/apps/web/src/components/HorizontalTabBar.tsx
@@ -1,0 +1,285 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { ChevronDownIcon, PlusIcon, XIcon } from "lucide-react";
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useStore } from "../store";
+import { useComposerDraftStore } from "../composerDraftStore";
+import { newThreadId } from "../lib/utils";
+import { DEFAULT_RUNTIME_MODE } from "../types";
+import { isElectron } from "../env";
+import type { Thread, Project } from "../types";
+import { derivePendingApprovals } from "../session-logic";
+
+function statusDot(thread: Thread, hasPendingApproval: boolean): string | null {
+  if (hasPendingApproval) return "bg-amber-500";
+  if (thread.session?.status === "running" || thread.session?.status === "connecting")
+    return "bg-sky-500 animate-pulse";
+  return null;
+}
+
+const Tab = memo(function Tab({
+  thread,
+  isActive,
+  hasPendingApproval,
+  onSelect,
+  onClose,
+}: {
+  thread: Thread;
+  isActive: boolean;
+  hasPendingApproval: boolean;
+  onSelect: (id: ThreadId) => void;
+  onClose: (id: ThreadId) => void;
+}) {
+  const dot = statusDot(thread, hasPendingApproval);
+
+  return (
+    <button
+      type="button"
+      data-active={isActive || undefined}
+      className={`group relative flex h-full max-w-[200px] min-w-[100px] shrink items-center gap-1.5 border-r border-border px-3 text-left transition-colors ${
+        isActive
+          ? "bg-background text-foreground"
+          : "bg-card/50 text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+      }`}
+      onClick={() => onSelect(thread.id)}
+    >
+      {dot && <span className={`size-1.5 shrink-0 rounded-full ${dot}`} />}
+      <span className="min-w-0 flex-1 truncate text-xs">{thread.title}</span>
+      <span
+        role="button"
+        tabIndex={0}
+        aria-label="Close tab"
+        className="ml-auto shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-secondary group-hover:opacity-100"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose(thread.id);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.stopPropagation();
+            onClose(thread.id);
+          }
+        }}
+      >
+        <XIcon className="size-3" />
+      </span>
+      {isActive && (
+        <span className="absolute inset-x-0 bottom-0 h-0.5 bg-primary" />
+      )}
+    </button>
+  );
+});
+
+const ProjectDropdown = memo(function ProjectDropdown({
+  projects,
+  activeProjectId,
+  onSelect,
+}: {
+  projects: Project[];
+  activeProjectId: ProjectId | null;
+  onSelect: (id: ProjectId) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const [popupPos, setPopupPos] = useState({ top: 0, left: 0 });
+  const activeProject = projects.find((p) => p.id === activeProjectId);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        popupRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+    document.addEventListener("pointerdown", handler, true);
+    return () => document.removeEventListener("pointerdown", handler, true);
+  }, [open]);
+
+  const toggle = useCallback(() => {
+    setOpen((v) => {
+      if (!v && triggerRef.current) {
+        const rect = triggerRef.current.getBoundingClientRect();
+        setPopupPos({ top: rect.bottom, left: rect.left });
+      }
+      return !v;
+    });
+  }, []);
+
+  return (
+    <div className="shrink-0">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="flex h-full items-center gap-1.5 border-r border-border px-3 text-xs font-medium text-foreground transition-colors hover:bg-accent/50"
+        onClick={toggle}
+      >
+        <span className="max-w-[140px] truncate">
+          {activeProject?.name ?? "Select project"}
+        </span>
+        <ChevronDownIcon className={`size-3 transition-transform ${open ? "rotate-180" : ""}`} />
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={popupRef}
+            className="fixed z-[9999] min-w-[180px] rounded-md border border-border bg-popover py-1 shadow-lg"
+            style={{
+              top: popupPos.top,
+              left: popupPos.left,
+              WebkitAppRegion: "no-drag",
+            } as React.CSSProperties}
+          >
+            {projects.map((project) => (
+              <button
+                key={project.id}
+                type="button"
+                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-accent ${
+                  project.id === activeProjectId ? "font-medium text-foreground" : "text-muted-foreground"
+                }`}
+                onClick={() => {
+                  onSelect(project.id);
+                  setOpen(false);
+                }}
+              >
+                <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                {project.id === activeProjectId && (
+                  <span className="size-1.5 rounded-full bg-primary" />
+                )}
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+});
+
+export default function HorizontalTabBar() {
+  const projects = useStore((s) => s.projects);
+  const threads = useStore((s) => s.threads);
+  const navigate = useNavigate();
+  const routeThreadId = useParams({
+    strict: false,
+    select: (params) => (params.threadId ? ThreadId.makeUnsafe(params.threadId) : null),
+  });
+  const setProjectDraftThreadId = useComposerDraftStore((s) => s.setProjectDraftThreadId);
+  const getDraftThread = useComposerDraftStore((s) => s.getDraftThread);
+
+  const activeThread = threads.find((t) => t.id === routeThreadId);
+  const draftThread = routeThreadId ? getDraftThread(routeThreadId) : null;
+  const activeProjectId = activeThread?.projectId ?? draftThread?.projectId ?? projects[0]?.id ?? null;
+
+  const projectThreads = useMemo(
+    () =>
+      threads
+        .filter((t) => t.projectId === activeProjectId)
+        .toSorted((a, b) => {
+          const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          return byDate !== 0 ? byDate : b.id.localeCompare(a.id);
+        }),
+    [threads, activeProjectId],
+  );
+
+  const pendingApprovalByThreadId = useMemo(() => {
+    const map = new Map<ThreadId, boolean>();
+    for (const thread of projectThreads) {
+      map.set(thread.id, derivePendingApprovals(thread.activities).length > 0);
+    }
+    return map;
+  }, [projectThreads]);
+
+  const selectThread = useCallback(
+    (threadId: ThreadId) => {
+      void navigate({ to: "/$threadId", params: { threadId } });
+    },
+    [navigate],
+  );
+
+  const closeTab = useCallback(
+    (threadId: ThreadId) => {
+      if (routeThreadId === threadId) {
+        const idx = projectThreads.findIndex((t) => t.id === threadId);
+        const next = projectThreads[idx + 1] ?? projectThreads[idx - 1];
+        if (next) {
+          void navigate({ to: "/$threadId", params: { threadId: next.id } });
+        } else {
+          void navigate({ to: "/" });
+        }
+      }
+    },
+    [routeThreadId, projectThreads, navigate],
+  );
+
+  const switchProject = useCallback(
+    (projectId: ProjectId) => {
+      const firstThread = threads
+        .filter((t) => t.projectId === projectId)
+        .toSorted((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
+      if (firstThread) {
+        void navigate({ to: "/$threadId", params: { threadId: firstThread.id } });
+      }
+    },
+    [navigate, threads],
+  );
+
+  const addNewThread = useCallback(() => {
+    if (!activeProjectId) return;
+    const threadId = newThreadId();
+    const createdAt = new Date().toISOString();
+    setProjectDraftThreadId(activeProjectId, threadId, {
+      createdAt,
+      branch: null,
+      worktreePath: null,
+      envMode: "local",
+      runtimeMode: DEFAULT_RUNTIME_MODE,
+    });
+    void navigate({ to: "/$threadId", params: { threadId } });
+  }, [activeProjectId, navigate, setProjectDraftThreadId]);
+
+  return (
+    <div
+      className={`relative z-10 flex h-9 shrink-0 items-stretch border-b border-border bg-card ${
+        isElectron ? "drag-region" : ""
+      }`}
+    >
+      {isElectron && <div className="w-[78px] shrink-0" />}
+
+      <ProjectDropdown
+        projects={projects}
+        activeProjectId={activeProjectId}
+        onSelect={switchProject}
+      />
+
+      <div
+        className="flex min-w-0 flex-1 items-stretch overflow-x-auto"
+        style={{ scrollbarWidth: "none" }}
+      >
+        {projectThreads.map((thread) => (
+          <Tab
+            key={thread.id}
+            thread={thread}
+            isActive={routeThreadId === thread.id}
+            hasPendingApproval={pendingApprovalByThreadId.get(thread.id) === true}
+            onSelect={selectThread}
+            onClose={closeTab}
+          />
+        ))}
+        <button
+          type="button"
+          aria-label="New thread"
+          className="flex shrink-0 items-center justify-center px-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={addNewThread}
+        >
+          <PlusIcon className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -2,6 +2,7 @@ import { ThreadId } from "@t3tools/contracts";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Suspense, lazy, type ReactNode, useCallback, useEffect } from "react";
 
+import { useAppSettings } from "../appSettings";
 import ChatView from "../components/ChatView";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
@@ -134,6 +135,7 @@ const DiffPanelInlineSidebar = (props: {
 
 function ChatThreadRouteView() {
   const threadsHydrated = useStore((store) => store.threadsHydrated);
+  const { settings } = useAppSettings();
   const navigate = useNavigate();
   const threadId = Route.useParams({
     select: (params) => ThreadId.makeUnsafe(params.threadId),
@@ -181,10 +183,12 @@ function ChatThreadRouteView() {
     return null;
   }
 
+  const insetHeight = settings.horizontalTabs ? "h-full" : "h-dvh";
+
   if (!shouldUseDiffSheet) {
     return (
       <>
-        <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+        <SidebarInset className={`${insetHeight} min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground`}>
           <ChatView key={threadId} threadId={threadId} />
         </SidebarInset>
         <DiffPanelInlineSidebar diffOpen={diffOpen} onCloseDiff={closeDiff} onOpenDiff={openDiff} />
@@ -194,7 +198,7 @@ function ChatThreadRouteView() {
 
   return (
     <>
-      <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+      <SidebarInset className={`${insetHeight} min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground`}>
         <ChatView key={threadId} threadId={threadId} />
       </SidebarInset>
       <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={closeDiff}>

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -180,7 +180,7 @@ function SettingsRouteView() {
   );
 
   return (
-    <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
+    <SidebarInset className={`${settings.horizontalTabs ? "h-full" : "h-dvh"} min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate`}>
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
         {isElectron && (
           <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
@@ -240,6 +240,22 @@ function SettingsRouteView() {
               <p className="mt-4 text-xs text-muted-foreground">
                 Active theme: <span className="font-medium text-foreground">{resolvedTheme}</span>
               </p>
+
+              <div className="mt-4 flex items-center justify-between rounded-lg border border-border bg-background px-3 py-2">
+                <div>
+                  <p className="text-sm font-medium text-foreground">Horizontal tabs</p>
+                  <p className="text-xs text-muted-foreground">
+                    Show threads as browser-style tabs at the top instead of a sidebar.
+                  </p>
+                </div>
+                <Switch
+                  checked={settings.horizontalTabs}
+                  onCheckedChange={(checked) =>
+                    updateSettings({ horizontalTabs: Boolean(checked) })
+                  }
+                  aria-label="Horizontal tabs"
+                />
+              </div>
             </section>
 
             <section className="rounded-2xl border border-border bg-card p-5">

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,12 +1,15 @@
 import { Outlet, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
+import { useAppSettings } from "../appSettings";
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
+import HorizontalTabBar from "../components/HorizontalTabBar";
 import ThreadSidebar from "../components/Sidebar";
 import { Sidebar, SidebarProvider } from "~/components/ui/sidebar";
 
 function ChatRouteLayout() {
   const navigate = useNavigate();
+  const { settings } = useAppSettings();
 
   useEffect(() => {
     const onMenuAction = window.desktopBridge?.onMenuAction;
@@ -23,6 +26,21 @@ function ChatRouteLayout() {
       unsubscribe?.();
     };
   }, [navigate]);
+
+  if (settings.horizontalTabs) {
+    return (
+      <SidebarProvider defaultOpen={false}>
+        <div className="flex h-dvh w-full flex-col">
+          <HorizontalTabBar />
+          <div className="flex min-h-0 flex-1">
+            <DiffWorkerPoolProvider>
+              <Outlet />
+            </DiffWorkerPoolProvider>
+          </div>
+        </div>
+      </SidebarProvider>
+    );
+  }
 
   return (
     <SidebarProvider defaultOpen>


### PR DESCRIPTION
  - Adds a new "Horizontal tabs" toggle in Settings > Appearance that switches from the default sidebar layout to a browser-style horizontal tab bar
  - Threads display as tabs at the top with a project dropdown for switching between projects
  - The composer input floats over the message area instead of taking a dedicated row
  - When a plan is active, it renders in a right-hand side panel utilizing the blank space
  - Shows changed file count in the completion divider with a tooltip listing file names on hover
  - Setting persists across sessions via localStorage

  Changes

  - apps/web/src/appSettings.ts — Added horizontalTabs boolean to settings schema (default: false)
  - apps/web/src/routes/_chat.settings.tsx — Added toggle in Appearance section
  - apps/web/src/components/HorizontalTabBar.tsx — New component: project dropdown + scrollable thread tabs + new
  thread button
  - apps/web/src/routes/_chat.tsx — Conditionally renders horizontal tab layout or default sidebar layout
  - apps/web/src/routes/_chat.$threadId.tsx — Adjusts SidebarInset height (h-full vs h-dvh) for horizontal mode
  - apps/web/src/components/ChatView.tsx — Floating composer, side-panel plan view, and file change count in
  completion divider

  Test plan

  - Toggle "Horizontal tabs" in Settings > Appearance and verify tabs appear at top
  - Verify the setting persists after app restart
  - Switch between projects using the dropdown
  - Create new threads via the + button next to the last tab
  - Close tabs and verify navigation to adjacent thread
  - Verify the composer floats and last message is not overlapped
  - Trigger a plan and verify it renders in the right-hand side panel
  - Verify completion divider shows file count with tooltip listing file names
  - Toggle setting off and verify default sidebar layout is fully restored
  - Test in both Electron desktop and browser modes

Btw, Vibe coded with Opus.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add horizontal tabs mode and switch chat to a two-pane layout with a right resizable plan panel when `AppSettingsSchema.horizontalTabs` is true
> Introduce a `horizontalTabs` setting and render a top tab bar with a two-pane chat layout, hiding proposed plan rows in the timeline and adding a resizable, width-persisted plan panel. Update route and settings views to adapt height and expose a toggle. Add a files-changed badge with tooltip in assistant messages.
>
> #### 📍Where to Start
> Start with the layout switch in `ChatRouteLayout` in [apps/web/src/routes/_chat.tsx](https://github.com/pingdotgg/t3code/pull/351/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691), then review `ChatView` in [apps/web/src/components/ChatView.tsx](https://github.com/pingdotgg/t3code/pull/351/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) for the two-pane logic and `ResizablePlanPanel`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b57b23d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->