### PR TITLE
fix, feat: fixing gpt-5.3-codex-spark and letting it only for pro users, an…

### DIFF
--- a/apps/server/integration/TestProviderAdapter.integration.ts
+++ b/apps/server/integration/TestProviderAdapter.integration.ts
@@ -472,6 +472,16 @@ export const makeTestProviderAdapterHarness = (options?: MakeTestProviderAdapter
       sessions.clear();
     });
 
+  const readAccountSnapshot: ProviderAdapterShape<ProviderAdapterError>["readAccountSnapshot"] = () =>
+    Effect.succeed({
+      type: "chatgpt",
+      planType: "business",
+      sparkEnabled: false,
+    });
+
+  const logoutAccount: ProviderAdapterShape<ProviderAdapterError>["logoutAccount"] = () =>
+    Effect.void;
+
   const adapter: ProviderAdapterShape<ProviderAdapterError> = {
     provider,
     capabilities: {
@@ -488,6 +498,8 @@ export const makeTestProviderAdapterHarness = (options?: MakeTestProviderAdapter
     readThread,
     rollbackThread,
     stopAll,
+    readAccountSnapshot,
+    logoutAccount,
     streamEvents: Stream.fromQueue(runtimeEvents),
   };
 

--- a/apps/server/src/codexAccount.ts
+++ b/apps/server/src/codexAccount.ts
@@ -1,0 +1,93 @@
+type CodexPlanType =
+  | "free"
+  | "go"
+  | "plus"
+  | "pro"
+  | "business"
+  | "enterprise"
+  | "edu"
+  | "unknown"
+  | "team";
+
+export interface CodexAccountSnapshot {
+  readonly type: "apiKey" | "chatgpt" | "unknown";
+  readonly planType: CodexPlanType | null;
+  readonly sparkEnabled: boolean;
+}
+
+const CODEX_SPARK_DISABLED_PLAN_TYPES = new Set<CodexPlanType>([
+  "free",
+  "go",
+  "plus",
+  "business",
+]);
+
+function asObject(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function normalizePlanType(value: unknown): CodexPlanType {
+  if (value === "team") {
+    return "business";
+  }
+  switch (value) {
+    case "free":
+    case "go":
+    case "plus":
+    case "pro":
+    case "business":
+    case "enterprise":
+    case "edu":
+      return value;
+    default:
+      return "unknown";
+  }
+}
+
+export function createUnknownCodexAccountSnapshot(): CodexAccountSnapshot {
+  return {
+    type: "unknown",
+    planType: null,
+    sparkEnabled: false,
+  };
+}
+
+export function planLabelFromSnapshot(snapshot: CodexAccountSnapshot): string | undefined {
+  if (snapshot.type === "apiKey") return "API Key";
+  if (snapshot.type === "chatgpt" && snapshot.planType && snapshot.planType !== "unknown") {
+    return snapshot.planType.charAt(0).toUpperCase() + snapshot.planType.slice(1);
+  }
+  return undefined;
+}
+
+export function readCodexAccountSnapshot(response: unknown): CodexAccountSnapshot {
+  const record = asObject(response);
+  const account = asObject(record?.account) ?? record;
+  const accountType = asString(account?.type);
+
+  if (accountType === "apiKey") {
+    return {
+      type: "apiKey",
+      planType: null,
+      sparkEnabled: true,
+    };
+  }
+
+  if (accountType === "chatgpt") {
+    const planType = normalizePlanType(account?.planType);
+    return {
+      type: "chatgpt",
+      planType,
+      sparkEnabled: !CODEX_SPARK_DISABLED_PLAN_TYPES.has(planType),
+    };
+  }
+
+  return createUnknownCodexAccountSnapshot();
+}

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -220,6 +220,20 @@ describe("readCodexAccountSnapshot", () => {
     });
   });
 
+  it("disables spark for chatgpt business accounts", () => {
+    expect(
+      readCodexAccountSnapshot({
+        type: "chatgpt",
+        email: "business@example.com",
+        planType: "business",
+      }),
+    ).toEqual({
+      type: "chatgpt",
+      planType: "business",
+      sparkEnabled: false,
+    });
+  });
+
   it("keeps spark enabled for chatgpt pro accounts", () => {
     expect(
       readCodexAccountSnapshot({
@@ -231,6 +245,20 @@ describe("readCodexAccountSnapshot", () => {
       type: "chatgpt",
       planType: "pro",
       sparkEnabled: true,
+    });
+  });
+
+  it("maps legacy team plans to business", () => {
+    expect(
+      readCodexAccountSnapshot({
+        type: "chatgpt",
+        email: "team@example.com",
+        planType: "team",
+      }),
+    ).toEqual({
+      type: "chatgpt",
+      planType: "business",
+      sparkEnabled: false,
     });
   });
 

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -23,10 +23,22 @@ import { normalizeModelSlug } from "@t3tools/shared/model";
 import { Effect, ServiceMap } from "effect";
 
 import {
+  createUnknownCodexAccountSnapshot,
+  planLabelFromSnapshot,
+  readCodexAccountSnapshot,
+  type CodexAccountSnapshot,
+} from "./codexAccount";
+import {
   formatCodexCliUpgradeMessage,
   isCodexCliVersionSupported,
   parseCodexCliVersion,
 } from "./provider/codexCliVersion";
+
+export {
+  planLabelFromSnapshot,
+  readCodexAccountSnapshot,
+  type CodexAccountSnapshot,
+} from "./codexAccount";
 
 type PendingRequestKey = string;
 
@@ -96,23 +108,6 @@ interface JsonRpcNotification {
   params?: unknown;
 }
 
-type CodexPlanType =
-  | "free"
-  | "go"
-  | "plus"
-  | "pro"
-  | "team"
-  | "business"
-  | "enterprise"
-  | "edu"
-  | "unknown";
-
-interface CodexAccountSnapshot {
-  readonly type: "apiKey" | "chatgpt" | "unknown";
-  readonly planType: CodexPlanType | null;
-  readonly sparkEnabled: boolean;
-}
-
 export interface CodexAppServerSendTurnInput {
   readonly threadId: ThreadId;
   readonly input?: string;
@@ -163,47 +158,6 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
 ];
 const CODEX_DEFAULT_MODEL = "gpt-5.3-codex";
 const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
-const CODEX_SPARK_DISABLED_PLAN_TYPES = new Set<CodexPlanType>(["free", "go", "plus"]);
-
-function asObject(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  return value as Record<string, unknown>;
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
-export function readCodexAccountSnapshot(response: unknown): CodexAccountSnapshot {
-  const record = asObject(response);
-  const account = asObject(record?.account) ?? record;
-  const accountType = asString(account?.type);
-
-  if (accountType === "apiKey") {
-    return {
-      type: "apiKey",
-      planType: null,
-      sparkEnabled: true,
-    };
-  }
-
-  if (accountType === "chatgpt") {
-    const planType = (account?.planType as CodexPlanType | null) ?? "unknown";
-    return {
-      type: "chatgpt",
-      planType,
-      sparkEnabled: !CODEX_SPARK_DISABLED_PLAN_TYPES.has(planType),
-    };
-  }
-
-  return {
-    type: "unknown",
-    planType: null,
-    sparkEnabled: true,
-  };
-}
 
 export const CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Plan Mode (Conversational)
 
@@ -521,68 +475,83 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.runPromise = services ? Effect.runPromiseWith(services) : Effect.runPromise;
   }
 
+  async readAccountSnapshot(input: {
+    readonly cwd?: string;
+    readonly providerOptions?: ProviderSessionStartInput["providerOptions"];
+  } = {}): Promise<CodexAccountSnapshot> {
+    const temporaryThreadId = ThreadId.makeUnsafe(`codex-account-${randomUUID()}`);
+    const { context } = await this.startAppServerContext({
+      threadId: temporaryThreadId,
+      runtimeMode: "full-access",
+      registerSession: false,
+      emitLifecycle: false,
+      ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+      ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
+    });
+
+    try {
+      const { snapshot } = await this.readAccountSnapshotFromContext(context);
+      return snapshot;
+    } finally {
+      this.disposeContext(context, { emitClosedEvent: false, removeSession: false });
+    }
+  }
+
+  async logout(input: {
+    readonly cwd?: string;
+    readonly providerOptions?: ProviderSessionStartInput["providerOptions"];
+  } = {}): Promise<void> {
+    const resolvedCwd = input.cwd ?? process.cwd();
+    const codexOptions = readCodexProviderOptions(input);
+    const codexBinaryPath = codexOptions.binaryPath ?? "codex";
+    const codexHomePath = codexOptions.homePath;
+
+    this.assertSupportedCodexCliVersion({
+      binaryPath: codexBinaryPath,
+      cwd: resolvedCwd,
+      ...(codexHomePath ? { homePath: codexHomePath } : {}),
+    });
+
+    const result = spawnSync(codexBinaryPath, ["logout"], {
+      cwd: resolvedCwd,
+      env: {
+        ...process.env,
+        ...(codexHomePath ? { CODEX_HOME: codexHomePath } : {}),
+      },
+      encoding: "utf8",
+      shell: process.platform === "win32",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: CODEX_VERSION_CHECK_TIMEOUT_MS,
+      maxBuffer: 1024 * 1024,
+    });
+
+    if (result.error) {
+      throw new Error(`Failed to execute Codex logout: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      const detail =
+        result.stderr?.trim() || result.stdout?.trim() || `Command exited with code ${result.status}.`;
+      throw new Error(`Codex logout failed. ${detail}`);
+    }
+  }
+
   async startSession(input: CodexAppServerStartSessionInput): Promise<ProviderSession> {
     const threadId = input.threadId;
-    const now = new Date().toISOString();
     let context: CodexSessionContext | undefined;
 
     try {
-      const resolvedCwd = input.cwd ?? process.cwd();
-
-      const session: ProviderSession = {
-        provider: "codex",
-        status: "connecting",
-        runtimeMode: input.runtimeMode,
-        model: normalizeCodexModelSlug(input.model),
-        cwd: resolvedCwd,
+      const started = await this.startAppServerContext({
         threadId,
-        createdAt: now,
-        updatedAt: now,
-      };
-
-      const codexOptions = readCodexProviderOptions(input);
-      const codexBinaryPath = codexOptions.binaryPath ?? "codex";
-      const codexHomePath = codexOptions.homePath;
-      this.assertSupportedCodexCliVersion({
-        binaryPath: codexBinaryPath,
-        cwd: resolvedCwd,
-        ...(codexHomePath ? { homePath: codexHomePath } : {}),
+        runtimeMode: input.runtimeMode,
+        registerSession: true,
+        emitLifecycle: true,
+        ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+        ...(input.model !== undefined ? { model: input.model } : {}),
+        ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
       });
-      const child = spawn(codexBinaryPath, ["app-server"], {
-        cwd: resolvedCwd,
-        env: {
-          ...process.env,
-          ...(codexHomePath ? { CODEX_HOME: codexHomePath } : {}),
-        },
-        stdio: ["pipe", "pipe", "pipe"],
-        shell: process.platform === "win32",
-      });
-      const output = readline.createInterface({ input: child.stdout });
+      context = started.context;
+      const resolvedCwd = started.resolvedCwd;
 
-      context = {
-        session,
-        account: {
-          type: "unknown",
-          planType: null,
-          sparkEnabled: true,
-        },
-        child,
-        output,
-        pending: new Map(),
-        pendingApprovals: new Map(),
-        pendingUserInputs: new Map(),
-        nextRequestId: 1,
-        stopping: false,
-      };
-
-      this.sessions.set(threadId, context);
-      this.attachProcessListeners(context);
-
-      this.emitLifecycleEvent(context, "session/connecting", "Starting codex app-server");
-
-      await this.sendRequest(context, "initialize", buildCodexInitializeParams());
-
-      this.writeMessage(context, { method: "initialized" });
       try {
         const modelListResponse = await this.sendRequest(context, "model/list", {});
         console.log("codex model/list response", modelListResponse);
@@ -590,13 +559,21 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         console.log("codex model/list failed", error);
       }
       try {
-        const accountReadResponse = await this.sendRequest(context, "account/read", {});
+        const { response: accountReadResponse } = await this.readAccountSnapshotFromContext(context);
         console.log("codex account/read response", accountReadResponse);
-        context.account = readCodexAccountSnapshot(accountReadResponse);
         console.log("codex subscription status", {
           type: context.account.type,
           planType: context.account.planType,
           sparkEnabled: context.account.sparkEnabled,
+        });
+        this.emitEvent({
+          id: EventId.makeUnsafe(randomUUID()),
+          kind: "notification",
+          provider: "codex",
+          threadId,
+          createdAt: new Date().toISOString(),
+          method: "account/updated",
+          payload: accountReadResponse,
         });
       } catch (error) {
         console.log("codex account/read failed", error);
@@ -976,7 +953,110 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     if (!context) {
       return;
     }
+    this.disposeContext(context, { emitClosedEvent: true, removeSession: true });
+  }
 
+  listSessions(): ProviderSession[] {
+    return Array.from(this.sessions.values(), ({ session }) => ({
+      ...session,
+    }));
+  }
+
+  hasSession(threadId: ThreadId): boolean {
+    return this.sessions.has(threadId);
+  }
+
+  stopAll(): void {
+    for (const threadId of this.sessions.keys()) {
+      this.stopSession(threadId);
+    }
+  }
+
+  private async startAppServerContext(input: {
+    readonly threadId: ThreadId;
+    readonly cwd?: string;
+    readonly model?: string;
+    readonly providerOptions?: ProviderSessionStartInput["providerOptions"];
+    readonly runtimeMode: RuntimeMode;
+    readonly registerSession: boolean;
+    readonly emitLifecycle: boolean;
+  }): Promise<{ context: CodexSessionContext; resolvedCwd: string }> {
+    const resolvedCwd = input.cwd ?? process.cwd();
+    const now = new Date().toISOString();
+    const session: ProviderSession = {
+      provider: "codex",
+      status: "connecting",
+      runtimeMode: input.runtimeMode,
+      model: normalizeCodexModelSlug(input.model),
+      cwd: resolvedCwd,
+      threadId: input.threadId,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const codexOptions = readCodexProviderOptions(input);
+    const codexBinaryPath = codexOptions.binaryPath ?? "codex";
+    const codexHomePath = codexOptions.homePath;
+    this.assertSupportedCodexCliVersion({
+      binaryPath: codexBinaryPath,
+      cwd: resolvedCwd,
+      ...(codexHomePath ? { homePath: codexHomePath } : {}),
+    });
+    const child = spawn(codexBinaryPath, ["app-server"], {
+      cwd: resolvedCwd,
+      env: {
+        ...process.env,
+        ...(codexHomePath ? { CODEX_HOME: codexHomePath } : {}),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32",
+    });
+    const output = readline.createInterface({ input: child.stdout });
+
+    const context: CodexSessionContext = {
+      session,
+      account: createUnknownCodexAccountSnapshot(),
+      child,
+      output,
+      pending: new Map(),
+      pendingApprovals: new Map(),
+      pendingUserInputs: new Map(),
+      nextRequestId: 1,
+      stopping: false,
+    };
+
+    if (input.registerSession) {
+      this.sessions.set(input.threadId, context);
+    }
+    this.attachProcessListeners(context);
+
+    if (input.emitLifecycle) {
+      this.emitLifecycleEvent(context, "session/connecting", "Starting codex app-server");
+    }
+
+    await this.sendRequest(context, "initialize", buildCodexInitializeParams());
+    this.writeMessage(context, { method: "initialized" });
+
+    return { context, resolvedCwd };
+  }
+
+  private async readAccountSnapshotFromContext(context: CodexSessionContext): Promise<{
+    response: unknown;
+    snapshot: CodexAccountSnapshot;
+  }> {
+    const response = await this.sendRequest(context, "account/read", {});
+    const snapshot = readCodexAccountSnapshot(response);
+    context.account = snapshot;
+    return { response, snapshot };
+  }
+
+  private disposeContext(
+    context: CodexSessionContext,
+    options: {
+      readonly emitClosedEvent: boolean;
+      readonly removeSession: boolean;
+    },
+  ): void {
     context.stopping = true;
 
     for (const pending of context.pending.values()) {
@@ -997,23 +1077,12 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       status: "closed",
       activeTurnId: undefined,
     });
-    this.emitLifecycleEvent(context, "session/closed", "Session stopped");
-    this.sessions.delete(threadId);
-  }
 
-  listSessions(): ProviderSession[] {
-    return Array.from(this.sessions.values(), ({ session }) => ({
-      ...session,
-    }));
-  }
-
-  hasSession(threadId: ThreadId): boolean {
-    return this.sessions.has(threadId);
-  }
-
-  stopAll(): void {
-    for (const threadId of this.sessions.keys()) {
-      this.stopSession(threadId);
+    if (options.emitClosedEvent) {
+      this.emitLifecycleEvent(context, "session/closed", "Session stopped");
+    }
+    if (options.removeSession) {
+      this.sessions.delete(context.session.threadId);
     }
   }
 
@@ -1507,7 +1576,9 @@ function normalizeProviderThreadId(value: string | undefined): string | undefine
   return brandIfNonEmpty(value, (normalized) => normalized);
 }
 
-function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
+function readCodexProviderOptions(input: {
+  readonly providerOptions?: ProviderSessionStartInput["providerOptions"];
+}): {
   readonly binaryPath?: string;
   readonly homePath?: string;
 } {

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -91,6 +91,8 @@ function createProviderServiceHarness(
     listSessions,
     getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
     rollbackConversation,
+    readAccountSnapshot: () => unsupported(),
+    logoutAccount: () => unsupported(),
     streamEvents: Stream.fromPubSub(runtimeEventPubSub),
   };
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -188,6 +188,8 @@ describe("ProviderCommandReactor", () => {
           sessionModelSwitch: provider === "codex" ? "in-session" : "in-session",
         }),
       rollbackConversation: () => unsupported(),
+      readAccountSnapshot: () => unsupported(),
+      logoutAccount: () => unsupported(),
       streamEvents: Stream.fromPubSub(runtimeEventPubSub),
     };
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -69,6 +69,8 @@ function createProviderServiceHarness() {
     listSessions: () => Effect.succeed([]),
     getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
     rollbackConversation: () => unsupported(),
+    readAccountSnapshot: () => unsupported(),
+    logoutAccount: () => unsupported(),
     streamEvents: Stream.fromPubSub(runtimeEventPubSub),
   };
 

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1450,6 +1450,30 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
         manager.stopAll();
       });
 
+    const readAccountSnapshot: CodexAdapterShape["readAccountSnapshot"] = () =>
+      Effect.tryPromise({
+        try: () => manager.readAccountSnapshot(),
+        catch: (cause) =>
+          new ProviderAdapterProcessError({
+            provider: PROVIDER,
+            threadId: "codex-account",
+            detail: toMessage(cause, "Failed to read Codex account snapshot."),
+            cause,
+          }),
+      });
+
+    const logoutAccount: CodexAdapterShape["logoutAccount"] = () =>
+      Effect.tryPromise({
+        try: () => manager.logout(),
+        catch: (cause) =>
+          new ProviderAdapterProcessError({
+            provider: PROVIDER,
+            threadId: "codex-account",
+            detail: toMessage(cause, "Failed to logout Codex account."),
+            cause,
+          }),
+      });
+
     const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
 
     yield* Effect.acquireRelease(
@@ -1506,6 +1530,8 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
       listSessions,
       hasSession,
       stopAll,
+      readAccountSnapshot,
+      logoutAccount,
       streamEvents: Stream.fromQueue(runtimeEventQueue),
     } satisfies CodexAdapterShape;
   });

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -24,6 +24,8 @@ const fakeCodexAdapter: CodexAdapterShape = {
   readThread: vi.fn(),
   rollbackThread: vi.fn(),
   stopAll: vi.fn(),
+  readAccountSnapshot: vi.fn(),
+  logoutAccount: vi.fn(),
   streamEvents: Stream.empty,
 };
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -172,6 +172,16 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
       }),
   );
 
+  const readAccountSnapshot = vi.fn(() =>
+    Effect.succeed({
+      type: "chatgpt" as const,
+      planType: "business" as const,
+      sparkEnabled: false,
+    }),
+  );
+
+  const logoutAccount = vi.fn(() => Effect.void);
+
   const adapter: ProviderAdapterShape<ProviderAdapterError> = {
     provider,
     capabilities: {
@@ -188,6 +198,8 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
     readThread,
     rollbackThread,
     stopAll,
+    readAccountSnapshot,
+    logoutAccount,
     streamEvents: Stream.fromPubSub(runtimeEventPubSub),
   };
 
@@ -209,6 +221,8 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
     readThread,
     rollbackThread,
     stopAll,
+    readAccountSnapshot,
+    logoutAccount,
   };
 }
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -475,6 +475,18 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         });
       });
 
+    const readAccountSnapshot: ProviderServiceShape["readAccountSnapshot"] = (provider) =>
+      Effect.gen(function* () {
+        const adapter = yield* registry.getByProvider(provider);
+        return yield* adapter.readAccountSnapshot();
+      });
+
+    const logoutAccount: ProviderServiceShape["logoutAccount"] = (provider) =>
+      Effect.gen(function* () {
+        const adapter = yield* registry.getByProvider(provider);
+        yield* adapter.logoutAccount();
+      });
+
     const runStopAll = () =>
       Effect.gen(function* () {
         const threadIds = yield* directory.listThreadIds();
@@ -517,6 +529,8 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       listSessions,
       getCapabilities,
       rollbackConversation,
+      readAccountSnapshot,
+      logoutAccount,
       streamEvents: Stream.fromPubSub(runtimeEventPubSub),
     } satisfies ProviderServiceShape;
   });

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -23,6 +23,8 @@ import type {
 import type { Effect } from "effect";
 import type { Stream } from "effect";
 
+import type { CodexAccountSnapshot } from "../../codexAccount";
+
 export type ProviderSessionModelSwitchMode = "in-session" | "restart-session" | "unsupported";
 
 export interface ProviderAdapterCapabilities {
@@ -123,6 +125,16 @@ export interface ProviderAdapterShape<TError> {
    * Stop all sessions owned by this adapter.
    */
   readonly stopAll: () => Effect.Effect<void, TError>;
+
+  /**
+   * Read the provider account snapshot without starting a durable thread session.
+   */
+  readonly readAccountSnapshot: () => Effect.Effect<CodexAccountSnapshot, TError>;
+
+  /**
+   * Remove stored provider account credentials.
+   */
+  readonly logoutAccount: () => Effect.Effect<void, TError>;
 
   /**
    * Canonical runtime event stream emitted by this adapter.

--- a/apps/server/src/provider/Services/ProviderService.ts
+++ b/apps/server/src/provider/Services/ProviderService.ts
@@ -27,6 +27,7 @@ import type {
 import { ServiceMap } from "effect";
 import type { Effect, Stream } from "effect";
 
+import type { CodexAccountSnapshot } from "../../codexAccount";
 import type { ProviderServiceError } from "../Errors.ts";
 import type { ProviderAdapterCapabilities } from "./ProviderAdapter.ts";
 
@@ -98,6 +99,18 @@ export interface ProviderServiceShape {
     readonly threadId: ThreadId;
     readonly numTurns: number;
   }) => Effect.Effect<void, ProviderServiceError>;
+
+  /**
+   * Read the provider account snapshot without starting a durable thread session.
+   */
+  readonly readAccountSnapshot: (
+    provider: ProviderKind,
+  ) => Effect.Effect<CodexAccountSnapshot, ProviderServiceError>;
+
+  /**
+   * Remove stored credentials for a provider account.
+   */
+  readonly logoutAccount: (provider: ProviderKind) => Effect.Effect<void, ProviderServiceError>;
 
   /**
    * Canonical provider runtime event stream.

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -761,6 +761,190 @@ describe("WebSocket Server", () => {
     expectAvailableEditors((response.result as { availableEditors: unknown }).availableEditors);
   });
 
+  it("bootstraps the codex account snapshot into server.getConfig", async () => {
+    const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
+    const unsupported = () => Effect.die(new Error("Unsupported provider call in test")) as never;
+    const readAccountSnapshot = vi.fn(() =>
+      Effect.succeed({
+        type: "chatgpt" as const,
+        planType: "business" as const,
+        sparkEnabled: false,
+      }),
+    );
+    const providerService: ProviderServiceShape = {
+      startSession: () => unsupported(),
+      sendTurn: () => unsupported(),
+      interruptTurn: () => unsupported(),
+      respondToRequest: () => unsupported(),
+      respondToUserInput: () => unsupported(),
+      stopSession: () => unsupported(),
+      listSessions: () => Effect.succeed([]),
+      getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
+      rollbackConversation: () => unsupported(),
+      readAccountSnapshot,
+      logoutAccount: () => unsupported(),
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+    };
+
+    server = await createTestServer({
+      cwd: "/my/workspace",
+      providerLayer: Layer.succeed(ProviderService, providerService),
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.serverGetConfig);
+    expect(response.error).toBeUndefined();
+    expect(response.result).toEqual({
+      cwd: "/my/workspace",
+      keybindingsConfigPath: expect.any(String),
+      keybindings: DEFAULT_RESOLVED_KEYBINDINGS,
+      issues: [],
+      providers: [
+        expect.objectContaining({
+          provider: "codex",
+          isPro: false,
+          planLabel: "Business",
+          accountType: "chatgpt",
+        }),
+      ],
+      availableEditors: expect.any(Array),
+    });
+    expect(readAccountSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("pushes updated provider account data when codex account events arrive", async () => {
+    const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
+    const emitRuntimeEvent = (event: ProviderRuntimeEvent) => {
+      Effect.runSync(PubSub.publish(runtimeEventPubSub, event));
+    };
+    const unsupported = () => Effect.die(new Error("Unsupported provider call in test")) as never;
+    const providerService: ProviderServiceShape = {
+      startSession: () => unsupported(),
+      sendTurn: () => unsupported(),
+      interruptTurn: () => unsupported(),
+      respondToRequest: () => unsupported(),
+      respondToUserInput: () => unsupported(),
+      stopSession: () => unsupported(),
+      listSessions: () => Effect.succeed([]),
+      getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
+      rollbackConversation: () => unsupported(),
+      readAccountSnapshot: () =>
+        Effect.succeed({
+          type: "chatgpt" as const,
+          planType: "business" as const,
+          sparkEnabled: false,
+        }),
+      logoutAccount: () => unsupported(),
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+    };
+
+    server = await createTestServer({
+      cwd: "/my/workspace",
+      providerLayer: Layer.succeed(ProviderService, providerService),
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    emitRuntimeEvent({
+      eventId: asEventId("evt-account-updated"),
+      provider: "codex",
+      threadId: asThreadId("thread-account-updated"),
+      createdAt: "2026-03-08T10:00:00.000Z",
+      type: "account.updated",
+      payload: {
+        account: {
+          type: "chatgpt",
+          planType: "pro",
+        },
+      },
+    });
+
+    const push = await waitForPush(
+      ws,
+      WS_CHANNELS.serverConfigUpdated,
+      (message) =>
+        Array.isArray((message.data as { providers?: unknown[] }).providers) &&
+        (message.data as { providers: Array<{ planLabel?: string }> }).providers[0]?.planLabel ===
+          "Pro",
+    );
+
+    expect(push.data).toEqual({
+      issues: [],
+      providers: [
+        expect.objectContaining({
+          provider: "codex",
+          isPro: true,
+          planLabel: "Pro",
+          accountType: "chatgpt",
+        }),
+      ],
+    });
+  });
+
+  it("logs out the codex account and clears the cached provider snapshot", async () => {
+    const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
+    const unsupported = () => Effect.die(new Error("Unsupported provider call in test")) as never;
+    const logoutAccount = vi.fn(() => Effect.void);
+    const providerService: ProviderServiceShape = {
+      startSession: () => unsupported(),
+      sendTurn: () => unsupported(),
+      interruptTurn: () => unsupported(),
+      respondToRequest: () => unsupported(),
+      respondToUserInput: () => unsupported(),
+      stopSession: () => unsupported(),
+      listSessions: () => Effect.succeed([]),
+      getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
+      rollbackConversation: () => unsupported(),
+      readAccountSnapshot: () =>
+        Effect.succeed({
+          type: "chatgpt" as const,
+          planType: "business" as const,
+          sparkEnabled: false,
+        }),
+      logoutAccount,
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+    };
+
+    server = await createTestServer({
+      cwd: "/my/workspace",
+      providerLayer: Layer.succeed(ProviderService, providerService),
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const ws = await connectWs(port);
+    connections.push(ws);
+    await waitForMessage(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.serverLogoutAccount, {
+      provider: "codex",
+    });
+    expect(response.error).toBeUndefined();
+    expect(logoutAccount).toHaveBeenCalledWith("codex");
+
+    const push = await waitForPush(ws, WS_CHANNELS.serverConfigUpdated);
+    expect(push.data).toEqual({
+      issues: [],
+      providers: [
+        expect.objectContaining({
+          provider: "codex",
+          isPro: false,
+          planLabel: undefined,
+          accountType: undefined,
+        }),
+      ],
+    });
+  });
+
   it("bootstraps default keybindings file when missing", async () => {
     const stateDir = makeTempDir("t3code-state-bootstrap-keybindings-");
     const keybindingsPath = path.join(stateDir, "keybindings.json");
@@ -1172,6 +1356,8 @@ describe("WebSocket Server", () => {
       listSessions: () => Effect.succeed([]),
       getCapabilities: () => Effect.succeed({ sessionModelSwitch: "in-session" }),
       rollbackConversation: () => unsupported(),
+      readAccountSnapshot: () => unsupported(),
+      logoutAccount: () => unsupported(),
       streamEvents: Stream.fromPubSub(runtimeEventPubSub),
     };
     const providerLayer = Layer.succeed(ProviderService, providerService);

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -56,6 +56,11 @@ import { ProviderService } from "./provider/Services/ProviderService";
 import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import { CheckpointDiffQuery } from "./checkpointing/Services/CheckpointDiffQuery";
 import { clamp } from "effect/Number";
+import {
+  planLabelFromSnapshot,
+  type CodexAccountSnapshot,
+  readCodexAccountSnapshot,
+} from "./codexAccount";
 import { Open, resolveAvailableEditors } from "./open";
 import { ServerConfig } from "./config";
 import { GitCore } from "./git/Services/GitCore.ts";
@@ -269,6 +274,8 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   );
 
   const providerStatuses = yield* providerHealth.getStatuses;
+  const providerService = yield* ProviderService;
+  const accountSnapshotRef = yield* Ref.make<CodexAccountSnapshot | undefined>(undefined);
 
   const clients = yield* Ref.make(new Set<WebSocket>());
   const logger = createLogger("ws");
@@ -625,14 +632,81 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     }),
   ).pipe(Effect.forkIn(subscriptionsScope));
 
-  yield* Stream.runForEach(keybindingsManager.changes, (event) =>
-    broadcastPush({
+  const mergeAccountIntoStatuses = (snapshot: CodexAccountSnapshot | undefined) =>
+    providerStatuses.map((status) => {
+      if (status.provider === "codex") {
+        return Object.assign({}, status, {
+          // Historical field name kept for compatibility; the UI uses it as Spark availability.
+          isPro: snapshot?.sparkEnabled ?? false,
+          planLabel: snapshot ? planLabelFromSnapshot(snapshot) : undefined,
+          accountType: snapshot?.type,
+        });
+      }
+      return status;
+    });
+
+  const broadcastServerConfigUpdated = Effect.fnUntraced(function* (
+    snapshot: CodexAccountSnapshot | undefined,
+  ) {
+    const keybindingsConfig = yield* keybindingsManager.loadConfigState;
+    yield* broadcastPush({
       type: "push",
       channel: WS_CHANNELS.serverConfigUpdated,
       data: {
-        issues: event.issues,
-        providers: providerStatuses,
+        issues: keybindingsConfig.issues,
+        providers: mergeAccountIntoStatuses(snapshot),
       },
+    });
+  });
+
+  const ensureAccountSnapshot = Effect.fnUntraced(function* () {
+    const cachedSnapshot = yield* Ref.get(accountSnapshotRef);
+    if (cachedSnapshot) {
+      return cachedSnapshot;
+    }
+
+    const snapshotExit = yield* Effect.exit(providerService.readAccountSnapshot("codex"));
+    if (snapshotExit._tag === "Failure") {
+      yield* Effect.logDebug("failed to bootstrap codex account snapshot", {
+        cause: Cause.pretty(snapshotExit.cause),
+      });
+      return undefined;
+    }
+
+    yield* Ref.set(accountSnapshotRef, snapshotExit.value);
+    return snapshotExit.value;
+  });
+
+  yield* ensureAccountSnapshot();
+
+  yield* Stream.runForEach(keybindingsManager.changes, (event) =>
+    Effect.gen(function* () {
+      const snapshot = yield* Ref.get(accountSnapshotRef);
+      yield* broadcastPush({
+        type: "push",
+        channel: WS_CHANNELS.serverConfigUpdated,
+        data: {
+          issues: event.issues,
+          providers: mergeAccountIntoStatuses(snapshot),
+        },
+      });
+    }),
+  ).pipe(Effect.forkIn(subscriptionsScope));
+
+  yield* Stream.runForEach(providerService.streamEvents, (event) =>
+    Effect.gen(function* () {
+      if (event.type !== "account.updated") return;
+      const nextSnapshot = readCodexAccountSnapshot(
+        (event as { payload?: unknown }).payload ?? {},
+      );
+      const prevSnapshot = yield* Ref.get(accountSnapshotRef);
+      yield* Ref.set(accountSnapshotRef, nextSnapshot);
+      const changed =
+        prevSnapshot?.type !== nextSnapshot.type ||
+        prevSnapshot?.planType !== nextSnapshot.planType ||
+        prevSnapshot?.sparkEnabled !== nextSnapshot.sparkEnabled;
+      if (!changed) return;
+      yield* broadcastServerConfigUpdated(nextSnapshot);
     }),
   ).pipe(Effect.forkIn(subscriptionsScope));
 
@@ -876,21 +950,31 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         return yield* terminalManager.close(body);
       }
 
-      case WS_METHODS.serverGetConfig:
+      case WS_METHODS.serverGetConfig: {
         const keybindingsConfig = yield* keybindingsManager.loadConfigState;
+        const snapshot = yield* ensureAccountSnapshot();
         return {
           cwd,
           keybindingsConfigPath,
           keybindings: keybindingsConfig.keybindings,
           issues: keybindingsConfig.issues,
-          providers: providerStatuses,
+          providers: mergeAccountIntoStatuses(snapshot),
           availableEditors,
         };
+      }
 
       case WS_METHODS.serverUpsertKeybinding: {
         const body = stripRequestTag(request.body);
         const keybindingsConfig = yield* keybindingsManager.upsertKeybindingRule(body);
         return { keybindings: keybindingsConfig, issues: [] };
+      }
+
+      case WS_METHODS.serverLogoutAccount: {
+        const body = stripRequestTag(request.body);
+        yield* providerService.logoutAccount(body.provider);
+        yield* Ref.set(accountSnapshotRef, undefined);
+        yield* broadcastServerConfigUpdated(undefined);
+        return undefined;
       }
 
       default: {

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  filterModelOptionsForPlan,
   getAppModelOptions,
   getSlashModelOptions,
   normalizeCustomModelSlugs,
@@ -46,6 +47,22 @@ describe("getAppModelOptions", () => {
       name: "custom/selected-model",
       isCustom: true,
     });
+  });
+});
+
+describe("filterModelOptionsForPlan", () => {
+  it("hides spark for unsupported business plans", () => {
+    const options = filterModelOptionsForPlan(getAppModelOptions("codex", []), { isPro: false });
+
+    expect(options.some((option) => option.slug === "gpt-5.3-codex-spark")).toBe(false);
+  });
+
+  it("hides spark until account capability is known", () => {
+    const options = filterModelOptionsForPlan(getAppModelOptions("codex", []), {
+      isPro: undefined,
+    });
+
+    expect(options.some((option) => option.slug === "gpt-5.3-codex-spark")).toBe(false);
   });
 });
 

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -264,6 +264,18 @@ function subscribe(listener: () => void): () => void {
   };
 }
 
+const SPARK_MODEL_SLUG = "gpt-5.3-codex-spark";
+
+export function filterModelOptionsForPlan(
+  options: AppModelOption[],
+  plan: { isPro: boolean | undefined },
+): AppModelOption[] {
+  if (plan.isPro !== true) {
+    return options.filter((o) => o.slug !== SPARK_MODEL_SLUG);
+  }
+  return options;
+}
+
 export function useAppSettings() {
   const settings = useSyncExternalStore(
     subscribe,

--- a/apps/web/src/components/AccountStatusWidget.tsx
+++ b/apps/web/src/components/AccountStatusWidget.tsx
@@ -1,0 +1,135 @@
+import { ChevronUpIcon, ExternalLinkIcon, LogOutIcon, UserIcon } from "lucide-react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { ServerProviderAuthStatus, ServerProviderAccountType } from "@t3tools/contracts";
+
+import { serverConfigQueryOptions } from "~/lib/serverReactQuery";
+import { readNativeApi } from "~/nativeApi";
+import { OpenAI, ClaudeAI, CursorIcon, OpenCodeIcon, Gemini } from "./Icons";
+import {
+  Menu,
+  MenuTrigger,
+  MenuPopup,
+  MenuItem,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+} from "./ui/menu";
+import { SidebarMenu, SidebarMenuItem, SidebarMenuButton } from "./ui/sidebar";
+
+function AuthDot({ status }: { status: ServerProviderAuthStatus | undefined }) {
+  const color =
+    status === "authenticated"
+      ? "bg-emerald-500"
+      : status === "unauthenticated"
+        ? "bg-red-500"
+        : "bg-amber-500";
+  return <span className={`inline-block size-2 shrink-0 rounded-full ${color}`} />;
+}
+
+function getManageAccountUrl(accountType: ServerProviderAccountType | undefined): string {
+  if (accountType === "apiKey") return "https://platform.openai.com";
+  return "https://chatgpt.com/#settings";
+}
+
+const COMING_SOON_PROVIDERS = [
+  { name: "Claude Code", Icon: ClaudeAI },
+  { name: "Cursor", Icon: CursorIcon },
+  { name: "OpenCode", Icon: OpenCodeIcon },
+  { name: "Gemini", Icon: Gemini },
+] as const;
+
+export function AccountStatusWidget() {
+  const { data: serverConfig } = useQuery(serverConfigQueryOptions());
+  const codexProvider = serverConfig?.providers?.find((s) => s.provider === "codex");
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const triggerLabel = "My Accounts";
+
+  const handleManageAccount = () => {
+    const api = readNativeApi();
+    if (!api) return;
+    void api.shell.openExternal(getManageAccountUrl(codexProvider?.accountType));
+  };
+
+  const handleLogout = async () => {
+    const api = readNativeApi();
+    if (!api || isLoggingOut) return;
+
+    setIsLoggingOut(true);
+    try {
+      await api.server.logoutAccount({ provider: "codex" });
+    } catch (error) {
+      console.error("Failed to logout Codex account", error);
+    } finally {
+      setIsLoggingOut(false);
+    }
+  };
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <Menu>
+          <MenuTrigger
+            render={
+              <SidebarMenuButton
+                size="sm"
+                className="gap-2 text-left text-xs text-muted-foreground hover:text-foreground"
+              />
+            }
+          >
+            <UserIcon className="size-4 shrink-0" />
+            <span className="truncate">{triggerLabel}</span>
+            <ChevronUpIcon className="ml-auto size-3.5 shrink-0 opacity-60" />
+          </MenuTrigger>
+
+          <MenuPopup side="top" align="start" sideOffset={8} className="w-56">
+            <MenuGroup>
+              <MenuGroupLabel>Accounts</MenuGroupLabel>
+              <MenuSub>
+                <MenuSubTrigger className="gap-3">
+                  <AuthDot status={codexProvider?.authStatus} />
+                  <OpenAI className="size-3.5 shrink-0 text-muted-foreground/85" />
+                  <span className="flex-1 truncate">Codex</span>
+                  {codexProvider?.planLabel && (
+                    <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                      {codexProvider.planLabel}
+                    </span>
+                  )}
+                </MenuSubTrigger>
+                <MenuSubPopup className="w-52">
+                  <MenuGroup>
+                    <MenuItem className="gap-2" onClick={handleManageAccount}>
+                      <span className="flex-1">Manage account</span>
+                      <ExternalLinkIcon className="size-3.5 opacity-60" />
+                    </MenuItem>
+                    <MenuItem className="gap-2" disabled={isLoggingOut} onClick={() => void handleLogout()}>
+                      <LogOutIcon className="size-3.5 opacity-80" />
+                      <span className="flex-1">{isLoggingOut ? "Logging out..." : "Logout"}</span>
+                    </MenuItem>
+                    <MenuItem className="gap-2 opacity-50" disabled>
+                      <span className="flex-1">Rate Limit (Coming soon)</span>
+                    </MenuItem>
+                  </MenuGroup>
+                </MenuSubPopup>
+              </MenuSub>
+            </MenuGroup>
+
+            <MenuGroup>
+              <MenuGroupLabel>Coming soon</MenuGroupLabel>
+              {COMING_SOON_PROVIDERS.map(({ name, Icon }) => (
+                <MenuItem key={name} className="cursor-default gap-3 opacity-50" disabled>
+                  <span className="inline-block size-2 shrink-0 rounded-full bg-muted-foreground/30" />
+                  <Icon className="size-3.5 shrink-0" />
+                  <span className="truncate">{name}</span>
+                </MenuItem>
+              ))}
+            </MenuGroup>
+          </MenuPopup>
+        </Menu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -199,6 +199,7 @@ import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import {
+  filterModelOptionsForPlan,
   getAppModelOptions,
   resolveAppModelSelection,
   resolveAppServiceTier,
@@ -831,9 +832,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
     return Object.keys(codexOptions).length > 0 ? { codex: codexOptions } : undefined;
   }, [selectedCodexFastModeEnabled, selectedEffort, selectedProvider, supportsReasoningEffort]);
   const selectedModelForPicker = selectedModel;
+  const codexProviderIsPro = useQuery(serverConfigQueryOptions()).data?.providers?.find(
+    (s) => s.provider === "codex",
+  )?.isPro;
   const modelOptionsByProvider = useMemo(
-    () => getCustomModelOptionsByProvider(settings),
-    [settings],
+    () => getCustomModelOptionsByProvider(settings, { isPro: codexProviderIsPro }),
+    [settings, codexProviderIsPro],
   );
   const selectedModelForPickerWithCustomFallback = useMemo(() => {
     const currentOptions = modelOptionsByProvider[selectedProvider];
@@ -5295,11 +5299,12 @@ const COMING_SOON_PROVIDER_OPTIONS = [
   { id: "gemini", label: "Gemini", icon: Gemini },
 ] as const;
 
-function getCustomModelOptionsByProvider(settings: {
-  customCodexModels: readonly string[];
-}): Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>> {
+function getCustomModelOptionsByProvider(
+  settings: { customCodexModels: readonly string[] },
+  plan: { isPro: boolean | undefined },
+): Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>> {
   return {
-    codex: getAppModelOptions("codex", settings.customCodexModels),
+    codex: filterModelOptionsForPlan(getAppModelOptions("codex", settings.customCodexModels), plan),
   };
 }
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -59,6 +59,7 @@ import {
   SidebarTrigger,
 } from "./ui/sidebar";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
+import { AccountStatusWidget } from "./AccountStatusWidget";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
@@ -1350,6 +1351,10 @@ export default function Sidebar() {
             + Add project
           </button>
         )}
+
+        <div className="mt-2">
+          <AccountStatusWidget />
+        </div>
       </SidebarFooter>
     </>
   );

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -237,7 +237,7 @@ function EventRouter() {
       })().catch(() => undefined);
     });
     const unsubServerConfigUpdated = onServerConfigUpdated((payload) => {
-      const signature = JSON.stringify(payload.issues);
+      const signature = JSON.stringify({ issues: payload.issues, providers: payload.providers });
       if (lastConfigIssuesSignatureRef.current === signature) {
         return;
       }

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -365,6 +365,18 @@ describe("wsNativeApi", () => {
     });
   });
 
+  it("routes server logout requests through the websocket transport", async () => {
+    requestMock.mockResolvedValue(undefined);
+    const { createWsNativeApi } = await import("./wsNativeApi");
+
+    const api = createWsNativeApi();
+    await api.server.logoutAccount({ provider: "codex" });
+
+    expect(requestMock).toHaveBeenCalledWith(WS_METHODS.serverLogoutAccount, {
+      provider: "codex",
+    });
+  });
+
   it("forwards context menu metadata to desktop bridge", async () => {
     const showContextMenu = vi.fn().mockResolvedValue("delete");
     Object.defineProperty(getWindowForTest(), "desktopBridge", {

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -185,6 +185,7 @@ export function createWsNativeApi(): NativeApi {
     server: {
       getConfig: () => transport.request(WS_METHODS.serverGetConfig),
       upsertKeybinding: (input) => transport.request(WS_METHODS.serverUpsertKeybinding, input),
+      logoutAccount: (input) => transport.request(WS_METHODS.serverLogoutAccount, input),
     },
     orchestration: {
       getSnapshot: () => transport.request(ORCHESTRATION_WS_METHODS.getSnapshot),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -30,7 +30,11 @@ import type {
   TerminalSessionSnapshot,
   TerminalWriteInput,
 } from "./terminal";
-import type { ServerUpsertKeybindingInput, ServerUpsertKeybindingResult } from "./server";
+import type {
+  ServerLogoutAccountInput,
+  ServerUpsertKeybindingInput,
+  ServerUpsertKeybindingResult,
+} from "./server";
 import type {
   ClientOrchestrationCommand,
   OrchestrationGetFullThreadDiffInput,
@@ -137,6 +141,7 @@ export interface NativeApi {
   server: {
     getConfig: () => Promise<ServerConfig>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;
+    logoutAccount: (input: ServerLogoutAccountInput) => Promise<void>;
   };
   orchestration: {
     getSnapshot: () => Promise<OrchestrationReadModel>;

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -33,6 +33,9 @@ export const ServerProviderAuthStatus = Schema.Literals([
 ]);
 export type ServerProviderAuthStatus = typeof ServerProviderAuthStatus.Type;
 
+export const ServerProviderAccountType = Schema.Literals(["apiKey", "chatgpt", "unknown"]);
+export type ServerProviderAccountType = typeof ServerProviderAccountType.Type;
+
 export const ServerProviderStatus = Schema.Struct({
   provider: ProviderKind,
   status: ServerProviderStatusState,
@@ -40,6 +43,10 @@ export const ServerProviderStatus = Schema.Struct({
   authStatus: ServerProviderAuthStatus,
   checkedAt: IsoDateTime,
   message: Schema.optional(TrimmedNonEmptyString),
+  // Historical field name kept for compatibility; this currently means Spark availability.
+  isPro: Schema.optional(Schema.Boolean),
+  planLabel: Schema.optional(TrimmedNonEmptyString),
+  accountType: Schema.optional(ServerProviderAccountType),
 });
 export type ServerProviderStatus = typeof ServerProviderStatus.Type;
 
@@ -57,6 +64,11 @@ export type ServerConfig = typeof ServerConfig.Type;
 
 export const ServerUpsertKeybindingInput = KeybindingRule;
 export type ServerUpsertKeybindingInput = typeof ServerUpsertKeybindingInput.Type;
+
+export const ServerLogoutAccountInput = Schema.Struct({
+  provider: ProviderKind,
+});
+export type ServerLogoutAccountInput = typeof ServerLogoutAccountInput.Type;
 
 export const ServerUpsertKeybindingResult = Schema.Struct({
   keybindings: ResolvedKeybindingsConfig,

--- a/packages/contracts/src/ws.test.ts
+++ b/packages/contracts/src/ws.test.ts
@@ -2,7 +2,7 @@ import { assert, it } from "@effect/vitest";
 import { Effect, Schema } from "effect";
 
 import { ORCHESTRATION_WS_METHODS } from "./orchestration";
-import { WebSocketRequest } from "./ws";
+import { WebSocketRequest, WS_METHODS } from "./ws";
 
 const decodeWebSocketRequest = Schema.decodeUnknownEffect(WebSocketRequest);
 
@@ -54,5 +54,18 @@ it.effect("trims websocket request id and nested orchestration ids", () =>
     if (parsed.body._tag === ORCHESTRATION_WS_METHODS.getTurnDiff) {
       assert.strictEqual(parsed.body.threadId, "thread-1");
     }
+  }),
+);
+
+it.effect("accepts server logout account requests", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeWebSocketRequest({
+      id: "req-logout",
+      body: {
+        _tag: WS_METHODS.serverLogoutAccount,
+        provider: "codex",
+      },
+    });
+    assert.strictEqual(parsed.body._tag, WS_METHODS.serverLogoutAccount);
   }),
 );

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -20,6 +20,7 @@ import {
   GitRunStackedActionInput,
   GitStatusInput,
 } from "./git";
+import { ServerLogoutAccountInput } from "./server";
 import {
   TerminalClearInput,
   TerminalCloseInput,
@@ -67,6 +68,7 @@ export const WS_METHODS = {
   // Server meta
   serverGetConfig: "server.getConfig",
   serverUpsertKeybinding: "server.upsertKeybinding",
+  serverLogoutAccount: "server.logoutAccount",
 } as const;
 
 // ── Push Event Channels ──────────────────────────────────────────────
@@ -129,6 +131,7 @@ const WebSocketRequestBody = Schema.Union([
   // Server meta
   tagRequestBody(WS_METHODS.serverGetConfig, Schema.Struct({})),
   tagRequestBody(WS_METHODS.serverUpsertKeybinding, KeybindingRule),
+  tagRequestBody(WS_METHODS.serverLogoutAccount, ServerLogoutAccountInput),
 ]);
 
 export const WebSocketRequest = Schema.Struct({


### PR DESCRIPTION
This PR fixes the Codex account experience in the sidebar and model picker.

It adds a provider-owned Codex account snapshot flow so account plan data is available before the first session starts, uses that snapshot to gate Spark availability correctly, and adds Codex account actions through the sidebar account menu. Business accounts now hide Spark, legacy Team responses normalize to Business, and the account menu now supports Manage account, Logout, and a disabled Rate Limit (Coming soon) entry.

It also updates the sidebar trigger UX so the bottom-left entry is no longer branded as a specific Codex plan. The trigger now reads My Accounts with a generic account icon, while Codex branding remains inside the popup where the actual Codex account row is shown.

Key user-facing changes
Go, Plus, Business accounts no longer see Codex Spark
account plan data is surfaced earlier instead of waiting for first session hydration
sidebar account popup uses a Codex submenu with account actions

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate the `gpt-5.3-codex-spark` model to pro plans and add Codex account read/logout flows across server and web in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/489/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) and [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/489/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Add Codex account snapshot parsing and logout to server adapters and manager, surface `isPro`, `planLabel`, and `accountType` via websocket config, and hide Spark in the web model picker when `isPro` is false; include a sidebar account widget and websocket logout route.
>
> #### 📍Where to Start
> Start with `createServer` in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/489/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679), then review `CodexAppServerManager.readAccountSnapshot` and `logout` in [codexAppServerManager.ts](https://github.com/pingdotgg/t3code/pull/489/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9), and `readCodexAccountSnapshot` in [codexAccount.ts](https://github.com/pingdotgg/t3code/pull/489/files#diff-26aa5f6697c099e017e5e59c5d8adde8184646bfb6d013d74ced1c5c04bc3697).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bbac583. 16 files reviewed, 12 issues evaluated, 2 issues filtered, 4 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Layers/ProviderService.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 497](https://github.com/pingdotgg/t3code/blob/bbac583cde86ab157db5da75060e6dff7d9ad787/apps/server/src/provider/Layers/ProviderService.ts#L497): The `runStopAll` function inside `makeProviderService` iterates over `threadIds` and tries to fetch the provider for each one using `directory.getProvider(threadId)`. However, the code then immediately calls `directory.upsert(...)` with a `provider` variable. Crucially, the arrow function `(threadId) => directory.getProvider(threadId).pipe(...)` is missing a return or implicit return of the Effect chain if it were not wrapped in a block, but here it is part of `Effect.forEach(threadIds, ...)`. Wait, looking closer at lines 494-509: <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/routes/__root.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 247](https://github.com/pingdotgg/t3code/blob/bbac583cde86ab157db5da75060e6dff7d9ad787/apps/web/src/routes/__root.tsx#L247): The `onServerConfigUpdated` handler incorrectly suppresses configuration errors unrelated to keybindings. If `payload.issues` contains non-keybinding errors (e.g., generic JSON syntax errors or provider validation failures), the `find` operation on line 247 returns `undefined`. The code then enters the `if (!issue)` block on line 248, displaying a "Keybindings updated" success toast. This masks actual configuration failures from the user, leading them to believe their configuration (including the newly added `providers` watched by the signature) was applied successfully when it may have been rejected. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->