### PR TITLE
feat(web): settings sidebar with section navigation

### DIFF
--- a/apps/web/src/components/SettingsSidebar.tsx
+++ b/apps/web/src/components/SettingsSidebar.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "~/lib/utils";
+import { SidebarContent, SidebarHeader } from "~/components/ui/sidebar";
+
+const SETTINGS_SECTIONS = [
+  { id: "settings-appearance", label: "Appearance" },
+  { id: "settings-codex-app-server", label: "Codex App Server" },
+  { id: "settings-models", label: "Models" },
+  { id: "settings-responses", label: "Responses" },
+  { id: "settings-keybindings", label: "Keybindings" },
+  { id: "settings-safety", label: "Safety" },
+] as const;
+
+export default function SettingsSidebar() {
+  const [activeSection, setActiveSection] = useState<string>(SETTINGS_SECTIONS[0].id);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const sectionIds = SETTINGS_SECTIONS.map((s) => s.id);
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+            break;
+          }
+        }
+      },
+      { rootMargin: "-20% 0px -70% 0px", threshold: 0 },
+    );
+
+    for (const id of sectionIds) {
+      const el = document.getElementById(id);
+      if (el) observerRef.current.observe(el);
+    }
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, []);
+
+  const scrollToSection = (id: string) => {
+    setActiveSection(id);
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <>
+      <SidebarHeader className="h-[52px] border-b border-border p-0" />
+
+      <SidebarContent className="p-0">
+        <nav className="flex flex-col px-3 pt-6" aria-label="Settings sections">
+          {SETTINGS_SECTIONS.map((section) => {
+            const isActive = activeSection === section.id;
+            return (
+              <button
+                key={section.id}
+                type="button"
+                onClick={() => scrollToSection(section.id)}
+                className={cn(
+                  "relative flex w-full items-center rounded-md py-1.5 pl-4 pr-3 text-sm transition-colors",
+                  isActive
+                    ? "font-medium text-foreground"
+                    : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+                )}
+              >
+                {isActive && (
+                  <span className="absolute left-1 top-1/2 h-[1.1rem] w-0.5 -translate-y-1/2 rounded-full bg-primary" />
+                )}
+                {section.label}
+              </button>
+            );
+          })}
+        </nav>
+      </SidebarContent>
+    </>
+  );
+}

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -199,7 +199,7 @@ function SettingsRouteView() {
               </p>
             </header>
 
-            <section className="rounded-2xl border border-border bg-card p-5">
+            <section id="settings-appearance" className="scroll-mt-20 rounded-2xl border border-border bg-card p-5">
               <div className="mb-4">
                 <h2 className="text-sm font-medium text-foreground">Appearance</h2>
                 <p className="mt-1 text-xs text-muted-foreground">
@@ -242,7 +242,7 @@ function SettingsRouteView() {
               </p>
             </section>
 
-            <section className="rounded-2xl border border-border bg-card p-5">
+            <section id="settings-codex-app-server" className="scroll-mt-20 rounded-2xl border border-border bg-card p-5">
               <div className="mb-4">
                 <h2 className="text-sm font-medium text-foreground">Codex App Server</h2>
                 <p className="mt-1 text-xs text-muted-foreground">
@@ -300,7 +300,7 @@ function SettingsRouteView() {
               </div>
             </section>
 
-            <section className="rounded-2xl border border-border bg-card p-5">
+            <section id="settings-models" className="scroll-mt-20 rounded-2xl border border-border bg-card p-5">
               <div className="mb-4">
                 <h2 className="text-sm font-medium text-foreground">Models</h2>
                 <p className="mt-1 text-xs text-muted-foreground">
@@ -476,7 +476,7 @@ function SettingsRouteView() {
               </div>
             </section>
 
-            <section className="rounded-2xl border border-border bg-card p-5">
+            <section id="settings-responses" className="scroll-mt-20 rounded-2xl border border-border bg-card p-5">
               <div className="mb-4">
                 <h2 className="text-sm font-medium text-foreground">Responses</h2>
                 <p className="mt-1 text-xs text-muted-foreground">
@@ -519,7 +519,7 @@ function SettingsRouteView() {
               ) : null}
             </section>
 
-            <section className="rounded-2xl border border-border bg-card p-5">
+            <section id="settings-keybindings" className="scroll-mt-20 rounded-2xl border border-border bg-card p-5">
               <div className="mb-4">
                 <h2 className="text-sm font-medium text-foreground">Keybindings</h2>
                 <p className="mt-1 text-xs text-muted-foreground">
@@ -555,7 +555,7 @@ function SettingsRouteView() {
               </div>
             </section>
 
-            <section className="rounded-2xl border border-border bg-card p-5">
+            <section id="settings-safety" className="scroll-mt-20 rounded-2xl border border-border bg-card p-5">
               <div className="mb-4">
                 <h2 className="text-sm font-medium text-foreground">Safety</h2>
                 <p className="mt-1 text-xs text-muted-foreground">

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,12 +1,17 @@
-import { Outlet, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Outlet, createFileRoute, useNavigate, useRouterState } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
 import ThreadSidebar from "../components/Sidebar";
+import SettingsSidebar from "../components/SettingsSidebar";
 import { Sidebar, SidebarProvider } from "~/components/ui/sidebar";
+
+const SETTINGS_PATH = "/settings";
 
 function ChatRouteLayout() {
   const navigate = useNavigate();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const isSettings = pathname === SETTINGS_PATH;
 
   useEffect(() => {
     const onMenuAction = window.desktopBridge?.onMenuAction;
@@ -25,13 +30,13 @@ function ChatRouteLayout() {
   }, [navigate]);
 
   return (
-    <SidebarProvider defaultOpen>
+    <SidebarProvider defaultOpen {...(isSettings && { open: true })}>
       <Sidebar
         side="left"
         collapsible="offcanvas"
         className="border-r border-border bg-card text-foreground"
       >
-        <ThreadSidebar />
+        {isSettings ? <SettingsSidebar /> : <ThreadSidebar />}
       </Sidebar>
       <DiffWorkerPoolProvider>
         <Outlet />


### PR DESCRIPTION
## Summary

Adds a dedicated sidebar for the settings page that replaces the thread list while on `/settings`, providing scrollspy navigation between sections.

## Changes

**`SettingsSidebar.tsx`** (new)
- `IntersectionObserver` tracks which section is in view and highlights it with a primary-coloured indicator in the nav
- Clicking a nav item smoothly scrolls to the target section
- Header matches the drag-region height so content aligns with the main panel

**`_chat.tsx`**
- Swaps `ThreadSidebar` for `SettingsSidebar` when on `/settings`
- Pins the sidebar open on the settings route so nav is always visible

**`_chat.settings.tsx`**
- Adds `id` + `scroll-mt-20` to all six sections so the scrollspy and anchor targets work correctly

## Sections

| ID | Label |
|----|-------|
| `settings-appearance` | Appearance |
| `settings-codex-app-server` | Codex App Server |
| `settings-models` | Models |
| `settings-responses` | Responses |
| `settings-keybindings` | Keybindings |
| `settings-safety` | Safety |

## Testing

- Navigate to Settings → sidebar shows section nav, thread list is hidden
- Scroll through settings → active section highlights in sidebar
- Click a nav item → smoothly scrolls to that section
- Navigate away from Settings → thread list sidebar restores

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a settings-specific sidebar to /settings that highlights the active section and forces the left sidebar open in `ChatRouteLayout` in [apps/web/src/routes/_chat.tsx](https://github.com/pingdotgg/t3code/pull/421/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691)
> Introduce `SettingsSidebar` with section navigation and IntersectionObserver-based active state in [apps/web/src/components/SettingsSidebar.tsx](https://github.com/pingdotgg/t3code/pull/421/files#diff-efb1a86b18b748ef7fa3ae842a687bc69d396f5136126477546245e0f98abdb5), wire it into `ChatRouteLayout` to render on `/settings`, and add IDs plus `scroll-mt-20` to settings sections in [apps/web/src/routes/_chat.settings.tsx](https://github.com/pingdotgg/t3code/pull/421/files#diff-0707e8295d0df761e405e66f02211b55d56c6eaea1ac3cb99562525a9c589cc6).
>
> #### 📍Where to Start
> Start with `SettingsSidebar` in [apps/web/src/components/SettingsSidebar.tsx](https://github.com/pingdotgg/t3code/pull/421/files#diff-efb1a86b18b748ef7fa3ae842a687bc69d396f5136126477546245e0f98abdb5), then review its integration in `ChatRouteLayout` in [apps/web/src/routes/_chat.tsx](https://github.com/pingdotgg/t3code/pull/421/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f0a0f14. 3 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->