### PR TITLE
add: Add Augment provider via ACP protocol.

### DIFF
--- a/apps/server/src/augmentACPManager.integration.test.ts
+++ b/apps/server/src/augmentACPManager.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration test for AugmentACPManager against actual Auggie CLI.
+ *
+ * Run with: bun run vitest run src/augmentACPManager.integration.test.ts
+ *
+ * Prerequisites:
+ * - Auggie CLI installed and available on PATH
+ * - Auggie authenticated (run `auggie login` first)
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { ThreadId } from "@t3tools/contracts";
+import { AugmentACPManager } from "./augmentACPManager.ts";
+
+describe("AugmentACPManager Integration", () => {
+  let manager: AugmentACPManager;
+
+  beforeAll(() => {
+    manager = new AugmentACPManager();
+  });
+
+  afterEach(() => {
+    manager.stopAll();
+  });
+
+  afterAll(() => {
+    manager.stopAll();
+  });
+
+  it("should start a session with auggie --acp", async () => {
+    const threadId = ThreadId.makeUnsafe("test-thread-1");
+
+    const events: string[] = [];
+    manager.on("event", (event) => {
+      events.push(event.method);
+      console.log("Event:", event.method, event.message ?? "");
+    });
+
+    const session = await manager.startSession({
+      threadId,
+      runtimeMode: "full-access",
+      cwd: process.cwd(),
+    });
+
+    expect(session.provider).toBe("augment");
+    expect(session.status).toBe("ready");
+    expect(session.threadId).toBe(threadId);
+
+    // Check we got lifecycle events
+    expect(events).toContain("session/connecting");
+    expect(events).toContain("session/ready");
+
+    // Check available models were fetched
+    const models = manager.getAvailableModels(threadId);
+    expect(models.length).toBeGreaterThan(0);
+    console.log(
+      "Available models:",
+      models.map((m) => m.modelId),
+    );
+  }, 30_000);
+
+  it("should send a turn and receive streaming responses", async () => {
+    const threadId = ThreadId.makeUnsafe("test-thread-2");
+
+    const events: Array<{ method: string; textDelta?: string | undefined }> = [];
+    manager.on("event", (event) => {
+      events.push({ method: event.method, textDelta: event.textDelta ?? undefined });
+      if (event.textDelta) {
+        process.stdout.write(event.textDelta);
+      }
+    });
+
+    await manager.startSession({
+      threadId,
+      runtimeMode: "full-access",
+      cwd: process.cwd(),
+    });
+
+    const turnResult = await manager.sendTurn({
+      threadId,
+      input: "What is 2+2? Reply with just the number, nothing else.",
+    });
+
+    expect(turnResult.threadId).toBe(threadId);
+    expect(turnResult.turnId).toBeDefined();
+
+    // Wait for the turn to complete (streaming events will come in)
+    await new Promise<void>((resolve) => {
+      const checkComplete = () => {
+        const hasCompleted = events.some((e) => e.method === "turn/completed");
+        if (hasCompleted) {
+          resolve();
+        } else {
+          setTimeout(checkComplete, 100);
+        }
+      };
+      checkComplete();
+    });
+
+    // Check we got streaming content
+    const deltas = events.filter((e) => e.method === "item/agentMessage/delta");
+    expect(deltas.length).toBeGreaterThan(0);
+
+    console.log("\n\nTotal events:", events.length);
+    console.log(
+      "Event types:",
+      [...new Set(events.map((e) => e.method))].join(", "),
+    );
+  }, 60_000);
+
+  it("should interrupt a turn", async () => {
+    const threadId = ThreadId.makeUnsafe("test-thread-3");
+
+    await manager.startSession({
+      threadId,
+      runtimeMode: "full-access",
+      cwd: process.cwd(),
+    });
+
+    const turnPromise = manager.sendTurn({
+      threadId,
+      input: "Write a very long essay about the history of computing. Make it at least 1000 words.",
+    });
+
+    // Wait a bit then interrupt
+    await new Promise((r) => setTimeout(r, 2000));
+    await manager.interruptTurn(threadId);
+
+    const turnResult = await turnPromise;
+    expect(turnResult.turnId).toBeDefined();
+  }, 30_000);
+
+  it("should stop a session cleanly", async () => {
+    const threadId = ThreadId.makeUnsafe("test-thread-4");
+
+    await manager.startSession({
+      threadId,
+      runtimeMode: "full-access",
+      cwd: process.cwd(),
+    });
+
+    expect(manager.hasSession(threadId)).toBe(true);
+
+    manager.stopSession(threadId);
+
+    expect(manager.hasSession(threadId)).toBe(false);
+  }, 30_000);
+});
+

