### PR TITLE
fix(checkpoint): prevent fake placeholder entries from blocking real Git checkpoint capture

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
@@ -50,10 +50,9 @@ const make = Effect.gen(function* () {
         });
       }
 
-      const maxTurnCount = thread.checkpoints.reduce(
-        (max, checkpoint) => Math.max(max, checkpoint.checkpointTurnCount),
-        0,
-      );
+      const maxTurnCount = thread.checkpoints
+        .filter((checkpoint) => checkpoint.status !== "missing")
+        .reduce((max, checkpoint) => Math.max(max, checkpoint.checkpointTurnCount), 0);
       if (input.toTurnCount > maxTurnCount) {
         return yield* new CheckpointUnavailableError({
           threadId: input.threadId,
@@ -76,9 +75,11 @@ const make = Effect.gen(function* () {
       const fromCheckpointRef =
         input.fromTurnCount === 0
           ? checkpointRefForThreadTurn(input.threadId, 0)
-          : thread.checkpoints.find(
-              (checkpoint) => checkpoint.checkpointTurnCount === input.fromTurnCount,
-            )?.checkpointRef;
+          : thread.checkpoints
+              .filter((checkpoint) => checkpoint.status !== "missing")
+              .find(
+                (checkpoint) => checkpoint.checkpointTurnCount === input.fromTurnCount,
+              )?.checkpointRef;
       if (!fromCheckpointRef) {
         return yield* new CheckpointUnavailableError({
           threadId: input.threadId,
@@ -87,9 +88,11 @@ const make = Effect.gen(function* () {
         });
       }
 
-      const toCheckpointRef = thread.checkpoints.find(
-        (checkpoint) => checkpoint.checkpointTurnCount === input.toTurnCount,
-      )?.checkpointRef;
+      const toCheckpointRef = thread.checkpoints
+        .filter((checkpoint) => checkpoint.status !== "missing")
+        .find(
+          (checkpoint) => checkpoint.checkpointTurnCount === input.toTurnCount,
+        )?.checkpointRef;
       if (!toCheckpointRef) {
         return yield* new CheckpointUnavailableError({
           threadId: input.threadId,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -333,10 +333,9 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const currentTurnCount = thread.checkpoints.reduce(
-      (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
-      0,
-    );
+    const currentTurnCount = thread.checkpoints
+      .filter((checkpoint) => checkpoint.status !== "missing")
+      .reduce((maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount), 0);
     const baselineCheckpointRef = checkpointRefForThreadTurn(thread.id, currentTurnCount);
     const baselineExists = yield* checkpointStore.hasCheckpointRef({
       cwd: checkpointCwd,
@@ -395,10 +394,9 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const currentTurnCount = thread.checkpoints.reduce(
-      (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
-      0,
-    );
+    const currentTurnCount = thread.checkpoints
+      .filter((checkpoint) => checkpoint.status !== "missing")
+      .reduce((maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount), 0);
     const baselineCheckpointRef = checkpointRefForThreadTurn(threadId, currentTurnCount);
     const baselineExists = yield* checkpointStore.hasCheckpointRef({
       cwd: checkpointCwd,
@@ -451,10 +449,9 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const currentTurnCount = thread.checkpoints.reduce(
-      (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
-      0,
-    );
+    const currentTurnCount = thread.checkpoints
+      .filter((checkpoint) => checkpoint.status !== "missing")
+      .reduce((maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount), 0);
 
     if (event.payload.turnCount > currentTurnCount) {
       yield* appendRevertFailureActivity({

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -166,7 +166,7 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    if (thread.checkpoints.some((checkpoint) => checkpoint.turnId === turnId)) {
+    if (thread.checkpoints.some((checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing")) {
       return;
     }
 
@@ -196,10 +196,9 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const currentTurnCount = thread.checkpoints.reduce(
-      (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
-      0,
-    );
+    const currentTurnCount = thread.checkpoints
+      .filter((checkpoint) => checkpoint.status !== "missing")
+      .reduce((maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount), 0);
     const nextTurnCount = currentTurnCount + 1;
     const fromTurnCount = Math.max(0, nextTurnCount - 1);
     const fromCheckpointRef = checkpointRefForThreadTurn(thread.id, fromTurnCount);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1059,10 +1059,17 @@ const make = Effect.gen(function* () {
 
       if (event.type === "turn.diff.updated") {
         const turnId = toTurnId(event.turnId);
-        if (turnId && (yield* isGitRepoForThread(thread.id))) {
+        const hasRealCheckpoint = turnId
+          ? thread.checkpoints.some((c) => c.turnId === turnId && c.status !== "missing")
+          : false;
+        if (turnId && !hasRealCheckpoint && (yield* isGitRepoForThread(thread.id))) {
           const assistantMessageId = MessageId.makeUnsafe(
             `assistant:${event.itemId ?? event.turnId ?? event.eventId}`,
           );
+          const placeholderTurnCount =
+            thread.checkpoints
+              .filter((c) => c.status !== "missing")
+              .reduce((max, c) => Math.max(max, c.checkpointTurnCount), 0) + 1;
           yield* orchestrationEngine.dispatch({
             type: "thread.turn.diff.complete",
             commandId: providerCommandId(event, "thread-turn-diff-complete"),
@@ -1073,7 +1080,7 @@ const make = Effect.gen(function* () {
             status: "missing",
             files: [],
             assistantMessageId,
-            checkpointTurnCount: thread.checkpoints.length + 1,
+            checkpointTurnCount: placeholderTurnCount,
             createdAt: now,
           });
         }


### PR DESCRIPTION
## Problem

Opening the diff panel always showed a red error: **"Checkpoint ref is unavailable for turn number X"**. All diffs were broken for every turn.

## Root Cause

Two code paths both dispatched `thread.turn.diff.complete` for the same turn, creating a race condition:

**Primary race (most common):**
1. Codex fires `turn/diff/updated` → `ProviderRuntimeIngestion` immediately creates a placeholder checkpoint entry with `status: "missing"` and `checkpointRef: "provider-diff:xxx"` (not a real Git ref)
2. `turn.completed` fires → `CheckpointReactor.captureCheckpointFromTurnCompletion` checks `thread.checkpoints.some(c => c.turnId === turnId)` — finds the fake entry — **returns early, skipping all real Git checkpoint creation**
3. Diff query calls `hasCheckpointRef("provider-diff:xxx")` → false → error

**Secondary race:**
- If CheckpointReactor ran first, the subsequent `turn.diff.updated` handler used `thread.checkpoints.length + 1` for `checkpointTurnCount`, which could produce the wrong turn number and overwrite the real checkpoint entry with a fake one

## Fix

**`CheckpointReactor.ts`** (`captureCheckpointFromTurnCompletion`):
- Early-return guard now only skips when a **real** (`status !== "missing"`) checkpoint exists for the turn
- `currentTurnCount` computation now excludes `status: "missing"` entries so fake placeholders don't inflate the turn counter

**`ProviderRuntimeIngestion.ts`** (`turn.diff.updated` handler):
- Skips placeholder dispatch entirely if a real checkpoint already exists for the `turnId`
- `checkpointTurnCount` now uses `max(non-missing checkpoints) + 1` instead of `length + 1`

## Testing

- All 20 existing `ProviderRuntimeIngestion` tests pass
- `CheckpointReactor` test suite: went from 2 failing → 1 failing (the remaining failure is a pre-existing Windows `\r\n` line-ending issue unrelated to this change)
- `bun lint` and `bun typecheck` both pass clean

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat 'missing' checkpoints as non-existent to unblock real Git checkpoint capture across `checkpointing.CheckpointDiffQuery.make` and `orchestration.CheckpointReactor.make`
> Exclude checkpoints with status `'missing'` when computing turn counts, selecting checkpoint refs, validating reverts, and gating duplicate completion captures, and skip emitting placeholder checkpoints if a real one exists in [apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts](https://github.com/pingdotgg/t3code/pull/412/files#diff-a7f6357814d1957a562de3ea25f26bd4dc2f18e4ccf790082ae04e2bc484da51), [apps/server/src/orchestration/Layers/CheckpointReactor.ts](https://github.com/pingdotgg/t3code/pull/412/files#diff-79dc41615f79575ae1404bd102df915797fb24ba34989557f80e229d305521fb), and [apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/412/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7).
>
> #### 📍Where to Start
> Start with the `getTurnDiff` logic in `checkpointing.CheckpointDiffQuery.make` in [apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts](https://github.com/pingdotgg/t3code/pull/412/files#diff-a7f6357814d1957a562de3ea25f26bd4dc2f18e4ccf790082ae04e2bc484da51), then review the post-turn capture path in `orchestration.CheckpointReactor.make` in [apps/server/src/orchestration/Layers/CheckpointReactor.ts](https://github.com/pingdotgg/t3code/pull/412/files#diff-79dc41615f79575ae1404bd102df915797fb24ba34989557f80e229d305521fb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 611a011.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->