### PR TITLE
Project scripts: add worktree deletion lifecycle hooks

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -1909,6 +1909,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
             command: "bun run build",
             icon: "build",
             runOnWorktreeCreate: false,
+            runOnWorktreeDelete: false,
           },
         ],
         defaultModel: "gpt-5",
@@ -1927,7 +1928,7 @@ engineLayer("OrchestrationProjectionPipeline via engine dispatch", (it) => {
       assert.deepEqual(projectRows, [
         {
           scriptsJson:
-            '[{"id":"script-1","name":"Build","command":"bun run build","icon":"build","runOnWorktreeCreate":false}]',
+            '[{"id":"script-1","name":"Build","command":"bun run build","icon":"build","runOnWorktreeCreate":false,"runOnWorktreeDelete":false}]',
           defaultModel: "gpt-5",
         },
       ]);

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -51,7 +51,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           'Project 1',
           '/tmp/project-1',
           'gpt-5-codex',
-          '[{"id":"script-1","name":"Build","command":"bun run build","icon":"build","runOnWorktreeCreate":false}]',
+          '[{"id":"script-1","name":"Build","command":"bun run build","icon":"build","runOnWorktreeCreate":false,"runOnWorktreeDelete":false}]',
           '2026-02-24T00:00:00.000Z',
           '2026-02-24T00:00:01.000Z',
           NULL
@@ -221,6 +221,7 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
               command: "bun run build",
               icon: "build",
               runOnWorktreeCreate: false,
+              runOnWorktreeDelete: false,
             },
           ],
           createdAt: "2026-02-24T00:00:00.000Z",

--- a/apps/server/src/orchestration/decider.projectScripts.test.ts
+++ b/apps/server/src/orchestration/decider.projectScripts.test.ts
@@ -74,6 +74,7 @@ describe("decider project scripts", () => {
         command: "bun run lint",
         icon: "lint",
         runOnWorktreeCreate: false,
+        runOnWorktreeDelete: false,
       },
     ] as const;
 

