### PR TITLE
Add Gemini CLI provider support and improve live agent UX

### DIFF
--- a/apps/server/src/cliEnvironment.ts
+++ b/apps/server/src/cliEnvironment.ts
@@ -73,11 +73,11 @@ export function buildNonInteractiveGitEnv(
   overrides: NodeJS.ProcessEnv = {},
 ): NodeJS.ProcessEnv {
   return buildPopupSafeEnv(baseEnv, {
-    GIT_TERMINAL_PROMPT: baseEnv.GIT_TERMINAL_PROMPT ?? "0",
-    GCM_INTERACTIVE: baseEnv.GCM_INTERACTIVE ?? "never",
-    GCM_MODAL_PROMPT: baseEnv.GCM_MODAL_PROMPT ?? "false",
-    GIT_ASKPASS: baseEnv.GIT_ASKPASS ?? "echo",
-    SSH_ASKPASS: baseEnv.SSH_ASKPASS ?? "echo",
+    GIT_TERMINAL_PROMPT: "0",
+    GCM_INTERACTIVE: "never",
+    GCM_MODAL_PROMPT: "false",
+    GIT_ASKPASS: "echo",
+    SSH_ASKPASS: "echo",
     ...overrides,
   });
 }

--- a/apps/server/src/cliEnvironment.ts
+++ b/apps/server/src/cliEnvironment.ts
@@ -1,0 +1,136 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+import { isCommandAvailable } from "./open";
+
+export interface CliLaunchSpec {
+  readonly command: string;
+  readonly argsPrefix: ReadonlyArray<string>;
+}
+
+function splitPathEntries(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): ReadonlyArray<string> {
+  const rawPath = env.PATH ?? env.Path ?? env.path ?? "";
+  if (rawPath.length === 0) {
+    return [];
+  }
+
+  return rawPath
+    .split(platform === "win32" ? ";" : ":")
+    .map((entry) => entry.trim().replace(/^"+|"+$/g, ""))
+    .filter((entry) => entry.length > 0);
+}
+
+function resolveGeminiDistFromDirectory(directory: string): string | null {
+  const candidate = path.join(directory, "node_modules", "@google", "gemini-cli", "dist", "index.js");
+  return existsSync(candidate) ? candidate : null;
+}
+
+function resolveGeminiDistFromPath(env: NodeJS.ProcessEnv): string | null {
+  if (process.platform !== "win32") {
+    return null;
+  }
+
+  for (const entry of splitPathEntries(env, process.platform)) {
+    const candidate = resolveGeminiDistFromDirectory(entry);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function resolveWindowsGeminiDist(env: NodeJS.ProcessEnv): string | null {
+  const appDataCandidate = env.APPDATA
+    ? path.join(env.APPDATA, "npm", "node_modules", "@google", "gemini-cli", "dist", "index.js")
+    : null;
+  if (appDataCandidate && existsSync(appDataCandidate)) {
+    return appDataCandidate;
+  }
+
+  return resolveGeminiDistFromPath(env);
+}
+
+function resolveGeminiPackageRootFromDist(distPath: string): string | null {
+  const packageRoot = path.dirname(path.dirname(distPath));
+  return existsSync(path.join(packageRoot, "package.json")) ? packageRoot : null;
+}
+
+export function buildPopupSafeEnv(
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  overrides: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    NO_BROWSER: baseEnv.NO_BROWSER ?? "true",
+    BROWSER: baseEnv.BROWSER ?? "none",
+    ...overrides,
+  };
+}
+
+export function buildNonInteractiveGitEnv(
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  overrides: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return buildPopupSafeEnv(baseEnv, {
+    GIT_TERMINAL_PROMPT: baseEnv.GIT_TERMINAL_PROMPT ?? "0",
+    GCM_INTERACTIVE: baseEnv.GCM_INTERACTIVE ?? "never",
+    GCM_MODAL_PROMPT: baseEnv.GCM_MODAL_PROMPT ?? "false",
+    GIT_ASKPASS: baseEnv.GIT_ASKPASS ?? "echo",
+    SSH_ASKPASS: baseEnv.SSH_ASKPASS ?? "echo",
+    ...overrides,
+  });
+}
+
+export function resolveGeminiCliLaunchSpec(env: NodeJS.ProcessEnv = process.env): CliLaunchSpec | null {
+  if (process.platform === "win32") {
+    const distPath = resolveWindowsGeminiDist(env);
+    if (!distPath) {
+      return null;
+    }
+    return {
+      command: "node",
+      argsPrefix: [distPath],
+    };
+  }
+
+  if (!isCommandAvailable("gemini", { env, platform: process.platform })) {
+    return null;
+  }
+
+  return {
+    command: "gemini",
+    argsPrefix: [],
+  };
+}
+
+export function resolveGeminiAcpModulePath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const launch = resolveGeminiCliLaunchSpec(env);
+  const distPath = launch?.argsPrefix[0];
+  if (!distPath || !existsSync(distPath)) {
+    return null;
+  }
+
+  const packageRoot = resolveGeminiPackageRootFromDist(distPath);
+  if (!packageRoot) {
+    return null;
+  }
+
+  const candidate = path.join(
+    packageRoot,
+    "node_modules",
+    "@agentclientprotocol",
+    "sdk",
+    "dist",
+    "acp.js",
+  );
+  return existsSync(candidate) ? candidate : null;
+}
+
+export function isCodexCliAvailable(env: NodeJS.ProcessEnv = process.env): boolean {
+  return isCommandAvailable("codex", { env, platform: process.platform });
+}
+
+export function isGeminiCliAvailable(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveGeminiCliLaunchSpec(env) !== null;
+}

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -316,59 +316,6 @@ describe("startSession", () => {
       manager.stopAll();
     }
   });
-
-  it("fails fast with an upgrade message when codex is below the minimum supported version", async () => {
-    const manager = new CodexAppServerManager();
-    const events: Array<{ method: string; kind: string; message?: string }> = [];
-    manager.on("event", (event) => {
-      events.push({
-        method: event.method,
-        kind: event.kind,
-        ...(event.message ? { message: event.message } : {}),
-      });
-    });
-
-    const versionCheck = vi
-      .spyOn(
-        manager as unknown as {
-          assertSupportedCodexCliVersion: (input: {
-            binaryPath: string;
-            cwd: string;
-            homePath?: string;
-          }) => void;
-        },
-        "assertSupportedCodexCliVersion",
-      )
-      .mockImplementation(() => {
-        throw new Error(
-          "Codex CLI v0.36.0 is too old for T3 Code. Upgrade to v0.37.0 or newer and restart T3 Code.",
-        );
-      });
-
-    try {
-      await expect(
-        manager.startSession({
-          threadId: asThreadId("thread-1"),
-          provider: "codex",
-          runtimeMode: "full-access",
-        }),
-      ).rejects.toThrow(
-        "Codex CLI v0.36.0 is too old for T3 Code. Upgrade to v0.37.0 or newer and restart T3 Code.",
-      );
-      expect(versionCheck).toHaveBeenCalledTimes(1);
-      expect(events).toEqual([
-        {
-          method: "session/startFailed",
-          kind: "error",
-          message:
-            "Codex CLI v0.36.0 is too old for T3 Code. Upgrade to v0.37.0 or newer and restart T3 Code.",
-        },
-      ]);
-    } finally {
-      versionCheck.mockRestore();
-      manager.stopAll();
-    }
-  });
 });
 
 describe("sendTurn", () => {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -539,9 +539,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const codexHomePath = codexOptions.homePath;
       const child = spawn(codexBinaryPath, ["app-server"], {
         cwd: resolvedCwd,
-        env: buildPopupSafeEnv(process.env, {
-          CODEX_HOME: codexHomePath,
-        }),
+        env: buildPopupSafeEnv(process.env, codexHomePath ? { CODEX_HOME: codexHomePath } : {}),
         stdio: ["pipe", "pipe", "pipe"],
         shell: process.platform === "win32",
       });

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -22,11 +22,7 @@ import {
 import { normalizeModelSlug } from "@t3tools/shared/model";
 import { Effect, ServiceMap } from "effect";
 
-import {
-  formatCodexCliUpgradeMessage,
-  isCodexCliVersionSupported,
-  parseCodexCliVersion,
-} from "./provider/codexCliVersion";
+import { buildPopupSafeEnv } from "./cliEnvironment";
 
 type PendingRequestKey = string;
 
@@ -143,8 +139,6 @@ export interface CodexThreadSnapshot {
   threadId: string;
   turns: CodexThreadTurnSnapshot[];
 }
-
-const CODEX_VERSION_CHECK_TIMEOUT_MS = 4_000;
 
 const ANSI_ESCAPE_CHAR = String.fromCharCode(27);
 const ANSI_ESCAPE_REGEX = new RegExp(`${ANSI_ESCAPE_CHAR}\\[[0-9;]*m`, "g");
@@ -543,17 +537,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const codexOptions = readCodexProviderOptions(input);
       const codexBinaryPath = codexOptions.binaryPath ?? "codex";
       const codexHomePath = codexOptions.homePath;
-      this.assertSupportedCodexCliVersion({
-        binaryPath: codexBinaryPath,
-        cwd: resolvedCwd,
-        ...(codexHomePath ? { homePath: codexHomePath } : {}),
-      });
       const child = spawn(codexBinaryPath, ["app-server"], {
         cwd: resolvedCwd,
-        env: {
-          ...process.env,
-          ...(codexHomePath ? { CODEX_HOME: codexHomePath } : {}),
-        },
+        env: buildPopupSafeEnv(process.env, {
+          CODEX_HOME: codexHomePath,
+        }),
         stdio: ["pipe", "pipe", "pipe"],
         shell: process.platform === "win32",
       });
@@ -583,24 +571,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       await this.sendRequest(context, "initialize", buildCodexInitializeParams());
 
       this.writeMessage(context, { method: "initialized" });
-      try {
-        const modelListResponse = await this.sendRequest(context, "model/list", {});
-        console.log("codex model/list response", modelListResponse);
-      } catch (error) {
-        console.log("codex model/list failed", error);
-      }
-      try {
-        const accountReadResponse = await this.sendRequest(context, "account/read", {});
-        console.log("codex account/read response", accountReadResponse);
-        context.account = readCodexAccountSnapshot(accountReadResponse);
-        console.log("codex subscription status", {
-          type: context.account.type,
-          planType: context.account.planType,
-          sparkEnabled: context.account.sparkEnabled,
-        });
-      } catch (error) {
-        console.log("codex account/read failed", error);
-      }
 
       const normalizedModel = resolveCodexModelForAccount(
         normalizeCodexModelSlug(input.model),
@@ -1333,14 +1303,6 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.emit("event", event);
   }
 
-  private assertSupportedCodexCliVersion(input: {
-    readonly binaryPath: string;
-    readonly cwd: string;
-    readonly homePath?: string;
-  }): void {
-    assertSupportedCodexCliVersion(input);
-  }
-
   private updateSession(context: CodexSessionContext, updates: Partial<ProviderSession>): void {
     context.session = {
       ...context.session,
@@ -1519,51 +1481,6 @@ function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
     ...(options.binaryPath ? { binaryPath: options.binaryPath } : {}),
     ...(options.homePath ? { homePath: options.homePath } : {}),
   };
-}
-
-function assertSupportedCodexCliVersion(input: {
-  readonly binaryPath: string;
-  readonly cwd: string;
-  readonly homePath?: string;
-}): void {
-  const result = spawnSync(input.binaryPath, ["--version"], {
-    cwd: input.cwd,
-    env: {
-      ...process.env,
-      ...(input.homePath ? { CODEX_HOME: input.homePath } : {}),
-    },
-    encoding: "utf8",
-    shell: process.platform === "win32",
-    stdio: ["ignore", "pipe", "pipe"],
-    timeout: CODEX_VERSION_CHECK_TIMEOUT_MS,
-    maxBuffer: 1024 * 1024,
-  });
-
-  if (result.error) {
-    const lower = result.error.message.toLowerCase();
-    if (
-      lower.includes("enoent") ||
-      lower.includes("command not found") ||
-      lower.includes("not found")
-    ) {
-      throw new Error(`Codex CLI (${input.binaryPath}) is not installed or not executable.`);
-    }
-    throw new Error(
-      `Failed to execute Codex CLI version check: ${result.error.message || String(result.error)}`,
-    );
-  }
-
-  const stdout = result.stdout ?? "";
-  const stderr = result.stderr ?? "";
-  if (result.status !== 0) {
-    const detail = stderr.trim() || stdout.trim() || `Command exited with code ${result.status}.`;
-    throw new Error(`Codex CLI version check failed. ${detail}`);
-  }
-
-  const parsedVersion = parseCodexCliVersion(`${stdout}\n${stderr}`);
-  if (parsedVersion && !isCodexCliVersionSupported(parsedVersion)) {
-    throw new Error(formatCodexCliUpgradeMessage(parsedVersion));
-  }
 }
 
 function readResumeCursorThreadId(resumeCursor: unknown): string | undefined {

--- a/apps/server/src/geminiCliManager.test.ts
+++ b/apps/server/src/geminiCliManager.test.ts
@@ -323,4 +323,56 @@ describe("GeminiCliManager", () => {
     await waitFor(() => seenPrompts.length === 1);
     expect(seenPrompts[0]?.some((entry) => entry.type === "image")).toBe(true);
   });
+
+  it("preserves the text instruction when prompt attachments omit a text block", async () => {
+    const seenPrompts: Array<ReadonlyArray<Record<string, unknown>>> = [];
+    const manager = new GeminiCliManager({
+      prewarmSessions: false,
+      runtimeFactory: async (_model, handlers) => ({
+        model: "gemini-2.5-pro",
+        initialize: async () => undefined,
+        newSession: vi.fn(async () => ({
+          sessionId: "session-image-no-text",
+          modes: { currentModeId: "default" },
+        })),
+        loadSession: vi.fn(async (sessionId: string) => ({
+          sessionId,
+          modes: { currentModeId: "default" },
+        })),
+        setSessionMode: vi.fn(async () => undefined),
+        prompt: vi.fn(async (_sessionId: string, prompt) => {
+          seenPrompts.push(prompt as ReadonlyArray<Record<string, unknown>>);
+          handlers.onSessionUpdate({
+            sessionId: "session-image-no-text",
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "processed prompt" },
+            },
+          });
+          return { stopReason: "end_turn" };
+        }),
+        cancel: vi.fn(async () => undefined),
+        close: vi.fn(() => undefined),
+      }),
+    });
+
+    manager.startSession({
+      threadId: "thread-image-no-text",
+      model: "gemini-2.5-pro",
+      cwd: process.cwd(),
+    });
+
+    manager.sendTurn({
+      threadId: "thread-image-no-text",
+      text: "analyze the attached screenshot",
+      prompt: [{ type: "image", data: "ZmFrZQ==", mimeType: "image/png" }],
+      approvalMode: "yolo",
+    });
+
+    await waitFor(() => seenPrompts.length === 1);
+    expect(seenPrompts[0]).toEqual([
+      { type: "text", text: "analyze the attached screenshot" },
+      { type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+    ]);
+  });
 });

--- a/apps/server/src/geminiCliManager.test.ts
+++ b/apps/server/src/geminiCliManager.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GeminiCliManager } from "./geminiCliManager";
+
+function promptText(
+  prompt: ReadonlyArray<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }>,
+): string {
+  return prompt
+    .filter((entry): entry is { type: "text"; text: string } => entry.type === "text")
+    .map((entry) => entry.text)
+    .join("\n");
+}
+
+function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const startedAt = Date.now();
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt > timeoutMs) {
+        reject(new Error("Timed out waiting for condition."));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+describe("GeminiCliManager", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reuses a warm ACP runtime for follow-up turns on the same thread", async () => {
+    const createdRuntimes: string[] = [];
+    const promptCalls: string[] = [];
+    const events: Array<Record<string, unknown>> = [];
+
+    const manager = new GeminiCliManager({
+      prewarmSessions: false,
+      runtimeFactory: async (model, handlers) => {
+        createdRuntimes.push(model);
+        return {
+          model,
+          initialize: async () => undefined,
+          newSession: vi.fn(async () => ({
+            sessionId: `session-${model}`,
+            modes: { currentModeId: "default" },
+          })),
+          loadSession: vi.fn(async (sessionId: string) => ({
+            sessionId,
+            modes: { currentModeId: "default" },
+          })),
+          setSessionMode: vi.fn(async () => undefined),
+          prompt: vi.fn(async (sessionId: string, prompt) => {
+            const text = promptText(prompt);
+            promptCalls.push(`${sessionId}:${text}`);
+            handlers.onSessionUpdate({
+              sessionId,
+              update: {
+                sessionUpdate: "agent_message_chunk",
+                content: { type: "text", text: `reply:${text}` },
+              },
+            });
+            return { stopReason: "end_turn" };
+          }),
+          cancel: vi.fn(async () => undefined),
+          close: vi.fn(() => undefined),
+        };
+      },
+    });
+
+    manager.on("event", (event: Record<string, unknown>) => {
+      events.push(event);
+    });
+
+    manager.startSession({
+      threadId: "thread-1",
+      model: "gemini-3-flash-preview",
+      cwd: process.cwd(),
+    });
+
+    manager.sendTurn({
+      threadId: "thread-1",
+      text: "first",
+      approvalMode: "yolo",
+    });
+
+    await waitFor(() => promptCalls.length === 1);
+
+    manager.sendTurn({
+      threadId: "thread-1",
+      text: "second",
+      approvalMode: "yolo",
+    });
+
+    await waitFor(() => promptCalls.length === 2);
+
+    expect(createdRuntimes).toEqual(["gemini-3-flash-preview"]);
+    expect(promptCalls).toEqual([
+      "session-gemini-3-flash-preview:first",
+      "session-gemini-3-flash-preview:second",
+    ]);
+
+    const configuredEvents = events.filter((event) => event.method === "session/configured");
+    expect(configuredEvents).toHaveLength(1);
+
+    const messageEvents = events.filter((event) => event.method === "gemini/message");
+    expect(messageEvents).toHaveLength(2);
+  });
+
+  it("loads a persisted Gemini session without replaying hydrated history into live events", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const manager = new GeminiCliManager({
+      prewarmSessions: false,
+      runtimeFactory: async (_model, handlers) => ({
+        model: "gemini-2.5-pro",
+        initialize: async () => undefined,
+        newSession: vi.fn(async () => ({ sessionId: "new-session", modes: { currentModeId: "default" } })),
+        loadSession: vi.fn(async (sessionId: string) => {
+          handlers.onSessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "old-history" },
+            },
+          });
+          return { sessionId, modes: { currentModeId: "default" } };
+        }),
+        setSessionMode: vi.fn(async () => undefined),
+        prompt: vi.fn(async (sessionId: string) => {
+          handlers.onSessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "fresh-reply" },
+            },
+          });
+          return { stopReason: "end_turn" };
+        }),
+        cancel: vi.fn(async () => undefined),
+        close: vi.fn(() => undefined),
+      }),
+    });
+
+    manager.on("event", (event: Record<string, unknown>) => {
+      events.push(event);
+    });
+
+    manager.startSession({
+      threadId: "thread-2",
+      model: "gemini-2.5-pro",
+      cwd: process.cwd(),
+      resumeCursor: { sessionId: "persisted-session" },
+    });
+
+    manager.sendTurn({
+      threadId: "thread-2",
+      text: "continue",
+      approvalMode: "yolo",
+    });
+
+    await waitFor(
+      () => events.some((event) => event.method === "gemini/message" && event.content === "fresh-reply"),
+    );
+
+    const messageContents = events
+      .filter((event) => event.method === "gemini/message")
+      .map((event) => event.content);
+
+    expect(messageContents).toEqual(["fresh-reply"]);
+  });
+
+  it("emits thought, plan, and incremental tool update events during an ACP turn", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const manager = new GeminiCliManager({
+      prewarmSessions: false,
+      runtimeFactory: async (_model, handlers) => ({
+        model: "gemini-2.5-pro",
+        initialize: async () => undefined,
+        newSession: vi.fn(async () => ({
+          sessionId: "session-live-events",
+          modes: { currentModeId: "default" },
+        })),
+        loadSession: vi.fn(async (sessionId: string) => ({
+          sessionId,
+          modes: { currentModeId: "default" },
+        })),
+        setSessionMode: vi.fn(async () => undefined),
+        prompt: vi.fn(async (sessionId: string) => {
+          handlers.onSessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "agent_thought_chunk",
+              content: { type: "text", text: "Inspecting files" },
+            },
+          });
+          handlers.onSessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "plan",
+              entries: [
+                { content: "Inspect files", status: "completed", priority: "high" },
+                { content: "Apply patch", status: "in_progress", priority: "high" },
+              ],
+            },
+          });
+          handlers.onSessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "tool_call",
+              toolCallId: "tool-1",
+              title: "Edit app shell",
+              kind: "edit",
+              status: "pending",
+              locations: [{ path: "apps/web/src/components/ChatView.tsx", line: 10 }],
+            },
+          });
+          handlers.onSessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "tool_call_update",
+              toolCallId: "tool-1",
+              title: "Edit app shell",
+              kind: "edit",
+              status: "in_progress",
+              locations: [{ path: "apps/web/src/components/ChatView.tsx", line: 10 }],
+              content: [{ type: "diff", path: "apps/web/src/components/ChatView.tsx" }],
+            },
+          });
+          handlers.onSessionUpdate({
+            sessionId,
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "Done." },
+            },
+          });
+          return { stopReason: "end_turn" };
+        }),
+        cancel: vi.fn(async () => undefined),
+        close: vi.fn(() => undefined),
+      }),
+    });
+
+    manager.on("event", (event: Record<string, unknown>) => {
+      events.push(event);
+    });
+
+    manager.startSession({
+      threadId: "thread-live-events",
+      model: "gemini-2.5-pro",
+      cwd: process.cwd(),
+    });
+
+    manager.sendTurn({
+      threadId: "thread-live-events",
+      text: "fix the ui",
+      approvalMode: "yolo",
+    });
+
+    await waitFor(() => events.some((event) => event.method === "gemini/result"));
+
+    expect(events.some((event) => event.method === "gemini/thought")).toBe(true);
+    expect(events.some((event) => event.method === "gemini/plan")).toBe(true);
+    expect(
+      events.some(
+        (event) => event.method === "gemini/tool_update" && event.status === "in_progress",
+      ),
+    ).toBe(true);
+  });
+
+  it("passes image prompt blocks through to the ACP runtime", async () => {
+    const seenPrompts: Array<ReadonlyArray<Record<string, unknown>>> = [];
+    const manager = new GeminiCliManager({
+      prewarmSessions: false,
+      runtimeFactory: async (_model, handlers) => ({
+        model: "gemini-2.5-pro",
+        initialize: async () => undefined,
+        newSession: vi.fn(async () => ({
+          sessionId: "session-image",
+          modes: { currentModeId: "default" },
+        })),
+        loadSession: vi.fn(async (sessionId: string) => ({
+          sessionId,
+          modes: { currentModeId: "default" },
+        })),
+        setSessionMode: vi.fn(async () => undefined),
+        prompt: vi.fn(async (_sessionId: string, prompt) => {
+          seenPrompts.push(prompt as ReadonlyArray<Record<string, unknown>>);
+          handlers.onSessionUpdate({
+            sessionId: "session-image",
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: "saw image" },
+            },
+          });
+          return { stopReason: "end_turn" };
+        }),
+        cancel: vi.fn(async () => undefined),
+        close: vi.fn(() => undefined),
+      }),
+    });
+
+    manager.startSession({
+      threadId: "thread-image",
+      model: "gemini-2.5-pro",
+      cwd: process.cwd(),
+    });
+
+    manager.sendTurn({
+      threadId: "thread-image",
+      text: "describe this image",
+      prompt: [
+        { type: "text", text: "describe this image" },
+        { type: "image", data: "ZmFrZQ==", mimeType: "image/png" },
+      ],
+      approvalMode: "yolo",
+    });
+
+    await waitFor(() => seenPrompts.length === 1);
+    expect(seenPrompts[0]?.some((entry) => entry.type === "image")).toBe(true);
+  });
+});

