### PR TITLE
fix(web): compact plan questionnaire navigation buttons

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -2,12 +2,15 @@
 import "../index.css";
 
 import {
+  EventId,
   ORCHESTRATION_WS_METHODS,
   type MessageId,
   type OrchestrationReadModel,
+  type OrchestrationThreadActivity,
   type ProjectId,
   type ServerConfig,
   type ThreadId,
+  TurnId,
   type WsWelcomePayload,
   WS_CHANNELS,
   WS_METHODS,
@@ -85,6 +88,29 @@ interface MountedChatView {
   cleanup: () => Promise<void>;
   measureUserRow: (targetMessageId: MessageId) => Promise<UserRowMeasurement>;
   setViewport: (viewport: ViewportSpec) => Promise<void>;
+}
+
+function makeActivity(overrides: {
+  id?: string;
+  createdAt?: string;
+  kind?: string;
+  summary?: string;
+  tone?: OrchestrationThreadActivity["tone"];
+  payload?: Record<string, unknown>;
+  turnId?: string;
+  sequence?: number;
+}): OrchestrationThreadActivity {
+  const payload = overrides.payload ?? {};
+  return {
+    id: EventId.makeUnsafe(overrides.id ?? crypto.randomUUID()),
+    createdAt: overrides.createdAt ?? NOW_ISO,
+    kind: overrides.kind ?? "tool.started",
+    summary: overrides.summary ?? "Tool call",
+    tone: overrides.tone ?? "tool",
+    payload,
+    turnId: overrides.turnId ? TurnId.makeUnsafe(overrides.turnId) : null,
+    ...(overrides.sequence !== undefined ? { sequence: overrides.sequence } : {}),
+  };
 }
 
 function isoAt(offsetSeconds: number): string {
@@ -253,6 +279,62 @@ function createDraftOnlySnapshot(): OrchestrationReadModel {
   return {
     ...snapshot,
     threads: [],
+  };
+}
+
+function createPendingUserInputSnapshot(): OrchestrationReadModel {
+  const snapshot = createSnapshotForTargetUser({
+    targetMessageId: "msg-user-pending-input-target" as MessageId,
+    targetText: "pending input target",
+  });
+  const thread = snapshot.threads[0];
+  if (!thread) {
+    throw new Error("expected snapshot thread");
+  }
+
+  return {
+    ...snapshot,
+    threads: [
+      {
+        ...thread,
+        activities: [
+          makeActivity({
+            id: "pending-user-input-open",
+            createdAt: NOW_ISO,
+            kind: "user-input.requested",
+            summary: "User input requested",
+            tone: "info",
+            payload: {
+              requestId: "req-user-input-browser",
+              questions: [
+                {
+                  id: "sandbox_mode",
+                  header: "Sandbox",
+                  question: "Which mode should be used?",
+                  options: [
+                    {
+                      label: "workspace-write",
+                      description: "Allow workspace writes only",
+                    },
+                  ],
+                },
+                {
+                  id: "approval_policy",
+                  header: "Approvals",
+                  question: "How should approvals work?",
+                  options: [
+                    {
+                      label: "never",
+                      description: "Do not ask for approvals",
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+        ],
+      },
+    ],
   };
 }
 
@@ -862,6 +944,75 @@ describe("ChatView timeline estimator parity (full app)", () => {
           expect((await waitForInteractionModeButton("Chat")).title).toContain("enter plan mode");
         },
         { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("renders compact questionnaire navigation controls within the composer at narrow widths", async () => {
+    const mounted = await mountChatView({
+      viewport: TEXT_VIEWPORT_MATRIX[3],
+      snapshot: createPendingUserInputSnapshot(),
+    });
+
+    try {
+      const composerForm = await waitForElement(
+        () => document.querySelector<HTMLFormElement>('[data-chat-composer-form="true"]'),
+        "Unable to find composer form.",
+      );
+      const firstOptionButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "workspace-write",
+          ) as HTMLButtonElement | null,
+        "Unable to find first questionnaire option.",
+      );
+      firstOptionButton.click();
+      await waitForLayout();
+
+      const nextButton = await waitForElement(
+        () => document.querySelector<HTMLButtonElement>('button[aria-label="Next question"]'),
+        "Unable to find next question button.",
+      );
+      expect(nextButton.textContent?.trim() ?? "").toBe("");
+      expect(
+        Array.from(document.querySelectorAll("button")).some(
+          (button) => button.textContent?.trim() === "Next question",
+        ),
+      ).toBe(false);
+      expect(nextButton.getBoundingClientRect().right).toBeLessThanOrEqual(
+        composerForm.getBoundingClientRect().right + 1,
+      );
+
+      nextButton.click();
+      await waitForLayout();
+
+      const previousButton = await waitForElement(
+        () => document.querySelector<HTMLButtonElement>('button[aria-label="Previous question"]'),
+        "Unable to find previous question button.",
+      );
+      const submitButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Submit",
+          ) as HTMLButtonElement | null,
+        "Unable to find submit button.",
+      );
+
+      expect(
+        Array.from(document.querySelectorAll("button")).some(
+          (button) =>
+            button.textContent?.trim() === "Previous" || button.textContent?.trim() === "Submit answers",
+        ),
+      ).toBe(false);
+      expect(previousButton.textContent?.trim() ?? "").toBe("");
+      expect(previousButton.getBoundingClientRect().right).toBeLessThanOrEqual(
+        composerForm.getBoundingClientRect().right + 1,
+      );
+      expect(submitButton.querySelector("svg")).toBeTruthy();
+      expect(submitButton.getBoundingClientRect().right).toBeLessThanOrEqual(
+        composerForm.getBoundingClientRect().right + 1,
       );
     } finally {
       await mounted.cleanup();

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3701,34 +3701,50 @@ export default function ChatView({ threadId }: ChatViewProps) {
                     <span className="text-muted-foreground/70 text-xs">Preparing worktree...</span>
                   ) : null}
                   {activePendingProgress ? (
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-1.5">
                       {activePendingProgress.questionIndex > 0 ? (
                         <Button
-                          size="sm"
+                          size="icon-sm"
                           variant="outline"
                           className="rounded-full"
                           onClick={onPreviousActivePendingUserInputQuestion}
                           disabled={activePendingIsResponding}
+                          aria-label="Previous question"
                         >
-                          Previous
+                          <ChevronLeftIcon aria-hidden="true" className="size-4" />
                         </Button>
                       ) : null}
                       <Button
                         type="submit"
-                        size="sm"
-                        className="rounded-full px-4"
+                        size={activePendingProgress.isLastQuestion ? "sm" : "icon-sm"}
+                        className={cn(
+                          "rounded-full",
+                          activePendingProgress.isLastQuestion ? "px-3" : undefined,
+                        )}
                         disabled={
                           activePendingIsResponding ||
                           (activePendingProgress.isLastQuestion
                             ? !activePendingResolvedAnswers
                             : !activePendingProgress.canAdvance)
                         }
+                        aria-label={
+                          activePendingProgress.isLastQuestion
+                            ? undefined
+                            : "Next question"
+                        }
                       >
                         {activePendingIsResponding
                           ? "Submitting..."
                           : activePendingProgress.isLastQuestion
-                            ? "Submit answers"
-                            : "Next question"}
+                            ? (
+                                <>
+                                  <CheckIcon aria-hidden="true" className="size-4" />
+                                  <span>Submit</span>
+                                </>
+                              )
+                            : (
+                                <ChevronRightIcon aria-hidden="true" className="size-4" />
+                              )}
                       </Button>
                     </div>
                   ) : phase === "running" ? (


### PR DESCRIPTION
## Summary
- replace the plan questionnaire's text-heavy previous/next controls with compact icon buttons in the composer footer
- keep the final action explicit with a compact `Submit` button that includes a check icon
- add a narrow-viewport browser regression to verify the questionnaire controls stay inside the composer bounds

## Problem
The plan questionnaire footer was using full text labels like `Previous`, `Next question`, and `Submit answers` inside the composer action row. On narrower widths, those controls could push outside the composer container and break the layout.

## Solution
Switch the intermediate questionnaire navigation to icon-only chevron buttons with accessible `aria-label`s, and shorten the final action to `Submit` with a check icon. This preserves the existing questionnaire behavior and disabled states while reducing the action row footprint enough to stay within the composer on narrow viewports.

## Testing
- bun lint
- bun typecheck
- bun run test:browser -- src/components/ChatView.browser.tsx

## Screenshots
Provided in the request context during PR preparation.
<img width="1043" height="370" alt="image" src="https://github.com/user-attachments/assets/feed8e1a-2e8c-4ba4-98db-475ed7e0626a" />
<img width="987" height="335" alt="image" src="https://github.com/user-attachments/assets/67d484b4-7abf-4982-a801-87eee153619c" />

Included states:
- step 2 of 3 showing the compact chevron next button inside the composer footer
- step 3 of 3 showing the compact previous chevron plus `Submit` button inside the composer footer


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make compact questionnaire navigation in `ChatView` render icon-only previous/next controls with aria-labels and a `Submit` button at narrow widths in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/508/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Update pending-user-input controls to use `ChevronLeftIcon` and `ChevronRightIcon` with `aria-label`s, reduce gap from 2 to 1.5, and show `CheckIcon` with "Submit" on the final step; add snapshot/test utilities and an integration test in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/508/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f).
>
> #### 📍Where to Start
> Start with the pending-user-input controls in `ChatView` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/508/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), then review the compact UI test in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/508/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 260c0ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->