### PR TITLE
feat(desktop): add spellcheck suggestions to context menu

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1114,6 +1114,34 @@ function createWindow(): BrowserWindow {
     },
   });
 
+  window.webContents.on("context-menu", (event, params) => {
+    event.preventDefault();
+
+    const menuTemplate: MenuItemConstructorOptions[] = [];
+
+    if (params.misspelledWord) {
+      for (const suggestion of params.dictionarySuggestions.slice(0, 5)) {
+        menuTemplate.push({
+          label: suggestion,
+          click: () => window.webContents.replaceMisspelling(suggestion),
+        });
+      }
+      if (params.dictionarySuggestions.length === 0) {
+        menuTemplate.push({ label: "No suggestions", enabled: false });
+      }
+      menuTemplate.push({ type: "separator" });
+    }
+
+    menuTemplate.push(
+      { role: "cut", enabled: params.editFlags.canCut },
+      { role: "copy", enabled: params.editFlags.canCopy },
+      { role: "paste", enabled: params.editFlags.canPaste },
+      { role: "selectAll", enabled: params.editFlags.canSelectAll },
+    );
+
+    Menu.buildFromTemplate(menuTemplate).popup({ window });
+  });
+
   window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
   window.on("page-title-updated", (event) => {
     event.preventDefault();


### PR DESCRIPTION
## What
Surface spellcheck correction suggestions in the right-click context menu on the Electron desktop app.

## Why
Chromium's spellchecker already detects and underlines misspelled words, but Electron does not automatically populate the context menu with dictionary suggestions. Users expect right-click spelling corrections, consistent with other desktop applications.

## Key Changes
- Add `context-menu` event handler on `webContents` in `createWindow()`
- Show up to 5 dictionary suggestions when right-clicking a misspelled word, clicking a suggestion calls `replaceMisspelling()`
- Show "No suggestions" placeholder when the word is misspelled but the dictionary has no matches
- Always include standard edit actions (Cut, Copy, Paste, Select All) with proper `editFlags` gating

Closes to #473

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add spellcheck suggestions to the desktop window context menu and invoke `Electron.WebContents.replaceMisspelling` for up to five items in [main.ts](https://github.com/pingdotgg/t3code/pull/500/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb)
> Register a `webContents` `context-menu` listener to render a custom menu with up to five spelling suggestions, a fallback disabled "No suggestions" item, a separator, and edit role items (`cut`, `copy`, `paste`, `selectAll`) with states from `params.editFlags`.
>
> #### 📍Where to Start
> Start at the `createWindow` initializer where the `webContents.on('context-menu', ...)` handler is added in [main.ts](https://github.com/pingdotgg/t3code/pull/500/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e6e78e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->