### PR TITLE
Fix macOS TCC permissions for apps launched from integrated terminal

### DIFF
--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+</dict>
+</plist>

--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -55,6 +55,16 @@ function patchMainBundleInfoPlist(appBundlePath, iconPath) {
   copyFileSync(iconPath, join(resourcesDir, "electron.icns"));
 }
 
+function resignAppBundle(appBundlePath) {
+  const result = spawnSync("codesign", ["--force", "--deep", "--sign", "-", appBundlePath], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    const detail = result.stderr?.trim() || result.stdout?.trim() || "";
+    throw new Error(`Failed to re-sign app bundle at ${appBundlePath}: ${detail}`);
+  }
+}
+
 function patchHelperBundleInfoPlists(appBundlePath) {
   const frameworksDir = join(appBundlePath, "Contents", "Frameworks");
   if (!existsSync(frameworksDir)) {
@@ -127,6 +137,7 @@ function buildMacLauncher(electronBinaryPath) {
   cpSync(sourceAppBundlePath, targetAppBundlePath, { recursive: true });
   patchMainBundleInfoPlist(targetAppBundlePath, iconPath);
   patchHelperBundleInfoPlists(targetAppBundlePath);
+  resignAppBundle(targetAppBundlePath);
   writeFileSync(metadataPath, `${JSON.stringify(expectedMetadata, null, 2)}\n`);
 
   return targetBinaryPath;

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -464,6 +464,26 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       target: target === "dmg" ? [target, "zip"] : [target],
       icon: "icon.icns",
       category: "public.app-category.developer-tools",
+      extendInfo: {
+        NSMicrophoneUsageDescription:
+          "T3 Code needs microphone access so that apps launched from its integrated terminal can use audio input.",
+        NSCameraUsageDescription:
+          "T3 Code needs camera access so that apps launched from its integrated terminal can use the camera.",
+        NSAppleEventsUsageDescription:
+          "T3 Code needs to send Apple events to control other applications.",
+      },
+      ...(signed
+        ? {
+            // Signed builds: hardened runtime + entitlements (required for notarization).
+            entitlements: "apps/desktop/resources/entitlements.mac.plist",
+            entitlementsInherit: "apps/desktop/resources/entitlements.mac.plist",
+          }
+        : {
+            // Unsigned builds: ad-hoc sign without hardened runtime so macOS TCC
+            // can identify the app and show privacy permission prompts.
+            identity: "-",
+            hardenedRuntime: false,
+          }),
     };
   }
 
@@ -654,7 +674,14 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     }
   }
   if (!options.signed) {
-    buildEnv.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+    // On macOS, we still need at least ad-hoc signing (identity: "-" in the
+    // mac build config) so macOS TCC can attribute privacy permissions (mic,
+    // camera, etc.) to the app.  Disabling signing entirely would leave the
+    // app with an unbound Info.plist and no sealed resources, causing macOS to
+    // silently deny TCC prompts for child processes launched from the terminal.
+    if (options.platform !== "mac") {
+      buildEnv.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+    }
     delete buildEnv.CSC_LINK;
     delete buildEnv.CSC_KEY_PASSWORD;
     delete buildEnv.APPLE_API_KEY;


### PR DESCRIPTION
Re-sign the patched Electron dev bundle with an ad-hoc signature so macOS TCC can bind the Info.plist and show privacy permission prompts (microphone, camera, etc.) for child processes.

For production builds, ad-hoc sign unsigned Mac builds (identity: "-", hardenedRuntime: false) and inject NSMicrophoneUsageDescription and NSCameraUsageDescription via extendInfo.  Signed/notarized builds use entitlements with hardened runtime instead.

**Note**: I wasn't able to test with production build signing. I don't have that all set up yet, so I'm just trusting that Claude did the prod build signing correctly. I did test the dev build `bun run dist:desktop:dmg:arm64` and it worked.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add macOS TCC permissions for terminal-launched apps by introducing hardened runtime entitlements and ad‑hoc re‑signing in [electron-launcher.mjs](https://github.com/pingdotgg/t3code/pull/441/files#diff-8a117bf8144a87af3b3928053a08e442ffe3b14884df08757b77d55907d596b4)
> Add an entitlements plist with JIT, unsigned executable memory, and microphone access; ad‑hoc re‑sign the mac app bundle during launcher build; include mac privacy usage descriptions and adjust mac signing config for signed vs. unsigned builds.
>
> #### 📍Where to Start
> Start with `buildMacLauncher` and `resignAppBundle` in [electron-launcher.mjs](https://github.com/pingdotgg/t3code/pull/441/files#diff-8a117bf8144a87af3b3928053a08e442ffe3b14884df08757b77d55907d596b4).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dc66007. 3 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/desktop/scripts/electron-launcher.mjs — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 140](https://github.com/pingdotgg/t3code/blob/dc660073c3506207b3af386a2319191c494dbf56/apps/desktop/scripts/electron-launcher.mjs#L140): The cache invalidation logic at lines 128-134 will incorrectly reuse existing cached app bundles that were built before the `resignAppBundle` step was added. The metadata check compares `launcherVersion`, but `LAUNCHER_VERSION` at line 22 was not incremented as part of this change. Users with existing cached bundles will have invalid code signatures since the previous builds modified plist files without re-signing, and this change won't fix their cached copies. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->