### PR TITLE
Draft: GPT-5.4 example implementation for desktop/chat UX fixes

### DIFF
--- a/apps/desktop/scripts/validate-feedback.mjs
+++ b/apps/desktop/scripts/validate-feedback.mjs
@@ -1,0 +1,873 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { DatabaseSync } from "node:sqlite";
+
+import { _electron as electron } from "playwright";
+
+import { desktopDir } from "./electron-launcher.mjs";
+
+const repoRoot = path.resolve(desktopDir, "../..");
+const artifactDir = path.join(repoRoot, "output", "playwright", "desktop-feedback");
+const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3code-feedback-"));
+const dbPath = path.join(stateDir, "state.sqlite");
+const appName = "T3 Code (Alpha)";
+const require = createRequire(path.join(desktopDir, "package.json"));
+const electronBinaryPath = require("electron");
+const userMessageText =
+  "I need a printable version of Ransom Notes, plus the print-ready files and a local app for testing.";
+const assistantMessageText =
+  "The print-ready assets are in place, and the prompt view now reads with much stronger contrast.";
+const workCommand = '/bin/zsh -lc "bun run build:desktop"';
+const queuedFollowUpText = "Queue this once the current run finishes.";
+const previewBusyActionText = "Preview the busy action";
+const staticThreadTitle = "Adam feedback static";
+const runningThreadTitle = "Adam feedback running";
+const markdownImageSvg =
+  "<svg xmlns='http://www.w3.org/2000/svg' width='240' height='160' viewBox='0 0 240 160'><rect width='240' height='160' rx='16' fill='#142534'/><circle cx='48' cy='44' r='18' fill='#f59e0d'/><path d='M30 128l46-44 30 28 36-36 68 52' fill='none' stroke='#60bbf4' stroke-width='14' stroke-linecap='round' stroke-linejoin='round'/></svg>";
+let markdownImageUrl = null;
+
+function log(message) {
+  console.log(`[desktop-feedback] ${message}`);
+}
+
+async function startMarkdownImageServer() {
+  return await new Promise((resolve, reject) => {
+    const server = http.createServer((request, response) => {
+      if (request.url !== "/markdown-image.svg") {
+        response.writeHead(404).end("Not found");
+        return;
+      }
+      response.writeHead(200, {
+        "content-type": "image/svg+xml",
+        "cache-control": "no-store",
+      });
+      response.end(markdownImageSvg);
+    });
+
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Unable to resolve the markdown image server port."));
+        return;
+      }
+      resolve({
+        server,
+        url: `http://127.0.0.1:${address.port}/markdown-image.svg`,
+      });
+    });
+  });
+}
+
+function makeDb() {
+  const db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA busy_timeout = 5000;");
+  db.exec("PRAGMA foreign_keys = ON;");
+  return db;
+}
+
+function readBootstrapIds() {
+  const db = makeDb();
+  try {
+    const row = db
+      .prepare(
+        `
+          SELECT
+            p.project_id AS projectId,
+            t.thread_id AS threadId
+          FROM projection_projects p
+          JOIN projection_threads t ON t.project_id = p.project_id
+          ORDER BY t.created_at ASC, t.thread_id ASC
+          LIMIT 1
+        `,
+      )
+      .get();
+    assert(row?.projectId, "Bootstrap project id was not created.");
+    assert(row?.threadId, "Bootstrap thread id was not created.");
+    return {
+      projectId: row.projectId,
+      threadId: row.threadId,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+function resetThreadProjection(db, ids) {
+  db.prepare("DELETE FROM projection_thread_messages WHERE thread_id = ?").run(ids.threadId);
+  db.prepare("DELETE FROM projection_thread_activities WHERE thread_id = ?").run(ids.threadId);
+  db.prepare("DELETE FROM projection_thread_proposed_plans WHERE thread_id = ?").run(ids.threadId);
+  db.prepare("DELETE FROM projection_turns WHERE thread_id = ?").run(ids.threadId);
+  db.prepare("DELETE FROM projection_pending_approvals WHERE thread_id = ?").run(ids.threadId);
+}
+
+function updateProjectAndThread(db, ids, input) {
+  db.prepare(
+    `
+      UPDATE projection_projects
+      SET title = ?,
+          workspace_root = ?,
+          default_model = ?,
+          scripts_json = '[]',
+          updated_at = ?
+      WHERE project_id = ?
+    `,
+  ).run(input.projectTitle, repoRoot, "gpt-5.4", input.updatedAt, ids.projectId);
+
+  db.prepare(
+    `
+      UPDATE projection_threads
+      SET title = ?,
+          model = ?,
+          runtime_mode = 'full-access',
+          interaction_mode = 'default',
+          branch = 'main',
+          worktree_path = NULL,
+          latest_turn_id = ?,
+          updated_at = ?,
+          deleted_at = NULL
+      WHERE thread_id = ?
+    `,
+  ).run(input.threadTitle, "gpt-5.4", input.latestTurnId, input.updatedAt, ids.threadId);
+}
+
+function upsertSession(db, ids, input) {
+  db.prepare(
+    `
+      INSERT INTO projection_thread_sessions (
+        thread_id,
+        status,
+        provider_name,
+        provider_session_id,
+        provider_thread_id,
+        runtime_mode,
+        active_turn_id,
+        last_error,
+        updated_at
+      )
+      VALUES (?, ?, ?, NULL, NULL, 'full-access', ?, NULL, ?)
+      ON CONFLICT(thread_id) DO UPDATE SET
+        status = excluded.status,
+        provider_name = excluded.provider_name,
+        provider_session_id = excluded.provider_session_id,
+        provider_thread_id = excluded.provider_thread_id,
+        runtime_mode = excluded.runtime_mode,
+        active_turn_id = excluded.active_turn_id,
+        last_error = excluded.last_error,
+        updated_at = excluded.updated_at
+    `,
+  ).run(ids.threadId, input.status, "codex", input.activeTurnId, input.updatedAt);
+}
+
+function insertMessage(db, input) {
+  db.prepare(
+    `
+      INSERT INTO projection_thread_messages (
+        message_id,
+        thread_id,
+        turn_id,
+        role,
+        text,
+        attachments_json,
+        is_streaming,
+        created_at,
+        updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)
+    `,
+  ).run(
+    input.messageId,
+    input.threadId,
+    input.turnId,
+    input.role,
+    input.text,
+    input.isStreaming ? 1 : 0,
+    input.createdAt,
+    input.updatedAt,
+  );
+}
+
+function insertActivity(db, input) {
+  db.prepare(
+    `
+      INSERT INTO projection_thread_activities (
+        activity_id,
+        thread_id,
+        turn_id,
+        tone,
+        kind,
+        summary,
+        payload_json,
+        created_at,
+        sequence
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+  ).run(
+    input.activityId,
+    input.threadId,
+    input.turnId,
+    input.tone,
+    input.kind,
+    input.summary,
+    JSON.stringify(input.payload),
+    input.createdAt,
+    input.sequence,
+  );
+}
+
+function insertTurn(db, input) {
+  db.prepare(
+    `
+      INSERT INTO projection_turns (
+        thread_id,
+        turn_id,
+        pending_message_id,
+        assistant_message_id,
+        state,
+        requested_at,
+        started_at,
+        completed_at,
+        checkpoint_turn_count,
+        checkpoint_ref,
+        checkpoint_status,
+        checkpoint_files_json
+      )
+      VALUES (?, ?, NULL, ?, ?, ?, ?, ?, NULL, NULL, NULL, '[]')
+    `,
+  ).run(
+    input.threadId,
+    input.turnId,
+    input.assistantMessageId,
+    input.state,
+    input.requestedAt,
+    input.startedAt,
+    input.completedAt,
+  );
+}
+
+function updateProjectionState(db, updatedAt) {
+  const projectorNames = [
+    "projects",
+    "threads",
+    "threadMessages",
+    "threadProposedPlans",
+    "threadActivities",
+    "threadSessions",
+    "checkpoints",
+  ];
+  for (const projector of projectorNames) {
+    db.prepare(
+      `
+        INSERT INTO projection_state (projector, last_applied_sequence, updated_at)
+        VALUES (?, 1, ?)
+        ON CONFLICT(projector) DO UPDATE SET
+          last_applied_sequence = excluded.last_applied_sequence,
+          updated_at = excluded.updated_at
+      `,
+    ).run(projector, updatedAt);
+  }
+}
+
+function seedStaticScenario(ids) {
+  const db = makeDb();
+  try {
+    const turnId = "turn-static-1";
+    resetThreadProjection(db, ids);
+    updateProjectAndThread(db, ids, {
+      projectTitle: "T3 Code",
+      threadTitle: staticThreadTitle,
+      latestTurnId: turnId,
+      updatedAt: "2026-03-07T12:00:06.000Z",
+    });
+    upsertSession(db, ids, {
+      status: "ready",
+      activeTurnId: null,
+      updatedAt: "2026-03-07T12:00:06.000Z",
+    });
+    insertMessage(db, {
+      messageId: "msg-user-static-1",
+      threadId: ids.threadId,
+      turnId: null,
+      role: "user",
+      text: userMessageText,
+      isStreaming: false,
+      createdAt: "2026-03-07T12:00:00.000Z",
+      updatedAt: "2026-03-07T12:00:00.000Z",
+    });
+    insertMessage(db, {
+      messageId: "msg-assistant-static-1",
+      threadId: ids.threadId,
+      turnId,
+      role: "assistant",
+      text: assistantMessageText,
+      isStreaming: false,
+      createdAt: "2026-03-07T12:00:02.000Z",
+      updatedAt: "2026-03-07T12:00:03.000Z",
+    });
+    insertActivity(db, {
+      activityId: "activity-tool-1",
+      threadId: ids.threadId,
+      turnId,
+      tone: "tool",
+      kind: "tool.updated",
+      summary: "Command run complete",
+      payload: {
+        data: {
+          command: workCommand,
+        },
+      },
+      createdAt: "2026-03-07T12:00:02.250Z",
+      sequence: 1,
+    });
+    insertActivity(db, {
+      activityId: "activity-tool-2",
+      threadId: ids.threadId,
+      turnId,
+      tone: "tool",
+      kind: "tool.completed",
+      summary: "File change complete",
+      payload: {
+        data: {
+          changes: [{ path: "apps/web/src/components/ChatView.tsx" }],
+        },
+      },
+      createdAt: "2026-03-07T12:00:02.500Z",
+      sequence: 2,
+    });
+    insertMessage(db, {
+      messageId: "msg-assistant-static-2",
+      threadId: ids.threadId,
+      turnId,
+      role: "assistant",
+      text: `Preview this image:\n\n![diagram](${markdownImageUrl})`,
+      isStreaming: false,
+      createdAt: "2026-03-07T12:00:04.000Z",
+      updatedAt: "2026-03-07T12:00:05.000Z",
+    });
+    insertTurn(db, {
+      threadId: ids.threadId,
+      turnId,
+      assistantMessageId: "msg-assistant-static-2",
+      state: "completed",
+      requestedAt: "2026-03-07T12:00:00.250Z",
+      startedAt: "2026-03-07T12:00:00.500Z",
+      completedAt: "2026-03-07T12:00:05.000Z",
+    });
+    updateProjectionState(db, "2026-03-07T12:00:06.000Z");
+  } finally {
+    db.close();
+  }
+}
+
+function seedRunningScenario(ids) {
+  const db = makeDb();
+  try {
+    const turnId = "turn-running-1";
+    resetThreadProjection(db, ids);
+    updateProjectAndThread(db, ids, {
+      projectTitle: "T3 Code",
+      threadTitle: runningThreadTitle,
+      latestTurnId: turnId,
+      updatedAt: "2026-03-07T12:10:03.000Z",
+    });
+    upsertSession(db, ids, {
+      status: "running",
+      activeTurnId: turnId,
+      updatedAt: "2026-03-07T12:10:03.000Z",
+    });
+    insertMessage(db, {
+      messageId: "msg-user-running-1",
+      threadId: ids.threadId,
+      turnId: null,
+      role: "user",
+      text: "Tighten the prompt card layout and keep the working indicator obvious.",
+      isStreaming: false,
+      createdAt: "2026-03-07T12:10:00.000Z",
+      updatedAt: "2026-03-07T12:10:00.000Z",
+    });
+    insertTurn(db, {
+      threadId: ids.threadId,
+      turnId,
+      assistantMessageId: null,
+      state: "running",
+      requestedAt: "2026-03-07T12:10:00.250Z",
+      startedAt: "2026-03-07T12:10:00.500Z",
+      completedAt: null,
+    });
+    updateProjectionState(db, "2026-03-07T12:10:03.000Z");
+  } finally {
+    db.close();
+  }
+}
+
+function completeRunningScenario(ids) {
+  const db = makeDb();
+  try {
+    db.prepare(
+      `
+        UPDATE projection_thread_sessions
+        SET status = 'ready',
+            active_turn_id = NULL,
+            updated_at = ?
+        WHERE thread_id = ?
+      `,
+    ).run("2026-03-07T12:11:04.000Z", ids.threadId);
+    db.prepare(
+      `
+        UPDATE projection_turns
+        SET assistant_message_id = ?,
+            state = 'completed',
+            completed_at = ?
+        WHERE thread_id = ? AND turn_id = ?
+      `,
+    ).run(
+      "msg-assistant-running-1",
+      "2026-03-07T12:11:03.500Z",
+      ids.threadId,
+      "turn-running-1",
+    );
+    insertMessage(db, {
+      messageId: "msg-assistant-running-1",
+      threadId: ids.threadId,
+      turnId: "turn-running-1",
+      role: "assistant",
+      text: "Finished the layout cleanup and closed out the turn cleanly.",
+      isStreaming: false,
+      createdAt: "2026-03-07T12:11:03.000Z",
+      updatedAt: "2026-03-07T12:11:03.500Z",
+    });
+    db.prepare(
+      `
+        UPDATE projection_threads
+        SET updated_at = ?
+        WHERE thread_id = ?
+      `,
+    ).run("2026-03-07T12:11:04.000Z", ids.threadId);
+    updateProjectionState(db, "2026-03-07T12:11:04.000Z");
+  } finally {
+    db.close();
+  }
+}
+
+async function launchDesktop() {
+  const env = {
+    ...process.env,
+    T3CODE_STATE_DIR: stateDir,
+    T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: "1",
+    T3CODE_DISABLE_AUTO_UPDATE: "1",
+  };
+  delete env.ELECTRON_RUN_AS_NODE;
+
+  const app = await electron.launch({
+    executablePath: electronBinaryPath,
+    args: [
+      "--disable-gpu",
+      "--disable-software-rasterizer",
+      path.join(desktopDir, "dist-electron/main.js"),
+    ],
+    cwd: desktopDir,
+    env,
+  });
+  await app.evaluate(({ BrowserWindow }, size) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    window?.setSize(size.width, size.height);
+    window?.center();
+  }, {
+    width: 1280,
+    height: 920,
+  });
+  const page = await app.firstWindow();
+  await page.waitForLoadState("domcontentloaded");
+  return { app, page };
+}
+
+async function closeDesktop(app) {
+  await app.close();
+  await delay(250);
+}
+
+async function preparePage(page, threadTitle, appSettings = {}) {
+  await page.evaluate((settings) => {
+    localStorage.clear();
+    localStorage.setItem("t3code:theme", "dark");
+    localStorage.setItem("t3code:app-settings:v1", JSON.stringify(settings));
+  }, appSettings);
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.getByText(threadTitle, { exact: true }).first().waitFor({ timeout: 15_000 });
+}
+
+function measureContrast(element) {
+  // These helpers must stay inside the page function because Playwright serializes
+  // the function body that runs in the browser context.
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const sampleColor = (value) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("Unable to create a canvas context for color sampling.");
+    }
+    context.fillStyle = value;
+    context.fillRect(0, 0, 1, 1);
+    const [r, g, b, a] = context.getImageData(0, 0, 1, 1).data;
+    return {
+      r,
+      g,
+      b,
+      a: a / 255,
+    };
+  };
+  const parseColor = (value) => {
+    if (value.startsWith("rgb")) {
+      const match = value.match(/rgba?\(([^)]+)\)/);
+      if (!match) {
+        throw new Error(`Unsupported color value: ${value}`);
+      }
+      const [r, g, b, a = "1"] = match[1].split(",").map((entry) => entry.trim());
+      return {
+        r: Number(r),
+        g: Number(g),
+        b: Number(b),
+        a: Number(a),
+      };
+    }
+    return sampleColor(value);
+  };
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const compositeColor = (top, bottom) => {
+    const alpha = top.a + bottom.a * (1 - top.a);
+    if (alpha <= 0) {
+      return { r: 0, g: 0, b: 0, a: 0 };
+    }
+    return {
+      r: (top.r * top.a + bottom.r * bottom.a * (1 - top.a)) / alpha,
+      g: (top.g * top.a + bottom.g * bottom.a * (1 - top.a)) / alpha,
+      b: (top.b * top.a + bottom.b * bottom.a * (1 - top.a)) / alpha,
+      a: alpha,
+    };
+  };
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  const toLuminance = (channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+  const relativeLuminance = (color) =>
+    0.2126 * toLuminance(color.r) +
+    0.7152 * toLuminance(color.g) +
+    0.0722 * toLuminance(color.b);
+
+  const text = parseColor(getComputedStyle(element).color);
+  const layers = [];
+  let node = element;
+  while (node) {
+    layers.push(parseColor(getComputedStyle(node).backgroundColor));
+    node = node.parentElement;
+  }
+  let background = { r: 0, g: 0, b: 0, a: 1 };
+  for (let index = layers.length - 1; index >= 0; index -= 1) {
+    background = compositeColor(layers[index], background);
+  }
+
+  const lighter = Math.max(relativeLuminance(text), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(text), relativeLuminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+async function contrastRatioForLocator(locator) {
+  return locator.evaluate(measureContrast);
+}
+
+async function userTimestampDisplay(page) {
+  const userBubble = page
+    .locator("pre")
+    .filter({ hasText: userMessageText })
+    .first();
+  return userBubble.evaluate((pre) => {
+    const bubble = pre.parentElement;
+    const metadataRow = bubble?.lastElementChild;
+    if (!(metadataRow instanceof HTMLElement)) {
+      throw new Error("Unable to find the user-message metadata row.");
+    }
+    return getComputedStyle(metadataRow).display;
+  });
+}
+
+async function validateStaticScenario(ids) {
+  seedStaticScenario(ids);
+  const { app, page } = await launchDesktop();
+  try {
+    await preparePage(page, staticThreadTitle);
+
+    await page.getByRole("button", { name: "Settings" }).first().waitFor();
+
+    const assistantText = page
+      .locator(".chat-markdown")
+      .filter({ hasText: assistantMessageText })
+      .first();
+    const workText = page.getByText("File change complete").first();
+    const assistantContrast = await contrastRatioForLocator(assistantText);
+    const workContrast = await contrastRatioForLocator(workText);
+    assert(
+      assistantContrast >= 8,
+      `Assistant text contrast regressed to ${assistantContrast.toFixed(2)}.`,
+    );
+    assert(workContrast >= 6, `Work-log contrast regressed to ${workContrast.toFixed(2)}.`);
+
+    const hiddenDisplay = await userTimestampDisplay(page);
+    assert.equal(hiddenDisplay, "none", "User message metadata still reserves vertical space.");
+    await page
+      .locator("pre")
+      .filter({ hasText: userMessageText })
+      .first()
+      .hover();
+    const visibleDisplay = await userTimestampDisplay(page);
+    assert.notEqual(visibleDisplay, "none", "User message metadata did not reappear on hover.");
+
+    await page.getByText("Tool calls (2)").first().waitFor();
+    assert.equal(
+      await page.getByText(workCommand, { exact: true }).count(),
+      0,
+      "Tool-command details should start collapsed.",
+    );
+    await page.getByRole("button", { name: "Expand" }).first().click();
+    await page.getByText(workCommand, { exact: true }).waitFor();
+
+    await page.locator(".chat-markdown-image-button").first().click();
+    await page.getByRole("dialog", { name: "Expanded image preview" }).waitFor();
+
+    await page.screenshot({
+      path: path.join(artifactDir, "static-preview.png"),
+      fullPage: true,
+    });
+
+    await page.getByRole("button", { name: "Close image preview" }).last().click();
+  } finally {
+    await closeDesktop(app);
+  }
+}
+
+async function navigateBackToThread(page, threadTitle) {
+  await page.goBack({ waitUntil: "domcontentloaded" }).catch(() => undefined);
+  const threadTitleLocator = page.getByText(threadTitle, { exact: true }).first();
+  const threadButtonVisible = await threadTitleLocator
+    .waitFor({ timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (threadButtonVisible) {
+    return;
+  }
+  await page.getByText(threadTitle, { exact: true }).last().click();
+  await page.getByText(threadTitle, { exact: true }).first().waitFor({ timeout: 10_000 });
+}
+
+async function validateRunningScenario(ids) {
+  seedRunningScenario(ids);
+  const { app, page } = await launchDesktop();
+  try {
+    await preparePage(page, runningThreadTitle, {
+      busyTurnSubmissionBehavior: "steer",
+    });
+    const runningComposer = page.locator('[contenteditable="true"]').first();
+    await runningComposer.click();
+    await page.keyboard.type(previewBusyActionText);
+    const steerButton = page.getByRole("button", { name: "Steer now" });
+    const steerVisible = await steerButton
+      .waitFor({ timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!steerVisible) {
+      const buttonLabels = await page.locator("button").evaluateAll((buttons) =>
+        buttons
+          .map((button) => (button.textContent ?? "").trim() || button.getAttribute("aria-label") || "")
+          .filter((label) => label.length > 0),
+      );
+      await page.screenshot({
+        path: path.join(artifactDir, "running-debug.png"),
+        fullPage: true,
+      });
+      throw new Error(`Unable to find the running primary action. Buttons: ${buttonLabels.join(" | ")}`);
+    }
+    const loaderLabel = page.getByText(/Working for/).first();
+    const verticalAlignmentDelta = await loaderLabel.evaluate((label) => {
+      const dots = label.previousElementSibling;
+      if (!(dots instanceof HTMLElement)) {
+        throw new Error("Unable to find the working indicator dot grid.");
+      }
+      const labelRect = label.getBoundingClientRect();
+      const dotsRect = dots.getBoundingClientRect();
+      const labelCenter = labelRect.top + labelRect.height / 2;
+      const dotsCenter = dotsRect.top + dotsRect.height / 2;
+      return Math.abs(labelCenter - dotsCenter);
+    });
+    assert(
+      verticalAlignmentDelta <= 4,
+      `Working indicator is vertically misaligned by ${verticalAlignmentDelta.toFixed(2)}px.`,
+    );
+
+    await page.getByRole("button", { name: "Settings" }).first().click();
+    await page.getByRole("heading", { name: "Settings" }).waitFor();
+    await page.getByText("General").waitFor();
+    const queueOption = page.getByRole("radio", { name: /Queue next turn/i });
+    await queueOption.click();
+    await page.waitForFunction(
+      () =>
+        [...document.querySelectorAll('[role="radio"]')].some(
+          (element) =>
+            element.getAttribute("aria-checked") === "true" &&
+            (element.textContent ?? "").includes("Queue next turn"),
+        ),
+    );
+
+    await navigateBackToThread(page, runningThreadTitle);
+    const queueButton = page.getByRole("button", { name: "Queue next" });
+    let expectedQueuedText = previewBusyActionText;
+    const queueButtonVisible = await queueButton
+      .waitFor({ timeout: 3_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!queueButtonVisible) {
+      await runningComposer.click();
+      await page.keyboard.press(`${process.platform === "darwin" ? "Meta" : "Control"}+A`);
+      await page.keyboard.press("Backspace");
+      await page.keyboard.type(queuedFollowUpText);
+      await queueButton.waitFor();
+      expectedQueuedText = queuedFollowUpText;
+    }
+
+    await page.getByRole("button", { name: "Queue next" }).click();
+    await page.getByText("Queued next turn").waitFor();
+    await page.getByText(expectedQueuedText).waitFor();
+
+    await page.screenshot({
+      path: path.join(artifactDir, "running-queue.png"),
+      fullPage: true,
+    });
+  } finally {
+    await closeDesktop(app);
+  }
+}
+
+function activateFinder() {
+  execFileSync("osascript", ["-e", 'tell application "Finder" to activate']);
+}
+
+function activateApp() {
+  execFileSync("osascript", ["-e", `tell application "${appName}" to activate`]);
+}
+
+async function blurWindow(app) {
+  await app.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0]?.blur();
+  });
+  try {
+    activateFinder();
+  } catch {
+    // Ignore AppleScript failures; BrowserWindow.blur is the primary mechanism.
+  }
+  await delay(750);
+}
+
+async function focusWindow(app, page) {
+  await app.evaluate(({ BrowserWindow }) => {
+    BrowserWindow.getAllWindows()[0]?.focus();
+  });
+  try {
+    activateApp();
+  } catch {
+    // Ignore AppleScript failures; BrowserWindow.focus is the primary mechanism.
+  }
+  await page.waitForFunction(() => document.hasFocus(), null, { timeout: 3_000 }).catch(() => undefined);
+  await page.evaluate(() => {
+    for (const eventName of ["focus", "pageshow", "online"]) {
+      window.dispatchEvent(new Event(eventName));
+    }
+  });
+  await delay(750);
+}
+
+async function validateFocusHealingScenario(ids) {
+  seedRunningScenario(ids);
+  const { app, page } = await launchDesktop();
+  try {
+    await preparePage(page, runningThreadTitle, {
+      busyTurnSubmissionBehavior: "steer",
+    });
+    await page.getByText(/Working for/).waitFor();
+    await blurWindow(app);
+    completeRunningScenario(ids);
+    await focusWindow(app, page);
+    await page.getByText("Finished the layout cleanup and closed out the turn cleanly.").waitFor({
+      timeout: 20_000,
+    });
+    assert.equal(
+      await page.getByText(/Working for/).count(),
+      0,
+      "The running indicator did not clear after the focus resync.",
+    );
+
+    await page.screenshot({
+      path: path.join(artifactDir, "focus-healed.png"),
+      fullPage: true,
+    });
+  } finally {
+    await closeDesktop(app);
+  }
+}
+
+async function bootstrapStateDir() {
+  const { app, page } = await launchDesktop();
+  try {
+    await page.getByText("New thread", { exact: true }).first().waitFor({ timeout: 15_000 });
+  } finally {
+    await closeDesktop(app);
+  }
+}
+
+async function main() {
+  fs.mkdirSync(artifactDir, { recursive: true });
+  const markdownImageServer = await startMarkdownImageServer();
+  markdownImageUrl = markdownImageServer.url;
+  log(`State dir: ${stateDir}`);
+  try {
+    log("Bootstrapping the state database through the real desktop app...");
+    await bootstrapStateDir();
+    const ids = readBootstrapIds();
+    log(`Using project ${ids.projectId} and thread ${ids.threadId}.`);
+
+    log("Validating static thread behaviors...");
+    await validateStaticScenario(ids);
+
+    log("Validating running-turn controls and settings...");
+    await validateRunningScenario(ids);
+
+    log("Validating focus-healing for stale running state...");
+    await validateFocusHealingScenario(ids);
+
+    log(`Desktop feedback validation passed. Screenshots saved to ${artifactDir}.`);
+  } finally {
+    await new Promise((resolve, reject) => {
+      markdownImageServer.server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(undefined);
+      });
+    });
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,7 +15,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "node scripts/cli.ts build",
+    "build": "bun scripts/cli.ts build",
     "start": "node dist/index.mjs",
     "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -6,6 +6,22 @@ import { getDefaultModel, getModelOptions, normalizeModelSlug } from "@t3tools/s
 const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
 const MAX_CUSTOM_MODEL_COUNT = 32;
 export const MAX_CUSTOM_MODEL_LENGTH = 256;
+export const BUSY_TURN_SUBMISSION_OPTIONS = [
+  {
+    value: "steer",
+    label: "Steer current turn",
+    shortLabel: "Steer now",
+    description: "Interrupt the current run, then send your message as soon as the agent stops.",
+  },
+  {
+    value: "queue",
+    label: "Queue next turn",
+    shortLabel: "Queue next",
+    description: "Let the current run finish, then send your message automatically afterward.",
+  },
+] as const;
+export type BusyTurnSubmissionBehavior = (typeof BUSY_TURN_SUBMISSION_OPTIONS)[number]["value"];
+const BusyTurnSubmissionBehaviorSchema = Schema.Literals(["steer", "queue"]);
 export const APP_SERVICE_TIER_OPTIONS = [
   {
     value: "auto",
@@ -41,7 +57,12 @@ const AppSettingsSchema = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(
     Schema.withConstructorDefault(() => Option.some(false)),
   ),
-  codexServiceTier: AppServiceTierSchema.pipe(Schema.withConstructorDefault(() => Option.some("auto"))),
+  busyTurnSubmissionBehavior: BusyTurnSubmissionBehaviorSchema.pipe(
+    Schema.withConstructorDefault(() => Option.some("steer")),
+  ),
+  codexServiceTier: AppServiceTierSchema.pipe(
+    Schema.withConstructorDefault(() => Option.some("auto")),
+  ),
   customCodexModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
   ),

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -53,6 +53,7 @@ interface ChatMarkdownProps {
   text: string;
   cwd: string | undefined;
   isStreaming?: boolean;
+  onImagePreview?: (input: { src: string; alt: string }) => void;
 }
 
 const CODE_FENCE_LANGUAGE_REGEX = /(?:^|\s)language-([^\s]+)/;
@@ -232,7 +233,7 @@ function SuspenseShikiCodeBlock({
   );
 }
 
-function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
+function ChatMarkdown({ text, cwd, isStreaming = false, onImagePreview }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
   const markdownComponents = useMemo<Components>(
@@ -281,12 +282,49 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
           </MarkdownCodeBlock>
         );
       },
+      img({ node: _node, src, alt, ...props }) {
+        if (typeof src !== "string" || src.length === 0) {
+          return null;
+        }
+
+        const image = (
+          <img
+            {...props}
+            src={src}
+            alt={alt ?? ""}
+            loading="lazy"
+            className="chat-markdown-image"
+          />
+        );
+
+        if (!onImagePreview) {
+          return <span className="chat-markdown-media">{image}</span>;
+        }
+
+        return (
+          <span className="chat-markdown-media">
+            <button
+              type="button"
+              className="chat-markdown-image-button"
+              onClick={() => {
+                onImagePreview({
+                  src,
+                  alt: alt ?? "Image attachment",
+                });
+              }}
+              aria-label={alt ? `Preview ${alt}` : "Preview image"}
+            >
+              {image}
+            </button>
+          </span>
+        );
+      },
     }),
-    [cwd, diffThemeName, isStreaming],
+    [cwd, diffThemeName, isStreaming, onImagePreview],
   );
 
   return (
-    <div className="chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80">
+    <div className="chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/92">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
         {text}
       </ReactMarkdown>

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -8,6 +8,7 @@ import {
   type ProjectId,
   type ServerConfig,
   type ThreadId,
+  type TurnId,
   type WsWelcomePayload,
   WS_CHANNELS,
   WS_METHODS,
@@ -29,6 +30,7 @@ const PROJECT_ID = "project-1" as ProjectId;
 const NOW_ISO = "2026-03-04T12:00:00.000Z";
 const BASE_TIME_MS = Date.parse(NOW_ISO);
 const ATTACHMENT_SVG = "<svg xmlns='http://www.w3.org/2000/svg' width='120' height='300'></svg>";
+const MARKDOWN_IMAGE_URL = "http://localhost:3020/markdown-image.svg";
 
 interface WsRequestEnvelope {
   id: string;
@@ -336,6 +338,13 @@ const worker = setupWorker(
       },
     }),
   ),
+  http.get("*/markdown-image.svg", () =>
+    HttpResponse.text(ATTACHMENT_SVG, {
+      headers: {
+        "Content-Type": "image/svg+xml",
+      },
+    }),
+  ),
   http.get("*/api/project-favicon", () => new HttpResponse(null, { status: 204 })),
 );
 
@@ -359,9 +368,9 @@ async function setViewport(viewport: ViewportSpec): Promise<void> {
 async function waitForProductionStyles(): Promise<void> {
   await vi.waitFor(
     () => {
-      expect(getComputedStyle(document.documentElement).getPropertyValue("--background").trim()).not.toBe(
-        "",
-      );
+      expect(
+        getComputedStyle(document.documentElement).getPropertyValue("--background").trim(),
+      ).not.toBe("");
       expect(getComputedStyle(document.body).marginTop).toBe("0px");
     },
     {
@@ -399,13 +408,25 @@ async function waitForComposerEditor(): Promise<HTMLElement> {
   );
 }
 
-async function waitForInteractionModeButton(expectedLabel: "Chat" | "Plan"): Promise<HTMLButtonElement> {
+async function waitForInteractionModeButton(
+  expectedLabel: "Chat" | "Plan",
+): Promise<HTMLButtonElement> {
   return waitForElement(
     () =>
       Array.from(document.querySelectorAll("button")).find(
         (button) => button.textContent?.trim() === expectedLabel,
       ) as HTMLButtonElement | null,
     `Unable to find ${expectedLabel} interaction mode button.`,
+  );
+}
+
+async function waitForButtonByText(expectedLabel: string): Promise<HTMLButtonElement> {
+  return waitForElement(
+    () =>
+      Array.from(document.querySelectorAll("button")).find(
+        (button) => button.textContent?.trim() === expectedLabel,
+      ) as HTMLButtonElement | null,
+    `Unable to find '${expectedLabel}' button.`,
   );
 }
 
@@ -642,7 +663,9 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
-      const measurements: Array<UserRowMeasurement & { viewport: ViewportSpec; estimatedHeightPx: number }> = [];
+      const measurements: Array<
+        UserRowMeasurement & { viewport: ViewportSpec; estimatedHeightPx: number }
+      > = [];
 
       for (const viewport of TEXT_VIEWPORT_MATRIX) {
         await mounted.setViewport(viewport);
@@ -659,7 +682,10 @@ describe("ChatView timeline estimator parity (full app)", () => {
         measurements.push({ ...measurement, viewport, estimatedHeightPx });
       }
 
-      expect(new Set(measurements.map((measurement) => Math.round(measurement.timelineWidthMeasuredPx))).size).toBeGreaterThanOrEqual(3);
+      expect(
+        new Set(measurements.map((measurement) => Math.round(measurement.timelineWidthMeasuredPx)))
+          .size,
+      ).toBeGreaterThanOrEqual(3);
 
       const byMeasuredWidth = measurements.toSorted(
         (left, right) => left.timelineWidthMeasuredPx - right.timelineWidthMeasuredPx,
@@ -701,7 +727,8 @@ describe("ChatView timeline estimator parity (full app)", () => {
       { timelineWidthPx: mobileMeasurement.timelineWidthMeasuredPx },
     );
 
-    const measuredDeltaPx = mobileMeasurement.measuredRowHeightPx - desktopMeasurement.measuredRowHeightPx;
+    const measuredDeltaPx =
+      mobileMeasurement.measuredRowHeightPx - desktopMeasurement.measuredRowHeightPx;
     const estimatedDeltaPx = estimatedMobilePx - estimatedDesktopPx;
     expect(measuredDeltaPx).toBeGreaterThan(0);
     expect(estimatedDeltaPx).toBeGreaterThan(0);
@@ -789,7 +816,9 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       await vi.waitFor(
         () => {
-          const openRequest = wsRequests.find((request) => request._tag === WS_METHODS.shellOpenInEditor);
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenInEditor,
+          );
           expect(openRequest).toMatchObject({
             _tag: WS_METHODS.shellOpenInEditor,
             cwd: "/repo/project",
@@ -862,6 +891,134 @@ describe("ChatView timeline estimator parity (full app)", () => {
           expect((await waitForInteractionModeButton("Chat")).title).toContain("enter plan mode");
         },
         { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("shows busy-turn steering controls and dispatches an interrupt before follow-up send", async () => {
+    useComposerDraftStore.getState().setPrompt(THREAD_ID, "Please change course.");
+
+    const snapshot = createSnapshotForTargetUser({
+      targetMessageId: "msg-user-running" as MessageId,
+      targetText: "running target",
+    });
+    const runningThread = snapshot.threads[0];
+    if (!runningThread) {
+      throw new Error("Expected running thread fixture.");
+    }
+    const runningSnapshot: OrchestrationReadModel = {
+      ...snapshot,
+      threads: [
+        {
+          ...runningThread,
+          latestTurn: {
+            turnId: "turn-running" as TurnId,
+            state: "running",
+            requestedAt: NOW_ISO,
+            startedAt: NOW_ISO,
+            completedAt: null,
+            assistantMessageId: null,
+          },
+          session: {
+            threadId: THREAD_ID,
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: "turn-running" as TurnId,
+            lastError: null,
+            updatedAt: NOW_ISO,
+          },
+        },
+      ],
+    };
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: runningSnapshot,
+    });
+
+    try {
+      const steerButton = await waitForButtonByText("Steer now");
+      steerButton.click();
+
+      await vi.waitFor(
+        () => {
+          const interruptRequest = wsRequests.find((request) => {
+            const command = (request as { command?: { type?: string } }).command;
+            return (
+              request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+              command?.type === "thread.turn.interrupt"
+            );
+          });
+          expect(interruptRequest).toBeTruthy();
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("p")).find(
+            (element) => element.textContent?.trim() === "Steer pending",
+          ) ?? null,
+        "Unable to find steer pending banner.",
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("renders assistant markdown images inline and opens the expanded preview", async () => {
+    const snapshot = createSnapshotForTargetUser({
+      targetMessageId: "msg-user-markdown-image" as MessageId,
+      targetText: "show image preview",
+    });
+    const thread = snapshot.threads[0];
+    if (!thread) {
+      throw new Error("Expected assistant message fixture.");
+    }
+    const assistantMessageIndex = thread.messages.findLastIndex(
+      (message) => message.role === "assistant",
+    );
+    if (assistantMessageIndex < 0) {
+      throw new Error("Expected assistant message fixture.");
+    }
+    const assistantMessage = thread.messages[assistantMessageIndex];
+    if (!assistantMessage) {
+      throw new Error("Expected assistant message fixture.");
+    }
+    const messages = thread.messages.slice();
+    messages[assistantMessageIndex] = {
+      ...assistantMessage,
+      text: `Preview this image:\n\n![diagram](${MARKDOWN_IMAGE_URL})`,
+    };
+    const imageSnapshot: OrchestrationReadModel = {
+      ...snapshot,
+      threads: [
+        {
+          ...thread,
+          messages,
+        },
+      ],
+    };
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: imageSnapshot,
+    });
+
+    try {
+      const imageButton = await waitForElement(
+        () => document.querySelector<HTMLButtonElement>(".chat-markdown-image-button"),
+        "Unable to find assistant markdown image preview button.",
+      );
+      await waitForImagesToLoad(document);
+      imageButton.click();
+
+      await waitForElement(
+        () => document.querySelector<HTMLElement>('[aria-label="Expanded image preview"]'),
+        "Unable to open expanded image preview.",
       );
     } finally {
       await mounted.cleanup();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -199,10 +199,12 @@ import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import {
+  BUSY_TURN_SUBMISSION_OPTIONS,
   getAppModelOptions,
   resolveAppModelSelection,
   resolveAppServiceTier,
   shouldShowFastTierIcon,
+  type BusyTurnSubmissionBehavior,
   type AppServiceTier,
   useAppSettings,
 } from "../appSettings";
@@ -249,7 +251,6 @@ function formatWorkingTimer(startIso: string, endIso: string): string | null {
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
 const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
-const MAX_VISIBLE_WORK_LOG_ENTRIES = 6;
 const ALWAYS_UNVIRTUALIZED_TAIL_ROWS = 8;
 const ATTACHMENT_PREVIEW_HANDOFF_TTL_MS = 5000;
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
@@ -285,10 +286,10 @@ function readLastInvokedScriptByProjectFromStorage(): Record<string, string> {
 }
 
 function workToneClass(tone: "thinking" | "tool" | "info" | "error"): string {
-  if (tone === "error") return "text-rose-300/50 dark:text-rose-300/50";
-  if (tone === "tool") return "text-muted-foreground/70";
-  if (tone === "thinking") return "text-muted-foreground/50";
-  return "text-muted-foreground/40";
+  if (tone === "error") return "text-rose-700 dark:text-rose-300/90";
+  if (tone === "tool") return "text-foreground/92";
+  if (tone === "thinking") return "text-foreground/86";
+  return "text-foreground/84";
 }
 
 function normalizePlanMarkdownForExport(planMarkdown: string): string {
@@ -334,6 +335,21 @@ function buildExpandedImagePreview(
   return {
     images: previewableImages.map((image) => ({ src: image.src, name: image.name })),
     index: selectedIndex,
+  };
+}
+
+function buildSingleExpandedImagePreview(input: {
+  src: string;
+  name: string;
+}): ExpandedImagePreview {
+  return {
+    images: [
+      {
+        src: input.src,
+        name: input.name,
+      },
+    ],
+    index: 0,
   };
 }
 
@@ -424,6 +440,12 @@ type ComposerCommandItem =
     };
 
 type SendPhase = "idle" | "preparing-worktree" | "sending-turn";
+interface PendingBusyTurnSubmission {
+  threadId: ThreadId;
+  text: string;
+  images: ComposerImageAttachment[];
+  behavior: BusyTurnSubmissionBehavior;
+}
 
 function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -459,6 +481,12 @@ function cloneComposerImageForRetry(image: ComposerImageAttachment): ComposerIma
     };
   } catch {
     return image;
+  }
+}
+
+function revokeComposerImagePreviewUrls(images: ReadonlyArray<ComposerImageAttachment>): void {
+  for (const image of images) {
+    revokeBlobPreviewUrl(image.previewUrl);
   }
 }
 
@@ -643,6 +671,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
     Record<ThreadId, string | null>
   >({});
   const [sendPhase, setSendPhase] = useState<SendPhase>("idle");
+  const [pendingBusyTurnSubmission, setPendingBusyTurnSubmission] =
+    useState<PendingBusyTurnSubmission | null>(null);
   const [sendStartedAt, setSendStartedAt] = useState<string | null>(null);
   const [isConnecting, _setIsConnecting] = useState(false);
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
@@ -693,6 +723,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewHandoffTimeoutByMessageIdRef = useRef<Record<string, number>>({});
   const sendInFlightRef = useRef(false);
+  const pendingBusyTurnDispatchRef = useRef(false);
   const dragDepthRef = useRef(0);
   const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
   const setMessagesScrollContainerRef = useCallback((element: HTMLDivElement | null) => {
@@ -734,6 +765,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
     },
     [removeComposerDraftImage, threadId],
   );
+  const clearComposerInput = useCallback(() => {
+    promptRef.current = "";
+    clearComposerDraftContent(threadId);
+    setComposerHighlightedItemId(null);
+    setComposerCursor(0);
+    setComposerTrigger(null);
+  }, [clearComposerDraftContent, threadId]);
 
   const serverThread = threads.find((t) => t.id === threadId);
   const fallbackDraftProject = projects.find((project) => project.id === draftThread?.projectId);
@@ -793,6 +831,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       activeThread.messages.length > 0 ||
       activeThread.session !== null),
   );
+  const busyTurnSubmissionBehavior = settings.busyTurnSubmissionBehavior;
   const selectedServiceTierSetting = settings.codexServiceTier;
   const selectedServiceTier = resolveAppServiceTier(selectedServiceTierSetting);
   const lockedProvider: ProviderKind | null = hasThreadStarted
@@ -862,6 +901,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const isSendBusy = sendPhase !== "idle";
   const isPreparingWorktree = sendPhase === "preparing-worktree";
   const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const pendingBusySubmissionForActiveThread =
+    pendingBusyTurnSubmission?.threadId === activeThread?.id ? pendingBusyTurnSubmission : null;
+  const defaultBusyTurnSubmissionOption =
+    BUSY_TURN_SUBMISSION_OPTIONS.find((option) => option.value === busyTurnSubmissionBehavior) ??
+    BUSY_TURN_SUBMISSION_OPTIONS[0];
+  const alternateBusyTurnSubmissionOption = BUSY_TURN_SUBMISSION_OPTIONS.find(
+    (option) => option.value !== defaultBusyTurnSubmissionOption?.value,
+  );
   const nowIso = new Date(nowTick).toISOString();
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
@@ -2395,6 +2442,360 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [activeThread, isConnecting, isRevertingCheckpoint, isSendBusy, phase, setThreadError],
   );
 
+  const submitComposerTurn = useCallback(
+    async (input: {
+      text: string;
+      images: ComposerImageAttachment[];
+      interactionModeOverride?: ProviderInteractionMode;
+    }): Promise<boolean> => {
+      const api = readNativeApi();
+      if (
+        !api ||
+        !activeThread ||
+        !activeProject ||
+        isSendBusy ||
+        isConnecting ||
+        sendInFlightRef.current
+      ) {
+        return false;
+      }
+
+      const trimmed = input.text.trim();
+      const composerImagesSnapshot = [...input.images];
+      if (!trimmed && composerImagesSnapshot.length === 0) {
+        return false;
+      }
+
+      const effectiveInteractionMode = input.interactionModeOverride ?? interactionMode;
+      const threadIdForSend = activeThread.id;
+      const isFirstMessage = !isServerThread || activeThread.messages.length === 0;
+      const baseBranchForWorktree =
+        isFirstMessage && envMode === "worktree" && !activeThread.worktreePath
+          ? activeThread.branch
+          : null;
+
+      const shouldCreateWorktree =
+        isFirstMessage && envMode === "worktree" && !activeThread.worktreePath;
+      if (shouldCreateWorktree && !activeThread.branch) {
+        setStoreThreadError(
+          threadIdForSend,
+          "Select a base branch before sending in New worktree mode.",
+        );
+        return false;
+      }
+
+      sendInFlightRef.current = true;
+      beginSendPhase(baseBranchForWorktree ? "preparing-worktree" : "sending-turn");
+
+      const messageIdForSend = newMessageId();
+      const messageCreatedAt = new Date().toISOString();
+      const turnAttachmentsPromise = Promise.all(
+        composerImagesSnapshot.map(async (image) => ({
+          type: "image" as const,
+          name: image.name,
+          mimeType: image.mimeType,
+          sizeBytes: image.sizeBytes,
+          dataUrl: await readFileAsDataUrl(image.file),
+        })),
+      );
+      const optimisticAttachments = composerImagesSnapshot.map((image) => ({
+        type: "image" as const,
+        id: image.id,
+        name: image.name,
+        mimeType: image.mimeType,
+        sizeBytes: image.sizeBytes,
+        previewUrl: image.previewUrl,
+      }));
+      setOptimisticUserMessages((existing) => [
+        ...existing,
+        {
+          id: messageIdForSend,
+          role: "user",
+          text: trimmed,
+          ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
+          createdAt: messageCreatedAt,
+          streaming: false,
+        },
+      ]);
+      shouldAutoScrollRef.current = true;
+      forceStickToBottom();
+
+      setThreadError(threadIdForSend, null);
+      clearComposerInput();
+
+      let createdServerThreadForLocalDraft = false;
+      let turnStartSucceeded = false;
+      let nextThreadBranch = activeThread.branch;
+      let nextThreadWorktreePath = activeThread.worktreePath;
+      await (async () => {
+        if (baseBranchForWorktree) {
+          beginSendPhase("preparing-worktree");
+          const newBranch = buildTemporaryWorktreeBranchName();
+          const result = await createWorktreeMutation.mutateAsync({
+            cwd: activeProject.cwd,
+            branch: baseBranchForWorktree,
+            newBranch,
+          });
+          nextThreadBranch = result.worktree.branch;
+          nextThreadWorktreePath = result.worktree.path;
+          if (isServerThread) {
+            await api.orchestration.dispatchCommand({
+              type: "thread.meta.update",
+              commandId: newCommandId(),
+              threadId: threadIdForSend,
+              branch: result.worktree.branch,
+              worktreePath: result.worktree.path,
+            });
+            setStoreThreadBranch(threadIdForSend, result.worktree.branch, result.worktree.path);
+          }
+        }
+
+        const firstComposerImageName = composerImagesSnapshot[0]?.name ?? null;
+        let titleSeed = trimmed;
+        if (!titleSeed) {
+          titleSeed = firstComposerImageName ? `Image: ${firstComposerImageName}` : "New thread";
+        }
+        const title = truncateTitle(titleSeed);
+        const threadCreateModel: ModelSlug =
+          selectedModel || (activeProject.model as ModelSlug) || DEFAULT_MODEL_BY_PROVIDER.codex;
+
+        if (isLocalDraftThread) {
+          await api.orchestration.dispatchCommand({
+            type: "thread.create",
+            commandId: newCommandId(),
+            threadId: threadIdForSend,
+            projectId: activeProject.id,
+            title,
+            model: threadCreateModel,
+            runtimeMode,
+            interactionMode: effectiveInteractionMode,
+            branch: nextThreadBranch,
+            worktreePath: nextThreadWorktreePath,
+            createdAt: activeThread.createdAt,
+          });
+          createdServerThreadForLocalDraft = true;
+        }
+
+        let setupScript: ProjectScript | null = null;
+        if (baseBranchForWorktree) {
+          setupScript = setupProjectScript(activeProject.scripts);
+        }
+        if (setupScript) {
+          const shouldRunSetupScript = isServerThread || createdServerThreadForLocalDraft;
+          if (shouldRunSetupScript) {
+            const setupScriptOptions: Parameters<typeof runProjectScript>[1] = {
+              worktreePath: nextThreadWorktreePath,
+              rememberAsLastInvoked: false,
+              allowLocalDraftThread: createdServerThreadForLocalDraft,
+            };
+            if (nextThreadWorktreePath) {
+              setupScriptOptions.cwd = nextThreadWorktreePath;
+            }
+            await runProjectScript(setupScript, setupScriptOptions);
+          }
+        }
+
+        if (isFirstMessage && isServerThread) {
+          await api.orchestration.dispatchCommand({
+            type: "thread.meta.update",
+            commandId: newCommandId(),
+            threadId: threadIdForSend,
+            title,
+          });
+        }
+
+        if (isServerThread) {
+          await persistThreadSettingsForNextTurn({
+            threadId: threadIdForSend,
+            createdAt: messageCreatedAt,
+            ...(selectedModel ? { model: selectedModel } : {}),
+            runtimeMode,
+            interactionMode: effectiveInteractionMode,
+          });
+        }
+
+        beginSendPhase("sending-turn");
+        const turnAttachments = await turnAttachmentsPromise;
+        await api.orchestration.dispatchCommand({
+          type: "thread.turn.start",
+          commandId: newCommandId(),
+          threadId: threadIdForSend,
+          message: {
+            messageId: messageIdForSend,
+            role: "user",
+            text: trimmed || IMAGE_ONLY_BOOTSTRAP_PROMPT,
+            attachments: turnAttachments,
+          },
+          model: selectedModel || undefined,
+          serviceTier: selectedServiceTier,
+          ...(selectedModelOptionsForDispatch
+            ? { modelOptions: selectedModelOptionsForDispatch }
+            : {}),
+          provider: selectedProvider,
+          assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
+          runtimeMode,
+          interactionMode: effectiveInteractionMode,
+          createdAt: messageCreatedAt,
+        });
+        turnStartSucceeded = true;
+        if (isFirstMessage) {
+          clearDraftThread(threadIdForSend);
+        }
+      })().catch(async (err: unknown) => {
+        if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
+          await api.orchestration
+            .dispatchCommand({
+              type: "thread.delete",
+              commandId: newCommandId(),
+              threadId: threadIdForSend,
+            })
+            .catch(() => undefined);
+        }
+        if (
+          !turnStartSucceeded &&
+          promptRef.current.length === 0 &&
+          composerImagesRef.current.length === 0
+        ) {
+          setOptimisticUserMessages((existing) => {
+            const removed = existing.filter((message) => message.id === messageIdForSend);
+            for (const message of removed) {
+              revokeUserMessagePreviewUrls(message);
+            }
+            const next = existing.filter((message) => message.id !== messageIdForSend);
+            return next.length === existing.length ? existing : next;
+          });
+          promptRef.current = trimmed;
+          setPrompt(trimmed);
+          setComposerCursor(trimmed.length);
+          addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageForRetry));
+          setComposerTrigger(detectComposerTrigger(trimmed, trimmed.length));
+        }
+        setThreadError(
+          threadIdForSend,
+          err instanceof Error ? err.message : "Failed to send message.",
+        );
+      });
+      sendInFlightRef.current = false;
+      if (!turnStartSucceeded) {
+        resetSendPhase();
+      }
+      return turnStartSucceeded;
+    },
+    [
+      activeProject,
+      activeThread,
+      addComposerImagesToDraft,
+      beginSendPhase,
+      clearComposerInput,
+      clearDraftThread,
+      createWorktreeMutation,
+      envMode,
+      forceStickToBottom,
+      interactionMode,
+      isConnecting,
+      isLocalDraftThread,
+      isSendBusy,
+      isServerThread,
+      persistThreadSettingsForNextTurn,
+      resetSendPhase,
+      runProjectScript,
+      runtimeMode,
+      selectedModel,
+      selectedModelOptionsForDispatch,
+      selectedProvider,
+      selectedServiceTier,
+      setPrompt,
+      setStoreThreadError,
+      setStoreThreadBranch,
+      setThreadError,
+      settings.enableAssistantStreaming,
+    ],
+  );
+
+  const onInterrupt = useCallback(async () => {
+    const api = readNativeApi();
+    if (!api || !activeThread) return;
+    await api.orchestration.dispatchCommand({
+      type: "thread.turn.interrupt",
+      commandId: newCommandId(),
+      threadId: activeThread.id,
+      createdAt: new Date().toISOString(),
+    });
+  }, [activeThread]);
+
+  const queueBusyTurnSubmission = useCallback(
+    async (behavior: BusyTurnSubmissionBehavior) => {
+      if (!activeThread) {
+        return;
+      }
+      const trimmed = prompt.trim();
+      if (!trimmed && composerImages.length === 0) {
+        return;
+      }
+      if (pendingBusySubmissionForActiveThread) {
+        setThreadError(
+          activeThread.id,
+          "A follow-up is already pending. Edit or cancel it before sending another one.",
+        );
+        return;
+      }
+
+      const images = composerImages.map(cloneComposerImageForRetry);
+      setPendingBusyTurnSubmission({
+        threadId: activeThread.id,
+        text: trimmed,
+        images,
+        behavior,
+      });
+      setThreadError(activeThread.id, null);
+      clearComposerInput();
+
+      if (behavior === "steer") {
+        await onInterrupt();
+      }
+    },
+    [
+      activeThread,
+      clearComposerInput,
+      composerImages,
+      onInterrupt,
+      pendingBusySubmissionForActiveThread,
+      prompt,
+      setThreadError,
+    ],
+  );
+
+  const restorePendingBusyTurnSubmission = useCallback(() => {
+    if (!pendingBusySubmissionForActiveThread) {
+      return;
+    }
+    const queuedPrompt = pendingBusySubmissionForActiveThread.text;
+    const queuedImages = pendingBusySubmissionForActiveThread.images;
+    setPendingBusyTurnSubmission(null);
+    promptRef.current = queuedPrompt;
+    setPrompt(queuedPrompt);
+    addComposerImagesToDraft(queuedImages.map(cloneComposerImageForRetry));
+    revokeComposerImagePreviewUrls(queuedImages);
+    setComposerHighlightedItemId(null);
+    setComposerCursor(queuedPrompt.length);
+    setComposerTrigger(detectComposerTrigger(queuedPrompt, queuedPrompt.length));
+    scheduleComposerFocus();
+  }, [
+    addComposerImagesToDraft,
+    pendingBusySubmissionForActiveThread,
+    scheduleComposerFocus,
+    setPrompt,
+  ]);
+
+  const cancelPendingBusyTurnSubmission = useCallback(() => {
+    if (!pendingBusySubmissionForActiveThread) {
+      return;
+    }
+    revokeComposerImagePreviewUrls(pendingBusySubmissionForActiveThread.images);
+    setPendingBusyTurnSubmission(null);
+    scheduleComposerFocus();
+  }, [pendingBusySubmissionForActiveThread, scheduleComposerFocus]);
+
   const onSend = async (e?: { preventDefault: () => void }) => {
     e?.preventDefault();
     const api = readNativeApi();
@@ -2409,11 +2810,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
       });
-      promptRef.current = "";
-      clearComposerDraftContent(activeThread.id);
-      setComposerHighlightedItemId(null);
-      setComposerCursor(0);
-      setComposerTrigger(null);
+      clearComposerInput();
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
@@ -2424,268 +2821,58 @@ export default function ChatView({ threadId }: ChatViewProps) {
       composerImages.length === 0 ? parseStandaloneComposerSlashCommand(trimmed) : null;
     if (standaloneSlashCommand) {
       await handleInteractionModeChange(standaloneSlashCommand);
-      promptRef.current = "";
-      clearComposerDraftContent(activeThread.id);
-      setComposerHighlightedItemId(null);
-      setComposerCursor(0);
-      setComposerTrigger(null);
+      clearComposerInput();
       return;
     }
     if (!trimmed && composerImages.length === 0) return;
-    if (!activeProject) return;
-    const threadIdForSend = activeThread.id;
-    const isFirstMessage = !isServerThread || activeThread.messages.length === 0;
-    const baseBranchForWorktree =
-      isFirstMessage && envMode === "worktree" && !activeThread.worktreePath
-        ? activeThread.branch
-        : null;
+    if (phase === "running") {
+      await queueBusyTurnSubmission(busyTurnSubmissionBehavior);
+      return;
+    }
+    await submitComposerTurn({
+      text: trimmed,
+      images: composerImages,
+    });
+  };
 
-    // In worktree mode, require an explicit base branch so we don't silently
-    // fall back to local execution when branch selection is missing.
-    const shouldCreateWorktree =
-      isFirstMessage && envMode === "worktree" && !activeThread.worktreePath;
-    if (shouldCreateWorktree && !activeThread.branch) {
-      setStoreThreadError(
-        threadIdForSend,
-        "Select a base branch before sending in New worktree mode.",
-      );
+  useEffect(() => {
+    if (!pendingBusySubmissionForActiveThread || pendingBusyTurnDispatchRef.current) {
+      return;
+    }
+    if (
+      phase === "running" ||
+      isSendBusy ||
+      isConnecting ||
+      sendInFlightRef.current ||
+      promptRef.current.length > 0 ||
+      composerImagesRef.current.length > 0
+    ) {
       return;
     }
 
-    sendInFlightRef.current = true;
-    beginSendPhase(baseBranchForWorktree ? "preparing-worktree" : "sending-turn");
-
-    const composerImagesSnapshot = [...composerImages];
-    const messageIdForSend = newMessageId();
-    const messageCreatedAt = new Date().toISOString();
-    const turnAttachmentsPromise = Promise.all(
-      composerImagesSnapshot.map(async (image) => ({
-        type: "image" as const,
-        name: image.name,
-        mimeType: image.mimeType,
-        sizeBytes: image.sizeBytes,
-        dataUrl: await readFileAsDataUrl(image.file),
-      })),
-    );
-    const optimisticAttachments = composerImagesSnapshot.map((image) => ({
-      type: "image" as const,
-      id: image.id,
-      name: image.name,
-      mimeType: image.mimeType,
-      sizeBytes: image.sizeBytes,
-      previewUrl: image.previewUrl,
-    }));
-    setOptimisticUserMessages((existing) => [
-      ...existing,
-      {
-        id: messageIdForSend,
-        role: "user",
-        text: trimmed,
-        ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
-        createdAt: messageCreatedAt,
-        streaming: false,
-      },
-    ]);
-    // Sending a message should always bring the latest user turn into view.
-    shouldAutoScrollRef.current = true;
-    forceStickToBottom();
-
-    setThreadError(threadIdForSend, null);
-    promptRef.current = "";
-    clearComposerDraftContent(threadIdForSend);
-    setComposerHighlightedItemId(null);
-    setComposerCursor(0);
-    setComposerTrigger(null);
-
-    let createdServerThreadForLocalDraft = false;
-    let turnStartSucceeded = false;
-    let nextThreadBranch = activeThread.branch;
-    let nextThreadWorktreePath = activeThread.worktreePath;
-    await (async () => {
-      // On first message: lock in branch + create worktree if needed.
-      if (baseBranchForWorktree) {
-        beginSendPhase("preparing-worktree");
-        const newBranch = buildTemporaryWorktreeBranchName();
-        const result = await createWorktreeMutation.mutateAsync({
-          cwd: activeProject.cwd,
-          branch: baseBranchForWorktree,
-          newBranch,
-        });
-        nextThreadBranch = result.worktree.branch;
-        nextThreadWorktreePath = result.worktree.path;
-        if (isServerThread) {
-          await api.orchestration.dispatchCommand({
-            type: "thread.meta.update",
-            commandId: newCommandId(),
-            threadId: threadIdForSend,
-            branch: result.worktree.branch,
-            worktreePath: result.worktree.path,
-          });
-          // Keep local thread state in sync immediately so terminal drawer opens
-          // with the worktree cwd/env instead of briefly using the project root.
-          setStoreThreadBranch(threadIdForSend, result.worktree.branch, result.worktree.path);
-        }
-      }
-
-      let firstComposerImageName: string | null = null;
-      if (composerImagesSnapshot.length > 0) {
-        const firstComposerImage = composerImagesSnapshot[0];
-        if (firstComposerImage) {
-          firstComposerImageName = firstComposerImage.name;
-        }
-      }
-      let titleSeed = trimmed;
-      if (!titleSeed) {
-        if (firstComposerImageName) {
-          titleSeed = `Image: ${firstComposerImageName}`;
-        } else {
-          titleSeed = "New thread";
-        }
-      }
-      const title = truncateTitle(titleSeed);
-      let threadCreateModel: ModelSlug =
-        selectedModel || (activeProject.model as ModelSlug) || DEFAULT_MODEL_BY_PROVIDER.codex;
-
-      if (isLocalDraftThread) {
-        await api.orchestration.dispatchCommand({
-          type: "thread.create",
-          commandId: newCommandId(),
-          threadId: threadIdForSend,
-          projectId: activeProject.id,
-          title,
-          model: threadCreateModel,
-          runtimeMode,
-          interactionMode,
-          branch: nextThreadBranch,
-          worktreePath: nextThreadWorktreePath,
-          createdAt: activeThread.createdAt,
-        });
-        createdServerThreadForLocalDraft = true;
-      }
-
-      let setupScript: ProjectScript | null = null;
-      if (baseBranchForWorktree) {
-        setupScript = setupProjectScript(activeProject.scripts);
-      }
-      if (setupScript) {
-        let shouldRunSetupScript = false;
-        if (isServerThread) {
-          shouldRunSetupScript = true;
-        } else {
-          if (createdServerThreadForLocalDraft) {
-            shouldRunSetupScript = true;
-          }
-        }
-        if (shouldRunSetupScript) {
-          const setupScriptOptions: Parameters<typeof runProjectScript>[1] = {
-            worktreePath: nextThreadWorktreePath,
-            rememberAsLastInvoked: false,
-            allowLocalDraftThread: createdServerThreadForLocalDraft,
-          };
-          if (nextThreadWorktreePath) {
-            setupScriptOptions.cwd = nextThreadWorktreePath;
-          }
-          await runProjectScript(setupScript, setupScriptOptions);
-        }
-      }
-
-      // Auto-title from first message
-      if (isFirstMessage && isServerThread) {
-        await api.orchestration.dispatchCommand({
-          type: "thread.meta.update",
-          commandId: newCommandId(),
-          threadId: threadIdForSend,
-          title,
-        });
-      }
-
-      if (isServerThread) {
-        await persistThreadSettingsForNextTurn({
-          threadId: threadIdForSend,
-          createdAt: messageCreatedAt,
-          ...(selectedModel ? { model: selectedModel } : {}),
-          runtimeMode,
-          interactionMode,
-        });
-      }
-
-      beginSendPhase("sending-turn");
-      const turnAttachments = await turnAttachmentsPromise;
-      await api.orchestration.dispatchCommand({
-        type: "thread.turn.start",
-        commandId: newCommandId(),
-        threadId: threadIdForSend,
-        message: {
-          messageId: messageIdForSend,
-          role: "user",
-          text: trimmed || IMAGE_ONLY_BOOTSTRAP_PROMPT,
-          attachments: turnAttachments,
-        },
-        model: selectedModel || undefined,
-        serviceTier: selectedServiceTier,
-        ...(selectedModelOptionsForDispatch
-          ? { modelOptions: selectedModelOptionsForDispatch }
-          : {}),
-        provider: selectedProvider,
-        assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
-        runtimeMode,
-        interactionMode,
-        createdAt: messageCreatedAt,
+    const pendingSubmission = pendingBusySubmissionForActiveThread;
+    pendingBusyTurnDispatchRef.current = true;
+    void (async () => {
+      const succeeded = await submitComposerTurn({
+        text: pendingSubmission.text,
+        images: pendingSubmission.images,
       });
-      turnStartSucceeded = true;
-      if (isFirstMessage) {
-        clearDraftThread(threadIdForSend);
+      if (!succeeded) {
+        revokeComposerImagePreviewUrls(pendingSubmission.images);
       }
-    })().catch(async (err: unknown) => {
-      if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
-        await api.orchestration
-          .dispatchCommand({
-            type: "thread.delete",
-            commandId: newCommandId(),
-            threadId: threadIdForSend,
-          })
-          .catch(() => undefined);
-      }
-      if (
-        !turnStartSucceeded &&
-        promptRef.current.length === 0 &&
-        composerImagesRef.current.length === 0
-      ) {
-        setOptimisticUserMessages((existing) => {
-          const removed = existing.filter((message) => message.id === messageIdForSend);
-          for (const message of removed) {
-            revokeUserMessagePreviewUrls(message);
-          }
-          const next = existing.filter((message) => message.id !== messageIdForSend);
-          return next.length === existing.length ? existing : next;
-        });
-        promptRef.current = trimmed;
-        setPrompt(trimmed);
-        setComposerCursor(trimmed.length);
-        addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageForRetry));
-        setComposerTrigger(detectComposerTrigger(trimmed, trimmed.length));
-      }
-      setThreadError(
-        threadIdForSend,
-        err instanceof Error ? err.message : "Failed to send message.",
-      );
+      setPendingBusyTurnSubmission((current) => (current === pendingSubmission ? null : current));
+      pendingBusyTurnDispatchRef.current = false;
+    })().catch(() => {
+      pendingBusyTurnDispatchRef.current = false;
     });
-    sendInFlightRef.current = false;
-    if (!turnStartSucceeded) {
-      resetSendPhase();
-    }
-  };
-
-  const onInterrupt = async () => {
-    const api = readNativeApi();
-    if (!api || !activeThread) return;
-    await api.orchestration.dispatchCommand({
-      type: "thread.turn.interrupt",
-      commandId: newCommandId(),
-      threadId: activeThread.id,
-      createdAt: new Date().toISOString(),
-    });
-  };
+  }, [
+    composerImagesRef,
+    isConnecting,
+    isSendBusy,
+    pendingBusySubmissionForActiveThread,
+    phase,
+    submitComposerTurn,
+  ]);
 
   const onRespondToApproval = useCallback(
     async (requestId: ApprovalRequestId, decision: ProviderApprovalDecision) => {
@@ -3519,70 +3706,112 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 </div>
               )}
 
-              {!isComposerApprovalState && pendingUserInputs.length === 0 && composerImages.length > 0 && (
-                <div className="mb-3 flex flex-wrap gap-2">
-                  {composerImages.map((image) => (
-                    <div
-                      key={image.id}
-                      className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
-                    >
-                      {image.previewUrl ? (
-                        <button
-                          type="button"
-                          className="h-full w-full cursor-zoom-in"
-                          aria-label={`Preview ${image.name}`}
-                          onClick={() => {
-                            const preview = buildExpandedImagePreview(composerImages, image.id);
-                            if (!preview) return;
-                            setExpandedImage(preview);
-                          }}
-                        >
-                          <img
-                            src={image.previewUrl}
-                            alt={image.name}
-                            className="h-full w-full object-cover"
-                          />
-                        </button>
-                      ) : (
-                        <div className="flex h-full w-full items-center justify-center px-1 text-center text-[10px] text-muted-foreground/70">
-                          {image.name}
-                        </div>
-                      )}
-                      {nonPersistedComposerImageIdSet.has(image.id) && (
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <span
-                                role="img"
-                                aria-label="Draft attachment may not persist"
-                                className="absolute left-1 top-1 inline-flex items-center justify-center rounded bg-background/85 p-0.5 text-amber-600"
-                              >
-                                <CircleAlertIcon className="size-3" />
-                              </span>
-                            }
-                          />
-                          <TooltipPopup
-                            side="top"
-                            className="max-w-64 whitespace-normal leading-tight"
-                          >
-                            Draft attachment could not be saved locally and may be lost on
-                            navigation.
-                          </TooltipPopup>
-                        </Tooltip>
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        className="absolute right-1 top-1 bg-background/80 hover:bg-background/90"
-                        onClick={() => removeComposerImage(image.id)}
-                        aria-label={`Remove ${image.name}`}
+              {!isComposerApprovalState &&
+                pendingUserInputs.length === 0 &&
+                composerImages.length > 0 && (
+                  <div className="mb-3 flex flex-wrap gap-2">
+                    {composerImages.map((image) => (
+                      <div
+                        key={image.id}
+                        className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
                       >
-                        <XIcon />
+                        {image.previewUrl ? (
+                          <button
+                            type="button"
+                            className="h-full w-full cursor-zoom-in"
+                            aria-label={`Preview ${image.name}`}
+                            onClick={() => {
+                              const preview = buildExpandedImagePreview(composerImages, image.id);
+                              if (!preview) return;
+                              setExpandedImage(preview);
+                            }}
+                          >
+                            <img
+                              src={image.previewUrl}
+                              alt={image.name}
+                              className="h-full w-full object-cover"
+                            />
+                          </button>
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center px-1 text-center text-[10px] text-muted-foreground/70">
+                            {image.name}
+                          </div>
+                        )}
+                        {nonPersistedComposerImageIdSet.has(image.id) && (
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <span
+                                  role="img"
+                                  aria-label="Draft attachment may not persist"
+                                  className="absolute left-1 top-1 inline-flex items-center justify-center rounded bg-background/85 p-0.5 text-amber-600"
+                                >
+                                  <CircleAlertIcon className="size-3" />
+                                </span>
+                              }
+                            />
+                            <TooltipPopup
+                              side="top"
+                              className="max-w-64 whitespace-normal leading-tight"
+                            >
+                              Draft attachment could not be saved locally and may be lost on
+                              navigation.
+                            </TooltipPopup>
+                          </Tooltip>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          className="absolute right-1 top-1 bg-background/80 hover:bg-background/90"
+                          onClick={() => removeComposerImage(image.id)}
+                          aria-label={`Remove ${image.name}`}
+                        >
+                          <XIcon />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              {!isComposerApprovalState &&
+                pendingUserInputs.length === 0 &&
+                pendingBusySubmissionForActiveThread && (
+                  <div className="mb-3 flex flex-wrap items-start justify-between gap-3 rounded-lg border border-border/75 bg-muted/20 px-3 py-2">
+                    <div className="min-w-0 flex-1">
+                      <p className="text-xs font-medium text-foreground">
+                        {pendingBusySubmissionForActiveThread.behavior === "steer"
+                          ? "Steer pending"
+                          : "Queued next turn"}
+                      </p>
+                      <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground/85">
+                        {pendingBusySubmissionForActiveThread.behavior === "steer"
+                          ? "The current run will be interrupted and this follow-up will send as soon as the agent stops."
+                          : "This follow-up will send automatically as soon as the current run finishes."}
+                      </p>
+                      <p className="mt-1 truncate text-[11px] text-foreground/80">
+                        {pendingBusySubmissionForActiveThread.text ||
+                          `${pendingBusySubmissionForActiveThread.images.length} image attachment${pendingBusySubmissionForActiveThread.images.length === 1 ? "" : "s"}`}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="outline"
+                        onClick={restorePendingBusyTurnSubmission}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="ghost"
+                        onClick={cancelPendingBusyTurnSubmission}
+                      >
+                        Cancel
                       </Button>
                     </div>
-                  ))}
-                </div>
-              )}
+                  </div>
+                )}
               <ComposerPromptEditor
                 ref={composerEditorRef}
                 value={
@@ -3600,12 +3829,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
                   isComposerApprovalState
                     ? (activePendingApproval?.detail ?? "Resolve this approval request to continue")
                     : activePendingProgress
-                    ? "Type your own answer, or leave this blank to use the selected option"
-                    : showPlanFollowUpPrompt && activeProposedPlan
-                      ? "Add feedback to refine the plan, or leave this blank to implement it"
-                      : phase === "disconnected"
-                        ? "Ask for follow-up changes or attach images"
-                        : "Ask anything, @tag files/folders, or use /model"
+                      ? "Type your own answer, or leave this blank to use the selected option"
+                      : showPlanFollowUpPrompt && activeProposedPlan
+                        ? "Add feedback to refine the plan, or leave this blank to implement it"
+                        : phase === "disconnected"
+                          ? "Ask for follow-up changes or attach images"
+                          : "Ask anything, @tag files/folders, or use /model"
                 }
                 disabled={isConnecting || isComposerApprovalState}
               />
@@ -3732,22 +3961,68 @@ export default function ChatView({ threadId }: ChatViewProps) {
                       </Button>
                     </div>
                   ) : phase === "running" ? (
-                    <button
-                      type="button"
-                      className="flex size-8 items-center justify-center rounded-full bg-rose-500/90 text-white transition-all duration-150 hover:bg-rose-500 hover:scale-105 sm:h-8 sm:w-8"
-                      onClick={() => void onInterrupt()}
-                      aria-label="Stop generation"
-                    >
-                      <svg
-                        width="12"
-                        height="12"
-                        viewBox="0 0 12 12"
-                        fill="currentColor"
-                        aria-hidden="true"
+                    <div className="flex items-center gap-2">
+                      {(prompt.trim().length > 0 || composerImages.length > 0) && (
+                        <div className="flex items-center">
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="h-9 rounded-l-full rounded-r-none px-4 sm:h-8"
+                            disabled={Boolean(pendingBusySubmissionForActiveThread)}
+                            onClick={() =>
+                              void queueBusyTurnSubmission(defaultBusyTurnSubmissionOption.value)
+                            }
+                          >
+                            {defaultBusyTurnSubmissionOption.shortLabel}
+                          </Button>
+                          {alternateBusyTurnSubmissionOption ? (
+                            <Menu>
+                              <MenuTrigger
+                                render={
+                                  <Button
+                                    size="sm"
+                                    variant="default"
+                                    className="h-9 rounded-l-none rounded-r-full border-l-white/12 px-2 sm:h-8"
+                                    aria-label="Choose busy-turn action"
+                                    disabled={Boolean(pendingBusySubmissionForActiveThread)}
+                                  />
+                                }
+                              >
+                                <ChevronDownIcon className="size-3.5" />
+                              </MenuTrigger>
+                              <MenuPopup align="end" side="top">
+                                <MenuItem
+                                  disabled={Boolean(pendingBusySubmissionForActiveThread)}
+                                  onClick={() =>
+                                    void queueBusyTurnSubmission(
+                                      alternateBusyTurnSubmissionOption.value,
+                                    )
+                                  }
+                                >
+                                  {alternateBusyTurnSubmissionOption.label}
+                                </MenuItem>
+                              </MenuPopup>
+                            </Menu>
+                          ) : null}
+                        </div>
+                      )}
+                      <button
+                        type="button"
+                        className="flex size-8 items-center justify-center rounded-full bg-rose-500/90 text-white transition-all duration-150 hover:bg-rose-500 hover:scale-105 sm:h-8 sm:w-8"
+                        onClick={() => void onInterrupt()}
+                        aria-label="Stop generation"
                       >
-                        <rect x="2" y="2" width="8" height="8" rx="1.5" />
-                      </svg>
-                    </button>
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 12 12"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <rect x="2" y="2" width="8" height="8" rx="1.5" />
+                        </svg>
+                      </button>
+                    </div>
                   ) : pendingUserInputs.length === 0 ? (
                     showPlanFollowUpPrompt ? (
                       prompt.trim().length > 0 ? (
@@ -4961,14 +5236,10 @@ const MessagesTimeline = memo(function MessagesTimeline({
         (() => {
           const groupId = row.id;
           const groupedEntries = row.groupedEntries;
-          const isExpanded = expandedWorkGroups[groupId] ?? false;
-          const hasOverflow = groupedEntries.length > MAX_VISIBLE_WORK_LOG_ENTRIES;
-          const visibleEntries =
-            hasOverflow && !isExpanded
-              ? groupedEntries.slice(-MAX_VISIBLE_WORK_LOG_ENTRIES)
-              : groupedEntries;
-          const hiddenCount = groupedEntries.length - visibleEntries.length;
           const onlyToolEntries = groupedEntries.every((entry) => entry.tone === "tool");
+          const canCollapse = groupedEntries.length > 1;
+          const isExpanded = expandedWorkGroups[groupId] ?? (!onlyToolEntries || !canCollapse);
+          const latestEntry = groupedEntries[groupedEntries.length - 1];
           const groupLabel = onlyToolEntries
             ? groupedEntries.length === 1
               ? "Tool call"
@@ -4980,63 +5251,95 @@ const MessagesTimeline = memo(function MessagesTimeline({
           return (
             <div className="rounded-lg border border-border/80 bg-card/45 px-3 py-2">
               <div className="mb-1.5 flex items-center justify-between gap-3">
-                <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
-                  {groupLabel}
-                </p>
-                {hasOverflow && (
+                <button
+                  type="button"
+                  disabled={!canCollapse}
+                  className={cn(
+                    "flex min-w-0 flex-1 items-center gap-2 text-left",
+                    canCollapse ? "cursor-pointer" : "cursor-default",
+                  )}
+                  onClick={() => {
+                    if (!canCollapse) return;
+                    onToggleWorkGroup(groupId);
+                  }}
+                >
+                  {canCollapse ? (
+                    <ChevronRightIcon
+                      className={cn(
+                        "size-3.5 shrink-0 text-muted-foreground/78 transition-transform",
+                        isExpanded && "rotate-90",
+                      )}
+                    />
+                  ) : (
+                    <span aria-hidden="true" className="size-3.5 shrink-0" />
+                  )}
+                  <div className="min-w-0">
+                    <p className="text-[10px] uppercase tracking-[0.12em] text-foreground/72">
+                      {groupLabel}
+                    </p>
+                    {!isExpanded && latestEntry ? (
+                      <p className="truncate text-[11px] text-foreground/88">{latestEntry.label}</p>
+                    ) : null}
+                  </div>
+                </button>
+                {canCollapse && (
                   <button
                     type="button"
-                    className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/55 transition-colors duration-150 hover:text-muted-foreground/80"
+                    className="text-[10px] uppercase tracking-[0.12em] text-foreground/72 transition-colors duration-150 hover:text-foreground"
                     onClick={() => onToggleWorkGroup(groupId)}
                   >
-                    {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
+                    {isExpanded ? "Collapse" : "Expand"}
                   </button>
                 )}
               </div>
-              <div className="space-y-1">
-                {visibleEntries.map((workEntry) => (
-                  <div key={`work-row:${workEntry.id}`} className="flex items-start gap-2 py-0.5">
-                    <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
-                    <div className="min-w-0 flex-1 py-[2px]">
-                      <p className={`text-[11px] leading-relaxed ${workToneClass(workEntry.tone)}`}>
-                        {workEntry.label}
-                      </p>
-                      {workEntry.command && (
-                        <pre className="mt-1 overflow-x-auto rounded-md border border-border/70 bg-background/80 px-2 py-1 font-mono text-[11px] leading-relaxed text-foreground/80">
-                          {workEntry.command}
-                        </pre>
-                      )}
-                      {workEntry.changedFiles && workEntry.changedFiles.length > 0 && (
-                        <div className="mt-1 flex flex-wrap gap-1">
-                          {workEntry.changedFiles.slice(0, 6).map((filePath) => (
-                            <span
-                              key={`${workEntry.id}:${filePath}`}
-                              className="rounded-md border border-border/70 bg-background/65 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/85"
-                              title={filePath}
-                            >
-                              {filePath}
-                            </span>
-                          ))}
-                          {workEntry.changedFiles.length > 6 && (
-                            <span className="px-1 text-[10px] text-muted-foreground/65">
-                              +{workEntry.changedFiles.length - 6} more
-                            </span>
-                          )}
-                        </div>
-                      )}
-                      {workEntry.detail &&
-                        (!workEntry.command || workEntry.detail !== workEntry.command) && (
-                          <p
-                            className="mt-1 text-[11px] leading-relaxed text-muted-foreground/75"
-                            title={workEntry.detail}
-                          >
-                            {workEntry.detail}
-                          </p>
+              {isExpanded ? (
+                <div className="space-y-1">
+                  {groupedEntries.map((workEntry) => (
+                    <div key={`work-row:${workEntry.id}`} className="flex items-start gap-2 py-0.5">
+                      <span className="mt-[7px] h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
+                      <div className="min-w-0 flex-1 py-[2px]">
+                        <p
+                          className={`text-[11px] leading-relaxed ${workToneClass(workEntry.tone)}`}
+                        >
+                          {workEntry.label}
+                        </p>
+                        {workEntry.command && (
+                          <pre className="mt-1 overflow-x-auto rounded-md border border-border/70 bg-background/80 px-2 py-1 font-mono text-[11px] leading-relaxed text-foreground/92">
+                            {workEntry.command}
+                          </pre>
                         )}
+                        {workEntry.changedFiles && workEntry.changedFiles.length > 0 && (
+                          <div className="mt-1 flex flex-wrap gap-1">
+                            {workEntry.changedFiles.slice(0, 6).map((filePath) => (
+                              <span
+                                key={`${workEntry.id}:${filePath}`}
+                                className="rounded-md border border-border/70 bg-background/65 px-1.5 py-0.5 font-mono text-[10px] text-foreground/82"
+                                title={filePath}
+                              >
+                                {filePath}
+                              </span>
+                            ))}
+                            {workEntry.changedFiles.length > 6 && (
+                              <span className="px-1 text-[10px] text-foreground/80">
+                                +{workEntry.changedFiles.length - 6} more
+                              </span>
+                            )}
+                          </div>
+                        )}
+                        {workEntry.detail &&
+                          (!workEntry.command || workEntry.detail !== workEntry.command) && (
+                            <p
+                              className="mt-1 text-[11px] leading-relaxed text-foreground/80"
+                              title={workEntry.detail}
+                            >
+                              {workEntry.detail}
+                            </p>
+                          )}
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+              ) : null}
             </div>
           );
         })()}
@@ -5091,8 +5394,8 @@ const MessagesTimeline = memo(function MessagesTimeline({
                     {row.message.text}
                   </pre>
                 )}
-                <div className="mt-1.5 flex items-center justify-end gap-2">
-                  <div className="flex items-center gap-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+                <div className="mt-1.5 hidden items-center justify-end gap-2 group-focus-within:flex group-hover:flex">
+                  <div className="flex items-center gap-1.5">
                     {row.message.text && <MessageCopyButton text={row.message.text} />}
                     {canRevertAgentWork && (
                       <Button
@@ -5107,7 +5410,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
                       </Button>
                     )}
                   </div>
-                  <p className="text-right text-[10px] text-muted-foreground/30">
+                  <p className="text-right text-[10px] text-muted-foreground/65">
                     {formatTimestamp(row.message.createdAt)}
                   </p>
                 </div>
@@ -5136,6 +5439,14 @@ const MessagesTimeline = memo(function MessagesTimeline({
                   text={messageText}
                   cwd={markdownCwd}
                   isStreaming={Boolean(row.message.streaming)}
+                  onImagePreview={(image) =>
+                    onImageExpand(
+                      buildSingleExpandedImagePreview({
+                        src: image.src,
+                        name: image.alt,
+                      }),
+                    )
+                  }
                 />
                 {(() => {
                   const turnSummary = turnDiffSummaryByAssistantMessageId.get(row.message.id);
@@ -5149,7 +5460,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
                   return (
                     <div className="mt-2 rounded-lg border border-border/80 bg-card/45 p-2.5">
                       <div className="mb-1.5 flex items-center justify-between gap-2">
-                        <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
+                        <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/82">
                           <span>Changed files ({changedFileCountLabel})</span>
                           {hasNonZeroStat(summaryStat) && (
                             <>
@@ -5193,7 +5504,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
                     </div>
                   );
                 })()}
-                <p className="mt-1.5 text-[10px] text-muted-foreground/30">
+                <p className="mt-1.5 text-[10px] text-muted-foreground/62">
                   {formatMessageMeta(
                     row.message.createdAt,
                     row.message.streaming
@@ -5217,20 +5528,21 @@ const MessagesTimeline = memo(function MessagesTimeline({
       )}
 
       {row.kind === "working" && (
-        <div className="flex items-center gap-2 py-0.5 pl-1.5">
-          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
-          <div className="flex items-center gap-2 pt-1 text-[11px] text-muted-foreground/70">
-            <span className="inline-flex items-center gap-[3px]">
-              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse" />
-              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:200ms]" />
-              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:400ms]" />
-            </span>
-            <span>
-              {row.createdAt
-                ? `Working for ${formatWorkingTimer(row.createdAt, nowIso) ?? "0s"}`
-                : "Working..."}
-            </span>
-          </div>
+        <div className="flex items-center gap-2.5 py-0.5 pl-1">
+          <span aria-hidden="true" className="grid grid-cols-2 gap-1">
+            {[0, 1, 2, 3].map((index) => (
+              <span
+                key={`working-dot:${index}`}
+                className="h-1.5 w-1.5 rounded-[2px] bg-muted-foreground/55 animate-pulse"
+                style={{ animationDelay: `${index * 140}ms` }}
+              />
+            ))}
+          </span>
+          <span className="pt-px text-[11px] font-medium text-foreground/82">
+            {row.createdAt
+              ? `Working for ${formatWorkingTimer(row.createdAt, nowIso) ?? "0s"}`
+              : "Working..."}
+          </span>
         </div>
       )}
     </div>
@@ -5239,7 +5551,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
   if (!hasMessages && !isWorking) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-sm text-muted-foreground/30">
+        <p className="text-sm text-muted-foreground/68">
           Send a message to start the conversation.
         </p>
       </div>
@@ -5380,7 +5692,8 @@ const ProviderModelPicker = memo(function ProviderModelPicker(props: {
       >
         <span className="flex min-w-0 items-center gap-2">
           <ProviderIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
-          {props.provider === "codex" && shouldShowFastTierIcon(props.model, props.serviceTierSetting) ? (
+          {props.provider === "codex" &&
+          shouldShowFastTierIcon(props.model, props.serviceTierSetting) ? (
             <ZapIcon className="size-3.5 shrink-0 text-amber-500" />
           ) : null}
           <span className="truncate">{selectedModelLabel}</span>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   FolderIcon,
   GitPullRequestIcon,
   RocketIcon,
+  Settings2Icon,
   SquarePenIcon,
   TerminalIcon,
 } from "lucide-react";
@@ -1342,13 +1343,25 @@ export default function Sidebar() {
             </div>
           </>
         ) : (
-          <button
-            type="button"
-            className="flex w-full items-center justify-center gap-1 rounded-md border border-dashed border-border py-2 text-xs text-muted-foreground/70 transition-colors duration-150 hover:border-ring hover:text-muted-foreground"
-            onClick={() => setAddingProject(true)}
-          >
-            + Add project
-          </button>
+          <div className="space-y-2">
+            <button
+              type="button"
+              className="flex w-full items-center justify-center gap-1 rounded-md border border-dashed border-border py-2 text-xs text-muted-foreground/70 transition-colors duration-150 hover:border-ring hover:text-muted-foreground"
+              onClick={() => setAddingProject(true)}
+            >
+              + Add project
+            </button>
+            <button
+              type="button"
+              className="flex w-full items-center justify-center gap-1 rounded-md border border-border py-2 text-xs text-muted-foreground/80 transition-colors duration-150 hover:bg-secondary hover:text-foreground"
+              onClick={() => {
+                void navigate({ to: "/settings" });
+              }}
+            >
+              <Settings2Icon className="size-3.5" />
+              <span>Settings</span>
+            </button>
+          </div>
         )}
       </SidebarFooter>
     </>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -335,6 +335,27 @@ label:has(> select#reasoning-effort) select {
   font-size: 0.875rem;
 }
 
+.chat-markdown .chat-markdown-media {
+  margin: 0.8rem 0;
+}
+
+.chat-markdown .chat-markdown-image-button {
+  display: block;
+  width: min(100%, 32rem);
+  cursor: zoom-in;
+}
+
+.chat-markdown .chat-markdown-image {
+  display: block;
+  max-width: min(100%, 32rem);
+  max-height: 22rem;
+  overflow: clip;
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
+  background: color-mix(in srgb, var(--muted) 72%, var(--background));
+  object-fit: contain;
+}
+
 .chat-markdown .chat-markdown-codeblock {
   position: relative;
   margin: 0.65rem 0;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -187,6 +187,13 @@ function EventRouter() {
 
     void syncSnapshot().catch(() => undefined);
 
+    const syncSnapshotOnResume = () => {
+      if (document.visibilityState === "hidden") {
+        return;
+      }
+      void syncSnapshot().catch(() => undefined);
+    };
+
     const unsubDomainEvent = api.orchestration.onDomainEvent((event) => {
       if (event.sequence <= latestSequence) {
         return;
@@ -278,12 +285,20 @@ function EventRouter() {
         },
       });
     });
+    window.addEventListener("focus", syncSnapshotOnResume);
+    window.addEventListener("pageshow", syncSnapshotOnResume);
+    window.addEventListener("online", syncSnapshotOnResume);
+    document.addEventListener("visibilitychange", syncSnapshotOnResume);
     return () => {
       disposed = true;
       unsubDomainEvent();
       unsubTerminalEvent();
       unsubWelcome();
       unsubServerConfigUpdated();
+      window.removeEventListener("focus", syncSnapshotOnResume);
+      window.removeEventListener("pageshow", syncSnapshotOnResume);
+      window.removeEventListener("online", syncSnapshotOnResume);
+      document.removeEventListener("visibilitychange", syncSnapshotOnResume);
     };
   }, [
     navigate,

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -7,6 +7,7 @@ import { ZapIcon } from "lucide-react";
 
 import {
   APP_SERVICE_TIER_OPTIONS,
+  BUSY_TURN_SUBMISSION_OPTIONS,
   MAX_CUSTOM_MODEL_LENGTH,
   shouldShowFastTierIcon,
   useAppSettings,
@@ -18,7 +19,13 @@ import { ensureNativeApi } from "../nativeApi";
 import { preferredTerminalEditor } from "../terminal-links";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
-import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../components/ui/select";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
 import { Switch } from "../components/ui/switch";
 import { SidebarInset } from "~/components/ui/sidebar";
 
@@ -103,6 +110,7 @@ function SettingsRouteView() {
 
   const codexBinaryPath = settings.codexBinaryPath;
   const codexHomePath = settings.codexHomePath;
+  const busyTurnSubmissionBehavior = settings.busyTurnSubmissionBehavior;
   const codexServiceTier = settings.codexServiceTier;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
 
@@ -123,54 +131,62 @@ function SettingsRouteView() {
       });
   }, [keybindingsConfigPath]);
 
-  const addCustomModel = useCallback((provider: ProviderKind) => {
-    const customModelInput = customModelInputByProvider[provider];
-    const customModels = getCustomModelsForProvider(settings, provider);
-    const normalized = normalizeModelSlug(customModelInput, provider);
-    if (!normalized) {
-      setCustomModelErrorByProvider((existing) => ({
-        ...existing,
-        [provider]: "Enter a model slug.",
-      }));
-      return;
-    }
-    if (getModelOptions(provider).some((option) => option.slug === normalized)) {
-      setCustomModelErrorByProvider((existing) => ({
-        ...existing,
-        [provider]: "That model is already built in.",
-      }));
-      return;
-    }
-    if (normalized.length > MAX_CUSTOM_MODEL_LENGTH) {
-      setCustomModelErrorByProvider((existing) => ({
-        ...existing,
-        [provider]: `Model slugs must be ${MAX_CUSTOM_MODEL_LENGTH} characters or less.`,
-      }));
-      return;
-    }
-    if (customModels.includes(normalized)) {
-      setCustomModelErrorByProvider((existing) => ({
-        ...existing,
-        [provider]: "That custom model is already saved.",
-      }));
-      return;
-    }
+  const addCustomModel = useCallback(
+    (provider: ProviderKind) => {
+      const customModelInput = customModelInputByProvider[provider];
+      const customModels = getCustomModelsForProvider(settings, provider);
+      const normalized = normalizeModelSlug(customModelInput, provider);
+      if (!normalized) {
+        setCustomModelErrorByProvider((existing) => ({
+          ...existing,
+          [provider]: "Enter a model slug.",
+        }));
+        return;
+      }
+      if (getModelOptions(provider).some((option) => option.slug === normalized)) {
+        setCustomModelErrorByProvider((existing) => ({
+          ...existing,
+          [provider]: "That model is already built in.",
+        }));
+        return;
+      }
+      if (normalized.length > MAX_CUSTOM_MODEL_LENGTH) {
+        setCustomModelErrorByProvider((existing) => ({
+          ...existing,
+          [provider]: `Model slugs must be ${MAX_CUSTOM_MODEL_LENGTH} characters or less.`,
+        }));
+        return;
+      }
+      if (customModels.includes(normalized)) {
+        setCustomModelErrorByProvider((existing) => ({
+          ...existing,
+          [provider]: "That custom model is already saved.",
+        }));
+        return;
+      }
 
-    updateSettings(patchCustomModels(provider, [...customModels, normalized]));
-    setCustomModelInputByProvider((existing) => ({
-      ...existing,
-      [provider]: "",
-    }));
-    setCustomModelErrorByProvider((existing) => ({
-      ...existing,
-      [provider]: null,
-    }));
-  }, [customModelInputByProvider, settings, updateSettings]);
+      updateSettings(patchCustomModels(provider, [...customModels, normalized]));
+      setCustomModelInputByProvider((existing) => ({
+        ...existing,
+        [provider]: "",
+      }));
+      setCustomModelErrorByProvider((existing) => ({
+        ...existing,
+        [provider]: null,
+      }));
+    },
+    [customModelInputByProvider, settings, updateSettings],
+  );
 
   const removeCustomModel = useCallback(
     (provider: ProviderKind, slug: string) => {
       const customModels = getCustomModelsForProvider(settings, provider);
-      updateSettings(patchCustomModels(provider, customModels.filter((model) => model !== slug)));
+      updateSettings(
+        patchCustomModels(
+          provider,
+          customModels.filter((model) => model !== slug),
+        ),
+      );
       setCustomModelErrorByProvider((existing) => ({
         ...existing,
         [provider]: null,
@@ -240,6 +256,80 @@ function SettingsRouteView() {
               <p className="mt-4 text-xs text-muted-foreground">
                 Active theme: <span className="font-medium text-foreground">{resolvedTheme}</span>
               </p>
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <div className="mb-4">
+                <h2 className="text-sm font-medium text-foreground">General</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Pick default workflow preferences for everyday chat behavior.
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    When you send while the agent is already working
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Choose the default action for follow-up messages sent during an active turn.
+                  </p>
+                </div>
+
+                <div
+                  className="space-y-2"
+                  role="radiogroup"
+                  aria-label="Busy turn submission behavior"
+                >
+                  {BUSY_TURN_SUBMISSION_OPTIONS.map((option) => {
+                    const selected = busyTurnSubmissionBehavior === option.value;
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        role="radio"
+                        aria-checked={selected}
+                        className={`flex w-full items-start justify-between rounded-lg border px-3 py-2 text-left transition-colors ${
+                          selected
+                            ? "border-primary/60 bg-primary/8 text-foreground"
+                            : "border-border bg-background text-muted-foreground hover:bg-accent"
+                        }`}
+                        onClick={() =>
+                          updateSettings({
+                            busyTurnSubmissionBehavior: option.value,
+                          })
+                        }
+                      >
+                        <span className="flex flex-col pr-3">
+                          <span className="text-sm font-medium">{option.label}</span>
+                          <span className="text-xs">{option.description}</span>
+                        </span>
+                        {selected ? (
+                          <span className="rounded bg-primary/14 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-primary">
+                            Default
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {busyTurnSubmissionBehavior !== defaults.busyTurnSubmissionBehavior ? (
+                <div className="mt-3 flex justify-end">
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={() =>
+                      updateSettings({
+                        busyTurnSubmissionBehavior: defaults.busyTurnSubmissionBehavior,
+                      })
+                    }
+                  >
+                    Restore default
+                  </Button>
+                </div>
+              ) : null}
             </section>
 
             <section className="rounded-2xl border border-border bg-card p-5">
@@ -426,10 +516,9 @@ function SettingsRouteView() {
                                 variant="outline"
                                 onClick={() =>
                                   updateSettings(
-                                    patchCustomModels(
-                                      provider,
-                                      [...getDefaultCustomModelsForProvider(defaults, provider)],
-                                    ),
+                                    patchCustomModels(provider, [
+                                      ...getDefaultCustomModelsForProvider(defaults, provider),
+                                    ]),
                                   )
                                 }
                               >
@@ -446,7 +535,8 @@ function SettingsRouteView() {
                                   className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2"
                                 >
                                   <div className="flex min-w-0 flex-1 items-center gap-2">
-                                    {provider === "codex" && shouldShowFastTierIcon(slug, codexServiceTier) ? (
+                                    {provider === "codex" &&
+                                    shouldShowFastTierIcon(slug, codexServiceTier) ? (
                                       <ZapIcon className="size-3.5 shrink-0 text-amber-500" />
                                     ) : null}
                                     <code className="min-w-0 flex-1 truncate text-xs text-foreground">


### PR DESCRIPTION
This PR is not something you need to accept.

I DM'd you a prompt that should let you run this locally in your own checkout and have your agent make the same changes there. That is probably the better path if you want something you trust.

This branch is just an example implementation I generated with GPT-5.4. I have not reviewed it carefully line by line. I only did a quick local sanity check to make sure it basically works.

What this appears to cover:
- remove idle timestamp spacing in user bubbles
- increase contrast for assistant and work-log text
- replace the subtle working indicator with a clearer aligned version
- add a steer-vs-queue setting in a general settings page
- default tool-call chains to collapsed with expand/collapse controls
- resync stale running state on focus or resume-related events
- add inline markdown image previews with expanded preview
- fix the desktop build path if the server TypeScript CLI is invoked through Node
- add a scripted Electron validation harness for these behaviors

What I ran locally:
- bun run lint
- bun run typecheck
- bun run test
- bun run test:browser in apps/web
- bun run build:desktop
- bun run test:desktop-smoke
- node apps/desktop/scripts/validate-feedback.mjs

Again, no pressure to merge this. The prompt I DM'd you is the thing I actually expect you to use if you want to reproduce this in your own environment.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add busy-turn queue/steer controls in `ChatView` with image preview in markdown and a desktop validation script to fix desktop/chat UX per GPT-5.4 motivation
> Introduce queued follow-up submission and steering in `ChatView`, render markdown images with optional preview, add a settings control for busy-turn behavior, trigger snapshot sync on resume events, and include a desktop Playwright script to validate scenarios. Key changes span [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/468/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), [`ChatMarkdown.tsx`](https://github.com/pingdotgg/t3code/pull/468/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05), [`_chat.settings.tsx`](https://github.com/pingdotgg/t3code/pull/468/files#diff-0707e8295d0df761e405e66f02211b55d56c6eaea1ac3cb99562525a9c589cc6), [`__root.tsx`](https://github.com/pingdotgg/t3code/pull/468/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100), and [`validate-feedback.mjs`](https://github.com/pingdotgg/t3code/pull/468/files#diff-73a7623721499523c19b522279ac52c4e20216a3a3e5cbcf1c8f8634a8aa0b83).
>
> #### 📍Where to Start
> Start with the busy-turn submission flow in `submitComposerTurn` and `queueBusyTurnSubmission` within [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/468/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4eabcbb. 8 files reviewed, 4 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->