--- a/apps/server/src/geminiCliManager.ts
+++ b/apps/server/src/geminiCliManager.ts
@@ -1173,7 +1173,11 @@ function inputPromptBlocks(
   prompt: ReadonlyArray<GeminiAcpPromptBlock> | undefined,
 ): ReadonlyArray<GeminiAcpPromptBlock> {
   if (prompt && prompt.length > 0) {
-    return prompt;
+    const promptHasText = prompt.some(
+      (entry): entry is Extract<GeminiAcpPromptBlock, { type: "text" }> =>
+        entry.type === "text" && entry.text.trim().length > 0,
+    );
+    return promptHasText ? prompt : [{ type: "text", text }, ...prompt];
   }
   return [{ type: "text", text }];
 }

--- a/apps/server/src/geminiCliManager.ts
+++ b/apps/server/src/geminiCliManager.ts
@@ -1,0 +1,1245 @@
+import { randomUUID } from "node:crypto";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync } from "node:fs";
+import { createInterface, type Interface as ReadlineInterface } from "node:readline";
+import { Readable, Writable } from "node:stream";
+import { pathToFileURL } from "node:url";
+
+import { normalizeModelSlug } from "@t3tools/shared/model";
+
+import {
+  buildPopupSafeEnv,
+  resolveGeminiAcpModulePath,
+  resolveGeminiCliLaunchSpec,
+} from "./cliEnvironment";
+
+export interface GeminiStreamEvent {
+  readonly type: "init" | "message" | "tool_use" | "tool_result" | "error" | "result";
+  readonly [key: string]: unknown;
+}
+
+type GeminiApprovalMode = "default" | "auto_edit" | "yolo" | "plan";
+type GeminiSessionModeId = "default" | "autoEdit" | "yolo" | "plan";
+type GeminiAcpPromptBlock =
+  | { readonly type: "text"; readonly text: string }
+  | { readonly type: "image"; readonly data: string; readonly mimeType: string; readonly uri?: string };
+
+interface GeminiAcpMessageContent {
+  readonly type?: unknown;
+  readonly text?: unknown;
+  readonly path?: unknown;
+  readonly oldText?: unknown;
+  readonly newText?: unknown;
+  readonly terminalId?: unknown;
+}
+
+interface GeminiAcpPlanEntry {
+  readonly content?: unknown;
+  readonly status?: unknown;
+  readonly priority?: unknown;
+}
+
+interface GeminiAcpSessionUpdate {
+  readonly sessionUpdate:
+    | "user_message_chunk"
+    | "agent_message_chunk"
+    | "agent_thought_chunk"
+    | "tool_call"
+    | "tool_call_update"
+    | "plan"
+    | "available_commands_update"
+    | "current_mode_update"
+    | "config_option_update"
+    | "session_info_update"
+    | string;
+  readonly content?:
+    | GeminiAcpMessageContent
+    | ReadonlyArray<GeminiAcpMessageContent | Record<string, unknown>>;
+  readonly toolCallId?: unknown;
+  readonly title?: unknown;
+  readonly kind?: unknown;
+  readonly status?: unknown;
+  readonly rawInput?: unknown;
+  readonly rawOutput?: unknown;
+  readonly locations?: unknown;
+  readonly currentModeId?: unknown;
+  readonly modeId?: unknown;
+  readonly entries?: ReadonlyArray<GeminiAcpPlanEntry>;
+  readonly updatedAt?: unknown;
+}
+
+interface GeminiAcpNotification {
+  readonly sessionId: string;
+  readonly update: GeminiAcpSessionUpdate;
+}
+
+interface GeminiAcpRequestPermissionOption {
+  readonly optionId?: unknown;
+  readonly kind?: unknown;
+}
+
+interface GeminiAcpRequestPermissionParams {
+  readonly sessionId?: unknown;
+  readonly options?: ReadonlyArray<GeminiAcpRequestPermissionOption>;
+}
+
+interface GeminiAcpPromptResult {
+  readonly stopReason?: unknown;
+}
+
+interface GeminiAcpSessionResponse {
+  readonly sessionId?: unknown;
+  readonly modes?: {
+    readonly currentModeId?: unknown;
+  };
+}
+
+interface GeminiAcpConnection {
+  initialize(params: Record<string, unknown>): Promise<Record<string, unknown>>;
+  newSession(params: { cwd: string; mcpServers: ReadonlyArray<unknown> }): Promise<GeminiAcpSessionResponse>;
+  loadSession(params: {
+    sessionId: string;
+    cwd: string;
+    mcpServers: ReadonlyArray<unknown>;
+  }): Promise<GeminiAcpSessionResponse>;
+  setSessionMode(params: { sessionId: string; modeId: GeminiSessionModeId }): Promise<Record<string, unknown>>;
+  prompt(params: {
+    sessionId: string;
+    prompt: ReadonlyArray<GeminiAcpPromptBlock>;
+  }): Promise<GeminiAcpPromptResult>;
+  cancel(params: { sessionId: string }): Promise<void>;
+}
+
+interface GeminiAcpRuntime {
+  readonly model: string;
+  initialize(): Promise<void>;
+  newSession(cwd: string): Promise<GeminiAcpSessionResponse>;
+  loadSession(sessionId: string, cwd: string): Promise<GeminiAcpSessionResponse>;
+  setSessionMode(sessionId: string, modeId: GeminiSessionModeId): Promise<void>;
+  prompt(sessionId: string, prompt: ReadonlyArray<GeminiAcpPromptBlock>): Promise<GeminiAcpPromptResult>;
+  cancel(sessionId: string): Promise<void>;
+  close(): void;
+}
+
+interface GeminiAcpRuntimeHandlers {
+  readonly onSessionUpdate: (notification: GeminiAcpNotification) => void;
+  readonly onRequestPermission: (
+    params: GeminiAcpRequestPermissionParams,
+  ) => Promise<{ outcome: { outcome: string; optionId?: string } }>;
+  readonly onClose: (error?: Error) => void;
+}
+
+type GeminiAcpRuntimeFactory = (
+  model: string,
+  handlers: GeminiAcpRuntimeHandlers,
+) => Promise<GeminiAcpRuntime>;
+
+export interface GeminiCliManagerOptions {
+  readonly runtimeFactory?: GeminiAcpRuntimeFactory;
+  readonly prewarmSessions?: boolean;
+}
+
+export interface GeminiSessionContext {
+  readonly sessionId: string;
+  readonly threadId: string;
+  model: string;
+  cwd: string;
+  geminiSessionId?: string;
+  status: "idle" | "running" | "stopped";
+  activeTurnId: string | null;
+  activeProcess: ChildProcess | null;
+  currentMode: GeminiSessionModeId;
+  runtimeModel: string | null;
+  sessionSetupPromise: Promise<void> | null;
+  hydrating: boolean;
+}
+
+export interface GeminiSessionResumeCursor {
+  readonly sessionId: string;
+}
+
+export interface GeminiStartSessionInput {
+  readonly threadId: string;
+  readonly model: string;
+  readonly cwd: string;
+  readonly resumeCursor?: GeminiSessionResumeCursor;
+}
+
+export interface GeminiSendTurnInput {
+  readonly threadId: string;
+  readonly text: string;
+  readonly prompt?: ReadonlyArray<GeminiAcpPromptBlock>;
+  readonly model?: string;
+  readonly cwd?: string;
+  readonly approvalMode?: GeminiApprovalMode;
+}
+
+export interface GeminiTurnResult {
+  readonly turnId: string;
+  readonly threadId: string;
+  readonly resumeCursor?: GeminiSessionResumeCursor;
+}
+
+export class GeminiCliManager extends EventEmitter {
+  private readonly sessions = new Map<string, GeminiSessionContext>();
+  private readonly threadIdByGeminiSessionId = new Map<string, string>();
+  private readonly runtimePromises = new Map<string, Promise<GeminiAcpRuntime>>();
+  private readonly runtimeFactory: GeminiAcpRuntimeFactory;
+  private readonly prewarmSessions: boolean;
+  private readonly acpModulePath: string | null;
+  private readonly forceAcp: boolean;
+
+  constructor(options: GeminiCliManagerOptions = {}) {
+    super();
+    this.runtimeFactory = options.runtimeFactory ?? createGeminiAcpRuntime;
+    this.prewarmSessions = options.prewarmSessions ?? true;
+    this.acpModulePath = resolveGeminiAcpModulePath();
+    this.forceAcp = options.runtimeFactory !== undefined;
+  }
+
+  startSession(input: GeminiStartSessionInput): GeminiSessionContext {
+    const context: GeminiSessionContext = {
+      sessionId: randomUUID(),
+      threadId: input.threadId,
+      model: normalizeModelSlug(input.model, "gemini") ?? input.model,
+      cwd: input.cwd,
+      status: "idle",
+      activeTurnId: null,
+      activeProcess: null,
+      currentMode: "default",
+      runtimeModel: null,
+      sessionSetupPromise: null,
+      hydrating: false,
+      ...(input.resumeCursor?.sessionId
+        ? { geminiSessionId: input.resumeCursor.sessionId }
+        : {}),
+    };
+
+    this.sessions.set(input.threadId, context);
+    if (context.geminiSessionId) {
+      this.threadIdByGeminiSessionId.set(context.geminiSessionId, context.threadId);
+    }
+
+    this.emit("event", {
+      type: "session",
+      method: "session/started",
+      kind: "lifecycle",
+      threadId: input.threadId,
+      sessionId: context.sessionId,
+      provider: "gemini",
+    });
+
+    if (context.geminiSessionId) {
+      this.emit("event", {
+        type: "session",
+        method: "session/configured",
+        kind: "lifecycle",
+        threadId: input.threadId,
+        sessionId: context.sessionId,
+        provider: "gemini",
+        resumeCursor: { sessionId: context.geminiSessionId },
+      });
+    }
+
+    if (this.prewarmSessions && this.canUseAcp()) {
+      void this.queueSessionSetup(context, async () => {
+        const runtime = await this.ensureAcpRuntime(context.model);
+        await this.prepareAcpSession(context, runtime, "yolo", { emitConfigured: false });
+      }).catch(() => undefined);
+    }
+
+    return context;
+  }
+
+  sendTurn(input: GeminiSendTurnInput): GeminiTurnResult {
+    const context = this.sessions.get(input.threadId);
+    if (!context) {
+      throw new Error(`No Gemini session for thread: ${input.threadId}`);
+    }
+    if (context.status === "stopped") {
+      throw new Error(`Gemini session is stopped for thread: ${input.threadId}`);
+    }
+
+    const trimmedText = input.text.trim();
+    if (trimmedText.length === 0) {
+      throw new Error("Turn input must include text.");
+    }
+    if (context.status === "running") {
+      throw new Error(`Gemini turn already running for thread: ${input.threadId}`);
+    }
+
+    context.cwd = input.cwd ?? context.cwd;
+    const nextModel = normalizeModelSlug(input.model ?? context.model, "gemini") ?? context.model;
+    if (nextModel !== context.model) {
+      this.clearSessionBinding(context);
+      context.model = nextModel;
+    }
+
+    const turnId = `turn_${randomUUID().slice(0, 8)}`;
+    const approvalMode = input.approvalMode ?? "yolo";
+    const desiredMode = toSessionModeId(approvalMode);
+
+    context.activeTurnId = turnId;
+    context.status = "running";
+
+    this.emit("event", {
+      type: "session",
+      method: "session/connecting",
+      kind: "lifecycle",
+      threadId: input.threadId,
+      sessionId: context.sessionId,
+      provider: "gemini",
+      message: `Connecting to Gemini CLI for ${context.model}`,
+    });
+
+    this.emit("event", {
+      type: "turn",
+      method: "turn/started",
+      kind: "lifecycle",
+      threadId: input.threadId,
+      turnId,
+      provider: "gemini",
+      model: context.model,
+    });
+
+    if (this.canUseAcp()) {
+      void this.runTurnViaAcp(context, turnId, trimmedText, input.prompt, desiredMode);
+    } else {
+      this.runTurnViaLegacyCli(context, turnId, trimmedText, approvalMode);
+    }
+
+    return {
+      turnId,
+      threadId: input.threadId,
+      ...(context.geminiSessionId ? { resumeCursor: { sessionId: context.geminiSessionId } } : {}),
+    };
+  }
+
+  interruptTurn(threadId: string): void {
+    const context = this.sessions.get(threadId);
+    if (!context) {
+      return;
+    }
+
+    if (context.geminiSessionId && this.canUseAcp()) {
+      void this.ensureAcpRuntime(context.model)
+        .then((runtime) => runtime.cancel(context.geminiSessionId!))
+        .catch(() => undefined);
+      return;
+    }
+
+    if (context.activeProcess) {
+      killChildTree(context.activeProcess);
+    }
+  }
+
+  stopSession(threadId: string): void {
+    const context = this.sessions.get(threadId);
+    if (!context) {
+      return;
+    }
+
+    if (context.geminiSessionId && this.canUseAcp()) {
+      void this.ensureAcpRuntime(context.model)
+        .then((runtime) => runtime.cancel(context.geminiSessionId!))
+        .catch(() => undefined);
+    }
+
+    if (context.activeProcess) {
+      killChildTree(context.activeProcess);
+    }
+
+    context.status = "stopped";
+    context.activeProcess = null;
+    this.clearSessionBinding(context);
+    this.sessions.delete(threadId);
+  }
+
+  listSessions(): GeminiSessionContext[] {
+    return Array.from(this.sessions.values());
+  }
+
+  hasSession(threadId: string): boolean {
+    return this.sessions.has(threadId);
+  }
+
+  stopAll(): void {
+    for (const [threadId] of this.sessions) {
+      this.stopSession(threadId);
+    }
+
+    for (const runtimePromise of this.runtimePromises.values()) {
+      void runtimePromise.then((runtime) => runtime.close()).catch(() => undefined);
+    }
+    this.runtimePromises.clear();
+  }
+
+  private canUseAcp(): boolean {
+    return this.forceAcp || this.acpModulePath !== null;
+  }
+
+  private async runTurnViaAcp(
+    context: GeminiSessionContext,
+    turnId: string,
+    text: string,
+    prompt: ReadonlyArray<GeminiAcpPromptBlock> | undefined,
+    desiredMode: GeminiSessionModeId,
+  ): Promise<void> {
+    try {
+      const runtime = await this.ensureAcpRuntime(context.model);
+      await this.queueSessionSetup(context, async () => {
+        await this.prepareAcpSession(context, runtime, desiredMode, { emitConfigured: true });
+      });
+
+      if (context.status === "stopped" || context.activeTurnId !== turnId || !context.geminiSessionId) {
+        return;
+      }
+
+      this.emit("event", {
+        type: "session",
+        method: "session/ready",
+        kind: "lifecycle",
+        threadId: context.threadId,
+        sessionId: context.sessionId,
+        provider: "gemini",
+        ...(context.geminiSessionId
+          ? { resumeCursor: { sessionId: context.geminiSessionId } }
+          : {}),
+        message: "Gemini CLI is ready",
+      });
+
+      const result = await runtime.prompt(
+        context.geminiSessionId,
+        inputPromptBlocks(text, prompt),
+      );
+      const stopReason = typeof result.stopReason === "string" ? result.stopReason : "end_turn";
+
+      this.emit("event", {
+        type: "result",
+        method: "gemini/result",
+        kind: stopReason === "cancelled" ? "error" : "data",
+        threadId: context.threadId,
+        turnId,
+        provider: "gemini",
+        status: stopReason === "cancelled" ? "error" : "completed",
+        ...(stopReason === "cancelled"
+          ? { error: { message: "Gemini turn cancelled." } }
+          : {}),
+        stopReason,
+      });
+
+      this.emit("event", {
+        type: "turn",
+        method: "turn/ended",
+        kind: "lifecycle",
+        threadId: context.threadId,
+        turnId,
+        provider: "gemini",
+        exitCode: 0,
+      });
+    } catch (error) {
+      this.emit("event", {
+        type: "error",
+        method: "turn/error",
+        kind: "error",
+        threadId: context.threadId,
+        turnId,
+        provider: "gemini",
+        message: toErrorMessage(error, "Gemini ACP turn failed."),
+      });
+
+      this.emit("event", {
+        type: "turn",
+        method: "turn/ended",
+        kind: "lifecycle",
+        threadId: context.threadId,
+        turnId,
+        provider: "gemini",
+        exitCode: 1,
+      });
+    } finally {
+      if (context.activeTurnId === turnId) {
+        context.activeTurnId = null;
+        context.status = "idle";
+      }
+    }
+  }
+
+  private runTurnViaLegacyCli(
+    context: GeminiSessionContext,
+    turnId: string,
+    text: string,
+    approvalMode: GeminiApprovalMode,
+  ): void {
+    const launch = resolveGeminiLaunch();
+    const args = [
+      ...launch.argsPrefix,
+      "--prompt",
+      text,
+      "--output-format",
+      "stream-json",
+      "--approval-mode",
+      approvalMode,
+      "--model",
+      context.model,
+    ];
+
+    if (approvalMode !== "plan") {
+      args.push("--sandbox", "false");
+    }
+
+    if (context.geminiSessionId) {
+      args.push("--resume", context.geminiSessionId);
+    }
+
+    const child = spawn(launch.command, args, {
+      cwd: context.cwd,
+      env: buildPopupSafeEnv(),
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+    });
+
+    context.activeProcess = child;
+
+    const stdout = child.stdout;
+    if (!stdout) {
+      throw new Error("Gemini CLI stdout pipe is unavailable.");
+    }
+
+    const rl: ReadlineInterface = createInterface({ input: stdout });
+    let stderrBuffer = "";
+    let readyEventEmitted = false;
+
+    const emitReady = () => {
+      if (readyEventEmitted) {
+        return;
+      }
+      readyEventEmitted = true;
+      this.emit("event", {
+        type: "session",
+        method: "session/ready",
+        kind: "lifecycle",
+        threadId: context.threadId,
+        sessionId: context.sessionId,
+        provider: "gemini",
+        ...(context.geminiSessionId
+          ? { resumeCursor: { sessionId: context.geminiSessionId } }
+          : {}),
+        message: "Gemini CLI is ready",
+      });
+    };
+
+    rl.on("line", (line: string) => {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        return;
+      }
+
+      try {
+        const event = JSON.parse(trimmed) as GeminiStreamEvent & {
+          readonly session_id?: unknown;
+        };
+
+        if (event.type === "init" && typeof event.session_id === "string") {
+          this.updateGeminiSessionId(context, event.session_id, true);
+          emitReady();
+        }
+
+        this.emit("event", {
+          ...event,
+          method: `gemini/${event.type}`,
+          kind: event.type === "error" ? "error" : "data",
+          threadId: context.threadId,
+          turnId,
+          provider: "gemini",
+        });
+      } catch {
+        emitReady();
+        this.emit("event", {
+          type: "message",
+          method: "gemini/message",
+          kind: "data",
+          threadId: context.threadId,
+          turnId,
+          provider: "gemini",
+          role: "assistant",
+          content: trimmed,
+          delta: true,
+        });
+      }
+    });
+
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderrBuffer += chunk.toString();
+    });
+
+    child.on("close", (code: number | null) => {
+      rl.close();
+      context.status = "idle";
+      context.activeTurnId = null;
+      context.activeProcess = null;
+
+      const trimmedStderr = stderrBuffer.trim();
+      if (code !== 0 && code !== null) {
+        this.emit("event", {
+          type: "error",
+          method: "turn/error",
+          kind: "error",
+          threadId: context.threadId,
+          turnId,
+          provider: "gemini",
+          exitCode: code,
+          message: trimmedStderr || `Gemini CLI exited with code ${code}.`,
+        });
+      }
+
+      this.emit("event", {
+        type: "turn",
+        method: "turn/ended",
+        kind: "lifecycle",
+        threadId: context.threadId,
+        turnId,
+        provider: "gemini",
+        exitCode: code ?? 0,
+        ...(trimmedStderr ? { stderr: trimmedStderr } : {}),
+      });
+    });
+
+    child.on("error", (error: Error) => {
+      rl.close();
+      context.status = "idle";
+      context.activeTurnId = null;
+      context.activeProcess = null;
+
+      this.emit("event", {
+        type: "error",
+        method: "turn/error",
+        kind: "error",
+        threadId: context.threadId,
+        turnId,
+        provider: "gemini",
+        message: error.message,
+      });
+    });
+  }
+
+  private queueSessionSetup(
+    context: GeminiSessionContext,
+    operation: () => Promise<void>,
+  ): Promise<void> {
+    const previous = context.sessionSetupPromise ?? Promise.resolve();
+    const next = previous.then(operation, operation);
+    let tracked: Promise<void>;
+    tracked = next.finally(() => {
+      if (context.sessionSetupPromise === tracked) {
+        context.sessionSetupPromise = null;
+      }
+    });
+    context.sessionSetupPromise = tracked;
+    return tracked;
+  }
+
+  private async prepareAcpSession(
+    context: GeminiSessionContext,
+    runtime: GeminiAcpRuntime,
+    desiredMode: GeminiSessionModeId,
+    options: { emitConfigured: boolean },
+  ): Promise<void> {
+    const canReuseLoadedSession =
+      context.geminiSessionId !== undefined && context.runtimeModel === runtime.model;
+
+    if (!canReuseLoadedSession && context.geminiSessionId) {
+      context.hydrating = true;
+      this.threadIdByGeminiSessionId.set(context.geminiSessionId, context.threadId);
+      try {
+        const response = await runtime.loadSession(context.geminiSessionId, context.cwd);
+        context.currentMode = asSessionModeId(response.modes?.currentModeId) ?? context.currentMode;
+        context.runtimeModel = runtime.model;
+      } catch {
+        this.clearSessionBinding(context);
+      } finally {
+        context.hydrating = false;
+      }
+    }
+
+    if (!context.geminiSessionId) {
+      const response = await runtime.newSession(context.cwd);
+      const sessionId = response.sessionId;
+      if (typeof sessionId !== "string" || sessionId.length === 0) {
+        throw new Error("Gemini ACP did not return a session id.");
+      }
+
+      this.updateGeminiSessionId(context, sessionId, options.emitConfigured);
+      context.currentMode = asSessionModeId(response.modes?.currentModeId) ?? "default";
+      context.runtimeModel = runtime.model;
+    }
+
+    if (context.currentMode !== desiredMode) {
+      const sessionId = context.geminiSessionId;
+      if (!sessionId) {
+        throw new Error("Gemini ACP session is missing after preparation.");
+      }
+      await runtime.setSessionMode(sessionId, desiredMode);
+      context.currentMode = desiredMode;
+    }
+  }
+
+  private updateGeminiSessionId(
+    context: GeminiSessionContext,
+    sessionId: string,
+    emitConfigured: boolean,
+  ): void {
+    if (context.geminiSessionId && context.geminiSessionId !== sessionId) {
+      this.threadIdByGeminiSessionId.delete(context.geminiSessionId);
+    }
+    context.geminiSessionId = sessionId;
+    this.threadIdByGeminiSessionId.set(sessionId, context.threadId);
+
+    if (emitConfigured) {
+      this.emit("event", {
+        type: "session",
+        method: "session/configured",
+        kind: "lifecycle",
+        threadId: context.threadId,
+        sessionId: context.sessionId,
+        provider: "gemini",
+        resumeCursor: { sessionId },
+      });
+    }
+  }
+
+  private clearSessionBinding(context: GeminiSessionContext): void {
+    if (context.geminiSessionId) {
+      this.threadIdByGeminiSessionId.delete(context.geminiSessionId);
+    }
+    delete context.geminiSessionId;
+    context.runtimeModel = null;
+    context.currentMode = "default";
+  }
+
+  private async ensureAcpRuntime(model: string): Promise<GeminiAcpRuntime> {
+    const normalizedModel = normalizeModelSlug(model, "gemini") ?? model;
+    const existing = this.runtimePromises.get(normalizedModel);
+    if (existing) {
+      return existing;
+    }
+
+    const promise = this.runtimeFactory(normalizedModel, {
+      onSessionUpdate: (notification) => {
+        this.handleAcpSessionUpdate(notification);
+      },
+      onRequestPermission: async (params) => this.handleAcpPermissionRequest(params),
+      onClose: (error) => {
+        this.runtimePromises.delete(normalizedModel);
+        this.handleRuntimeClose(normalizedModel, error);
+      },
+    }).catch((error) => {
+      this.runtimePromises.delete(normalizedModel);
+      throw error;
+    });
+
+    this.runtimePromises.set(normalizedModel, promise);
+    return promise;
+  }
+
+  private handleAcpSessionUpdate(notification: GeminiAcpNotification): void {
+    const threadId = this.threadIdByGeminiSessionId.get(notification.sessionId);
+    if (!threadId) {
+      return;
+    }
+    const context = this.sessions.get(threadId);
+    if (!context || context.hydrating) {
+      return;
+    }
+
+    const turnId = context.activeTurnId;
+    const update = notification.update;
+    if (!turnId) {
+      return;
+    }
+
+    switch (update.sessionUpdate) {
+      case "agent_message_chunk": {
+        const text = readContentText(update.content);
+        if (!text) {
+          return;
+        }
+        this.emit("event", {
+          type: "message",
+          method: "gemini/message",
+          kind: "data",
+          threadId,
+          turnId,
+          provider: "gemini",
+          role: "assistant",
+          content: text,
+          delta: true,
+        });
+        return;
+      }
+
+      case "agent_thought_chunk": {
+        const text = readContentText(update.content);
+        if (!text) {
+          return;
+        }
+        this.emit("event", {
+          type: "thought",
+          method: "gemini/thought",
+          kind: "data",
+          threadId,
+          turnId,
+          provider: "gemini",
+          content: text,
+          delta: true,
+        });
+        return;
+      }
+
+      case "tool_call": {
+        this.emit("event", {
+          type: "tool_use",
+          method: "gemini/tool_use",
+          kind: "data",
+          threadId,
+          turnId,
+          provider: "gemini",
+          tool_id:
+            typeof update.toolCallId === "string" && update.toolCallId.length > 0
+              ? update.toolCallId
+              : undefined,
+          tool_name: typeof update.title === "string" ? update.title : "Gemini tool",
+          status: update.status,
+          tool_kind: update.kind,
+          parameters: update.rawInput,
+          locations: update.locations,
+        });
+        return;
+      }
+
+      case "tool_call_update": {
+        const normalizedStatus = normalizeToolCallStatus(update.status);
+        const toolName = typeof update.title === "string" ? update.title : "Gemini tool";
+        const output =
+          flattenToolCallContent(update.content) ??
+          stringifyUnknown(update.rawOutput) ??
+          flattenContentBlocks(update.content);
+
+        this.emit("event", {
+          type: "tool_update",
+          method: "gemini/tool_update",
+          kind: "data",
+          threadId,
+          turnId,
+          provider: "gemini",
+          tool_id:
+            typeof update.toolCallId === "string" && update.toolCallId.length > 0
+              ? update.toolCallId
+              : undefined,
+          tool_name: toolName,
+          status: normalizedStatus,
+          output,
+          rawInput: update.rawInput,
+          rawOutput: update.rawOutput,
+          tool_kind: update.kind,
+          locations: update.locations,
+        });
+        if (normalizedStatus === "completed" || normalizedStatus === "failed") {
+          this.emit("event", {
+            type: "tool_result",
+            method: "gemini/tool_result",
+            kind: normalizedStatus === "failed" ? "error" : "data",
+            threadId,
+            turnId,
+            provider: "gemini",
+            tool_id:
+              typeof update.toolCallId === "string" && update.toolCallId.length > 0
+                ? update.toolCallId
+                : undefined,
+            tool_name: toolName,
+            status: normalizedStatus,
+            output,
+            rawOutput: update.rawOutput,
+            tool_kind: update.kind,
+            locations: update.locations,
+          });
+        }
+        return;
+      }
+
+      case "plan": {
+        this.emit("event", {
+          type: "plan",
+          method: "gemini/plan",
+          kind: "data",
+          threadId,
+          turnId,
+          provider: "gemini",
+          entries: Array.isArray(update.entries) ? update.entries : [],
+        });
+        return;
+      }
+
+      case "current_mode_update": {
+        context.currentMode =
+          asSessionModeId(update.currentModeId ?? update.modeId) ?? context.currentMode;
+        return;
+      }
+
+      case "session_info_update": {
+        this.emit("event", {
+          type: "session_info",
+          method: "gemini/session_info",
+          kind: "data",
+          threadId,
+          turnId,
+          provider: "gemini",
+          title: typeof update.title === "string" ? update.title : undefined,
+          updatedAt: typeof update.updatedAt === "string" ? update.updatedAt : undefined,
+        });
+        return;
+      }
+
+      default:
+        return;
+    }
+  }
+
+  private async handleAcpPermissionRequest(
+    params: GeminiAcpRequestPermissionParams,
+  ): Promise<{ outcome: { outcome: string; optionId?: string } }> {
+    const sessionId = typeof params.sessionId === "string" ? params.sessionId : undefined;
+    const threadId = sessionId ? this.threadIdByGeminiSessionId.get(sessionId) : undefined;
+    const context = threadId ? this.sessions.get(threadId) : undefined;
+    const options = Array.isArray(params.options) ? params.options : [];
+
+    if (context?.currentMode === "plan") {
+      return { outcome: { outcome: "cancelled" } };
+    }
+
+    const allowOption = options.find((option) => {
+      const kind = typeof option.kind === "string" ? option.kind : "";
+      return kind.includes("allow") || kind.includes("approve");
+    });
+    const selected = allowOption ?? options[0];
+    const optionId = typeof selected?.optionId === "string" ? selected.optionId : undefined;
+    return optionId
+      ? { outcome: { outcome: "selected", optionId } }
+      : { outcome: { outcome: "cancelled" } };
+  }
+
+  private handleRuntimeClose(model: string, error?: Error): void {
+    const message = error?.message?.trim();
+    for (const context of this.sessions.values()) {
+      if (context.runtimeModel !== model) {
+        continue;
+      }
+
+      context.runtimeModel = null;
+      if (context.activeTurnId) {
+        this.emit("event", {
+          type: "error",
+          method: "turn/error",
+          kind: "error",
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          provider: "gemini",
+          message: message || `Gemini runtime for ${model} exited unexpectedly.`,
+        });
+
+        this.emit("event", {
+          type: "turn",
+          method: "turn/ended",
+          kind: "lifecycle",
+          threadId: context.threadId,
+          turnId: context.activeTurnId,
+          provider: "gemini",
+          exitCode: 1,
+          ...(message ? { stderr: message } : {}),
+        });
+
+        context.activeTurnId = null;
+        context.status = "idle";
+      }
+    }
+  }
+}
+
+function resolveGeminiLaunch(): { command: string; argsPrefix: ReadonlyArray<string> } {
+  const resolved = resolveGeminiCliLaunchSpec();
+  if (!resolved) {
+    throw new Error(
+      "Gemini CLI is not installed or could not be resolved. Install `@google/gemini-cli` and ensure it is available.",
+    );
+  }
+
+  return resolved;
+}
+
+async function createGeminiAcpRuntime(
+  model: string,
+  handlers: GeminiAcpRuntimeHandlers,
+): Promise<GeminiAcpRuntime> {
+  const launch = resolveGeminiLaunch();
+  const acpModulePath = resolveGeminiAcpModulePath();
+  if (!acpModulePath || !existsSync(acpModulePath)) {
+    throw new Error("Gemini ACP runtime is unavailable on this installation.");
+  }
+
+  const child = spawn(
+    launch.command,
+    [...launch.argsPrefix, "--experimental-acp", "--model", model, "--sandbox", "false"],
+    {
+      cwd: process.cwd(),
+      env: buildPopupSafeEnv(),
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: false,
+    },
+  );
+
+  let stderrBuffer = "";
+  let closing = false;
+  let closeNotified = false;
+
+  const notifyClose = (error?: Error) => {
+    if (closeNotified) {
+      return;
+    }
+    closeNotified = true;
+    handlers.onClose(error);
+  };
+
+  child.stderr?.on("data", (chunk: Buffer | string) => {
+    stderrBuffer += chunk.toString();
+  });
+
+  child.on("error", (error: Error) => {
+    notifyClose(error);
+  });
+
+  child.on("close", (code) => {
+    if (closing) {
+      notifyClose();
+      return;
+    }
+
+    const message = stderrBuffer.trim() || `Gemini ACP runtime exited with code ${code ?? "unknown"}.`;
+    notifyClose(new Error(message));
+  });
+
+  const acp = (await import(pathToFileURL(acpModulePath).href)) as {
+    PROTOCOL_VERSION: number;
+    ndJsonStream: (
+      output: WritableStream<Uint8Array>,
+      input: ReadableStream<Uint8Array>,
+    ) => unknown;
+    ClientSideConnection: new (
+      clientFactory: () => {
+        requestPermission: GeminiAcpRuntimeHandlers["onRequestPermission"];
+        sessionUpdate: GeminiAcpRuntimeHandlers["onSessionUpdate"];
+      },
+      stream: unknown,
+    ) => GeminiAcpConnection;
+  };
+
+  const connection = new acp.ClientSideConnection(
+    () => ({
+      requestPermission: handlers.onRequestPermission,
+      sessionUpdate: async (notification: GeminiAcpNotification) => {
+        handlers.onSessionUpdate(notification);
+      },
+    }),
+    acp.ndJsonStream(
+      Writable.toWeb(child.stdin as NonNullable<typeof child.stdin>),
+      Readable.toWeb(child.stdout as NonNullable<typeof child.stdout>),
+    ),
+  );
+
+  let initializePromise: Promise<void> | null = null;
+  const initialize = async () => {
+    initializePromise ??= connection
+      .initialize({
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientCapabilities: {},
+      })
+      .then(() => undefined);
+    return initializePromise;
+  };
+
+  return {
+    model,
+    initialize,
+    async newSession(cwd: string) {
+      await initialize();
+      return connection.newSession({ cwd, mcpServers: [] });
+    },
+    async loadSession(sessionId: string, cwd: string) {
+      await initialize();
+      return connection.loadSession({ sessionId, cwd, mcpServers: [] });
+    },
+    async setSessionMode(sessionId: string, modeId: GeminiSessionModeId) {
+      await initialize();
+      await connection.setSessionMode({ sessionId, modeId });
+    },
+    async prompt(sessionId: string, prompt: ReadonlyArray<GeminiAcpPromptBlock>) {
+      await initialize();
+      return connection.prompt({
+        sessionId,
+        prompt: prompt.length > 0 ? [...prompt] : [{ type: "text", text: "" }],
+      });
+    },
+    async cancel(sessionId: string) {
+      await initialize();
+      await connection.cancel({ sessionId });
+    },
+    close() {
+      closing = true;
+      killChildTree(child);
+    },
+  };
+}
+
+function readContentText(content: unknown): string | undefined {
+  if (!content || typeof content !== "object" || Array.isArray(content)) {
+    return undefined;
+  }
+
+  const text = (content as GeminiAcpMessageContent).text;
+  return typeof text === "string" && text.length > 0 ? text : undefined;
+}
+
+function flattenContentBlocks(content: unknown): string | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+
+  const text = content
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return "";
+      }
+      const contentBlock = (entry as { content?: unknown }).content;
+      return readContentText(contentBlock) ?? "";
+    })
+    .join("");
+
+  return text.length > 0 ? text : undefined;
+}
+
+function flattenToolCallContent(content: unknown): string | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+
+  const text = content
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") {
+        return "";
+      }
+      const record = entry as Record<string, unknown>;
+      const entryType = typeof record.type === "string" ? record.type : "";
+      if (entryType === "diff") {
+        const path = typeof record.path === "string" ? record.path : "file";
+        return `Diff updated: ${path}`;
+      }
+      if (entryType === "terminal") {
+        const terminalId = typeof record.terminalId === "string" ? record.terminalId : "terminal";
+        return `Terminal activity: ${terminalId}`;
+      }
+      const contentBlock = record.content;
+      return readContentText(contentBlock) ?? "";
+    })
+    .filter((entry) => entry.length > 0)
+    .join("\n");
+
+  return text.length > 0 ? text : undefined;
+}
+
+function normalizeToolCallStatus(value: unknown): "pending" | "in_progress" | "completed" | "failed" {
+  switch (value) {
+    case "pending":
+    case "in_progress":
+    case "completed":
+    case "failed":
+      return value;
+    default:
+      return "in_progress";
+  }
+}
+
+function inputPromptBlocks(
+  text: string,
+  prompt: ReadonlyArray<GeminiAcpPromptBlock> | undefined,
+): ReadonlyArray<GeminiAcpPromptBlock> {
+  if (prompt && prompt.length > 0) {
+    return prompt;
+  }
+  return [{ type: "text", text }];
+}
+
+function stringifyUnknown(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function toSessionModeId(approvalMode: GeminiApprovalMode): GeminiSessionModeId {
+  switch (approvalMode) {
+    case "auto_edit":
+      return "autoEdit";
+    case "plan":
+      return "plan";
+    case "default":
+      return "default";
+    case "yolo":
+    default:
+      return "yolo";
+  }
+}
+
+function asSessionModeId(value: unknown): GeminiSessionModeId | undefined {
+  return value === "default" || value === "autoEdit" || value === "yolo" || value === "plan"
+    ? value
+    : undefined;
+}
+
+function toErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message.trim();
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error.trim();
+  }
+  return fallback;
+}
+
+function killChildTree(child: ChildProcess): void {
+  if (process.platform === "win32" && child.pid !== undefined) {
+    try {
+      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      return;
+    } catch {
+      // Fall through to direct kill.
+    }
+  }
+
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Process is already dead.
+    }
+  }
+}

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -8,6 +8,7 @@ const STATUS_UPSTREAM_REFRESH_INTERVAL = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
 const DEFAULT_BASE_BRANCH_CANDIDATES = ["main", "master"] as const;
