### PR TITLE
feat: add GitHub Copilot provider integration

### DIFF
--- a/apps/server/src/copilotAcpManager.test.ts
+++ b/apps/server/src/copilotAcpManager.test.ts
@@ -1,10 +1,22 @@
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+
+import { ApprovalRequestId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vitest";
 
 import {
+  CopilotAcpManager,
   isCopilotModelAvailable,
   readAvailableCopilotModelIds,
   readCopilotReasoningEffortSelector,
 } from "./copilotAcpManager";
+
+class FakeChildStderr extends EventEmitter {
+  setEncoding(_encoding: string) {}
+}
+
+class FakeChildProcess extends EventEmitter {
+  readonly stderr = new FakeChildStderr();
+}
 
 describe("copilotAcpManager model availability", () => {
   it("reads ACP-advertised model ids", () => {
@@ -55,8 +67,8 @@ describe("copilotAcpManager model availability", () => {
       ]),
     ).toEqual({
       id: "reasoning_effort",
-      currentValue: "xhigh",
-      options: ["low", "medium", "high", "xhigh"],
+      currentValue: null,
+      options: ["low", "medium", "high"],
     });
   });
 
@@ -87,5 +99,153 @@ describe("copilotAcpManager model availability", () => {
       currentValue: "high",
       options: ["low", "medium", "high"],
     });
+  });
+
+  it("does not widen single-use approvals into session approvals", async () => {
+    const manager = new CopilotAcpManager();
+    const threadId = ThreadId.makeUnsafe("thread-approval");
+    const requestId = ApprovalRequestId.makeUnsafe("request-approval");
+    const resolve = vi.fn();
+
+    (manager as any).sessions.set(threadId, {
+      session: {
+        provider: "copilot",
+        status: "ready",
+        runtimeMode: "approval-required",
+        cwd: "/tmp",
+        threadId,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+      },
+      child: {} as never,
+      connection: {} as never,
+      acpSessionId: "session-1",
+      models: null,
+      configOptions: null,
+      pendingApprovals: new Map([
+        [
+          requestId,
+          {
+            requestId,
+            toolCallId: "tool-1",
+            turnId: undefined,
+            requestType: "command_execution_approval",
+            options: [
+              {
+                optionId: "allow-always",
+                kind: "allow_always",
+              },
+            ],
+            resolve,
+          },
+        ],
+      ]),
+      toolSnapshots: new Map(),
+      currentTurnId: undefined,
+      turnInFlight: false,
+      stopping: false,
+    });
+
+    await manager.respondToRequest(threadId, requestId, "accept");
+
+    expect(resolve).toHaveBeenCalledWith({
+      outcome: { outcome: "cancelled" },
+    });
+  });
+
+  it("rejects overlapping turns for a single Copilot session", async () => {
+    const manager = new CopilotAcpManager();
+    const threadId = ThreadId.makeUnsafe("thread-running");
+    const pendingPrompt = Promise.withResolvers<{ stopReason: "completed" }>();
+
+    (manager as any).sessions.set(threadId, {
+      session: {
+        provider: "copilot",
+        status: "ready",
+        runtimeMode: "approval-required",
+        cwd: "/tmp",
+        threadId,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+      },
+      child: {} as never,
+      connection: {
+        prompt: vi.fn(() => pendingPrompt.promise),
+      },
+      acpSessionId: "session-1",
+      models: null,
+      configOptions: null,
+      pendingApprovals: new Map(),
+      toolSnapshots: new Map(),
+      currentTurnId: undefined,
+      turnInFlight: false,
+      stopping: false,
+    });
+
+    const firstTurnPromise = manager.sendTurn({ threadId, input: "hello" });
+
+    await expect(manager.sendTurn({ threadId, input: "again" })).rejects.toThrow(
+      "GitHub Copilot already has a turn in progress for this session.",
+    );
+
+    pendingPrompt.resolve({ stopReason: "completed" });
+
+    await expect(firstTurnPromise).resolves.toMatchObject({ threadId });
+  });
+
+  it("converts child process spawn errors into session exit events", () => {
+    const manager = new CopilotAcpManager();
+    const threadId = ThreadId.makeUnsafe("thread-child-error");
+    const child = new FakeChildProcess();
+    const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+
+    const context = {
+      session: {
+        provider: "copilot",
+        status: "ready",
+        runtimeMode: "approval-required",
+        cwd: "/tmp",
+        threadId,
+        createdAt: "2026-03-07T12:00:00.000Z",
+        updatedAt: "2026-03-07T12:00:00.000Z",
+      },
+      child: child as never,
+      connection: {
+        closed: Promise.resolve(),
+      } as never,
+      acpSessionId: "session-1",
+      models: null,
+      configOptions: null,
+      pendingApprovals: new Map(),
+      toolSnapshots: new Map(),
+      currentTurnId: undefined,
+      turnInFlight: false,
+      stopping: false,
+    };
+
+    manager.on("event", (event) => {
+      events.push(event as { type: string; payload?: Record<string, unknown> });
+    });
+
+    (manager as any).sessions.set(threadId, context);
+    (manager as any).attachProcessListeners(context);
+
+    expect(() => {
+      child.emit("error", new Error("spawn ENOENT"));
+    }).not.toThrow();
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "session.exited",
+          payload: expect.objectContaining({
+            reason: "spawn ENOENT",
+            exitKind: "error",
+            recoverable: false,
+          }),
+        }),
+      ]),
+    );
+    expect((manager as any).sessions.has(threadId)).toBe(false);
   });
 });

