### PR TITLE
Remove extra dot from working indicator

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5217,8 +5217,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
       )}
 
       {row.kind === "working" && (
-        <div className="flex items-center gap-2 py-0.5 pl-1.5">
-          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/30" />
+        <div className="py-0.5 pl-1.5">
           <div className="flex items-center gap-2 pt-1 text-[11px] text-muted-foreground/70">
             <span className="inline-flex items-center gap-[3px]">
               <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse" />


### PR DESCRIPTION
The in-progress “...Working” status showed an extra small dot before the animated dots, which looks weird. This change removes that extra dot/bullet point.

**Before:**
<img width="431" height="205" alt="image" src="https://github.com/user-attachments/assets/87608181-1840-482b-8eb0-097b8de6bd4e" />

**After:**
<img width="900" height="432" alt="image" src="https://github.com/user-attachments/assets/2ada5829-861f-419c-996e-1daf7c1c20b3" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove the leading static dot and adjust spacing in the MessagesTimeline 'working' row in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/481/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Updates the 'working' row by dropping the outer `flex`/`gap-2` container, removing the decorative dot `span`, and adding `pt-1` to the inner status line in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/481/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> #### 📍Where to Start
> Start at the 'working' row render path in `MessagesTimeline` within [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/481/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8766038.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->