### PR TITLE
Add linuxbrew support for codex installation.

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1512,12 +1512,18 @@ function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
   readonly homePath?: string;
 } {
   const options = input.providerOptions?.codex;
-  if (!options) {
-    return {};
+
+  // Determine binary path with a fallback for homebrew on Linux.
+  let binaryPath: string | undefined;
+  if (options?.binaryPath) {
+    binaryPath = options.binaryPath;
+  } else if (process.platform === "linux" && FS.existsSync("/home/linuxbrew/.linuxbrew/bin/codex")) {
+    binaryPath = "/home/linuxbrew/.linuxbrew/bin/codex";
   }
+
   return {
-    ...(options.binaryPath ? { binaryPath: options.binaryPath } : {}),
-    ...(options.homePath ? { homePath: options.homePath } : {}),
+    ...(binaryPath ? { binaryPath } : {}),
+    ...(options?.homePath ? { homePath: options.homePath } : {}),
   };
 }
 


### PR DESCRIPTION
I had homebrew in my path and it didn't detect codex, and my workaround had to be running `ln -s /home/linuxbrew/.linuxbrew/bin/codex ~/.local/bin/codex` to fix it, so this patch aims to prevent that workaround.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Linuxbrew fallback path resolution for Codex binary in `apps/server/src/codexAppServerManager.ts` to support Codex installation via Linuxbrew
> Update `readCodexProviderOptions` to compute `binaryPath` using `/home/linuxbrew/.linuxbrew/bin/codex` on Linux when not provided, guard `options` with optional chaining, and return `homePath` only when present in [codexAppServerManager.ts](https://github.com/pingdotgg/t3code/pull/482/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9).
>
> #### 📍Where to Start
> Start with the `readCodexProviderOptions` logic in [codexAppServerManager.ts](https://github.com/pingdotgg/t3code/pull/482/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c31972.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->