### PR TITLE
Rename Open PR action label to View PR

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -42,7 +42,7 @@ describe("when: branch is clean and has an open PR", () => {
       }),
       false,
     );
-    assert.deepInclude(quick, { kind: "open_pr", label: "Open PR", disabled: false });
+    assert.deepInclude(quick, { kind: "open_pr", label: "View PR", disabled: false });
   });
 
   it("buildMenuItems disables commit/push and enables open PR", () => {
@@ -78,7 +78,7 @@ describe("when: branch is clean and has an open PR", () => {
       },
       {
         id: "pr",
-        label: "Open PR",
+        label: "View PR",
         disabled: false,
         icon: "pr",
         kind: "open_pr",
@@ -199,7 +199,7 @@ describe("when: branch is clean, ahead, and has an open PR", () => {
       },
       {
         id: "pr",
-        label: "Open PR",
+        label: "View PR",
         disabled: false,
         icon: "pr",
         kind: "open_pr",
@@ -547,7 +547,7 @@ describe("when: branch has no upstream configured", () => {
     );
     assert.deepInclude(quick, {
       kind: "open_pr",
-      label: "Open PR",
+      label: "View PR",
       disabled: false,
     });
   });

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -151,7 +151,7 @@ export function buildMenuItems(
     hasOpenPr
       ? {
           id: "pr",
-          label: "Open PR",
+          label: "View PR",
           disabled: !canOpenPr,
           icon: "pr",
           kind: "open_pr",
@@ -216,7 +216,7 @@ export function resolveQuickAction(
   if (!gitStatus.hasUpstream) {
     if (!isAhead) {
       if (hasOpenPr) {
-        return { label: "Open PR", disabled: false, kind: "open_pr" };
+        return { label: "View PR", disabled: false, kind: "open_pr" };
       }
       return {
         label: "Push",
@@ -266,7 +266,7 @@ export function resolveQuickAction(
   }
 
   if (hasOpenPr && gitStatus.hasUpstream) {
-    return { label: "Open PR", disabled: false, kind: "open_pr" };
+    return { label: "View PR", disabled: false, kind: "open_pr" };
   }
 
   return {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -98,7 +98,7 @@ function getMenuActionDisabledReason(
   }
 
   if (hasOpenPr) {
-    return "Open PR is currently unavailable.";
+    return "View PR is currently unavailable.";
   }
   if (!hasBranch) {
     return "Detached HEAD: checkout a branch before creating a PR.";
@@ -374,12 +374,12 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
                 },
               }
             : shouldOfferOpenPrCta
-              ? {
-                  actionProps: {
-                    children: "Open PR",
-                    onClick: () => {
-                      const api = readNativeApi();
-                      if (!api) return;
+                ? {
+                    actionProps: {
+                      children: "View PR",
+                      onClick: () => {
+                        const api = readNativeApi();
+                        if (!api) return;
                       closeResultToast();
                       void api.shell.openExternal(prUrl);
                     },


### PR DESCRIPTION
In my opinion "View PR" just sounds a lot better/is more intuitive than "Open PR"
<img width="482" height="221" alt="image" src="https://github.com/user-attachments/assets/0865bc6d-ba67-454e-9884-0905a6dd6ffd" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename PR action labels in GitActionsControl to say View PR to match the stated purpose
> Update labels and tests to use View PR when an open PR exists across `GitActionsControl` quick action, menu item, CTA text, and disabled tooltip. Core logic changes are in [apps/web/src/components/GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/467/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0), with UI text updates in [apps/web/src/components/GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/467/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) and test updates in [apps/web/src/components/GitActionsControl.logic.test.ts](https://github.com/pingdotgg/t3code/pull/467/files#diff-79f146696fea703958d884951c23db9a7b4f33ef2f6fa4721329eca56a48bdfb).
>
> #### 📍Where to Start
> Start with `buildMenuItems` and `resolveQuickAction` in [apps/web/src/components/GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/467/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0), then review the UI text changes in [apps/web/src/components/GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/467/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cbca9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->