### PR TITLE
Fix CLAUDE.md to auto-load AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
+---
+desc: Update AGENTS.md when asked to update your instructions.
+---
+
 @AGENTS.md


### PR DESCRIPTION
## What
Update CLAUDE.md to auto-load AGENTS.md and direct Claude to update it when asked to change instructions.

## Why
CLAUDE.md lists `AGENTS.md` as plain text, so Claude does not auto-load it into context. The `@` prefix triggers auto-import. The `desc` frontmatter tells Claude where to persist instruction updates.

## Key Changes
- CLAUDE.md: `AGENTS.md` -> `@AGENTS.md` for auto-import
- CLAUDE.md: Add `desc: Update AGENTS.md when asked to update your instructions.` frontmatter

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update CLAUDE.md to auto-load AGENTS.md using YAML front matter for auto-loading
> Replace the single-line `AGENTS.md` reference with a YAML front matter block containing `desc` and a trailing delimiter, followed by a blank line and `@AGENTS.md` in [CLAUDE.md](https://github.com/pingdotgg/t3code/pull/501/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7).
>
> #### 📍Where to Start
> Start with the content and front matter changes in [CLAUDE.md](https://github.com/pingdotgg/t3code/pull/501/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 189e956.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->