+const ENABLE_STATUS_UPSTREAM_REFRESH = process.env.T3CODE_ENABLE_STATUS_UPSTREAM_REFRESH === "1";
 
 class StatusUpstreamRefreshCacheKey extends Data.Class<{
   cwd: string;
@@ -524,7 +525,9 @@ const makeGitCore = Effect.gen(function* () {
 
   const statusDetails: GitCoreShape["statusDetails"] = (cwd) =>
     Effect.gen(function* () {
-      yield* refreshStatusUpstreamIfStale(cwd).pipe(Effect.catch(() => Effect.void));
+      if (ENABLE_STATUS_UPSTREAM_REFRESH) {
+        yield* refreshStatusUpstreamIfStale(cwd).pipe(Effect.catch(() => Effect.void));
+      }
 
       const [statusStdout, unstagedNumstatStdout, stagedNumstatStdout] = yield* Effect.all(
         [

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -1,10 +1,14 @@
 import { Effect, Layer } from "effect";
 
+import { buildNonInteractiveGitEnv } from "../../cliEnvironment";
 import { runProcess } from "../../processRunner";
 import { GitHubCliError } from "../Errors.ts";
 import { GitHubCli, type GitHubCliShape } from "../Services/GitHubCli.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+const NON_INTERACTIVE_GH_ENV: NodeJS.ProcessEnv = buildNonInteractiveGitEnv(process.env, {
+  GH_PROMPT_DISABLED: "1",
+});
 
 function normalizeGitHubCliError(operation: "execute" | "stdout", error: unknown): GitHubCliError {
   if (error instanceof Error) {
@@ -106,6 +110,7 @@ const makeGitHubCli = Effect.sync(() => {
         runProcess("gh", input.args, {
           cwd: input.cwd,
           timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+          env: NON_INTERACTIVE_GH_ENV,
         }),
       catch: (error) => normalizeGitHubCliError("execute", error),
     });

--- a/apps/server/src/git/Layers/GitService.ts
+++ b/apps/server/src/git/Layers/GitService.ts
@@ -8,6 +8,8 @@
  */
 import { Effect, Layer, Option, Schema, Stream } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import { buildNonInteractiveGitEnv } from "../../cliEnvironment";
 import { GitCommandError } from "../Errors.ts";
 import {
   ExecuteGitInput,
@@ -18,6 +20,7 @@ import {
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+const NON_INTERACTIVE_GIT_ENV = buildNonInteractiveGitEnv(process.env);
 
 function quoteGitCommand(args: ReadonlyArray<string>): string {
   return `git ${args.join(" ")}`;
@@ -83,7 +86,10 @@ const makeGitService = Effect.gen(function* () {
         .spawn(
           ChildProcess.make("git", commandInput.args, {
             cwd: commandInput.cwd,
-            ...(input.env ? { env: input.env } : {}),
+            env: {
+              ...NON_INTERACTIVE_GIT_ENV,
+              ...input.env,
+            },
           }),
         )
         .pipe(Effect.mapError(toGitCommandError(commandInput, "failed to spawn.")));

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -213,7 +213,7 @@ const make = Effect.gen(function* () {
 
     const desiredRuntimeMode = thread.runtimeMode;
     const currentProvider: ProviderKind | undefined =
-      thread.session?.providerName === "codex" ? thread.session.providerName : undefined;
+      (thread.session?.providerName as ProviderKind | null) ?? undefined;
     const preferredProvider: ProviderKind | undefined = options?.provider ?? currentProvider;
     const desiredModel = options?.model ?? thread.model;
     const effectiveCwd = resolveThreadWorkspaceCwd({

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -45,7 +45,7 @@ const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
   readonly eventId: EventId;
-  readonly provider: "codex";
+  readonly provider: "codex" | "gemini";
   readonly createdAt: string;
   readonly threadId: ThreadId;
   readonly turnId?: string | undefined;
@@ -391,6 +391,62 @@ describe("ProviderRuntimeIngestion", () => {
       threadId: asThreadId("thread-1"),
       turnId: asTurnId("turn-midturn-lifecycle"),
       status: "completed",
+    });
+
+    await waitForThread(
+      harness.engine,
+      (thread) => thread.session?.status === "ready" && thread.session?.activeTurnId === null,
+    );
+  });
+
+  it("preserves running status when provider emits session ready during an active turn", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-ready-heartbeat"),
+      provider: "gemini",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-ready-heartbeat"),
+    });
+
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" && thread.session?.activeTurnId === "turn-ready-heartbeat",
+    );
+
+    harness.emit({
+      type: "session.state.changed",
+      eventId: asEventId("evt-session-ready-midturn"),
+      provider: "gemini",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-ready-heartbeat"),
+      payload: {
+        state: "ready",
+        reason: "runtime warm",
+      },
+    });
+
+    await Effect.runPromise(Effect.sleep("40 millis"));
+    const midReadModel = await Effect.runPromise(harness.engine.getReadModel());
+    const midThread = midReadModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+    expect(midThread?.session?.status).toBe("running");
+    expect(midThread?.session?.activeTurnId).toBe("turn-ready-heartbeat");
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-ready-heartbeat"),
+      provider: "gemini",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-ready-heartbeat"),
+      payload: {
+        state: "completed",
+      },
     });
 
     await waitForThread(

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -155,6 +155,36 @@ function orchestrationSessionStatusFromRuntimeState(
   }
 }
 
+function statusFromLifecycleEvent(
+  event:
+    | Extract<ProviderRuntimeEvent, { type: "session.state.changed" }>
+    | Extract<ProviderRuntimeEvent, { type: "turn.started" }>
+    | Extract<ProviderRuntimeEvent, { type: "session.exited" }>
+    | Extract<ProviderRuntimeEvent, { type: "turn.completed" }>
+    | Extract<ProviderRuntimeEvent, { type: "session.started" }>
+    | Extract<ProviderRuntimeEvent, { type: "thread.started" }>,
+  activeTurnId: string | null,
+): "starting" | "running" | "ready" | "interrupted" | "stopped" | "error" {
+  switch (event.type) {
+    case "session.state.changed":
+      // Some providers emit a "ready" heartbeat while a turn is still actively running.
+      // Preserve the run lock until the active turn closes.
+      if (activeTurnId !== null && event.payload.state === "ready") {
+        return "running";
+      }
+      return orchestrationSessionStatusFromRuntimeState(event.payload.state);
+    case "turn.started":
+      return "running";
+    case "session.exited":
+      return "stopped";
+    case "turn.completed":
+      return runtimeTurnState(event) === "failed" ? "error" : "ready";
+    case "session.started":
+    case "thread.started":
+      return activeTurnId !== null ? "running" : "ready";
+  }
+}
+
 function requestKindFromCanonicalRequestType(
   requestType: string | undefined,
 ): "command" | "file-read" | "file-change" | undefined {
@@ -839,23 +869,7 @@ const make = Effect.gen(function* () {
             : event.type === "turn.completed" || event.type === "session.exited"
               ? null
               : activeTurnId;
-        const status = (() => {
-          switch (event.type) {
-            case "session.state.changed":
-              return orchestrationSessionStatusFromRuntimeState(event.payload.state);
-            case "turn.started":
-              return "running";
-            case "session.exited":
-              return "stopped";
-            case "turn.completed":
-              return runtimeTurnState(event) === "failed" ? "error" : "ready";
-            case "session.started":
-            case "thread.started":
-              // Provider thread/session start notifications can arrive during an
-              // active turn; preserve turn-running state in that case.
-              return activeTurnId !== null ? "running" : "ready";
-          }
-        })();
+        const status = statusFromLifecycleEvent(event, activeTurnId);
         const lastError =
           event.type === "session.state.changed" && event.payload.state === "error"
             ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")

--- a/apps/server/src/provider/Layers/GeminiAdapter.ts
+++ b/apps/server/src/provider/Layers/GeminiAdapter.ts
@@ -1,0 +1,643 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderTurnStartResult,
+  type ChatAttachment,
+  EventId,
+  RuntimeItemId,
+  RuntimeTaskId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import { getDefaultModel, normalizeModelSlug } from "@t3tools/shared/model";
+import { Effect, FileSystem, Layer, Queue, Stream } from "effect";
+
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
+import { GeminiAdapter, type GeminiAdapterShape } from "../Services/GeminiAdapter.ts";
+import { GeminiCliManager } from "../../geminiCliManager.ts";
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+
+const PROVIDER = "gemini" as const;
+
+function toMessage(cause: unknown, fallback: string): string {
+  if (cause instanceof Error && cause.message.length > 0) {
+    return cause.message;
+  }
+  return fallback;
+}
+
+function makeEventId(): EventId {
+  return EventId.makeUnsafe(`gemini_${randomUUID()}`);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function itemIdFromRaw(value: unknown): RuntimeItemId | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? RuntimeItemId.makeUnsafe(value)
+    : undefined;
+}
+
+function mapGeminiPlanStatus(value: unknown): "pending" | "inProgress" | "completed" {
+  switch (value) {
+    case "completed":
+      return "completed";
+    case "in_progress":
+      return "inProgress";
+    default:
+      return "pending";
+  }
+}
+
+function mapGeminiToolLifecycleStatus(
+  value: unknown,
+): "inProgress" | "completed" | "failed" | undefined {
+  switch (value) {
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+    case "pending":
+    case "in_progress":
+      return "inProgress";
+    default:
+      return undefined;
+  }
+}
+
+function stringFromUnknown(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function buildGeminiPromptAttachment(input: {
+  readonly attachment: ChatAttachment;
+  readonly stateDir: string;
+  readonly threadId: ThreadId;
+  readonly fileSystem: FileSystem.FileSystem;
+}): Effect.Effect<
+  { readonly type: "image"; readonly data: string; readonly mimeType: string },
+  ProviderAdapterError
+> {
+  return Effect.gen(function* () {
+    const attachmentPath = resolveAttachmentPath({
+      stateDir: input.stateDir,
+      attachment: input.attachment,
+    });
+    if (!attachmentPath) {
+      return yield* new ProviderAdapterRequestError({
+        provider: PROVIDER,
+        method: "sendTurn",
+        detail: `Invalid attachment id '${input.attachment.id}'.`,
+      });
+    }
+
+    const bytes = yield* input.fileSystem.readFile(attachmentPath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "sendTurn",
+            detail: toMessage(cause, "Failed to read Gemini attachment"),
+            cause: cause instanceof Error ? cause : undefined,
+          }),
+      ),
+    );
+
+    return {
+      type: "image" as const,
+      data: Buffer.from(bytes).toString("base64"),
+      mimeType: input.attachment.mimeType,
+    };
+  });
+}
+
+function mapGeminiEventToCanonical(rawEvent: Record<string, unknown>): ProviderRuntimeEvent | null {
+  const method = rawEvent.method;
+  const threadId = rawEvent.threadId;
+  const turnId = rawEvent.turnId;
+
+  if (typeof method !== "string" || typeof threadId !== "string") {
+    return null;
+  }
+
+  const base: Omit<ProviderRuntimeEvent, "type" | "payload"> = {
+    eventId: makeEventId(),
+    provider: PROVIDER,
+    threadId: ThreadId.makeUnsafe(threadId),
+    createdAt: nowIso(),
+    ...(typeof turnId === "string" && turnId.length > 0
+      ? { turnId: TurnId.makeUnsafe(turnId) }
+      : {}),
+  };
+
+  switch (method) {
+    case "session/started":
+      return {
+        ...base,
+        type: "session.started",
+        payload: {},
+      };
+
+    case "session/connecting":
+      return {
+        ...base,
+        type: "session.state.changed",
+        payload: {
+          state: "starting",
+          ...(typeof rawEvent.message === "string" ? { reason: rawEvent.message } : {}),
+        },
+      };
+
+    case "session/ready":
+      return {
+        ...base,
+        type: "session.state.changed",
+        payload: {
+          state: "ready",
+          ...(typeof rawEvent.message === "string" ? { reason: rawEvent.message } : {}),
+        },
+      };
+
+    case "session/configured":
+      return {
+        ...base,
+        type: "session.configured",
+        payload: {
+          config: {
+            resumeCursor: rawEvent.resumeCursor,
+          },
+        },
+      };
+
+    case "turn/started":
+      return {
+        ...base,
+        type: "turn.started",
+        payload: typeof rawEvent.model === "string" ? { model: rawEvent.model } : {},
+      };
+
+    case "turn/ended":
+      if (typeof rawEvent.exitCode !== "number" || rawEvent.exitCode === 0) {
+        return null;
+      }
+      return {
+        ...base,
+        type: "turn.completed",
+        payload: {
+          state:
+            typeof rawEvent.exitCode === "number" && rawEvent.exitCode !== 0 ? "failed" : "completed",
+          ...(typeof rawEvent.stderr === "string" && rawEvent.stderr.trim().length > 0
+            ? { errorMessage: rawEvent.stderr.trim() }
+            : {}),
+        },
+      };
+
+    case "turn/error":
+      return {
+        ...base,
+        type: "runtime.error",
+        payload: {
+          message:
+            typeof rawEvent.message === "string" && rawEvent.message.trim().length > 0
+              ? rawEvent.message.trim()
+              : "Gemini CLI error",
+          class: "provider_error",
+          detail: rawEvent,
+        },
+      };
+
+    case "gemini/init":
+      return {
+        ...base,
+        type: "session.configured",
+        payload: {
+          config: {
+            ...(typeof rawEvent.session_id === "string"
+              ? { resumeCursor: { sessionId: rawEvent.session_id } }
+              : {}),
+            ...(typeof rawEvent.model === "string" ? { model: rawEvent.model } : {}),
+          },
+        },
+      };
+
+    case "gemini/message": {
+      const role = rawEvent.role;
+      const content = rawEvent.content;
+
+      if (role !== "assistant" || typeof content !== "string" || content.length === 0) {
+        return null;
+      }
+
+      return {
+        ...base,
+        type: "content.delta",
+        payload: {
+          streamKind: "assistant_text",
+          delta: content,
+        },
+      };
+    }
+
+    case "gemini/thought": {
+      const content = rawEvent.content;
+      if (typeof content !== "string" || content.trim().length === 0) {
+        return null;
+      }
+      return {
+        ...base,
+        type: "task.progress",
+        payload: {
+          taskId: RuntimeTaskId.makeUnsafe(`gemini-thought:${turnId ?? threadId}`),
+          description: content.trim(),
+        },
+      };
+    }
+
+    case "gemini/plan": {
+      const entries = Array.isArray(rawEvent.entries) ? rawEvent.entries : [];
+      return {
+        ...base,
+        type: "turn.plan.updated",
+        payload: {
+          plan: entries
+            .map((entry) => (entry && typeof entry === "object" ? (entry as Record<string, unknown>) : null))
+            .filter((entry): entry is Record<string, unknown> => entry !== null)
+            .map((entry) => ({
+              step:
+                typeof entry.content === "string" && entry.content.trim().length > 0
+                  ? entry.content.trim()
+                  : "Gemini plan step",
+              status: mapGeminiPlanStatus(entry.status),
+            })),
+        },
+      };
+    }
+
+    case "gemini/tool_use": {
+      const itemId = itemIdFromRaw(rawEvent.tool_id);
+      return {
+        ...base,
+        ...(itemId ? { itemId } : {}),
+        type: "item.started",
+        payload: {
+          itemType: "dynamic_tool_call",
+          status: "inProgress",
+          ...(typeof rawEvent.tool_name === "string" ? { title: rawEvent.tool_name } : {}),
+          ...(rawEvent.parameters !== undefined
+            ? { detail: JSON.stringify(rawEvent.parameters) }
+            : {}),
+          data: rawEvent,
+        },
+      };
+    }
+
+    case "gemini/tool_update": {
+      const itemId = itemIdFromRaw(rawEvent.tool_id);
+      const detail =
+        (typeof rawEvent.output === "string" && rawEvent.output.trim().length > 0
+          ? rawEvent.output.trim()
+          : stringFromUnknown(rawEvent.rawOutput)) ?? stringFromUnknown(rawEvent.rawInput);
+
+      return {
+        ...base,
+        ...(itemId ? { itemId } : {}),
+        type: "item.updated",
+        payload: {
+          itemType: "dynamic_tool_call",
+          ...(mapGeminiToolLifecycleStatus(rawEvent.status)
+            ? { status: mapGeminiToolLifecycleStatus(rawEvent.status) }
+            : {}),
+          ...(typeof rawEvent.tool_name === "string" ? { title: rawEvent.tool_name } : {}),
+          ...(detail ? { detail } : {}),
+          data: rawEvent,
+        },
+      };
+    }
+
+    case "gemini/tool_result": {
+      const itemId = itemIdFromRaw(rawEvent.tool_id);
+      const status = rawEvent.status === "failed" || rawEvent.status === "error" ? "failed" : "completed";
+      const detail =
+        typeof rawEvent.output === "string" && rawEvent.output.trim().length > 0
+          ? rawEvent.output
+          : typeof rawEvent.error === "object" && rawEvent.error !== null
+            ? JSON.stringify(rawEvent.error)
+            : undefined;
+
+      return {
+        ...base,
+        ...(itemId ? { itemId } : {}),
+        type: "item.completed",
+        payload: {
+          itemType: "dynamic_tool_call",
+          status,
+          ...(typeof rawEvent.tool_name === "string" ? { title: rawEvent.tool_name } : {}),
+          ...(detail ? { detail } : {}),
+          data: rawEvent,
+        },
+      };
+    }
+
+    case "gemini/session_info": {
+      if (typeof rawEvent.title !== "string" || rawEvent.title.trim().length === 0) {
+        return null;
+      }
+      return {
+        ...base,
+        type: "thread.metadata.updated",
+        payload: {
+          name: rawEvent.title.trim(),
+        },
+      };
+    }
+
+    case "gemini/error":
+      if (rawEvent.severity === "warning") {
+        return {
+          ...base,
+          type: "runtime.warning",
+          payload: {
+            message:
+              typeof rawEvent.message === "string" ? rawEvent.message : "Gemini CLI warning",
+            detail: rawEvent,
+          },
+        };
+      }
+
+      return {
+        ...base,
+        type: "runtime.error",
+        payload: {
+          message: typeof rawEvent.message === "string" ? rawEvent.message : "Gemini CLI error",
+          class: "provider_error",
+          detail: rawEvent,
+        },
+      };
+
+    case "gemini/result": {
+      const resultErrorMessage =
+        typeof rawEvent.error === "object" &&
+        rawEvent.error !== null &&
+        typeof (rawEvent.error as { message?: unknown }).message === "string"
+          ? (rawEvent.error as { message: string }).message
+          : undefined;
+      return {
+        ...base,
+        type: "turn.completed",
+        payload: {
+          state: rawEvent.status === "error" ? "failed" : "completed",
+          ...(resultErrorMessage ? { errorMessage: resultErrorMessage } : {}),
+          ...(rawEvent.stats !== undefined ? { usage: rawEvent.stats } : {}),
+        },
+      };
+    }
+
+    default:
+      return null;
+  }
+}
+
+const makeGeminiAdapter = () =>
+  Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const eventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+    const manager = new GeminiCliManager();
+
+    manager.on("event", (rawEvent: Record<string, unknown>) => {
+      const canonical = mapGeminiEventToCanonical(rawEvent);
+      if (!canonical) {
+        return;
+      }
+
+      Effect.runSync(Queue.offer(eventQueue, canonical));
+    });
+
+    const adapter: GeminiAdapterShape = {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "restart-session" },
+
+      startSession: (input) =>
+        Effect.try({
+          try: () => {
+            const cwd = input.cwd ?? process.cwd();
+            const model = normalizeModelSlug(input.model, "gemini") ?? getDefaultModel("gemini");
+            const resumeCursor =
+              input.resumeCursor &&
+              typeof input.resumeCursor === "object" &&
+              !Array.isArray(input.resumeCursor) &&
+              typeof (input.resumeCursor as { sessionId?: unknown }).sessionId === "string"
+                ? {
+                    sessionId: (input.resumeCursor as { sessionId: string }).sessionId,
+                  }
+                : undefined;
+
+            const context = manager.startSession({
+              threadId: String(input.threadId),
+              model,
+              cwd,
+              ...(resumeCursor ? { resumeCursor } : {}),
+            });
+            const now = nowIso();
+
+            return {
+              provider: PROVIDER,
+              status: "ready",
+              runtimeMode: input.runtimeMode ?? "full-access",
+              cwd,
+              model: context.model,
+              threadId: input.threadId,
+              createdAt: now,
+              updatedAt: now,
+              ...(context.geminiSessionId
+                ? { resumeCursor: { sessionId: context.geminiSessionId } }
+                : resumeCursor
+                  ? { resumeCursor }
+                  : {}),
+            } satisfies ProviderSession;
+          },
+          catch: (cause: unknown) =>
+            new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: toMessage(cause, "Failed to start Gemini session"),
+              cause: cause instanceof Error ? cause : undefined,
+            }),
+        }) as Effect.Effect<ProviderSession, ProviderAdapterError>,
+
+      sendTurn: (input) =>
+        Effect.gen(function* () {
+          const text = input.input;
+          if (!text || typeof text !== "string" || text.trim().length === 0) {
+            return yield* new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "sendTurn",
+              detail: "Turn input must include text.",
+            });
+          }
+
+          const promptAttachments = yield* Effect.forEach(
+            input.attachments ?? [],
+            (attachment) =>
+              buildGeminiPromptAttachment({
+                attachment,
+                stateDir: serverConfig.stateDir,
+                threadId: input.threadId,
+                fileSystem,
+              }),
+            { concurrency: 1 },
+          );
+
+          const result = yield* Effect.try({
+            try: () =>
+              manager.sendTurn({
+                threadId: String(input.threadId),
+                text,
+                prompt: [{ type: "text", text }, ...promptAttachments],
+                ...(input.model ? { model: input.model } : {}),
+                approvalMode: input.interactionMode === "plan" ? "plan" : "yolo",
+              }),
+            catch: (cause: unknown) => {
+              const message = toMessage(cause, "Failed to send Gemini turn");
+              if (message.includes("No Gemini session")) {
+                return new ProviderAdapterSessionNotFoundError({
+                  provider: PROVIDER,
+                  threadId: String(input.threadId),
+                  cause: cause instanceof Error ? cause : undefined,
+                });
+              }
+
+              return new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "sendTurn",
+                detail: message,
+                cause: cause instanceof Error ? cause : undefined,
+              });
+            },
+          });
+
+          return {
+            turnId: TurnId.makeUnsafe(result.turnId),
+            threadId: input.threadId,
+            ...(result.resumeCursor ? { resumeCursor: result.resumeCursor } : {}),
+          } satisfies ProviderTurnStartResult;
+        }) as Effect.Effect<ProviderTurnStartResult, ProviderAdapterError>,
+
+      interruptTurn: (threadId, _turnId) =>
+        Effect.try({
+          try: () => {
+            manager.interruptTurn(String(threadId));
+          },
+          catch: (cause: unknown) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: String(threadId),
+              detail: toMessage(cause, "Failed to interrupt turn"),
+              cause: cause instanceof Error ? cause : undefined,
+            }),
+        }) as Effect.Effect<void, ProviderAdapterError>,
+
+      respondToRequest: (_threadId, _requestId, _decision) =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "respondToRequest",
+            detail:
+              "Gemini CLI does not support mid-turn approval requests. Use --approval-mode=yolo.",
+          }),
+        ) as Effect.Effect<void, ProviderAdapterError>,
+
+      respondToUserInput: (_threadId, _requestId, _answers) =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "respondToUserInput",
+            detail:
+              "Gemini CLI does not support mid-turn user input requests in headless mode.",
+          }),
+        ) as Effect.Effect<void, ProviderAdapterError>,
+
+      stopSession: (threadId) =>
+        Effect.sync(() => {
+          manager.stopSession(String(threadId));
+        }),
+
+      listSessions: () =>
+        Effect.sync(() => {
+          const now = nowIso();
+          return manager.listSessions().map((context): ProviderSession => {
+            const session: ProviderSession = {
+              provider: PROVIDER,
+              status: context.status === "stopped" ? "closed" : "ready",
+              runtimeMode: "full-access",
+              cwd: context.cwd,
+              model: context.model,
+              threadId: ThreadId.makeUnsafe(context.threadId),
+              createdAt: now,
+              updatedAt: now,
+            };
+            return context.geminiSessionId
+              ? Object.assign({}, session, {
+                  resumeCursor: { sessionId: context.geminiSessionId },
+                })
+              : session;
+          });
+        }),
+
+      hasSession: (threadId) => Effect.sync(() => manager.hasSession(String(threadId))),
+
+      readThread: (_threadId) =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "readThread",
+            detail: "Gemini CLI does not expose thread snapshots in headless mode.",
+          }),
+        ) as Effect.Effect<any, ProviderAdapterError>,
+
+      rollbackThread: (_threadId, _numTurns) =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "rollbackThread",
+            detail: "Gemini CLI does not support thread rollback in headless mode.",
+          }),
+        ) as Effect.Effect<any, ProviderAdapterError>,
+
+      stopAll: () =>
+        Effect.sync(() => {
+          manager.stopAll();
+        }),
+
+      streamEvents: Stream.fromQueue(eventQueue),
+    };
+
+    return adapter;
+  });
+
+export const GeminiAdapterLive = Layer.effect(GeminiAdapter, makeGeminiAdapter());
+
+export function makeGeminiAdapterLive() {
+  return Layer.effect(GeminiAdapter, makeGeminiAdapter());
+}

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -5,6 +5,7 @@ import { assertFailure } from "@effect/vitest/utils";
 import { Effect, Layer, Stream } from "effect";
 
 import { CodexAdapter, CodexAdapterShape } from "../Services/CodexAdapter.ts";
