### PR TITLE
feat: show inline submodule changes in checkpoint diffs

### DIFF
--- a/apps/server/src/checkpointing/Diffs.test.ts
+++ b/apps/server/src/checkpointing/Diffs.test.ts
@@ -65,4 +65,22 @@ describe("parseTurnDiffFilesFromUnifiedDiff", () => {
       { path: "a.txt", additions: 2, deletions: 1 },
     ]);
   });
+
+  it("parses inline submodule patch output", () => {
+    const diff = [
+      "Submodule packages/submodule 1111111..2222222:",
+      "diff --git a/packages/submodule/file.txt b/packages/submodule/file.txt",
+      "index 1111111..2222222 100644",
+      "--- a/packages/submodule/file.txt",
+      "+++ b/packages/submodule/file.txt",
+      "@@ -1 +1,2 @@",
+      " one",
+      "+two",
+      "",
+    ].join("\n");
+
+    expect(parseTurnDiffFilesFromUnifiedDiff(diff)).toEqual([
+      { path: "packages/submodule/file.txt", additions: 1, deletions: 0 },
+    ]);
+  });
 });

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
@@ -1,0 +1,127 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ThreadId } from "@t3tools/contracts";
+import { Effect, Layer, ManagedRuntime } from "effect";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseTurnDiffFilesFromUnifiedDiff } from "../Diffs.ts";
+import { checkpointRefForThreadTurn } from "../Utils.ts";
+import { CheckpointStore } from "../Services/CheckpointStore.ts";
+import { CheckpointStoreLive } from "./CheckpointStore.ts";
+
+function runGit(cwd: string, args: ReadonlyArray<string>) {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+}
+
+function createRepository(prefix: string) {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  runGit(cwd, ["init", "--initial-branch=main"]);
+  runGit(cwd, ["config", "user.email", "test@example.com"]);
+  runGit(cwd, ["config", "user.name", "Test User"]);
+  return cwd;
+}
+
+function commitFile(cwd: string, relativePath: string, content: string, message: string) {
+  fs.mkdirSync(path.dirname(path.join(cwd, relativePath)), { recursive: true });
+  fs.writeFileSync(path.join(cwd, relativePath), content, "utf8");
+  runGit(cwd, ["add", relativePath]);
+  runGit(cwd, ["commit", "-m", message]);
+  return runGit(cwd, ["rev-parse", "HEAD"]).trim();
+}
+
+function checkoutSubmoduleCommit(cwd: string, relativePath: string, commitOid: string) {
+  runGit(path.join(cwd, relativePath), ["checkout", commitOid]);
+}
+
+describe("CheckpointStore", () => {
+  let runtime: ManagedRuntime.ManagedRuntime<CheckpointStore, unknown> | null = null;
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    if (runtime) {
+      await runtime.dispose();
+    }
+    runtime = null;
+
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("includes inline submodule diffs between checkpoints", async () => {
+    const submoduleRepo = createRepository("t3-checkpoint-submodule-");
+    const superRepo = createRepository("t3-checkpoint-super-");
+    tempDirs.push(submoduleRepo, superRepo);
+
+    const initialSubmoduleCommit = commitFile(
+      submoduleRepo,
+      "file.txt",
+      "one\n",
+      "Initial submodule commit",
+    );
+    const updatedSubmoduleCommit = commitFile(
+      submoduleRepo,
+      "file.txt",
+      "one\ntwo\n",
+      "Update submodule file",
+    );
+
+    runGit(superRepo, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      submoduleRepo,
+      "packages/submodule",
+    ]);
+    checkoutSubmoduleCommit(superRepo, "packages/submodule", initialSubmoduleCommit);
+    runGit(superRepo, ["add", "."]);
+    runGit(superRepo, ["commit", "-m", "Add submodule"]);
+
+    runtime = ManagedRuntime.make(CheckpointStoreLive.pipe(Layer.provideMerge(NodeServices.layer)));
+    const checkpointStore = await runtime.runPromise(Effect.service(CheckpointStore));
+    const threadId = ThreadId.makeUnsafe("thread-submodule");
+    const checkpoint0 = checkpointRefForThreadTurn(threadId, 0);
+    const checkpoint1 = checkpointRefForThreadTurn(threadId, 1);
+
+    await runtime.runPromise(
+      checkpointStore.captureCheckpoint({
+        cwd: superRepo,
+        checkpointRef: checkpoint0,
+      }),
+    );
+
+    checkoutSubmoduleCommit(superRepo, "packages/submodule", updatedSubmoduleCommit);
+
+    await runtime.runPromise(
+      checkpointStore.captureCheckpoint({
+        cwd: superRepo,
+        checkpointRef: checkpoint1,
+      }),
+    );
+
+    const diff = await runtime.runPromise(
+      checkpointStore.diffCheckpoints({
+        cwd: superRepo,
+        fromCheckpointRef: checkpoint0,
+        toCheckpointRef: checkpoint1,
+      }),
+    );
+
+    expect(diff).toContain("diff --git a/packages/submodule/file.txt b/packages/submodule/file.txt");
+    expect(parseTurnDiffFilesFromUnifiedDiff(diff)).toEqual([
+      { path: "packages/submodule/file.txt", additions: 1, deletions: 0 },
+    ]);
+  });
+});

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -244,7 +244,16 @@ const makeCheckpointStore = Effect.gen(function* () {
       const result = yield* git.execute({
         operation,
         cwd: input.cwd,
-        args: ["diff", "--patch", "--minimal", "--no-color", fromCommitOid, toCommitOid],
+        args: [
+          "diff",
+          "--patch",
+          "--minimal",
+          "--no-color",
+          "--submodule=diff",
+          "--ignore-submodules=none",
+          fromCommitOid,
+          toCommitOid,
+        ],
       });
 
       return result.stdout;


### PR DESCRIPTION
## Summary
- include inline submodule patches in checkpoint diffs by enabling `git diff --submodule=diff`
- keep submodule changes visible to the existing unified diff parser and diff view
- add regression tests for submodule patch parsing and real checkpoint diffs across submodule revisions

## Testing
- PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun run test --filter=t3
- PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun run lint
- PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun run typecheck
- PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun run dev:server
- PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun run dev:web

Closes #480

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show inline submodule changes by invoking `makeCheckpointStore.diffCheckpoints` with `git diff --submodule=diff --ignore-submodules=none` in [CheckpointStore.ts](https://github.com/pingdotgg/t3code/pull/483/files#diff-246091edd41db39269d7b4458744037fe70cb1d30ee21e10ad8ad4ad80e2d705)
> Add submodule diff flags to `makeCheckpointStore.diffCheckpoints`; add tests covering inline submodule patch parsing and checkpoint diffs in [Diffs.test.ts](https://github.com/pingdotgg/t3code/pull/483/files#diff-e28509571615557ec1c37bdec7e4fa0cc9dc4e74ce097d79bd9c4744cec3f8cc) and [CheckpointStore.test.ts](https://github.com/pingdotgg/t3code/pull/483/files#diff-36b5308fff593fa364029f2d1b0c728035a7f24c2d027c165c56826d70c1f9e6).
>
> #### 📍Where to Start
> Start with `makeCheckpointStore.diffCheckpoints` in [CheckpointStore.ts](https://github.com/pingdotgg/t3code/pull/483/files#diff-246091edd41db39269d7b4458744037fe70cb1d30ee21e10ad8ad4ad80e2d705).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59271f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->