--- a/apps/server/src/projectScriptRunner.test.ts
+++ b/apps/server/src/projectScriptRunner.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { runProjectLifecycleScript } from "./projectScriptRunner";
+
+function quotedNodeCommand(source: string): string {
+  return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(source)}`;
+}
+
+describe("runProjectLifecycleScript", () => {
+  it("runs lifecycle scripts from the requested cwd with the provided env", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-project-script-runner-"));
+    const resolvedTempDir = fs.realpathSync.native(tempDir);
+    const command = quotedNodeCommand(
+      "require('node:fs').writeFileSync('hook.txt', [process.cwd(), process.env.T3CODE_PROJECT_ROOT || '', process.env.T3CODE_WORKTREE_PATH || ''].join(String.fromCharCode(10)), 'utf8')",
+    );
+
+    await runProjectLifecycleScript({
+      cwd: tempDir,
+      command,
+      env: {
+        T3CODE_PROJECT_ROOT: "/repo/project",
+        T3CODE_WORKTREE_PATH: "/repo/worktrees/thread-1",
+      },
+    });
+
+    expect(fs.readFileSync(path.join(tempDir, "hook.txt"), "utf8")).toBe(
+      `${resolvedTempDir}\n/repo/project\n/repo/worktrees/thread-1`,
+    );
+  });
+
+  it("surfaces non-zero exits as normalized lifecycle errors", async () => {
+    await expect(
+      runProjectLifecycleScript({
+        cwd: process.cwd(),
+        command: quotedNodeCommand("process.exit(3)"),
+      }),
+    ).rejects.toThrow("Project lifecycle script failed: exited with code 3.");
+  });
+
+  it("surfaces timeouts as normalized lifecycle errors", async () => {
+    const runProcessMock = vi.fn(async () => ({
+      stdout: "",
+      stderr: "",
+      code: null,
+      signal: null,
+      timedOut: true,
+    }));
+
+    await expect(
+      runProjectLifecycleScript(
+        {
+          cwd: process.cwd(),
+          command: "echo lifecycle",
+        },
+        { runProcess: runProcessMock },
+      ),
+    ).rejects.toThrow("Project lifecycle script failed: timed out after 300 seconds.");
+  });
+});

--- a/apps/server/src/projectScriptRunner.ts
+++ b/apps/server/src/projectScriptRunner.ts
@@ -1,0 +1,78 @@
+import { runProcess } from "./processRunner";
+import { createTerminalSpawnEnv } from "./terminal/spawnEnv";
+
+const PROJECT_LIFECYCLE_SCRIPT_TIMEOUT_MS = 300_000;
+const PROJECT_LIFECYCLE_SCRIPT_MAX_OUTPUT_BYTES = 1_000_000;
+
+interface ProjectLifecycleScriptInput {
+  cwd: string;
+  command: string;
+  env?: Record<string, string> | undefined;
+}
+
+interface ProjectLifecycleScriptDependencies {
+  runProcess?: typeof runProcess;
+}
+
+function stripWrappingQuotes(value: string): string {
+  return value.replace(/^['"]+|['"]+$/g, "");
+}
+
+function resolveShellCommand(): string {
+  if (process.platform === "win32") {
+    const shell = process.env.ComSpec?.trim();
+    return shell && shell.length > 0 ? shell : "cmd.exe";
+  }
+
+  const shell = process.env.SHELL?.trim();
+  if (!shell) {
+    return "/bin/sh";
+  }
+  const [firstToken] = shell.split(/\s+/g);
+  return firstToken ? stripWrappingQuotes(firstToken) : "/bin/sh";
+}
+
+function shellArgsForCommand(command: string): string[] {
+  return process.platform === "win32" ? ["/d", "/s", "/c", command] : ["-lc", command];
+}
+
+function buildLifecycleScriptError(message: string): Error {
+  return new Error(`Project lifecycle script failed: ${message}`);
+}
+
+export async function runProjectLifecycleScript(
+  input: ProjectLifecycleScriptInput,
+  dependencies: ProjectLifecycleScriptDependencies = {},
+): Promise<void> {
+  const run = dependencies.runProcess ?? runProcess;
+  const shellCommand = resolveShellCommand();
+
+  let result;
+  try {
+    result = await run(shellCommand, shellArgsForCommand(input.command), {
+      cwd: input.cwd,
+      env: createTerminalSpawnEnv(process.env, input.env),
+      timeoutMs: PROJECT_LIFECYCLE_SCRIPT_TIMEOUT_MS,
+      allowNonZeroExit: true,
+      maxBufferBytes: PROJECT_LIFECYCLE_SCRIPT_MAX_OUTPUT_BYTES,
+      outputMode: "truncate",
+    });
+  } catch (error) {
+    throw buildLifecycleScriptError(
+      error instanceof Error ? error.message : "Unable to start the script.",
+    );
+  }
+
+  if (result.timedOut) {
+    throw buildLifecycleScriptError(
+      `timed out after ${Math.round(PROJECT_LIFECYCLE_SCRIPT_TIMEOUT_MS / 1000)} seconds.`,
+    );
+  }
+  if (result.code === 0) {
+    return;
+  }
+
+  const detail = result.stderr.trim() || result.stdout.trim();
+  const exitSummary = `exited with code ${result.code ?? "null"}${result.signal ? ` (signal ${result.signal})` : ""}.`;
+  throw buildLifecycleScriptError(detail.length > 0 ? `${exitSummary} ${detail}` : exitSummary);
+}

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -18,6 +18,7 @@ import { createLogger } from "../../logger";
 import { PtyAdapter, PtyAdapterShape, type PtyExitEvent, type PtyProcess } from "../Services/PTY";
 import { runProcess } from "../../processRunner";
 import { ServerConfig } from "../../config";
+import { createTerminalSpawnEnv } from "../spawnEnv";
 import {
   ShellCandidate,
   TerminalError,
@@ -34,7 +35,6 @@ const DEFAULT_PROCESS_KILL_GRACE_MS = 1_000;
 const DEFAULT_MAX_RETAINED_INACTIVE_SESSIONS = 128;
 const DEFAULT_OPEN_COLS = 120;
 const DEFAULT_OPEN_ROWS = 30;
-const TERMINAL_ENV_BLOCKLIST = new Set(["PORT", "ELECTRON_RENDERER_PORT", "ELECTRON_RUN_AS_NODE"]);
 
 const decodeTerminalOpenInput = Schema.decodeUnknownSync(TerminalOpenInput);
 const decodeTerminalWriteInput = Schema.decodeUnknownSync(TerminalWriteInput);
@@ -266,35 +266,6 @@ function toSafeTerminalId(terminalId: string): string {
 
 function toSessionKey(threadId: string, terminalId: string): string {
   return `${threadId}\u0000${terminalId}`;
-}
-
-function shouldExcludeTerminalEnvKey(key: string): boolean {
-  const normalizedKey = key.toUpperCase();
-  if (normalizedKey.startsWith("T3CODE_")) {
-    return true;
-  }
-  if (normalizedKey.startsWith("VITE_")) {
-    return true;
-  }
-  return TERMINAL_ENV_BLOCKLIST.has(normalizedKey);
-}
-
-function createTerminalSpawnEnv(
-  baseEnv: NodeJS.ProcessEnv,
-  runtimeEnv?: Record<string, string> | null,
-): NodeJS.ProcessEnv {
-  const spawnEnv: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(baseEnv)) {
-    if (value === undefined) continue;
-    if (shouldExcludeTerminalEnvKey(key)) continue;
-    spawnEnv[key] = value;
-  }
-  if (runtimeEnv) {
-    for (const [key, value] of Object.entries(runtimeEnv)) {
-      spawnEnv[key] = value;
-    }
-  }
-  return spawnEnv;
 }
 
 function normalizedRuntimeEnv(

--- a/apps/server/src/terminal/spawnEnv.ts
+++ b/apps/server/src/terminal/spawnEnv.ts
@@ -1,0 +1,30 @@
+const TERMINAL_ENV_BLOCKLIST = new Set(["PORT", "ELECTRON_RENDERER_PORT", "ELECTRON_RUN_AS_NODE"]);
+
+function shouldExcludeTerminalEnvKey(key: string): boolean {
+  const normalizedKey = key.toUpperCase();
+  if (normalizedKey.startsWith("T3CODE_")) {
+    return true;
+  }
+  if (normalizedKey.startsWith("VITE_")) {
+    return true;
+  }
+  return TERMINAL_ENV_BLOCKLIST.has(normalizedKey);
+}
+
+export function createTerminalSpawnEnv(
+  baseEnv: NodeJS.ProcessEnv,
+  runtimeEnv?: Record<string, string> | null,
+): NodeJS.ProcessEnv {
+  const spawnEnv: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (value === undefined) continue;
+    if (shouldExcludeTerminalEnvKey(key)) continue;
+    spawnEnv[key] = value;
+  }
+  if (runtimeEnv) {
+    for (const [key, value] of Object.entries(runtimeEnv)) {
+      spawnEnv[key] = value;
+    }
+  }
+  return spawnEnv;
+}

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -1552,6 +1552,52 @@ describe("WebSocket Server", () => {
     );
   });
 
+  it("supports projects.runLifecycleScript", async () => {
+    const workspace = makeTempDir("t3code-ws-run-lifecycle-script-");
+    const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(
+      "require('node:fs').writeFileSync('lifecycle.txt', process.env.T3CODE_PROJECT_ROOT || '', 'utf8')",
+    )}`;
+
+    server = await createTestServer({ cwd: "/test" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.projectsRunLifecycleScript, {
+      cwd: workspace,
+      command,
+      env: {
+        T3CODE_PROJECT_ROOT: "/repo/project",
+      },
+    });
+
+    expect(response.error).toBeUndefined();
+    expect(fs.readFileSync(path.join(workspace, "lifecycle.txt"), "utf8")).toBe("/repo/project");
+  });
+
+  it("returns lifecycle script failures over websocket", async () => {
+    server = await createTestServer({ cwd: "/test" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.projectsRunLifecycleScript, {
+      cwd: process.cwd(),
+      command: `${JSON.stringify(process.execPath)} -e ${JSON.stringify("process.exit(5)")}`,
+    });
+
+    expect(response.result).toBeUndefined();
+    expect(response.error?.message).toContain(
+      "Project lifecycle script failed: exited with code 5.",
+    );
+  });
+
   it("rejects projects.writeFile paths outside the workspace root", async () => {
     const workspace = makeTempDir("t3code-ws-write-file-reject-");
 

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -73,6 +73,7 @@ import {
 import { parseBase64DataUrl } from "./imageMime.ts";
 import { AnalyticsService } from "./telemetry/Services/AnalyticsService.ts";
 import { expandHomePath } from "./os-jank.ts";
+import { runProjectLifecycleScript } from "./projectScriptRunner";
 
 /**
  * ServerShape - Service API for server lifecycle control.
@@ -794,6 +795,20 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
           ),
         );
         return { relativePath: target.relativePath };
+      }
+
+      case WS_METHODS.projectsRunLifecycleScript: {
+        const body = stripRequestTag(request.body);
+        return yield* Effect.tryPromise({
+          try: () => runProjectLifecycleScript(body),
+          catch: (cause) =>
+            new RouteRequestError({
+              message:
+                cause instanceof Error
+                  ? cause.message
+                  : "Project lifecycle script failed: Unknown error.",
+            }),
+        });
       }
 
       case WS_METHODS.shellOpenInEditor: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -193,6 +193,7 @@ import {
   projectScriptRuntimeEnv,
   projectScriptIdFromCommand,
   setupProjectScript,
+  upsertProjectScript,
 } from "~/projectScripts";
 import { Toggle } from "./ui/toggle";
 import { SidebarTrigger } from "./ui/sidebar";
@@ -1555,15 +1556,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
         command: input.command,
         icon: input.icon,
         runOnWorktreeCreate: input.runOnWorktreeCreate,
+        runOnWorktreeDelete: input.runOnWorktreeDelete,
       };
-      const nextScripts = input.runOnWorktreeCreate
-        ? [
-            ...activeProject.scripts.map((script) =>
-              script.runOnWorktreeCreate ? { ...script, runOnWorktreeCreate: false } : script,
-            ),
-            nextScript,
-          ]
-        : [...activeProject.scripts, nextScript];
+      const nextScripts = upsertProjectScript(activeProject.scripts, nextScript);
 
       await persistProjectScripts({
         projectId: activeProject.id,
@@ -1590,14 +1585,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
         command: input.command,
         icon: input.icon,
         runOnWorktreeCreate: input.runOnWorktreeCreate,
+        runOnWorktreeDelete: input.runOnWorktreeDelete,
       };
-      const nextScripts = activeProject.scripts.map((script) =>
-        script.id === scriptId
-          ? updatedScript
-          : input.runOnWorktreeCreate
-            ? { ...script, runOnWorktreeCreate: false }
-            : script,
-      );
+      const nextScripts = upsertProjectScript(activeProject.scripts, updatedScript);
 
       await persistProjectScripts({
         projectId: activeProject.id,

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -24,6 +24,7 @@ import {
   commandForProjectScript,
   nextProjectScriptId,
   primaryProjectScript,
+  projectScriptLifecycleLabel,
 } from "~/projectScripts";
 import { shortcutLabelForCommand } from "~/keybindings";
 import { isMacPlatform } from "~/lib/utils";
@@ -74,6 +75,7 @@ export interface NewProjectScriptInput {
   command: string;
   icon: ProjectScriptIcon;
   runOnWorktreeCreate: boolean;
+  runOnWorktreeDelete: boolean;
   keybinding: string | null;
 }
 
@@ -153,6 +155,7 @@ export default function ProjectScriptsControl({
   const [icon, setIcon] = useState<ProjectScriptIcon>("play");
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const [runOnWorktreeCreate, setRunOnWorktreeCreate] = useState(false);
+  const [runOnWorktreeDelete, setRunOnWorktreeDelete] = useState(false);
   const [keybinding, setKeybinding] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -209,6 +212,7 @@ export default function ProjectScriptsControl({
         command: trimmedCommand,
         icon,
         runOnWorktreeCreate,
+        runOnWorktreeDelete,
         keybinding: keybindingRule?.key ?? null,
       } satisfies NewProjectScriptInput;
       if (editingScriptId) {
@@ -230,6 +234,7 @@ export default function ProjectScriptsControl({
     setIcon("play");
     setIconPickerOpen(false);
     setRunOnWorktreeCreate(false);
+    setRunOnWorktreeDelete(false);
     setKeybinding("");
     setValidationError(null);
     setDialogOpen(true);
@@ -242,6 +247,7 @@ export default function ProjectScriptsControl({
     setIcon(script.icon);
     setIconPickerOpen(false);
     setRunOnWorktreeCreate(script.runOnWorktreeCreate);
+    setRunOnWorktreeDelete(script.runOnWorktreeDelete);
     setKeybinding(keybindingValueForCommand(keybindings, commandForProjectScript(script.id)) ?? "");
     setValidationError(null);
     setDialogOpen(true);
@@ -275,6 +281,7 @@ export default function ProjectScriptsControl({
                   keybindings,
                   commandForProjectScript(script.id),
                 );
+                const lifecycleLabel = projectScriptLifecycleLabel(script);
                 return (
                   <MenuItem
                     key={script.id}
@@ -283,7 +290,7 @@ export default function ProjectScriptsControl({
                   >
                     <ScriptIcon icon={script.icon} className="size-4" />
                     <span className="truncate">
-                      {script.runOnWorktreeCreate ? `${script.name} (setup)` : script.name}
+                      {lifecycleLabel ? `${script.name} (${lifecycleLabel})` : script.name}
                     </span>
                     <span className="relative ms-auto flex h-6 min-w-6 items-center justify-end">
                       {shortcutLabel && (
@@ -343,6 +350,7 @@ export default function ProjectScriptsControl({
           setCommand("");
           setIcon("play");
           setRunOnWorktreeCreate(false);
+          setRunOnWorktreeDelete(false);
           setKeybinding("");
           setValidationError(null);
         }}
@@ -434,6 +442,13 @@ export default function ProjectScriptsControl({
                 <Switch
                   checked={runOnWorktreeCreate}
                   onCheckedChange={(checked) => setRunOnWorktreeCreate(Boolean(checked))}
+                />
+              </label>
+              <label className="flex items-center justify-between gap-3 rounded-md border border-border/70 px-3 py-2 text-sm">
+                <span>Run automatically on worktree deletion</span>
+                <Switch
+                  checked={runOnWorktreeDelete}
+                  onCheckedChange={(checked) => setRunOnWorktreeDelete(Boolean(checked))}
                 />
               </label>
               {validationError && <p className="text-sm text-destructive">{validationError}</p>}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -60,6 +60,7 @@ import {
 } from "./ui/sidebar";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
+import { deleteThreadWorktree } from "../worktreeDeleteFlow";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_PREVIEW_LIMIT = 6;
@@ -678,13 +679,40 @@ export default function Sidebar() {
           .catch(() => undefined);
       }
 
-      try {
-        await api.terminal.close({
-          threadId,
-          deleteHistory: true,
-        });
-      } catch {
-        // Terminal may already be closed
+      if (shouldDeleteWorktree && orphanedWorktreePath && threadProject) {
+        try {
+          await deleteThreadWorktree({
+            api,
+            thread,
+            project: threadProject,
+            worktreePath: orphanedWorktreePath,
+            removeWorktree: (input) => removeWorktreeMutation.mutateAsync(input),
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Unknown error removing worktree.";
+          console.error("Failed to remove orphaned worktree before thread deletion", {
+            threadId,
+            projectCwd: threadProject.cwd,
+            worktreePath: orphanedWorktreePath,
+            error,
+          });
+          toastManager.add({
+            type: "error",
+            title: "Failed to delete worktree",
+            description: `Could not remove ${displayWorktreePath ?? orphanedWorktreePath}. ${message}`,
+          });
+          return;
+        }
+      } else {
+        try {
+          await api.terminal.close({
+            threadId,
+            deleteHistory: true,
+          });
+        } catch {
+          // Terminal may already be closed
+        }
       }
 
       const shouldNavigateToFallback = routeThreadId === threadId;
@@ -694,6 +722,16 @@ export default function Sidebar() {
         commandId: newCommandId(),
         threadId,
       });
+
+      if (shouldDeleteWorktree && orphanedWorktreePath && threadProject) {
+        await api.terminal
+          .close({
+            threadId,
+            deleteHistory: true,
+          })
+          .catch(() => undefined);
+      }
+
       clearComposerDraftForThread(threadId);
       clearProjectDraftThreadById(thread.projectId, thread.id);
       clearTerminalState(threadId);
@@ -707,31 +745,6 @@ export default function Sidebar() {
         } else {
           void navigate({ to: "/", replace: true });
         }
-      }
-
-      if (!shouldDeleteWorktree || !orphanedWorktreePath || !threadProject) {
-        return;
-      }
-
-      try {
-        await removeWorktreeMutation.mutateAsync({
-          cwd: threadProject.cwd,
-          path: orphanedWorktreePath,
-          force: true,
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error removing worktree.";
-        console.error("Failed to remove orphaned worktree after thread deletion", {
-          threadId,
-          projectCwd: threadProject.cwd,
-          worktreePath: orphanedWorktreePath,
-          error,
-        });
-        toastManager.add({
-          type: "error",
-          title: "Thread deleted, but worktree removal failed",
-          description: `Could not remove ${displayWorktreePath ?? orphanedWorktreePath}. ${message}`,
-        });
       }
     },
     [

--- a/apps/web/src/projectScripts.test.ts
+++ b/apps/web/src/projectScripts.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  cleanupProjectScript,
   commandForProjectScript,
   nextProjectScriptId,
   primaryProjectScript,
   projectScriptRuntimeEnv,
+  projectScriptLifecycleLabel,
   projectScriptIdFromCommand,
   setupProjectScript,
+  upsertProjectScript,
 } from "./projectScripts";
 
 describe("projectScripts helpers", () => {
@@ -31,6 +34,15 @@ describe("projectScripts helpers", () => {
         command: "bun install",
         icon: "configure" as const,
         runOnWorktreeCreate: true,
+        runOnWorktreeDelete: false,
+      },
+      {
+        id: "cleanup",
+        name: "Cleanup",
+        command: "git pull --ff-only",
+        icon: "configure" as const,
+        runOnWorktreeCreate: false,
+        runOnWorktreeDelete: true,
       },
       {
         id: "test",
@@ -38,11 +50,167 @@ describe("projectScripts helpers", () => {
         command: "bun test",
         icon: "test" as const,
         runOnWorktreeCreate: false,
+        runOnWorktreeDelete: false,
       },
     ];
 
     expect(primaryProjectScript(scripts)?.id).toBe("test");
     expect(setupProjectScript(scripts)?.id).toBe("setup");
+    expect(cleanupProjectScript(scripts)?.id).toBe("cleanup");
+  });
+
+  it("falls back to the first script when all actions are lifecycle hooks", () => {
+    const scripts = [
+      {
+        id: "cleanup",
+        name: "Cleanup",
+        command: "git pull --ff-only",
+        icon: "configure" as const,
+        runOnWorktreeCreate: false,
+        runOnWorktreeDelete: true,
+      },
+    ];
+
+    expect(primaryProjectScript(scripts)?.id).toBe("cleanup");
+  });
+
+  it("formats lifecycle labels", () => {
+    expect(
+      projectScriptLifecycleLabel({
+        id: "setup",
+        name: "Setup",
+        command: "bun install",
+        icon: "configure",
+        runOnWorktreeCreate: true,
+        runOnWorktreeDelete: false,
+      }),
+    ).toBe("setup");
+    expect(
+      projectScriptLifecycleLabel({
+        id: "cleanup",
+        name: "Cleanup",
+        command: "git pull --ff-only",
+        icon: "configure",
+        runOnWorktreeCreate: false,
+        runOnWorktreeDelete: true,
+      }),
+    ).toBe("cleanup");
+    expect(
+      projectScriptLifecycleLabel({
+        id: "both",
+        name: "Both",
+        command: "echo done",
+        icon: "play",
+        runOnWorktreeCreate: true,
+        runOnWorktreeDelete: true,
+      }),
+    ).toBe("setup, cleanup");
+  });
+
+  it("enforces one create hook and one delete hook while allowing both on one action", () => {
+    const scripts = [
+      {
+        id: "setup",
+        name: "Setup",
+        command: "bun install",
+        icon: "configure" as const,
+        runOnWorktreeCreate: true,
+        runOnWorktreeDelete: false,
+      },
+      {
+        id: "cleanup",
+        name: "Cleanup",
+        command: "git pull --ff-only",
+        icon: "configure" as const,
+        runOnWorktreeCreate: false,
+        runOnWorktreeDelete: true,
+      },
+    ];
+
+    const nextScripts = upsertProjectScript(scripts, {
+      id: "all-hooks",
+      name: "All hooks",
+      command: "echo hooks",
+      icon: "play",
+      runOnWorktreeCreate: true,
+      runOnWorktreeDelete: true,
+    });
+
+    expect(nextScripts).toEqual([
+      {
+        id: "setup",
+        name: "Setup",
+        command: "bun install",
+        icon: "configure",
+        runOnWorktreeCreate: false,
+        runOnWorktreeDelete: false,
+      },
+      {
+        id: "cleanup",
+        name: "Cleanup",
+        command: "git pull --ff-only",
+        icon: "configure",
+        runOnWorktreeCreate: false,
+        runOnWorktreeDelete: false,
+      },
+      {
+        id: "all-hooks",
+        name: "All hooks",
+        command: "echo hooks",
+        icon: "play",
+        runOnWorktreeCreate: true,
+        runOnWorktreeDelete: true,
+      },
+    ]);
+  });
+
+  it("only clears conflicting lifecycle slots on update", () => {
+    const scripts = [
+      {
+        id: "setup",
+        name: "Setup",
+        command: "bun install",
+        icon: "configure" as const,
+        runOnWorktreeCreate: true,
+        runOnWorktreeDelete: false,
+      },
+      {
+        id: "cleanup",
+        name: "Cleanup",
+        command: "git pull --ff-only",
+        icon: "configure" as const,
+        runOnWorktreeCreate: false,
+        runOnWorktreeDelete: true,
+      },
+    ];
+
+    const nextScripts = upsertProjectScript(scripts, {
+      id: "setup",
+      name: "Setup",
+      command: "bun install --frozen-lockfile",
+      icon: "configure",
+      runOnWorktreeCreate: true,
+      runOnWorktreeDelete: true,
+    });
+
+    expect(nextScripts).toEqual([
+      {
+        id: "setup",
+        name: "Setup",
+        command: "bun install --frozen-lockfile",
+        icon: "configure",
+        runOnWorktreeCreate: true,
+        runOnWorktreeDelete: true,
+      },
+      {
+        id: "cleanup",
+        name: "Cleanup",
+        command: "git pull --ff-only",
+        icon: "configure",
+        runOnWorktreeCreate: false,
+        runOnWorktreeDelete: false,
+      },
+    ]);
   });
 
   it("builds default runtime env for scripts", () => {

--- a/apps/web/src/projectScripts.ts
+++ b/apps/web/src/projectScripts.ts
@@ -4,6 +4,7 @@ import {
   type KeybindingCommand,
   type ProjectScript,
 } from "@t3tools/contracts";
+import { projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { Schema } from "effect";
 
 function normalizeScriptId(value: string): string {
@@ -55,34 +56,65 @@ export function nextProjectScriptId(name: string, existingIds: Iterable<string>)
   return `${baseId}-${Date.now()}`.slice(0, MAX_SCRIPT_ID_LENGTH);
 }
 
-interface ProjectScriptRuntimeEnvInput {
-  project: {
-    cwd: string;
-  };
-  worktreePath?: string | null;
-  extraEnv?: Record<string, string>;
+function isLifecycleProjectScript(script: ProjectScript): boolean {
+  return script.runOnWorktreeCreate || script.runOnWorktreeDelete;
 }
 
-export function projectScriptRuntimeEnv(
-  input: ProjectScriptRuntimeEnvInput,
-): Record<string, string> {
-  const env: Record<string, string> = {
-    T3CODE_PROJECT_ROOT: input.project.cwd,
-  };
-  if (input.worktreePath) {
-    env.T3CODE_WORKTREE_PATH = input.worktreePath;
-  }
-  if (input.extraEnv) {
-    return { ...env, ...input.extraEnv };
-  }
-  return env;
-}
+export { projectScriptRuntimeEnv };
 
 export function primaryProjectScript(scripts: ProjectScript[]): ProjectScript | null {
-  const regular = scripts.find((script) => !script.runOnWorktreeCreate);
+  const regular = scripts.find((script) => !isLifecycleProjectScript(script));
   return regular ?? scripts[0] ?? null;
 }
 
 export function setupProjectScript(scripts: ProjectScript[]): ProjectScript | null {
   return scripts.find((script) => script.runOnWorktreeCreate) ?? null;
+}
+
+export function cleanupProjectScript(scripts: ProjectScript[]): ProjectScript | null {
+  return scripts.find((script) => script.runOnWorktreeDelete) ?? null;
+}
+
+export function projectScriptLifecycleLabel(script: ProjectScript): string | null {
+  if (script.runOnWorktreeCreate && script.runOnWorktreeDelete) {
+    return "setup, cleanup";
+  }
+  if (script.runOnWorktreeCreate) {
+    return "setup";
+  }
+  if (script.runOnWorktreeDelete) {
+    return "cleanup";
+  }
+  return null;
+}
+
+export function upsertProjectScript(
+  scripts: ProjectScript[],
+  nextScript: ProjectScript,
+): ProjectScript[] {
+  const nextScripts: ProjectScript[] = [];
+  let replacedExisting = false;
+
+  for (const script of scripts) {
+    if (script.id === nextScript.id) {
+      nextScripts.push(nextScript);
+      replacedExisting = true;
+      continue;
+    }
+
+    let normalizedScript = script;
+    if (nextScript.runOnWorktreeCreate && normalizedScript.runOnWorktreeCreate) {
+      normalizedScript = { ...normalizedScript, runOnWorktreeCreate: false };
+    }
+    if (nextScript.runOnWorktreeDelete && normalizedScript.runOnWorktreeDelete) {
+      normalizedScript = { ...normalizedScript, runOnWorktreeDelete: false };
+    }
+    nextScripts.push(normalizedScript);
+  }
+
+  if (!replacedExisting) {
+    nextScripts.push(nextScript);
+  }
+
+  return nextScripts;
 }

--- a/apps/web/src/worktreeDeleteFlow.test.ts
+++ b/apps/web/src/worktreeDeleteFlow.test.ts
@@ -1,0 +1,168 @@
+import { ThreadId, type NativeApi } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { deleteThreadWorktree } from "./worktreeDeleteFlow";
+
+function createNativeApiMock() {
+  return {
+    projects: {
+      runLifecycleScript: vi.fn(async () => undefined),
+    },
+    terminal: {
+      close: vi.fn(async () => undefined),
+    },
+  };
+}
+
+describe("deleteThreadWorktree", () => {
+  it("runs the delete hook before closing terminals and removing the worktree", async () => {
+    const callOrder: string[] = [];
+    const api = createNativeApiMock();
+    api.projects.runLifecycleScript.mockImplementation(async () => {
+      callOrder.push("hook");
+    });
+    api.terminal.close.mockImplementation(async () => {
+      callOrder.push("terminal.close");
+    });
+    const removeWorktree = vi.fn(async () => {
+      callOrder.push("worktree.remove");
+    });
+
+    await deleteThreadWorktree({
+      api: api as unknown as NativeApi,
+      thread: { id: ThreadId.makeUnsafe("thread-1") },
+      project: {
+        cwd: "/repo/project",
+        scripts: [
+          {
+            id: "cleanup",
+            name: "Cleanup",
+            command: "git pull --ff-only",
+            icon: "configure",
+            runOnWorktreeCreate: false,
+            runOnWorktreeDelete: true,
+          },
+        ],
+      },
+      worktreePath: "/repo/worktrees/thread-1",
+      removeWorktree,
+    });
+
+    expect(api.projects.runLifecycleScript).toHaveBeenCalledWith({
+      cwd: "/repo/worktrees/thread-1",
+      command: "git pull --ff-only",
+      env: {
+        T3CODE_PROJECT_ROOT: "/repo/project",
+        T3CODE_WORKTREE_PATH: "/repo/worktrees/thread-1",
+      },
+    });
+    expect(api.terminal.close).toHaveBeenCalledWith({
+      threadId: "thread-1",
+    });
+    expect(removeWorktree).toHaveBeenCalledWith({
+      cwd: "/repo/project",
+      path: "/repo/worktrees/thread-1",
+      force: true,
+    });
+    expect(callOrder).toEqual(["hook", "terminal.close", "worktree.remove"]);
+  });
+
+  it("skips the delete hook when no action owns the delete slot", async () => {
+    const api = createNativeApiMock();
+    const removeWorktree = vi.fn(async () => undefined);
+
+    await deleteThreadWorktree({
+      api: api as unknown as NativeApi,
+      thread: { id: ThreadId.makeUnsafe("thread-1") },
+      project: {
+        cwd: "/repo/project",
+        scripts: [
+          {
+            id: "setup",
+            name: "Setup",
+            command: "bun install",
+            icon: "configure",
+            runOnWorktreeCreate: true,
+            runOnWorktreeDelete: false,
+          },
+        ],
+      },
+      worktreePath: "/repo/worktrees/thread-1",
+      removeWorktree,
+    });
+
+    expect(api.projects.runLifecycleScript).not.toHaveBeenCalled();
+    expect(api.terminal.close).toHaveBeenCalledTimes(1);
+    expect(removeWorktree).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts before closing terminals when the delete hook fails", async () => {
+    const api = createNativeApiMock();
+    api.projects.runLifecycleScript.mockRejectedValue(new Error("hook failed"));
+    const removeWorktree = vi.fn(async () => undefined);
+
+    await expect(
+      deleteThreadWorktree({
+        api: api as unknown as NativeApi,
+        thread: { id: ThreadId.makeUnsafe("thread-1") },
+        project: {
+          cwd: "/repo/project",
+          scripts: [
+            {
+              id: "cleanup",
+              name: "Cleanup",
+              command: "git pull --ff-only",
+              icon: "configure",
+              runOnWorktreeCreate: false,
+              runOnWorktreeDelete: true,
+            },
+          ],
+        },
+        worktreePath: "/repo/worktrees/thread-1",
+        removeWorktree,
+      }),
+    ).rejects.toThrow("hook failed");
+
+    expect(api.terminal.close).not.toHaveBeenCalled();
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it("propagates worktree removal failures after the hook and terminal close complete", async () => {
+    const callOrder: string[] = [];
+    const api = createNativeApiMock();
+    api.projects.runLifecycleScript.mockImplementation(async () => {
+      callOrder.push("hook");
+    });
+    api.terminal.close.mockImplementation(async () => {
+      callOrder.push("terminal.close");
+    });
+    const removeWorktree = vi.fn(async () => {
+      callOrder.push("worktree.remove");
+      throw new Error("remove failed");
+    });
+
+    await expect(
+      deleteThreadWorktree({
+        api: api as unknown as NativeApi,
+        thread: { id: ThreadId.makeUnsafe("thread-1") },
+        project: {
+          cwd: "/repo/project",
+          scripts: [
+            {
+              id: "cleanup",
+              name: "Cleanup",
+              command: "git pull --ff-only",
+              icon: "configure",
+              runOnWorktreeCreate: false,
+              runOnWorktreeDelete: true,
+            },
+          ],
+        },
+        worktreePath: "/repo/worktrees/thread-1",
+        removeWorktree,
+      }),
+    ).rejects.toThrow("remove failed");
+
+    expect(callOrder).toEqual(["hook", "terminal.close", "worktree.remove"]);
+  });
+});

--- a/apps/web/src/worktreeDeleteFlow.ts
+++ b/apps/web/src/worktreeDeleteFlow.ts
@@ -1,0 +1,43 @@
+import { projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
+import type { NativeApi } from "@t3tools/contracts";
+
+import { cleanupProjectScript } from "./projectScripts";
+import type { Project, Thread } from "./types";
+
+interface DeleteThreadWorktreeInput {
+  api: NativeApi;
+  thread: Pick<Thread, "id">;
+  project: Pick<Project, "cwd" | "scripts">;
+  worktreePath: string;
+  removeWorktree: (input: { cwd: string; path: string; force: boolean }) => Promise<void>;
+}
+
+export async function deleteThreadWorktree(
+  input: DeleteThreadWorktreeInput,
+): Promise<void> {
+  const deleteHookScript = cleanupProjectScript(input.project.scripts);
+  if (deleteHookScript) {
+    await input.api.projects.runLifecycleScript({
+      cwd: input.worktreePath,
+      command: deleteHookScript.command,
+      env: projectScriptRuntimeEnv({
+        project: { cwd: input.project.cwd },
+        worktreePath: input.worktreePath,
+      }),
+    });
+  }
+
+  try {
+    await input.api.terminal.close({
+      threadId: input.thread.id,
+    });
+  } catch {
+    // Terminal may already be closed
+  }
+
+  await input.removeWorktree({
+    cwd: input.project.cwd,
+    path: input.worktreePath,
+    force: true,
+  });
+}

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -349,6 +349,30 @@ describe("wsNativeApi", () => {
     });
   });
 
+  it("forwards lifecycle script runs to the websocket project method", async () => {
+    requestMock.mockResolvedValue(undefined);
+    const { createWsNativeApi } = await import("./wsNativeApi");
+
+    const api = createWsNativeApi();
+    await api.projects.runLifecycleScript({
+      cwd: "/tmp/worktree",
+      command: "git pull --ff-only",
+      env: {
+        T3CODE_PROJECT_ROOT: "/tmp/project",
+        T3CODE_WORKTREE_PATH: "/tmp/worktree",
+      },
+    });
+
+    expect(requestMock).toHaveBeenCalledWith(WS_METHODS.projectsRunLifecycleScript, {
+      cwd: "/tmp/worktree",
+      command: "git pull --ff-only",
+      env: {
+        T3CODE_PROJECT_ROOT: "/tmp/project",
+        T3CODE_WORKTREE_PATH: "/tmp/worktree",
+      },
+    });
+  });
+
   it("forwards full-thread diff requests to the orchestration websocket method", async () => {
     requestMock.mockResolvedValue({ diff: "patch" });
     const { createWsNativeApi } = await import("./wsNativeApi");

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -142,6 +142,8 @@ export function createWsNativeApi(): NativeApi {
     projects: {
       searchEntries: (input) => transport.request(WS_METHODS.projectsSearchEntries, input),
       writeFile: (input) => transport.request(WS_METHODS.projectsWriteFile, input),
+      runLifecycleScript: (input) =>
+        transport.request(WS_METHODS.projectsRunLifecycleScript, input),
     },
     shell: {
       openInEditor: (cwd, editor) =>

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -15,6 +15,7 @@ import type {
   GitStatusResult,
 } from "./git";
 import type {
+  ProjectRunLifecycleScriptInput,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
   ProjectWriteFileInput,
@@ -110,6 +111,7 @@ export interface NativeApi {
   projects: {
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;
+    runLifecycleScript: (input: ProjectRunLifecycleScriptInput) => Promise<void>;
   };
   shell: {
     openInEditor: (cwd: string, editor: EditorId) => Promise<void>;

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_RUNTIME_MODE,
   OrchestrationGetTurnDiffInput,
   OrchestrationSession,
+  ProjectScript,
   ProjectCreateCommand,
   ThreadTurnStartCommand,
   ThreadCreatedPayload,
@@ -23,6 +24,7 @@ const decodeThreadTurnStartRequestedPayload = Schema.decodeUnknownEffect(
 );
 const decodeOrchestrationSession = Schema.decodeUnknownEffect(OrchestrationSession);
 const decodeThreadCreatedPayload = Schema.decodeUnknownEffect(ThreadCreatedPayload);
+const decodeProjectScript = Schema.decodeUnknownEffect(ProjectScript);
 
 it.effect("parses turn diff input when fromTurnCount <= toTurnCount", () =>
   Effect.gen(function* () {
@@ -155,6 +157,20 @@ it.effect("decodes thread.created runtime mode for historical events", () =>
     });
 
     assert.strictEqual(parsed.runtimeMode, DEFAULT_RUNTIME_MODE);
+  }),
+);
+
+it.effect("decodes legacy project scripts without the delete hook flag", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeProjectScript({
+      id: "script-1",
+      name: "Build",
+      command: "bun run build",
+      icon: "build",
+      runOnWorktreeCreate: false,
+    });
+
+    assert.strictEqual(parsed.runOnWorktreeDelete, false);
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -121,6 +121,7 @@ export const ProjectScript = Schema.Struct({
   command: TrimmedNonEmptyString,
   icon: ProjectScriptIcon,
   runOnWorktreeCreate: Schema.Boolean,
+  runOnWorktreeDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
 });
 export type ProjectScript = typeof ProjectScript.Type;
 

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -3,6 +3,9 @@ import { PositiveInt, TrimmedNonEmptyString } from "./baseSchemas";
 
 const PROJECT_SEARCH_ENTRIES_MAX_LIMIT = 200;
 const PROJECT_WRITE_FILE_PATH_MAX_LENGTH = 512;
+const PROJECT_LIFECYCLE_SCRIPT_COMMAND_MAX_LENGTH = 10_000;
+const PROJECT_LIFECYCLE_ENV_MAX_PROPERTIES = 128;
+const PROJECT_LIFECYCLE_ENV_VALUE_MAX_LENGTH = 8_192;
 
 export const ProjectSearchEntriesInput = Schema.Struct({
   cwd: TrimmedNonEmptyString,
@@ -39,3 +42,23 @@ export const ProjectWriteFileResult = Schema.Struct({
   relativePath: TrimmedNonEmptyString,
 });
 export type ProjectWriteFileResult = typeof ProjectWriteFileResult.Type;
+
+const ProjectLifecycleEnvKey = Schema.String.check(
+  Schema.isPattern(/^[A-Za-z_][A-Za-z0-9_]*$/),
+).check(Schema.isMaxLength(128));
+const ProjectLifecycleEnvValue = Schema.String.check(
+  Schema.isMaxLength(PROJECT_LIFECYCLE_ENV_VALUE_MAX_LENGTH),
+);
+const ProjectLifecycleEnv = Schema.Record(
+  ProjectLifecycleEnvKey,
+  ProjectLifecycleEnvValue,
+).check(Schema.isMaxProperties(PROJECT_LIFECYCLE_ENV_MAX_PROPERTIES));
+
+export const ProjectRunLifecycleScriptInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  command: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(PROJECT_LIFECYCLE_SCRIPT_COMMAND_MAX_LENGTH),
+  ),
+  env: Schema.optional(ProjectLifecycleEnv),
+});
+export type ProjectRunLifecycleScriptInput = typeof ProjectRunLifecycleScriptInput.Type;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -29,7 +29,11 @@ import {
   TerminalWriteInput,
 } from "./terminal";
 import { KeybindingRule } from "./keybindings";
-import { ProjectSearchEntriesInput, ProjectWriteFileInput } from "./project";
+import {
+  ProjectRunLifecycleScriptInput,
+  ProjectSearchEntriesInput,
+  ProjectWriteFileInput,
+} from "./project";
 import { OpenInEditorInput } from "./editor";
 
 // ── WebSocket RPC Method Names ───────────────────────────────────────
@@ -41,6 +45,7 @@ export const WS_METHODS = {
   projectsRemove: "projects.remove",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
+  projectsRunLifecycleScript: "projects.runLifecycleScript",
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
@@ -103,6 +108,7 @@ const WebSocketRequestBody = Schema.Union([
   // Project Search
   tagRequestBody(WS_METHODS.projectsSearchEntries, ProjectSearchEntriesInput),
   tagRequestBody(WS_METHODS.projectsWriteFile, ProjectWriteFileInput),
+  tagRequestBody(WS_METHODS.projectsRunLifecycleScript, ProjectRunLifecycleScriptInput),
 
   // Shell methods
   tagRequestBody(WS_METHODS.shellOpenInEditor, OpenInEditorInput),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,6 +16,10 @@
       "types": "./src/logging.ts",
       "import": "./src/logging.ts"
     },
+    "./projectScripts": {
+      "types": "./src/projectScripts.ts",
+      "import": "./src/projectScripts.ts"
+    },
     "./shell": {
       "types": "./src/shell.ts",
       "import": "./src/shell.ts"

--- a/packages/shared/src/projectScripts.ts
+++ b/packages/shared/src/projectScripts.ts
@@ -1,0 +1,22 @@
+export interface ProjectScriptRuntimeEnvInput {
+  project: {
+    cwd: string;
+  };
+  worktreePath?: string | null;
+  extraEnv?: Record<string, string>;
+}
+
+export function projectScriptRuntimeEnv(
+  input: ProjectScriptRuntimeEnvInput,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    T3CODE_PROJECT_ROOT: input.project.cwd,
+  };
+  if (input.worktreePath) {
+    env.T3CODE_WORKTREE_PATH = input.worktreePath;
+  }
+  if (input.extraEnv) {
+    return { ...env, ...input.extraEnv };
+  }
+  return env;
+}


### PR DESCRIPTION
# Summary
- add a second lifecycle hook so project scripts can run automatically when a worktree is deleted
- run deletion hooks on the server before `git worktree remove` and abort the delete flow on failures or timeouts
- preserve manual script execution while enforcing one create hook and one delete hook in the UI

# Changes
- extend the shared project script contract with `runOnWorktreeDelete` and add a new `projects.runLifecycleScript` native API method
- add a dedicated server-side lifecycle runner and reuse a shared project script runtime env helper across web and server
- update the project actions UI, lifecycle selectors, and thread deletion flow to support delete hooks, labels, invariants, and failure-aware worktree removal

# Testing
- `cd apps/web && bun run test -- src/projectScripts.test.ts src/worktreeDeleteFlow.test.ts src/wsNativeApi.test.ts` - Pass (26 tests)
- `cd apps/server && bun run test -- src/projectScriptRunner.test.ts src/wsServer.test.ts src/orchestration/decider.projectScripts.test.ts src/orchestration/Layers/ProjectionSnapshotQuery.test.ts src/orchestration/Layers/ProjectionPipeline.test.ts` - Pass (62 tests)
- `cd packages/contracts && bun run test -- src/orchestration.test.ts` - Pass (12 tests)
- `bun lint` - Pass
- Manual UI verification - Pass (confirmed locally that the delete hook runs from the worktree cwd, receives `T3CODE_PROJECT_ROOT` and `T3CODE_WORKTREE_PATH`, and blocks deletion on failure)
- Not run: `bun typecheck`
  Local checkout currently resolves mismatched `effect` versions under Bun `1.2.19` (`effect@4.0.0-beta.25` at the workspace root and `effect@4.0.0-beta.27` nested under `@effect/platform-node`), which produces unrelated server-side type errors.

# Risks and Rollback
- Risk: worktree deletion now intentionally waits for the configured cleanup hook and aborts on failures or timeouts, so a broken cleanup script can block deletion until it is fixed or disabled
- Rollback: revert commit `ed0a0248f1376a4651cfbf34611a3d2a4c212f45`

# Notes
- no SQL migration is required; legacy `ProjectScript` payloads decode with `runOnWorktreeDelete = false`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add worktree deletion lifecycle hooks and implement `apps/server/src/projectScriptRunner.ts` `runProjectLifecycleScript` with a 300s timeout, 1MB buffer, normalized errors, and WebSocket handler `apps/server/src/wsServer.ts` for `WS_METHODS.projectsRunLifecycleScript`
> Introduce delete lifecycle hooks across contracts, web UI, and server, add a centralized env builder, and wire a server-side runner with normalized error handling and a websocket RPC; update tests to cover lifecycle selection, env propagation, and failure cases.
>
> #### 📍Where to Start
> Start with `runProjectLifecycleScript` in [projectScriptRunner.ts](https://github.com/pingdotgg/t3code/pull/425/files#diff-225153a221042afd95d656fc323bc0e1d5ee518b19ba224426ad0dfa9b19b07f), then review the websocket handler case for `WS_METHODS.projectsRunLifecycleScript` in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/425/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679), and the UI flow in [worktreeDeleteFlow.ts](https://github.com/pingdotgg/t3code/pull/425/files#diff-68d434b58b6b27a586a6cd7b5a5c3447c74ca0a74e82431b6e9b08b4b368496d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed0a024.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->