### PR TITLE
fix(web): sidebar toggle and traffic light clearance for macOS Electron

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -195,7 +195,7 @@ import {
   setupProjectScript,
 } from "~/projectScripts";
 import { Toggle } from "./ui/toggle";
-import { SidebarTrigger } from "./ui/sidebar";
+import { SidebarTrigger, useSidebar } from "./ui/sidebar";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import {
@@ -590,6 +590,7 @@ interface ChatViewProps {
 }
 
 export default function ChatView({ threadId }: ChatViewProps) {
+  const { open: sidebarOpen } = useSidebar();
   const threads = useStore((store) => store.threads);
   const projects = useStore((store) => store.projects);
   const markThreadVisited = useStore((store) => store.markThreadVisited);
@@ -3364,7 +3365,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
           </header>
         )}
         {isElectron && (
-          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+          <div className={cn("drag-region flex h-[52px] shrink-0 items-center border-b border-border pr-5", sidebarOpen ? "pl-5" : "pl-[82px]")}>
+            <SidebarTrigger className="mr-3 size-7 shrink-0" />
             <span className="text-xs text-muted-foreground/50">No active thread</span>
           </div>
         )}
@@ -3382,8 +3384,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
       {/* Top bar */}
       <header
         className={cn(
-          "border-b border-border px-3 sm:px-5",
-          isElectron ? "drag-region flex h-[52px] items-center" : "py-2 sm:py-3",
+          "border-b border-border",
+          isElectron ? "drag-region flex h-[52px] items-center" : "px-3 py-2 sm:px-5 sm:py-3",
+          isElectron && (sidebarOpen ? "px-3 sm:px-5" : "pl-[82px] pr-3 sm:pr-5"),
         )}
       >
         <ChatHeader

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -1,9 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
-import { SidebarTrigger } from "../components/ui/sidebar";
+import { cn } from "../lib/utils";
+import { SidebarTrigger, useSidebar } from "../components/ui/sidebar";
 
 function ChatIndexRouteView() {
+  const { open: sidebarOpen } = useSidebar();
+
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-muted-foreground/40">
       {!isElectron && (
@@ -16,7 +19,8 @@ function ChatIndexRouteView() {
       )}
 
       {isElectron && (
-        <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+        <div className={cn("drag-region flex h-[52px] shrink-0 items-center border-b border-border pr-5", sidebarOpen ? "pl-5" : "pl-[82px]")}>
+          <SidebarTrigger className="mr-3 size-7 shrink-0" />
           <span className="text-xs text-muted-foreground/50">No active thread</span>
         </div>
       )}

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -20,7 +20,8 @@ import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../components/ui/select";
 import { Switch } from "../components/ui/switch";
-import { SidebarInset } from "~/components/ui/sidebar";
+import { cn } from "~/lib/utils";
+import { SidebarInset, SidebarTrigger, useSidebar } from "~/components/ui/sidebar";
 
 const THEME_OPTIONS = [
   {
@@ -87,6 +88,7 @@ function patchCustomModels(provider: ProviderKind, models: string[]) {
 }
 
 function SettingsRouteView() {
+  const { open: sidebarOpen } = useSidebar();
   const { theme, setTheme, resolvedTheme } = useTheme();
   const { settings, defaults, updateSettings } = useAppSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
@@ -183,7 +185,8 @@ function SettingsRouteView() {
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
         {isElectron && (
-          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+          <div className={cn("drag-region flex h-[52px] shrink-0 items-center border-b border-border pr-5", sidebarOpen ? "pl-5" : "pl-[82px]")}>
+            <SidebarTrigger className="mr-3 size-7 shrink-0" />
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
             </span>


### PR DESCRIPTION
## Context

The Electron app uses an offcanvas sidebar that can be fully collapsed. When collapsed, the main content area stretches to the window edge. On macOS, the traffic light buttons (close/minimise/maximise) are pinned at ~0–80px from the top-left — directly overlapping the drag-region headers in the main panel.

There were two compounding issues:

1. **No sidebar toggle in Electron headers** — the non-web headers rendered for the thread index, settings page, and ChatView empty state did not include a `SidebarTrigger`. Once the sidebar was collapsed there was no way to reopen it from those pages without a keyboard shortcut.

2. **Fixed `px-5` left padding** — the symmetric padding placed header text and buttons directly under the traffic lights when the sidebar was closed.

The regular thread view (`ChatHeader`) already had `SidebarTrigger` and the sidebar's own header already used `pl-[82px]` correctly — the Electron-specific fallback headers were just missed.

## Fix

- Add `SidebarTrigger` to all three Electron drag-region headers
- Use `useSidebar()` to apply `pl-[82px]` only when the sidebar is collapsed, falling back to normal padding when open

```tsx
// Before — no toggle, always 20px left padding
<div className="drag-region ... px-5">
  <span>No active thread</span>
</div>

// After — toggle present, padding clears traffic lights only when needed
<div className={cn("drag-region ... pr-5", sidebarOpen ? "pl-5" : "pl-[82px]")}>
  <SidebarTrigger className="mr-3 size-7 shrink-0" />
  <span>No active thread</span>
</div>
```

## Files Changed

| File | Change |
|------|--------|
| `apps/web/src/routes/_chat.index.tsx` | Add `SidebarTrigger` + conditional padding |
| `apps/web/src/routes/_chat.settings.tsx` | Add `SidebarTrigger` + conditional padding |
| `apps/web/src/components/ChatView.tsx` | Add `SidebarTrigger` to empty state + conditional padding on both empty state and active thread headers |

## Testing

In Electron on macOS:
- Collapse sidebar → header text/buttons clear the traffic lights on all affected pages; toggle button is visible
- Click toggle → sidebar reopens from any page
- Open sidebar → normal padding applies, no excessive gap