--- a/apps/server/src/augmentACPManager.ts
+++ b/apps/server/src/augmentACPManager.ts
@@ -1,0 +1,811 @@
+import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import readline from "node:readline";
+
+import {
+  ApprovalRequestId,
+  EventId,
+  ProviderInteractionMode,
+  ProviderItemId,
+  ProviderRequestKind,
+  RuntimeMode,
+  ThreadId,
+  TurnId,
+  type ProviderApprovalDecision,
+  type ProviderEvent,
+  type ProviderSession,
+  type ProviderSessionStartInput,
+  type ProviderTurnStartResult,
+} from "@t3tools/contracts";
+import { normalizeModelSlug } from "@t3tools/shared/model";
+import { Effect, ServiceMap } from "effect";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type PendingRequestKey = string;
+
+interface PendingRequest {
+  method: string;
+  timeout: ReturnType<typeof setTimeout>;
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+interface PendingApprovalRequest {
+  requestId: ApprovalRequestId;
+  jsonRpcId: string | number;
+  threadId: ThreadId;
+  turnId?: TurnId | undefined;
+  itemId?: ProviderItemId | undefined;
+}
+
+interface AugmentSessionContext {
+  session: ProviderSession;
+  acpSessionId: string | null;
+  child: ChildProcessWithoutNullStreams;
+  output: readline.Interface;
+  pending: Map<PendingRequestKey, PendingRequest>;
+  pendingApprovals: Map<ApprovalRequestId, PendingApprovalRequest>;
+  nextRequestId: number;
+  stopping: boolean;
+  availableModels: Array<{ modelId: string; name: string; description?: string }>;
+  currentModelId: string | null;
+}
+
+interface JsonRpcError {
+  code?: number;
+  message?: string;
+  data?: unknown;
+}
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string | number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string | number;
+  result?: unknown;
+  error?: JsonRpcError;
+}
+
+interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+// ACP-specific types
+interface ACPInitializeResult {
+  protocolVersion: number;
+  agentCapabilities: {
+    loadSession?: boolean;
+    promptCapabilities?: { image?: boolean };
+    sessionCapabilities?: { list?: object };
+  };
+  agentInfo: {
+    name: string;
+    title: string;
+    version: string;
+  };
+  authMethods: unknown[];
+}
+
+interface ACPSessionNewResult {
+  sessionId: string;
+  modes: {
+    currentModeId: string;
+    availableModes: Array<{ id: string; name: string; description: string }>;
+  };
+  models: {
+    currentModelId: string;
+    availableModels: Array<{ modelId: string; name: string; description?: string }>;
+  };
+}
+
+interface ACPSessionPromptResult {
+  stopReason: "end_turn" | "cancelled" | "max_turns" | "tool_error";
+}
+
+interface ACPSessionUpdate {
+  sessionId: string;
+  update: {
+    sessionUpdate:
+      | "agent_message_chunk"
+      | "agent_thought_chunk"
+      | "tool_call_added"
+      | "tool_call_updated"
+      | "plan_update";
+    content?: { type: string; text?: string };
+    toolCall?: unknown;
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AugmentACPStartSessionInput {
+  readonly threadId: ThreadId;
+  readonly provider?: "augment";
+  readonly cwd?: string;
+  readonly model?: string;
+  readonly providerOptions?: ProviderSessionStartInput["providerOptions"];
+  readonly runtimeMode: RuntimeMode;
+}
+
+export interface AugmentACPSendTurnInput {
+  readonly threadId: ThreadId;
+  readonly input?: string;
+  readonly attachments?: ReadonlyArray<{ type: "image"; url: string }>;
+  readonly model?: string;
+  readonly interactionMode?: ProviderInteractionMode;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Utility functions
+// ─────────────────────────────────────────────────────────────────────────────
+
+function killChildTree(child: ChildProcessWithoutNullStreams): void {
+  if (process.platform === "win32" && child.pid !== undefined) {
+    const result = spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+    if (result.status === 0) {
+      return;
+    }
+  }
+  child.kill();
+}
+
+function readAugmentProviderOptions(input: AugmentACPStartSessionInput): {
+  binaryPath: string | undefined;
+} {
+  const augmentOptions = input.providerOptions?.augment;
+  return {
+    binaryPath: augmentOptions?.binaryPath,
+  };
+}
+
+function buildACPInitializeParams() {
+  return {
+    protocolVersion: 1,
+    clientInfo: {
+      name: "t3code",
+      version: "0.1.0",
+    },
+  } as const;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AugmentACPManager class
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AugmentACPManagerEvents {
+  event: [event: ProviderEvent];
+}
+
+export class AugmentACPManager extends EventEmitter<AugmentACPManagerEvents> {
+  private readonly sessions = new Map<ThreadId, AugmentSessionContext>();
+
+  private runPromise: (effect: Effect.Effect<unknown, never>) => Promise<unknown>;
+  constructor(services?: ServiceMap.ServiceMap<never>) {
+    super();
+    this.runPromise = services ? Effect.runPromiseWith(services) : Effect.runPromise;
+  }
+
+  async startSession(input: AugmentACPStartSessionInput): Promise<ProviderSession> {
+    const threadId = input.threadId;
+    const now = new Date().toISOString();
+    let context: AugmentSessionContext | undefined;
+
+    try {
+      const resolvedCwd = input.cwd ?? process.cwd();
+
+      const session: ProviderSession = {
+        provider: "augment",
+        status: "connecting",
+        runtimeMode: input.runtimeMode,
+        model: normalizeModelSlug(input.model, "augment") ?? undefined,
+        cwd: resolvedCwd,
+        threadId,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      const augmentOptions = readAugmentProviderOptions(input);
+      const augmentBinaryPath = augmentOptions.binaryPath ?? "auggie";
+      const spawnArgs = [
+        "--acp",
+        "--allow-indexing", // Skip indexing confirmation prompt
+        "--workspace-root",
+        resolvedCwd,
+      ];
+      const child = spawn(augmentBinaryPath, spawnArgs, {
+        cwd: resolvedCwd,
+        env: process.env,
+        stdio: ["pipe", "pipe", "pipe"],
+        shell: process.platform === "win32",
+      });
+      const output = readline.createInterface({ input: child.stdout });
+
+      context = {
+        session,
+        acpSessionId: null,
+        child,
+        output,
+        pending: new Map(),
+        pendingApprovals: new Map(),
+        nextRequestId: 1,
+        stopping: false,
+        availableModels: [],
+        currentModelId: null,
+      };
+
+      this.sessions.set(threadId, context);
+      this.attachProcessListeners(context);
+
+      this.emitLifecycleEvent(context, "session/connecting", "Starting auggie --acp");
+
+      // ACP Initialize
+      const initResponse = await this.sendRequest<ACPInitializeResult>(
+        context,
+        "initialize",
+        buildACPInitializeParams(),
+      );
+      await Effect.logInfo("augment ACP initialize response", initResponse).pipe(this.runPromise);
+
+      // ACP session/new
+      const sessionNewResponse = await this.sendRequest<ACPSessionNewResult>(
+        context,
+        "session/new",
+        {
+          cwd: resolvedCwd,
+          mcpServers: [],
+        },
+      );
+      await Effect.logInfo("augment ACP session/new response", sessionNewResponse).pipe(
+        this.runPromise,
+      );
+
+      context.acpSessionId = sessionNewResponse.sessionId;
+      context.availableModels = sessionNewResponse.models.availableModels;
+      context.currentModelId = sessionNewResponse.models.currentModelId;
+
+      // Track the requested model - it will be passed to session/prompt
+      const requestedModel = normalizeModelSlug(input.model, "augment");
+      if (requestedModel) {
+        context.currentModelId = requestedModel;
+      }
+
+      this.updateSession(context, {
+        status: "ready",
+        model: context.currentModelId ?? undefined,
+        resumeCursor: { sessionId: context.acpSessionId },
+      });
+      this.emitLifecycleEvent(
+        context,
+        "session/ready",
+        `Connected to Augment session ${context.acpSessionId}`,
+      );
+      return { ...context.session };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to start Augment session.";
+      if (context) {
+        this.updateSession(context, {
+          status: "error",
+          lastError: message,
+        });
+        this.emitErrorEvent(context, "session/startFailed", message);
+        this.stopSession(threadId);
+      } else {
+        this.emitEvent({
+          id: EventId.makeUnsafe(randomUUID()),
+          kind: "error",
+          provider: "augment",
+          threadId,
+          createdAt: new Date().toISOString(),
+          method: "session/startFailed",
+          message,
+        });
+      }
+      throw new Error(message, { cause: error });
+    }
+  }
+
+  async sendTurn(input: AugmentACPSendTurnInput): Promise<ProviderTurnStartResult> {
+    const context = this.requireSession(input.threadId);
+
+    if (!context.acpSessionId) {
+      throw new Error("Session is missing ACP session ID.");
+    }
+
+    // Build prompt content parts (ACP format)
+    const promptParts: Array<{ type: "text"; text: string } | { type: "image"; data: string }> = [];
+    if (input.input) {
+      promptParts.push({ type: "text", text: input.input });
+    }
+    for (const attachment of input.attachments ?? []) {
+      if (attachment.type === "image") {
+        promptParts.push({ type: "image", data: attachment.url });
+      }
+    }
+    if (promptParts.length === 0) {
+      throw new Error("Turn input must include text or attachments.");
+    }
+
+    // Generate turn ID
+    const turnId = TurnId.makeUnsafe(randomUUID());
+
+    this.updateSession(context, {
+      status: "running",
+      activeTurnId: turnId,
+    });
+
+    // Emit turn started event
+    this.emitEvent({
+      id: EventId.makeUnsafe(randomUUID()),
+      kind: "notification",
+      provider: "augment",
+      threadId: context.session.threadId,
+      createdAt: new Date().toISOString(),
+      method: "turn/started",
+      turnId,
+      payload: { turnId },
+    });
+
+    // Determine model for this turn
+    const modelForTurn = input.model
+      ? normalizeModelSlug(input.model, "augment")
+      : context.currentModelId;
+
+    // Send ACP session/prompt - this returns when the turn completes
+    // Streaming updates come as notifications
+    // Use a very long timeout (10 minutes) since turns can take a while
+    this.sendRequest<ACPSessionPromptResult>(
+      context,
+      "session/prompt",
+      {
+        sessionId: context.acpSessionId,
+        prompt: promptParts,
+        ...(modelForTurn ? { model: modelForTurn } : {}),
+      },
+      10 * 60 * 1000, // 10 minutes
+    )
+      .then((result) => {
+        this.updateSession(context, {
+          status: "ready",
+          activeTurnId: undefined,
+        });
+
+        this.emitEvent({
+          id: EventId.makeUnsafe(randomUUID()),
+          kind: "notification",
+          provider: "augment",
+          threadId: context.session.threadId,
+          createdAt: new Date().toISOString(),
+          method: "turn/completed",
+          turnId,
+          payload: { turnId, stopReason: result.stopReason },
+        });
+      })
+      .catch((error) => {
+        const message = error instanceof Error ? error.message : "Turn failed.";
+        this.updateSession(context, {
+          status: "error",
+          activeTurnId: undefined,
+          lastError: message,
+        });
+
+        this.emitErrorEvent(context, "turn/failed", message);
+      });
+
+    return {
+      threadId: context.session.threadId,
+      turnId,
+      resumeCursor: context.session.resumeCursor,
+    };
+  }
+
+  async interruptTurn(threadId: ThreadId, _turnId?: TurnId): Promise<void> {
+    const context = this.requireSession(threadId);
+
+    if (!context.acpSessionId) {
+      return;
+    }
+
+    // ACP uses session/cancel notification (no response expected)
+    this.writeMessage(context, {
+      jsonrpc: "2.0",
+      method: "session/cancel",
+      params: { sessionId: context.acpSessionId },
+    });
+  }
+
+  async respondToRequest(
+    threadId: ThreadId,
+    requestId: ApprovalRequestId,
+    decision: ProviderApprovalDecision,
+  ): Promise<void> {
+    const context = this.requireSession(threadId);
+    const pendingRequest = context.pendingApprovals.get(requestId);
+    if (!pendingRequest) {
+      throw new Error(`Unknown pending approval request: ${requestId}`);
+    }
+
+    context.pendingApprovals.delete(requestId);
+
+    // ACP permission response
+    const outcome = decision === "accept" || decision === "acceptForSession" ? "allow" : "deny";
+    this.writeMessage(context, {
+      jsonrpc: "2.0",
+      id: pendingRequest.jsonRpcId,
+      result: { outcome },
+    });
+
+    this.emitEvent({
+      id: EventId.makeUnsafe(randomUUID()),
+      kind: "notification",
+      provider: "augment",
+      threadId: context.session.threadId,
+      createdAt: new Date().toISOString(),
+      method: "item/requestApproval/decision",
+      turnId: pendingRequest.turnId,
+      itemId: pendingRequest.itemId,
+      requestId: pendingRequest.requestId,
+      payload: { requestId: pendingRequest.requestId, decision },
+    });
+  }
+
+  stopSession(threadId: ThreadId): void {
+    const context = this.sessions.get(threadId);
+    if (!context) {
+      return;
+    }
+
+    context.stopping = true;
+
+    for (const pending of context.pending.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(new Error("Session stopped before request completed."));
+    }
+    context.pending.clear();
+    context.pendingApprovals.clear();
+
+    context.output.close();
+
+    if (!context.child.killed) {
+      killChildTree(context.child);
+    }
+
+    this.updateSession(context, {
+      status: "closed",
+      activeTurnId: undefined,
+    });
+    this.emitLifecycleEvent(context, "session/closed", "Session stopped");
+    this.sessions.delete(threadId);
+  }
+
+  listSessions(): ProviderSession[] {
+    return Array.from(this.sessions.values(), ({ session }) => ({ ...session }));
+  }
+
+  hasSession(threadId: ThreadId): boolean {
+    return this.sessions.has(threadId);
+  }
+
+  stopAll(): void {
+    for (const threadId of this.sessions.keys()) {
+      this.stopSession(threadId);
+    }
+  }
+
+  getAvailableModels(threadId: ThreadId): Array<{ modelId: string; name: string }> {
+    const context = this.sessions.get(threadId);
+    return context?.availableModels ?? [];
+  }
+
+  private requireSession(threadId: ThreadId): AugmentSessionContext {
+    const context = this.sessions.get(threadId);
+    if (!context) {
+      throw new Error(`Unknown session for thread: ${threadId}`);
+    }
+
+    if (context.session.status === "closed") {
+      throw new Error(`Session is closed for thread: ${threadId}`);
+    }
+
+    return context;
+  }
+
+  private attachProcessListeners(context: AugmentSessionContext): void {
+    context.output.on("line", (line) => {
+      this.handleStdoutLine(context, line);
+    });
+
+    context.child.stderr.on("data", (chunk: Buffer) => {
+      const raw = chunk.toString();
+      // Log stderr but don't emit as errors unless it looks like an error
+      if (raw.toLowerCase().includes("error")) {
+        this.emitErrorEvent(context, "process/stderr", raw.trim());
+      }
+    });
+
+    context.child.on("error", (error) => {
+      const message = error.message || "auggie --acp process errored.";
+      this.updateSession(context, {
+        status: "error",
+        lastError: message,
+      });
+      this.emitErrorEvent(context, "process/error", message);
+    });
+
+    context.child.on("exit", (code, signal) => {
+      if (context.stopping) {
+        return;
+      }
+
+      const message = `auggie --acp exited (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
+      const exitError = new Error(message);
+      for (const pending of context.pending.values()) {
+        clearTimeout(pending.timeout);
+        pending.reject(exitError);
+      }
+      context.pending.clear();
+      context.pendingApprovals.clear();
+
+      this.updateSession(context, {
+        status: "closed",
+        activeTurnId: undefined,
+        lastError: code === 0 ? context.session.lastError : message,
+      });
+      this.emitLifecycleEvent(context, "session/exited", message);
+      this.sessions.delete(context.session.threadId);
+    });
+  }
+
+  private handleStdoutLine(context: AugmentSessionContext, line: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // Not JSON, might be debug output
+      return;
+    }
+
+    if (!parsed || typeof parsed !== "object") {
+      return;
+    }
+
+    const message = parsed as Record<string, unknown>;
+
+    // Check if it's a response (has id and result/error)
+    if ("id" in message && ("result" in message || "error" in message)) {
+      this.handleResponse(context, message as unknown as JsonRpcResponse);
+      return;
+    }
+
+    // Check if it's a request (has id and method)
+    if ("id" in message && "method" in message) {
+      this.handleServerRequest(context, message as unknown as JsonRpcRequest);
+      return;
+    }
+
+    // Check if it's a notification (has method, no id)
+    if ("method" in message && !("id" in message)) {
+      this.handleServerNotification(context, message as unknown as JsonRpcNotification);
+      return;
+    }
+  }
+
+  private handleServerNotification(
+    context: AugmentSessionContext,
+    notification: JsonRpcNotification,
+  ): void {
+    const params = notification.params as Record<string, unknown> | undefined;
+
+    if (notification.method === "session/update" && params) {
+      const update = params.update as ACPSessionUpdate["update"] | undefined;
+      if (!update) return;
+
+      const turnId = context.session.activeTurnId;
+
+      // Map ACP session updates to T3 Code events
+      if (update.sessionUpdate === "agent_message_chunk") {
+        const text = (update.content as { text?: string })?.text;
+        if (text) {
+          this.emitEvent({
+            id: EventId.makeUnsafe(randomUUID()),
+            kind: "notification",
+            provider: "augment",
+            threadId: context.session.threadId,
+            createdAt: new Date().toISOString(),
+            method: "item/agentMessage/delta",
+            turnId,
+            textDelta: text,
+            payload: update,
+          });
+        }
+      } else if (update.sessionUpdate === "agent_thought_chunk") {
+        const text = (update.content as { text?: string })?.text;
+        if (text) {
+          this.emitEvent({
+            id: EventId.makeUnsafe(randomUUID()),
+            kind: "notification",
+            provider: "augment",
+            threadId: context.session.threadId,
+            createdAt: new Date().toISOString(),
+            method: "item/agentThought/delta",
+            turnId,
+            textDelta: text,
+            payload: update,
+          });
+        }
+      } else if (update.sessionUpdate === "tool_call_added") {
+        this.emitEvent({
+          id: EventId.makeUnsafe(randomUUID()),
+          kind: "notification",
+          provider: "augment",
+          threadId: context.session.threadId,
+          createdAt: new Date().toISOString(),
+          method: "item/toolCall/started",
+          turnId,
+          payload: update,
+        });
+      } else if (update.sessionUpdate === "tool_call_updated") {
+        this.emitEvent({
+          id: EventId.makeUnsafe(randomUUID()),
+          kind: "notification",
+          provider: "augment",
+          threadId: context.session.threadId,
+          createdAt: new Date().toISOString(),
+          method: "item/toolCall/updated",
+          turnId,
+          payload: update,
+        });
+      }
+    }
+  }
+
+  private handleServerRequest(context: AugmentSessionContext, request: JsonRpcRequest): void {
+    const turnId = context.session.activeTurnId;
+
+    // ACP permission requests
+    if (request.method === "session/request_permission") {
+      const requestId = ApprovalRequestId.makeUnsafe(randomUUID());
+      const pendingRequest: PendingApprovalRequest = {
+        requestId,
+        jsonRpcId: request.id,
+        threadId: context.session.threadId,
+        turnId,
+      };
+      context.pendingApprovals.set(requestId, pendingRequest);
+
+      this.emitEvent({
+        id: EventId.makeUnsafe(randomUUID()),
+        kind: "request",
+        provider: "augment",
+        threadId: context.session.threadId,
+        createdAt: new Date().toISOString(),
+        method: request.method,
+        turnId,
+        requestId,
+        payload: request.params,
+      });
+      return;
+    }
+
+    // Unknown request - send error response
+    this.writeMessage(context, {
+      jsonrpc: "2.0",
+      id: request.id,
+      error: {
+        code: -32601,
+        message: `Unsupported server request: ${request.method}`,
+      },
+    });
+  }
+
+  private handleResponse(context: AugmentSessionContext, response: JsonRpcResponse): void {
+    const key = String(response.id);
+    const pending = context.pending.get(key);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    context.pending.delete(key);
+
+    if (response.error) {
+      pending.reject(new Error(`${pending.method} failed: ${String(response.error.message ?? "Unknown error")}`));
+      return;
+    }
+
+    pending.resolve(response.result);
+  }
+
+  private async sendRequest<TResponse>(
+    context: AugmentSessionContext,
+    method: string,
+    params: unknown,
+    timeoutMs = 30_000,
+  ): Promise<TResponse> {
+    const id = context.nextRequestId;
+    context.nextRequestId += 1;
+
+    const result = await new Promise<unknown>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        context.pending.delete(String(id));
+        reject(new Error(`Timed out waiting for ${method}.`));
+      }, timeoutMs);
+
+      context.pending.set(String(id), {
+        method,
+        timeout,
+        resolve,
+        reject,
+      });
+      this.writeMessage(context, {
+        jsonrpc: "2.0",
+        method,
+        id,
+        params,
+      });
+    });
+
+    return result as TResponse;
+  }
+
+  private writeMessage(context: AugmentSessionContext, message: unknown): void {
+    const encoded = JSON.stringify(message);
+    if (!context.child.stdin.writable) {
+      throw new Error("Cannot write to auggie --acp stdin.");
+    }
+
+    context.child.stdin.write(`${encoded}\n`);
+  }
+
+  private emitLifecycleEvent(context: AugmentSessionContext, method: string, message: string): void {
+    this.emitEvent({
+      id: EventId.makeUnsafe(randomUUID()),
+      kind: "session",
+      provider: "augment",
+      threadId: context.session.threadId,
+      createdAt: new Date().toISOString(),
+      method,
+      message,
+    });
+  }
+
+  private emitErrorEvent(context: AugmentSessionContext, method: string, message: string): void {
+    this.emitEvent({
+      id: EventId.makeUnsafe(randomUUID()),
+      kind: "error",
+      provider: "augment",
+      threadId: context.session.threadId,
+      createdAt: new Date().toISOString(),
+      method,
+      message,
+    });
+  }
+
+  private emitEvent(event: ProviderEvent): void {
+    this.emit("event", event);
+  }
+
+  private updateSession(
+    context: AugmentSessionContext,
+    updates: Partial<ProviderSession>,
+  ): void {
+    context.session = {
+      ...context.session,
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+}
+

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_PROVIDER_INTERACTION_MODE,
   EventId,
   MessageId,
+  type ProviderKind,
   ProjectId,
   ThreadId,
   TurnId,
@@ -43,7 +44,7 @@ const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
   readonly eventId: EventId;
-  readonly provider: "codex";
+  readonly provider: ProviderKind;
   readonly createdAt: string;
   readonly threadId: ThreadId;
   readonly turnId?: string | undefined;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -5,6 +5,7 @@ import {
   type OrchestrationEvent,
   type ProviderModelOptions,
   type ProviderKind,
+  isProviderKind,
   type ProviderServiceTier,
   type OrchestrationSession,
   ThreadId,
@@ -212,8 +213,9 @@ const make = Effect.gen(function* () {
     }
 
     const desiredRuntimeMode = thread.runtimeMode;
-    const currentProvider: ProviderKind | undefined =
-      thread.session?.providerName === "codex" ? thread.session.providerName : undefined;
+    const currentProvider: ProviderKind | undefined = isProviderKind(thread.session?.providerName)
+      ? thread.session.providerName
+      : undefined;
     const preferredProvider: ProviderKind | undefined = options?.provider ?? currentProvider;
     const desiredModel = options?.model ?? thread.model;
     const effectiveCwd = resolveThreadWorkspaceCwd({

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -7,6 +7,7 @@ import {
   MessageId,
   ProjectId,
   ProviderItemId,
+  type ProviderKind,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -41,7 +42,7 @@ const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
   readonly eventId: EventId;
-  readonly provider: "codex";
+  readonly provider: ProviderKind;
   readonly createdAt: string;
   readonly threadId: ThreadId;
   readonly turnId?: string | undefined;

--- a/apps/server/src/provider/Layers/AugmentAdapter.integration.test.ts
+++ b/apps/server/src/provider/Layers/AugmentAdapter.integration.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration test for AugmentAdapter against actual Auggie CLI.
+ *
+ * Run with: bun run vitest run src/provider/Layers/AugmentAdapter.integration.test.ts
+ *
+ * Prerequisites:
+ * - Auggie CLI installed and available on PATH
+ * - Auggie authenticated (run `auggie login` first)
+ */
+
+import { describe, it, expect } from "vitest";
+import { Effect, Layer, Stream } from "effect";
+import { ThreadId } from "@t3tools/contracts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { AugmentAdapter } from "../Services/AugmentAdapter.ts";
+import { makeAugmentAdapterLive } from "./AugmentAdapter.ts";
+import { ServerConfig } from "../../config.ts";
+
+// Use the test layer helper from ServerConfig
+const TestServerConfig = ServerConfig.layerTest(process.cwd(), "/tmp/t3code-test").pipe(
+  Layer.provide(NodeServices.layer),
+);
+
+describe("AugmentAdapter Integration", () => {
+  const testLayer = makeAugmentAdapterLive().pipe(Layer.provide(TestServerConfig));
+
+  it("should start a session and send a turn with streaming events", async () => {
+    const threadId = ThreadId.makeUnsafe("adapter-test-1");
+
+    const program = Effect.gen(function* () {
+      const adapter = yield* AugmentAdapter;
+
+      // Start session
+      const session = yield* adapter.startSession({
+        threadId,
+        runtimeMode: "full-access",
+        cwd: process.cwd(),
+      });
+
+      expect(session.provider).toBe("augment");
+      expect(session.status).toBe("ready");
+      expect(session.threadId).toBe(threadId);
+
+      // Collect events in background
+      const events: unknown[] = [];
+      const collectEvents = adapter.streamEvents.pipe(
+        Stream.tap((event) =>
+          Effect.sync(() => {
+            events.push(event);
+            console.log("Event:", event.type);
+          }),
+        ),
+        Stream.takeUntil((event) => event.type === "turn.completed"),
+        Stream.runDrain,
+      );
+
+      // Send turn
+      const turnResult = yield* adapter.sendTurn({
+        threadId,
+        input: "What is 2+2? Reply with just the number.",
+      });
+
+      expect(turnResult.threadId).toBe(threadId);
+      expect(turnResult.turnId).toBeDefined();
+
+      // Wait for events to complete
+      yield* collectEvents;
+
+      console.log("Total events:", events.length);
+      console.log(
+        "Event types:",
+        [...new Set(events.map((e: unknown) => (e as { type: string }).type))].join(", "),
+      );
+
+      // Verify we got streaming content
+      const contentDeltas = events.filter(
+        (e: unknown) => (e as { type: string }).type === "content.delta",
+      );
+      expect(contentDeltas.length).toBeGreaterThan(0);
+
+      // Stop session
+      yield* adapter.stopSession(threadId);
+
+      return { session, turnResult, events };
+    });
+
+    const result = await Effect.runPromise(
+      program.pipe(Effect.scoped, Effect.provide(testLayer)),
+    );
+
+    expect(result.session.status).toBe("ready");
+  }, 60_000);
+
+  it("should handle session lifecycle correctly", async () => {
+    const threadId = ThreadId.makeUnsafe("adapter-test-2");
+
+    const program = Effect.gen(function* () {
+      const adapter = yield* AugmentAdapter;
+
+      // Start session
+      const session = yield* adapter.startSession({
+        threadId,
+        runtimeMode: "full-access",
+        cwd: process.cwd(),
+      });
+
+      expect(session.status).toBe("ready");
+
+      // Check session exists
+      const hasSession = yield* adapter.hasSession(threadId);
+      expect(hasSession).toBe(true);
+
+      // List sessions
+      const sessions = yield* adapter.listSessions();
+      expect(sessions.some((s) => s.threadId === threadId)).toBe(true);
+
+      // Stop session
+      yield* adapter.stopSession(threadId);
+
+      // Check session is gone
+      const hasSessionAfter = yield* adapter.hasSession(threadId);
+      expect(hasSessionAfter).toBe(false);
+
+      return { session };
+    });
+
+    const result = await Effect.runPromise(
+      program.pipe(Effect.scoped, Effect.provide(testLayer)),
+    );
+
+    expect(result.session.provider).toBe("augment");
+  }, 30_000);
+
+  it("should interrupt a turn", async () => {
+    const threadId = ThreadId.makeUnsafe("adapter-test-3");
+
+    const program = Effect.gen(function* () {
+      const adapter = yield* AugmentAdapter;
+
+      yield* adapter.startSession({
+        threadId,
+        runtimeMode: "full-access",
+        cwd: process.cwd(),
+      });
+
+      // Start a long turn
+      const turnResultEffect = adapter.sendTurn({
+        threadId,
+        input: "Write a very long essay about computing history. Make it at least 2000 words.",
+      });
+
+      const turnResult = yield* turnResultEffect;
+
+      // Wait a bit then interrupt
+      yield* Effect.sleep("1 second");
+      yield* adapter.interruptTurn(threadId, turnResult.turnId);
+
+      yield* adapter.stopSession(threadId);
+
+      return { turnResult };
+    });
+
+    const result = await Effect.runPromise(
+      program.pipe(Effect.scoped, Effect.provide(testLayer)),
+    );
+
+    expect(result.turnResult.turnId).toBeDefined();
+  }, 30_000);
+});
+

--- a/apps/server/src/provider/Layers/AugmentAdapter.ts
+++ b/apps/server/src/provider/Layers/AugmentAdapter.ts
@@ -1,0 +1,589 @@
+/**
+ * AugmentAdapterLive - Scoped live implementation for the Augment provider adapter.
+ *
+ * Wraps `AugmentACPManager` behind the `AugmentAdapter` service contract and
+ * maps manager failures into the shared `ProviderAdapterError` algebra.
+ *
+ * @module AugmentAdapterLive
+ */
+import {
+  ProviderApprovalDecision,
+  ProviderItemId,
+  RuntimeItemId,
+  RuntimeRequestId,
+  ThreadId,
+  TurnId,
+  type CanonicalItemType,
+  type CanonicalRequestType,
+  type ProviderEvent,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+import { Effect, Layer, Queue, Schema, ServiceMap, Stream } from "effect";
+
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionClosedError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
+import { AugmentAdapter, type AugmentAdapterShape } from "../Services/AugmentAdapter.ts";
+import {
+  AugmentACPManager,
+  type AugmentACPStartSessionInput,
+} from "../../augmentACPManager.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const PROVIDER = "augment" as const;
+
+export interface AugmentAdapterLiveOptions {
+  readonly manager?: AugmentACPManager;
+  readonly makeManager?: (services?: ServiceMap.ServiceMap<never>) => AugmentACPManager;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+}
+
+function toMessage(cause: unknown, fallback: string): string {
+  if (cause instanceof Error && cause.message.length > 0) {
+    return cause.message;
+  }
+  return fallback;
+}
+
+function toSessionError(
+  threadId: ThreadId,
+  cause: unknown,
+): ProviderAdapterSessionNotFoundError | ProviderAdapterSessionClosedError | undefined {
+  const normalized = toMessage(cause, "").toLowerCase();
+  if (normalized.includes("unknown session") || normalized.includes("unknown provider session")) {
+    return new ProviderAdapterSessionNotFoundError({
+      provider: PROVIDER,
+      threadId,
+      cause,
+    });
+  }
+  if (normalized.includes("session is closed")) {
+    return new ProviderAdapterSessionClosedError({
+      provider: PROVIDER,
+      threadId,
+      cause,
+    });
+  }
+  return undefined;
+}
+
+function toRequestError(threadId: ThreadId, method: string, cause: unknown): ProviderAdapterError {
+  const sessionError = toSessionError(threadId, cause);
+  if (sessionError) {
+    return sessionError;
+  }
+  return new ProviderAdapterRequestError({
+    provider: PROVIDER,
+    method,
+    detail: toMessage(cause, `${method} failed`),
+    cause,
+  });
+}
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asRuntimeItemId(itemId: ProviderItemId): RuntimeItemId {
+  return RuntimeItemId.makeUnsafe(itemId);
+}
+
+function asRuntimeRequestId(requestId: string): RuntimeRequestId {
+  return RuntimeRequestId.makeUnsafe(requestId);
+}
+
+// Map ACP update types to canonical item types
+function toCanonicalItemType(updateType: string): CanonicalItemType {
+  switch (updateType) {
+    case "agent_message_chunk":
+      return "assistant_message";
+    case "agent_thought_chunk":
+      return "reasoning";
+    case "tool_call_added":
+    case "tool_call_updated":
+      return "dynamic_tool_call";
+    case "plan_update":
+      return "plan";
+    default:
+      return "unknown";
+  }
+}
+
+function toCanonicalRequestType(method: string): CanonicalRequestType {
+  if (method === "session/request_permission") {
+    // ACP permission requests - determine type from payload if available
+    return "command_execution_approval";
+  }
+  return "unknown";
+}
+
+function eventRawSource(
+  event: ProviderEvent,
+): NonNullable<ProviderRuntimeEvent["raw"]>["source"] {
+  return event.kind === "request" ? "augment.acp.request" : "augment.acp.notification";
+}
+
+function providerRefsFromEvent(
+  event: ProviderEvent,
+): ProviderRuntimeEvent["providerRefs"] | undefined {
+  const refs: Record<string, string> = {};
+  if (event.turnId) refs.providerTurnId = event.turnId;
+  if (event.itemId) refs.providerItemId = event.itemId;
+  if (event.requestId) refs.providerRequestId = event.requestId;
+
+  return Object.keys(refs).length > 0 ? (refs as ProviderRuntimeEvent["providerRefs"]) : undefined;
+}
+
+function runtimeEventBase(
+  event: ProviderEvent,
+  canonicalThreadId: ThreadId,
+): Omit<ProviderRuntimeEvent, "type" | "payload"> {
+  const refs = providerRefsFromEvent(event);
+  return {
+    eventId: event.id,
+    provider: event.provider,
+    threadId: canonicalThreadId,
+    createdAt: event.createdAt,
+    ...(event.turnId ? { turnId: event.turnId } : {}),
+    ...(event.itemId ? { itemId: asRuntimeItemId(event.itemId) } : {}),
+    ...(event.requestId ? { requestId: asRuntimeRequestId(event.requestId) } : {}),
+    ...(refs ? { providerRefs: refs } : {}),
+    raw: {
+      source: eventRawSource(event),
+      method: event.method,
+      payload: event.payload ?? {},
+    },
+  };
+}
+
+/**
+ * Maps Augment ACP events to T3 Code's canonical ProviderRuntimeEvent format.
+ */
+function mapToRuntimeEvents(
+  event: ProviderEvent,
+  canonicalThreadId: ThreadId,
+): ReadonlyArray<ProviderRuntimeEvent> {
+  const payload = asObject(event.payload);
+
+  // Error events
+  if (event.kind === "error") {
+    if (!event.message) {
+      return [];
+    }
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "runtime.error",
+        payload: {
+          message: event.message,
+          class: "provider_error",
+          ...(event.payload !== undefined ? { detail: event.payload } : {}),
+        },
+      },
+    ];
+  }
+
+  // Permission request events
+  if (event.kind === "request") {
+    if (event.method === "session/request_permission") {
+      return [
+        {
+          ...runtimeEventBase(event, canonicalThreadId),
+          type: "request.opened",
+          payload: {
+            requestType: toCanonicalRequestType(event.method),
+            ...(event.payload !== undefined ? { args: event.payload } : {}),
+          },
+        },
+      ];
+    }
+    return [];
+  }
+
+  // Session lifecycle events
+  if (event.method === "session/connecting") {
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "session.state.changed",
+        payload: {
+          state: "starting",
+          ...(event.message ? { reason: event.message } : {}),
+        },
+      },
+    ];
+  }
+
+  if (event.method === "session/ready") {
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "session.state.changed",
+        payload: {
+          state: "ready",
+          ...(event.message ? { reason: event.message } : {}),
+        },
+      },
+    ];
+  }
+
+  if (event.method === "session/closed" || event.method === "session/exited") {
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "session.exited",
+        payload: {
+          ...(event.message ? { reason: event.message } : {}),
+        },
+      },
+    ];
+  }
+
+  // Turn lifecycle events
+  if (event.method === "turn/started") {
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "turn.started",
+        payload: {},
+      },
+    ];
+  }
+
+  if (event.method === "turn/completed") {
+    const stopReason = asString(asObject(event.payload)?.stopReason);
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "turn.completed",
+        payload: {
+          state: stopReason === "cancelled" ? "cancelled" : "completed",
+        },
+      },
+    ];
+  }
+
+  if (event.method === "turn/failed") {
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "turn.completed",
+        payload: {
+          state: "failed",
+          ...(event.message ? { errorMessage: event.message } : {}),
+        },
+      },
+    ];
+  }
+
+  // Content streaming events (agent message / thought deltas)
+  if (event.method === "item/agentMessage/delta") {
+    const delta = event.textDelta ?? asString(payload?.delta) ?? asString(payload?.text);
+    if (!delta || delta.length === 0) {
+      return [];
+    }
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "content.delta",
+        payload: {
+          streamKind: "assistant_text",
+          delta,
+        },
+      },
+    ];
+  }
+
+  if (event.method === "item/agentThought/delta") {
+    const delta = event.textDelta ?? asString(payload?.delta) ?? asString(payload?.text);
+    if (!delta || delta.length === 0) {
+      return [];
+    }
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "content.delta",
+        payload: {
+          streamKind: "reasoning_text",
+          delta,
+        },
+      },
+    ];
+  }
+
+  // Tool call events
+  if (event.method === "item/toolCall/started") {
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "item.started",
+        payload: {
+          itemType: "dynamic_tool_call",
+          status: "inProgress",
+          title: "Tool call",
+          ...(event.payload !== undefined ? { data: event.payload } : {}),
+        },
+      },
+    ];
+  }
+
+  if (event.method === "item/toolCall/updated") {
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "item.updated",
+        payload: {
+          itemType: "dynamic_tool_call",
+          ...(event.payload !== undefined ? { data: event.payload } : {}),
+        },
+      },
+    ];
+  }
+
+  // Approval decision events
+  if (event.method === "item/requestApproval/decision" && event.requestId) {
+    const decisionOption = Schema.decodeUnknownOption(ProviderApprovalDecision)(payload?.decision);
+    const decision = decisionOption._tag === "Some" ? decisionOption.value : undefined;
+    return [
+      {
+        ...runtimeEventBase(event, canonicalThreadId),
+        type: "request.resolved",
+        payload: {
+          requestType: "command_execution_approval",
+          ...(decision ? { decision } : {}),
+          ...(event.payload !== undefined ? { resolution: event.payload } : {}),
+        },
+      },
+    ];
+  }
+
+  // Unhandled events - return empty array
+  return [];
+}
+
+const makeAugmentAdapter = (options?: AugmentAdapterLiveOptions) =>
+  Effect.gen(function* () {
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, {
+            stream: "native",
+          })
+        : undefined);
+
+    const manager = yield* Effect.acquireRelease(
+      Effect.gen(function* () {
+        if (options?.manager) {
+          return options.manager;
+        }
+        const services = yield* Effect.services<never>();
+        return options?.makeManager?.(services) ?? new AugmentACPManager(services);
+      }),
+      (manager) =>
+        Effect.sync(() => {
+          try {
+            manager.stopAll();
+          } catch {
+            // Finalizers should never fail and block shutdown.
+          }
+        }),
+    );
+
+    const startSession: AugmentAdapterShape["startSession"] = (input) => {
+      if (input.provider !== undefined && input.provider !== PROVIDER) {
+        return Effect.fail(
+          new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+          }),
+        );
+      }
+
+      const managerInput: AugmentACPStartSessionInput = {
+        threadId: input.threadId,
+        provider: "augment",
+        ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+        ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
+        runtimeMode: input.runtimeMode,
+        ...(input.model !== undefined ? { model: input.model } : {}),
+      };
+
+      return Effect.tryPromise({
+        try: () => manager.startSession(managerInput),
+        catch: (cause) =>
+          new ProviderAdapterProcessError({
+            provider: PROVIDER,
+            threadId: input.threadId,
+            detail: toMessage(cause, "Failed to start Augment adapter session."),
+            cause,
+          }),
+      });
+    };
+
+    const sendTurn: AugmentAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        // Convert attachments to base64 data URLs if needed
+        const augmentAttachments: Array<{ type: "image"; url: string }> = [];
+        for (const attachment of input.attachments ?? []) {
+          // For now, pass through image attachments directly
+          // TODO: Handle attachment file reading if needed
+          augmentAttachments.push({
+            type: "image",
+            url: `attachment:${attachment.id}`,
+          });
+        }
+
+        return yield* Effect.tryPromise({
+          try: () => {
+            const managerInput = {
+              threadId: input.threadId,
+              ...(input.input !== undefined ? { input: input.input } : {}),
+              ...(input.model !== undefined ? { model: input.model } : {}),
+              ...(input.interactionMode !== undefined
+                ? { interactionMode: input.interactionMode }
+                : {}),
+              ...(augmentAttachments.length > 0 ? { attachments: augmentAttachments } : {}),
+            };
+            return manager.sendTurn(managerInput);
+          },
+          catch: (cause) => toRequestError(input.threadId, "turn/start", cause),
+        }).pipe(
+          Effect.map((result) => ({
+            ...result,
+            threadId: input.threadId,
+          })),
+        );
+      });
+
+    const interruptTurn: AugmentAdapterShape["interruptTurn"] = (threadId, turnId) =>
+      Effect.tryPromise({
+        try: () => manager.interruptTurn(threadId, turnId),
+        catch: (cause) => toRequestError(threadId, "turn/interrupt", cause),
+      });
+
+    // Augment/ACP doesn't support thread reading/rollback yet
+    const readThread: AugmentAdapterShape["readThread"] = (threadId) =>
+      Effect.succeed({
+        threadId,
+        turns: [],
+      });
+
+    const rollbackThread: AugmentAdapterShape["rollbackThread"] = (threadId, _numTurns) =>
+      Effect.succeed({
+        threadId,
+        turns: [],
+      });
+
+    const respondToRequest: AugmentAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.tryPromise({
+        try: () => manager.respondToRequest(threadId, requestId, decision),
+        catch: (cause) => toRequestError(threadId, "item/requestApproval/decision", cause),
+      });
+
+    // Augment/ACP doesn't support user input prompts yet
+    const respondToUserInput: AugmentAdapterShape["respondToUserInput"] = (
+      _threadId,
+      _requestId,
+      _answers,
+    ) => Effect.void;
+
+    const stopSession: AugmentAdapterShape["stopSession"] = (threadId) =>
+      Effect.sync(() => {
+        manager.stopSession(threadId);
+      });
+
+    const listSessions: AugmentAdapterShape["listSessions"] = () =>
+      Effect.sync(() => manager.listSessions());
+
+    const hasSession: AugmentAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => manager.hasSession(threadId));
+
+    const stopAll: AugmentAdapterShape["stopAll"] = () =>
+      Effect.sync(() => {
+        manager.stopAll();
+      });
+
+    const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+
+    yield* Effect.acquireRelease(
+      Effect.gen(function* () {
+        const writeNativeEvent = (event: ProviderEvent) =>
+          Effect.gen(function* () {
+            if (!nativeEventLogger) {
+              return;
+            }
+            yield* nativeEventLogger.write(event, event.threadId);
+          });
+
+        const services = yield* Effect.services<never>();
+        const listener = (event: ProviderEvent) =>
+          Effect.gen(function* () {
+            yield* writeNativeEvent(event);
+            const runtimeEvents = mapToRuntimeEvents(event, event.threadId);
+            if (runtimeEvents.length === 0) {
+              yield* Effect.logDebug("ignoring unhandled Augment provider event", {
+                method: event.method,
+                threadId: event.threadId,
+                turnId: event.turnId,
+                itemId: event.itemId,
+              });
+              return;
+            }
+            yield* Queue.offerAll(runtimeEventQueue, runtimeEvents);
+          }).pipe(Effect.runPromiseWith(services));
+        manager.on("event", listener);
+        return listener;
+      }),
+      (listener) =>
+        Effect.gen(function* () {
+          yield* Effect.sync(() => {
+            manager.off("event", listener);
+          });
+          yield* Queue.shutdown(runtimeEventQueue);
+        }),
+    );
+
+    return {
+      provider: PROVIDER,
+      capabilities: {
+        sessionModelSwitch: "restart-session", // ACP sessions are model-bound
+      },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents: Stream.fromQueue(runtimeEventQueue),
+    } satisfies AugmentAdapterShape;
+  });
+
+export const AugmentAdapterLive = Layer.effect(AugmentAdapter, makeAugmentAdapter());
+
+export function makeAugmentAdapterLive(options?: AugmentAdapterLiveOptions) {
+  return Layer.effect(AugmentAdapter, makeAugmentAdapter(options));
+}
+

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -5,6 +5,7 @@ import { assertFailure } from "@effect/vitest/utils";
 import { Effect, Layer, Stream } from "effect";
 
 import { CodexAdapter, CodexAdapterShape } from "../Services/CodexAdapter.ts";
+import { AugmentAdapter, AugmentAdapterShape } from "../Services/AugmentAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderAdapterRegistryLive } from "./ProviderAdapterRegistry.ts";
 import { ProviderUnsupportedError } from "../Errors.ts";
@@ -27,11 +28,31 @@ const fakeCodexAdapter: CodexAdapterShape = {
   streamEvents: Stream.empty,
 };
 
+const fakeAugmentAdapter: AugmentAdapterShape = {
+  provider: "augment",
+  capabilities: { sessionModelSwitch: "restart-session" },
+  startSession: vi.fn(),
+  sendTurn: vi.fn(),
+  interruptTurn: vi.fn(),
+  respondToRequest: vi.fn(),
+  respondToUserInput: vi.fn(),
+  stopSession: vi.fn(),
+  listSessions: vi.fn(),
+  hasSession: vi.fn(),
+  readThread: vi.fn(),
+  rollbackThread: vi.fn(),
+  stopAll: vi.fn(),
+  streamEvents: Stream.empty,
+};
+
 const layer = it.layer(
   Layer.mergeAll(
     Layer.provide(
       ProviderAdapterRegistryLive,
-      Layer.succeed(CodexAdapter, fakeCodexAdapter),
+      Layer.mergeAll(
+        Layer.succeed(CodexAdapter, fakeCodexAdapter),
+        Layer.succeed(AugmentAdapter, fakeAugmentAdapter),
+      ),
     ),
     NodeServices.layer,
   ),
@@ -44,8 +65,13 @@ layer("ProviderAdapterRegistryLive", (it) => {
       const codex = yield* registry.getByProvider("codex");
       assert.equal(codex, fakeCodexAdapter);
 
+      const augment = yield* registry.getByProvider("augment");
+      assert.equal(augment, fakeAugmentAdapter);
+
       const providers = yield* registry.listProviders();
-      assert.deepEqual(providers, ["codex"]);
+      assert.ok(providers.includes("codex"));
+      assert.ok(providers.includes("augment"));
+      assert.equal(providers.length, 2);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -1,7 +1,7 @@
 /**
  * ProviderAdapterRegistryLive - In-memory provider adapter lookup layer.
  *
- * Binds provider kinds (codex/cursor/...) to concrete adapter services.
+ * Binds provider kinds (codex/augment/cursor/...) to concrete adapter services.
  * This layer only performs adapter lookup; it does not route session-scoped
  * calls or own provider lifecycle workflows.
  *
@@ -16,6 +16,7 @@ import {
   type ProviderAdapterRegistryShape,
 } from "../Services/ProviderAdapterRegistry.ts";
 import { CodexAdapter } from "../Services/CodexAdapter.ts";
+import { AugmentAdapter } from "../Services/AugmentAdapter.ts";
 
 export interface ProviderAdapterRegistryLiveOptions {
   readonly adapters?: ReadonlyArray<ProviderAdapterShape<ProviderAdapterError>>;
@@ -26,7 +27,7 @@ const makeProviderAdapterRegistry = (options?: ProviderAdapterRegistryLiveOption
     const adapters =
       options?.adapters !== undefined
         ? options.adapters
-        : [yield* CodexAdapter];
+        : [yield* CodexAdapter, yield* AugmentAdapter];
     const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));
 
     const getByProvider: ProviderAdapterRegistryShape["getByProvider"] = (provider) => {

--- a/apps/server/src/provider/Layers/ProviderHealth.integration.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.integration.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Integration test for ProviderHealth against actual Auggie CLI.
+ *
+ * Run with: bun run vitest run src/provider/Layers/ProviderHealth.integration.test.ts
+ *
+ * Prerequisites:
+ * - Auggie CLI installed and available on PATH
+ * - Auggie authenticated (run `auggie login` first)
+ */
+
+import { describe, it, expect } from "vitest";
+import { Effect } from "effect";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { checkAugmentProviderStatus } from "./ProviderHealth.ts";
+
+describe("ProviderHealth Integration", () => {
+  it("should detect Auggie CLI status", async () => {
+    const program = Effect.gen(function* () {
+      const status = yield* checkAugmentProviderStatus;
+
+      console.log("Augment provider status:", JSON.stringify(status, null, 2));
+
+      expect(status.provider).toBe("augment");
+      expect(status.checkedAt).toBeDefined();
+
+      // If Auggie is installed, it should be available
+      if (status.available) {
+        expect(status.status).toMatch(/ready|warning|error/);
+        // If authenticated, should be ready
+        if (status.authStatus === "authenticated") {
+          expect(status.status).toBe("ready");
+        }
+      } else {
+        expect(status.status).toBe("error");
+        expect(status.message).toBeDefined();
+      }
+
+      return status;
+    });
+
+    const result = await Effect.runPromise(
+      program.pipe(Effect.provide(NodeServices.layer)),
+    );
+
+    // Since we know Auggie is installed, verify it's available
+    expect(result.available).toBe(true);
+    // Status should be ready (may not be able to verify auth without actually starting a session)
+    expect(result.status).toBe("ready");
+  }, 30_000);
+});
+

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -20,6 +20,7 @@ import { ProviderHealth, type ProviderHealthShape } from "../Services/ProviderHe
 
 const DEFAULT_TIMEOUT_MS = 4_000;
 const CODEX_PROVIDER = "codex" as const;
+const AUGMENT_PROVIDER = "augment" as const;
 
 // ── Pure helpers ────────────────────────────────────────────────────
 
@@ -35,12 +36,23 @@ function nonEmptyTrimmed(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function isCommandMissingCause(error: unknown): boolean {
+function isCodexCommandMissingCause(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const lower = error.message.toLowerCase();
   return (
     lower.includes("command not found: codex") ||
     lower.includes("spawn codex enoent") ||
+    lower.includes("enoent") ||
+    lower.includes("notfound")
+  );
+}
+
+function isAugmentCommandMissingCause(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const lower = error.message.toLowerCase();
+  return (
+    lower.includes("command not found: auggie") ||
+    lower.includes("spawn auggie enoent") ||
     lower.includes("enoent") ||
     lower.includes("notfound")
   );
@@ -215,7 +227,7 @@ export const checkCodexProviderStatus: Effect.Effect<
       available: false,
       authStatus: "unknown" as const,
       checkedAt,
-      message: isCommandMissingCause(error)
+      message: isCodexCommandMissingCause(error)
         ? "Codex CLI (`codex`) is not installed or not on PATH."
         : `Failed to execute Codex CLI health check: ${error instanceof Error ? error.message : String(error)}.`,
     };
@@ -290,14 +302,147 @@ export const checkCodexProviderStatus: Effect.Effect<
   } satisfies ServerProviderStatus;
 });
 
+// ── Augment health check ─────────────────────────────────────────────
+
+const runAugmentCommand = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const command = ChildProcess.make("auggie", [...args], {
+      shell: process.platform === "win32",
+    });
+
+    const child = yield* spawner.spawn(command);
+
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [
+        collectStreamAsString(child.stdout),
+        collectStreamAsString(child.stderr),
+        child.exitCode.pipe(Effect.map(Number)),
+      ],
+      { concurrency: "unbounded" },
+    );
+
+    return { stdout, stderr, code: exitCode } satisfies CommandResult;
+  }).pipe(Effect.scoped);
+
+export const checkAugmentProviderStatus: Effect.Effect<
+  ServerProviderStatus,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner
+> = Effect.gen(function* () {
+  const checkedAt = new Date().toISOString();
+
+  // Probe 1: `auggie --version` — is the CLI reachable?
+  const versionProbe = yield* runAugmentCommand(["--version"]).pipe(
+    Effect.timeoutOption(DEFAULT_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  if (Result.isFailure(versionProbe)) {
+    const error = versionProbe.failure;
+    return {
+      provider: AUGMENT_PROVIDER,
+      status: "error" as const,
+      available: false,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message: isAugmentCommandMissingCause(error)
+        ? "Auggie CLI (`auggie`) is not installed or not on PATH."
+        : `Failed to execute Auggie CLI health check: ${error instanceof Error ? error.message : String(error)}.`,
+    };
+  }
+
+  if (Option.isNone(versionProbe.success)) {
+    return {
+      provider: AUGMENT_PROVIDER,
+      status: "error" as const,
+      available: false,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message: "Auggie CLI is installed but failed to run. Timed out while running command.",
+    };
+  }
+
+  const version = versionProbe.success.value;
+  if (version.code !== 0) {
+    const detail = detailFromResult(version);
+    return {
+      provider: AUGMENT_PROVIDER,
+      status: "error" as const,
+      available: false,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message: detail
+        ? `Auggie CLI is installed but failed to run. ${detail}`
+        : "Auggie CLI is installed but failed to run.",
+    };
+  }
+
+  // Probe 2: Check authentication by looking for session file or using `auggie token status`
+  // Since Auggie doesn't have a simple `login status` command, we check via `auggie token status`
+  const authProbe = yield* runAugmentCommand(["token", "status"]).pipe(
+    Effect.timeoutOption(DEFAULT_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  // If auth probe fails or times out, the CLI is still available
+  if (Result.isFailure(authProbe) || Option.isNone(authProbe.success)) {
+    // CLI works, assume auth is ok (will fail at session start if not)
+    return {
+      provider: AUGMENT_PROVIDER,
+      status: "ready" as const,
+      available: true,
+      authStatus: "unknown" as const,
+      checkedAt,
+      message: "Auggie CLI is available. Authentication will be verified when starting a session.",
+    };
+  }
+
+  const authResult = authProbe.success.value;
+  const combinedOutput = `${authResult.stdout}\n${authResult.stderr}`.toLowerCase();
+
+  // Check for common unauthenticated patterns
+  if (
+    combinedOutput.includes("not logged in") ||
+    combinedOutput.includes("login required") ||
+    combinedOutput.includes("authentication required") ||
+    combinedOutput.includes("run `auggie login`") ||
+    combinedOutput.includes("run auggie login") ||
+    combinedOutput.includes("no token") ||
+    combinedOutput.includes("not authenticated")
+  ) {
+    return {
+      provider: AUGMENT_PROVIDER,
+      status: "error" as const,
+      available: true,
+      authStatus: "unauthenticated" as const,
+      checkedAt,
+      message: "Auggie CLI is not authenticated. Run `auggie login` and try again.",
+    };
+  }
+
+  // If command succeeded or didn't indicate auth failure, assume authenticated
+  // Authentication will be verified when actually starting a session
+  return {
+    provider: AUGMENT_PROVIDER,
+    status: "ready" as const,
+    available: true,
+    authStatus: authResult.code === 0 ? ("authenticated" as const) : ("unknown" as const),
+    checkedAt,
+  };
+});
+
 // ── Layer ───────────────────────────────────────────────────────────
 
 export const ProviderHealthLive = Layer.effect(
   ProviderHealth,
   Effect.gen(function* () {
-    const codexStatus = yield* checkCodexProviderStatus;
+    const [codexStatus, augmentStatus] = yield* Effect.all(
+      [checkCodexProviderStatus, checkAugmentProviderStatus],
+      { concurrency: "unbounded" },
+    );
     return {
-      getStatuses: Effect.succeed([codexStatus]),
+      getStatuses: Effect.succeed([codexStatus, augmentStatus]),
     } satisfies ProviderHealthShape;
   }),
 );

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -52,7 +52,7 @@ const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
   readonly eventId: EventId;
-  readonly provider: "codex";
+  readonly provider: ProviderKind;
   readonly createdAt: string;
   readonly threadId: ThreadId;
   readonly turnId?: string | undefined;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -12,6 +12,7 @@
 import {
   NonNegativeInt,
   ThreadId,
+  DEFAULT_PROVIDER_KIND,
   ProviderInterruptTurnInput,
   ProviderRespondToRequestInput,
   ProviderRespondToUserInputInput,
@@ -261,7 +262,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         const input = {
           ...parsed,
           threadId,
-          provider: parsed.provider ?? "codex",
+          provider: parsed.provider ?? DEFAULT_PROVIDER_KIND,
         };
         const adapter = yield* registry.getByProvider(input.provider);
         const session = yield* adapter.startSession(input);

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -1,4 +1,4 @@
-import { type ProviderKind, type ThreadId } from "@t3tools/contracts";
+import { type ProviderKind, type ThreadId, isProviderKind } from "@t3tools/contracts";
 import { Effect, Layer, Option } from "effect";
 
 import { ProviderSessionRuntimeRepository } from "../../persistence/Services/ProviderSessionRuntime.ts";
@@ -25,7 +25,7 @@ function decodeProviderKind(
   providerName: string,
   operation: string,
 ): Effect.Effect<ProviderKind, ProviderSessionDirectoryPersistenceError> {
-  if (providerName === "codex") {
+  if (isProviderKind(providerName)) {
     return Effect.succeed(providerName);
   }
   return Effect.fail(

--- a/apps/server/src/provider/Services/AugmentAdapter.ts
+++ b/apps/server/src/provider/Services/AugmentAdapter.ts
@@ -1,0 +1,31 @@
+/**
+ * AugmentAdapter - Augment implementation of the generic provider adapter contract.
+ *
+ * This service owns Augment ACP (Agent Client Protocol) process / JSON-RPC semantics
+ * and emits Augment provider events. It does not perform cross-provider routing, shared
+ * event fan-out, or checkpoint orchestration.
+ *
+ * Uses Effect `ServiceMap.Service` for dependency injection and returns the
+ * shared provider-adapter error channel with `provider: "augment"` context.
+ *
+ * @module AugmentAdapter
+ */
+import { ServiceMap } from "effect";
+
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * AugmentAdapterShape - Service API for the Augment provider adapter.
+ */
+export interface AugmentAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {
+  readonly provider: "augment";
+}
+
+/**
+ * AugmentAdapter - Service tag for Augment provider adapter operations.
+ */
+export class AugmentAdapter extends ServiceMap.Service<AugmentAdapter, AugmentAdapterShape>()(
+  "t3/provider/Services/AugmentAdapter",
+) {}
+

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -19,6 +19,7 @@ import { OrchestrationProjectionSnapshotQueryLive } from "./orchestration/Layers
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion";
 import { ProviderUnsupportedError } from "./provider/Errors";
 import { makeCodexAdapterLive } from "./provider/Layers/CodexAdapter";
+import { makeAugmentAdapterLive } from "./provider/Layers/AugmentAdapter";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry";
 import { makeProviderServiceLive } from "./provider/Layers/ProviderService";
 import { ProviderSessionDirectoryLive } from "./provider/Layers/ProviderSessionDirectory";
@@ -57,8 +58,12 @@ export function makeServerProviderLayer(): Layer.Layer<
     const codexAdapterLayer = makeCodexAdapterLive(
       nativeEventLogger ? { nativeEventLogger } : undefined,
     );
+    const augmentAdapterLayer = makeAugmentAdapterLive(
+      nativeEventLogger ? { nativeEventLogger } : undefined,
+    );
     const adapterRegistryLayer = ProviderAdapterRegistryLive.pipe(
       Layer.provide(codexAdapterLayer),
+      Layer.provide(augmentAdapterLayer),
       Layer.provideMerge(providerSessionDirectoryLayer),
     );
     return makeProviderServiceLive(

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -28,6 +28,7 @@ const AppServiceTierSchema = Schema.Literals(["auto", "fast", "flex"]);
 const MODELS_WITH_FAST_SUPPORT = new Set(["gpt-5.4"]);
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
+  augment: new Set(getModelOptions("augment").map((option) => option.slug)),
 };
 
 const AppSettingsSchema = Schema.Struct({

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,6 +1,7 @@
 import {
   type ApprovalRequestId,
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_KIND,
   EDITORS,
   type EditorId,
   type KeybindingCommand,
@@ -161,6 +162,7 @@ import {
   MenuTrigger,
 } from "./ui/menu";
 import {
+  AugmentIcon,
   ClaudeAI,
   CursorIcon,
   Gemini,
@@ -606,6 +608,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
   const clearDraftThread = useComposerDraftStore((store) => store.clearDraftThread);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const setLastProviderForProject = useComposerDraftStore((store) => store.setLastProviderForProject);
   const draftThread = useComposerDraftStore(
     (store) => store.draftThreadsByThreadId[threadId] ?? null,
   );
@@ -762,6 +765,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
   const sessionProvider = activeThread?.session?.provider ?? null;
   const selectedProviderByThreadId = composerDraft.provider;
+  const lastProviderForProject = useComposerDraftStore(
+    (state) => activeThread?.projectId ? state.lastProviderByProjectId[activeThread.projectId] : null,
+  );
   const hasThreadStarted = Boolean(
     activeThread &&
     (activeThread.latestTurn !== null ||
@@ -773,7 +779,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const lockedProvider: ProviderKind | null = hasThreadStarted
     ? (sessionProvider ?? selectedProviderByThreadId ?? null)
     : null;
-  const selectedProvider: ProviderKind = lockedProvider ?? selectedProviderByThreadId ?? "codex";
+  // Use the last provider for this project as a fallback for new threads
+  const selectedProvider: ProviderKind = lockedProvider ?? selectedProviderByThreadId ?? lastProviderForProject ?? DEFAULT_PROVIDER_KIND;
   const baseThreadModel = resolveModelSlugForProvider(
     selectedProvider,
     activeThread?.model ?? activeProject?.model ?? getDefaultModel(selectedProvider),
@@ -2573,6 +2580,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
       turnStartSucceeded = true;
       if (isFirstMessage) {
         clearDraftThread(threadIdForSend);
+      }
+      // Remember the last used provider for this project
+      if (activeProject?.id) {
+        setLastProviderForProject(activeProject.id, selectedProvider);
       }
     })().catch(async (err: unknown) => {
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
@@ -5197,11 +5208,14 @@ function getCustomModelOptionsByProvider(settings: {
 }): Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>> {
   return {
     codex: getAppModelOptions("codex", settings.customCodexModels),
+    // Augment models are fetched dynamically from ACP, custom models not supported yet
+    augment: getAppModelOptions("augment", []),
   };
 }
 
 const PROVIDER_ICON_BY_PROVIDER: Record<ProviderPickerKind, Icon> = {
   codex: OpenAI,
+  augment: AugmentIcon,
   claudeCode: ClaudeAI,
   cursor: CursorIcon,
 };

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -2,6 +2,12 @@ import { type SVGProps, useId } from "react";
 
 export type Icon = React.FC<SVGProps<SVGSVGElement>>;
 
+export const AugmentIcon: Icon = (props) => (
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 2L2 22h4l2-4h8l2 4h4L12 2zm0 6l3 8H9l3-8z" />
+  </svg>
+);
+
 export const GitHubIcon: Icon = (props) => (
   <svg {...props} viewBox="0 0 1024 1024" fill="none">
     <path

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1,10 +1,12 @@
 import {
   DEFAULT_REASONING_EFFORT_BY_PROVIDER,
+  DEFAULT_PROVIDER_KIND,
   ProjectId,
   REASONING_EFFORT_OPTIONS_BY_PROVIDER,
   ThreadId,
   type CodexReasoningEffort,
   type ProviderKind,
+  normalizeProviderKind,
   type ProviderInteractionMode,
   type RuntimeMode,
 } from "@t3tools/contracts";
@@ -59,6 +61,7 @@ interface PersistedComposerDraftStoreState {
   draftsByThreadId: Record<ThreadId, PersistedComposerThreadDraftState>;
   draftThreadsByThreadId: Record<ThreadId, PersistedDraftThreadState>;
   projectDraftThreadIdByProjectId: Record<ProjectId, ThreadId>;
+  lastProviderByProjectId: Record<ProjectId, ProviderKind>;
 }
 
 interface ComposerThreadDraftState {
@@ -92,8 +95,11 @@ interface ComposerDraftStoreState {
   draftsByThreadId: Record<ThreadId, ComposerThreadDraftState>;
   draftThreadsByThreadId: Record<ThreadId, DraftThreadState>;
   projectDraftThreadIdByProjectId: Record<ProjectId, ThreadId>;
+  lastProviderByProjectId: Record<ProjectId, ProviderKind>;
   getDraftThreadByProjectId: (projectId: ProjectId) => ProjectDraftThread | null;
   getDraftThread: (threadId: ThreadId) => DraftThreadState | null;
+  getLastProviderForProject: (projectId: ProjectId) => ProviderKind | null;
+  setLastProviderForProject: (projectId: ProjectId, provider: ProviderKind) => void;
   setProjectDraftThreadId: (
     projectId: ProjectId,
     threadId: ThreadId,
@@ -147,6 +153,7 @@ const EMPTY_PERSISTED_DRAFT_STORE_STATE: PersistedComposerDraftStoreState = {
   draftsByThreadId: {},
   draftThreadsByThreadId: {},
   projectDraftThreadIdByProjectId: {},
+  lastProviderByProjectId: {},
 };
 
 const EMPTY_IMAGES: ComposerImageAttachment[] = [];
@@ -205,10 +212,6 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
     draft.effort === null &&
     draft.codexFastMode === false
   );
-}
-
-function normalizeProviderKind(value: unknown): ProviderKind | null {
-  return value === "codex" ? value : null;
 }
 
 function revokeObjectPreviewUrl(previewUrl: string): void {
@@ -270,6 +273,7 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
   const rawDraftMap = candidate.draftsByThreadId;
   const rawDraftThreadsByThreadId = candidate.draftThreadsByThreadId;
   const rawProjectDraftThreadIdByProjectId = candidate.projectDraftThreadIdByProjectId;
+  const rawLastProviderByProjectId = candidate.lastProviderByProjectId;
   const draftThreadsByThreadId: PersistedComposerDraftStoreState["draftThreadsByThreadId"] = {};
   if (rawDraftThreadsByThreadId && typeof rawDraftThreadsByThreadId === "object") {
     for (const [threadId, rawDraftThread] of Object.entries(
@@ -348,7 +352,7 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
     }
   }
   if (!rawDraftMap || typeof rawDraftMap !== "object") {
-    return { draftsByThreadId: {}, draftThreadsByThreadId, projectDraftThreadIdByProjectId };
+    return { draftsByThreadId: {}, draftThreadsByThreadId, projectDraftThreadIdByProjectId, lastProviderByProjectId: {} };
   }
   const nextDraftsByThreadId: PersistedComposerDraftStoreState["draftsByThreadId"] = {};
   for (const [threadId, draftValue] of Object.entries(rawDraftMap as Record<string, unknown>)) {
@@ -369,7 +373,7 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
     const provider = normalizeProviderKind(draftCandidate.provider);
     const model =
       typeof draftCandidate.model === "string"
-        ? normalizeModelSlug(draftCandidate.model, provider ?? "codex")
+        ? normalizeModelSlug(draftCandidate.model, provider ?? DEFAULT_PROVIDER_KIND)
         : null;
     const runtimeMode =
       draftCandidate.runtimeMode === "approval-required" ||
@@ -412,10 +416,26 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
       ...(codexFastMode ? { codexFastMode } : {}),
     };
   }
+  const lastProviderByProjectId: PersistedComposerDraftStoreState["lastProviderByProjectId"] = {};
+  if (rawLastProviderByProjectId && typeof rawLastProviderByProjectId === "object") {
+    for (const [projectId, rawProvider] of Object.entries(
+      rawLastProviderByProjectId as Record<string, unknown>,
+    )) {
+      if (typeof projectId !== "string" || projectId.length === 0) {
+        continue;
+      }
+      const provider = normalizeProviderKind(rawProvider);
+      if (provider) {
+        lastProviderByProjectId[projectId as ProjectId] = provider;
+      }
+    }
+  }
+
   return {
     draftsByThreadId: nextDraftsByThreadId,
     draftThreadsByThreadId,
     projectDraftThreadIdByProjectId,
+    lastProviderByProjectId,
   };
 }
 
@@ -526,6 +546,30 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
       draftsByThreadId: {},
       draftThreadsByThreadId: {},
       projectDraftThreadIdByProjectId: {},
+      lastProviderByProjectId: {},
+      getLastProviderForProject: (projectId) => {
+        if (projectId.length === 0) {
+          return null;
+        }
+        return get().lastProviderByProjectId[projectId] ?? null;
+      },
+      setLastProviderForProject: (projectId, provider) => {
+        if (projectId.length === 0) {
+          return;
+        }
+        set((state) => {
+          if (state.lastProviderByProjectId[projectId] === provider) {
+            return state;
+          }
+          return {
+            ...state,
+            lastProviderByProjectId: {
+              ...state.lastProviderByProjectId,
+              [projectId]: provider,
+            },
+          };
+        });
+      },
       getDraftThreadByProjectId: (projectId) => {
         if (projectId.length === 0) {
           return null;
@@ -1216,6 +1260,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           draftsByThreadId: persistedDraftsByThreadId,
           draftThreadsByThreadId: state.draftThreadsByThreadId,
           projectDraftThreadIdByProjectId: state.projectDraftThreadIdByProjectId,
+          lastProviderByProjectId: state.lastProviderByProjectId,
         };
       },
       merge: (persistedState, currentState) => {
@@ -1231,6 +1276,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           draftsByThreadId,
           draftThreadsByThreadId: normalizedPersisted.draftThreadsByThreadId,
           projectDraftThreadIdByProjectId: normalizedPersisted.projectDraftThreadIdByProjectId,
+          lastProviderByProjectId: normalizedPersisted.lastProviderByProjectId,
         };
       },
     },

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -96,6 +96,7 @@ function SettingsRouteView() {
     Record<ProviderKind, string>
   >({
     codex: "",
+    augment: "",
   });
   const [customModelErrorByProvider, setCustomModelErrorByProvider] = useState<
     Partial<Record<ProviderKind, string | null>>

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -18,6 +18,7 @@ export const PROVIDER_OPTIONS: Array<{
   available: boolean;
 }> = [
   { value: "codex", label: "Codex", available: true },
+  { value: "augment", label: "Augment", available: true },
   { value: "claudeCode", label: "Claude Code", available: false },
   { value: "cursor", label: "Cursor", available: false },
 ];

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -1,7 +1,10 @@
 import { Fragment, type ReactNode, createElement, useEffect } from "react";
 import {
   DEFAULT_MODEL_BY_PROVIDER,
+  DEFAULT_PROVIDER_KIND,
   type ProviderKind,
+  normalizeProviderKind,
+  isProviderKind,
   ThreadId,
   type OrchestrationReadModel,
   type OrchestrationSessionStatus,
@@ -143,26 +146,32 @@ function toLegacySessionStatus(
 }
 
 function toLegacyProvider(providerName: string | null): ProviderKind {
-  if (providerName === "codex") {
-    return providerName;
-  }
-  return "codex";
+  const normalized = normalizeProviderKind(providerName);
+  return normalized ?? DEFAULT_PROVIDER_KIND;
 }
 
 const CODEX_MODEL_SLUGS = new Set<string>(getModelOptions("codex").map((option) => option.slug));
+
+const AUGMENT_MODEL_SLUGS = new Set<string>(getModelOptions("augment").map((option) => option.slug));
 
 function inferProviderForThreadModel(input: {
   readonly model: string;
   readonly sessionProviderName: string | null;
 }): ProviderKind {
-  if (input.sessionProviderName === "codex") {
+  // If session already has a valid provider, use it
+  if (isProviderKind(input.sessionProviderName)) {
     return input.sessionProviderName;
   }
+  // Try to infer provider from model slug
   const normalizedCodex = normalizeModelSlug(input.model, "codex");
   if (normalizedCodex && CODEX_MODEL_SLUGS.has(normalizedCodex)) {
     return "codex";
   }
-  return "codex";
+  const normalizedAugment = normalizeModelSlug(input.model, "augment");
+  if (normalizedAugment && AUGMENT_MODEL_SLUGS.has(normalizedAugment)) {
+    return "augment";
+  }
+  return DEFAULT_PROVIDER_KIND;
 }
 
 function resolveWsHttpOrigin(): string {

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -10,8 +10,12 @@ export const CodexModelOptions = Schema.Struct({
 });
 export type CodexModelOptions = typeof CodexModelOptions.Type;
 
+export const AugmentModelOptions = Schema.Struct({});
+export type AugmentModelOptions = typeof AugmentModelOptions.Type;
+
 export const ProviderModelOptions = Schema.Struct({
   codex: Schema.optional(CodexModelOptions),
+  augment: Schema.optional(AugmentModelOptions),
 });
 export type ProviderModelOptions = typeof ProviderModelOptions.Type;
 
@@ -28,6 +32,15 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     { slug: "gpt-5.2-codex", name: "GPT-5.2 Codex" },
     { slug: "gpt-5.2", name: "GPT-5.2" },
   ],
+  // Augment models available via ACP
+  augment: [
+    { slug: "claude-opus-4-5", name: "Claude Opus 4.5" },
+    { slug: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+    { slug: "claude-sonnet-4", name: "Claude Sonnet 4" },
+    { slug: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+    { slug: "gpt-5-1", name: "GPT-5.1" },
+    { slug: "gpt-5", name: "GPT-5" },
+  ],
 } as const satisfies Record<ProviderKind, readonly ModelOption[]>;
 export type ModelOptionsByProvider = typeof MODEL_OPTIONS_BY_PROVIDER;
 
@@ -36,6 +49,7 @@ export type ModelSlug = BuiltInModelSlug | (string & {});
 
 export const DEFAULT_MODEL_BY_PROVIDER = {
   codex: "gpt-5.4",
+  augment: "claude-opus-4-5",
 } as const satisfies Record<ProviderKind, ModelSlug>;
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
@@ -46,12 +60,19 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
     "5.3-spark": "gpt-5.3-codex-spark",
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
+  augment: {
+    opus: "claude-opus-4-5",
+    sonnet: "claude-sonnet-4-5",
+    haiku: "claude-haiku-4-5",
+  },
 } as const satisfies Record<ProviderKind, Record<string, ModelSlug>>;
 
 export const REASONING_EFFORT_OPTIONS_BY_PROVIDER = {
   codex: CODEX_REASONING_EFFORT_OPTIONS,
+  augment: [], // Augment doesn't use reasoning effort levels
 } as const satisfies Record<ProviderKind, readonly CodexReasoningEffort[]>;
 
 export const DEFAULT_REASONING_EFFORT_BY_PROVIDER = {
   codex: "high",
+  augment: null, // Augment doesn't use reasoning effort
 } as const satisfies Record<ProviderKind, CodexReasoningEffort | null>;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -27,8 +27,23 @@ export const ORCHESTRATION_WS_CHANNELS = {
   domainEvent: "orchestration.domainEvent",
 } as const;
 
-export const ProviderKind = Schema.Literal("codex");
+export const PROVIDER_KINDS = ["codex", "augment"] as const;
+export const ProviderKind = Schema.Literals(PROVIDER_KINDS);
 export type ProviderKind = typeof ProviderKind.Type;
+
+/**
+ * Check if a value is a valid ProviderKind.
+ */
+export function isProviderKind(value: unknown): value is ProviderKind {
+  return PROVIDER_KINDS.includes(value as ProviderKind);
+}
+
+/**
+ * Normalize a string to a ProviderKind, returning null if invalid.
+ */
+export function normalizeProviderKind(value: unknown): ProviderKind | null {
+  return isProviderKind(value) ? value : null;
+}
 export const ProviderApprovalPolicy = Schema.Literals([
   "untrusted",
   "on-failure",

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -53,8 +53,13 @@ const CodexProviderStartOptions = Schema.Struct({
   homePath: Schema.optional(TrimmedNonEmptyStringSchema),
 });
 
+const AugmentProviderStartOptions = Schema.Struct({
+  binaryPath: Schema.optional(TrimmedNonEmptyStringSchema),
+});
+
 const ProviderStartOptions = Schema.Struct({
   codex: Schema.optional(CodexProviderStartOptions),
+  augment: Schema.optional(AugmentProviderStartOptions),
 });
 
 export const ProviderSessionStartInput = Schema.Struct({

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -20,6 +20,8 @@ const RuntimeEventRawSource = Schema.Literals([
   "codex.app-server.request",
   "codex.eventmsg",
   "codex.sdk.thread-event",
+  "augment.acp.notification",
+  "augment.acp.request",
 ]);
 export type RuntimeEventRawSource = typeof RuntimeEventRawSource.Type;
 

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -12,6 +12,7 @@ type CatalogProvider = keyof typeof MODEL_OPTIONS_BY_PROVIDER;
 
 const MODEL_SLUG_SET_BY_PROVIDER: Record<CatalogProvider, ReadonlySet<ModelSlug>> = {
   codex: new Set(MODEL_OPTIONS_BY_PROVIDER.codex.map((option) => option.slug)),
+  augment: new Set(MODEL_OPTIONS_BY_PROVIDER.augment.map((option) => option.slug)),
 };
 
 export function getModelOptions(provider: ProviderKind = "codex") {


### PR DESCRIPTION
I've been testing it for a few hours and didn't run into any issues.
There are some incidental bug fixes like many parts of the codebase assuming only Codex ever exists as a provider or defaulting back to codex after switching providers.

This was 95% vibe coded then manually spot-checked and tested.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Augment provider via ACP and register end-to-end across server adapters, health checks, and web model/provider selection
> Introduce `AugmentACPManager` with ACP JSON-RPC session/turn handling, add `AugmentAdapter` that maps ACP events to canonical runtime events, register the adapter in the provider registry and server layer, extend contracts to include `ProviderKind` "augment" and model options, and update web stores/UI to select and persist the Augment provider and models.
>
> #### 📍Where to Start
> Start with the `AugmentACPManager` class in [augmentACPManager.ts](https://github.com/pingdotgg/t3code/pull/475/files#diff-86cef1e63da4fc08aad3b5ae94ba5c99548e583ff5c640fcd0e7ff252d53bb76), then review event mapping in `AugmentAdapter` in [AugmentAdapter.ts](https://github.com/pingdotgg/t3code/pull/475/files#diff-dcf7ef5a6695880b77abda47f4c03ce272aad4ec91f0708f24e7c55983c84bb9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b5196a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->