### PR TITLE
fix: handle Ctrl++ zoom-in on Windows

### DIFF
--- a/.docs/quick-start.md
+++ b/.docs/quick-start.md
@@ -4,7 +4,7 @@
 # Development (with hot reload)
 bun run dev
 
-# Desktop development
+# Desktop development (works on Windows too)
 bun run dev:desktop
 
 # Desktop development on an isolated port set
@@ -16,6 +16,9 @@ bun run start
 
 # Build a shareable macOS .dmg (arm64 by default)
 bun run dist:desktop:dmg
+
+# Build a shareable Windows installer (.exe via NSIS)
+bun run dist:desktop:win
 
 # Or from any project directory after publishing:
 npx t3

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -15,6 +15,7 @@ import { NetService } from "@t3tools/shared/Net";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
 import { fixPath } from "./fixPath";
+import { isWindowsZoomInShortcut } from "./zoomShortcuts";
 import {
   getAutoUpdateDisabledReason,
   shouldBroadcastDownloadProgress,
@@ -1115,6 +1116,11 @@ function createWindow(): BrowserWindow {
   });
 
   window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  window.webContents.on("before-input-event", (event, input) => {
+    if (!isWindowsZoomInShortcut(input)) return;
+    event.preventDefault();
+    window.webContents.setZoomLevel(window.webContents.getZoomLevel() + 0.5);
+  });
   window.on("page-title-updated", (event) => {
     event.preventDefault();
     window.setTitle(APP_DISPLAY_NAME);

--- a/apps/desktop/src/zoomShortcuts.test.ts
+++ b/apps/desktop/src/zoomShortcuts.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { isWindowsZoomInShortcut } from "./zoomShortcuts";
+
+describe("isWindowsZoomInShortcut", () => {
+  it("matches Ctrl++ from the main keyboard on Windows", () => {
+    expect(
+      isWindowsZoomInShortcut(
+        {
+          type: "keyDown",
+          control: true,
+          shift: true,
+          key: "+",
+          code: "Equal",
+        },
+        "win32",
+      ),
+    ).toBe(true);
+    expect(
+      isWindowsZoomInShortcut(
+        {
+          type: "keyDown",
+          control: true,
+          shift: true,
+          key: "=",
+          code: "Equal",
+        },
+        "win32",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches Ctrl+numpad plus on Windows", () => {
+    expect(
+      isWindowsZoomInShortcut(
+        {
+          type: "keyDown",
+          control: true,
+          key: "+",
+          code: "NumpadAdd",
+        },
+        "win32",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated shortcuts or other platforms", () => {
+    expect(
+      isWindowsZoomInShortcut(
+        {
+          type: "keyDown",
+          control: true,
+          key: "-",
+          code: "Minus",
+        },
+        "win32",
+      ),
+    ).toBe(false);
+    expect(
+      isWindowsZoomInShortcut(
+        {
+          type: "keyDown",
+          control: true,
+          shift: true,
+          key: "+",
+          code: "Equal",
+        },
+        "linux",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/zoomShortcuts.ts
+++ b/apps/desktop/src/zoomShortcuts.ts
@@ -1,0 +1,24 @@
+interface ZoomShortcutInput {
+  alt?: boolean;
+  code?: string;
+  control?: boolean;
+  key?: string;
+  meta?: boolean;
+  shift?: boolean;
+  type?: string;
+}
+
+export function isWindowsZoomInShortcut(
+  input: ZoomShortcutInput,
+  platform = process.platform,
+): boolean {
+  if (platform !== "win32") return false;
+  if (input.type !== "keyDown") return false;
+  if (!input.control || input.alt || input.meta) return false;
+
+  return (
+    input.key === "+" ||
+    input.code === "NumpadAdd" ||
+    (input.shift === true && (input.key === "=" || input.code === "Equal"))
+  );
+}


### PR DESCRIPTION
Electron's default accelerator handling misses the Ctrl++, Ctrl+Shift+= and Ctrl+NumpadAdd chords on Windows. Hook before-input-event in the BrowserWindow to detect these combos and increment the zoom level.

Also add the Windows desktop build command to the quick-start docs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Intercept Windows Ctrl++ zoom-in in `apps/desktop/src/main.ts` and increase `webContents` zoom level by 0.5
> Add `isWindowsZoomInShortcut` predicate and hook `before-input-event` in [main.ts](https://github.com/pingdotgg/t3code/pull/491/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb) to apply a +0.5 zoom for Windows shortcuts; implement utility in [zoomShortcuts.ts](https://github.com/pingdotgg/t3code/pull/491/files#diff-8bbc96d36fb2ab6e3f1d71731f42a909c2173e6648efcc6686f5dd3ea9c39e1c) and tests in [zoomShortcuts.test.ts](https://github.com/pingdotgg/t3code/pull/491/files#diff-a79719386b1adfe2080ae8e40d96327dcd2e29525cd93a8cc914f8084737a9fc); update Windows notes in [quick-start.md](https://github.com/pingdotgg/t3code/pull/491/files#diff-2f11576685249bbdd186c87a12a6fb1a5c2303fd9505043b5c7e18bdd5851c37).
>
> #### 📍Where to Start
> Start with the `main.createWindow` handler and its `webContents` input listener in [main.ts](https://github.com/pingdotgg/t3code/pull/491/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afa0ffc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->