### PR TITLE
fix: avoid duplicating streamed assistant completion text

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -834,6 +834,7 @@ describe("ProviderRuntimeIngestion", () => {
       payload: {
         itemType: "assistant_message",
         status: "completed",
+        detail: "hello live",
       },
     });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -951,6 +951,10 @@ const make = Effect.gen(function* () {
       if (assistantCompletion) {
         const assistantMessageId = assistantCompletion.messageId;
         const turnId = toTurnId(event.turnId);
+        const existingAssistantMessage = thread.messages.find((entry) => entry.id === assistantMessageId);
+        const shouldApplyFallbackCompletionText =
+          !existingAssistantMessage ||
+          existingAssistantMessage.text.length === 0;
         if (turnId) {
           yield* rememberAssistantMessageId(thread.id, turnId, assistantMessageId);
         }
@@ -963,7 +967,7 @@ const make = Effect.gen(function* () {
           createdAt: now,
           commandTag: "assistant-complete",
           finalDeltaCommandTag: "assistant-delta-finalize",
-          ...(assistantCompletion.fallbackText !== undefined
+          ...(assistantCompletion.fallbackText !== undefined && shouldApplyFallbackCompletionText
             ? { fallbackText: assistantCompletion.fallbackText }
             : {}),
         });


### PR DESCRIPTION
## Summary
Prevent assistant message text from being appended twice when streaming deltas are followed by item.completed detail.

## Changes
- Only apply completion fallbackText when the target assistant message has no existing text.
- Keep streaming behavior unchanged.
- Extend streaming regression coverage to include item.completed.detail and assert no duplicated text.

## Validation
- bun run test src/orchestration/Layers/ProviderRuntimeIngestion.test.ts (from apps/server)
- bun lint
- bun typecheck


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply fallback completion text only when the existing assistant message is missing or empty in `ProviderRuntimeIngestion.make` to avoid duplicating streamed assistant text
> Adds a check in `ProviderRuntimeIngestion.make` to compute `shouldApplyFallbackCompletionText` by looking up the assistant message in `thread.messages`, and passes `fallbackText` to `finalizeAssistantMessage` only when the message is missing or empty; updates the streaming-mode test data to include `detail: "hello live"` in the `item.completed` payload. See [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/465/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) and [ProviderRuntimeIngestion.test.ts](https://github.com/pingdotgg/t3code/pull/465/files#diff-ea511ca36a45f5254c8f22ac107b5469fed67d652de6af2c5d2763bf00ce53c3).
>
> #### 📍Where to Start
> Start in `ProviderRuntimeIngestion.make` where assistant completion events are handled in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/465/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f4b976.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assistant message completion to prevent fallback text from overwriting existing message content during streaming mode.
  * Improved message detail preservation in completion events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->