### PR TITLE
chore(release): enforce homebrew cask release contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,9 @@ jobs:
         run: |
           node scripts/validate-homebrew-release-contract.ts \
             --version "${{ steps.release_meta.outputs.version }}" \
-            --tag "${{ steps.release_meta.outputs.tag }}"
+            --tag "${{ steps.release_meta.outputs.tag }}" \
+            --repository "${{ github.repository }}" \
+            --expected-repository "pingdotgg/t3code"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -274,6 +276,8 @@ jobs:
           node scripts/validate-homebrew-release-contract.ts \
             --version "${{ needs.preflight.outputs.version }}" \
             --tag "${{ needs.preflight.outputs.tag }}" \
+            --repository "${{ github.repository }}" \
+            --expected-repository "pingdotgg/t3code" \
             --assets-dir "release-assets"
 
       - name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
+      - name: Validate Homebrew release contract (metadata)
+        run: |
+          node scripts/validate-homebrew-release-contract.ts \
+            --version "${{ steps.release_meta.outputs.version }}" \
+            --tag "${{ steps.release_meta.outputs.tag }}"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -246,12 +252,29 @@ jobs:
     needs: [preflight, build, publish_cli]
     runs-on: ubuntu-24.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
       - name: Download all desktop artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: desktop-*
           merge-multiple: true
           path: release-assets