--- a/apps/server/src/copilotAcpManager.ts
+++ b/apps/server/src/copilotAcpManager.ts
@@ -47,6 +47,7 @@ interface CopilotSessionContext {
   pendingApprovals: Map<ApprovalRequestId, PendingApprovalRequest>;
   toolSnapshots: Map<string, ToolSnapshot>;
   currentTurnId: TurnId | undefined;
+  turnInFlight: boolean;
   stopping: boolean;
   lastStderrLine?: string;
 }
@@ -296,8 +297,7 @@ function createPermissionOutcome(
       );
     case "accept":
       return (
-        selectByKind("allow_once") ??
-        selectByKind("allow_always") ?? {
+        selectByKind("allow_once") ?? {
           outcome: { outcome: "cancelled" },
         }
       );
@@ -665,6 +665,11 @@ export class CopilotAcpManager extends EventEmitter<CopilotAcpManagerEvents> {
       this.sessions.delete(context.session.threadId);
     };
 
+    context.child.once("error", (error) => {
+      context.lastStderrLine = toMessage(error, "Failed to start GitHub Copilot CLI.");
+      onExit(null, null);
+    });
+
     context.child.once("exit", onExit);
     context.connection.closed.catch(() => undefined);
   }
@@ -797,6 +802,7 @@ export class CopilotAcpManager extends EventEmitter<CopilotAcpManagerEvents> {
       pendingApprovals: new Map(),
       toolSnapshots: new Map(),
       currentTurnId: undefined,
+      turnInFlight: false,
       stopping: false,
     };
     this.sessions.set(input.threadId, context);
