### PR TITLE
Fix Codex app-server enum serialization for thread start

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -12,9 +12,11 @@ import {
   CodexAppServerManager,
   classifyCodexStderrLine,
   isRecoverableThreadResumeError,
+  mapCodexRuntimeMode,
   normalizeCodexModelSlug,
   readCodexAccountSnapshot,
   resolveCodexModelForAccount,
+  toCodexAppServerSandboxMode,
 } from "./codexAppServerManager";
 
 const asThreadId = (value: string): ThreadId => ThreadId.makeUnsafe(value);
@@ -47,7 +49,9 @@ function createSendTurnHarness() {
     .mockReturnValue(context);
   const sendRequest = vi
     .spyOn(
-      manager as unknown as { sendRequest: (...args: unknown[]) => Promise<unknown> },
+      manager as unknown as {
+        sendRequest: (...args: unknown[]) => Promise<unknown>;
+      },
       "sendRequest",
     )
     .mockResolvedValue({
@@ -56,7 +60,10 @@ function createSendTurnHarness() {
       },
     });
   const updateSession = vi
-    .spyOn(manager as unknown as { updateSession: (...args: unknown[]) => void }, "updateSession")
+    .spyOn(
+      manager as unknown as { updateSession: (...args: unknown[]) => void },
+      "updateSession",
+    )
     .mockImplementation(() => {});
 
   return { manager, context, requireSession, sendRequest, updateSession };
@@ -84,11 +91,16 @@ function createThreadControlHarness() {
     )
     .mockReturnValue(context);
   const sendRequest = vi.spyOn(
-    manager as unknown as { sendRequest: (...args: unknown[]) => Promise<unknown> },
+    manager as unknown as {
+      sendRequest: (...args: unknown[]) => Promise<unknown>;
+    },
     "sendRequest",
   );
   const updateSession = vi
-    .spyOn(manager as unknown as { updateSession: (...args: unknown[]) => void }, "updateSession")
+    .spyOn(
+      manager as unknown as { updateSession: (...args: unknown[]) => void },
+      "updateSession",
+    )
     .mockImplementation(() => {});
 
   return { manager, context, requireSession, sendRequest, updateSession };
@@ -126,10 +138,16 @@ function createPendingUserInputHarness() {
     )
     .mockReturnValue(context);
   const writeMessage = vi
-    .spyOn(manager as unknown as { writeMessage: (...args: unknown[]) => void }, "writeMessage")
+    .spyOn(
+      manager as unknown as { writeMessage: (...args: unknown[]) => void },
+      "writeMessage",
+    )
     .mockImplementation(() => {});
   const emitEvent = vi
-    .spyOn(manager as unknown as { emitEvent: (...args: unknown[]) => void }, "emitEvent")
+    .spyOn(
+      manager as unknown as { emitEvent: (...args: unknown[]) => void },
+      "emitEvent",
+    )
     .mockImplementation(() => {});
 
   return { manager, context, requireSession, writeMessage, emitEvent };
@@ -153,7 +171,8 @@ describe("classifyCodexStderrLine", () => {
   });
 
   it("keeps unknown structured errors", () => {
-    const line = "2026-02-08T04:24:20.085687Z ERROR codex_core::runtime: unrecoverable failure";
+    const line =
+      "2026-02-08T04:24:20.085687Z ERROR codex_core::runtime: unrecoverable failure";
     expect(classifyCodexStderrLine(line)).toEqual({
       message: line,
     });
@@ -174,7 +193,9 @@ describe("normalizeCodexModelSlug", () => {
   });
 
   it("prefers codex id when model differs", () => {
-    expect(normalizeCodexModelSlug("gpt-5.3", "gpt-5.3-codex")).toBe("gpt-5.3-codex");
+    expect(normalizeCodexModelSlug("gpt-5.3", "gpt-5.3-codex")).toBe(
+      "gpt-5.3-codex",
+    );
   });
 
   it("keeps non-aliased models as-is", () => {
@@ -183,16 +204,46 @@ describe("normalizeCodexModelSlug", () => {
   });
 });
 
+describe("Codex app-server enum mapping", () => {
+  it("maps canonical sandbox modes to Codex app-server variants", () => {
+    expect(toCodexAppServerSandboxMode("read-only")).toBe("readOnly");
+    expect(toCodexAppServerSandboxMode("workspace-write")).toBe(
+      "workspaceWrite",
+    );
+    expect(toCodexAppServerSandboxMode("danger-full-access")).toBe(
+      "dangerFullAccess",
+    );
+  });
+
+  it("maps full-access runtime mode to Codex thread/start params", () => {
+    expect(mapCodexRuntimeMode("full-access")).toEqual({
+      approvalPolicy: "never",
+      sandbox: "dangerFullAccess",
+    });
+  });
+
+  it("maps approval-required runtime mode to Codex thread/start params", () => {
+    expect(mapCodexRuntimeMode("approval-required")).toEqual({
+      approvalPolicy: "onRequest",
+      sandbox: "workspaceWrite",
+    });
+  });
+});
+
 describe("isRecoverableThreadResumeError", () => {
   it("matches not-found resume errors", () => {
     expect(
-      isRecoverableThreadResumeError(new Error("thread/resume failed: thread not found")),
+      isRecoverableThreadResumeError(
+        new Error("thread/resume failed: thread not found"),
+      ),
     ).toBe(true);
   });
 
   it("ignores non-resume errors", () => {
     expect(
-      isRecoverableThreadResumeError(new Error("thread/start failed: permission denied")),
+      isRecoverableThreadResumeError(
+        new Error("thread/start failed: permission denied"),
+      ),
     ).toBe(false);
   });
 
@@ -285,7 +336,8 @@ describe("startSession", () => {
 
   it("emits session/startFailed when resolving cwd throws before process launch", async () => {
     const manager = new CodexAppServerManager();
-    const events: Array<{ method: string; kind: string; message?: string }> = [];
+    const events: Array<{ method: string; kind: string; message?: string }> =
+      [];
     manager.on("event", (event) => {
       events.push({
         method: event.method,
@@ -319,7 +371,8 @@ describe("startSession", () => {
 
   it("fails fast with an upgrade message when codex is below the minimum supported version", async () => {
     const manager = new CodexAppServerManager();
-    const events: Array<{ method: string; kind: string; message?: string }> = [];
+    const events: Array<{ method: string; kind: string; message?: string }> =
+      [];
     manager.on("event", (event) => {
       events.push({
         method: event.method,
@@ -549,14 +602,20 @@ describe("sendTurn", () => {
 
 describe("thread checkpoint control", () => {
   it("reads thread turns from thread/read", async () => {
-    const { manager, context, requireSession, sendRequest } = createThreadControlHarness();
+    const { manager, context, requireSession, sendRequest } =
+      createThreadControlHarness();
     sendRequest.mockResolvedValue({
       thread: {
         id: "thread_1",
         turns: [
           {
             id: "turn_1",
-            items: [{ type: "userMessage", content: [{ type: "text", text: "hello" }] }],
+            items: [
+              {
+                type: "userMessage",
+                content: [{ type: "text", text: "hello" }],
+              },
+            ],
           },
         ],
       },
@@ -574,7 +633,9 @@ describe("thread checkpoint control", () => {
       turns: [
         {
           id: "turn_1",
-          items: [{ type: "userMessage", content: [{ type: "text", text: "hello" }] }],
+          items: [
+            { type: "userMessage", content: [{ type: "text", text: "hello" }] },
+          ],
         },
       ],
     });
@@ -587,7 +648,9 @@ describe("thread checkpoint control", () => {
       turns: [
         {
           id: "turn_1",
-          items: [{ type: "userMessage", content: [{ type: "text", text: "hello" }] }],
+          items: [
+            { type: "userMessage", content: [{ type: "text", text: "hello" }] },
+          ],
         },
       ],
     });
@@ -603,14 +666,17 @@ describe("thread checkpoint control", () => {
       turns: [
         {
           id: "turn_1",
-          items: [{ type: "userMessage", content: [{ type: "text", text: "hello" }] }],
+          items: [
+            { type: "userMessage", content: [{ type: "text", text: "hello" }] },
+          ],
         },
       ],
     });
   });
 
   it("rolls back turns via thread/rollback and resets session running state", async () => {
-    const { manager, context, sendRequest, updateSession } = createThreadControlHarness();
+    const { manager, context, sendRequest, updateSession } =
+      createThreadControlHarness();
     sendRequest.mockResolvedValue({
       thread: {
         id: "thread_1",
@@ -707,6 +773,40 @@ describe("respondToUserInput", () => {
     );
   });
 
+  it("maps sandbox_mode answers to Codex app-server variants", async () => {
+    const { manager, context, requireSession, writeMessage, emitEvent } =
+      createPendingUserInputHarness();
+
+    await manager.respondToUserInput(
+      asThreadId("thread_1"),
+      ApprovalRequestId.makeUnsafe("req-user-input-1"),
+      {
+        sandbox_mode: "danger-full-access",
+      },
+    );
+
+    expect(requireSession).toHaveBeenCalledWith("thread_1");
+    expect(writeMessage).toHaveBeenCalledWith(context, {
+      id: 42,
+      result: {
+        answers: {
+          sandbox_mode: { answers: ["dangerFullAccess"] },
+        },
+      },
+    });
+    expect(emitEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "item/tool/requestUserInput/answered",
+        payload: {
+          requestId: "req-user-input-1",
+          answers: {
+            sandbox_mode: { answers: ["dangerFullAccess"] },
+          },
+        },
+      }),
+    );
+  });
+
   it("tracks file-read approval requests with the correct method", () => {
     const manager = new CodexAppServerManager();
     const context = {
@@ -748,11 +848,13 @@ describe("respondToUserInput", () => {
   });
 });
 
-describe.skipIf(!process.env.CODEX_BINARY_PATH)("startSession live Codex resume", () => {
-  it(
-    "keeps prior thread history when resuming with a changed runtime mode",
-    async () => {
-      const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "codex-live-resume-"));
+describe.skipIf(!process.env.CODEX_BINARY_PATH)(
+  "startSession live Codex resume",
+  () => {
+    it("keeps prior thread history when resuming with a changed runtime mode", async () => {
+      const workspaceDir = mkdtempSync(
+        path.join(os.tmpdir(), "codex-live-resume-"),
+      );
       writeFileSync(path.join(workspaceDir, "README.md"), "hello\n", "utf8");
 
       const manager = new CodexAppServerManager();
@@ -782,10 +884,13 @@ describe.skipIf(!process.env.CODEX_BINARY_PATH)("startSession live Codex resume"
 
         expect(firstTurn.threadId).toBe(firstSession.threadId);
 
-        await vi.waitFor(async () => {
-          const snapshot = await manager.readThread(firstSession.threadId);
-          expect(snapshot.turns.length).toBeGreaterThan(0);
-        }, { timeout: 120_000, interval: 1_000 });
+        await vi.waitFor(
+          async () => {
+            const snapshot = await manager.readThread(firstSession.threadId);
+            expect(snapshot.turns.length).toBeGreaterThan(0);
+          },
+          { timeout: 120_000, interval: 1_000 },
+        );
 
         const firstSnapshot = await manager.readThread(firstSession.threadId);
         const originalThreadId = firstSnapshot.threadId;
@@ -813,24 +918,30 @@ describe.skipIf(!process.env.CODEX_BINARY_PATH)("startSession live Codex resume"
 
         expect(resumedSession.threadId).toBe(originalThreadId);
 
-        const resumedSnapshotBeforeTurn = await manager.readThread(resumedSession.threadId);
+        const resumedSnapshotBeforeTurn = await manager.readThread(
+          resumedSession.threadId,
+        );
         expect(resumedSnapshotBeforeTurn.threadId).toBe(originalThreadId);
-        expect(resumedSnapshotBeforeTurn.turns.length).toBeGreaterThanOrEqual(originalTurnCount);
+        expect(resumedSnapshotBeforeTurn.turns.length).toBeGreaterThanOrEqual(
+          originalTurnCount,
+        );
 
         await manager.sendTurn({
           threadId: resumedSession.threadId,
           input: `Reply with exactly the word BETA ${randomUUID()}`,
         });
 
-        await vi.waitFor(async () => {
-          const snapshot = await manager.readThread(resumedSession.threadId);
-          expect(snapshot.turns.length).toBeGreaterThan(originalTurnCount);
-        }, { timeout: 120_000, interval: 1_000 });
+        await vi.waitFor(
+          async () => {
+            const snapshot = await manager.readThread(resumedSession.threadId);
+            expect(snapshot.turns.length).toBeGreaterThan(originalTurnCount);
+          },
+          { timeout: 120_000, interval: 1_000 },
+        );
       } finally {
         manager.stopAll();
         rmSync(workspaceDir, { recursive: true, force: true });
       }
-    },
-    180_000,
-  );
-});
+    }, 180_000);
+  },
+);

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1,4 +1,8 @@
-import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:child_process";
+import {
+  type ChildProcessWithoutNullStreams,
+  spawn,
+  spawnSync,
+} from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import readline from "node:readline";
@@ -8,6 +12,7 @@ import {
   EventId,
   ProviderItemId,
   ProviderRequestKind,
+  type ProviderSandboxMode,
   type ProviderUserInputAnswers,
   ThreadId,
   TurnId,
@@ -163,7 +168,11 @@ const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
 ];
 const CODEX_DEFAULT_MODEL = "gpt-5.3-codex";
 const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
-const CODEX_SPARK_DISABLED_PLAN_TYPES = new Set<CodexPlanType>(["free", "go", "plus"]);
+const CODEX_SPARK_DISABLED_PLAN_TYPES = new Set<CodexPlanType>([
+  "free",
+  "go",
+  "plus",
+]);
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object") {
@@ -176,7 +185,9 @@ function asString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
 }
 
-export function readCodexAccountSnapshot(response: unknown): CodexAccountSnapshot {
+export function readCodexAccountSnapshot(
+  response: unknown,
+): CodexAccountSnapshot {
   const record = asObject(response);
   const account = asObject(record?.account) ?? record;
   const accountType = asString(account?.type);
@@ -340,20 +351,50 @@ The \`request_user_input\` tool is unavailable in Default mode. If you call it w
 In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
 </collaboration_mode>`;
 
-function mapCodexRuntimeMode(runtimeMode: RuntimeMode): {
-  readonly approvalPolicy: "on-request" | "never";
-  readonly sandbox: "workspace-write" | "danger-full-access";
+type CodexAppServerApprovalPolicy = "onRequest" | "never";
+type CodexAppServerSandboxMode =
+  | "readOnly"
+  | "workspaceWrite"
+  | "dangerFullAccess";
+
+export function toCodexAppServerSandboxMode(
+  sandboxMode: ProviderSandboxMode,
+): CodexAppServerSandboxMode {
+  switch (sandboxMode) {
+    case "read-only":
+      return "readOnly";
+    case "workspace-write":
+      return "workspaceWrite";
+    case "danger-full-access":
+      return "dangerFullAccess";
+  }
+}
+
+function toCodexAppServerSandboxModeValue(value: string): string {
+  switch (value) {
+    case "read-only":
+    case "workspace-write":
+    case "danger-full-access":
+      return toCodexAppServerSandboxMode(value);
+    default:
+      return value;
+  }
+}
+
+export function mapCodexRuntimeMode(runtimeMode: RuntimeMode): {
+  readonly approvalPolicy: CodexAppServerApprovalPolicy;
+  readonly sandbox: CodexAppServerSandboxMode;
 } {
   if (runtimeMode === "approval-required") {
     return {
-      approvalPolicy: "on-request",
-      sandbox: "workspace-write",
+      approvalPolicy: "onRequest",
+      sandbox: "workspaceWrite",
     };
   }
 
   return {
     approvalPolicy: "never",
-    sandbox: "danger-full-access",
+    sandbox: "dangerFullAccess",
   };
 }
 
@@ -376,7 +417,9 @@ export function resolveCodexModelForAccount(
 function killChildTree(child: ChildProcessWithoutNullStreams): void {
   if (process.platform === "win32" && child.pid !== undefined) {
     try {
-      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
       return;
     } catch {
       // fallback to direct kill
@@ -451,14 +494,18 @@ function toCodexUserInputAnswer(value: unknown): CodexUserInputAnswer {
   }
 
   if (Array.isArray(value)) {
-    const answers = value.filter((entry): entry is string => typeof entry === "string");
+    const answers = value.filter(
+      (entry): entry is string => typeof entry === "string",
+    );
     return { answers };
   }
 
   if (value && typeof value === "object") {
     const maybeAnswers = (value as { answers?: unknown }).answers;
     if (Array.isArray(maybeAnswers)) {
-      const answers = maybeAnswers.filter((entry): entry is string => typeof entry === "string");
+      const answers = maybeAnswers.filter(
+        (entry): entry is string => typeof entry === "string",
+      );
       return { answers };
     }
   }
@@ -470,14 +517,25 @@ function toCodexUserInputAnswers(
   answers: ProviderUserInputAnswers,
 ): Record<string, CodexUserInputAnswer> {
   return Object.fromEntries(
-    Object.entries(answers).map(([questionId, value]) => [
-      questionId,
-      toCodexUserInputAnswer(value),
-    ]),
+    Object.entries(answers).map(([questionId, value]) => {
+      const normalizedAnswer = toCodexUserInputAnswer(value);
+      return [
+        questionId,
+        {
+          answers: normalizedAnswer.answers.map((answer) =>
+            questionId === "sandbox_mode"
+              ? toCodexAppServerSandboxModeValue(answer)
+              : answer,
+          ),
+        },
+      ] as const;
+    }),
   );
 }
 
-export function classifyCodexStderrLine(rawLine: string): { message: string } | null {
+export function classifyCodexStderrLine(
+  rawLine: string,
+): { message: string } | null {
   const line = rawLine.replaceAll(ANSI_ESCAPE_REGEX, "").trim();
   if (!line) {
     return null;
@@ -490,7 +548,9 @@ export function classifyCodexStderrLine(rawLine: string): { message: string } | 
       return null;
     }
 
-    const isBenignError = BENIGN_ERROR_LOG_SNIPPETS.some((snippet) => line.includes(snippet));
+    const isBenignError = BENIGN_ERROR_LOG_SNIPPETS.some((snippet) =>
+      line.includes(snippet),
+    );
     if (isBenignError) {
       return null;
     }
@@ -500,12 +560,16 @@ export function classifyCodexStderrLine(rawLine: string): { message: string } | 
 }
 
 export function isRecoverableThreadResumeError(error: unknown): boolean {
-  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  const message = (
+    error instanceof Error ? error.message : String(error)
+  ).toLowerCase();
   if (!message.includes("thread/resume")) {
     return false;
   }
 
-  return RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS.some((snippet) => message.includes(snippet));
+  return RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS.some((snippet) =>
+    message.includes(snippet),
+  );
 }
 
 export interface CodexAppServerManagerEvents {
@@ -515,13 +579,19 @@ export interface CodexAppServerManagerEvents {
 export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEvents> {
   private readonly sessions = new Map<ThreadId, CodexSessionContext>();
 
-  private runPromise: (effect: Effect.Effect<unknown, never>) => Promise<unknown>;
+  private runPromise: (
+    effect: Effect.Effect<unknown, never>,
+  ) => Promise<unknown>;
   constructor(services?: ServiceMap.ServiceMap<never>) {
     super();
-    this.runPromise = services ? Effect.runPromiseWith(services) : Effect.runPromise;
+    this.runPromise = services
+      ? Effect.runPromiseWith(services)
+      : Effect.runPromise;
   }
 
-  async startSession(input: CodexAppServerStartSessionInput): Promise<ProviderSession> {
+  async startSession(
+    input: CodexAppServerStartSessionInput,
+  ): Promise<ProviderSession> {
     const threadId = input.threadId;
     const now = new Date().toISOString();
     let context: CodexSessionContext | undefined;
@@ -578,19 +648,35 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       this.sessions.set(threadId, context);
       this.attachProcessListeners(context);
 
-      this.emitLifecycleEvent(context, "session/connecting", "Starting codex app-server");
+      this.emitLifecycleEvent(
+        context,
+        "session/connecting",
+        "Starting codex app-server",
+      );
 
-      await this.sendRequest(context, "initialize", buildCodexInitializeParams());
+      await this.sendRequest(
+        context,
+        "initialize",
+        buildCodexInitializeParams(),
+      );
 
       this.writeMessage(context, { method: "initialized" });
       try {
-        const modelListResponse = await this.sendRequest(context, "model/list", {});
+        const modelListResponse = await this.sendRequest(
+          context,
+          "model/list",
+          {},
+        );
         console.log("codex model/list response", modelListResponse);
       } catch (error) {
         console.log("codex model/list failed", error);
       }
       try {
-        const accountReadResponse = await this.sendRequest(context, "account/read", {});
+        const accountReadResponse = await this.sendRequest(
+          context,
+          "account/read",
+          {},
+        );
         console.log("codex account/read response", accountReadResponse);
         context.account = readCodexAccountSnapshot(accountReadResponse);
         console.log("codex subscription status", {
@@ -608,7 +694,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       );
       const sessionOverrides = {
         model: normalizedModel ?? null,
-        ...(input.serviceTier !== undefined ? { serviceTier: input.serviceTier } : {}),
+        ...(input.serviceTier !== undefined
+          ? { serviceTier: input.serviceTier }
+          : {}),
         cwd: input.cwd ?? null,
         ...mapCodexRuntimeMode(input.runtimeMode ?? "full-access"),
       };
@@ -638,16 +726,22 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       if (resumeThreadId) {
         try {
           threadOpenMethod = "thread/resume";
-          threadOpenResponse = await this.sendRequest(context, "thread/resume", {
-            ...sessionOverrides,
-            threadId: resumeThreadId,
-          });
+          threadOpenResponse = await this.sendRequest(
+            context,
+            "thread/resume",
+            {
+              ...sessionOverrides,
+              threadId: resumeThreadId,
+            },
+          );
         } catch (error) {
           if (!isRecoverableThreadResumeError(error)) {
             this.emitErrorEvent(
               context,
               "session/threadResumeFailed",
-              error instanceof Error ? error.message : "Codex thread resume failed.",
+              error instanceof Error
+                ? error.message
+                : "Codex thread resume failed.",
             );
             await Effect.logWarning("codex app-server thread resume failed", {
               threadId,
@@ -665,18 +759,29 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
             "session/threadResumeFallback",
             `Could not resume thread ${resumeThreadId}; started a new thread instead.`,
           );
-          await Effect.logWarning("codex app-server thread resume fell back to fresh start", {
-            threadId,
-            requestedRuntimeMode: input.runtimeMode,
-            resumeThreadId,
-            recoverable: true,
-            cause: error instanceof Error ? error.message : String(error),
-          }).pipe(this.runPromise);
-          threadOpenResponse = await this.sendRequest(context, "thread/start", threadStartParams);
+          await Effect.logWarning(
+            "codex app-server thread resume fell back to fresh start",
+            {
+              threadId,
+              requestedRuntimeMode: input.runtimeMode,
+              resumeThreadId,
+              recoverable: true,
+              cause: error instanceof Error ? error.message : String(error),
+            },
+          ).pipe(this.runPromise);
+          threadOpenResponse = await this.sendRequest(
+            context,
+            "thread/start",
+            threadStartParams,
+          );
         }
       } else {
         threadOpenMethod = "thread/start";
-        threadOpenResponse = await this.sendRequest(context, "thread/start", threadStartParams);
+        threadOpenResponse = await this.sendRequest(
+          context,
+          "thread/start",
+          threadStartParams,
+        );
       }
 
       const threadOpenRecord = this.readObject(threadOpenResponse);
@@ -684,7 +789,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         this.readString(this.readObject(threadOpenRecord, "thread"), "id") ??
         this.readString(threadOpenRecord, "threadId");
       if (!threadIdRaw) {
-        throw new Error(`${threadOpenMethod} response did not include a thread id.`);
+        throw new Error(
+          `${threadOpenMethod} response did not include a thread id.`,
+        );
       }
       const providerThreadId = threadIdRaw;
 
@@ -704,10 +811,17 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         resolvedThreadId: providerThreadId,
         requestedRuntimeMode: input.runtimeMode,
       }).pipe(this.runPromise);
-      this.emitLifecycleEvent(context, "session/ready", `Connected to thread ${providerThreadId}`);
+      this.emitLifecycleEvent(
+        context,
+        "session/ready",
+        `Connected to thread ${providerThreadId}`,
+      );
       return { ...context.session };
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to start Codex session.";
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to start Codex session.";
       if (context) {
         this.updateSession(context, {
           status: "error",
@@ -730,11 +844,14 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
   }
 
-  async sendTurn(input: CodexAppServerSendTurnInput): Promise<ProviderTurnStartResult> {
+  async sendTurn(
+    input: CodexAppServerSendTurnInput,
+  ): Promise<ProviderTurnStartResult> {
     const context = this.requireSession(input.threadId);
 
     const turnInput: Array<
-      { type: "text"; text: string; text_elements: [] } | { type: "image"; url: string }
+      | { type: "text"; text: string; text_elements: [] }
+      | { type: "image"; url: string }
     > = [];
     if (input.input) {
       turnInput.push({
@@ -766,7 +883,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     const turnStartParams: {
       threadId: string;
       input: Array<
-        { type: "text"; text: string; text_elements: [] } | { type: "image"; url: string }
+        | { type: "text"; text: string; text_elements: [] }
+        | { type: "image"; url: string }
       >;
       model?: string;
       serviceTier?: string | null;
@@ -797,7 +915,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       turnStartParams.effort = input.effort;
     }
     const collaborationMode = buildCodexCollaborationMode({
-      ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
+      ...(input.interactionMode !== undefined
+        ? { interactionMode: input.interactionMode }
+        : {}),
       ...(normalizedModel !== undefined ? { model: normalizedModel } : {}),
       ...(input.effort !== undefined ? { effort: input.effort } : {}),
     });
@@ -808,7 +928,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       turnStartParams.collaborationMode = collaborationMode;
     }
 
-    const response = await this.sendRequest(context, "turn/start", turnStartParams);
+    const response = await this.sendRequest(
+      context,
+      "turn/start",
+      turnStartParams,
+    );
 
     const turn = this.readObject(this.readObject(response), "turn");
     const turnIdRaw = this.readString(turn, "id");
@@ -871,7 +995,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     return this.parseThreadSnapshot("thread/read", response);
   }
 
-  async rollbackThread(threadId: ThreadId, numTurns: number): Promise<CodexThreadSnapshot> {
+  async rollbackThread(
+    threadId: ThreadId,
+    numTurns: number,
+  ): Promise<CodexThreadSnapshot> {
     const context = this.requireSession(threadId);
     const providerThreadId = readResumeThreadId({
       threadId: context.session.threadId,
@@ -1145,13 +1272,17 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         this.readString(this.readObject(notification.params)?.thread, "id"),
       );
       if (providerThreadId) {
-        this.updateSession(context, { resumeCursor: { threadId: providerThreadId } });
+        this.updateSession(context, {
+          resumeCursor: { threadId: providerThreadId },
+        });
       }
       return;
     }
 
     if (notification.method === "turn/started") {
-      const turnId = toTurnId(this.readString(this.readObject(notification.params)?.turn, "id"));
+      const turnId = toTurnId(
+        this.readString(this.readObject(notification.params)?.turn, "id"),
+      );
       this.updateSession(context, {
         status: "running",
         activeTurnId: turnId,
@@ -1162,7 +1293,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     if (notification.method === "turn/completed") {
       const turn = this.readObject(notification.params, "turn");
       const status = this.readString(turn, "status");
-      const errorMessage = this.readString(this.readObject(turn, "error"), "message");
+      const errorMessage = this.readString(
+        this.readObject(turn, "error"),
+        "message",
+      );
       this.updateSession(context, {
         status: status === "failed" ? "error" : "ready",
         activeTurnId: undefined,
@@ -1172,7 +1306,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     if (notification.method === "error") {
-      const message = this.readString(this.readObject(notification.params)?.error, "message");
+      const message = this.readString(
+        this.readObject(notification.params)?.error,
+        "message",
+      );
       const willRetry = this.readBoolean(notification.params, "willRetry");
 
       this.updateSession(context, {
@@ -1182,7 +1319,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
   }
 
-  private handleServerRequest(context: CodexSessionContext, request: JsonRpcRequest): void {
+  private handleServerRequest(
+    context: CodexSessionContext,
+    request: JsonRpcRequest,
+  ): void {
     const route = this.readRouteFields(request.params);
     const requestKind = this.requestKindForMethod(request.method);
     let requestId: ApprovalRequestId | undefined;
@@ -1247,7 +1387,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     });
   }
 
-  private handleResponse(context: CodexSessionContext, response: JsonRpcResponse): void {
+  private handleResponse(
+    context: CodexSessionContext,
+    response: JsonRpcResponse,
+  ): void {
     const key = String(response.id);
     const pending = context.pending.get(key);
     if (!pending) {
@@ -1258,7 +1401,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     context.pending.delete(key);
 
     if (response.error?.message) {
-      pending.reject(new Error(`${pending.method} failed: ${String(response.error.message)}`));
+      pending.reject(
+        new Error(
+          `${pending.method} failed: ${String(response.error.message)}`,
+        ),
+      );
       return;
     }
 
@@ -1305,7 +1452,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     context.child.stdin.write(`${encoded}\n`);
   }
 
-  private emitLifecycleEvent(context: CodexSessionContext, method: string, message: string): void {
+  private emitLifecycleEvent(
+    context: CodexSessionContext,
+    method: string,
+    message: string,
+  ): void {
     this.emitEvent({
       id: EventId.makeUnsafe(randomUUID()),
       kind: "session",
@@ -1317,7 +1468,11 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     });
   }
 
-  private emitErrorEvent(context: CodexSessionContext, method: string, message: string): void {
+  private emitErrorEvent(
+    context: CodexSessionContext,
+    method: string,
+    message: string,
+  ): void {
     this.emitEvent({
       id: EventId.makeUnsafe(randomUUID()),
       kind: "error",
@@ -1341,7 +1496,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     assertSupportedCodexCliVersion(input);
   }
 
-  private updateSession(context: CodexSessionContext, updates: Partial<ProviderSession>): void {
+  private updateSession(
+    context: CodexSessionContext,
+    updates: Partial<ProviderSession>,
+  ): void {
     context.session = {
       ...context.session,
       ...updates,
@@ -1349,7 +1507,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     };
   }
 
-  private requestKindForMethod(method: string): ProviderRequestKind | undefined {
+  private requestKindForMethod(
+    method: string,
+  ): ProviderRequestKind | undefined {
     if (method === "item/commandExecution/requestApproval") {
       return "command";
     }
@@ -1365,19 +1525,26 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     return undefined;
   }
 
-  private parseThreadSnapshot(method: string, response: unknown): CodexThreadSnapshot {
+  private parseThreadSnapshot(
+    method: string,
+    response: unknown,
+  ): CodexThreadSnapshot {
     const responseRecord = this.readObject(response);
     const thread = this.readObject(responseRecord, "thread");
     const threadIdRaw =
-      this.readString(thread, "id") ?? this.readString(responseRecord, "threadId");
+      this.readString(thread, "id") ??
+      this.readString(responseRecord, "threadId");
     if (!threadIdRaw) {
       throw new Error(`${method} response did not include a thread id.`);
     }
     const turnsRaw =
-      this.readArray(thread, "turns") ?? this.readArray(responseRecord, "turns") ?? [];
+      this.readArray(thread, "turns") ??
+      this.readArray(responseRecord, "turns") ??
+      [];
     const turns = turnsRaw.map((turnValue, index) => {
       const turn = this.readObject(turnValue);
-      const turnIdRaw = this.readString(turn, "id") ?? `${threadIdRaw}:turn:${index + 1}`;
+      const turnIdRaw =
+        this.readString(turn, "id") ?? `${threadIdRaw}:turn:${index + 1}`;
       const turnId = TurnId.makeUnsafe(turnIdRaw);
       const items = this.readArray(turn, "items") ?? [];
       return {
@@ -1419,7 +1586,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     const candidate = value as Record<string, unknown>;
-    const hasId = typeof candidate.id === "string" || typeof candidate.id === "number";
+    const hasId =
+      typeof candidate.id === "string" || typeof candidate.id === "number";
     const hasMethod = typeof candidate.method === "string";
     return hasId && !hasMethod;
   }
@@ -1434,10 +1602,12 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     } = {};
 
     const turnId = toTurnId(
-      this.readString(params, "turnId") ?? this.readString(this.readObject(params, "turn"), "id"),
+      this.readString(params, "turnId") ??
+        this.readString(this.readObject(params, "turn"), "id"),
     );
     const itemId = toProviderItemId(
-      this.readString(params, "itemId") ?? this.readString(this.readObject(params, "item"), "id"),
+      this.readString(params, "itemId") ??
+        this.readString(this.readObject(params, "item"), "id"),
     );
 
     if (turnId) {
@@ -1451,7 +1621,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     return route;
   }
 
-  private readObject(value: unknown, key?: string): Record<string, unknown> | undefined {
+  private readObject(
+    value: unknown,
+    key?: string,
+  ): Record<string, unknown> | undefined {
     const target =
       key === undefined
         ? value
@@ -1503,7 +1676,9 @@ function brandIfNonEmpty<T extends string>(
   return normalized?.length ? maker(normalized) : undefined;
 }
 
-function normalizeProviderThreadId(value: string | undefined): string | undefined {
+function normalizeProviderThreadId(
+  value: string | undefined,
+): string | undefined {
   return brandIfNonEmpty(value, (normalized) => normalized);
 }
 
@@ -1546,7 +1721,9 @@ function assertSupportedCodexCliVersion(input: {
       lower.includes("command not found") ||
       lower.includes("not found")
     ) {
-      throw new Error(`Codex CLI (${input.binaryPath}) is not installed or not executable.`);
+      throw new Error(
+        `Codex CLI (${input.binaryPath}) is not installed or not executable.`,
+      );
     }
     throw new Error(
       `Failed to execute Codex CLI version check: ${result.error.message || String(result.error)}`,
@@ -1556,7 +1733,10 @@ function assertSupportedCodexCliVersion(input: {
   const stdout = result.stdout ?? "";
   const stderr = result.stderr ?? "";
   if (result.status !== 0) {
-    const detail = stderr.trim() || stdout.trim() || `Command exited with code ${result.status}.`;
+    const detail =
+      stderr.trim() ||
+      stdout.trim() ||
+      `Command exited with code ${result.status}.`;
     throw new Error(`Codex CLI version check failed. ${detail}`);
   }
 
@@ -1567,14 +1747,22 @@ function assertSupportedCodexCliVersion(input: {
 }
 
 function readResumeCursorThreadId(resumeCursor: unknown): string | undefined {
-  if (!resumeCursor || typeof resumeCursor !== "object" || Array.isArray(resumeCursor)) {
+  if (
+    !resumeCursor ||
+    typeof resumeCursor !== "object" ||
+    Array.isArray(resumeCursor)
+  ) {
     return undefined;
   }
   const rawThreadId = (resumeCursor as Record<string, unknown>).threadId;
-  return typeof rawThreadId === "string" ? normalizeProviderThreadId(rawThreadId) : undefined;
+  return typeof rawThreadId === "string"
+    ? normalizeProviderThreadId(rawThreadId)
+    : undefined;
 }
 
-function readResumeThreadId(input: CodexAppServerStartSessionInput): string | undefined {
+function readResumeThreadId(
+  input: CodexAppServerStartSessionInput,
+): string | undefined {
   return readResumeCursorThreadId(input.resumeCursor);
 }
 
@@ -1582,6 +1770,8 @@ function toTurnId(value: string | undefined): TurnId | undefined {
   return brandIfNonEmpty(value, TurnId.makeUnsafe);
 }
 
-function toProviderItemId(value: string | undefined): ProviderItemId | undefined {
+function toProviderItemId(
+  value: string | undefined,
+): ProviderItemId | undefined {
   return brandIfNonEmpty(value, ProviderItemId.makeUnsafe);
 }


### PR DESCRIPTION
## Summary
- map runtime-mode enums to the Codex app-server camelCase variants
- normalize `sandbox_mode` user-input answers before sending them back
- add focused coverage for both mappings

## Validation
- `bunx vitest run apps/server/src/codexAppServerManager.test.ts`
- `bun run lint`
- `bun run typecheck`

Closes #453

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Map canonical sandbox modes and runtime approval policy to Codex app-server enums for thread/start in `apps/server/src/codexAppServerManager.ts`
> Introduce `toCodexAppServerSandboxMode` and `toCodexAppServerSandboxModeValue`; update `mapCodexRuntimeMode` to return `approvalPolicy` and `sandbox` camelCase enums; convert `sandbox_mode` answers in `toCodexUserInputAnswers`; add tests in [codexAppServerManager.test.ts](https://github.com/pingdotgg/t3code/pull/541/files#diff-e0b57ec17b32e60d14081ebeb4bcfb13db511905869ef4ffbd669b229c0bb2c1).
>
> #### 📍Where to Start
> Start with `mapCodexRuntimeMode` and `toCodexAppServerSandboxMode` in [codexAppServerManager.ts](https://github.com/pingdotgg/t3code/pull/541/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9), then review new assertions in [codexAppServerManager.test.ts](https://github.com/pingdotgg/t3code/pull/541/files#diff-e0b57ec17b32e60d14081ebeb4bcfb13db511905869ef4ffbd669b229c0bb2c1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec2ff6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->