+
+      - name: Validate Homebrew release contract (assets)
+        run: |
+          node scripts/validate-homebrew-release-contract.ts \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --tag "${{ needs.preflight.outputs.tag }}" \
+            --assets-dir "release-assets"
 
       - name: Publish release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ You can also just install the desktop app. It's cooler.
 
 Install the [desktop app from the Releases page](https://github.com/pingdotgg/t3code/releases)
 
+Or install it with Homebrew:
+
+```bash
+brew install --cask t3-code
+```
+
+See the cask details on [Formulae](https://formulae.brew.sh/cask/t3-code#default).
+
 ## Some notes
 
 We are very very early in this project. Expect bugs.

--- a/docs/homebrew-release-contract.md
+++ b/docs/homebrew-release-contract.md
@@ -1,0 +1,27 @@
+# Homebrew Release Contract
+
+This document defines the release invariants required for `Homebrew/homebrew-cask` (`t3-code`) autobump compatibility.
+
+## Required invariants
+
+1. Release tag format is `vX.Y.Z` (for example `v0.0.4`).
+2. Release assets include both macOS DMGs:
+   - `T3-Code-<version>-arm64.dmg`
+   - `T3-Code-<version>-x64.dmg`
+3. Desktop app bundle product name remains `T3 Code (Alpha)` (used by cask `app` stanza).
+
+## Validation
+
+Use the validator script from repository root:
+
+```bash
+node scripts/validate-homebrew-release-contract.ts \
+  --version 0.0.4 \
+  --tag v0.0.4 \
+  --assets-dir release-assets
+```
+
+In CI (`.github/workflows/release.yml`), the validator runs:
+
+1. In preflight (metadata only: version/tag/product name).
+2. In release job before publishing assets (metadata + DMG presence).

--- a/docs/homebrew-release-contract.md
+++ b/docs/homebrew-release-contract.md
@@ -5,10 +5,11 @@ This document defines the release invariants required for `Homebrew/homebrew-cas
 ## Required invariants
 
 1. Release tag format is `vX.Y.Z` (for example `v0.0.4`).
-2. Release assets include both macOS DMGs:
+2. Release workflow repository is `pingdotgg/t3code` (fork releases must not be used for official Homebrew flow).
+3. Release assets include both macOS DMGs:
    - `T3-Code-<version>-arm64.dmg`
    - `T3-Code-<version>-x64.dmg`
-3. Desktop app bundle product name remains `T3 Code (Alpha)` (used by cask `app` stanza).
+4. Desktop app bundle product name remains `T3 Code (Alpha)` (used by cask `app` stanza).
 
 ## Validation
 
@@ -18,6 +19,8 @@ Use the validator script from repository root:
 node scripts/validate-homebrew-release-contract.ts \
   --version 0.0.4 \
   --tag v0.0.4 \
+  --repository pingdotgg/t3code \
+  --expected-repository pingdotgg/t3code \
   --assets-dir release-assets
 ```
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,6 +6,7 @@ This document covers how to run desktop releases from one tag, first without sig
 
 - Trigger: push tag matching `v*.*.*`.
 - Runs quality gates first: lint, typecheck, test.
+- Validates Homebrew release contract (tag/version/product name + required macOS DMGs).
 - Builds four artifacts in parallel:
   - macOS `arm64` DMG
   - macOS `x64` DMG
@@ -15,6 +16,8 @@ This document covers how to run desktop releases from one tag, first without sig
 - Includes Electron auto-update metadata (for example `latest*.yml` and `*.blockmap`) in release assets.
 - Publishes the CLI package (`apps/server`, npm package `t3`) with OIDC trusted publishing.
 - Signing is optional and auto-detected per platform from secrets.
+
+See also: [Homebrew release contract](./homebrew-release-contract.md).
 
 ## Desktop auto-update notes
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -6,7 +6,7 @@ This document covers how to run desktop releases from one tag, first without sig
 
 - Trigger: push tag matching `v*.*.*`.
 - Runs quality gates first: lint, typecheck, test.
-- Validates Homebrew release contract (tag/version/product name + required macOS DMGs).
+- Validates Homebrew release contract (tag/version, upstream repository, product name, and required macOS DMGs).
 - Builds four artifacts in parallel:
   - macOS `arm64` DMG
   - macOS `x64` DMG

--- a/scripts/validate-homebrew-release-contract.ts
+++ b/scripts/validate-homebrew-release-contract.ts
@@ -23,6 +23,9 @@ const { values } = parseArgs({
   options: {
     version: { type: "string" },
     tag: { type: "string" },
+    repository: { type: "string" },
+    "expected-repository": { type: "string", default: "pingdotgg/t3code" },
+    expectedRepository: { type: "string" },
     "assets-dir": { type: "string" },
     assetsDir: { type: "string" },
     "expected-product-name": { type: "string", default: "T3 Code (Alpha)" },
@@ -34,6 +37,8 @@ const { values } = parseArgs({
 
 const version = values.version;
 const tag = values.tag;
+const repository = values.repository;
+const expectedRepository = values["expected-repository"] ?? values.expectedRepository;
 const assetsDirInput = values["assets-dir"] ?? values.assetsDir;
 const expectedProductName = values["expected-product-name"] ?? values.expectedProductName;
 const desktopPackagePathInput = values["desktop-package-path"] ?? values.desktopPackagePath;
@@ -52,6 +57,12 @@ if (!tag) {
 
 if (tag !== `v${version}`) {
   fail(`Tag '${tag}' must exactly match 'v${version}'.`);
+}
+
+if (repository && repository !== expectedRepository) {
+  fail(
+    `Release repository must be '${expectedRepository}' for Homebrew compatibility (current: '${repository}').`,
+  );
 }
 
 const desktopPackagePath = isAbsolute(desktopPackagePathInput)
@@ -104,5 +115,5 @@ if (assetsDirInput) {
 }
 
 process.stdout.write(
-  `[homebrew-release-contract] OK version=${version} tag=${tag} productName='${expectedProductName}'\n`,
+  `[homebrew-release-contract] OK version=${version} tag=${tag} repository='${repository ?? "n/a"}' productName='${expectedProductName}'\n`,
 );

--- a/scripts/validate-homebrew-release-contract.ts
+++ b/scripts/validate-homebrew-release-contract.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+
+interface DesktopPackageJson {
+  readonly productName?: unknown;
+}
+
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:[.-][0-9A-Za-z.-]+)?$/;
+
+function fail(message: string): never {
+  process.stderr.write(`[homebrew-release-contract] ${message}\n`);
+  process.exit(1);
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "..");
+
+const { values } = parseArgs({
+  options: {
+    version: { type: "string" },
+    tag: { type: "string" },
+    "assets-dir": { type: "string" },
+    assetsDir: { type: "string" },
+    "expected-product-name": { type: "string", default: "T3 Code (Alpha)" },
+    expectedProductName: { type: "string" },
+    "desktop-package-path": { type: "string", default: "apps/desktop/package.json" },
+    desktopPackagePath: { type: "string" },
+  },
+});
+
+const version = values.version;
+const tag = values.tag;
+const assetsDirInput = values["assets-dir"] ?? values.assetsDir;
+const expectedProductName = values["expected-product-name"] ?? values.expectedProductName;
+const desktopPackagePathInput = values["desktop-package-path"] ?? values.desktopPackagePath;
+
+if (!version) {
+  fail("Missing required --version argument.");
+}
+
+if (!VERSION_PATTERN.test(version)) {
+  fail(`Version '${version}' does not match expected semver-like format.`);
+}
+
+if (!tag) {
+  fail("Missing required --tag argument.");
+}
+
+if (tag !== `v${version}`) {
+  fail(`Tag '${tag}' must exactly match 'v${version}'.`);
+}
+
+const desktopPackagePath = isAbsolute(desktopPackagePathInput)
+  ? desktopPackagePathInput
+  : join(repoRoot, desktopPackagePathInput);
+
+if (!existsSync(desktopPackagePath)) {
+  fail(`Desktop package.json not found at '${desktopPackagePath}'.`);
+}
+
+let desktopPackageJson: DesktopPackageJson;
+try {
+  desktopPackageJson = JSON.parse(readFileSync(desktopPackagePath, "utf8")) as DesktopPackageJson;
+} catch (error) {
+  fail(
+    `Failed to parse desktop package.json at '${desktopPackagePath}': ${
+      error instanceof Error ? error.message : String(error)
+    }`,
+  );
+}
+
+if (desktopPackageJson.productName !== expectedProductName) {
+  fail(
+    `Desktop productName must remain '${expectedProductName}' for Homebrew cask compatibility (current: '${String(
+      desktopPackageJson.productName,
+    )}').`,
+  );
+}
+
+if (assetsDirInput) {
+  const assetsDir = isAbsolute(assetsDirInput) ? assetsDirInput : join(repoRoot, assetsDirInput);
+  if (!existsSync(assetsDir) || !statSync(assetsDir).isDirectory()) {
+    fail(`Assets directory '${assetsDir}' does not exist or is not a directory.`);
+  }
+
+  const requiredDmgAssets = [`T3-Code-${version}-arm64.dmg`, `T3-Code-${version}-x64.dmg`];
+  for (const assetName of requiredDmgAssets) {
+    const assetPath = join(assetsDir, assetName);
+    if (!existsSync(assetPath)) {
+      fail(`Missing required macOS DMG asset '${assetName}' in '${assetsDir}'.`);
+    }
+    const stat = statSync(assetPath);
+    if (!stat.isFile()) {
+      fail(`Expected '${assetPath}' to be a file.`);
+    }
+    if (stat.size <= 0) {
+      fail(`Asset '${assetPath}' is empty.`);
+    }
+  }
+}
+
+process.stdout.write(
+  `[homebrew-release-contract] OK version=${version} tag=${tag} productName='${expectedProductName}'\n`,
+);

--- a/scripts/validate-homebrew-release-contract.ts
+++ b/scripts/validate-homebrew-release-contract.ts
@@ -38,10 +38,10 @@ const { values } = parseArgs({
 const version = values.version;
 const tag = values.tag;
 const repository = values.repository;
-const expectedRepository = values["expected-repository"] ?? values.expectedRepository;
+const expectedRepository = values.expectedRepository ?? values["expected-repository"];
 const assetsDirInput = values["assets-dir"] ?? values.assetsDir;
-const expectedProductName = values["expected-product-name"] ?? values.expectedProductName;
-const desktopPackagePathInput = values["desktop-package-path"] ?? values.desktopPackagePath;
+const expectedProductName = values.expectedProductName ?? values["expected-product-name"];
+const desktopPackagePathInput = values.desktopPackagePath ?? values["desktop-package-path"];
 
 if (!version) {
   fail("Missing required --version argument.");


### PR DESCRIPTION
## Summary

Adds Homebrew release-contract guardrails so `t3-code` cask updates stay compatible with upstream release assets.

### Changes

- Added `docs/homebrew-release-contract.md` with required invariants:
  - tags must be `vX.Y.Z`
  - both DMGs must exist: `T3-Code-<version>-arm64.dmg` and `T3-Code-<version>-x64.dmg`
  - desktop product name must remain `T3 Code (Alpha)` for cask `app` stanza compatibility
- Added `scripts/validate-homebrew-release-contract.ts`.
- Wired validator into `.github/workflows/release.yml`:
  - preflight metadata check (version/tag/product name)
  - asset check before publishing release assets
- Updated `docs/release.md` to include this contract.

## Why

This codifies a stable Homebrew-facing release contract so future release changes do not silently break cask install/autobump.

## Related

- t3code issue: https://github.com/pingdotgg/t3code/issues/201
- Homebrew cask PR: https://github.com/Homebrew/homebrew-cask/pull/252744

## Validation

- `node scripts/validate-homebrew-release-contract.ts --version 0.0.4 --tag v0.0.4`
- `node scripts/validate-homebrew-release-contract.ts --version 0.0.4 --tag v0.0.4 --assets-dir /tmp/t3code-homebrew-check`
- `bun lint` ✅
- `bun typecheck` ❌ currently fails in existing unrelated server/integration typing paths on this machine (effect/runtime type identity mismatch in dependencies), not introduced by this PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce the Homebrew cask release contract by validating metadata and DMG assets in `.github/workflows/release.yml` using `scripts/validate-homebrew-release-contract.ts` and document installation and contract details
> Add preflight and release job steps to run `scripts/validate-homebrew-release-contract.ts` for version/tag/repository checks and asset presence, align release checkout with preflight ref, and add docs and README install notes; validator enforces semver `version`, `tag === v<version>`, repository `pingdotgg/t3code`, product name `T3 Code (Alpha)`, and non-empty `arm64`/`x64` DMGs.
>
> #### 📍Where to Start
> Start with the validator CLI in [validate-homebrew-release-contract.ts](https://github.com/pingdotgg/t3code/pull/368/files#diff-3c4df9b607dbcc4cb278154a7b4d9b830596e67ef9feada6abb8a93a60606f57) and its invocation in the workflow at [release.yml](https://github.com/pingdotgg/t3code/pull/368/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97adcd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->