@@ -862,12 +868,18 @@ export class CopilotAcpManager extends EventEmitter<CopilotAcpManagerEvents> {
       this.emitSessionStarted(context);
       return { ...context.session };
     } catch (error) {
-      const message = toMessage(error, "Failed to start GitHub Copilot session.");
+      const message = context.lastStderrLine ?? toMessage(error, "Failed to start GitHub Copilot session.");
       this.updateSession(context, {
         status: "error",
         lastError: message,
       });
       this.emitRuntimeError(context, message);
+      if (this.sessions.has(input.threadId)) {
+        this.emitSessionExit(context, {
+          reason: message,
+          exitKind: "error",
+        });
+      }
       context.stopping = true;
       this.resolvePendingApprovalsAsCancelled(context);
       killChildTree(context.child);
@@ -892,84 +904,93 @@ export class CopilotAcpManager extends EventEmitter<CopilotAcpManagerEvents> {
       throw new Error("GitHub Copilot integration currently supports text prompts only.");
     }
 
-    const requestedModel = input.model?.trim();
-    if (requestedModel && requestedModel !== context.session.model) {
-      if (isCopilotModelAvailable(context.models, requestedModel)) {
-        await this.setSessionModel(context, requestedModel);
-      }
+    if (context.turnInFlight || context.session.status === "running" || context.session.activeTurnId) {
+      throw new Error("GitHub Copilot already has a turn in progress for this session.");
     }
 
-    if (input.reasoningEffort) {
-      await this.setSessionReasoningEffort(context, input.reasoningEffort);
-    }
-
-    const turnId = TurnId.makeUnsafe(randomUUID());
-    context.currentTurnId = turnId;
-    this.updateSession(context, {
-      status: "running",
-      activeTurnId: turnId,
-    });
-
-    this.emitRuntimeEvent({
-      ...this.createEventBase(context),
-      turnId,
-      type: "turn.started",
-      payload: context.session.model ? { model: context.session.model } : {},
-    });
+    context.turnInFlight = true;
 
     try {
-      const result = await context.connection.prompt({
-        sessionId: context.acpSessionId,
-        prompt: [
-          {
-            type: "text",
-            text: promptText,
+      const requestedModel = input.model?.trim();
+      if (requestedModel && requestedModel !== context.session.model) {
+        if (isCopilotModelAvailable(context.models, requestedModel)) {
+          await this.setSessionModel(context, requestedModel);
+        }
+      }
+
+      if (input.reasoningEffort) {
+        await this.setSessionReasoningEffort(context, input.reasoningEffort);
+      }
+
+      const turnId = TurnId.makeUnsafe(randomUUID());
+      context.currentTurnId = turnId;
+      this.updateSession(context, {
+        status: "running",
+        activeTurnId: turnId,
+      });
+
+      this.emitRuntimeEvent({
+        ...this.createEventBase(context),
+        turnId,
+        type: "turn.started",
+        payload: context.session.model ? { model: context.session.model } : {},
+      });
+
+      try {
+        const result = await context.connection.prompt({
+          sessionId: context.acpSessionId,
+          prompt: [
+            {
+              type: "text",
+              text: promptText,
+            },
+          ],
+        });
+
+        this.emitRuntimeEvent({
+          ...this.createEventBase(context),
+          turnId,
+          type: "turn.completed",
+          payload: {
+            state: result.stopReason === "cancelled" ? "interrupted" : "completed",
+            stopReason: result.stopReason,
+            ...(result.usage ? { usage: result.usage } : {}),
           },
-        ],
-      });
+        });
 
-      this.emitRuntimeEvent({
-        ...this.createEventBase(context),
-        turnId,
-        type: "turn.completed",
-        payload: {
-          state: result.stopReason === "cancelled" ? "interrupted" : "completed",
-          stopReason: result.stopReason,
-          ...(result.usage ? { usage: result.usage } : {}),
-        },
-      });
+        this.updateSession(context, {
+          status: "ready",
+          activeTurnId: undefined,
+        });
 
-      this.updateSession(context, {
-        status: "ready",
-        activeTurnId: undefined,
-      });
-
-      return {
-        threadId: input.threadId,
-        turnId,
-        resumeCursor: { sessionId: context.acpSessionId },
-      };
-    } catch (error) {
-      const message = toMessage(error, "GitHub Copilot turn failed.");
-      this.emitRuntimeEvent({
-        ...this.createEventBase(context),
-        turnId,
-        type: "turn.completed",
-        payload: {
-          state: "failed",
-          stopReason: null,
-          errorMessage: message,
-        },
-      });
-      this.emitRuntimeError(context, message, turnId);
-      this.updateSession(context, {
-        status: "error",
-        activeTurnId: undefined,
-        lastError: message,
-      });
-      throw new Error(message, { cause: error });
+        return {
+          threadId: input.threadId,
+          turnId,
+          resumeCursor: { sessionId: context.acpSessionId },
+        };
+      } catch (error) {
+        const message = toMessage(error, "GitHub Copilot turn failed.");
+        this.emitRuntimeEvent({
+          ...this.createEventBase(context),
+          turnId,
+          type: "turn.completed",
+          payload: {
+            state: "failed",
+            stopReason: null,
+            errorMessage: message,
+          },
+        });
+        this.emitRuntimeError(context, message, turnId);
+        this.updateSession(context, {
+          status: "error",
+          activeTurnId: undefined,
+          lastError: message,
+        });
+        throw new Error(message, { cause: error });
+      }
     } finally {
       context.currentTurnId = undefined;
+      context.turnInFlight = false;
     }
   }
 

--- a/apps/server/src/copilotUsage.test.ts
+++ b/apps/server/src/copilotUsage.test.ts
@@ -21,6 +21,15 @@ describe("buildGitHubApiBaseUrl", () => {
       "https://api.example.ghe.com:8443",
     );
   });
+
+  it("preserves path-based enterprise API roots", () => {
+    expect(buildGitHubApiBaseUrl("https://example.ghe.com/github")).toBe(
+      "https://example.ghe.com/github/api/v3",
+    );
+    expect(buildGitHubApiBaseUrl("https://example.ghe.com/github/api/v3")).toBe(
+      "https://example.ghe.com/github/api/v3",
+    );
+  });
 });
 
 describe("fetchCopilotUsageSummary", () => {
@@ -137,5 +146,46 @@ describe("createCopilotUsageReader", () => {
 
     await expect(readUsage()).resolves.toMatchObject({ status: "available", remaining: 200 });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache requires-auth responses", async () => {
+    let nowMs = Date.parse("2026-03-07T12:00:00.000Z");
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          login: "octocat",
+          quota_reset_date_utc: "2026-03-31T00:00:00.000Z",
+          quota_snapshots: {
+            premium_interactions: {
+              entitlement: 300,
+              remaining: 200,
+              overage_count: 0,
+              overage_permitted: true,
+              unlimited: false,
+            },
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const resolveGitHubToken = vi
+      .fn<(hostname: string | null) => Promise<string | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce("ghu_test_token");
+
+    const readUsage = createCopilotUsageReader({
+      fetchImpl,
+      now: () => new Date(nowMs),
+      readCliConfig: async () => ({ host: "https://github.com", login: "octocat" }),
+      resolveGitHubToken,
+    });
+
+    await expect(readUsage()).resolves.toMatchObject({ status: "requires-auth" });
+
+    nowMs += 1;
+
+    await expect(readUsage()).resolves.toMatchObject({ status: "available", remaining: 200 });
+    expect(resolveGitHubToken).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/src/copilotUsage.ts
+++ b/apps/server/src/copilotUsage.ts
@@ -87,6 +87,14 @@ export function buildGitHubApiBaseUrl(host: string | null | undefined): string {
     return DEFAULT_GITHUB_API_BASE_URL;
   }
 
+  const normalizedPath = normalizedHost.pathname.replace(/\/+$/, "");
+  if (normalizedPath.length > 0) {
+    const apiPath = normalizedPath.endsWith("/api/v3")
+      ? normalizedPath
+      : `${normalizedPath}/api/v3`;
+    return `${normalizedHost.protocol}//${normalizedHost.hostname}${normalizedHost.port ? `:${normalizedHost.port}` : ""}${apiPath}`;
+  }
+
   const apiHost = normalizedHost.hostname.startsWith("api.")
     ? normalizedHost.hostname
     : `api.${normalizedHost.hostname}`;
@@ -307,10 +315,13 @@ export function createCopilotUsageReader(deps: CopilotUsageDependencies = {}) {
 
     inFlight = fetchCopilotUsageSummary(deps)
       .then((value) => {
-        cached = {
-          expiresAtMs: (deps.now?.() ?? new Date()).getTime() + COPILOT_USAGE_CACHE_TTL_MS,
-          value,
-        };
+        cached =
+          value.status === "available"
+            ? {
+                expiresAtMs: (deps.now?.() ?? new Date()).getTime() + COPILOT_USAGE_CACHE_TTL_MS,
+                value,
+              }
+            : null;
         return value;
       })
       .finally(() => {

--- a/apps/server/src/provider/Layers/CopilotAdapter.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.ts
@@ -72,10 +72,22 @@ export const makeCopilotAdapterLive = (options?: CopilotAdapterLiveOptions) =>
         options?.makeManager?.() ??
         new CopilotAcpManager();
 
-      const handleEvent = (event: ProviderRuntimeEvent) => {
-        void Effect.runPromise(Queue.offer(eventQueue, event).pipe(Effect.asVoid));
-      };
-      manager.on("event", handleEvent);
+      yield* Effect.acquireRelease(
+        Effect.sync(() => {
+          const handleEvent = (event: ProviderRuntimeEvent) => {
+            void Effect.runPromise(Queue.offer(eventQueue, event).pipe(Effect.asVoid));
+          };
+          manager.on("event", handleEvent);
+          return handleEvent;
+        }),
+        (handleEvent) =>
+          Effect.gen(function* () {
+            yield* Effect.sync(() => {
+              manager.off("event", handleEvent);
+            });
+            yield* Queue.shutdown(eventQueue);
+          }),
+      );
 
       const streamEvents = Stream.fromQueue(eventQueue);
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -943,7 +943,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
 
     if (selectedProvider === "copilot") {
-      const copilotReasoningEffort = supportsReasoningEffort ? selectedEffort : undefined;
+      const copilotReasoningEffort =
+        supportsReasoningEffort && selectedEffort !== "xhigh" ? selectedEffort : undefined;
       const copilotOptions = copilotReasoningEffort
         ? { reasoningEffort: copilotReasoningEffort }
         : undefined;

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1,7 +1,11 @@
 import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { type ComposerImageAttachment, useComposerDraftStore } from "./composerDraftStore";
+import {
+  normalizePersistedComposerDraftState,
+  type ComposerImageAttachment,
+  useComposerDraftStore,
+} from "./composerDraftStore";
 
 function makeImage(input: {
   id: string;
@@ -337,6 +341,9 @@ describe("composerDraftStore reasoning effort normalization", () => {
   const threadId = ThreadId.makeUnsafe("thread-reasoning");
 
   beforeEach(() => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.clear();
+    }
     useComposerDraftStore.setState({
       draftsByThreadId: {},
       draftThreadsByThreadId: {},
@@ -344,13 +351,33 @@ describe("composerDraftStore reasoning effort normalization", () => {
     });
   });
 
-  it("preserves copilot xhigh selections in the draft store", () => {
+  it("drops unsupported Copilot reasoning values from the draft store", () => {
     const store = useComposerDraftStore.getState();
 
     store.setProvider(threadId, "copilot");
     store.setEffort(threadId, "xhigh");
 
-    expect(useComposerDraftStore.getState().draftsByThreadId[threadId]?.effort).toBe("xhigh");
+    expect(useComposerDraftStore.getState().draftsByThreadId[threadId]?.effort).toBeNull();
+  });
+
+  it("drops unsupported Copilot reasoning values while rehydrating persisted drafts", () => {
+    const normalized = normalizePersistedComposerDraftState(
+      {
+        draftsByThreadId: {
+          [threadId]: {
+            prompt: "",
+            attachments: [],
+            provider: "copilot",
+            effort: "xhigh",
+          },
+        },
+        draftThreadsByThreadId: {},
+        projectDraftThreadIdByProjectId: {},
+      },
+    );
+
+    expect(normalized.draftsByThreadId[threadId]?.provider).toBe("copilot");
+    expect(normalized.draftsByThreadId[threadId]?.effort).toBeUndefined();
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -196,7 +196,8 @@ function normalizeReasoningEffortForProvider(
   }
 
   const providerOptions = REASONING_EFFORT_OPTIONS_BY_PROVIDER[provider];
-  if (provider !== "copilot" && !providerOptions.includes(effort)) {
+  const providerOptionSet = new Set<CodexReasoningEffort>(providerOptions);
+  if (!providerOptionSet.has(effort)) {
     return null;
   }
 
@@ -278,7 +279,9 @@ function normalizeDraftThreadEnvMode(
   return fallbackWorktreePath ? "worktree" : "local";
 }
 
-function normalizePersistedComposerDraftState(value: unknown): PersistedComposerDraftStoreState {
+export function normalizePersistedComposerDraftState(
+  value: unknown,
+): PersistedComposerDraftStoreState {
   if (!value || typeof value !== "object") {
     return EMPTY_PERSISTED_DRAFT_STORE_STATE;
   }
@@ -396,12 +399,12 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
       draftCandidate.interactionMode === "plan" || draftCandidate.interactionMode === "default"
         ? draftCandidate.interactionMode
         : null;
-    const effortCandidate =
-      typeof draftCandidate.effort === "string" ? draftCandidate.effort : null;
-    const effort =
-      effortCandidate && REASONING_EFFORT_VALUES.has(effortCandidate as CodexReasoningEffort)
-        ? (effortCandidate as CodexReasoningEffort)
-        : null;
+    const effort = normalizeReasoningEffortForProvider(
+      typeof draftCandidate.effort === "string"
+        ? (draftCandidate.effort as CodexReasoningEffort)
+        : null,
+      provider ?? "codex",
+    );
     const codexFastMode =
       draftCandidate.codexFastMode === true ||
       (typeof draftCandidate.serviceTier === "string" && draftCandidate.serviceTier === "fast");
@@ -808,10 +811,6 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           const nextEffort =
             normalizedProvider === null
               ? null
-              : normalizedProvider === "copilot" &&
-                  base.effort !== null &&
-                  !REASONING_EFFORT_OPTIONS_BY_PROVIDER.copilot.includes(base.effort)
-                ? null
                 : normalizeReasoningEffortForProvider(base.effort, normalizedProvider);
           if (base.provider === normalizedProvider) {
             return state;

--- a/apps/web/src/lib/copilotBilling.test.ts
+++ b/apps/web/src/lib/copilotBilling.test.ts
@@ -13,6 +13,7 @@ describe("copilotBilling", () => {
     expect(getCopilotModelMultiplier("claude-haiku-4.5")).toBe(0.33);
     expect(getCopilotModelMultiplier("claude-opus-4.6-fast")).toBe(30);
     expect(getCopilotModelMultiplier("unknown-model")).toBeNull();
+    expect(getCopilotModelMultiplier("constructor")).toBeNull();
   });
 
   it("computes estimated overage costs per request", () => {

--- a/apps/web/src/lib/copilotBilling.ts
+++ b/apps/web/src/lib/copilotBilling.ts
@@ -29,7 +29,11 @@ function formatMultiplierValue(multiplier: number): string {
 }
 
 export function getCopilotModelMultiplier(model: string): number | null {
-  return COPILOT_MODEL_MULTIPLIER_BY_SLUG[model as keyof typeof COPILOT_MODEL_MULTIPLIER_BY_SLUG] ?? null;
+  if (!Object.prototype.hasOwnProperty.call(COPILOT_MODEL_MULTIPLIER_BY_SLUG, model)) {
+    return null;
+  }
+
+  return COPILOT_MODEL_MULTIPLIER_BY_SLUG[model as keyof typeof COPILOT_MODEL_MULTIPLIER_BY_SLUG];
 }
 
 export function getCopilotEstimatedOverageUsd(model: string): number | null {

--- a/apps/web/src/lib/serverReactQuery.test.ts
+++ b/apps/web/src/lib/serverReactQuery.test.ts
@@ -27,6 +27,20 @@ afterEach(() => {
 });
 
 describe("serverCopilotUsageQueryOptions", () => {
+  it("returns an unavailable payload when the native bridge is unavailable", async () => {
+    vi.spyOn(nativeApi, "ensureNativeApi").mockImplementation(() => {
+      throw new Error("Bridge unavailable");
+    });
+
+    const queryClient = new QueryClient();
+    const result = await queryClient.fetchQuery(serverCopilotUsageQueryOptions());
+
+    expect(result).toMatchObject({
+      status: "unavailable",
+      message: "GitHub Copilot quota request failed: Bridge unavailable",
+    });
+  });
+
   it("returns an unavailable payload when the rpc rejects", async () => {
     const getCopilotUsage = vi.fn().mockRejectedValue(new Error("Transport disposed"));
     mockNativeApi({ getCopilotUsage });
@@ -70,7 +84,7 @@ describe("serverCopilotReasoningProbeQueryOptions", () => {
       status: "supported",
       fetchedAt: "2026-01-01T00:00:00.000Z",
       model: "gpt-5",
-      options: ["medium", "high", "xhigh"],
+      options: ["low", "medium", "high"],
       currentValue: "high",
     });
     mockNativeApi({ probeCopilotReasoning });
@@ -83,7 +97,7 @@ describe("serverCopilotReasoningProbeQueryOptions", () => {
     expect(probeCopilotReasoning).toHaveBeenCalledWith({ model: "gpt-5" });
     expect(result).toMatchObject({
       status: "supported",
-      options: ["medium", "high", "xhigh"],
+      options: ["low", "medium", "high"],
     });
   });
 });

--- a/apps/web/src/lib/serverReactQuery.ts
+++ b/apps/web/src/lib/serverReactQuery.ts
@@ -17,9 +17,8 @@ function buildUnavailableCopilotUsage(message: string): ServerCopilotUsage {
 }
 
 async function readCopilotUsageSafely(): Promise<ServerCopilotUsage> {
-  const api = ensureNativeApi();
-
   try {
+    const api = ensureNativeApi();
     const timeoutPromise = new Promise<ServerCopilotUsage>((resolve) => {
       const timer = setTimeout(() => {
         resolve(

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -334,7 +334,7 @@ describe("deriveConfiguredModelOptions", () => {
 });
 
 describe("deriveConfiguredReasoningEffortStateFromActivityGroups", () => {
-  it("reads Copilot reasoning selectors from session configuration payloads", () => {
+  it("filters unsupported Copilot reasoning values from session configuration payloads", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "session-configured-copilot-reasoning",
@@ -366,8 +366,8 @@ describe("deriveConfiguredReasoningEffortStateFromActivityGroups", () => {
     ];
 
     expect(deriveConfiguredReasoningEffortStateFromActivityGroups([activities], "copilot")).toEqual({
-      options: ["low", "medium", "high", "xhigh"],
-      currentValue: "xhigh",
+      options: ["low", "medium", "high"],
+      currentValue: null,
     });
   });
 
@@ -411,6 +411,66 @@ describe("deriveConfiguredReasoningEffortStateFromActivityGroups", () => {
       options: ["low", "medium", "high"],
       currentValue: "high",
     });
+  });
+
+  it("clears stale reasoning state when the latest session configuration omits the selector", () => {
+    const olderActivities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "session-configured-old-selector",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        kind: "session.configured",
+        summary: "Session configured",
+        tone: "info",
+        payload: {
+          provider: "copilot",
+          config: {
+            configOptions: [
+              {
+                type: "select",
+                id: "reasoning_effort",
+                name: "Reasoning Effort",
+                category: "thought_level",
+                currentValue: "medium",
+                options: [
+                  { value: "low", name: "low" },
+                  { value: "medium", name: "medium" },
+                  { value: "high", name: "high" },
+                ],
+              },
+            ],
+          },
+        },
+      }),
+    ];
+    const newerActivities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "session-configured-no-selector",
+        createdAt: "2026-02-23T00:00:05.000Z",
+        kind: "session.configured",
+        summary: "Session configured",
+        tone: "info",
+        payload: {
+          provider: "copilot",
+          config: {
+            configOptions: [
+              {
+                type: "toggle",
+                id: "unrelated",
+                name: "Unrelated",
+                currentValue: true,
+              },
+            ],
+          },
+        },
+      }),
+    ];
+
+    expect(
+      deriveConfiguredReasoningEffortStateFromActivityGroups(
+        [olderActivities, newerActivities],
+        "copilot",
+      ),
+    ).toBeNull();
   });
 });
 describe("deriveActivePlanState", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1,5 +1,6 @@
 import {
   CODEX_REASONING_EFFORT_OPTIONS,
+  REASONING_EFFORT_OPTIONS_BY_PROVIDER,
   ApprovalRequestId,
   type OrchestrationLatestTurn,
   type OrchestrationThreadActivity,
@@ -423,6 +424,9 @@ export function deriveConfiguredReasoningEffortStateFromActivityGroups(
   activityGroups: ReadonlyArray<ReadonlyArray<OrchestrationThreadActivity>>,
   provider: ProviderKind,
 ): ConfiguredReasoningEffortState | null {
+  const allowedReasoningEffortValues = new Set<CodexReasoningEffort>(
+    REASONING_EFFORT_OPTIONS_BY_PROVIDER[provider],
+  );
   const ordered = activityGroups
     .flatMap((activities) => activities)
     .toSorted(compareActivitiesByOrder)
@@ -448,7 +452,7 @@ export function deriveConfiguredReasoningEffortStateFromActivityGroups(
         : null;
     const configOptions = Array.isArray(config?.configOptions) ? config.configOptions : null;
     if (!configOptions) {
-      continue;
+      return null;
     }
 
     const selector = configOptions.find((entry) => {
@@ -462,7 +466,7 @@ export function deriveConfiguredReasoningEffortStateFromActivityGroups(
       );
     });
     if (!selector || typeof selector !== "object") {
-      continue;
+      return null;
     }
 
     const selectorRecord = selector as Record<string, unknown>;
@@ -470,7 +474,11 @@ export function deriveConfiguredReasoningEffortStateFromActivityGroups(
     const seen = new Set<CodexReasoningEffort>();
     for (const entry of flattenConfigSelectorOptions(selectorRecord.options)) {
       const value = entry.value;
-      if (!isReasoningEffortValue(value) || seen.has(value)) {
+      if (
+        !isReasoningEffortValue(value) ||
+        !allowedReasoningEffortValues.has(value) ||
+        seen.has(value)
+      ) {
         continue;
       }
       seen.add(value);
@@ -479,9 +487,11 @@ export function deriveConfiguredReasoningEffortStateFromActivityGroups(
 
     return {
       options,
-      currentValue: isReasoningEffortValue(selectorRecord.currentValue)
-        ? selectorRecord.currentValue
-        : null,
+      currentValue:
+        isReasoningEffortValue(selectorRecord.currentValue) &&
+        allowedReasoningEffortValues.has(selectorRecord.currentValue)
+          ? selectorRecord.currentValue
+          : null,
     };
   }
 

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -4,8 +4,8 @@ import { ProviderKind } from "./orchestration";
 export const CODEX_REASONING_EFFORT_OPTIONS = ["xhigh", "high", "medium", "low"] as const;
 export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORT_OPTIONS)[number];
 
-export const COPILOT_REASONING_EFFORT_VALUES = CODEX_REASONING_EFFORT_OPTIONS;
 export const COPILOT_REASONING_EFFORT_OPTIONS = ["low", "medium", "high"] as const;
+export const COPILOT_REASONING_EFFORT_VALUES = COPILOT_REASONING_EFFORT_OPTIONS;
 export type CopilotReasoningEffort = (typeof COPILOT_REASONING_EFFORT_VALUES)[number];
 
 export const CodexModelOptions = Schema.Struct({

--- a/packages/contracts/src/provider.test.ts
+++ b/packages/contracts/src/provider.test.ts
@@ -87,6 +87,20 @@ describe("ProviderSendTurnInput", () => {
     expect(parsed.modelOptions?.codex?.fastMode).toBe(true);
   });
 
+  it("rejects unsupported Copilot reasoning-effort model options", () => {
+    expect(() =>
+      decodeProviderSendTurnInput({
+        threadId: "thread-1",
+        model: "gpt-5.4",
+        modelOptions: {
+          copilot: {
+            reasoningEffort: "xhigh",
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
   it("accepts copilot reasoning-effort model options", () => {
     const parsed = decodeProviderSendTurnInput({
       threadId: "thread-1",

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -2,7 +2,7 @@ import { Schema } from "effect";
 import { IsoDateTime, TrimmedNonEmptyString } from "./baseSchemas";
 import { KeybindingRule, ResolvedKeybindingsConfig } from "./keybindings";
 import { EditorId } from "./editor";
-import { CODEX_REASONING_EFFORT_OPTIONS } from "./model";
+import { COPILOT_REASONING_EFFORT_VALUES } from "./model";
 import { ProviderKind } from "./orchestration";
 
 const KeybindingsMalformedConfigIssue = Schema.Struct({
@@ -79,7 +79,7 @@ export const ServerCopilotUsage = Schema.Union([
 ]);
 export type ServerCopilotUsage = typeof ServerCopilotUsage.Type;
 
-const ServerCopilotReasoningOption = Schema.Literals(CODEX_REASONING_EFFORT_OPTIONS);
+const ServerCopilotReasoningOption = Schema.Literals(COPILOT_REASONING_EFFORT_VALUES);
 
 export const ServerCopilotReasoningProbeInput = Schema.Struct({
   model: TrimmedNonEmptyString,


### PR DESCRIPTION
## Summary

This pull request adds a full GitHub Copilot provider integration to t3code, scoped to the provider path itself rather than the broader git and checkpoint work in #295.

The branch includes:

- a server-side ACP-backed GitHub Copilot runtime
- provider registration and health checks for Copilot
- Copilot model selection and provider-specific reasoning-effort handling
- Copilot quota and billing metadata retrieval
- web UI support for selecting and configuring Copilot in chat
- contract, server, and web test coverage for the integration and the follow-up review fixes

## Scope

I reviewed the ongoing work in #295 before preparing this branch.

That PR explores a broader Copilot surface area, including additional git and checkpoint flows. For this PR, I intentionally kept the scope focused on the end-to-end Copilot provider integration so the change set stays easier to review and can land independently.

Because #295 is opened from a branch in another fork, there is not a clean way to open an upstream-stacked PR directly on top of that branch in the official repository. This branch was rebuilt from `main` against the official repository so the Copilot provider work can be reviewed on its own.

## What changed

### Server runtime and provider wiring

These files add the Copilot runtime and connect it to the existing provider orchestration flow.

- `apps/server/src/copilotAcpManager.ts`
  - adds the ACP session manager for the GitHub Copilot CLI
  - manages session creation, resume cursors, model configuration, approval handling, turn streaming, and runtime event translation
  - includes follow-up fixes to prevent approval escalation, reject overlapping turns, and handle child-process spawn failures without crashing the server
- `apps/server/src/provider/Layers/CopilotAdapter.ts`
  - bridges the provider service layer to the Copilot ACP manager
  - now also cleans up the manager event listener and queue when the layer is released
- `apps/server/src/provider/Services/CopilotAdapter.ts`
  - exposes the adapter through the provider service map
- `apps/server/src/provider/Layers/ProviderAdapterRegistry.ts`
  - registers Copilot as a supported provider
- `apps/server/src/provider/Layers/ProviderHealth.ts`
  - adds Copilot health reporting so the UI can surface availability and auth state cleanly
- `apps/server/src/provider/Layers/ProviderService.ts`
  - allows orchestration to start and drive Copilot sessions like other providers
- `apps/server/src/orchestration/Layers/ProviderCommandReactor.ts`
  - forwards Copilot model options and provider options into session start and turn-send flows
- `apps/server/src/wsServer.ts`
  - exposes server endpoints for Copilot usage and reasoning support probing

### Copilot usage, billing, and reasoning metadata

These files make Copilot behave like a first-class provider instead of a hard-coded shell.

- `apps/server/src/copilotUsage.ts`
  - reads reusable GitHub authentication and calls the Copilot internal usage endpoint
  - normalizes quota, remaining usage, reset date, and overage metadata
  - includes follow-up fixes for GitHub Enterprise path-based API roots and for avoiding stale cached `requires-auth` responses
- `packages/contracts/src/model.ts`
  - narrows Copilot reasoning-effort values so unsupported `xhigh` is rejected at the contract layer
- `packages/contracts/src/server.ts`
  - aligns the server-side Copilot reasoning probe contract with the provider-specific reasoning options
- `packages/contracts/src/provider.test.ts`
  - adds regression coverage for rejecting unsupported Copilot reasoning-effort payloads
- `packages/contracts/src/ipc.ts`
- `packages/contracts/src/ws.ts`
  - wire the transport payloads for the new Copilot server interactions
- `packages/shared/src/model.ts`
  - provides shared Copilot model and reasoning defaults used consistently across the app

### Web UI integration

These files expose Copilot in the product UI and make the selection behave correctly end to end.

- `apps/web/src/routes/_chat.settings.tsx`
  - adds Copilot-specific settings such as CLI path and custom model configuration
- `apps/web/src/appSettings.ts`
  - persists Copilot settings and model lists
- `apps/web/src/components/ChatView.tsx`
  - adds Copilot as a selectable provider
  - supports Copilot model picking
  - reads runtime model catalogs from session activity
  - prevents unsupported Copilot reasoning values from being dispatched
  - displays Copilot quota and billing metadata in the chat UI
- `apps/web/src/composerDraftStore.ts`
  - persists provider-aware model and reasoning selections in composer drafts
  - now rejects unsupported Copilot reasoning values during editing and persisted-state rehydration
- `apps/web/src/lib/serverReactQuery.ts`
  - adds the client query used to fetch Copilot usage and converts missing-bridge failures into unavailable payloads instead of hook errors
- `apps/web/src/wsNativeApi.ts`
  - adds the client calls used to query Copilot usage and reasoning support
- `apps/web/src/session-logic.ts`
  - derives configured Copilot models and reasoning selectors from session activity
  - now clears stale reasoning selectors when the latest runtime configuration removes them
- `apps/web/src/lib/copilotBilling.ts`
  - formats Copilot overage estimates and now guards against unsafe prototype-property lookups when resolving model multipliers

### Tests

This PR adds and updates tests around the Copilot runtime, contracts, and UI integration.

- `apps/server/src/copilotAcpManager.test.ts`
  - covers reasoning-selector filtering, single-use approval behavior, overlapping-turn rejection, and child-process spawn-error handling
- `apps/server/src/copilotUsage.test.ts`
  - covers enterprise API URL handling and non-sticky auth failures in the usage cache
- `apps/web/src/composerDraftStore.test.ts`
  - covers draft-state normalization for unsupported Copilot reasoning values
- `apps/web/src/lib/copilotBilling.test.ts`
  - covers invalid model-key lookups
- `apps/web/src/lib/serverReactQuery.test.ts`
  - covers native-bridge failure handling and provider-specific reasoning options
- `apps/web/src/session-logic.test.ts`
  - covers provider-specific reasoning filtering and stale-selector removal
- `packages/contracts/src/provider.test.ts`
  - covers provider-scoped validation for Copilot reasoning-effort input

These test changes were added because the review comments identified behavior that could regress silently at the contract, runtime, persistence, and UI layers if not locked down with targeted coverage.

## Why these follow-up files were modified

The latest revision focuses on review follow-ups rather than expanding scope.

- Contract files were modified to enforce Copilot-specific reasoning constraints at decode time.
- Server runtime files were modified to prevent incorrect approval behavior, overlapping turns, stale usage caching, GHES API failures, listener leaks, and child-process crash paths.
- Web state and query files were modified to prevent invalid Copilot reasoning values from being stored, displayed, or dispatched.
- Test files were added or expanded so each review fix is covered where the bug actually surfaced.

No local dev-state artifacts are included in the branch.

## Validation

I re-validated the branch locally with focused coverage around the Copilot integration and the review follow-ups:

- `bun x vitest run apps/server/src/copilotAcpManager.test.ts apps/server/src/copilotUsage.test.ts packages/contracts/src/provider.test.ts apps/web/src/lib/copilotBilling.test.ts apps/web/src/lib/serverReactQuery.test.ts apps/web/src/session-logic.test.ts apps/web/src/composerDraftStore.test.ts`
- editor diagnostics
  - no current TypeScript or editor errors across the changed server, web, and contracts files
- package type diagnostics
  - no current diagnostics in `packages/contracts`, `apps/web`, or `apps/server`

A local end-to-end dev startup is currently blocked by pre-existing persisted provider state containing an unknown provider value (`kimi`) in the local environment, so I did not rely on that environment-specific run as the primary validation signal for this revision.

## Credit

Credit to @zortos293 for the ongoing GitHub Copilot work in #295. I reviewed that branch before putting this together, and it helped confirm the overall problem shape and several implementation details even though this PR is intentionally scoped more narrowly to the core provider integration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub Copilot provider across web, server, and contracts and expose websocket RPCs `WS_METHODS.serverGetCopilotUsage` and `WS_METHODS.serverProbeCopilotReasoning` with 10,000 ms client timeout and 250 ms stability check
> Introduce `copilot` as a first-class provider: add model catalogs and defaults, reasoning-effort validation (`low`/`medium`/`high`), provider start options, session adapter and ACP manager, server health/status and usage reader, UI picker with usage summary and per-model cost, and react-query hooks for usage and reasoning probe.
>
> #### 📍Where to Start
> Start with provider contracts to understand types and RPCs, then the server entry: review `WS_METHODS` additions in [ws.ts](https://github.com/pingdotgg/t3code/pull/429/files#diff-d7bcbddcc940489f8023f941eb2da10fc497046d131eecae771396692ed8a3dc), Copilot schemas in [server.ts](https://github.com/pingdotgg/t3code/pull/429/files#diff-e575e7eac4053ca860f2d99f4f5bf09331b4e959961ac7bfed0562e916fc5dbb), and the WebSocket handler in `createServer` in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/429/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bfc2f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->