### PR TITLE
feat: add Claude Code provider

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@effect/platform-node": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.71",
     "@pierre/diffs": "^1.1.0-beta.16",
     "effect": "catalog:",
     "node-pty": "^1.1.0",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -213,7 +213,9 @@ const make = Effect.gen(function* () {
 
     const desiredRuntimeMode = thread.runtimeMode;
     const currentProvider: ProviderKind | undefined =
-      thread.session?.providerName === "codex" ? thread.session.providerName : undefined;
+      thread.session?.providerName === "codex" || thread.session?.providerName === "claudeCode"
+        ? thread.session.providerName
+        : undefined;
     const preferredProvider: ProviderKind | undefined = options?.provider ?? currentProvider;
     const desiredModel = options?.model ?? thread.model;
     const effectiveCwd = resolveThreadWorkspaceCwd({

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -45,7 +45,7 @@ const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
   readonly eventId: EventId;
-  readonly provider: "codex";
+  readonly provider: "codex" | "claudeCode";
   readonly createdAt: string;
   readonly threadId: ThreadId;
   readonly turnId?: string | undefined;

--- a/apps/server/src/provider/Layers/ClaudeCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCodeAdapter.test.ts
@@ -1,0 +1,930 @@
+import type {
+  Options as ClaudeQueryOptions,
+  PermissionMode,
+  PermissionResult,
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { ApprovalRequestId, ThreadId } from "@t3tools/contracts";
+import { assert, describe, it } from "@effect/vitest";
+import { Effect, Fiber, Random, Stream } from "effect";
+
+import {
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { ClaudeCodeAdapter } from "../Services/ClaudeCodeAdapter.ts";
+import {
+  makeClaudeCodeAdapterLive,
+  type ClaudeCodeAdapterLiveOptions,
+} from "./ClaudeCodeAdapter.ts";
+
+class FakeClaudeQuery implements AsyncIterable<SDKMessage> {
+  private readonly queue: Array<SDKMessage> = [];
+  private readonly resolvers: Array<(value: IteratorResult<SDKMessage>) => void> = [];
+  private done = false;
+
+  public readonly interruptCalls: Array<void> = [];
+  public readonly setModelCalls: Array<string | undefined> = [];
+  public readonly setPermissionModeCalls: Array<string> = [];
+  public readonly setMaxThinkingTokensCalls: Array<number | null> = [];
+  public closeCalls = 0;
+
+  emit(message: SDKMessage): void {
+    if (this.done) {
+      return;
+    }
+    const resolver = this.resolvers.shift();
+    if (resolver) {
+      resolver({ done: false, value: message });
+      return;
+    }
+    this.queue.push(message);
+  }
+
+  finish(): void {
+    if (this.done) {
+      return;
+    }
+    this.done = true;
+    for (const resolver of this.resolvers.splice(0)) {
+      resolver({ done: true, value: undefined });
+    }
+  }
+
+  readonly interrupt = async (): Promise<void> => {
+    this.interruptCalls.push(undefined);
+  };
+
+  readonly setModel = async (model?: string): Promise<void> => {
+    this.setModelCalls.push(model);
+  };
+
+  readonly setPermissionMode = async (mode: PermissionMode): Promise<void> => {
+    this.setPermissionModeCalls.push(mode);
+  };
+
+  readonly setMaxThinkingTokens = async (maxThinkingTokens: number | null): Promise<void> => {
+    this.setMaxThinkingTokensCalls.push(maxThinkingTokens);
+  };
+
+  readonly close = (): void => {
+    this.closeCalls += 1;
+    this.finish();
+  };
+
+  [Symbol.asyncIterator](): AsyncIterator<SDKMessage> {
+    return {
+      next: () => {
+        if (this.queue.length > 0) {
+          const value = this.queue.shift();
+          if (value) {
+            return Promise.resolve({
+              done: false,
+              value,
+            });
+          }
+        }
+        if (this.done) {
+          return Promise.resolve({
+            done: true,
+            value: undefined,
+          });
+        }
+        return new Promise((resolve) => {
+          this.resolvers.push(resolve);
+        });
+      },
+    };
+  }
+}
+
+interface Harness {
+  readonly layer: ReturnType<typeof makeClaudeCodeAdapterLive>;
+  readonly query: FakeClaudeQuery;
+  readonly getLastCreateQueryInput: () =>
+    | {
+        readonly prompt: AsyncIterable<SDKUserMessage>;
+        readonly options: ClaudeQueryOptions;
+      }
+    | undefined;
+}
+
+function makeHarness(config?: {
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: ClaudeCodeAdapterLiveOptions["nativeEventLogger"];
+}): Harness {
+  const query = new FakeClaudeQuery();
+  let createInput:
+    | {
+        readonly prompt: AsyncIterable<SDKUserMessage>;
+        readonly options: ClaudeQueryOptions;
+      }
+    | undefined;
+
+  const adapterOptions: ClaudeCodeAdapterLiveOptions = {
+    createQuery: (input) => {
+      createInput = input;
+      return query;
+    },
+    ...(config?.nativeEventLogger
+      ? {
+          nativeEventLogger: config.nativeEventLogger,
+        }
+      : {}),
+    ...(config?.nativeEventLogPath
+      ? {
+          nativeEventLogPath: config.nativeEventLogPath,
+        }
+      : {}),
+  };
+
+  return {
+    layer: makeClaudeCodeAdapterLive(adapterOptions),
+    query,
+    getLastCreateQueryInput: () => createInput,
+  };
+}
+
+function makeDeterministicRandomService(seed = 0x1234_5678): {
+  nextIntUnsafe: () => number;
+  nextDoubleUnsafe: () => number;
+} {
+  let state = seed >>> 0;
+  const nextIntUnsafe = (): number => {
+    state = (Math.imul(1_664_525, state) + 1_013_904_223) >>> 0;
+    return state;
+  };
+
+  return {
+    nextIntUnsafe,
+    nextDoubleUnsafe: () => nextIntUnsafe() / 0x1_0000_0000,
+  };
+}
+
+
+const THREAD_ID = ThreadId.makeUnsafe("thread-claude-1");
+const RESUME_THREAD_ID = ThreadId.makeUnsafe("thread-claude-resume");
+
+describe("ClaudeCodeAdapterLive", () => {
+  it.effect("returns validation error for non-claudeCode provider on startSession", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+      const result = yield* adapter
+        .startSession({ threadId: THREAD_ID, provider: "codex", runtimeMode: "full-access" })
+        .pipe(Effect.result);
+
+      assert.equal(result._tag, "Failure");
+      if (result._tag !== "Failure") {
+        return;
+      }
+      assert.deepEqual(
+        result.failure,
+        new ProviderAdapterValidationError({
+          provider: "claudeCode",
+          operation: "startSession",
+          issue: "Expected provider 'claudeCode' but received 'codex'.",
+        }),
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("derives bypass permission mode from full-access runtime policy", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, "bypassPermissions");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("keeps explicit claude permission mode over runtime-derived defaults", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+        providerOptions: {
+          claudeCode: {
+            permissionMode: "plan",
+          },
+        },
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, "plan");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("maps Claude stream/runtime messages to canonical provider runtime events", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 11).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        model: "claude-sonnet-4-5",
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-1",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "text_delta",
+            text: "Hi",
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-2",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 1,
+          content_block: {
+            type: "tool_use",
+            id: "tool-1",
+            name: "Bash",
+            input: {
+              command: "ls",
+            },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-1",
+        uuid: "stream-3",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_stop",
+          index: 1,
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-1",
+        uuid: "assistant-1",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-message-1",
+          content: [{ type: "text", text: "Hi" }],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-1",
+        uuid: "result-1",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        [
+          "session.started",
+          "session.configured",
+          "session.state.changed",
+          "turn.started",
+          "thread.started",
+          "content.delta",
+          "item.started",
+          "item.completed",
+          "item.updated",
+          "item.completed",
+          "turn.completed",
+        ],
+      );
+
+      const turnStarted = runtimeEvents[3];
+      assert.equal(turnStarted?.type, "turn.started");
+      if (turnStarted?.type === "turn.started") {
+        assert.equal(String(turnStarted.turnId), String(turn.turnId));
+      }
+
+      const deltaEvent = runtimeEvents.find((event) => event.type === "content.delta");
+      assert.equal(deltaEvent?.type, "content.delta");
+      if (deltaEvent?.type === "content.delta") {
+        assert.equal(deltaEvent.payload.delta, "Hi");
+        assert.equal(String(deltaEvent.turnId), String(turn.turnId));
+      }
+
+      const toolStarted = runtimeEvents.find((event) => event.type === "item.started");
+      assert.equal(toolStarted?.type, "item.started");
+      if (toolStarted?.type === "item.started") {
+        assert.equal(toolStarted.payload.itemType, "command_execution");
+      }
+
+      const turnCompleted = runtimeEvents[runtimeEvents.length - 1];
+      assert.equal(turnCompleted?.type, "turn.completed");
+      if (turnCompleted?.type === "turn.completed") {
+        assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+        assert.equal(turnCompleted.payload.state, "completed");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("emits completion only after turn result when assistant frames arrive before deltas", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 9).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-early-assistant",
+        uuid: "assistant-early",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-message-early",
+          content: [{ type: "tool_use", id: "tool-early", name: "Read", input: { path: "a.ts" } }],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-early-assistant",
+        uuid: "stream-early",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "text_delta",
+            text: "Late text",
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-early-assistant",
+        uuid: "result-early",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        [
+          "session.started",
+          "session.configured",
+          "session.state.changed",
+          "turn.started",
+          "thread.started",
+          "item.updated",
+          "content.delta",
+          "item.completed",
+          "turn.completed",
+        ],
+      );
+
+      const deltaIndex = runtimeEvents.findIndex((event) => event.type === "content.delta");
+      const completedIndex = runtimeEvents.findIndex((event) => event.type === "item.completed");
+      assert.equal(deltaIndex >= 0 && completedIndex >= 0 && deltaIndex < completedIndex, true);
+
+      const deltaEvent = runtimeEvents[deltaIndex];
+      assert.equal(deltaEvent?.type, "content.delta");
+      if (deltaEvent?.type === "content.delta") {
+        assert.equal(deltaEvent.payload.delta, "Late text");
+        assert.equal(String(deltaEvent.turnId), String(turn.turnId));
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("falls back to assistant payload text when stream deltas are absent", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 9).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "assistant",
+        session_id: "sdk-session-fallback-text",
+        uuid: "assistant-fallback",
+        parent_tool_use_id: null,
+        message: {
+          id: "assistant-message-fallback",
+          content: [{ type: "text", text: "Fallback hello" }],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-fallback-text",
+        uuid: "result-fallback",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        [
+          "session.started",
+          "session.configured",
+          "session.state.changed",
+          "turn.started",
+          "thread.started",
+          "item.updated",
+          "content.delta",
+          "item.completed",
+          "turn.completed",
+        ],
+      );
+
+      const deltaEvent = runtimeEvents.find((event) => event.type === "content.delta");
+      assert.equal(deltaEvent?.type, "content.delta");
+      if (deltaEvent?.type === "content.delta") {
+        assert.equal(deltaEvent.payload.delta, "Fallback hello");
+        assert.equal(String(deltaEvent.turnId), String(turn.turnId));
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not fabricate provider thread ids before first SDK session_id", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 5).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+      });
+      assert.equal(session.threadId, undefined);
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+      assert.equal(turn.threadId, undefined);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-thread-real",
+        uuid: "stream-thread-real",
+        parent_tool_use_id: null,
+        event: {
+          type: "message_start",
+          message: {
+            id: "msg-thread-real",
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-thread-real",
+        uuid: "result-thread-real",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      assert.deepEqual(
+        runtimeEvents.map((event) => event.type),
+        [
+          "session.started",
+          "session.configured",
+          "session.state.changed",
+          "turn.started",
+          "thread.started",
+        ],
+      );
+
+      const sessionStarted = runtimeEvents[0];
+      assert.equal(sessionStarted?.type, "session.started");
+      if (sessionStarted?.type === "session.started") {
+        assert.equal("threadId" in sessionStarted, false);
+      }
+
+      const threadStarted = runtimeEvents[4];
+      assert.equal(threadStarted?.type, "thread.started");
+      if (threadStarted?.type === "thread.started") {
+        assert.equal(threadStarted.threadId, "sdk-thread-real");
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("bridges approval request/response lifecycle through canUseTool", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "approval-required",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+
+      const createInput = harness.getLastCreateQueryInput();
+      const canUseTool = createInput?.options.canUseTool;
+      assert.equal(typeof canUseTool, "function");
+      if (!canUseTool) {
+        return;
+      }
+
+      const permissionPromise = canUseTool(
+        "Bash",
+        { command: "pwd" },
+        {
+          signal: new AbortController().signal,
+          suggestions: [
+            {
+              type: "setMode",
+              mode: "default",
+              destination: "session",
+            },
+          ],
+          toolUseID: "tool-use-1",
+        },
+      );
+
+      const requested = yield* Stream.runHead(adapter.streamEvents);
+      assert.equal(requested._tag, "Some");
+      if (requested._tag !== "Some") {
+        return;
+      }
+      assert.equal(requested.value.type, "request.opened");
+      if (requested.value.type !== "request.opened") {
+        return;
+      }
+      const runtimeRequestId = requested.value.requestId;
+      assert.equal(typeof runtimeRequestId, "string");
+      if (runtimeRequestId === undefined) {
+        return;
+      }
+
+      yield* adapter.respondToRequest(
+        session.threadId,
+        ApprovalRequestId.makeUnsafe(runtimeRequestId),
+        "accept",
+      );
+
+      const resolved = yield* Stream.runHead(adapter.streamEvents);
+      assert.equal(resolved._tag, "Some");
+      if (resolved._tag !== "Some") {
+        return;
+      }
+      assert.equal(resolved.value.type, "request.resolved");
+      if (resolved.value.type !== "request.resolved") {
+        return;
+      }
+      assert.equal(resolved.value.requestId, requested.value.requestId);
+      assert.equal(resolved.value.payload.decision, "accept");
+
+      const permissionResult = yield* Effect.promise(() => permissionPromise);
+      assert.equal((permissionResult as PermissionResult).behavior, "allow");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("passes parsed resume cursor values to Claude query options", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: RESUME_THREAD_ID,
+        provider: "claudeCode",
+        resumeCursor: {
+          threadId: "resume-thread-1",
+          resume: "550e8400-e29b-41d4-a716-446655440000",
+          resumeSessionAt: "assistant-99",
+          turnCount: 3,
+        },
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(session.threadId, "resume-thread-1");
+      assert.deepEqual(session.resumeCursor, {
+        threadId: "resume-thread-1",
+        resume: "550e8400-e29b-41d4-a716-446655440000",
+        resumeSessionAt: "assistant-99",
+        turnCount: 3,
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.resume, "550e8400-e29b-41d4-a716-446655440000");
+      assert.equal(createInput?.options.resumeSessionAt, "assistant-99");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("does not synthesize resume session id from generated thread ids", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(
+        "resume" in (session.resumeCursor as Record<string, unknown>),
+        false,
+      );
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.resume, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("supports rollbackThread by trimming in-memory turns and preserving earlier turns", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+      });
+
+      const firstTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "first",
+        attachments: [],
+      });
+
+      const firstCompletedFiber = yield* Stream.filter(adapter.streamEvents, (event) => event.type === "turn.completed").pipe(
+        Stream.runHead,
+        Effect.forkChild,
+      );
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-rollback",
+        uuid: "result-first",
+      } as unknown as SDKMessage);
+
+      const firstCompleted = yield* Fiber.join(firstCompletedFiber);
+      assert.equal(firstCompleted._tag, "Some");
+      if (firstCompleted._tag === "Some" && firstCompleted.value.type === "turn.completed") {
+        assert.equal(String(firstCompleted.value.turnId), String(firstTurn.turnId));
+      }
+
+      const secondTurn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "second",
+        attachments: [],
+      });
+
+      const secondCompletedFiber = yield* Stream.filter(adapter.streamEvents, (event) => event.type === "turn.completed").pipe(
+        Stream.runHead,
+        Effect.forkChild,
+      );
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-rollback",
+        uuid: "result-second",
+      } as unknown as SDKMessage);
+
+      const secondCompleted = yield* Fiber.join(secondCompletedFiber);
+      assert.equal(secondCompleted._tag, "Some");
+      if (secondCompleted._tag === "Some" && secondCompleted.value.type === "turn.completed") {
+        assert.equal(String(secondCompleted.value.turnId), String(secondTurn.turnId));
+      }
+
+      const threadBeforeRollback = yield* adapter.readThread(session.threadId);
+      assert.equal(threadBeforeRollback.turns.length, 2);
+
+      const rolledBack = yield* adapter.rollbackThread(session.threadId, 1);
+      assert.equal(rolledBack.turns.length, 1);
+      assert.equal(rolledBack.turns[0]?.id, firstTurn.turnId);
+
+      const threadAfterRollback = yield* adapter.readThread(session.threadId);
+      assert.equal(threadAfterRollback.turns.length, 1);
+      assert.equal(threadAfterRollback.turns[0]?.id, firstTurn.turnId);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("updates model on sendTurn when model override is provided", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        model: "claude-opus-4-6",
+        attachments: [],
+      });
+
+      assert.deepEqual(harness.query.setModelCalls, ["claude-opus-4-6"]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("writes provider-native observability records when enabled", () => {
+    const nativeEvents: Array<{
+      event?: {
+        provider?: string;
+        method?: string;
+        threadId?: string;
+        turnId?: string;
+      };
+    }> = [];
+    const harness = makeHarness({
+      nativeEventLogger: {
+        filePath: "memory://claude-native-events",
+        write: (event) => {
+          nativeEvents.push(event as (typeof nativeEvents)[number]);
+          return Effect.void;
+        },
+        close: () => Effect.void,
+      },
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeCodeAdapter;
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeCode",
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      const turnCompletedFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "turn.completed",
+      ).pipe(Stream.runHead, Effect.forkChild);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-native-log",
+        uuid: "stream-native-log",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "text_delta",
+            text: "hi",
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-native-log",
+        uuid: "result-native-log",
+      } as unknown as SDKMessage);
+
+      const turnCompleted = yield* Fiber.join(turnCompletedFiber);
+      assert.equal(turnCompleted._tag, "Some");
+
+      assert.equal(nativeEvents.length > 0, true);
+      assert.equal(nativeEvents.some((record) => record.event?.provider === "claudeCode"), true);
+      assert.equal(nativeEvents.some((record) => String(record.event?.threadId) === String(session.threadId)), true);
+      assert.equal(
+        nativeEvents.some((record) => String(record.event?.turnId) === String(turn.turnId)),
+        true,
+      );
+      assert.equal(
+        nativeEvents.some(
+          (record) => record.event?.method === "claude/stream_event/content_block_delta/text_delta",
+        ),
+        true,
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+});

--- a/apps/server/src/provider/Layers/ClaudeCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeCodeAdapter.ts
@@ -1,0 +1,1872 @@
+/**
+ * ClaudeCodeAdapterLive - Scoped live implementation for the Claude Code provider adapter.
+ *
+ * Wraps `@anthropic-ai/claude-agent-sdk` query sessions behind the generic
+ * provider adapter contract and emits canonical runtime events.
+ *
+ * @module ClaudeCodeAdapterLive
+ */
+import {
+  type CanUseTool,
+  query,
+  type Options as ClaudeQueryOptions,
+  type PermissionMode,
+  type PermissionResult,
+  type PermissionUpdate,
+  type SDKMessage,
+  type SDKResultMessage,
+  type SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import {
+  ApprovalRequestId,
+  type CanonicalItemType,
+  type CanonicalRequestType,
+  EventId,
+  type ProviderApprovalDecision,
+  ProviderItemId,
+  type ProviderRuntimeEvent,
+  type ProviderRuntimeTurnStatus,
+  type ProviderSendTurnInput,
+  type ProviderSession,
+  RuntimeItemId,
+  RuntimeRequestId,
+  RuntimeTaskId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import { Cause, DateTime, Deferred, Effect, Layer, Queue, Random, Ref, Stream } from "effect";
+
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionClosedError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
+import { ClaudeCodeAdapter, type ClaudeCodeAdapterShape } from "../Services/ClaudeCodeAdapter.ts";
+import { createRequire } from "node:module";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const PROVIDER = "claudeCode" as const;
+
+function resolveClaudeCodeCliPath(): string | undefined {
+  try {
+    const require = createRequire(import.meta.url);
+    const sdkEntry = require.resolve("@anthropic-ai/claude-agent-sdk");
+    const sdkDir = sdkEntry.substring(0, sdkEntry.lastIndexOf("/"));
+    const cliPath = `${sdkDir}/cli.js`;
+    if (cliPath.includes("app.asar/")) {
+      return cliPath.replace("app.asar/", "app.asar.unpacked/");
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+type PromptQueueItem =
+  | {
+      readonly type: "message";
+      readonly message: SDKUserMessage;
+    }
+  | {
+      readonly type: "terminate";
+    };
+
+interface ClaudeResumeState {
+  readonly threadId?: ThreadId;
+  readonly resume?: string;
+  readonly resumeSessionAt?: string;
+  readonly turnCount?: number;
+}
+
+interface ClaudeTurnState {
+  readonly turnId: TurnId;
+  readonly assistantItemId: string;
+  readonly startedAt: string;
+  readonly items: Array<unknown>;
+  readonly messageCompleted: boolean;
+  readonly emittedTextDelta: boolean;
+  readonly fallbackAssistantText: string;
+}
+
+interface PendingApproval {
+  readonly requestType: CanonicalRequestType;
+  readonly detail?: string;
+  readonly suggestions?: ReadonlyArray<PermissionUpdate>;
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+}
+
+interface ToolInFlight {
+  readonly itemId: string;
+  readonly itemType: CanonicalItemType;
+  readonly toolName: string;
+  readonly title: string;
+  readonly detail?: string;
+}
+
+interface ClaudeSessionContext {
+  session: ProviderSession;
+  readonly promptQueue: Queue.Queue<PromptQueueItem>;
+  readonly query: ClaudeQueryRuntime;
+  readonly startedAt: string;
+  resumeSessionId: string | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly turns: Array<{
+    id: TurnId;
+    items: Array<unknown>;
+  }>;
+  readonly inFlightTools: Map<number, ToolInFlight>;
+  turnState: ClaudeTurnState | undefined;
+  lastAssistantUuid: string | undefined;
+  lastThreadStartedId: string | undefined;
+  stopped: boolean;
+}
+
+interface ClaudeQueryRuntime extends AsyncIterable<SDKMessage> {
+  readonly interrupt: () => Promise<void>;
+  readonly setModel: (model?: string) => Promise<void>;
+  readonly setPermissionMode: (mode: PermissionMode) => Promise<void>;
+  readonly setMaxThinkingTokens: (maxThinkingTokens: number | null) => Promise<void>;
+  readonly close: () => void;
+}
+
+export interface ClaudeCodeAdapterLiveOptions {
+  readonly createQuery?: (input: {
+    readonly prompt: AsyncIterable<SDKUserMessage>;
+    readonly options: ClaudeQueryOptions;
+  }) => ClaudeQueryRuntime;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function isSyntheticClaudeThreadId(value: string): boolean {
+  return value.startsWith("claude-thread-");
+}
+
+function toMessage(cause: unknown, fallback: string): string {
+  if (cause instanceof Error && cause.message.length > 0) {
+    return cause.message;
+  }
+  return fallback;
+}
+
+function asRuntimeItemId(value: string): RuntimeItemId {
+  return RuntimeItemId.makeUnsafe(value);
+}
+
+function asCanonicalTurnId(value: TurnId): TurnId {
+  return value;
+}
+
+function asRuntimeRequestId(value: ApprovalRequestId): RuntimeRequestId {
+  return RuntimeRequestId.makeUnsafe(value);
+}
+
+function toPermissionMode(value: unknown): PermissionMode | undefined {
+  switch (value) {
+    case "default":
+    case "acceptEdits":
+    case "bypassPermissions":
+    case "plan":
+    case "dontAsk":
+      return value;
+    default:
+      return undefined;
+  }
+}
+
+function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undefined {
+  if (!resumeCursor || typeof resumeCursor !== "object") {
+    return undefined;
+  }
+  const cursor = resumeCursor as {
+    threadId?: unknown;
+    resume?: unknown;
+    sessionId?: unknown;
+    resumeSessionAt?: unknown;
+    turnCount?: unknown;
+  };
+
+  const threadIdCandidate = typeof cursor.threadId === "string" ? cursor.threadId : undefined;
+  const threadId =
+    threadIdCandidate && !isSyntheticClaudeThreadId(threadIdCandidate)
+      ? ThreadId.makeUnsafe(threadIdCandidate)
+      : undefined;
+  const resumeCandidate =
+    typeof cursor.resume === "string"
+      ? cursor.resume
+      : typeof cursor.sessionId === "string"
+        ? cursor.sessionId
+        : undefined;
+  const resume = resumeCandidate && isUuid(resumeCandidate) ? resumeCandidate : undefined;
+  const resumeSessionAt =
+    typeof cursor.resumeSessionAt === "string" ? cursor.resumeSessionAt : undefined;
+  const turnCountValue = typeof cursor.turnCount === "number" ? cursor.turnCount : undefined;
+
+  return {
+    ...(threadId ? { threadId } : {}),
+    ...(resume ? { resume } : {}),
+    ...(resumeSessionAt ? { resumeSessionAt } : {}),
+    ...(turnCountValue !== undefined && Number.isInteger(turnCountValue) && turnCountValue >= 0
+      ? { turnCount: turnCountValue }
+      : {}),
+  };
+}
+
+function classifyToolItemType(toolName: string): CanonicalItemType {
+  const normalized = toolName.toLowerCase();
+  if (
+    normalized.includes("bash") ||
+    normalized.includes("command") ||
+    normalized.includes("shell") ||
+    normalized.includes("terminal")
+  ) {
+    return "command_execution";
+  }
+  if (
+    normalized.includes("edit") ||
+    normalized.includes("write") ||
+    normalized.includes("file") ||
+    normalized.includes("patch") ||
+    normalized.includes("replace") ||
+    normalized.includes("create") ||
+    normalized.includes("delete")
+  ) {
+    return "file_change";
+  }
+  if (normalized.includes("mcp")) {
+    return "mcp_tool_call";
+  }
+  return "dynamic_tool_call";
+}
+
+function classifyRequestType(toolName: string): CanonicalRequestType {
+  const normalized = toolName.toLowerCase();
+  if (normalized === "read" || normalized.includes("read file") || normalized.includes("view")) {
+    return "file_read_approval";
+  }
+  return classifyToolItemType(toolName) === "command_execution"
+    ? "command_execution_approval"
+    : "file_change_approval";
+}
+
+function summarizeToolRequest(toolName: string, input: Record<string, unknown>): string {
+  const commandValue = input.command ?? input.cmd;
+  const command = typeof commandValue === "string" ? commandValue : undefined;
+  if (command && command.trim().length > 0) {
+    return `${toolName}: ${command.trim().slice(0, 400)}`;
+  }
+
+  const serialized = JSON.stringify(input);
+  if (serialized.length <= 400) {
+    return `${toolName}: ${serialized}`;
+  }
+  return `${toolName}: ${serialized.slice(0, 397)}...`;
+}
+
+function titleForTool(itemType: CanonicalItemType): string {
+  switch (itemType) {
+    case "command_execution":
+      return "Command run";
+    case "file_change":
+      return "File change";
+    case "mcp_tool_call":
+      return "MCP tool call";
+    case "dynamic_tool_call":
+      return "Tool call";
+    default:
+      return "Item";
+  }
+}
+
+function buildUserMessage(input: ProviderSendTurnInput): SDKUserMessage {
+  const fragments: string[] = [];
+
+  if (input.input && input.input.trim().length > 0) {
+    fragments.push(input.input.trim());
+  }
+
+  for (const attachment of input.attachments ?? []) {
+    if (attachment.type === "image") {
+      fragments.push(
+        `Attached image: ${attachment.name} (${attachment.mimeType}, ${attachment.sizeBytes} bytes).`,
+      );
+    }
+  }
+
+  const text = fragments.join("\n\n");
+
+  return {
+    type: "user",
+    session_id: "",
+    parent_tool_use_id: null,
+    message: {
+      role: "user",
+      content: [{ type: "text", text }],
+    },
+  } as SDKUserMessage;
+}
+
+function turnStatusFromResult(result: SDKResultMessage): ProviderRuntimeTurnStatus {
+  if (result.subtype === "success") {
+    return "completed";
+  }
+
+  const errors = result.errors.join(" ").toLowerCase();
+  if (errors.includes("interrupt")) {
+    return "interrupted";
+  }
+  if (errors.includes("cancel")) {
+    return "cancelled";
+  }
+  return "failed";
+}
+
+function streamKindFromDeltaType(deltaType: string): "assistant_text" | "reasoning_text" {
+  return deltaType.includes("thinking") ? "reasoning_text" : "assistant_text";
+}
+
+function providerThreadRef(
+  context: ClaudeSessionContext,
+): { readonly providerThreadId: string } | {} {
+  return context.resumeSessionId ? { providerThreadId: context.resumeSessionId } : {};
+}
+
+function extractAssistantText(message: SDKMessage): string {
+  if (message.type !== "assistant") {
+    return "";
+  }
+
+  const content = (message.message as { content?: unknown } | undefined)?.content;
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  const fragments: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const candidate = block as { type?: unknown; text?: unknown };
+    if (
+      candidate.type === "text" &&
+      typeof candidate.text === "string" &&
+      candidate.text.length > 0
+    ) {
+      fragments.push(candidate.text);
+    }
+  }
+
+  return fragments.join("");
+}
+
+function toSessionError(
+  threadId: ThreadId,
+  cause: unknown,
+): ProviderAdapterSessionNotFoundError | ProviderAdapterSessionClosedError | undefined {
+  const normalized = toMessage(cause, "").toLowerCase();
+  if (normalized.includes("unknown session") || normalized.includes("not found")) {
+    return new ProviderAdapterSessionNotFoundError({
+      provider: PROVIDER,
+      threadId,
+      cause,
+    });
+  }
+  if (normalized.includes("closed")) {
+    return new ProviderAdapterSessionClosedError({
+      provider: PROVIDER,
+      threadId,
+      cause,
+    });
+  }
+  return undefined;
+}
+
+function toRequestError(
+  threadId: ThreadId,
+  method: string,
+  cause: unknown,
+): ProviderAdapterError {
+  const sessionError = toSessionError(threadId, cause);
+  if (sessionError) {
+    return sessionError;
+  }
+  return new ProviderAdapterRequestError({
+    provider: PROVIDER,
+    method,
+    detail: toMessage(cause, `${method} failed`),
+    cause,
+  });
+}
+
+function sdkMessageType(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as { type?: unknown };
+  return typeof record.type === "string" ? record.type : undefined;
+}
+
+function sdkMessageSubtype(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as { subtype?: unknown };
+  return typeof record.subtype === "string" ? record.subtype : undefined;
+}
+
+function sdkNativeMethod(message: SDKMessage): string {
+  const subtype = sdkMessageSubtype(message);
+  if (subtype) {
+    return `claude/${message.type}/${subtype}`;
+  }
+
+  if (message.type === "stream_event") {
+    const streamType = sdkMessageType(message.event);
+    if (streamType) {
+      const deltaType =
+        streamType === "content_block_delta"
+          ? sdkMessageType((message.event as { delta?: unknown }).delta)
+          : undefined;
+      if (deltaType) {
+        return `claude/${message.type}/${streamType}/${deltaType}`;
+      }
+      return `claude/${message.type}/${streamType}`;
+    }
+  }
+
+  return `claude/${message.type}`;
+}
+
+function sdkNativeItemId(message: SDKMessage): string | undefined {
+  if (message.type === "assistant") {
+    const maybeId = (message.message as { id?: unknown }).id;
+    if (typeof maybeId === "string") {
+      return maybeId;
+    }
+    return undefined;
+  }
+
+  if (message.type === "stream_event") {
+    const event = message.event as {
+      type?: unknown;
+      content_block?: { id?: unknown };
+    };
+    if (event.type === "content_block_start" && typeof event.content_block?.id === "string") {
+      return event.content_block.id;
+    }
+  }
+
+  return undefined;
+}
+
+function makeClaudeCodeAdapter(options?: ClaudeCodeAdapterLiveOptions) {
+  return Effect.gen(function* () {
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, {
+            stream: "native",
+          })
+        : undefined);
+
+    const createQuery =
+      options?.createQuery ??
+      ((input: {
+        readonly prompt: AsyncIterable<SDKUserMessage>;
+        readonly options: ClaudeQueryOptions;
+      }) => query({ prompt: input.prompt, options: input.options }) as ClaudeQueryRuntime);
+
+    const sessions = new Map<ThreadId, ClaudeSessionContext>();
+    const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const nextEventId = Effect.map(Random.nextUUIDv4, (id) => EventId.makeUnsafe(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent): Effect.Effect<void> =>
+      Queue.offer(runtimeEventQueue, event).pipe(Effect.asVoid);
+
+    const logNativeSdkMessage = (
+      context: ClaudeSessionContext,
+      message: SDKMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) {
+          return;
+        }
+
+        const observedAt = new Date().toISOString();
+        const itemId = sdkNativeItemId(message);
+
+        yield* nativeEventLogger
+          .write(
+            {
+              observedAt,
+              event: {
+                id:
+                  "uuid" in message && typeof message.uuid === "string"
+                    ? message.uuid
+                    : crypto.randomUUID(),
+                kind: "notification",
+                provider: PROVIDER,
+                createdAt: observedAt,
+                method: sdkNativeMethod(message),
+                ...(typeof message.session_id === "string"
+                  ? { providerThreadId: message.session_id }
+                  : {}),
+                ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+                ...(itemId ? { itemId: ProviderItemId.makeUnsafe(itemId) } : {}),
+                payload: message,
+              },
+            },
+            null,
+          );
+      });
+
+    const snapshotThread = (
+      context: ClaudeSessionContext,
+    ): Effect.Effect<{
+      threadId: ThreadId;
+      turns: ReadonlyArray<{
+        id: TurnId;
+        items: ReadonlyArray<unknown>;
+      }>;
+    }, ProviderAdapterValidationError> =>
+      Effect.gen(function* () {
+        const threadId = context.session.threadId;
+        if (!threadId) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "readThread",
+            issue: "Session thread id is not initialized yet.",
+          });
+        }
+        return {
+          threadId,
+          turns: context.turns.map((turn) => ({
+            id: turn.id,
+            items: [...turn.items],
+          })),
+        };
+      });
+
+    const updateResumeCursor = (context: ClaudeSessionContext): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const threadId = context.session.threadId;
+        if (!threadId) return;
+
+        const resumeCursor = {
+          threadId,
+          ...(context.resumeSessionId ? { resume: context.resumeSessionId } : {}),
+          ...(context.lastAssistantUuid ? { resumeSessionAt: context.lastAssistantUuid } : {}),
+          turnCount: context.turns.length,
+        };
+
+        context.session = {
+          ...context.session,
+          resumeCursor,
+          updatedAt: yield* nowIso,
+        };
+      });
+
+    const ensureThreadId = (
+      context: ClaudeSessionContext,
+      message: SDKMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (typeof message.session_id !== "string" || message.session_id.length === 0) {
+          return;
+        }
+        const nextThreadId = message.session_id;
+        context.resumeSessionId = message.session_id;
+        yield* updateResumeCursor(context);
+
+        if (context.lastThreadStartedId !== nextThreadId) {
+          context.lastThreadStartedId = nextThreadId;
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+            createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            payload: {
+              providerThreadId: nextThreadId,
+            },
+            providerRefs: {},
+            raw: {
+              source: "claude.sdk.message",
+              method: "claude/thread/started",
+              payload: {
+                session_id: message.session_id,
+              },
+            },
+          });
+        }
+      });
+
+    const emitRuntimeError = (
+      context: ClaudeSessionContext,
+      message: string,
+      cause?: unknown,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (cause !== undefined) {
+          void cause;
+        }
+        const turnState = context.turnState;
+        const stamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "runtime.error",
+          eventId: stamp.eventId,
+          provider: PROVIDER,
+          createdAt: stamp.createdAt,
+          threadId: context.session.threadId,
+          ...(turnState ? { turnId: asCanonicalTurnId(turnState.turnId) } : {}),
+          payload: {
+            message,
+            class: "provider_error",
+            ...(cause !== undefined ? { detail: cause } : {}),
+          },
+          providerRefs: {
+            ...providerThreadRef(context),
+            ...(turnState ? { providerTurnId: String(turnState.turnId) } : {}),
+          },
+        });
+      });
+
+    const emitRuntimeWarning = (
+      context: ClaudeSessionContext,
+      message: string,
+      detail?: unknown,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const turnState = context.turnState;
+        const stamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "runtime.warning",
+          eventId: stamp.eventId,
+          provider: PROVIDER,
+          createdAt: stamp.createdAt,
+          threadId: context.session.threadId,
+          ...(turnState ? { turnId: asCanonicalTurnId(turnState.turnId) } : {}),
+          payload: {
+            message,
+            ...(detail !== undefined ? { detail } : {}),
+          },
+          providerRefs: {
+            ...providerThreadRef(context),
+            ...(turnState ? { providerTurnId: String(turnState.turnId) } : {}),
+          },
+        });
+      });
+
+    const completeTurn = (
+      context: ClaudeSessionContext,
+      status: ProviderRuntimeTurnStatus,
+      errorMessage?: string,
+      result?: SDKResultMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const turnState = context.turnState;
+        if (!turnState) {
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "turn.completed",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+            createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            payload: {
+              state: status,
+              ...(result?.stop_reason !== undefined ? { stopReason: result.stop_reason } : {}),
+              ...(result?.usage ? { usage: result.usage } : {}),
+              ...(result?.modelUsage ? { modelUsage: result.modelUsage } : {}),
+              ...(typeof result?.total_cost_usd === "number"
+                ? { totalCostUsd: result.total_cost_usd }
+                : {}),
+              ...(errorMessage ? { errorMessage } : {}),
+            },
+            providerRefs: {},
+          });
+          return;
+        }
+
+        if (!turnState.messageCompleted) {
+          if (!turnState.emittedTextDelta && turnState.fallbackAssistantText.length > 0) {
+            const deltaStamp = yield* makeEventStamp();
+            yield* offerRuntimeEvent({
+              type: "content.delta",
+              eventId: deltaStamp.eventId,
+              provider: PROVIDER,
+              createdAt: deltaStamp.createdAt,
+              threadId: context.session.threadId,
+              turnId: turnState.turnId,
+              itemId: asRuntimeItemId(turnState.assistantItemId),
+              payload: {
+                streamKind: "assistant_text",
+                delta: turnState.fallbackAssistantText,
+              },
+              providerRefs: {
+                ...providerThreadRef(context),
+                providerTurnId: String(turnState.turnId),
+                providerItemId: ProviderItemId.makeUnsafe(turnState.assistantItemId),
+              },
+            });
+          }
+
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "item.completed",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+            createdAt: stamp.createdAt,
+            itemId: asRuntimeItemId(turnState.assistantItemId),
+            threadId: context.session.threadId,
+            turnId: turnState.turnId,
+            payload: {
+              itemType: "assistant_message",
+              status: "completed",
+              title: "Assistant message",
+            },
+            providerRefs: {
+              ...providerThreadRef(context),
+              providerTurnId: turnState.turnId,
+              providerItemId: ProviderItemId.makeUnsafe(turnState.assistantItemId),
+            },
+          });
+        }
+
+        context.turns.push({
+          id: turnState.turnId,
+          items: [...turnState.items],
+        });
+
+        const stamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "turn.completed",
+          eventId: stamp.eventId,
+          provider: PROVIDER,
+          createdAt: stamp.createdAt,
+          threadId: context.session.threadId,
+          turnId: turnState.turnId,
+          payload: {
+            state: status,
+            ...(result?.stop_reason !== undefined ? { stopReason: result.stop_reason } : {}),
+            ...(result?.usage ? { usage: result.usage } : {}),
+            ...(result?.modelUsage ? { modelUsage: result.modelUsage } : {}),
+            ...(typeof result?.total_cost_usd === "number"
+              ? { totalCostUsd: result.total_cost_usd }
+              : {}),
+            ...(errorMessage ? { errorMessage } : {}),
+          },
+          providerRefs: {
+            ...providerThreadRef(context),
+            providerTurnId: turnState.turnId,
+          },
+        });
+
+        const updatedAt = yield* nowIso;
+        context.turnState = undefined;
+        context.session = {
+          ...context.session,
+          status: "ready",
+          activeTurnId: undefined,
+          updatedAt,
+          ...(status === "failed" && errorMessage ? { lastError: errorMessage } : {}),
+        };
+        yield* updateResumeCursor(context);
+      });
+
+    const handleStreamEvent = (
+      context: ClaudeSessionContext,
+      message: SDKMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (message.type !== "stream_event") {
+          return;
+        }
+
+        const { event } = message;
+
+        if (event.type === "content_block_delta") {
+          if (
+            event.delta.type === "text_delta" &&
+            event.delta.text.length > 0 &&
+            context.turnState
+          ) {
+            if (!context.turnState.emittedTextDelta) {
+              context.turnState = {
+                ...context.turnState,
+                emittedTextDelta: true,
+              };
+            }
+            const stamp = yield* makeEventStamp();
+            yield* offerRuntimeEvent({
+              type: "content.delta",
+              eventId: stamp.eventId,
+              provider: PROVIDER,
+              createdAt: stamp.createdAt,
+              threadId: context.session.threadId,
+              turnId: context.turnState.turnId,
+              itemId: asRuntimeItemId(context.turnState.assistantItemId),
+              payload: {
+                streamKind: streamKindFromDeltaType(event.delta.type),
+                delta: event.delta.text,
+              },
+              providerRefs: {
+                ...providerThreadRef(context),
+                providerTurnId: context.turnState.turnId,
+                providerItemId: ProviderItemId.makeUnsafe(context.turnState.assistantItemId),
+              },
+              raw: {
+                source: "claude.sdk.message",
+                method: "claude/stream_event/content_block_delta",
+                payload: message,
+              },
+            });
+          }
+          return;
+        }
+
+        if (event.type === "content_block_start") {
+          const { index, content_block: block } = event;
+          if (
+            block.type !== "tool_use" &&
+            block.type !== "server_tool_use" &&
+            block.type !== "mcp_tool_use"
+          ) {
+            return;
+          }
+
+          const toolName = block.name;
+          const itemType = classifyToolItemType(toolName);
+          const toolInput =
+            typeof block.input === "object" && block.input !== null
+              ? (block.input as Record<string, unknown>)
+              : {};
+          const itemId = block.id;
+          const detail = summarizeToolRequest(toolName, toolInput);
+
+          const tool: ToolInFlight = {
+            itemId,
+            itemType,
+            toolName,
+            title: titleForTool(itemType),
+            detail,
+          };
+          context.inFlightTools.set(index, tool);
+
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "item.started",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+              createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+            itemId: asRuntimeItemId(tool.itemId),
+            payload: {
+              itemType: tool.itemType,
+              status: "inProgress",
+              title: tool.title,
+              ...(tool.detail ? { detail: tool.detail } : {}),
+              data: {
+                toolName: tool.toolName,
+                input: toolInput,
+              },
+            },
+            providerRefs: {
+              ...providerThreadRef(context),
+              ...(context.turnState ? { providerTurnId: String(context.turnState.turnId) } : {}),
+              providerItemId: ProviderItemId.makeUnsafe(tool.itemId),
+            },
+            raw: {
+              source: "claude.sdk.message",
+              method: "claude/stream_event/content_block_start",
+              payload: message,
+            },
+          });
+          return;
+        }
+
+        if (event.type === "content_block_stop") {
+          const { index } = event;
+          const tool = context.inFlightTools.get(index);
+          if (!tool) {
+            return;
+          }
+          context.inFlightTools.delete(index);
+
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "item.completed",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+              createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+            itemId: asRuntimeItemId(tool.itemId),
+            payload: {
+              itemType: tool.itemType,
+              status: "completed",
+              title: tool.title,
+              ...(tool.detail ? { detail: tool.detail } : {}),
+            },
+            providerRefs: {
+              ...providerThreadRef(context),
+              ...(context.turnState ? { providerTurnId: String(context.turnState.turnId) } : {}),
+              providerItemId: ProviderItemId.makeUnsafe(tool.itemId),
+            },
+            raw: {
+              source: "claude.sdk.message",
+              method: "claude/stream_event/content_block_stop",
+              payload: message,
+            },
+          });
+        }
+      });
+
+    const handleAssistantMessage = (
+      context: ClaudeSessionContext,
+      message: SDKMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (message.type !== "assistant") {
+          return;
+        }
+
+        if (context.turnState) {
+          context.turnState.items.push(message.message);
+          const fallbackAssistantText = extractAssistantText(message);
+          if (
+            fallbackAssistantText.length > 0 &&
+            fallbackAssistantText !== context.turnState.fallbackAssistantText
+          ) {
+            context.turnState = {
+              ...context.turnState,
+              fallbackAssistantText,
+            };
+          }
+
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "item.updated",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+            createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            turnId: context.turnState.turnId,
+            itemId: asRuntimeItemId(context.turnState.assistantItemId),
+            payload: {
+              itemType: "assistant_message",
+              status: "inProgress",
+              title: "Assistant message",
+              data: message.message,
+            },
+            providerRefs: {
+              ...providerThreadRef(context),
+              providerTurnId: context.turnState.turnId,
+              providerItemId: ProviderItemId.makeUnsafe(context.turnState.assistantItemId),
+            },
+            raw: {
+              source: "claude.sdk.message",
+              method: "claude/assistant",
+              payload: message,
+            },
+          });
+        }
+
+        context.lastAssistantUuid = message.uuid;
+        yield* updateResumeCursor(context);
+      });
+
+    const handleResultMessage = (
+      context: ClaudeSessionContext,
+      message: SDKMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (message.type !== "result") {
+          return;
+        }
+
+        const status = turnStatusFromResult(message);
+        const errorMessage = message.subtype === "success" ? undefined : message.errors[0];
+
+        if (status === "failed") {
+          yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");
+        }
+
+        yield* completeTurn(context, status, errorMessage, message);
+      });
+
+    const handleSystemMessage = (
+      context: ClaudeSessionContext,
+      message: SDKMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (message.type !== "system") {
+          return;
+        }
+
+        const stamp = yield* makeEventStamp();
+        const base = {
+          eventId: stamp.eventId,
+          provider: PROVIDER,
+          createdAt: stamp.createdAt,
+          threadId: context.session.threadId,
+          ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+          providerRefs: {
+            ...providerThreadRef(context),
+            ...(context.turnState ? { providerTurnId: context.turnState.turnId } : {}),
+          },
+          raw: {
+            source: "claude.sdk.message" as const,
+            method: sdkNativeMethod(message),
+            messageType: `${message.type}:${message.subtype}`,
+            payload: message,
+          },
+        };
+
+        switch (message.subtype) {
+          case "init":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "session.configured",
+              payload: {
+                config: message as Record<string, unknown>,
+              },
+            });
+            return;
+          case "status":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "session.state.changed",
+              payload: {
+                state: message.status === "compacting" ? "waiting" : "running",
+                reason: `status:${message.status ?? "active"}`,
+                detail: message,
+              },
+            });
+            return;
+          case "compact_boundary":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "thread.state.changed",
+              payload: {
+                state: "compacted",
+                detail: message,
+              },
+            });
+            return;
+          case "hook_started":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "hook.started",
+              payload: {
+                hookId: message.hook_id,
+                hookName: message.hook_name,
+                hookEvent: message.hook_event,
+              },
+            });
+            return;
+          case "hook_progress":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "hook.progress",
+              payload: {
+                hookId: message.hook_id,
+                output: message.output,
+                stdout: message.stdout,
+                stderr: message.stderr,
+              },
+            });
+            return;
+          case "hook_response":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "hook.completed",
+              payload: {
+                hookId: message.hook_id,
+                outcome: message.outcome,
+                output: message.output,
+                stdout: message.stdout,
+                stderr: message.stderr,
+                ...(typeof message.exit_code === "number" ? { exitCode: message.exit_code } : {}),
+              },
+            });
+            return;
+          case "task_started":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "task.started",
+              payload: {
+                taskId: RuntimeTaskId.makeUnsafe(message.task_id),
+                description: message.description,
+                ...(message.task_type ? { taskType: message.task_type } : {}),
+              },
+            });
+            return;
+          case "task_progress":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "task.progress",
+              payload: {
+                taskId: RuntimeTaskId.makeUnsafe(message.task_id),
+                description: message.description,
+                ...(message.usage ? { usage: message.usage } : {}),
+                ...(message.last_tool_name ? { lastToolName: message.last_tool_name } : {}),
+              },
+            });
+            return;
+          case "task_notification":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "task.completed",
+              payload: {
+                taskId: RuntimeTaskId.makeUnsafe(message.task_id),
+                status: message.status,
+                ...(message.summary ? { summary: message.summary } : {}),
+                ...(message.usage ? { usage: message.usage } : {}),
+              },
+            });
+            return;
+          case "files_persisted":
+            yield* offerRuntimeEvent({
+              ...base,
+              type: "files.persisted",
+              payload: {
+                files: Array.isArray(message.files)
+                  ? message.files.map((file: { filename: string; file_id: string }) => ({
+                      filename: file.filename,
+                      fileId: file.file_id,
+                    }))
+                  : [],
+                ...(Array.isArray(message.failed)
+                  ? {
+                      failed: message.failed.map((entry: { filename: string; error: string }) => ({
+                        filename: entry.filename,
+                        error: entry.error,
+                      })),
+                    }
+                  : {}),
+              },
+            });
+            return;
+          default:
+            yield* emitRuntimeWarning(
+              context,
+              `Unhandled Claude system message subtype '${message.subtype}'.`,
+              message,
+            );
+            return;
+        }
+      });
+
+    const handleSdkTelemetryMessage = (
+      context: ClaudeSessionContext,
+      message: SDKMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const stamp = yield* makeEventStamp();
+        const base = {
+          eventId: stamp.eventId,
+          provider: PROVIDER,
+          createdAt: stamp.createdAt,
+          threadId: context.session.threadId,
+          ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+          providerRefs: {
+            ...providerThreadRef(context),
+            ...(context.turnState ? { providerTurnId: context.turnState.turnId } : {}),
+          },
+          raw: {
+            source: "claude.sdk.message" as const,
+            method: sdkNativeMethod(message),
+            messageType: message.type,
+            payload: message,
+          },
+        };
+
+        if (message.type === "tool_progress") {
+          yield* offerRuntimeEvent({
+            ...base,
+            type: "tool.progress",
+            payload: {
+              toolUseId: message.tool_use_id,
+              toolName: message.tool_name,
+              elapsedSeconds: message.elapsed_time_seconds,
+              ...(message.task_id ? { summary: `task:${message.task_id}` } : {}),
+            },
+          });
+          return;
+        }
+
+        if (message.type === "tool_use_summary") {
+          yield* offerRuntimeEvent({
+            ...base,
+            type: "tool.summary",
+            payload: {
+              summary: message.summary,
+              ...(message.preceding_tool_use_ids.length > 0
+                ? { precedingToolUseIds: message.preceding_tool_use_ids }
+                : {}),
+            },
+          });
+          return;
+        }
+
+        if (message.type === "auth_status") {
+          yield* offerRuntimeEvent({
+            ...base,
+            type: "auth.status",
+            payload: {
+              isAuthenticating: message.isAuthenticating,
+              output: message.output,
+              ...(message.error ? { error: message.error } : {}),
+            },
+          });
+          return;
+        }
+
+        if (message.type === "rate_limit_event") {
+          yield* offerRuntimeEvent({
+            ...base,
+            type: "account.rate-limits.updated",
+            payload: {
+              rateLimits: message,
+            },
+          });
+          return;
+        }
+      });
+
+    const handleSdkMessage = (
+      context: ClaudeSessionContext,
+      message: SDKMessage,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        yield* logNativeSdkMessage(context, message);
+        yield* ensureThreadId(context, message);
+
+        switch (message.type) {
+          case "stream_event":
+            yield* handleStreamEvent(context, message);
+            return;
+          case "user":
+            return;
+          case "assistant":
+            yield* handleAssistantMessage(context, message);
+            return;
+          case "result":
+            yield* handleResultMessage(context, message);
+            return;
+          case "system":
+            yield* handleSystemMessage(context, message);
+            return;
+          case "tool_progress":
+          case "tool_use_summary":
+          case "auth_status":
+          case "rate_limit_event":
+            yield* handleSdkTelemetryMessage(context, message);
+            return;
+          default:
+            yield* emitRuntimeWarning(
+              context,
+              `Unhandled Claude SDK message type '${message.type}'.`,
+              message,
+            );
+            return;
+        }
+      });
+
+    const runSdkStream = (context: ClaudeSessionContext): Effect.Effect<void> =>
+      Stream.fromAsyncIterable(context.query, (cause) => cause).pipe(
+        Stream.takeWhile(() => !context.stopped),
+        Stream.runForEach((message) => handleSdkMessage(context, message)),
+        Effect.catchCause((cause) =>
+          Effect.gen(function* () {
+            if (Cause.hasInterruptsOnly(cause) || context.stopped) {
+              return;
+            }
+            const message = toMessage(Cause.squash(cause), "Claude runtime stream failed.");
+            yield* emitRuntimeError(context, message, cause);
+            yield* completeTurn(context, "failed", message);
+          }),
+        ),
+      );
+
+    const stopSessionInternal = (
+      context: ClaudeSessionContext,
+      options?: { readonly emitExitEvent?: boolean },
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        if (context.stopped) return;
+
+        context.stopped = true;
+
+        for (const [requestId, pending] of context.pendingApprovals) {
+          yield* Deferred.succeed(pending.decision, "cancel");
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "request.resolved",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+              createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+            requestId: asRuntimeRequestId(requestId),
+            payload: {
+              requestType: pending.requestType,
+              decision: "cancel",
+            },
+            providerRefs: {
+              ...providerThreadRef(context),
+              ...(context.turnState ? { providerTurnId: String(context.turnState.turnId) } : {}),
+              providerRequestId: requestId,
+            },
+          });
+        }
+        context.pendingApprovals.clear();
+
+        if (context.turnState) {
+          yield* completeTurn(context, "interrupted", "Session stopped.");
+        }
+
+        yield* Queue.shutdown(context.promptQueue);
+
+        context.query.close();
+
+        const updatedAt = yield* nowIso;
+        context.session = {
+          ...context.session,
+          status: "closed",
+          activeTurnId: undefined,
+          updatedAt,
+        };
+
+        if (options?.emitExitEvent !== false) {
+          const stamp = yield* makeEventStamp();
+          yield* offerRuntimeEvent({
+            type: "session.exited",
+            eventId: stamp.eventId,
+            provider: PROVIDER,
+              createdAt: stamp.createdAt,
+            threadId: context.session.threadId,
+            payload: {
+              reason: "Session stopped",
+              exitKind: "graceful",
+            },
+            providerRefs: {},
+          });
+        }
+
+        sessions.delete(context.session.threadId);
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<ClaudeSessionContext, ProviderAdapterError> => {
+      const context = sessions.get(threadId);
+      if (!context) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({
+            provider: PROVIDER,
+            threadId,
+          }),
+        );
+      }
+      if (context.stopped || context.session.status === "closed") {
+        return Effect.fail(
+          new ProviderAdapterSessionClosedError({
+            provider: PROVIDER,
+            threadId,
+          }),
+        );
+      }
+      return Effect.succeed(context);
+    };
+
+    const startSession: ClaudeCodeAdapterShape["startSession"] = (input) =>
+      Effect.gen(function* () {
+        if (input.provider !== undefined && input.provider !== PROVIDER) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+          });
+        }
+
+        const startedAt = yield* nowIso;
+        const resumeState = readClaudeResumeState(input.resumeCursor);
+        const threadId = input.threadId;
+
+        const promptQueue = yield* Queue.unbounded<PromptQueueItem>();
+        const prompt = Stream.fromQueue(promptQueue).pipe(
+          Stream.filter((item) => item.type === "message"),
+          Stream.map((item) => item.message),
+          Stream.toAsyncIterable,
+        );
+
+        const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+        const inFlightTools = new Map<number, ToolInFlight>();
+
+        const contextRef = yield* Ref.make<ClaudeSessionContext | undefined>(undefined);
+
+        const canUseTool: CanUseTool = (toolName, toolInput, callbackOptions) =>
+          Effect.runPromise(
+            Effect.gen(function* () {
+              const context = yield* Ref.get(contextRef);
+              if (!context) {
+                return {
+                  behavior: "deny",
+                  message: "Claude session context is unavailable.",
+                } satisfies PermissionResult;
+              }
+
+              const runtimeMode = input.runtimeMode ?? "full-access";
+              if (runtimeMode === "full-access") {
+                return {
+                  behavior: "allow",
+                  updatedInput: toolInput,
+                } satisfies PermissionResult;
+              }
+
+              const requestId = ApprovalRequestId.makeUnsafe(yield* Random.nextUUIDv4);
+              const requestType = classifyRequestType(toolName);
+              const detail = summarizeToolRequest(toolName, toolInput);
+              const decisionDeferred = yield* Deferred.make<ProviderApprovalDecision>();
+              const pendingApproval: PendingApproval = {
+                requestType,
+                detail,
+                decision: decisionDeferred,
+                ...(callbackOptions.suggestions
+                  ? { suggestions: callbackOptions.suggestions }
+                  : {}),
+              };
+
+              const requestedStamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent({
+                type: "request.opened",
+                eventId: requestedStamp.eventId,
+                provider: PROVIDER,
+                      createdAt: requestedStamp.createdAt,
+                threadId: context.session.threadId,
+                ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+                requestId: asRuntimeRequestId(requestId),
+                payload: {
+                  requestType,
+                  detail,
+                  args: {
+                    toolName,
+                    input: toolInput,
+                    ...(callbackOptions.toolUseID ? { toolUseId: callbackOptions.toolUseID } : {}),
+                  },
+                },
+                providerRefs: {
+                      ...(context.session.threadId
+                    ? { providerThreadId: context.session.threadId }
+                    : {}),
+                  ...(context.turnState ? { providerTurnId: String(context.turnState.turnId) } : {}),
+                  providerRequestId: requestId,
+                },
+                raw: {
+                  source: "claude.sdk.permission",
+                  method: "canUseTool/request",
+                  payload: {
+                    toolName,
+                    input: toolInput,
+                  },
+                },
+              });
+
+              pendingApprovals.set(requestId, pendingApproval);
+
+              const onAbort = () => {
+                if (!pendingApprovals.has(requestId)) {
+                  return;
+                }
+                pendingApprovals.delete(requestId);
+                Effect.runFork(Deferred.succeed(decisionDeferred, "cancel"));
+              };
+
+              callbackOptions.signal.addEventListener("abort", onAbort, {
+                once: true,
+              });
+
+              const decision = yield* Deferred.await(decisionDeferred);
+              pendingApprovals.delete(requestId);
+
+              const resolvedStamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent({
+                type: "request.resolved",
+                eventId: resolvedStamp.eventId,
+                provider: PROVIDER,
+                      createdAt: resolvedStamp.createdAt,
+                threadId: context.session.threadId,
+                ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+                requestId: asRuntimeRequestId(requestId),
+                payload: {
+                  requestType,
+                  decision,
+                },
+                providerRefs: {
+                      ...(context.session.threadId
+                    ? { providerThreadId: context.session.threadId }
+                    : {}),
+                  ...(context.turnState ? { providerTurnId: String(context.turnState.turnId) } : {}),
+                  providerRequestId: requestId,
+                },
+                raw: {
+                  source: "claude.sdk.permission",
+                  method: "canUseTool/decision",
+                  payload: {
+                    decision,
+                  },
+                },
+              });
+
+              if (decision === "accept" || decision === "acceptForSession") {
+                return {
+                  behavior: "allow",
+                  updatedInput: toolInput,
+                  ...(decision === "acceptForSession" && pendingApproval.suggestions
+                    ? { updatedPermissions: [...pendingApproval.suggestions] }
+                    : {}),
+                } satisfies PermissionResult;
+              }
+
+              return {
+                behavior: "deny",
+                message:
+                  decision === "cancel"
+                    ? "User cancelled tool execution."
+                    : "User declined tool execution.",
+              } satisfies PermissionResult;
+            }),
+          );
+
+        const providerOptions = input.providerOptions?.claudeCode;
+        const permissionMode =
+          toPermissionMode(providerOptions?.permissionMode) ??
+          (input.runtimeMode === "full-access" ? "bypassPermissions" : undefined);
+
+        const cliPath = providerOptions?.binaryPath ?? resolveClaudeCodeCliPath();
+        const queryOptions: ClaudeQueryOptions = {
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+          ...(input.model ? { model: input.model } : {}),
+          ...(cliPath ? { pathToClaudeCodeExecutable: cliPath } : {}),
+          ...(permissionMode ? { permissionMode } : {}),
+          ...(permissionMode === "bypassPermissions"
+            ? { allowDangerouslySkipPermissions: true }
+            : {}),
+          ...(providerOptions?.maxThinkingTokens !== undefined
+            ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
+            : {}),
+          ...(resumeState?.resume ? { resume: resumeState.resume } : {}),
+          ...(resumeState?.resumeSessionAt ? { resumeSessionAt: resumeState.resumeSessionAt } : {}),
+          includePartialMessages: true,
+          canUseTool,
+          env: process.env,
+          ...(input.cwd ? { additionalDirectories: [input.cwd] } : {}),
+        };
+
+        const queryRuntime = yield* Effect.try({
+          try: () =>
+            createQuery({
+              prompt,
+              options: queryOptions,
+            }),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId,
+              detail: toMessage(cause, "Failed to start Claude runtime session."),
+              cause,
+            }),
+        });
+
+        const session: ProviderSession = {
+          threadId,
+          provider: PROVIDER,
+          status: "ready",
+          runtimeMode: input.runtimeMode,
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+          ...(input.model ? { model: input.model } : {}),
+          ...(threadId ? { threadId } : {}),
+          resumeCursor: {
+            ...(threadId ? { threadId } : {}),
+            ...(resumeState?.resume ? { resume: resumeState.resume } : {}),
+            ...(resumeState?.resumeSessionAt
+              ? { resumeSessionAt: resumeState.resumeSessionAt }
+              : {}),
+            turnCount: resumeState?.turnCount ?? 0,
+          },
+          createdAt: startedAt,
+          updatedAt: startedAt,
+        };
+
+        const context: ClaudeSessionContext = {
+          session,
+          promptQueue,
+          query: queryRuntime,
+          startedAt,
+          resumeSessionId: resumeState?.resume,
+          pendingApprovals,
+          turns: [],
+          inFlightTools,
+          turnState: undefined,
+          lastAssistantUuid: resumeState?.resumeSessionAt,
+          lastThreadStartedId: undefined,
+          stopped: false,
+        };
+        yield* Ref.set(contextRef, context);
+        sessions.set(threadId, context);
+
+        const sessionStartedStamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "session.started",
+          eventId: sessionStartedStamp.eventId,
+          provider: PROVIDER,
+          createdAt: sessionStartedStamp.createdAt,
+          threadId,
+          payload: input.resumeCursor !== undefined ? { resume: input.resumeCursor } : {},
+          providerRefs: {},
+        });
+
+        const configuredStamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "session.configured",
+          eventId: configuredStamp.eventId,
+          provider: PROVIDER,
+          createdAt: configuredStamp.createdAt,
+          threadId,
+          payload: {
+            config: {
+              ...(input.model ? { model: input.model } : {}),
+              ...(input.cwd ? { cwd: input.cwd } : {}),
+              ...(permissionMode ? { permissionMode } : {}),
+              ...(providerOptions?.maxThinkingTokens !== undefined
+                ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
+                : {}),
+            },
+          },
+          providerRefs: {},
+        });
+
+        const readyStamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "session.state.changed",
+          eventId: readyStamp.eventId,
+          provider: PROVIDER,
+          createdAt: readyStamp.createdAt,
+          threadId,
+          payload: {
+            state: "ready",
+          },
+          providerRefs: {},
+        });
+
+        Effect.runFork(runSdkStream(context));
+
+        return {
+          ...session,
+        };
+      });
+
+    const sendTurn: ClaudeCodeAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const context = yield* requireSession(input.threadId);
+
+        if (context.turnState) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: `Thread '${input.threadId}' already has an active turn '${context.turnState.turnId}'.`,
+          });
+        }
+
+        if (input.model) {
+          yield* Effect.tryPromise({
+            try: () => context.query.setModel(input.model),
+            catch: (cause) => toRequestError(input.threadId, "turn/setModel", cause),
+          });
+        }
+
+        const turnId = TurnId.makeUnsafe(yield* Random.nextUUIDv4);
+        const turnState: ClaudeTurnState = {
+          turnId,
+          assistantItemId: yield* Random.nextUUIDv4,
+          startedAt: yield* nowIso,
+          items: [],
+          messageCompleted: false,
+          emittedTextDelta: false,
+          fallbackAssistantText: "",
+        };
+
+        const updatedAt = yield* nowIso;
+        context.turnState = turnState;
+        context.session = {
+          ...context.session,
+          status: "running",
+          activeTurnId: turnId,
+          updatedAt,
+        };
+
+        const turnStartedStamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "turn.started",
+          eventId: turnStartedStamp.eventId,
+          provider: PROVIDER,
+          createdAt: turnStartedStamp.createdAt,
+          threadId: context.session.threadId,
+          turnId,
+          payload: input.model ? { model: input.model } : {},
+          providerRefs: {
+            providerTurnId: String(turnId),
+          },
+        });
+
+        const message = buildUserMessage(input);
+
+        yield* Queue.offer(context.promptQueue, {
+          type: "message",
+          message,
+        }).pipe(Effect.mapError((cause) => toRequestError(input.threadId, "turn/start", cause)));
+
+        return {
+          threadId: context.session.threadId,
+          turnId,
+          ...(context.session.resumeCursor !== undefined
+            ? { resumeCursor: context.session.resumeCursor }
+            : {}),
+        };
+      });
+
+    const interruptTurn: ClaudeCodeAdapterShape["interruptTurn"] = (threadId, _turnId) =>
+      Effect.gen(function* () {
+        const context = yield* requireSession(threadId);
+        yield* Effect.tryPromise({
+          try: () => context.query.interrupt(),
+          catch: (cause) => toRequestError(threadId, "turn/interrupt", cause),
+        });
+      });
+
+    const readThread: ClaudeCodeAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const context = yield* requireSession(threadId);
+        return yield* snapshotThread(context);
+      });
+
+    const rollbackThread: ClaudeCodeAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        const context = yield* requireSession(threadId);
+        const nextLength = Math.max(0, context.turns.length - numTurns);
+        context.turns.splice(nextLength);
+        yield* updateResumeCursor(context);
+        return yield* snapshotThread(context);
+      });
+
+    const respondToRequest: ClaudeCodeAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const context = yield* requireSession(threadId);
+        const pending = context.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "item/requestApproval/decision",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+
+        context.pendingApprovals.delete(requestId);
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: ClaudeCodeAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      _answers,
+    ) =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "item/tool/requestUserInput",
+          detail: `Claude Code does not yet support structured user-input responses for thread '${threadId}' and request '${requestId}'.`,
+        }),
+      );
+
+    const stopSession: ClaudeCodeAdapterShape["stopSession"] = (threadId) =>
+      Effect.gen(function* () {
+        const context = yield* requireSession(threadId);
+        yield* stopSessionInternal(context, {
+          emitExitEvent: true,
+        });
+      });
+
+    const listSessions: ClaudeCodeAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), ({ session }) => ({ ...session })));
+
+    const hasSession: ClaudeCodeAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const context = sessions.get(threadId);
+        return context !== undefined && !context.stopped;
+      });
+
+    const stopAll: ClaudeCodeAdapterShape["stopAll"] = () =>
+      Effect.forEach(
+        sessions,
+        ([, context]) =>
+          stopSessionInternal(context, {
+            emitExitEvent: true,
+          }),
+        { discard: true },
+      );
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(
+        sessions,
+        ([, context]) =>
+          stopSessionInternal(context, {
+            emitExitEvent: false,
+          }),
+        { discard: true },
+      ).pipe(Effect.tap(() => Queue.shutdown(runtimeEventQueue))),
+    );
+
+    return {
+      provider: PROVIDER,
+      capabilities: {
+        sessionModelSwitch: "in-session",
+      },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents: Stream.fromQueue(runtimeEventQueue),
+    } satisfies ClaudeCodeAdapterShape;
+  });
+}
+
+export const ClaudeCodeAdapterLive = Layer.effect(ClaudeCodeAdapter, makeClaudeCodeAdapter());
+
+export function makeClaudeCodeAdapterLive(options?: ClaudeCodeAdapterLiveOptions) {
+  return Layer.effect(ClaudeCodeAdapter, makeClaudeCodeAdapter(options));
+}

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -5,6 +5,7 @@ import { assertFailure } from "@effect/vitest/utils";
 import { Effect, Layer, Stream } from "effect";
 
 import { CodexAdapter, CodexAdapterShape } from "../Services/CodexAdapter.ts";