+import { GeminiAdapter, GeminiAdapterShape } from "../Services/GeminiAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderAdapterRegistryLive } from "./ProviderAdapterRegistry.ts";
 import { ProviderUnsupportedError } from "../Errors.ts";
@@ -27,11 +28,31 @@ const fakeCodexAdapter: CodexAdapterShape = {
   streamEvents: Stream.empty,
 };
 
+const fakeGeminiAdapter: GeminiAdapterShape = {
+  provider: "gemini",
+  capabilities: { sessionModelSwitch: "restart-session" },
+  startSession: vi.fn(),
+  sendTurn: vi.fn(),
+  interruptTurn: vi.fn(),
+  respondToRequest: vi.fn(),
+  respondToUserInput: vi.fn(),
+  stopSession: vi.fn(),
+  listSessions: vi.fn(),
+  hasSession: vi.fn(),
+  readThread: vi.fn(),
+  rollbackThread: vi.fn(),
+  stopAll: vi.fn(),
+  streamEvents: Stream.empty,
+};
+
 const layer = it.layer(
   Layer.mergeAll(
     Layer.provide(
       ProviderAdapterRegistryLive,
-      Layer.succeed(CodexAdapter, fakeCodexAdapter),
+      Layer.mergeAll(
+        Layer.succeed(CodexAdapter, fakeCodexAdapter),
+        Layer.succeed(GeminiAdapter, fakeGeminiAdapter),
+      ),
     ),
     NodeServices.layer,
   ),
@@ -45,7 +66,7 @@ layer("ProviderAdapterRegistryLive", (it) => {
       assert.equal(codex, fakeCodexAdapter);
 
       const providers = yield* registry.listProviders();
-      assert.deepEqual(providers, ["codex"]);
+      assert.deepEqual(providers, ["codex", "gemini"]);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -16,6 +16,7 @@ import {
   type ProviderAdapterRegistryShape,
 } from "../Services/ProviderAdapterRegistry.ts";
 import { CodexAdapter } from "../Services/CodexAdapter.ts";
+import { GeminiAdapter } from "../Services/GeminiAdapter.ts";
 
 export interface ProviderAdapterRegistryLiveOptions {
   readonly adapters?: ReadonlyArray<ProviderAdapterShape<ProviderAdapterError>>;
@@ -26,7 +27,7 @@ const makeProviderAdapterRegistry = (options?: ProviderAdapterRegistryLiveOption
     const adapters =
       options?.adapters !== undefined
         ? options.adapters
-        : [yield* CodexAdapter];
+        : [yield* CodexAdapter, yield* GeminiAdapter];
     const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));
 
     const getByProvider: ProviderAdapterRegistryShape["getByProvider"] = (provider) => {

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -1,212 +1,88 @@
 import assert from "node:assert/strict";
-import { it } from "@effect/vitest";
-import { Effect, Layer, Sink, Stream } from "effect";
-import * as PlatformError from "effect/PlatformError";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import { Effect } from "effect";
+import { afterEach, describe, it, vi } from "vitest";
 
-import { checkCodexProviderStatus, parseAuthStatusFromOutput } from "./ProviderHealth";
+import * as CliEnvironment from "../../cliEnvironment";
+import {
+  checkCodexProviderStatus,
+  checkGeminiProviderStatus,
+  parseAuthStatusFromOutput,
+} from "./ProviderHealth";
 
-// ── Test helpers ────────────────────────────────────────────────────
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
 
-const encoder = new TextEncoder();
+describe("ProviderHealth", () => {
+  it("returns ready when codex CLI is available", async () => {
+    vi.spyOn(CliEnvironment, "isCodexCliAvailable").mockReturnValue(true);
 
-function mockHandle(result: { stdout: string; stderr: string; code: number }) {
-  return ChildProcessSpawner.makeHandle({
-    pid: ChildProcessSpawner.ProcessId(1),
-    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(result.code)),
-    isRunning: Effect.succeed(false),
-    kill: () => Effect.void,
-    stdin: Sink.drain,
-    stdout: Stream.make(encoder.encode(result.stdout)),
-    stderr: Stream.make(encoder.encode(result.stderr)),
-    all: Stream.empty,
-    getInputFd: () => Sink.drain,
-    getOutputFd: () => Stream.empty,
-  });
-}
-
-function mockSpawnerLayer(
-  handler: (args: ReadonlyArray<string>) => { stdout: string; stderr: string; code: number },
-) {
-  return Layer.succeed(
-    ChildProcessSpawner.ChildProcessSpawner,
-    ChildProcessSpawner.make((command) => {
-      const cmd = command as unknown as { args: ReadonlyArray<string> };
-      return Effect.succeed(mockHandle(handler(cmd.args)));
-    }),
-  );
-}
-
-function failingSpawnerLayer(description: string) {
-  return Layer.succeed(
-    ChildProcessSpawner.ChildProcessSpawner,
-    ChildProcessSpawner.make(() =>
-      Effect.fail(
-        PlatformError.systemError({
-          _tag: "NotFound",
-          module: "ChildProcess",
-          method: "spawn",
-          description,
-        }),
-      ),
-    ),
-  );
-}
-
-// ── Tests ───────────────────────────────────────────────────────────
-
-it.effect("returns ready when codex is installed and authenticated", () =>
-  Effect.gen(function* () {
-    const status = yield* checkCodexProviderStatus;
+    const status = await Effect.runPromise(checkCodexProviderStatus);
     assert.strictEqual(status.provider, "codex");
     assert.strictEqual(status.status, "ready");
     assert.strictEqual(status.available, true);
-    assert.strictEqual(status.authStatus, "authenticated");
-  }).pipe(
-    Effect.provide(
-      mockSpawnerLayer((args) => {
-        const joined = args.join(" ");
-        if (joined === "--version") return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
-        if (joined === "login status") return { stdout: "Logged in\n", stderr: "", code: 0 };
-        throw new Error(`Unexpected args: ${joined}`);
-      }),
-    ),
-  ),
-);
+    assert.strictEqual(status.authStatus, "unknown");
+  });
 
-it.effect("returns unavailable when codex is missing", () =>
-  Effect.gen(function* () {
-    const status = yield* checkCodexProviderStatus;
+  it("returns unavailable when codex CLI is missing", async () => {
+    vi.spyOn(CliEnvironment, "isCodexCliAvailable").mockReturnValue(false);
+
+    const status = await Effect.runPromise(checkCodexProviderStatus);
     assert.strictEqual(status.provider, "codex");
     assert.strictEqual(status.status, "error");
     assert.strictEqual(status.available, false);
     assert.strictEqual(status.authStatus, "unknown");
     assert.strictEqual(status.message, "Codex CLI (`codex`) is not installed or not on PATH.");
-  }).pipe(Effect.provide(failingSpawnerLayer("spawn codex ENOENT"))),
-);
+  });
 
-it.effect("returns unavailable when codex is below the minimum supported version", () =>
-  Effect.gen(function* () {
-    const status = yield* checkCodexProviderStatus;
-    assert.strictEqual(status.provider, "codex");
-    assert.strictEqual(status.status, "error");
-    assert.strictEqual(status.available, false);
-    assert.strictEqual(status.authStatus, "unknown");
-    assert.strictEqual(
-      status.message,
-      "Codex CLI v0.36.0 is too old for T3 Code. Upgrade to v0.37.0 or newer and restart T3 Code.",
-    );
-  }).pipe(
-    Effect.provide(
-      mockSpawnerLayer((args) => {
-        const joined = args.join(" ");
-        if (joined === "--version") return { stdout: "codex 0.36.0\n", stderr: "", code: 0 };
-        throw new Error(`Unexpected args: ${joined}`);
-      }),
-    ),
-  ),
-);
+  it("returns ready when gemini CLI is available without forcing auth", async () => {
+    vi.spyOn(CliEnvironment, "isGeminiCliAvailable").mockReturnValue(true);
+    vi.stubEnv("GEMINI_API_KEY", "");
 
-it.effect("returns unauthenticated when auth probe reports login required", () =>
-  Effect.gen(function* () {
-    const status = yield* checkCodexProviderStatus;
-    assert.strictEqual(status.provider, "codex");
-    assert.strictEqual(status.status, "error");
-    assert.strictEqual(status.available, true);
-    assert.strictEqual(status.authStatus, "unauthenticated");
-    assert.strictEqual(
-      status.message,
-      "Codex CLI is not authenticated. Run `codex login` and try again.",
-    );
-  }).pipe(
-    Effect.provide(
-      mockSpawnerLayer((args) => {
-        const joined = args.join(" ");
-        if (joined === "--version") return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
-        if (joined === "login status") {
-          return { stdout: "", stderr: "Not logged in. Run codex login.", code: 1 };
-        }
-        throw new Error(`Unexpected args: ${joined}`);
-      }),
-    ),
-  ),
-);
-
-it.effect(
-  "returns unauthenticated when login status output includes 'not logged in'",
-  () =>
-    Effect.gen(function* () {
-      const status = yield* checkCodexProviderStatus;
-      assert.strictEqual(status.provider, "codex");
-      assert.strictEqual(status.status, "error");
-      assert.strictEqual(status.available, true);
-      assert.strictEqual(status.authStatus, "unauthenticated");
-      assert.strictEqual(
-        status.message,
-        "Codex CLI is not authenticated. Run `codex login` and try again.",
-      );
-    }).pipe(
-      Effect.provide(
-        mockSpawnerLayer((args) => {
-          const joined = args.join(" ");
-          if (joined === "--version") return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
-          if (joined === "login status")
-            return { stdout: "Not logged in\n", stderr: "", code: 1 };
-          throw new Error(`Unexpected args: ${joined}`);
-        }),
-      ),
-    ),
-);
-
-it.effect("returns warning when login status command is unsupported", () =>
-  Effect.gen(function* () {
-    const status = yield* checkCodexProviderStatus;
-    assert.strictEqual(status.provider, "codex");
-    assert.strictEqual(status.status, "warning");
+    const status = await Effect.runPromise(checkGeminiProviderStatus);
+    assert.strictEqual(status.provider, "gemini");
+    assert.strictEqual(status.status, "ready");
     assert.strictEqual(status.available, true);
     assert.strictEqual(status.authStatus, "unknown");
-    assert.strictEqual(
-      status.message,
-      "Codex CLI authentication status command is unavailable in this Codex version.",
-    );
-  }).pipe(
-    Effect.provide(
-      mockSpawnerLayer((args) => {
-        const joined = args.join(" ");
-        if (joined === "--version") return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
-        if (joined === "login status") {
-          return { stdout: "", stderr: "error: unknown command 'login'", code: 2 };
-        }
-        throw new Error(`Unexpected args: ${joined}`);
-      }),
-    ),
-  ),
-);
+  });
 
-// ── Pure function tests ─────────────────────────────────────────────
+  it("marks gemini as authenticated when GEMINI_API_KEY is present", async () => {
+    vi.spyOn(CliEnvironment, "isGeminiCliAvailable").mockReturnValue(true);
+    vi.stubEnv("GEMINI_API_KEY", "test-key");
 
-it("parseAuthStatusFromOutput: exit code 0 with no auth markers is ready", () => {
-  const parsed = parseAuthStatusFromOutput({ stdout: "OK\n", stderr: "", code: 0 });
-  assert.strictEqual(parsed.status, "ready");
-  assert.strictEqual(parsed.authStatus, "authenticated");
+    const status = await Effect.runPromise(checkGeminiProviderStatus);
+    assert.strictEqual(status.provider, "gemini");
+    assert.strictEqual(status.status, "ready");
+    assert.strictEqual(status.available, true);
+    assert.strictEqual(status.authStatus, "authenticated");
+  });
 });
 
-it("parseAuthStatusFromOutput: JSON with authenticated=false is unauthenticated", () => {
-  const parsed = parseAuthStatusFromOutput({
-    stdout: '[{"authenticated":false}]\n',
-    stderr: "",
-    code: 0,
+describe("parseAuthStatusFromOutput", () => {
+  it("treats exit code 0 with no auth markers as ready", () => {
+    const parsed = parseAuthStatusFromOutput({ stdout: "OK\n", stderr: "", code: 0 });
+    assert.strictEqual(parsed.status, "ready");
+    assert.strictEqual(parsed.authStatus, "authenticated");
   });
-  assert.strictEqual(parsed.status, "error");
-  assert.strictEqual(parsed.authStatus, "unauthenticated");
-});
 
-it("parseAuthStatusFromOutput: JSON without auth marker is warning", () => {
-  const parsed = parseAuthStatusFromOutput({
-    stdout: '[{"ok":true}]\n',
-    stderr: "",
-    code: 0,
+  it("detects authenticated=false in JSON", () => {
+    const parsed = parseAuthStatusFromOutput({
+      stdout: '[{"authenticated":false}]\n',
+      stderr: "",
+      code: 0,
+    });
+    assert.strictEqual(parsed.status, "error");
+    assert.strictEqual(parsed.authStatus, "unauthenticated");
   });
-  assert.strictEqual(parsed.status, "warning");
-  assert.strictEqual(parsed.authStatus, "unknown");
+
+  it("returns warning for JSON without auth markers", () => {
+    const parsed = parseAuthStatusFromOutput({
+      stdout: '[{"ok":true}]\n',
+      stderr: "",
+      code: 0,
+    });
+    assert.strictEqual(parsed.status, "warning");
+    assert.strictEqual(parsed.authStatus, "unknown");
+  });
 });

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -1,10 +1,12 @@
 /**
  * ProviderHealthLive - Startup-time provider health checks.
  *
- * Performs one-time provider readiness probes when the server starts and
+ * Performs one-time provider readiness checks when the server starts and
  * keeps the resulting snapshot in memory for `server.getConfig`.
  *
- * Uses effect's ChildProcessSpawner to run CLI probes natively.
+ * Startup checks must stay non-interactive. We only verify local CLI
+ * availability here and defer real authentication/runtime failures to the
+ * first provider session/turn.
  *
  * @module ProviderHealthLive
  */
@@ -13,20 +15,13 @@ import type {
   ServerProviderStatus,
   ServerProviderStatusState,
 } from "@t3tools/contracts";
-import { Effect, Layer, Option, Result, Stream } from "effect";
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { Effect, Layer } from "effect";
 
-import {
-  formatCodexCliUpgradeMessage,
-  isCodexCliVersionSupported,
-  parseCodexCliVersion,
-} from "../codexCliVersion";
+import { isCodexCliAvailable, isGeminiCliAvailable } from "../../cliEnvironment";
 import { ProviderHealth, type ProviderHealthShape } from "../Services/ProviderHealth";
 
-const DEFAULT_TIMEOUT_MS = 4_000;
 const CODEX_PROVIDER = "codex" as const;
-
-// ── Pure helpers ────────────────────────────────────────────────────
+const GEMINI_PROVIDER = "gemini" as const;
 
 export interface CommandResult {
   readonly stdout: string;
@@ -40,20 +35,7 @@ function nonEmptyTrimmed(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function isCommandMissingCause(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const lower = error.message.toLowerCase();
-  return (
-    lower.includes("command not found: codex") ||
-    lower.includes("spawn codex enoent") ||
-    lower.includes("enoent") ||
-    lower.includes("notfound")
-  );
-}
-
-function detailFromResult(
-  result: CommandResult & { readonly timedOut?: boolean },
-): string | undefined {
+function detailFromResult(result: CommandResult & { readonly timedOut?: boolean }): string | undefined {
   if (result.timedOut) return "Timed out while running command.";
   const stderr = nonEmptyTrimmed(result.stderr);
   if (stderr) return stderr;
@@ -167,154 +149,62 @@ export function parseAuthStatusFromOutput(result: CommandResult): {
   };
 }
 
-// ── Effect-native command execution ─────────────────────────────────
-
-const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
-  Stream.runFold(
-    stream,
-    () => "",
-    (acc, chunk) => acc + new TextDecoder().decode(chunk),
-  );
-
-const runCodexCommand = (args: ReadonlyArray<string>) =>
-  Effect.gen(function* () {
-    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const command = ChildProcess.make("codex", [...args], {
-      shell: process.platform === "win32",
-    });
-
-    const child = yield* spawner.spawn(command);
-
-    const [stdout, stderr, exitCode] = yield* Effect.all(
-      [
-        collectStreamAsString(child.stdout),
-        collectStreamAsString(child.stderr),
-        child.exitCode.pipe(Effect.map(Number)),
-      ],
-      { concurrency: "unbounded" },
-    );
-
-    return { stdout, stderr, code: exitCode } satisfies CommandResult;
-  }).pipe(Effect.scoped);
-
-// ── Health check ────────────────────────────────────────────────────
-
-export const checkCodexProviderStatus: Effect.Effect<
-  ServerProviderStatus,
-  never,
-  ChildProcessSpawner.ChildProcessSpawner
-> = Effect.gen(function* () {
+export const checkCodexProviderStatus: Effect.Effect<ServerProviderStatus, never> = Effect.sync(() => {
   const checkedAt = new Date().toISOString();
 
-  // Probe 1: `codex --version` — is the CLI reachable?
-  const versionProbe = yield* runCodexCommand(["--version"]).pipe(
-    Effect.timeoutOption(DEFAULT_TIMEOUT_MS),
-    Effect.result,
-  );
-
-  if (Result.isFailure(versionProbe)) {
-    const error = versionProbe.failure;
+  if (!isCodexCliAvailable()) {
     return {
       provider: CODEX_PROVIDER,
       status: "error" as const,
       available: false,
       authStatus: "unknown" as const,
       checkedAt,
-      message: isCommandMissingCause(error)
-        ? "Codex CLI (`codex`) is not installed or not on PATH."
-        : `Failed to execute Codex CLI health check: ${error instanceof Error ? error.message : String(error)}.`,
+      message: "Codex CLI (`codex`) is not installed or not on PATH.",
     };
   }
 
-  if (Option.isNone(versionProbe.success)) {
-    return {
-      provider: CODEX_PROVIDER,
-      status: "error" as const,
-      available: false,
-      authStatus: "unknown" as const,
-      checkedAt,
-      message: "Codex CLI is installed but failed to run. Timed out while running command.",
-    };
-  }
-
-  const version = versionProbe.success.value;
-  if (version.code !== 0) {
-    const detail = detailFromResult(version);
-    return {
-      provider: CODEX_PROVIDER,
-      status: "error" as const,
-      available: false,
-      authStatus: "unknown" as const,
-      checkedAt,
-      message: detail
-        ? `Codex CLI is installed but failed to run. ${detail}`
-        : "Codex CLI is installed but failed to run.",
-    };
-  }
-
-  const parsedVersion = parseCodexCliVersion(`${version.stdout}\n${version.stderr}`);
-  if (parsedVersion && !isCodexCliVersionSupported(parsedVersion)) {
-    return {
-      provider: CODEX_PROVIDER,
-      status: "error" as const,
-      available: false,
-      authStatus: "unknown" as const,
-      checkedAt,
-      message: formatCodexCliUpgradeMessage(parsedVersion),
-    };
-  }
-
-  // Probe 2: `codex login status` — is the user authenticated?
-  const authProbe = yield* runCodexCommand(["login", "status"]).pipe(
-    Effect.timeoutOption(DEFAULT_TIMEOUT_MS),
-    Effect.result,
-  );
-
-  if (Result.isFailure(authProbe)) {
-    const error = authProbe.failure;
-    return {
-      provider: CODEX_PROVIDER,
-      status: "warning" as const,
-      available: true,
-      authStatus: "unknown" as const,
-      checkedAt,
-      message:
-        error instanceof Error
-          ? `Could not verify Codex authentication status: ${error.message}.`
-          : "Could not verify Codex authentication status.",
-    };
-  }
-
-  if (Option.isNone(authProbe.success)) {
-    return {
-      provider: CODEX_PROVIDER,
-      status: "warning" as const,
-      available: true,
-      authStatus: "unknown" as const,
-      checkedAt,
-      message: "Could not verify Codex authentication status. Timed out while running command.",
-    };
-  }
-
-  const parsed = parseAuthStatusFromOutput(authProbe.success.value);
   return {
     provider: CODEX_PROVIDER,
-    status: parsed.status,
+    status: "ready" as const,
     available: true,
-    authStatus: parsed.authStatus,
+    authStatus: "unknown" as const,
     checkedAt,
-    ...(parsed.message ? { message: parsed.message } : {}),
   } satisfies ServerProviderStatus;
 });
 
-// ── Layer ───────────────────────────────────────────────────────────
+export const checkGeminiProviderStatus: Effect.Effect<ServerProviderStatus, never> = Effect.sync(() => {
+  const checkedAt = new Date().toISOString();
+
+  if (!isGeminiCliAvailable()) {
+    return {
+      provider: GEMINI_PROVIDER,
+      status: "error" as const,
+      available: false,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message: "Gemini CLI (`gemini`) is not installed or not on PATH.",
+    };
+  }
+
+  return {
+    provider: GEMINI_PROVIDER,
+    status: "ready" as const,
+    available: true,
+    authStatus: process.env.GEMINI_API_KEY ? "authenticated" : "unknown",
+    checkedAt,
+  };
+});
 
 export const ProviderHealthLive = Layer.effect(
   ProviderHealth,
   Effect.gen(function* () {
-    const codexStatus = yield* checkCodexProviderStatus;
+    const [codexStatus, geminiStatus] = yield* Effect.all(
+      [checkCodexProviderStatus, checkGeminiProviderStatus],
+      { concurrency: 2 },
+    );
+
     return {
-      getStatuses: Effect.succeed([codexStatus]),
+      getStatuses: Effect.succeed([codexStatus, geminiStatus]),
     } satisfies ProviderHealthShape;
   }),
 );

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts
@@ -204,4 +204,24 @@ it.layer(makeDirectoryLayer(SqlitePersistenceMemory))("ProviderSessionDirectoryL
 
       fs.rmSync(tempDir, { recursive: true, force: true });
     }));
+
+  it("accepts persisted gemini provider bindings", () =>
+    Effect.gen(function* () {
+      const directory = yield* ProviderSessionDirectory;
+      const threadId = ThreadId.makeUnsafe("thread-gemini");
+
+      yield* directory.upsert({
+        provider: "gemini",
+        threadId,
+      });
+
+      const provider = yield* directory.getProvider(threadId);
+      assert.equal(provider, "gemini");
+
+      const binding = yield* directory.getBinding(threadId);
+      assertSome(binding, {
+        threadId,
+        provider: "gemini",
+      });
+    }));
 });

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -25,7 +25,7 @@ function decodeProviderKind(
   providerName: string,
   operation: string,
 ): Effect.Effect<ProviderKind, ProviderSessionDirectoryPersistenceError> {
-  if (providerName === "codex") {
+  if (providerName === "codex" || providerName === "gemini") {
     return Effect.succeed(providerName);
   }
   return Effect.fail(

--- a/apps/server/src/provider/Services/GeminiAdapter.ts
+++ b/apps/server/src/provider/Services/GeminiAdapter.ts
@@ -1,0 +1,30 @@
+/**
+ * GeminiAdapter - Gemini implementation of the generic provider adapter contract.
+ *
+ * This service owns Gemini CLI headless process / JSONL streaming semantics
+ * and emits Gemini provider events. It does not perform cross-provider routing,
+ * shared event fan-out, or checkpoint orchestration.
+ *
+ * Uses Effect `ServiceMap.Service` for dependency injection and returns the
+ * shared provider-adapter error channel with `provider: "gemini"` context.
+ *
+ * @module GeminiAdapter
+ */
+import { ServiceMap } from "effect";
+
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * GeminiAdapterShape - Service API for the Gemini provider adapter.
+ */
+export interface GeminiAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {
+  readonly provider: "gemini";
+}
+
+/**
+ * GeminiAdapter - Service tag for Gemini provider adapter operations.
+ */
+export class GeminiAdapter extends ServiceMap.Service<GeminiAdapter, GeminiAdapterShape>()(
+  "t3/provider/Services/GeminiAdapter",
+) {}

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -19,6 +19,7 @@ import { OrchestrationProjectionSnapshotQueryLive } from "./orchestration/Layers
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion";
 import { ProviderUnsupportedError } from "./provider/Errors";
 import { makeCodexAdapterLive } from "./provider/Layers/CodexAdapter";
+import { makeGeminiAdapterLive } from "./provider/Layers/GeminiAdapter";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry";
 import { makeProviderServiceLive } from "./provider/Layers/ProviderService";
 import { ProviderSessionDirectoryLive } from "./provider/Layers/ProviderSessionDirectory";
@@ -57,8 +58,10 @@ export function makeServerProviderLayer(): Layer.Layer<
     const codexAdapterLayer = makeCodexAdapterLive(
       nativeEventLogger ? { nativeEventLogger } : undefined,
     );
+    const geminiAdapterLayer = makeGeminiAdapterLive();
     const adapterRegistryLayer = ProviderAdapterRegistryLive.pipe(
       Layer.provide(codexAdapterLayer),
+      Layer.provide(geminiAdapterLayer),
       Layer.provideMerge(providerSessionDirectoryLayer),
     );
     return makeProviderServiceLive(

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import {
   getAppModelOptions,
+  getCustomModelsForProvider,
   getSlashModelOptions,
   normalizeCustomModelSlugs,
+  patchCustomModelsForProvider,
   resolveAppServiceTier,
   shouldShowFastTierIcon,
   resolveAppModelSelection,
@@ -21,6 +23,16 @@ describe("normalizeCustomModelSlugs", () => {
         null,
       ]),
     ).toEqual(["custom/internal-model"]);
+  });
+
+  it("supports provider-specific Gemini custom models", () => {
+    const options = getAppModelOptions("gemini", ["gemini/internal-preview"]);
+
+    expect(options.at(-1)).toEqual({
+      slug: "gemini/internal-preview",
+      name: "gemini/internal-preview",
+      isCustom: true,
+    });
   });
 });
 
@@ -93,6 +105,26 @@ describe("resolveAppServiceTier", () => {
   it("preserves explicit service tier overrides", () => {
     expect(resolveAppServiceTier("fast")).toBe("fast");
     expect(resolveAppServiceTier("flex")).toBe("flex");
+  });
+});
+
+describe("provider-specific custom models", () => {
+  it("reads custom models for the requested provider", () => {
+    expect(
+      getCustomModelsForProvider(
+        {
+          customCodexModels: ["gpt-custom"],
+          customGeminiModels: ["gemini-custom"],
+        },
+        "gemini",
+      ),
+    ).toEqual(["gemini-custom"]);
+  });
+
+  it("patches the correct settings key for Gemini custom models", () => {
+    expect(patchCustomModelsForProvider("gemini", ["gemini-custom"])).toEqual({
+      customGeminiModels: ["gemini-custom"],
+    });
   });
 });
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -28,6 +28,7 @@ const AppServiceTierSchema = Schema.Literals(["auto", "fast", "flex"]);
 const MODELS_WITH_FAST_SUPPORT = new Set(["gpt-5.4"]);
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
+  gemini: new Set(getModelOptions("gemini").map((option) => option.slug)),
 };
 
 const AppSettingsSchema = Schema.Struct({
@@ -43,6 +44,9 @@ const AppSettingsSchema = Schema.Struct({
   ),
   codexServiceTier: AppServiceTierSchema.pipe(Schema.withConstructorDefault(() => Option.some("auto"))),
   customCodexModels: Schema.Array(Schema.String).pipe(
+    Schema.withConstructorDefault(() => Option.some([])),
+  ),
+  customGeminiModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
   ),
 });
@@ -108,7 +112,31 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
   return {
     ...settings,
     customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
+    customGeminiModels: normalizeCustomModelSlugs(settings.customGeminiModels, "gemini"),
   };
+}
+
+export function getCustomModelsForProvider(
+  settings: Pick<AppSettings, "customCodexModels" | "customGeminiModels">,
+  provider: ProviderKind,
+): readonly string[] {
+  switch (provider) {
+    case "gemini":
+      return settings.customGeminiModels;
+    case "codex":
+    default:
+      return settings.customCodexModels;
+  }
+}
+
+export function patchCustomModelsForProvider(provider: ProviderKind, models: string[]) {
+  switch (provider) {
+    case "gemini":
+      return { customGeminiModels: models } satisfies Partial<AppSettings>;
+    case "codex":
+    default:
+      return { customCodexModels: models } satisfies Partial<AppSettings>;
+  }
 }
 
 export function getAppModelOptions(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -73,6 +73,7 @@ import {
   type PendingApproval,
   type PendingUserInput,
   type ProviderPickerKind,
+  type WorkLogEntry,
   PROVIDER_OPTIONS,
   deriveWorkLogEntries,
   hasToolActivityForTurn,
@@ -103,17 +104,12 @@ import {
   MAX_THREAD_TERMINAL_COUNT,
   type ChatMessage,
   type Thread,
-  type TurnDiffFileChange,
   type TurnDiffSummary,
 } from "../types";
 import { basenameOfPath, getVscodeIconUrlForEntry } from "../vscode-icons";
 import { useTheme } from "../hooks/useTheme";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
-import {
-  buildTurnDiffTree,
-  summarizeTurnDiffStats,
-  type TurnDiffTreeNode,
-} from "../lib/turnDiffTree";
+import { summarizeTurnDiffStats } from "../lib/turnDiffTree";
 import BranchToolbar from "./BranchToolbar";
 import GitActionsControl from "./GitActionsControl";
 import {
@@ -200,6 +196,7 @@ import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import {
   getAppModelOptions,
+  getCustomModelsForProvider,
   resolveAppModelSelection,
   resolveAppServiceTier,
   shouldShowFastTierIcon,
@@ -218,6 +215,7 @@ import { selectThreadTerminalState, useTerminalStateStore } from "../terminalSta
 import { clamp } from "effect/Number";
 import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./ComposerPromptEditor";
 import { estimateTimelineMessageHeight } from "./timelineHeight";
+import { useThreadRunStateStore } from "../threadRunStateStore";
 
 function formatMessageMeta(createdAt: string, duration: string | null): string {
   if (!duration) return formatTimestamp(createdAt);
@@ -249,7 +247,6 @@ function formatWorkingTimer(startIso: string, endIso: string): string | null {
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
 const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
-const MAX_VISIBLE_WORK_LOG_ENTRIES = 6;
 const ALWAYS_UNVIRTUALIZED_TAIL_ROWS = 8;
 const ATTACHMENT_PREVIEW_HANDOFF_TTL_MS = 5000;
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
@@ -284,11 +281,29 @@ function readLastInvokedScriptByProjectFromStorage(): Record<string, string> {
   }
 }
 
-function workToneClass(tone: "thinking" | "tool" | "info" | "error"): string {
-  if (tone === "error") return "text-rose-300/50 dark:text-rose-300/50";
-  if (tone === "tool") return "text-muted-foreground/70";
-  if (tone === "thinking") return "text-muted-foreground/50";
-  return "text-muted-foreground/40";
+function providerDisplayName(provider: ProviderKind | null | undefined): string {
+  if (provider === "gemini") return "Gemini";
+  if (provider === "codex") return "Codex";
+  return "Assistant";
+}
+
+function summarizeActiveWorkEntry(entry: WorkLogEntry | null): { title: string; detail: string | null } {
+  if (!entry) {
+    return {
+      title: "Preparing response",
+      detail: null,
+    };
+  }
+
+  const title = entry.label.trim().length > 0 ? entry.label : "Working";
+  const detailSource =
+    entry.command ??
+    entry.detail ??
+    (entry.changedFiles && entry.changedFiles.length > 0
+      ? entry.changedFiles.slice(0, 3).join(", ")
+      : null);
+  const detail = detailSource?.trim().length ? detailSource.trim() : null;
+  return { title, detail };
 }
 
 function normalizePlanMarkdownForExport(planMarkdown: string): string {
@@ -643,7 +658,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
     Record<ThreadId, string | null>
   >({});
   const [sendPhase, setSendPhase] = useState<SendPhase>("idle");
-  const [sendStartedAt, setSendStartedAt] = useState<string | null>(null);
   const [isConnecting, _setIsConnecting] = useState(false);
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
   const [respondingRequestIds, setRespondingRequestIds] = useState<ApprovalRequestId[]>([]);
@@ -657,6 +671,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
     useState<Record<string, number>>({});
   const [expandedWorkGroups, setExpandedWorkGroups] = useState<Record<string, boolean>>({});
   const [nowTick, setNowTick] = useState(() => Date.now());
+  const [animatedAssistantMessageId, setAnimatedAssistantMessageId] = useState<MessageId | null>(
+    null,
+  );
   const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
   const [composerHighlightedItemId, setComposerHighlightedItemId] = useState<string | null>(null);
   const [attachmentPreviewHandoffByMessageId, setAttachmentPreviewHandoffByMessageId] = useState<
@@ -693,6 +710,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewHandoffTimeoutByMessageIdRef = useRef<Record<string, number>>({});
   const sendInFlightRef = useRef(false);
+  const previousWorkingRef = useRef(false);
   const dragDepthRef = useRef(0);
   const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
   const setMessagesScrollContainerRef = useCallback((element: HTMLDivElement | null) => {
@@ -709,6 +727,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const storeNewTerminal = useTerminalStateStore((s) => s.newTerminal);
   const storeSetActiveTerminal = useTerminalStateStore((s) => s.setActiveTerminal);
   const storeCloseTerminal = useTerminalStateStore((s) => s.closeTerminal);
+  const optimisticThreadRun = useThreadRunStateStore(
+    (state) => state.pendingRunByThreadId[threadId] ?? null,
+  );
+  const startPendingRun = useThreadRunStateStore((state) => state.startPendingRun);
+  const clearPendingRun = useThreadRunStateStore((state) => state.clearPendingRun);
 
   const setPrompt = useCallback(
     (nextPrompt: string) => {
@@ -803,7 +826,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     selectedProvider,
     activeThread?.model ?? activeProject?.model ?? getDefaultModel(selectedProvider),
   );
-  const customModelsForSelectedProvider = settings.customCodexModels;
+  const customModelsForSelectedProvider = getCustomModelsForProvider(settings, selectedProvider);
   const selectedModel = useMemo(() => {
     const draftModel = composerDraft.model;
     if (!draftModel) {
@@ -861,12 +884,18 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const phase = derivePhase(activeThread?.session ?? null);
   const isSendBusy = sendPhase !== "idle";
   const isPreparingWorktree = sendPhase === "preparing-worktree";
-  const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const isPendingThreadRun = optimisticThreadRun !== null;
+  const isWorking =
+    phase === "running" ||
+    isPendingThreadRun ||
+    isSendBusy ||
+    isConnecting ||
+    isRevertingCheckpoint;
   const nowIso = new Date(nowTick).toISOString();
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
     activeThread?.session ?? null,
-    sendStartedAt,
+    optimisticThreadRun?.startedAt ?? null,
   );
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
   const workLogEntries = useMemo(
@@ -938,6 +967,33 @@ export default function ChatView({ threadId }: ChatViewProps) {
     activeProposedPlan !== null;
   const activePendingApproval = pendingApprovals[0] ?? null;
   const isComposerApprovalState = activePendingApproval !== null;
+  const activeAssistantLabel = providerDisplayName(activeThread?.session?.provider ?? selectedProvider);
+  const activeWorkEntry = workLogEntries.at(-1) ?? null;
+  const activeWorkSummary = useMemo(() => {
+    if (activeWorkEntry) {
+      return summarizeActiveWorkEntry(activeWorkEntry);
+    }
+    if (optimisticThreadRun?.phase === "preparing-worktree") {
+      return {
+        title: "Preparing workspace",
+        detail: "Creating and configuring an isolated worktree before the turn starts.",
+      };
+    }
+    if (optimisticThreadRun?.phase === "sending-turn") {
+      return {
+        title: "Starting turn",
+        detail: "Handing the request to the provider and waiting for live events.",
+      };
+    }
+    return summarizeActiveWorkEntry(null);
+  }, [activeWorkEntry, optimisticThreadRun?.phase]);
+  const composerLocked =
+    isConnecting ||
+    isPendingThreadRun ||
+    isComposerApprovalState ||
+    phase === "running" ||
+    isSendBusy ||
+    isRevertingCheckpoint;
   const hasComposerHeader =
     isComposerApprovalState ||
     pendingUserInputs.length > 0 ||
@@ -1138,6 +1194,20 @@ export default function ChatView({ threadId }: ChatViewProps) {
     latestTurnHasToolActivity,
     latestTurnSettled,
   ]);
+  const latestCompletedAssistantMessage = useMemo(
+    () =>
+      timelineMessages
+        .toReversed()
+        .find((message) => message.role === "assistant" && !message.streaming) ?? null,
+    [timelineMessages],
+  );
+  useEffect(() => {
+    const wasWorking = previousWorkingRef.current;
+    if (wasWorking && !isWorking && latestCompletedAssistantMessage?.id) {
+      setAnimatedAssistantMessageId(latestCompletedAssistantMessage.id);
+    }
+    previousWorkingRef.current = isWorking;
+  }, [isWorking, latestCompletedAssistantMessage?.id]);
   const completionDividerBeforeEntryId = useMemo(() => {
     if (!latestTurnSettled) return null;
     if (!activeLatestTurn?.startedAt) return null;
@@ -1973,14 +2043,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
       return [];
     });
     setSendPhase("idle");
-    setSendStartedAt(null);
+    clearPendingRun(threadId);
     setComposerHighlightedItemId(null);
     setComposerCursor(promptRef.current.length);
     setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
     dragDepthRef.current = 0;
     setIsDragOverComposer(false);
     setExpandedImage(null);
-  }, [threadId]);
+  }, [clearPendingRun, threadId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -2104,24 +2174,31 @@ export default function ChatView({ threadId }: ChatViewProps) {
       : "local";
 
   useEffect(() => {
-    if (phase !== "running") return;
+    if (!isWorking) return;
     const timer = window.setInterval(() => {
       setNowTick(Date.now());
     }, 1000);
     return () => {
       window.clearInterval(timer);
     };
-  }, [phase]);
+  }, [isWorking]);
 
   const beginSendPhase = useCallback((nextPhase: Exclude<SendPhase, "idle">) => {
-    setSendStartedAt((current) => current ?? new Date().toISOString());
+    if (!activeThreadId) return;
+    startPendingRun(activeThreadId, {
+      phase: nextPhase,
+      provider: selectedProvider,
+      startedAt: new Date().toISOString(),
+    });
     setSendPhase(nextPhase);
-  }, []);
+  }, [activeThreadId, selectedProvider, startPendingRun]);
 
   const resetSendPhase = useCallback(() => {
     setSendPhase("idle");
-    setSendStartedAt(null);
-  }, []);
+    if (activeThreadId) {
+      clearPendingRun(activeThreadId);
+    }
+  }, [activeThreadId, clearPendingRun]);
 
   useEffect(() => {
     if (sendPhase === "idle") {
@@ -2398,7 +2475,17 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const onSend = async (e?: { preventDefault: () => void }) => {
     e?.preventDefault();
     const api = readNativeApi();
-    if (!api || !activeThread || isSendBusy || isConnecting || sendInFlightRef.current) return;
+    if (
+      !api ||
+      !activeThread ||
+      phase === "running" ||
+      isPendingThreadRun ||
+      isSendBusy ||
+      isConnecting ||
+      sendInFlightRef.current
+    ) {
+      return;
+    }
     if (activePendingProgress) {
       onAdvanceActivePendingUserInput();
       return;
@@ -2626,7 +2713,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         ...(selectedModelOptionsForDispatch
           ? { modelOptions: selectedModelOptionsForDispatch }
           : {}),
-        provider: selectedProvider,
+        ...(isFirstMessage ? { provider: selectedProvider } : {}),
         assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
         runtimeMode,
         interactionMode,
@@ -2843,6 +2930,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         !api ||
         !activeThread ||
         !isServerThread ||
+        isPendingThreadRun ||
         isSendBusy ||
         isConnecting ||
         sendInFlightRef.current
@@ -2898,7 +2986,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
             text: trimmed,
             attachments: [],
           },
-          provider: selectedProvider,
           model: selectedModel || undefined,
           ...(selectedModelOptionsForDispatch
             ? { modelOptions: selectedModelOptionsForDispatch }
@@ -2926,6 +3013,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       beginSendPhase,
       forceStickToBottom,
       isConnecting,
+      isPendingThreadRun,
       isSendBusy,
       isServerThread,
       persistThreadSettingsForNextTurn,
@@ -2933,7 +3021,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
       runtimeMode,
       selectedModel,
       selectedModelOptionsForDispatch,
-      selectedProvider,
       setComposerDraftInteractionMode,
       setThreadError,
       settings.enableAssistantStreaming,
@@ -2946,11 +3033,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
       !api ||
       !activeThread ||
       !activeProject ||
-      !activeProposedPlan ||
-      !isServerThread ||
-      isSendBusy ||
-      isConnecting ||
-      sendInFlightRef.current
+        !activeProposedPlan ||
+        !isServerThread ||
+        isPendingThreadRun ||
+        isSendBusy ||
+        isConnecting ||
+        sendInFlightRef.current
     ) {
       return;
     }
@@ -3045,6 +3133,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     activeThread,
     beginSendPhase,
     isConnecting,
+    isPendingThreadRun,
     isSendBusy,
     isServerThread,
     navigate,
@@ -3067,7 +3156,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setComposerDraftProvider(activeThread.id, provider);
       setComposerDraftModel(
         activeThread.id,
-        resolveAppModelSelection(provider, settings.customCodexModels, model),
+        resolveAppModelSelection(provider, getCustomModelsForProvider(settings, provider), model),
       );
       scheduleComposerFocus();
     },
@@ -3077,7 +3166,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       scheduleComposerFocus,
       setComposerDraftModel,
       setComposerDraftProvider,
-      settings.customCodexModels,
+      settings,
     ],
   );
   const onEffortSelect = useCallback(
@@ -3436,10 +3525,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
           isWorking={isWorking}
           activeTurnInProgress={isWorking || !latestTurnSettled}
           activeTurnStartedAt={activeWorkStartedAt}
+          activeAssistantLabel={activeAssistantLabel}
+          activeWorkSummary={activeWorkSummary}
+          liveWorkEntries={workLogEntries}
+          optimisticRunPhase={optimisticThreadRun?.phase ?? null}
           scrollContainer={messagesScrollElement}
           timelineEntries={timelineEntries}
           completionDividerBeforeEntryId={completionDividerBeforeEntryId}
           completionSummary={completionSummary}
+          animatedAssistantMessageId={animatedAssistantMessageId}
+          onAnimatedAssistantMessageComplete={() => setAnimatedAssistantMessageId(null)}
           turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
           nowIso={nowIso}
           expandedWorkGroups={expandedWorkGroups}
@@ -3450,7 +3545,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
           isRevertingCheckpoint={isRevertingCheckpoint}
           onImageExpand={onExpandTimelineImage}
           markdownCwd={gitCwd ?? undefined}
-          resolvedTheme={resolvedTheme}
           workspaceRoot={activeProject?.cwd ?? undefined}
         />
       </div>
@@ -3607,7 +3701,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                         ? "Ask for follow-up changes or attach images"
                         : "Ask anything, @tag files/folders, or use /model"
                 }
-                disabled={isConnecting || isComposerApprovalState}
+                disabled={composerLocked}
               />
             </div>
 
@@ -4383,134 +4477,6 @@ const DiffStatLabel = memo(function DiffStatLabel(props: {
   );
 });
 
-function collectDirectoryPaths(nodes: ReadonlyArray<TurnDiffTreeNode>): string[] {
-  const paths: string[] = [];
-  for (const node of nodes) {
-    if (node.kind !== "directory") continue;
-    paths.push(node.path);
-    paths.push(...collectDirectoryPaths(node.children));
-  }
-  return paths;
-}
-
-function buildDirectoryExpansionState(
-  directoryPaths: ReadonlyArray<string>,
-  expanded: boolean,
-): Record<string, boolean> {
-  const expandedState: Record<string, boolean> = {};
-  for (const directoryPath of directoryPaths) {
-    expandedState[directoryPath] = expanded;
-  }
-  return expandedState;
-}
-
-const ChangedFilesTree = memo(function ChangedFilesTree(props: {
-  turnId: TurnId;
-  files: ReadonlyArray<TurnDiffFileChange>;
-  allDirectoriesExpanded: boolean;
-  resolvedTheme: "light" | "dark";
-  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
-}) {
-  const { files, allDirectoriesExpanded, onOpenTurnDiff, resolvedTheme, turnId } = props;
-  const treeNodes = useMemo(() => buildTurnDiffTree(files), [files]);
-  const directoryPathsKey = useMemo(
-    () => collectDirectoryPaths(treeNodes).join("\u0000"),
-    [treeNodes],
-  );
-  const allDirectoryExpansionState = useMemo(
-    () =>
-      buildDirectoryExpansionState(
-        directoryPathsKey ? directoryPathsKey.split("\u0000") : [],
-        allDirectoriesExpanded,
-      ),
-    [allDirectoriesExpanded, directoryPathsKey],
-  );
-  const [expandedDirectories, setExpandedDirectories] = useState<Record<string, boolean>>(() =>
-    buildDirectoryExpansionState(directoryPathsKey ? directoryPathsKey.split("\u0000") : [], true),
-  );
-  useEffect(() => {
-    setExpandedDirectories(allDirectoryExpansionState);
-  }, [allDirectoryExpansionState]);
-
-  const toggleDirectory = useCallback((pathValue: string, fallbackExpanded: boolean) => {
-    setExpandedDirectories((current) => ({
-      ...current,
-      [pathValue]: !(current[pathValue] ?? fallbackExpanded),
-    }));
-  }, []);
-
-  const renderTreeNode = (node: TurnDiffTreeNode, depth: number) => {
-    const leftPadding = 8 + depth * 14;
-    if (node.kind === "directory") {
-      const isExpanded = expandedDirectories[node.path] ?? depth === 0;
-      return (
-        <div key={`dir:${node.path}`}>
-          <button
-            type="button"
-            className="group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80"
-            style={{ paddingLeft: `${leftPadding}px` }}
-            onClick={() => toggleDirectory(node.path, depth === 0)}
-          >
-            <ChevronRightIcon
-              aria-hidden="true"
-              className={cn(
-                "size-3.5 shrink-0 text-muted-foreground/70 transition-transform group-hover:text-foreground/80",
-                isExpanded && "rotate-90",
-              )}
-            />
-            {isExpanded ? (
-              <FolderIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
-            ) : (
-              <FolderClosedIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
-            )}
-            <span className="truncate font-mono text-[11px] text-muted-foreground/90 group-hover:text-foreground/90">
-              {node.name}
-            </span>
-            {hasNonZeroStat(node.stat) && (
-              <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums">
-                <DiffStatLabel additions={node.stat.additions} deletions={node.stat.deletions} />
-              </span>
-            )}
-          </button>
-          {isExpanded && (
-            <div className="space-y-0.5">
-              {node.children.map((childNode) => renderTreeNode(childNode, depth + 1))}
-            </div>
-          )}
-        </div>
-      );
-    }
-
-    return (
-      <button
-        key={`file:${node.path}`}
-        type="button"
-        className="group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80"
-        style={{ paddingLeft: `${leftPadding}px` }}
-        onClick={() => onOpenTurnDiff(turnId, node.path)}
-      >
-        <span aria-hidden="true" className="size-3.5 shrink-0" />
-        <VscodeEntryIcon
-          pathValue={node.path}
-          kind="file"
-          theme={resolvedTheme}
-          className="size-3.5 text-muted-foreground/70"
-        />
-        <span className="truncate font-mono text-[11px] text-muted-foreground/80 group-hover:text-foreground/90">
-          {node.name}
-        </span>
-        {node.stat && (
-          <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums">
-            <DiffStatLabel additions={node.stat.additions} deletions={node.stat.deletions} />
-          </span>
-        )}
-      </button>
-    );
-  };
-
-  return <div className="space-y-0.5">{treeNodes.map((node) => renderTreeNode(node, 0))}</div>;
-});
-
 const ProposedPlanCard = memo(function ProposedPlanCard({
   planMarkdown,
   cwd,
@@ -4687,10 +4653,16 @@ interface MessagesTimelineProps {
   isWorking: boolean;
   activeTurnInProgress: boolean;
   activeTurnStartedAt: string | null;
+  activeAssistantLabel: string;
+  activeWorkSummary: { title: string; detail: string | null };
+  liveWorkEntries: ReadonlyArray<WorkLogEntry>;
+  optimisticRunPhase: "sending-turn" | "preparing-worktree" | null;
   scrollContainer: HTMLDivElement | null;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
   completionDividerBeforeEntryId: string | null;
   completionSummary: string | null;
+  animatedAssistantMessageId: MessageId | null;
+  onAnimatedAssistantMessageComplete: () => void;
   turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
   nowIso: string;
   expandedWorkGroups: Record<string, boolean>;
@@ -4701,7 +4673,6 @@ interface MessagesTimelineProps {
   isRevertingCheckpoint: boolean;
   onImageExpand: (preview: ExpandedImagePreview) => void;
   markdownCwd: string | undefined;
-  resolvedTheme: "light" | "dark";
   workspaceRoot: string | undefined;
 }
 
@@ -4713,8 +4684,8 @@ type TimelineRow =
   | {
       kind: "work";
       id: string;
-      createdAt: string;
-      groupedEntries: TimelineWorkEntry[];
+      createdAt: string | null;
+      groupedEntries: ReadonlyArray<TimelineWorkEntry>;
     }
   | {
       kind: "message";
@@ -4722,6 +4693,7 @@ type TimelineRow =
       createdAt: string;
       message: TimelineMessage;
       showCompletionDivider: boolean;
+      changedFilesSummary: TurnDiffSummary | null;
     }
   | {
       kind: "proposed-plan";
@@ -4730,6 +4702,240 @@ type TimelineRow =
       proposedPlan: TimelineProposedPlan;
     }
   | { kind: "working"; id: string; createdAt: string | null };
+
+const AnimatedActivityText = memo(function AnimatedActivityText(props: {
+  text: string;
+  className?: string;
+}) {
+  const { text, className } = props;
+  const [visibleLength, setVisibleLength] = useState(text.length > 0 ? 1 : 0);
+
+  useEffect(() => {
+    setVisibleLength(text.length > 0 ? 1 : 0);
+  }, [text]);
+
+  useEffect(() => {
+    if (visibleLength >= text.length) {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      setVisibleLength((current) => Math.min(text.length, current + Math.max(1, Math.ceil(text.length / 24))));
+    }, 22);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [text.length, visibleLength]);
+
+  return <span className={className}>{text.slice(0, visibleLength)}</span>;
+});
+
+const CompactActivityStrip = memo(function CompactActivityStrip(props: {
+  assistantLabel: string;
+  title: string;
+  detail: string | null;
+  statusLabel: string;
+  elapsed: string | null;
+  entries: ReadonlyArray<TimelineWorkEntry>;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+}) {
+  const { assistantLabel, title, detail, statusLabel, elapsed, entries, expanded, onToggleExpanded } = props;
+  const eventCount = entries.length;
+  const canExpand = eventCount > 1 || Boolean(detail) || entries.some((entry) => entry.command || entry.detail);
+  const visibleEntries = expanded ? entries : entries.slice(-3);
+
+  return (
+    <div className="rounded-2xl border border-border/80 bg-card/45 px-4 py-3 shadow-sm">
+      <div className="flex items-start gap-3">
+        <span className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-full border border-border/70 bg-background/80 text-muted-foreground/75">
+          <BotIcon className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-sm font-medium text-foreground/92">{assistantLabel} is working</p>
+            <span className="rounded-full border border-border/70 bg-background/70 px-2 py-0.5 text-[10px] text-muted-foreground/72">
+              {statusLabel}
+            </span>
+            {elapsed ? (
+              <span className="text-[11px] text-muted-foreground/58">{elapsed}</span>
+            ) : null}
+          </div>
+          <div className="mt-1 flex min-w-0 items-center gap-2">
+            <span className="inline-flex items-center gap-[4px] text-muted-foreground/55" aria-hidden="true">
+              <span className="h-1.5 w-1.5 rounded-full bg-current animate-pulse" />
+              <span className="h-1.5 w-1.5 rounded-full bg-current animate-pulse [animation-delay:180ms]" />
+              <span className="h-1.5 w-1.5 rounded-full bg-current animate-pulse [animation-delay:360ms]" />
+            </span>
+            <AnimatedActivityText
+              text={detail ? `${title} — ${detail}` : title}
+              className="min-w-0 truncate text-sm leading-relaxed text-foreground/84"
+            />
+          </div>
+          {canExpand ? (
+            <div className="mt-2">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 text-[11px] text-muted-foreground/60 transition-colors hover:text-muted-foreground/85"
+                onClick={onToggleExpanded}
+              >
+                <ChevronDownIcon
+                  className={cn("size-3 transition-transform duration-150", expanded ? "rotate-180" : "")}
+                />
+                {expanded ? "Hide activity" : `${eventCount} live event${eventCount === 1 ? "" : "s"}`}
+              </button>
+            </div>
+          ) : null}
+          {expanded ? (
+            <div className="mt-2 space-y-1.5 border-t border-border/65 pt-2">
+              {visibleEntries.map((entry) => (
+                <div key={entry.id} className="flex items-start gap-2 text-[11px] leading-relaxed">
+                  <span className="mt-[6px] h-1 w-1 shrink-0 rounded-full bg-muted-foreground/35" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-muted-foreground/86">{entry.label}</p>
+                    {entry.command ? (
+                      <p className="truncate font-mono text-muted-foreground/66" title={entry.command}>
+                        {entry.command}
+                      </p>
+                    ) : entry.detail ? (
+                      <p className="truncate text-muted-foreground/62" title={entry.detail}>
+                        {entry.detail}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+const CompactChangedFilesSummary = memo(function CompactChangedFilesSummary(props: {
+  turnSummary: TurnDiffSummary;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+}) {
+  const { turnSummary, expanded, onToggleExpanded, onOpenTurnDiff } = props;
+  const summaryStat = summarizeTurnDiffStats(turnSummary.files);
+  const visibleFiles = expanded ? turnSummary.files : turnSummary.files.slice(0, 3);
+
+  return (
+    <div className="mt-3 overflow-hidden rounded-xl border border-border/75 bg-card/40">
+      <div className="flex items-center justify-between gap-3 px-3 py-2 text-[11px]">
+        <button
+          type="button"
+          className="inline-flex min-w-0 items-center gap-2 text-left text-foreground/82 transition-colors hover:text-foreground"
+          onClick={onToggleExpanded}
+        >
+          <span>{turnSummary.files.length} file{turnSummary.files.length === 1 ? "" : "s"} changed</span>
+          {hasNonZeroStat(summaryStat) ? (
+            <span className="font-mono tabular-nums">
+              <DiffStatLabel additions={summaryStat.additions} deletions={summaryStat.deletions} />
+            </span>
+          ) : null}
+          <ChevronDownIcon
+            className={cn("size-3 shrink-0 transition-transform duration-150", expanded ? "rotate-180" : "")}
+          />
+        </button>
+        <Button
+          type="button"
+          size="xs"
+          variant="ghost"
+          onClick={() => onOpenTurnDiff(turnSummary.turnId, turnSummary.files[0]?.path)}
+        >
+          View diff
+        </Button>
+      </div>
+      <div className="divide-y divide-border/60 border-t border-border/60">
+        {visibleFiles.map((file) => (
+          (() => {
+            const additions = file.additions ?? 0;
+            const deletions = file.deletions ?? 0;
+            return (
+              <button
+                key={`${turnSummary.turnId}:${file.path}`}
+                type="button"
+                className="flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-background/40"
+                onClick={() => onOpenTurnDiff(turnSummary.turnId, file.path)}
+              >
+                <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-foreground/84">
+                  {file.path}
+                </span>
+                {hasNonZeroStat({ additions, deletions }) ? (
+                  <span className="shrink-0 font-mono text-[11px] tabular-nums">
+                    <DiffStatLabel additions={additions} deletions={deletions} />
+                  </span>
+                ) : null}
+              </button>
+            );
+          })()
+        ))}
+        {!expanded && turnSummary.files.length > visibleFiles.length ? (
+          <button
+            type="button"
+            className="w-full px-3 py-2 text-left text-[11px] text-muted-foreground/62 transition-colors hover:bg-background/40 hover:text-muted-foreground/85"
+            onClick={onToggleExpanded}
+          >
+            Show {turnSummary.files.length - visibleFiles.length} more files
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+});
+
+
+const AnimatedAssistantMessage = memo(function AnimatedAssistantMessage({
+  message,
+  cwd,
+  animate,
+  onComplete,
+}: {
+  message: TimelineMessage;
+  cwd: string | undefined;
+  animate: boolean;
+  onComplete: () => void;
+}) {
+  const targetText = message.text || "(empty response)";
+  const [visibleLength, setVisibleLength] = useState(
+    animate ? Math.min(Math.max(10, Math.ceil(targetText.length * 0.08)), targetText.length) : targetText.length,
+  );
+
+  useEffect(() => {
+    if (!animate) {
+      setVisibleLength(targetText.length);
+      return;
+    }
+    const initialLength = Math.min(Math.max(10, Math.ceil(targetText.length * 0.08)), targetText.length);
+    setVisibleLength(initialLength);
+  }, [animate, targetText.length]);
+
+  useEffect(() => {
+    if (!animate) return;
+    if (visibleLength >= targetText.length) {
+      onComplete();
+      return;
+    }
+    const step = Math.max(8, Math.ceil(targetText.length / 28));
+    const timeout = window.setTimeout(() => {
+      setVisibleLength((current) => Math.min(targetText.length, current + step));
+    }, 20);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [animate, onComplete, targetText.length, visibleLength]);
+
+  return (
+    <ChatMarkdown
+      text={animate ? targetText.slice(0, visibleLength) : targetText}
+      cwd={cwd}
+      isStreaming={Boolean(message.streaming) || (animate && visibleLength < targetText.length)}
+    />
+  );
+});
 
 function estimateTimelineProposedPlanHeight(proposedPlan: TimelineProposedPlan): number {
   const estimatedLines = Math.max(1, Math.ceil(proposedPlan.planMarkdown.length / 72));
@@ -4741,10 +4947,16 @@ const MessagesTimeline = memo(function MessagesTimeline({
   isWorking,
   activeTurnInProgress,
   activeTurnStartedAt,
+  activeAssistantLabel,
+  activeWorkSummary,
+  liveWorkEntries,
+  optimisticRunPhase,
   scrollContainer,
   timelineEntries,
   completionDividerBeforeEntryId,
   completionSummary,
+  animatedAssistantMessageId,
+  onAnimatedAssistantMessageComplete,
   turnDiffSummaryByAssistantMessageId,
   nowIso,
   expandedWorkGroups,
@@ -4755,7 +4967,6 @@ const MessagesTimeline = memo(function MessagesTimeline({
   isRevertingCheckpoint,
   onImageExpand,
   markdownCwd,
-  resolvedTheme,
   workspaceRoot,
 }: MessagesTimelineProps) {
   const timelineRootRef = useRef<HTMLDivElement | null>(null);
@@ -4796,21 +5007,6 @@ const MessagesTimeline = memo(function MessagesTimeline({
       }
 
       if (timelineEntry.kind === "work") {
-        const groupedEntries = [timelineEntry.entry];
-        let cursor = index + 1;
-        while (cursor < timelineEntries.length) {
-          const nextEntry = timelineEntries[cursor];
-          if (!nextEntry || nextEntry.kind !== "work") break;
-          groupedEntries.push(nextEntry.entry);
-          cursor += 1;
-        }
-        nextRows.push({
-          kind: "work",
-          id: timelineEntry.id,
-          createdAt: timelineEntry.createdAt,
-          groupedEntries,
-        });
-        index = cursor - 1;
         continue;
       }
 
@@ -4832,19 +5028,40 @@ const MessagesTimeline = memo(function MessagesTimeline({
         showCompletionDivider:
           timelineEntry.message.role === "assistant" &&
           completionDividerBeforeEntryId === timelineEntry.id,
+        changedFilesSummary:
+          timelineEntry.message.role === "assistant"
+            ? (turnDiffSummaryByAssistantMessageId.get(timelineEntry.message.id) ?? null)
+            : null,
       });
     }
 
-    if (isWorking) {
-      nextRows.push({
-        kind: "working",
-        id: "working-indicator-row",
-        createdAt: activeTurnStartedAt,
-      });
+    if (activeTurnInProgress) {
+      if (liveWorkEntries.length > 0) {
+        nextRows.push({
+          kind: "work",
+          id: `live-work:${liveWorkEntries.at(-1)?.id ?? "current"}`,
+          createdAt: liveWorkEntries[0]?.createdAt ?? activeTurnStartedAt ?? null,
+          groupedEntries: liveWorkEntries,
+        });
+      } else if (isWorking) {
+        nextRows.push({
+          kind: "working",
+          id: "working-indicator-row",
+          createdAt: activeTurnStartedAt,
+        });
+      }
     }
 
     return nextRows;
-  }, [timelineEntries, completionDividerBeforeEntryId, isWorking, activeTurnStartedAt]);
+  }, [
+    timelineEntries,
+    completionDividerBeforeEntryId,
+    activeTurnInProgress,
+    isWorking,
+    activeTurnStartedAt,
+    liveWorkEntries,
+    turnDiffSummaryByAssistantMessageId,
+  ]);
 
   const firstUnvirtualizedRowIndex = useMemo(() => {
     const firstTailRowIndex = Math.max(rows.length - ALWAYS_UNVIRTUALIZED_TAIL_ROWS, 0);
@@ -4899,7 +5116,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
       if (!row) return 96;
       if (row.kind === "work") return 112;
       if (row.kind === "proposed-plan") return estimateTimelineProposedPlanHeight(row.proposedPlan);
-      if (row.kind === "working") return 40;
+      if (row.kind === "working") return 132;
       return estimateTimelineMessageHeight(row.message, { timelineWidthPx });
     },
     measureElement: measureVirtualElement,
@@ -4940,15 +5157,6 @@ const MessagesTimeline = memo(function MessagesTimeline({
 
   const virtualRows = rowVirtualizer.getVirtualItems();
   const nonVirtualizedRows = rows.slice(virtualizedRowCount);
-  const [allDirectoriesExpandedByTurnId, setAllDirectoriesExpandedByTurnId] = useState<
-    Record<string, boolean>
-  >({});
-  const onToggleAllDirectories = useCallback((turnId: TurnId) => {
-    setAllDirectoriesExpandedByTurnId((current) => ({
-      ...current,
-      [turnId]: !(current[turnId] ?? true),
-    }));
-  }, []);
 
   const renderRowContent = (row: TimelineRow) => (
     <div
@@ -4962,82 +5170,27 @@ const MessagesTimeline = memo(function MessagesTimeline({
           const groupId = row.id;
           const groupedEntries = row.groupedEntries;
           const isExpanded = expandedWorkGroups[groupId] ?? false;
-          const hasOverflow = groupedEntries.length > MAX_VISIBLE_WORK_LOG_ENTRIES;
-          const visibleEntries =
-            hasOverflow && !isExpanded
-              ? groupedEntries.slice(-MAX_VISIBLE_WORK_LOG_ENTRIES)
-              : groupedEntries;
-          const hiddenCount = groupedEntries.length - visibleEntries.length;
-          const onlyToolEntries = groupedEntries.every((entry) => entry.tone === "tool");
-          const groupLabel = onlyToolEntries
-            ? groupedEntries.length === 1
-              ? "Tool call"
-              : `Tool calls (${groupedEntries.length})`
-            : groupedEntries.length === 1
-              ? "Work event"
-              : `Work log (${groupedEntries.length})`;
+          const latestEntry = groupedEntries.at(-1) ?? null;
+          const status = latestEntry?.tone === "error" ? "Attention" : "Live";
+          const elapsed =
+            row.createdAt !== null ? formatWorkingTimer(row.createdAt, nowIso) : null;
 
           return (
-            <div className="rounded-lg border border-border/80 bg-card/45 px-3 py-2">
-              <div className="mb-1.5 flex items-center justify-between gap-3">
-                <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
-                  {groupLabel}
-                </p>
-                {hasOverflow && (
-                  <button
-                    type="button"
-                    className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/55 transition-colors duration-150 hover:text-muted-foreground/80"
-                    onClick={() => onToggleWorkGroup(groupId)}
-                  >
-                    {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
-                  </button>
-                )}
-              </div>
-              <div className="space-y-1">
-                {visibleEntries.map((workEntry) => (
-                  <div key={`work-row:${workEntry.id}`} className="flex items-start gap-2 py-0.5">
-                    <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
-                    <div className="min-w-0 flex-1 py-[2px]">
-                      <p className={`text-[11px] leading-relaxed ${workToneClass(workEntry.tone)}`}>
-                        {workEntry.label}
-                      </p>
-                      {workEntry.command && (
-                        <pre className="mt-1 overflow-x-auto rounded-md border border-border/70 bg-background/80 px-2 py-1 font-mono text-[11px] leading-relaxed text-foreground/80">
-                          {workEntry.command}
-                        </pre>
-                      )}
-                      {workEntry.changedFiles && workEntry.changedFiles.length > 0 && (
-                        <div className="mt-1 flex flex-wrap gap-1">
-                          {workEntry.changedFiles.slice(0, 6).map((filePath) => (
-                            <span
-                              key={`${workEntry.id}:${filePath}`}
-                              className="rounded-md border border-border/70 bg-background/65 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/85"
-                              title={filePath}
-                            >
-                              {filePath}
-                            </span>
-                          ))}
-                          {workEntry.changedFiles.length > 6 && (
-                            <span className="px-1 text-[10px] text-muted-foreground/65">
-                              +{workEntry.changedFiles.length - 6} more
-                            </span>
-                          )}
-                        </div>
-                      )}
-                      {workEntry.detail &&
-                        (!workEntry.command || workEntry.detail !== workEntry.command) && (
-                          <p
-                            className="mt-1 text-[11px] leading-relaxed text-muted-foreground/75"
-                            title={workEntry.detail}
-                          >
-                            {workEntry.detail}
-                          </p>
-                        )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
+            <CompactActivityStrip
+              assistantLabel={activeAssistantLabel}
+              title={latestEntry?.label ?? activeWorkSummary.title}
+              detail={
+                latestEntry?.command ??
+                latestEntry?.detail ??
+                latestEntry?.changedFiles?.slice(0, 2).join(", ") ??
+                activeWorkSummary.detail
+              }
+              statusLabel={status}
+              elapsed={elapsed ? `Working for ${elapsed}` : null}
+              entries={groupedEntries}
+              expanded={isExpanded}
+              onToggleExpanded={() => onToggleWorkGroup(groupId)}
+            />
           );
         })()}
 
@@ -5132,67 +5285,26 @@ const MessagesTimeline = memo(function MessagesTimeline({
                 </div>
               )}
               <div className="min-w-0 px-1 py-0.5">
-                <ChatMarkdown
-                  text={messageText}
+                <AnimatedAssistantMessage
+                  message={{ ...row.message, text: messageText }}
                   cwd={markdownCwd}
-                  isStreaming={Boolean(row.message.streaming)}
+                  animate={
+                    !row.message.streaming &&
+                    animatedAssistantMessageId === row.message.id &&
+                    messageText.length > 0
+                  }
+                  onComplete={onAnimatedAssistantMessageComplete}
                 />
-                {(() => {
-                  const turnSummary = turnDiffSummaryByAssistantMessageId.get(row.message.id);
-                  if (!turnSummary) return null;
-                  const checkpointFiles = turnSummary.files;
-                  if (checkpointFiles.length === 0) return null;
-                  const summaryStat = summarizeTurnDiffStats(checkpointFiles);
-                  const changedFileCountLabel = String(checkpointFiles.length);
-                  const allDirectoriesExpanded =
-                    allDirectoriesExpandedByTurnId[turnSummary.turnId] ?? true;
-                  return (
-                    <div className="mt-2 rounded-lg border border-border/80 bg-card/45 p-2.5">
-                      <div className="mb-1.5 flex items-center justify-between gap-2">
-                        <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
-                          <span>Changed files ({changedFileCountLabel})</span>
-                          {hasNonZeroStat(summaryStat) && (
-                            <>
-                              <span className="mx-1">•</span>
-                              <DiffStatLabel
-                                additions={summaryStat.additions}
-                                deletions={summaryStat.deletions}
-                              />
-                            </>
-                          )}
-                        </p>
-                        <div className="flex items-center gap-1.5">
-                          <Button
-                            type="button"
-                            size="xs"
-                            variant="outline"
-                            onClick={() => onToggleAllDirectories(turnSummary.turnId)}
-                          >
-                            {allDirectoriesExpanded ? "Collapse all" : "Expand all"}
-                          </Button>
-                          <Button
-                            type="button"
-                            size="xs"
-                            variant="outline"
-                            onClick={() =>
-                              onOpenTurnDiff(turnSummary.turnId, checkpointFiles[0]?.path)
-                            }
-                          >
-                            View diff
-                          </Button>
-                        </div>
-                      </div>
-                      <ChangedFilesTree
-                        key={`changed-files-tree:${turnSummary.turnId}`}
-                        turnId={turnSummary.turnId}
-                        files={checkpointFiles}
-                        allDirectoriesExpanded={allDirectoriesExpanded}
-                        resolvedTheme={resolvedTheme}
-                        onOpenTurnDiff={onOpenTurnDiff}
-                      />
-                    </div>
-                  );
-                })()}
+                {row.changedFilesSummary && row.changedFilesSummary.files.length > 0 ? (
+                  <CompactChangedFilesSummary
+                    turnSummary={row.changedFilesSummary}
+                    expanded={expandedWorkGroups[`changed:${row.changedFilesSummary.turnId}`] ?? false}
+                    onToggleExpanded={() =>
+                      onToggleWorkGroup(`changed:${row.changedFilesSummary?.turnId ?? row.message.id}`)
+                    }
+                    onOpenTurnDiff={onOpenTurnDiff}
+                  />
+                ) : null}
                 <p className="mt-1.5 text-[10px] text-muted-foreground/30">
                   {formatMessageMeta(
                     row.message.createdAt,
@@ -5217,20 +5329,19 @@ const MessagesTimeline = memo(function MessagesTimeline({
       )}
 
       {row.kind === "working" && (
-        <div className="flex items-center gap-2 py-0.5 pl-1.5">
-          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
-          <div className="flex items-center gap-2 pt-1 text-[11px] text-muted-foreground/70">
-            <span className="inline-flex items-center gap-[3px]">
-              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse" />
-              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:200ms]" />
-              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:400ms]" />
-            </span>
-            <span>
-              {row.createdAt
-                ? `Working for ${formatWorkingTimer(row.createdAt, nowIso) ?? "0s"}`
-                : "Working..."}
-            </span>
-          </div>
+        <div className="min-w-0 px-1 py-0.5">
+          <CompactActivityStrip
+            assistantLabel={activeAssistantLabel}
+            title={activeWorkSummary.title}
+            detail={activeWorkSummary.detail ?? "Thinking"}
+            statusLabel={optimisticRunPhase === "preparing-worktree" ? "Preparing" : "Thinking"}
+            elapsed={
+              row.createdAt ? `Working for ${formatWorkingTimer(row.createdAt, nowIso) ?? "0s"}` : null
+            }
+            entries={[]}
+            expanded={false}
+            onToggleExpanded={() => {}}
+          />
         </div>
       )}
     </div>
@@ -5292,19 +5403,21 @@ const AVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter(isAvailableProviderOp
 const UNAVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter((option) => !option.available);
 const COMING_SOON_PROVIDER_OPTIONS = [
   { id: "opencode", label: "OpenCode", icon: OpenCodeIcon },
-  { id: "gemini", label: "Gemini", icon: Gemini },
 ] as const;
 
 function getCustomModelOptionsByProvider(settings: {
   customCodexModels: readonly string[];
+  customGeminiModels: readonly string[];
 }): Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>> {
   return {
     codex: getAppModelOptions("codex", settings.customCodexModels),
+    gemini: getAppModelOptions("gemini", settings.customGeminiModels),
   };
 }
 
 const PROVIDER_ICON_BY_PROVIDER: Record<ProviderPickerKind, Icon> = {
   codex: OpenAI,
+  gemini: Gemini,
   claudeCode: ClaudeAI,
   cursor: CursorIcon,
 };

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -31,6 +31,7 @@ import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { type DraftThreadEnvMode, useComposerDraftStore } from "../composerDraftStore";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+import { useThreadRunStateStore } from "../threadRunStateStore";
 import { toastManager } from "./ui/toast";
 import {
   getDesktopUpdateActionError,
@@ -82,7 +83,7 @@ function formatRelativeTime(iso: string): string {
 }
 
 interface ThreadStatusPill {
-  label: "Working" | "Connecting" | "Completed" | "Pending Approval";
+  label: "Working" | "Connecting" | "Preparing" | "Completed" | "Pending Approval";
   colorClass: string;
   dotClass: string;
   pulse: boolean;
@@ -114,13 +115,36 @@ function hasUnseenCompletion(thread: Thread): boolean {
   return completedAt > lastVisitedAt;
 }
 
-function threadStatusPill(thread: Thread, hasPendingApprovals: boolean): ThreadStatusPill | null {
+function threadStatusPill(
+  thread: Thread,
+  hasPendingApprovals: boolean,
+  hasPendingRun: boolean,
+  pendingRunPhase: "sending-turn" | "preparing-worktree" | null,
+): ThreadStatusPill | null {
   if (hasPendingApprovals) {
     return {
       label: "Pending Approval",
       colorClass: "text-amber-600 dark:text-amber-300/90",
       dotClass: "bg-amber-500 dark:bg-amber-300/90",
       pulse: false,
+    };
+  }
+
+  if (hasPendingRun && pendingRunPhase === "preparing-worktree") {
+    return {
+      label: "Preparing",
+      colorClass: "text-sky-600 dark:text-sky-300/80",
+      dotClass: "bg-sky-500 dark:bg-sky-300/80",
+      pulse: true,
+    };
+  }
+
+  if (hasPendingRun) {
+    return {
+      label: "Connecting",
+      colorClass: "text-sky-600 dark:text-sky-300/80",
+      dotClass: "bg-sky-500 dark:bg-sky-300/80",
+      pulse: true,
     };
   }
 
@@ -268,6 +292,7 @@ export default function Sidebar() {
   );
   const getDraftThread = useComposerDraftStore((store) => store.getDraftThread);
   const terminalStateByThreadId = useTerminalStateStore((state) => state.terminalStateByThreadId);
+  const pendingRunByThreadId = useThreadRunStateStore((state) => state.pendingRunByThreadId);
   const clearTerminalState = useTerminalStateStore((state) => state.clearTerminalState);
   const setProjectDraftThreadId = useComposerDraftStore((store) => store.setProjectDraftThreadId);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
@@ -1112,10 +1137,17 @@ export default function Sidebar() {
                       <SidebarMenuSub className="mx-1 my-0 w-full translate-x-0 gap-0 px-1.5 py-0">
                         {visibleThreads.map((thread) => {
                           const isActive = routeThreadId === thread.id;
+                          const pendingRun = pendingRunByThreadId[thread.id] ?? null;
                           const threadStatus = threadStatusPill(
                             thread,
                             pendingApprovalByThreadId.get(thread.id) === true,
+                            pendingRun !== null,
+                            pendingRun?.phase ?? null,
                           );
+                          const threadTimestamp =
+                            threadStatus?.label === "Completed" && thread.latestTurn?.completedAt
+                              ? thread.latestTurn.completedAt
+                              : thread.createdAt;
                           const prStatus = prStatusIndicator(prByThreadId.get(thread.id) ?? null);
                           const terminalStatus = terminalStatusFromRunningIds(
                             selectThreadTerminalState(terminalStateByThreadId, thread.id)
@@ -1242,7 +1274,7 @@ export default function Sidebar() {
                                       isActive ? "text-foreground/65" : "text-muted-foreground/40"
                                     }`}
                                   >
-                                    {formatRelativeTime(thread.createdAt)}
+                                    {formatRelativeTime(threadTimestamp)}
                                   </span>
                                 </div>
                               </SidebarMenuSubButton>

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -208,7 +208,7 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
 }
 
 function normalizeProviderKind(value: unknown): ProviderKind | null {
-  return value === "codex" ? value : null;
+  return value === "codex" || value === "gemini" ? (value as ProviderKind) : null;
 }
 
 function revokeObjectPreviewUrl(previewUrl: string): void {
@@ -809,9 +809,10 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
         if (threadId.length === 0) {
           return;
         }
-        const normalizedModel = normalizeModelSlug(model) ?? null;
         set((state) => {
           const existing = state.draftsByThreadId[threadId];
+          const normalizedModel =
+            normalizeModelSlug(model, existing?.provider ?? "codex") ?? null;
           if (!existing && normalizedModel === null) {
             return state;
           }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -17,6 +17,7 @@ import { readNativeApi } from "../nativeApi";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useStore } from "../store";
 import { useTerminalStateStore } from "../terminalStateStore";
+import { useThreadRunStateStore } from "../threadRunStateStore";
 import { preferredTerminalEditor } from "../terminal-links";
 import { terminalRunningSubprocessFromEvent } from "../terminalActivity";
 import { onServerConfigUpdated, onServerWelcome } from "../wsNativeApi";
@@ -134,6 +135,10 @@ function EventRouter() {
   const removeOrphanedTerminalStates = useTerminalStateStore(
     (store) => store.removeOrphanedTerminalStates,
   );
+  const syncPendingRuns = useThreadRunStateStore((store) => store.syncPendingRuns);
+  const removeOrphanedPendingRuns = useThreadRunStateStore(
+    (store) => store.removeOrphanedPendingRuns,
+  );
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
@@ -156,6 +161,7 @@ function EventRouter() {
       if (disposed) return;
       latestSequence = Math.max(latestSequence, snapshot.snapshotSequence);
       syncServerReadModel(snapshot);
+      syncPendingRuns(snapshot);
       const draftThreadIds = Object.keys(
         useComposerDraftStore.getState().draftThreadsByThreadId,
       ) as ThreadId[];
@@ -164,6 +170,7 @@ function EventRouter() {
         draftThreadIds,
       });
       removeOrphanedTerminalStates(activeThreadIds);
+      removeOrphanedPendingRuns(activeThreadIds);
       if (pending) {
         pending = false;
         await flushSnapshotSync();
@@ -289,7 +296,9 @@ function EventRouter() {
     navigate,
     queryClient,
     removeOrphanedTerminalStates,
+    removeOrphanedPendingRuns,
     setProjectExpanded,
+    syncPendingRuns,
     syncServerReadModel,
   ]);
 

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -8,6 +8,8 @@ import { ZapIcon } from "lucide-react";
 import {
   APP_SERVICE_TIER_OPTIONS,
   MAX_CUSTOM_MODEL_LENGTH,
+  getCustomModelsForProvider,
+  patchCustomModelsForProvider,
   shouldShowFastTierIcon,
   useAppSettings,
 } from "../appSettings";
@@ -54,37 +56,14 @@ const MODEL_PROVIDER_SETTINGS: Array<{
     placeholder: "your-codex-model-slug",
     example: "gpt-6.7-codex-ultra-preview",
   },
+  {
+    provider: "gemini",
+    title: "Gemini",
+    description: "Save additional Gemini model slugs for the picker and `/model` command.",
+    placeholder: "your-gemini-model-slug",
+    example: "gemini-3.1-pro-preview-customtools",
+  },
 ] as const;
-
-function getCustomModelsForProvider(
-  settings: ReturnType<typeof useAppSettings>["settings"],
-  provider: ProviderKind,
-) {
-  switch (provider) {
-    case "codex":
-    default:
-      return settings.customCodexModels;
-  }
-}
-
-function getDefaultCustomModelsForProvider(
-  defaults: ReturnType<typeof useAppSettings>["defaults"],
-  provider: ProviderKind,
-) {
-  switch (provider) {
-    case "codex":
-    default:
-      return defaults.customCodexModels;
-  }
-}
-
-function patchCustomModels(provider: ProviderKind, models: string[]) {
-  switch (provider) {
-    case "codex":
-    default:
-      return { customCodexModels: models };
-  }
-}
 
 function SettingsRouteView() {
   const { theme, setTheme, resolvedTheme } = useTheme();
@@ -96,6 +75,7 @@ function SettingsRouteView() {
     Record<ProviderKind, string>
   >({
     codex: "",
+    gemini: "",
   });
   const [customModelErrorByProvider, setCustomModelErrorByProvider] = useState<
     Partial<Record<ProviderKind, string | null>>
@@ -156,7 +136,7 @@ function SettingsRouteView() {
       return;
     }
 
-    updateSettings(patchCustomModels(provider, [...customModels, normalized]));
+    updateSettings(patchCustomModelsForProvider(provider, [...customModels, normalized]));
     setCustomModelInputByProvider((existing) => ({
       ...existing,
       [provider]: "",
@@ -170,7 +150,9 @@ function SettingsRouteView() {
   const removeCustomModel = useCallback(
     (provider: ProviderKind, slug: string) => {
       const customModels = getCustomModelsForProvider(settings, provider);
-      updateSettings(patchCustomModels(provider, customModels.filter((model) => model !== slug)));
+      updateSettings(
+        patchCustomModelsForProvider(provider, customModels.filter((model) => model !== slug)),
+      );
       setCustomModelErrorByProvider((existing) => ({
         ...existing,
         [provider]: null,
@@ -426,9 +408,9 @@ function SettingsRouteView() {
                                 variant="outline"
                                 onClick={() =>
                                   updateSettings(
-                                    patchCustomModels(
+                                    patchCustomModelsForProvider(
                                       provider,
-                                      [...getDefaultCustomModelsForProvider(defaults, provider)],
+                                      [...getCustomModelsForProvider(defaults, provider)],
                                     ),
                                   )
                                 }

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -645,6 +645,7 @@ describe("PROVIDER_OPTIONS", () => {
     const cursor = PROVIDER_OPTIONS.find((option) => option.value === "cursor");
     expect(PROVIDER_OPTIONS).toEqual([
       { value: "codex", label: "Codex", available: true },
+      { value: "gemini", label: "Gemini", available: true },
       { value: "claudeCode", label: "Claude Code", available: false },
       { value: "cursor", label: "Cursor", available: false },
     ]);

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -18,6 +18,7 @@ export const PROVIDER_OPTIONS: Array<{
   available: boolean;
 }> = [
   { value: "codex", label: "Codex", available: true },
+  { value: "gemini", label: "Gemini", available: true },
   { value: "claudeCode", label: "Claude Code", available: false },
   { value: "cursor", label: "Cursor", available: false },
 ];
@@ -409,7 +410,6 @@ export function deriveWorkLogEntries(
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   return ordered
     .filter((activity) => (latestTurnId ? activity.turnId === latestTurnId : true))
-    .filter((activity) => activity.kind !== "tool.started")
     .filter((activity) => activity.kind !== "task.started" && activity.kind !== "task.completed")
     .filter((activity) => activity.summary !== "Checkpoint captured")
     .map((activity) => {
@@ -419,14 +419,15 @@ export function deriveWorkLogEntries(
           : null;
       const command = extractToolCommand(payload);
       const changedFiles = extractChangedFiles(payload);
+      const detail = extractWorkDetail(payload, changedFiles);
       const entry: WorkLogEntry = {
         id: activity.id,
         createdAt: activity.createdAt,
-        label: activity.summary,
+        label: deriveWorkLabel(activity.summary, payload, command, changedFiles, detail),
         tone: activity.tone === "approval" ? "info" : activity.tone,
       };
-      if (payload && typeof payload.detail === "string" && payload.detail.length > 0) {
-        entry.detail = payload.detail;
+      if (detail) {
+        entry.detail = detail;
       }
       if (command) {
         entry.command = command;
@@ -476,6 +477,120 @@ function extractToolCommand(payload: Record<string, unknown> | null): string | n
     normalizeCommandValue(data?.command),
   ];
   return candidates.find((candidate) => candidate !== null) ?? null;
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function summarizeVerboseText(value: string, maxLength = 180): string {
+  const normalized = normalizeWhitespace(value);
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function looksLikeCodeOrMarkup(value: string): boolean {
+  return /<!DOCTYPE|<html|<head|<body|function\s|\bconst\b|\blet\b|\bclass\b/.test(value);
+}
+
+function extractLocationPaths(payload: Record<string, unknown> | null): string[] {
+  const data = asRecord(payload?.data);
+  const locations = data?.locations;
+  if (!Array.isArray(locations)) {
+    return [];
+  }
+  return locations
+    .map((entry) => {
+      const record = asRecord(entry);
+      return (
+        asTrimmedString(record?.path) ??
+        asTrimmedString(record?.filePath) ??
+        asTrimmedString(record?.uri)
+      );
+    })
+    .filter((value): value is string => value !== null);
+}
+
+function extractToolName(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const candidates = [
+    asTrimmedString(payload?.title),
+    asTrimmedString(data?.title),
+    asTrimmedString(data?.tool_name),
+    asTrimmedString(data?.toolName),
+    asTrimmedString(item?.title),
+    asTrimmedString(item?.name),
+  ];
+  return candidates.find((candidate) => candidate !== null) ?? null;
+}
+
+function extractWorkDetail(
+  payload: Record<string, unknown> | null,
+  changedFiles: ReadonlyArray<string>,
+): string | null {
+  const data = asRecord(payload?.data);
+  const rawDetail =
+    asTrimmedString(payload?.detail) ??
+    asTrimmedString(data?.detail) ??
+    asTrimmedString(data?.output) ??
+    asTrimmedString(data?.rawOutput);
+
+  if (rawDetail) {
+    if (looksLikeCodeOrMarkup(rawDetail) && changedFiles.length > 0) {
+      return `Updated ${changedFiles.slice(0, 3).join(", ")}`;
+    }
+    return summarizeVerboseText(rawDetail);
+  }
+
+  const locationPaths = extractLocationPaths(payload);
+  if (locationPaths.length > 0) {
+    return `Working in ${locationPaths.slice(0, 3).join(", ")}`;
+  }
+
+  if (changedFiles.length > 0) {
+    return `Updated ${changedFiles.slice(0, 3).join(", ")}`;
+  }
+
+  return null;
+}
+
+function deriveWorkLabel(
+  summary: string,
+  payload: Record<string, unknown> | null,
+  command: string | null,
+  changedFiles: ReadonlyArray<string>,
+  detail: string | null,
+): string {
+  const normalizedSummary = normalizeWhitespace(summary);
+  const toolName = extractToolName(payload);
+  const genericGeminiSummary = /^gemini tool(?: complete)?$/i.test(normalizedSummary);
+
+  if (!genericGeminiSummary && normalizedSummary.length > 0) {
+    return normalizedSummary;
+  }
+
+  if (toolName && toolName.toLowerCase() !== "gemini tool") {
+    return toolName;
+  }
+
+  if (command) {
+    return summarizeVerboseText(command, 72);
+  }
+
+  if (changedFiles.length > 0) {
+    return changedFiles.length === 1
+      ? `Updating ${changedFiles[0]}`
+      : `Updating ${changedFiles.length} files`;
+  }
+
+  if (detail) {
+    return summarizeVerboseText(detail, 72);
+  }
+
+  return normalizedSummary.length > 0 ? normalizedSummary : "Working";
 }
 
 function pushChangedFile(target: string[], seen: Set<string>, value: unknown) {

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -147,4 +147,27 @@ describe("store read model sync", () => {
 
     expect(next.threads[0]?.model).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
   });
+
+  it("preserves Gemini provider and model from the server session", () => {
+    const initialState = makeState(makeThread());
+    const readModel = makeReadModel(
+      makeReadModelThread({
+        model: "gemini-3-flash-preview",
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "ready",
+          providerName: "gemini",
+          runtimeMode: DEFAULT_RUNTIME_MODE,
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-02-27T00:00:00.000Z",
+        },
+      }),
+    );
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.threads[0]?.model).toBe("gemini-3-flash-preview");
+    expect(next.threads[0]?.session?.provider).toBe("gemini");
+  });
 });

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -7,8 +7,7 @@ import {
   type OrchestrationSessionStatus,
 } from "@t3tools/contracts";
 import {
-  getModelOptions,
-  normalizeModelSlug,
+  resolveProviderForModel,
   resolveModelSlug,
   resolveModelSlugForProvider,
 } from "@t3tools/shared/model";
@@ -143,26 +142,20 @@ function toLegacySessionStatus(
 }
 
 function toLegacyProvider(providerName: string | null): ProviderKind {
-  if (providerName === "codex") {
+  if (providerName === "codex" || providerName === "gemini") {
     return providerName;
   }
   return "codex";
 }
 
-const CODEX_MODEL_SLUGS = new Set<string>(getModelOptions("codex").map((option) => option.slug));
-
 function inferProviderForThreadModel(input: {
   readonly model: string;
   readonly sessionProviderName: string | null;
 }): ProviderKind {
-  if (input.sessionProviderName === "codex") {
+  if (input.sessionProviderName === "codex" || input.sessionProviderName === "gemini") {
     return input.sessionProviderName;
   }
-  const normalizedCodex = normalizeModelSlug(input.model, "codex");
-  if (normalizedCodex && CODEX_MODEL_SLUGS.has(normalizedCodex)) {
-    return "codex";
-  }
-  return "codex";
+  return resolveProviderForModel(input.model);
 }
 
 function resolveWsHttpOrigin(): string {

--- a/apps/web/src/threadRunStateStore.ts
+++ b/apps/web/src/threadRunStateStore.ts
@@ -1,0 +1,94 @@
+import type {
+  OrchestrationReadModel,
+  OrchestrationSessionStatus,
+  ProviderKind,
+  ThreadId,
+} from "@t3tools/contracts";
+import { create } from "zustand";
+
+export type PendingThreadRunPhase = "sending-turn" | "preparing-worktree";
+
+export interface PendingThreadRunState {
+  phase: PendingThreadRunPhase;
+  provider: ProviderKind;
+  startedAt: string;
+}
+
+interface ThreadRunStateStore {
+  pendingRunByThreadId: Record<ThreadId, PendingThreadRunState>;
+  startPendingRun: (
+    threadId: ThreadId,
+    run: PendingThreadRunState,
+  ) => void;
+  clearPendingRun: (threadId: ThreadId) => void;
+  syncPendingRuns: (snapshot: OrchestrationReadModel) => void;
+  removeOrphanedPendingRuns: (activeThreadIds: Set<ThreadId>) => void;
+}
+
+function isSessionStillPendingOrRunning(status: OrchestrationSessionStatus | null | undefined): boolean {
+  return status === "starting" || status === "running";
+}
+
+export function syncPendingRunsWithSnapshot(
+  pendingRunByThreadId: Record<ThreadId, PendingThreadRunState>,
+  snapshot: OrchestrationReadModel,
+): Record<ThreadId, PendingThreadRunState> {
+  const next = { ...pendingRunByThreadId };
+  const threadById = new Map(snapshot.threads.map((thread) => [thread.id, thread] as const));
+
+  for (const threadId of Object.keys(next) as ThreadId[]) {
+    const thread = threadById.get(threadId);
+    if (!thread || thread.deletedAt !== null) {
+      delete next[threadId];
+      continue;
+    }
+
+    if (!isSessionStillPendingOrRunning(thread.session?.status ?? null)) {
+      delete next[threadId];
+    }
+  }
+
+  return next;
+}
+
+export const useThreadRunStateStore = create<ThreadRunStateStore>((set) => ({
+  pendingRunByThreadId: {},
+  startPendingRun: (threadId, run) =>
+    set((state) => ({
+      pendingRunByThreadId: {
+        ...state.pendingRunByThreadId,
+        [threadId]: run,
+      },
+    })),
+  clearPendingRun: (threadId) =>
+    set((state) => {
+      if (!(threadId in state.pendingRunByThreadId)) {
+        return state;
+      }
+      const next = { ...state.pendingRunByThreadId };
+      delete next[threadId];
+      return { pendingRunByThreadId: next };
+    }),
+  syncPendingRuns: (snapshot) =>
+    set((state) => {
+      const next = syncPendingRunsWithSnapshot(state.pendingRunByThreadId, snapshot);
+      if (next === state.pendingRunByThreadId) {
+        return state;
+      }
+      return { pendingRunByThreadId: next };
+    }),
+  removeOrphanedPendingRuns: (activeThreadIds) =>
+    set((state) => {
+      const orphanedIds = Object.keys(state.pendingRunByThreadId).filter(
+        (threadId) => !activeThreadIds.has(threadId as ThreadId),
+      );
+      if (orphanedIds.length === 0) {
+        return state;
+      }
+      const next = { ...state.pendingRunByThreadId };
+      for (const threadId of orphanedIds) {
+        delete next[threadId as ThreadId];
+      }
+      return { pendingRunByThreadId: next };
+    }),
+}));

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -10,8 +10,17 @@ export const CodexModelOptions = Schema.Struct({
 });
 export type CodexModelOptions = typeof CodexModelOptions.Type;
 
+export const GEMINI_THINKING_LEVEL_OPTIONS = ["high", "medium", "low"] as const;
+export type GeminiThinkingLevel = (typeof GEMINI_THINKING_LEVEL_OPTIONS)[number];
+
+export const GeminiModelOptions = Schema.Struct({
+  thinkingLevel: Schema.optional(Schema.Literals(GEMINI_THINKING_LEVEL_OPTIONS)),
+});
+export type GeminiModelOptions = typeof GeminiModelOptions.Type;
+
 export const ProviderModelOptions = Schema.Struct({
   codex: Schema.optional(CodexModelOptions),
+  gemini: Schema.optional(GeminiModelOptions),
 });
 export type ProviderModelOptions = typeof ProviderModelOptions.Type;
 
@@ -28,6 +37,14 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     { slug: "gpt-5.2-codex", name: "GPT-5.2 Codex" },
     { slug: "gpt-5.2", name: "GPT-5.2" },
   ],
+  gemini: [
+    { slug: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
+    { slug: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
+    { slug: "gemini-2.5-flash-lite", name: "Gemini 2.5 Flash Lite" },
+    { slug: "gemini-3-pro-preview", name: "Gemini 3 Pro Preview" },
+    { slug: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
+    { slug: "gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
+  ],
 } as const satisfies Record<ProviderKind, readonly ModelOption[]>;
 export type ModelOptionsByProvider = typeof MODEL_OPTIONS_BY_PROVIDER;
 
@@ -36,6 +53,7 @@ export type ModelSlug = BuiltInModelSlug | (string & {});
 
 export const DEFAULT_MODEL_BY_PROVIDER = {
   codex: "gpt-5.4",
+  gemini: "gemini-2.5-pro",
 } as const satisfies Record<ProviderKind, ModelSlug>;
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
@@ -46,12 +64,25 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
     "5.3-spark": "gpt-5.3-codex-spark",
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
+  gemini: {
+    "pro": "gemini-2.5-pro",
+    "flash": "gemini-2.5-flash",
+    "2.5-pro": "gemini-2.5-pro",
+    "2.5-flash": "gemini-2.5-flash",
+    "2.5-flash-lite": "gemini-2.5-flash-lite",
+    "lite": "gemini-2.5-flash-lite",
+    "3-pro": "gemini-3-pro-preview",
+    "3.1-pro": "gemini-3.1-pro-preview",
+    "3-flash": "gemini-3-flash-preview",
+  },
 } as const satisfies Record<ProviderKind, Record<string, ModelSlug>>;
 
 export const REASONING_EFFORT_OPTIONS_BY_PROVIDER = {
   codex: CODEX_REASONING_EFFORT_OPTIONS,
+  gemini: ["high", "medium", "low"] as const,
 } as const satisfies Record<ProviderKind, readonly CodexReasoningEffort[]>;
 
 export const DEFAULT_REASONING_EFFORT_BY_PROVIDER = {
   codex: "high",
+  gemini: "medium",
 } as const satisfies Record<ProviderKind, CodexReasoningEffort | null>;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -27,7 +27,7 @@ export const ORCHESTRATION_WS_CHANNELS = {
   domainEvent: "orchestration.domainEvent",
 } as const;
 
-export const ProviderKind = Schema.Literal("codex");
+export const ProviderKind = Schema.Literals(["codex", "gemini"]);
 export type ProviderKind = typeof ProviderKind.Type;
 export const ProviderApprovalPolicy = Schema.Literals([
   "untrusted",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -8,6 +8,7 @@ import {
   getReasoningEffortOptions,
   normalizeModelSlug,
   resolveModelSlug,
+  resolveProviderForModel,
 } from "./model";
 
 describe("normalizeModelSlug", () => {
@@ -65,5 +66,16 @@ describe("getReasoningEffortOptions", () => {
 describe("getDefaultReasoningEffort", () => {
   it("returns provider-scoped defaults", () => {
     expect(getDefaultReasoningEffort("codex")).toBe("high");
+  });
+});
+
+describe("resolveProviderForModel", () => {
+  it("returns the matching provider for built-in Gemini models", () => {
+    expect(resolveProviderForModel("gemini-2.5-pro")).toBe("gemini");
+    expect(resolveProviderForModel("3-flash")).toBe("gemini");
+  });
+
+  it("falls back to codex for unknown models", () => {
+    expect(resolveProviderForModel("unknown-model")).toBe("codex");
   });
 });

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -1,8 +1,10 @@
 import {
   CODEX_REASONING_EFFORT_OPTIONS,
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_REASONING_EFFORT_BY_PROVIDER,
   MODEL_OPTIONS_BY_PROVIDER,
   MODEL_SLUG_ALIASES_BY_PROVIDER,
+  REASONING_EFFORT_OPTIONS_BY_PROVIDER,
   type CodexReasoningEffort,
   type ModelSlug,
   type ProviderKind,
@@ -12,7 +14,14 @@ type CatalogProvider = keyof typeof MODEL_OPTIONS_BY_PROVIDER;
 
 const MODEL_SLUG_SET_BY_PROVIDER: Record<CatalogProvider, ReadonlySet<ModelSlug>> = {
   codex: new Set(MODEL_OPTIONS_BY_PROVIDER.codex.map((option) => option.slug)),
+  gemini: new Set(MODEL_OPTIONS_BY_PROVIDER.gemini.map((option) => option.slug)),
 };
+
+const MODEL_PROVIDER_BY_SLUG = new Map<ModelSlug, ProviderKind>(
+  Object.entries(MODEL_OPTIONS_BY_PROVIDER).flatMap(([provider, options]) =>
+    options.map((option) => [option.slug, provider as ProviderKind] as const),
+  ),
+);
 
 export function getModelOptions(provider: ProviderKind = "codex") {
   return MODEL_OPTIONS_BY_PROVIDER[provider];
@@ -61,18 +70,45 @@ export function resolveModelSlugForProvider(
   return resolveModelSlug(model, provider);
 }
 
+export function resolveProviderForModel(
+  model: string | null | undefined,
+  fallbackProvider: ProviderKind = "codex",
+): ProviderKind {
+  if (typeof model !== "string") {
+    return fallbackProvider;
+  }
+
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return fallbackProvider;
+  }
+
+  for (const provider of Object.keys(MODEL_OPTIONS_BY_PROVIDER) as ProviderKind[]) {
+    const normalized = normalizeModelSlug(trimmed, provider);
+    if (!normalized) {
+      continue;
+    }
+    if (MODEL_PROVIDER_BY_SLUG.get(normalized) === provider) {
+      return provider;
+    }
+  }
+
+  return fallbackProvider;
+}
+
 export function getReasoningEffortOptions(
   provider: ProviderKind = "codex",
 ): ReadonlyArray<CodexReasoningEffort> {
-  return provider === "codex" ? CODEX_REASONING_EFFORT_OPTIONS : [];
+  return REASONING_EFFORT_OPTIONS_BY_PROVIDER[provider] ?? [];
 }
 
 export function getDefaultReasoningEffort(provider: "codex"): CodexReasoningEffort;
+export function getDefaultReasoningEffort(provider: "gemini"): CodexReasoningEffort;
 export function getDefaultReasoningEffort(provider: ProviderKind): CodexReasoningEffort | null;
 export function getDefaultReasoningEffort(
   provider: ProviderKind = "codex",
 ): CodexReasoningEffort | null {
-  return provider === "codex" ? "high" : null;
+  return DEFAULT_REASONING_EFFORT_BY_PROVIDER[provider] ?? null;
 }
 
 export { CODEX_REASONING_EFFORT_OPTIONS };


### PR DESCRIPTION
## What Changed

Adds Gemini CLI as an additional provider alongside Codex.

Scope:

- Gemini provider registration and health reporting
- Gemini model selection and persistence
- Gemini session start/resume support
- Gemini runtime event handling
- Gemini-specific live state fixes so cold starts show `Connecting` before `Working`
- remember the last selected provider/model for new chats

## Why

This makes the app usable for people who want Gemini support without changing the existing chat flow.

While implementing the provider, I also fixed the Gemini-specific runtime UX bugs I hit during testing:

- the first Gemini send could show `Working` before the provider was actually connected
- resumed Gemini sends did not always show `Working`
- the UI could stay stuck in a responding state until switching chats

## UI Changes

### Settings page

Before:

![Before settings models](https://raw.githubusercontent.com/Amer-alsayed/t3code/codex/gemini-cli-support-and-ux/.docs/pr/447/before-models-section.png)

After:

![After settings models](https://raw.githubusercontent.com/Amer-alsayed/t3code/codex/gemini-cli-support-and-ux/.docs/pr/447/after-models-section.png)

### Composer provider picker

Before:

![Before provider picker](https://raw.githubusercontent.com/Amer-alsayed/t3code/codex/gemini-cli-support-and-ux/.docs/pr/447/before-provider-picker.png)

After:

![After provider picker](https://raw.githubusercontent.com/Amer-alsayed/t3code/codex/gemini-cli-support-and-ux/.docs/pr/447/after-provider-picker.png)

### Interaction

Provider picker:

![Provider picker interaction](https://raw.githubusercontent.com/Amer-alsayed/t3code/codex/gemini-cli-support-and-ux/.docs/pr/447/provider-picker.gif)

Gemini cold start status (`Connecting` -> `Working` -> completed):

![Gemini status interaction](https://raw.githubusercontent.com/Amer-alsayed/t3code/codex/gemini-cli-support-and-ux/.docs/pr/447/gemini-status.gif)

## Validation

- `bun lint`
- `bun typecheck`

## Checklist

- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI changes
- [x] I included a short interaction recording
