### PR TITLE
fix(web): use wss:// when page is served over HTTPS

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -225,7 +225,7 @@ function getServerHttpOrigin(): string {
       ? bridgeUrl
       : envUrl && envUrl.length > 0
         ? envUrl
-        : `ws://${window.location.hostname}:${window.location.port}`;
+        : `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.hostname}:${window.location.port}`;
   // Parse to extract just the origin, dropping path/query (e.g. ?token=…)
   const httpUrl = wsUrl.replace(/^wss:/, "https:").replace(/^ws:/, "http:");
   try {

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -44,7 +44,7 @@ export class WsTransport {
         ? bridgeUrl
         : envUrl && envUrl.length > 0
           ? envUrl
-          : `ws://${window.location.hostname}:${window.location.port}`);
+          : `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.hostname}:${window.location.port}`);
     this.connect();
   }
 


### PR DESCRIPTION
## Problem

When running T3 Code in web mode (`t3 --host 0.0.0.0`) behind a reverse proxy or Tailscale Serve (HTTPS), the WebSocket connection fails with:

```
Failed to construct 'WebSocket': An insecure WebSocket connection may not be initiated from a page loaded over HTTPS.
```

The client always constructs a `ws://` URL regardless of whether the page was loaded over HTTP or HTTPS.

## Fix

Derive the WebSocket protocol from `window.location.protocol`:

```ts
`${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.hostname}:${window.location.port}`
```

Applied in both `wsTransport.ts` and `Sidebar.tsx`.

## Reproduction

1. Run `t3 --host 0.0.0.0 --port 3773`
2. Put it behind an HTTPS reverse proxy (nginx, Tailscale Serve, etc.)
3. Open the HTTPS URL in Chrome → WebSocket connection blocked

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default to `wss` on HTTPS pages for WebSocket URLs in `Sidebar.getServerHttpOrigin` and `wsTransport.WsTransport` to fix protocol mismatch
> Adjust fallback WebSocket URL selection to use `wss` when `window.location.protocol` is `https:` and `ws` otherwise, updating `Sidebar.getServerHttpOrigin` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/391/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and the `WsTransport` constructor in [wsTransport.ts](https://github.com/pingdotgg/t3code/pull/391/files#diff-2129bf8b884f9eac0205e2de5672354ffe759743b6538d8dee077fb1944d1506).
>
> #### 📍Where to Start
> Start with the `WsTransport` constructor logic in [wsTransport.ts](https://github.com/pingdotgg/t3code/pull/391/files#diff-2129bf8b884f9eac0205e2de5672354ffe759743b6538d8dee077fb1944d1506), then review `Sidebar.getServerHttpOrigin` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/391/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fea0bd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->