+import { ClaudeCodeAdapter, type ClaudeCodeAdapterShape } from "../Services/ClaudeCodeAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderAdapterRegistryLive } from "./ProviderAdapterRegistry.ts";
 import { ProviderUnsupportedError } from "../Errors.ts";
@@ -27,11 +28,31 @@ const fakeCodexAdapter: CodexAdapterShape = {
   streamEvents: Stream.empty,
 };
 
+const fakeClaudeAdapter: ClaudeCodeAdapterShape = {
+  provider: "claudeCode",
+  capabilities: { sessionModelSwitch: "in-session" },
+  startSession: vi.fn(),
+  sendTurn: vi.fn(),
+  interruptTurn: vi.fn(),
+  respondToRequest: vi.fn(),
+  respondToUserInput: vi.fn(),
+  stopSession: vi.fn(),
+  listSessions: vi.fn(),
+  hasSession: vi.fn(),
+  readThread: vi.fn(),
+  rollbackThread: vi.fn(),
+  stopAll: vi.fn(),
+  streamEvents: Stream.empty,
+};
+
 const layer = it.layer(
   Layer.mergeAll(
     Layer.provide(
       ProviderAdapterRegistryLive,
-      Layer.succeed(CodexAdapter, fakeCodexAdapter),
+      Layer.mergeAll(
+        Layer.succeed(CodexAdapter, fakeCodexAdapter),
+        Layer.succeed(ClaudeCodeAdapter, fakeClaudeAdapter),
+      ),
     ),
     NodeServices.layer,
   ),

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -15,6 +15,7 @@ import {
   ProviderAdapterRegistry,
   type ProviderAdapterRegistryShape,
 } from "../Services/ProviderAdapterRegistry.ts";
+import { ClaudeCodeAdapter } from "../Services/ClaudeCodeAdapter.ts";
 import { CodexAdapter } from "../Services/CodexAdapter.ts";
 
 export interface ProviderAdapterRegistryLiveOptions {
@@ -26,7 +27,7 @@ const makeProviderAdapterRegistry = (options?: ProviderAdapterRegistryLiveOption
     const adapters =
       options?.adapters !== undefined
         ? options.adapters
-        : [yield* CodexAdapter];
+        : [yield* CodexAdapter, yield* ClaudeCodeAdapter];
     const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));
 
     const getByProvider: ProviderAdapterRegistryShape["getByProvider"] = (provider) => {

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -25,8 +25,8 @@ function decodeProviderKind(
   providerName: string,
   operation: string,
 ): Effect.Effect<ProviderKind, ProviderSessionDirectoryPersistenceError> {
-  if (providerName === "codex") {
-    return Effect.succeed(providerName);
+  if (providerName === "codex" || providerName === "claudeCode") {
+    return Effect.succeed(providerName as ProviderKind);
   }
   return Effect.fail(
     new ProviderSessionDirectoryPersistenceError({

--- a/apps/server/src/provider/Services/ClaudeCodeAdapter.ts
+++ b/apps/server/src/provider/Services/ClaudeCodeAdapter.ts
@@ -1,0 +1,32 @@
+/**
+ * ClaudeCodeAdapter - Claude Code implementation of the generic provider adapter contract.
+ *
+ * This service owns Claude runtime/session semantics and emits canonical
+ * provider runtime events. It does not perform cross-provider routing, shared
+ * event fan-out, or checkpoint orchestration.
+ *
+ * Uses Effect `ServiceMap.Service` for dependency injection and returns the
+ * shared provider-adapter error channel with `provider: "claudeCode"` context.
+ *
+ * @module ClaudeCodeAdapter
+ */
+import { ServiceMap } from "effect";
+
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * ClaudeCodeAdapterShape - Service API for the Claude Code provider adapter.
+ */
+export interface ClaudeCodeAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {
+  readonly provider: "claudeCode";
+}
+
+/**
+ * ClaudeCodeAdapter - Service tag for Claude Code provider adapter operations.
+ */
+export class ClaudeCodeAdapter extends ServiceMap.Service<
+  ClaudeCodeAdapter,
+  ClaudeCodeAdapterShape
+>()("t3/provider/Services/ClaudeCodeAdapter") {}
+

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -18,6 +18,7 @@ import { OrchestrationProjectionPipelineLive } from "./orchestration/Layers/Proj
 import { OrchestrationProjectionSnapshotQueryLive } from "./orchestration/Layers/ProjectionSnapshotQuery";
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion";
 import { ProviderUnsupportedError } from "./provider/Errors";
+import { makeClaudeCodeAdapterLive } from "./provider/Layers/ClaudeCodeAdapter";
 import { makeCodexAdapterLive } from "./provider/Layers/CodexAdapter";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry";
 import { makeProviderServiceLive } from "./provider/Layers/ProviderService";
@@ -57,8 +58,12 @@ export function makeServerProviderLayer(): Layer.Layer<
     const codexAdapterLayer = makeCodexAdapterLive(
       nativeEventLogger ? { nativeEventLogger } : undefined,
     );
+    const claudeAdapterLayer = makeClaudeCodeAdapterLive(
+      nativeEventLogger ? { nativeEventLogger } : undefined,
+    );
     const adapterRegistryLayer = ProviderAdapterRegistryLive.pipe(
       Layer.provide(codexAdapterLayer),
+      Layer.provide(claudeAdapterLayer),
       Layer.provideMerge(providerSessionDirectoryLayer),
     );
     return makeProviderServiceLive(

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -28,6 +28,7 @@ const AppServiceTierSchema = Schema.Literals(["auto", "fast", "flex"]);
 const MODELS_WITH_FAST_SUPPORT = new Set(["gpt-5.4"]);
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
+  claudeCode: new Set(getModelOptions("claudeCode").map((option) => option.slug)),
 };
 
 const AppSettingsSchema = Schema.Struct({
@@ -43,6 +44,9 @@ const AppSettingsSchema = Schema.Struct({
   ),
   codexServiceTier: AppServiceTierSchema.pipe(Schema.withConstructorDefault(() => Option.some("auto"))),
   customCodexModels: Schema.Array(Schema.String).pipe(
+    Schema.withConstructorDefault(() => Option.some([])),
+  ),
+  customClaudeModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
   ),
 });
@@ -108,6 +112,7 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
   return {
     ...settings,
     customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
+    customClaudeModels: normalizeCustomModelSlugs(settings.customClaudeModels, "claudeCode"),
   };
 }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -803,7 +803,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
     selectedProvider,
     activeThread?.model ?? activeProject?.model ?? getDefaultModel(selectedProvider),
   );
-  const customModelsForSelectedProvider = settings.customCodexModels;
+  const customModelsForSelectedProvider =
+    selectedProvider === "claudeCode" ? settings.customClaudeModels : settings.customCodexModels;
   const selectedModel = useMemo(() => {
     const draftModel = composerDraft.model;
     if (!draftModel) {
@@ -3065,9 +3066,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
         return;
       }
       setComposerDraftProvider(activeThread.id, provider);
+      const customModels =
+        provider === "claudeCode" ? settings.customClaudeModels : settings.customCodexModels;
       setComposerDraftModel(
         activeThread.id,
-        resolveAppModelSelection(provider, settings.customCodexModels, model),
+        resolveAppModelSelection(provider, customModels, model),
       );
       scheduleComposerFocus();
     },
@@ -3075,6 +3078,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       activeThread,
       lockedProvider,
       scheduleComposerFocus,
+      settings.customClaudeModels,
       setComposerDraftModel,
       setComposerDraftProvider,
       settings.customCodexModels,
@@ -5285,7 +5289,7 @@ function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): o
   label: string;
   available: true;
 } {
-  return option.available && option.value !== "claudeCode";
+  return option.available;
 }
 
 const AVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter(isAvailableProviderOption);
@@ -5297,9 +5301,11 @@ const COMING_SOON_PROVIDER_OPTIONS = [
 
 function getCustomModelOptionsByProvider(settings: {
   customCodexModels: readonly string[];
+  customClaudeModels: readonly string[];
 }): Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>> {
   return {
     codex: getAppModelOptions("codex", settings.customCodexModels),
+    claudeCode: getAppModelOptions("claudeCode", settings.customClaudeModels),
   };
 }
 

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -378,6 +378,18 @@ describe("composerDraftStore setModel", () => {
 
     expect(useComposerDraftStore.getState().draftsByThreadId[threadId]?.model).toBe("gpt-5.3-codex");
   });
+
+  it("normalizes aliases against the selected provider", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setProvider(threadId, "claudeCode");
+    store.setModel(threadId, "sonnet");
+
+    expect(useComposerDraftStore.getState().draftsByThreadId[threadId]).toMatchObject({
+      provider: "claudeCode",
+      model: "claude-sonnet-4-6",
+    });
+  });
 });
 
 describe("composerDraftStore setProvider", () => {
@@ -397,6 +409,16 @@ describe("composerDraftStore setProvider", () => {
     store.setProvider(threadId, "codex");
 
     expect(useComposerDraftStore.getState().draftsByThreadId[threadId]?.provider).toBe("codex");
+  });
+
+  it("persists Claude Code provider selection", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setProvider(threadId, "claudeCode");
+
+    expect(useComposerDraftStore.getState().draftsByThreadId[threadId]?.provider).toBe(
+      "claudeCode",
+    );
   });
 
   it("removes empty provider-only draft when provider is reset", () => {

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -208,7 +208,7 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
 }
 
 function normalizeProviderKind(value: unknown): ProviderKind | null {
-  return value === "codex" ? value : null;
+  return value === "codex" || value === "claudeCode" ? value : null;
 }
 
 function revokeObjectPreviewUrl(previewUrl: string): void {
@@ -809,9 +809,10 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
         if (threadId.length === 0) {
           return;
         }
-        const normalizedModel = normalizeModelSlug(model) ?? null;
         set((state) => {
           const existing = state.draftsByThreadId[threadId];
+          const normalizedModel =
+            normalizeModelSlug(model, existing?.provider ?? "codex") ?? null;
           if (!existing && normalizedModel === null) {
             return state;
           }

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -96,6 +96,7 @@ function SettingsRouteView() {
     Record<ProviderKind, string>
   >({
     codex: "",
+    claudeCode: "",
   });
   const [customModelErrorByProvider, setCustomModelErrorByProvider] = useState<
     Partial<Record<ProviderKind, string | null>>

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -18,7 +18,7 @@ export const PROVIDER_OPTIONS: Array<{
   available: boolean;
 }> = [
   { value: "codex", label: "Codex", available: true },
-  { value: "claudeCode", label: "Claude Code", available: false },
+  { value: "claudeCode", label: "Claude Code", available: true },
   { value: "cursor", label: "Cursor", available: false },
 ];
 

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -143,7 +143,7 @@ function toLegacySessionStatus(
 }
 
 function toLegacyProvider(providerName: string | null): ProviderKind {
-  if (providerName === "codex") {
+  if (providerName === "codex" || providerName === "claudeCode") {
     return providerName;
   }
   return "codex";
@@ -151,16 +151,24 @@ function toLegacyProvider(providerName: string | null): ProviderKind {
 
 const CODEX_MODEL_SLUGS = new Set<string>(getModelOptions("codex").map((option) => option.slug));
 
+const CLAUDE_MODEL_SLUGS = new Set<string>(
+  getModelOptions("claudeCode").map((option) => option.slug),
+);
+
 function inferProviderForThreadModel(input: {
   readonly model: string;
   readonly sessionProviderName: string | null;
 }): ProviderKind {
-  if (input.sessionProviderName === "codex") {
+  if (input.sessionProviderName === "codex" || input.sessionProviderName === "claudeCode") {
     return input.sessionProviderName;
   }
   const normalizedCodex = normalizeModelSlug(input.model, "codex");
   if (normalizedCodex && CODEX_MODEL_SLUGS.has(normalizedCodex)) {
     return "codex";
+  }
+  const normalizedClaude = normalizeModelSlug(input.model, "claudeCode");
+  if (normalizedClaude && CLAUDE_MODEL_SLUGS.has(normalizedClaude)) {
+    return "claudeCode";
   }
   return "codex";
 }

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "t3": "./dist/index.mjs",
       },
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.71",
         "@effect/platform-node": "catalog:",
         "@effect/sql-sqlite-bun": "catalog:",
         "@pierre/diffs": "^1.1.0-beta.16",
@@ -173,6 +174,8 @@
     "vitest": "^4.0.0",
   },
   "packages": {
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.71", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pIsQJnM7Y+cJHL7aFY6SCCW3FIni218gVEpPqG8XGowfYxboFNBbNssWiUNRwthT8bp9jypcX7q5kx0Xsw14xg=="],
+
     "@astrojs/check": ["@astrojs/check@0.9.6", "", { "dependencies": { "@astrojs/language-server": "^2.16.1", "chokidar": "^4.0.1", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA=="],
 
     "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -10,8 +10,14 @@ export const CodexModelOptions = Schema.Struct({
 });
 export type CodexModelOptions = typeof CodexModelOptions.Type;
 
+export const ClaudeCodeModelOptions = Schema.Struct({
+  thinking: Schema.optional(Schema.Boolean),
+});
+export type ClaudeCodeModelOptions = typeof ClaudeCodeModelOptions.Type;
+
 export const ProviderModelOptions = Schema.Struct({
   codex: Schema.optional(CodexModelOptions),
+  claudeCode: Schema.optional(ClaudeCodeModelOptions),
 });
 export type ProviderModelOptions = typeof ProviderModelOptions.Type;
 
@@ -28,17 +34,22 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     { slug: "gpt-5.2-codex", name: "GPT-5.2 Codex" },
     { slug: "gpt-5.2", name: "GPT-5.2" },
   ],
+  claudeCode: [
+    { slug: "claude-opus-4-6", name: "Claude Opus 4.6" },
+    { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    { slug: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+  ],
 } as const satisfies Record<ProviderKind, readonly ModelOption[]>;
-export type ModelOptionsByProvider = typeof MODEL_OPTIONS_BY_PROVIDER;
 
-type BuiltInModelSlug = ModelOptionsByProvider[ProviderKind][number]["slug"];
+type BuiltInModelSlug = (typeof MODEL_OPTIONS_BY_PROVIDER)[ProviderKind][number]["slug"];
 export type ModelSlug = BuiltInModelSlug | (string & {});
 
-export const DEFAULT_MODEL_BY_PROVIDER = {
+export const DEFAULT_MODEL_BY_PROVIDER: Record<ProviderKind, ModelSlug> = {
   codex: "gpt-5.4",
-} as const satisfies Record<ProviderKind, ModelSlug>;
+  claudeCode: "claude-sonnet-4-6",
+};
 
-export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
+export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string, ModelSlug>> = {
   codex: {
     "5.4": "gpt-5.4",
     "5.3": "gpt-5.3-codex",
@@ -46,12 +57,28 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
     "5.3-spark": "gpt-5.3-codex-spark",
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
-} as const satisfies Record<ProviderKind, Record<string, ModelSlug>>;
+  claudeCode: {
+    opus: "claude-opus-4-6",
+    "opus-4.6": "claude-opus-4-6",
+    "claude-opus-4.6": "claude-opus-4-6",
+    "claude-opus-4-6-20251117": "claude-opus-4-6",
+    sonnet: "claude-sonnet-4-6",
+    "sonnet-4.6": "claude-sonnet-4-6",
+    "claude-sonnet-4.6": "claude-sonnet-4-6",
+    "claude-sonnet-4-6-20251117": "claude-sonnet-4-6",
+    haiku: "claude-haiku-4-5",
+    "haiku-4.5": "claude-haiku-4-5",
+    "claude-haiku-4.5": "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001": "claude-haiku-4-5",
+  },
+};
 
 export const REASONING_EFFORT_OPTIONS_BY_PROVIDER = {
   codex: CODEX_REASONING_EFFORT_OPTIONS,
+  claudeCode: [],
 } as const satisfies Record<ProviderKind, readonly CodexReasoningEffort[]>;
 
 export const DEFAULT_REASONING_EFFORT_BY_PROVIDER = {
   codex: "high",
+  claudeCode: null,
 } as const satisfies Record<ProviderKind, CodexReasoningEffort | null>;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -27,7 +27,7 @@ export const ORCHESTRATION_WS_CHANNELS = {
   domainEvent: "orchestration.domainEvent",
 } as const;
 
-export const ProviderKind = Schema.Literal("codex");
+export const ProviderKind = Schema.Literals(["codex", "claudeCode"]);
 export type ProviderKind = typeof ProviderKind.Type;
 export const ProviderApprovalPolicy = Schema.Literals([
   "untrusted",

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -5,6 +5,7 @@ import {
   ApprovalRequestId,
   EventId,
   IsoDateTime,
+  NonNegativeInt,
   ProviderItemId,
   ThreadId,
   TurnId,
@@ -53,8 +54,15 @@ const CodexProviderStartOptions = Schema.Struct({
   homePath: Schema.optional(TrimmedNonEmptyStringSchema),
 });
 
+const ClaudeCodeProviderStartOptions = Schema.Struct({
+  binaryPath: Schema.optional(TrimmedNonEmptyStringSchema),
+  permissionMode: Schema.optional(TrimmedNonEmptyStringSchema),
+  maxThinkingTokens: Schema.optional(NonNegativeInt),
+});
+
 const ProviderStartOptions = Schema.Struct({
   codex: Schema.optional(CodexProviderStartOptions),
+  claudeCode: Schema.optional(ClaudeCodeProviderStartOptions),
 });
 
 export const ProviderSessionStartInput = Schema.Struct({

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -19,6 +19,8 @@ const RuntimeEventRawSource = Schema.Literals([
   "codex.app-server.notification",
   "codex.app-server.request",
   "codex.eventmsg",
+  "claude.sdk.message",
+  "claude.sdk.permission",
   "codex.sdk.thread-event",
 ]);
 export type RuntimeEventRawSource = typeof RuntimeEventRawSource.Type;

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -1,16 +1,17 @@
 import {
   CODEX_REASONING_EFFORT_OPTIONS,
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_REASONING_EFFORT_BY_PROVIDER,
   MODEL_OPTIONS_BY_PROVIDER,
   MODEL_SLUG_ALIASES_BY_PROVIDER,
+  REASONING_EFFORT_OPTIONS_BY_PROVIDER,
   type CodexReasoningEffort,
   type ModelSlug,
   type ProviderKind,
 } from "@t3tools/contracts";
 
-type CatalogProvider = keyof typeof MODEL_OPTIONS_BY_PROVIDER;
-
-const MODEL_SLUG_SET_BY_PROVIDER: Record<CatalogProvider, ReadonlySet<ModelSlug>> = {
+const MODEL_SLUG_SET_BY_PROVIDER: Record<ProviderKind, ReadonlySet<ModelSlug>> = {
+  claudeCode: new Set(MODEL_OPTIONS_BY_PROVIDER.claudeCode.map((option) => option.slug)),
   codex: new Set(MODEL_OPTIONS_BY_PROVIDER.codex.map((option) => option.slug)),
 };
 
@@ -35,9 +36,7 @@ export function normalizeModelSlug(
     return null;
   }
 
-  const aliases = MODEL_SLUG_ALIASES_BY_PROVIDER[provider] as Record<string, ModelSlug>;
-  const aliased = aliases[trimmed];
-  return typeof aliased === "string" ? aliased : (trimmed as ModelSlug);
+  return MODEL_SLUG_ALIASES_BY_PROVIDER[provider][trimmed] ?? (trimmed as ModelSlug);
 }
 
 export function resolveModelSlug(
@@ -51,7 +50,7 @@ export function resolveModelSlug(
 
   return MODEL_SLUG_SET_BY_PROVIDER[provider].has(normalized)
     ? normalized
-    : getDefaultModel(provider);
+    : DEFAULT_MODEL_BY_PROVIDER[provider];
 }
 
 export function resolveModelSlugForProvider(
@@ -64,7 +63,7 @@ export function resolveModelSlugForProvider(
 export function getReasoningEffortOptions(
   provider: ProviderKind = "codex",
 ): ReadonlyArray<CodexReasoningEffort> {
-  return provider === "codex" ? CODEX_REASONING_EFFORT_OPTIONS : [];
+  return REASONING_EFFORT_OPTIONS_BY_PROVIDER[provider];
 }
 
 export function getDefaultReasoningEffort(provider: "codex"): CodexReasoningEffort;
@@ -72,7 +71,7 @@ export function getDefaultReasoningEffort(provider: ProviderKind): CodexReasonin
 export function getDefaultReasoningEffort(
   provider: ProviderKind = "codex",
 ): CodexReasoningEffort | null {
-  return provider === "codex" ? "high" : null;
+  return DEFAULT_REASONING_EFFORT_BY_PROVIDER[provider];
 }
 
 export { CODEX_REASONING_EFFORT_OPTIONS };

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -455,9 +455,7 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     },
   };
   const publishConfig = resolveGitHubPublishConfig();
-  if (publishConfig) {
-    buildConfig.publish = [publishConfig];
-  }
+  buildConfig.publish = publishConfig ? [publishConfig] : null;
 
   if (platform === "mac") {
     buildConfig.mac = {


### PR DESCRIPTION
## Summary
- add the Claude Code provider adapter and register it in the server provider stack
- extend shared contracts and model metadata for Claude provider support
- enable Claude Code selection and draft/session provider handling in the web UI
- keep local desktop artifact builds working and bump `@anthropic-ai/claude-agent-sdk` to `^0.2.71`

## Testing
- bun lint
- bun typecheck
- bun dist:desktop:dmg:arm64

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude Code provider and wire `ClaudeCodeAdapterLive` into server registry and web UI selections
> Introduce `claudeCode` across contracts, server, and web, including a new `ClaudeCodeAdapterLive` backed by `@anthropic-ai/claude-agent-sdk`, default adapter registration, provider decoding, model aliasing, and UI availability. Core adapter logic, session/turn streaming, permissions, and tests are added in [ClaudeCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/369/files#diff-6971a178ab59334c6efbe6ec5c9e315d1ff93620c17e526a893dfc2991c46b5f).
>
> #### 📍Where to Start
> Start with the adapter factory `makeClaudeCodeAdapter` in [ClaudeCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/369/files#diff-6971a178ab59334c6efbe6ec5c9e315d1ff93620c17e526a893dfc2991c46b5f), then review its layer wiring in [serverLayers.ts](https://github.com/pingdotgg/t3code/pull/369/files#diff-520184bba510d5aba90d0e9de6f471e393fff91ff4cb283eaf0b6d0096fa83fe) and contract additions in [model.ts](https://github.com/pingdotgg/t3code/pull/369/files#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 338b807. 18 files reviewed, 12 issues evaluated, 2 issues filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/shared/src/model.ts — 0 comments posted, 3 evaluated, 1 filtered</summary>
>
> - [line 39](https://github.com/pingdotgg/t3code/blob/338b80766d58f7189603571302b76c98b06d2acb/packages/shared/src/model.ts#L39): Regression in `normalizeModelSlug`: Removing the explicit `typeof aliased === "string"` check makes this function unsafe for inputs matching `Object.prototype` properties. If `trimmed` is a reserved property name like `"constructor"` or `"toString"`, `MODEL_SLUG_ALIASES_BY_PROVIDER[provider][trimmed]` will resolve to a native function (e.g., `Object.constructor`) rather than `undefined`. The `??` operator treats this function as a valid non-nullish value, causing `normalizeModelSlug` to return a `Function` instead of a `string` (ModelSlug). This violates the return type contract and will cause runtime crashes in consumers that expect a string (e.g., calling `.toLowerCase()` on the result). <b>[ Out of scope ]</b>
> </details>
>
> <details>
> <summary>scripts/build-desktop-artifact.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 482](https://github.com/pingdotgg/t3code/blob/338b80766d58f7189603571302b76c98b06d2acb/scripts/build-desktop-artifact.ts#L482): `AzureTrustedSigningOptionsConfig` is defined as a `Config` object (via `Config.all`), which is a data structure describing configuration, not an executable Effect or an iterable. Attempting to `yield*` it directly inside the generator will throw a runtime `TypeError: ... is not iterable`. It must be converted to an Effect to be yielded, for example by wrapping it in `Effect.config(...)` or calling `.asEffect()` (as seen on line 215). This will crash the build process when `platform` is `'win'` and `signed` is `true`. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->