### PR TITLE
Added support for Trae IDE

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -34,6 +34,15 @@ describe("resolveEditorLaunch", () => {
         args: ["/tmp/workspace"],
       });
 
+      const traeLaunch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "trae" },
+        "darwin",
+      );
+      assert.deepEqual(traeLaunch, {
+        command: "trae",
+        args: ["/tmp/workspace"],
+      });
+
       const zedLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace", editor: "zed" },
         "darwin",
@@ -72,6 +81,15 @@ describe("resolveEditorLaunch", () => {
       assert.deepEqual(vscodeLineAndColumn, {
         command: "code",
         args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
+      });
+
+      const traeLineAndColumn = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "trae" },
+        "darwin",
+      );
+      assert.deepEqual(traeLineAndColumn, {
+        command: "trae",
+        args: ["/tmp/workspace/src/open.ts:71:5"],
       });
 
       const zedLineAndColumn = yield* resolveEditorLaunch(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -168,6 +168,7 @@ import {
   Icon,
   OpenAI,
   OpenCodeIcon,
+  TraeIcon,
   VisualStudioCode,
   Zed,
 } from "./Icons";
@@ -5576,6 +5577,11 @@ const OpenInPicker = memo(function OpenInPicker({
         value: "cursor",
       },
       {
+        label: "Trae",
+        Icon: TraeIcon,
+        value: "trae",
+      },
+      {
         label: "VS Code",
         Icon: VisualStudioCode,
         value: "vscode",
@@ -5606,6 +5612,15 @@ const OpenInPicker = memo(function OpenInPicker({
     ? lastEditor
     : (options[0]?.value ?? null);
   const primaryOption = options.find(({ value }) => value === effectiveEditor) ?? null;
+  const getEditorIconClassName = useCallback(
+    (editor: EditorId, surface: "button" | "menu") => {
+      if (surface === "button") {
+        return editor === "trae" ? "size-4" : "size-3.5";
+      }
+      return cn("text-muted-foreground", editor === "trae" && "size-5 sm:size-4.5");
+    },
+    [],
+  );
 
   const openInEditor = useCallback(
     (editorId: EditorId | null) => {
@@ -5647,7 +5662,12 @@ const OpenInPicker = memo(function OpenInPicker({
         disabled={!effectiveEditor || !openInCwd}
         onClick={() => openInEditor(effectiveEditor)}
       >
-        {primaryOption?.Icon && <primaryOption.Icon aria-hidden="true" className="size-3.5" />}
+        {primaryOption?.Icon && (
+          <primaryOption.Icon
+            aria-hidden="true"
+            className={getEditorIconClassName(primaryOption.value, "button")}
+          />
+        )}
         <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
           Open
         </span>
@@ -5661,7 +5681,7 @@ const OpenInPicker = memo(function OpenInPicker({
           {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
           {options.map(({ label, Icon, value }) => (
             <MenuItem key={value} onClick={() => openInEditor(value)}>
-              <Icon aria-hidden="true" className="text-muted-foreground" />
+              <Icon aria-hidden="true" className={getEditorIconClassName(value, "menu")} />
               {label}
               {value === effectiveEditor && openFavoriteEditorShortcutLabel && (
                 <MenuShortcut>{openFavoriteEditorShortcutLabel}</MenuShortcut>

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -20,6 +20,16 @@ export const CursorIcon: Icon = (props) => (
   </svg>
 );
 
+export const TraeIcon: Icon = (props) => (
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M24 20.541H3.428v-3.426H0V3.4h24V20.54zM3.428 17.115h17.144V6.827H3.428v10.288zm8.573-5.196-2.425 2.424-2.424-2.424 2.424-2.424 2.425 2.424zm6.857-.001-2.424 2.423-2.425-2.423 2.425-2.425 2.424 2.425z"
+    />
+  </svg>
+);
+
 export const VisualStudioCode: Icon = (props) => {
   const id = useId();
   const maskId = `${id}-vscode-a`;

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,0 +1,43 @@
+class MemoryStorage implements Storage {
+  readonly #values = new Map<string, string>();
+
+  get length(): number {
+    return this.#values.size;
+  }
+
+  clear(): void {
+    this.#values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.#values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.#values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.#values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.#values.set(key, String(value));
+  }
+}
+
+const storageLike = globalThis.localStorage;
+const hasCompleteStorageApi =
+  typeof storageLike?.getItem === "function" &&
+  typeof storageLike.setItem === "function" &&
+  typeof storageLike.removeItem === "function" &&
+  typeof storageLike.clear === "function" &&
+  typeof storageLike.key === "function";
+
+if (!hasCompleteStorageApi) {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: new MemoryStorage(),
+  });
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+
+import viteConfig from "./vite.config";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      setupFiles: ["./src/test/setup.ts"],
+    },
+  }),
+);

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@t3tools/monorepo",
@@ -159,6 +158,9 @@
         "vitest": "catalog:",
       },
     },
+  },
+  "overrides": {
+    "effect": "catalog:",
   },
   "catalog": {
     "@effect/language-service": "0.75.1",
@@ -1962,14 +1964,6 @@
     "@babel/traverse/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 
     "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
-
-    "@effect/platform-node/effect": ["effect@4.0.0-beta.27", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.5.3", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.8", "multipasta": "^0.2.7", "toml": "^3.0.0", "uuid": "^13.0.0", "yaml": "^2.8.2" } }, "sha512-bNQEF3vaVGF8jAJ+HW1A4DaxVNmujgEu89sO+VNW1AvUYtPGMtKPTBU15K9inu1rG+hkxNFFRlVvLAJsdaE2mg=="],
-
-    "@effect/platform-node-shared/effect": ["effect@4.0.0-beta.27", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.5.3", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.8", "multipasta": "^0.2.7", "toml": "^3.0.0", "uuid": "^13.0.0", "yaml": "^2.8.2" } }, "sha512-bNQEF3vaVGF8jAJ+HW1A4DaxVNmujgEu89sO+VNW1AvUYtPGMtKPTBU15K9inu1rG+hkxNFFRlVvLAJsdaE2mg=="],
-
-    "@effect/sql-sqlite-bun/effect": ["effect@4.0.0-beta.27", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.5.3", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.8", "multipasta": "^0.2.7", "toml": "^3.0.0", "uuid": "^13.0.0", "yaml": "^2.8.2" } }, "sha512-bNQEF3vaVGF8jAJ+HW1A4DaxVNmujgEu89sO+VNW1AvUYtPGMtKPTBU15K9inu1rG+hkxNFFRlVvLAJsdaE2mg=="],
-
-    "@effect/vitest/effect": ["effect@4.0.0-beta.27", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.5.3", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.8", "multipasta": "^0.2.7", "toml": "^3.0.0", "uuid": "^13.0.0", "yaml": "^2.8.2" } }, "sha512-bNQEF3vaVGF8jAJ+HW1A4DaxVNmujgEu89sO+VNW1AvUYtPGMtKPTBU15K9inu1rG+hkxNFFRlVvLAJsdaE2mg=="],
 
     "@electron/get/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "turbo": "^2.3.3",
     "vitest": "catalog:"
   },
+  "overrides": {
+    "effect": "catalog:"
+  },
   "engines": {
     "bun": "^1.3.9",
     "node": "^24.13.1"

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -3,6 +3,7 @@ import { TrimmedNonEmptyString } from "./baseSchemas";
 
 export const EDITORS = [
   { id: "cursor", label: "Cursor", command: "cursor" },
+  { id: "trae", label: "Trae", command: "trae" },
   { id: "vscode", label: "VS Code", command: "code" },
   { id: "zed", label: "Zed", command: "zed" },
   { id: "file-manager", label: "File Manager", command: null },

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -12,9 +12,14 @@ import { BRAND_ASSET_PATHS } from "./lib/brand-assets.ts";
 import { resolveCatalogDependencies } from "./lib/resolve-catalog.ts";
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
-import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import * as NodeStdio from "@effect/platform-node/NodeStdio";
+import * as NodeTerminal from "@effect/platform-node/NodeTerminal";
 import { Config, Data, Effect, FileSystem, Layer, Logger, Option, Path, Schema } from "effect";
 import { Command, Flag } from "effect/unstable/cli";
+import type { Environment as CliEnvironment } from "effect/unstable/cli/Command";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 const BuildPlatform = Schema.Literals(["mac", "linux", "win"]);
@@ -763,10 +768,21 @@ const buildDesktopArtifactCli = Command.make("build-desktop-artifact", {
   Command.withHandler((input) => Effect.flatMap(resolveBuildOptions(input), buildDesktopArtifact)),
 );
 
-const cliRuntimeLayer = Layer.mergeAll(Logger.layer([Logger.consolePretty()]), NodeServices.layer);
-
-Command.run(buildDesktopArtifactCli, { version: "0.0.0" }).pipe(
-  Effect.scoped,
-  Effect.provide(cliRuntimeLayer),
-  NodeRuntime.runMain,
+const childProcessRuntimeLayer = NodeChildProcessSpawner.layer.pipe(
+  Layer.provideMerge(NodeFileSystem.layer),
+  Layer.provideMerge(NodePath.layer),
 );
+
+const cliRuntimeLayer = Layer.mergeAll(
+  childProcessRuntimeLayer,
+  NodeStdio.layer,
+  NodeTerminal.layer,
+  Logger.layer([Logger.consolePretty()]),
+);
+
+const runtimeProgram = Effect.provide(
+  Effect.scoped(Command.run(buildDesktopArtifactCli, { version: "0.0.0" })),
+  cliRuntimeLayer as Layer.Layer<CliEnvironment>,
+);
+
+NodeRuntime.runMain(runtimeProgram);

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -3,10 +3,15 @@
 import { homedir } from "node:os";
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
-import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as NodeChildProcessSpawner from "@effect/platform-node/NodeChildProcessSpawner";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
+import * as NodePath from "@effect/platform-node/NodePath";
+import * as NodeStdio from "@effect/platform-node/NodeStdio";
+import * as NodeTerminal from "@effect/platform-node/NodeTerminal";
 import { NetService } from "@t3tools/shared/Net";
 import { Config, Data, Effect, Hash, Layer, Logger, Option, Path, Schema } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
+import type { Environment as CliEnvironment } from "effect/unstable/cli/Command";
 import { ChildProcess } from "effect/unstable/process";
 
 const BASE_SERVER_PORT = 3773;
@@ -536,15 +541,22 @@ const devRunnerCli = Command.make("dev-runner", {
   Command.withHandler((input) => runDevRunnerWithInput(input)),
 );
 
-const cliRuntimeLayer = Layer.mergeAll(
-  Logger.layer([Logger.consolePretty()]),
-  NodeServices.layer,
-  NetService.layer,
+const childProcessRuntimeLayer = NodeChildProcessSpawner.layer.pipe(
+  Layer.provideMerge(NodeFileSystem.layer),
+  Layer.provideMerge(NodePath.layer),
 );
 
-const runtimeProgram = Command.run(devRunnerCli, { version: "0.0.0" }).pipe(
-  Effect.scoped,
-  Effect.provide(cliRuntimeLayer),
+const cliRuntimeLayer = Layer.mergeAll(
+  childProcessRuntimeLayer,
+  NodeStdio.layer,
+  NodeTerminal.layer,
+  NetService.layer,
+  Logger.layer([Logger.consolePretty()]),
+);
+
+const runtimeProgram = Effect.provide(
+  Effect.scoped(Command.run(devRunnerCli, { version: "0.0.0" })),
+  cliRuntimeLayer as Layer.Layer<CliEnvironment | NetService>,
 );
 
 if (import.meta.main) {


### PR DESCRIPTION
To make all the tests pass, I had GPT-5.4 go through until they all passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Trae editor support across contracts, web UI Open in picker, and server tests to enable Trae IDE selection and launch
> Add `trae` to `EDITORS`, expose a `TraeIcon`, and update the Open in picker to render and size the Trae option; extend tests to assert `resolveEditorLaunch` returns command `trae` for directories and files with line/column; refactor CLI runtime composition in build/dev scripts and register a Vitest setup that polyfills `localStorage`.
>
> #### 📍Where to Start
> Start with the Trae option wiring in the Open in picker in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/365/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), then verify the editor contract in [editor.ts](https://github.com/pingdotgg/t3code/pull/365/files#diff-952d09e8dcc92b201e44f8f0b5edc71af952e9af9479b5853c41ce6e93d636f7) and the launch behavior tests in [open.test.ts](https://github.com/pingdotgg/t3code/pull/365/files#diff-8461679cd410b8ed7a51a0d456bc119318c2d6bea6e58b14b57bf6176220d22b).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e94349f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->