### PR TITLE
Add Debian desktop packaging support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,11 @@ jobs:
             platform: linux
             target: AppImage
             arch: x64
+          - label: Linux x64 deb
+            runner: ubuntu-24.04
+            platform: linux
+            target: deb
+            arch: x64
           - label: Windows x64
             runner: windows-2022
             platform: win
@@ -199,6 +204,7 @@ jobs:
             "release/*.dmg" \
             "release/*.zip" \
             "release/*.AppImage" \
+            "release/*.deb" \
             "release/*.exe" \
             "release/*.blockmap" \
             "release/latest*.yml"; do
@@ -216,7 +222,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-${{ matrix.platform }}-${{ matrix.arch }}
+          name: desktop-${{ matrix.platform }}-${{ matrix.target }}-${{ matrix.arch }}
           path: release-publish/*
           if-no-files-found: error
 
@@ -275,6 +281,7 @@ jobs:
             release-assets/*.dmg
             release-assets/*.zip
             release-assets/*.AppImage
+            release-assets/*.deb
             release-assets/*.exe
             release-assets/*.blockmap
             release-assets/latest*.yml

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "dist:desktop:dmg": "node scripts/build-desktop-artifact.ts --platform mac --target dmg",
     "dist:desktop:dmg:arm64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch arm64",
     "dist:desktop:dmg:x64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch x64",
+    "dist:desktop:deb": "node scripts/build-desktop-artifact.ts --platform linux --target deb --arch x64",
     "dist:desktop:linux": "node scripts/build-desktop-artifact.ts --platform linux --target AppImage --arch x64",
     "dist:desktop:win": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules apps/*/dist apps/*/dist-electron packages/*/dist .turbo apps/*/.turbo packages/*/.turbo",

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -13,7 +13,17 @@ import { resolveCatalogDependencies } from "./lib/resolve-catalog.ts";
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { Config, Data, Effect, FileSystem, Layer, Logger, Option, Path, Schema } from "effect";
+import {
+  Config,
+  Data,
+  Effect,
+  FileSystem,
+  Layer,
+  Logger,
+  Option,
+  Path,
+  Schema,
+} from "effect";
 import { Command, Flag } from "effect/unstable/cli";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
@@ -23,18 +33,23 @@ const BuildArch = Schema.Literals(["arm64", "x64", "universal"]);
 const RepoRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("..", import.meta.url))),
 );
-const ProductionMacIconSource = Effect.zipWith(RepoRoot, Effect.service(Path.Path), (repoRoot, path) =>
-  path.join(repoRoot, BRAND_ASSET_PATHS.productionMacIconPng),
+const ProductionMacIconSource = Effect.zipWith(
+  RepoRoot,
+  Effect.service(Path.Path),
+  (repoRoot, path) =>
+    path.join(repoRoot, BRAND_ASSET_PATHS.productionMacIconPng),
 );
 const ProductionLinuxIconSource = Effect.zipWith(
   RepoRoot,
   Effect.service(Path.Path),
-  (repoRoot, path) => path.join(repoRoot, BRAND_ASSET_PATHS.productionLinuxIconPng),
+  (repoRoot, path) =>
+    path.join(repoRoot, BRAND_ASSET_PATHS.productionLinuxIconPng),
 );
 const ProductionWindowsIconSource = Effect.zipWith(
   RepoRoot,
   Effect.service(Path.Path),
-  (repoRoot, path) => path.join(repoRoot, BRAND_ASSET_PATHS.productionWindowsIconIco),
+  (repoRoot, path) =>
+    path.join(repoRoot, BRAND_ASSET_PATHS.productionWindowsIconIco),
 );
 const encodeJsonString = Schema.encodeEffect(Schema.UnknownFromJsonString);
 
@@ -74,14 +89,18 @@ interface BuildCliInput {
   readonly verbose: Option.Option<boolean>;
 }
 
-function detectHostBuildPlatform(hostPlatform: string): typeof BuildPlatform.Type | undefined {
+function detectHostBuildPlatform(
+  hostPlatform: string,
+): typeof BuildPlatform.Type | undefined {
   if (hostPlatform === "darwin") return "mac";
   if (hostPlatform === "linux") return "linux";
   if (hostPlatform === "win32") return "win";
   return undefined;
 }
 
-function getDefaultArch(platform: typeof BuildPlatform.Type): typeof BuildArch.Type {
+function getDefaultArch(
+  platform: typeof BuildPlatform.Type,
+): typeof BuildArch.Type {
   const config = PLATFORM_CONFIG[platform];
   if (!config) {
     return "x64";
@@ -126,8 +145,19 @@ function resolvePythonForNodeGyp(): string | undefined {
   if (process.platform === "win32") {
     const localAppData = process.env.LOCALAPPDATA;
     if (localAppData) {
-      for (const version of ["Python313", "Python312", "Python311", "Python310"]) {
-        const candidate = join(localAppData, "Programs", "Python", version, "python.exe");
+      for (const version of [
+        "Python313",
+        "Python312",
+        "Python311",
+        "Python310",
+      ]) {
+        const candidate = join(
+          localAppData,
+          "Programs",
+          "Python",
+          version,
+          "python.exe",
+        );
         if (existsSync(candidate)) {
           return candidate;
         }
@@ -135,9 +165,13 @@ function resolvePythonForNodeGyp(): string | undefined {
     }
   }
 
-  const probe = spawnSync("python", ["-c", "import sys;print(sys.executable)"], {
-    encoding: "utf8",
-  });
+  const probe = spawnSync(
+    "python",
+    ["-c", "import sys;print(sys.executable)"],
+    {
+      encoding: "utf8",
+    },
+  );
   if (probe.status !== 0) {
     return undefined;
   }
@@ -169,7 +203,11 @@ interface StagePackageJson {
   readonly t3codeCommitHash: string;
   readonly private: true;
   readonly description: string;
-  readonly author: string;
+  readonly homepage: string;
+  readonly author: {
+    readonly name: string;
+    readonly email: string;
+  };
   readonly main: string;
   readonly build: Record<string, unknown>;
   readonly dependencies: Record<string, unknown>;
@@ -181,35 +219,69 @@ interface StagePackageJson {
 const AzureTrustedSigningOptionsConfig = Config.all({
   publisherName: Config.string("AZURE_TRUSTED_SIGNING_PUBLISHER_NAME"),
   endpoint: Config.string("AZURE_TRUSTED_SIGNING_ENDPOINT"),
-  certificateProfileName: Config.string("AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME"),
+  certificateProfileName: Config.string(
+    "AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME",
+  ),
   codeSigningAccountName: Config.string("AZURE_TRUSTED_SIGNING_ACCOUNT_NAME"),
-  fileDigest: Config.string("AZURE_TRUSTED_SIGNING_FILE_DIGEST").pipe(Config.withDefault("SHA256")),
+  fileDigest: Config.string("AZURE_TRUSTED_SIGNING_FILE_DIGEST").pipe(
+    Config.withDefault("SHA256"),
+  ),
   timestampDigest: Config.string("AZURE_TRUSTED_SIGNING_TIMESTAMP_DIGEST").pipe(
     Config.withDefault("SHA256"),
   ),
-  timestampRfc3161: Config.string("AZURE_TRUSTED_SIGNING_TIMESTAMP_RFC3161").pipe(
-    Config.withDefault("http://timestamp.acs.microsoft.com"),
-  ),
+  timestampRfc3161: Config.string(
+    "AZURE_TRUSTED_SIGNING_TIMESTAMP_RFC3161",
+  ).pipe(Config.withDefault("http://timestamp.acs.microsoft.com")),
 });
 
 const BuildEnvConfig = Config.all({
-  platform: Config.schema(BuildPlatform, "T3CODE_DESKTOP_PLATFORM").pipe(Config.option),
+  platform: Config.schema(BuildPlatform, "T3CODE_DESKTOP_PLATFORM").pipe(
+    Config.option,
+  ),
   target: Config.string("T3CODE_DESKTOP_TARGET").pipe(Config.option),
   arch: Config.schema(BuildArch, "T3CODE_DESKTOP_ARCH").pipe(Config.option),
   version: Config.string("T3CODE_DESKTOP_VERSION").pipe(Config.option),
   outputDir: Config.string("T3CODE_DESKTOP_OUTPUT_DIR").pipe(Config.option),
-  skipBuild: Config.boolean("T3CODE_DESKTOP_SKIP_BUILD").pipe(Config.withDefault(false)),
-  keepStage: Config.boolean("T3CODE_DESKTOP_KEEP_STAGE").pipe(Config.withDefault(false)),
-  signed: Config.boolean("T3CODE_DESKTOP_SIGNED").pipe(Config.withDefault(false)),
-  verbose: Config.boolean("T3CODE_DESKTOP_VERBOSE").pipe(Config.withDefault(false)),
+  skipBuild: Config.boolean("T3CODE_DESKTOP_SKIP_BUILD").pipe(
+    Config.withDefault(false),
+  ),
+  keepStage: Config.boolean("T3CODE_DESKTOP_KEEP_STAGE").pipe(
+    Config.withDefault(false),
+  ),
+  signed: Config.boolean("T3CODE_DESKTOP_SIGNED").pipe(
+    Config.withDefault(false),
+  ),
+  verbose: Config.boolean("T3CODE_DESKTOP_VERBOSE").pipe(
+    Config.withDefault(false),
+  ),
+});
+
+const BuildMetadataConfig = Config.all({
+  homepage: Config.string("T3CODE_DESKTOP_HOMEPAGE").pipe(
+    Config.withDefault("https://github.com/pingdotgg/t3code"),
+  ),
+  authorName: Config.string("T3CODE_DESKTOP_AUTHOR_NAME").pipe(
+    Config.withDefault("T3 Tools"),
+  ),
+  authorEmail: Config.string("T3CODE_DESKTOP_AUTHOR_EMAIL").pipe(
+    Config.withDefault("noreply@example.com"),
+  ),
+  linuxMaintainer: Config.string("T3CODE_DESKTOP_LINUX_MAINTAINER").pipe(
+    Config.option,
+  ),
 });
 
 const resolveBooleanFlag = (flag: Option.Option<boolean>, envValue: boolean) =>
   Option.getOrElse(Option.filter(flag, Boolean), () => envValue);
-const mergeOptions = <A>(a: Option.Option<A>, b: Option.Option<A>, defaultValue: A) =>
-  Option.getOrElse(a, () => Option.getOrElse(b, () => defaultValue));
+const mergeOptions = <A>(
+  a: Option.Option<A>,
+  b: Option.Option<A>,
+  defaultValue: A,
+) => Option.getOrElse(a, () => Option.getOrElse(b, () => defaultValue));
 
-const resolveBuildOptions = Effect.fn("resolveBuildOptions")(function* (input: BuildCliInput) {
+const resolveBuildOptions = Effect.fn("resolveBuildOptions")(function* (
+  input: BuildCliInput,
+) {
   const path = yield* Path.Path;
   const repoRoot = yield* RepoRoot;
   const env = yield* BuildEnvConfig.asEffect();
@@ -226,10 +298,17 @@ const resolveBuildOptions = Effect.fn("resolveBuildOptions")(function* (input: B
     });
   }
 
-  const target = mergeOptions(input.target, env.target, PLATFORM_CONFIG[platform].defaultTarget);
+  const target = mergeOptions(
+    input.target,
+    env.target,
+    PLATFORM_CONFIG[platform].defaultTarget,
+  );
   const arch = mergeOptions(input.arch, env.arch, getDefaultArch(platform));
   const version = mergeOptions(input.buildVersion, env.version, undefined);
-  const outputDir = path.resolve(repoRoot, mergeOptions(input.outputDir, env.outputDir, "release"));
+  const outputDir = path.resolve(
+    repoRoot,
+    mergeOptions(input.outputDir, env.outputDir, "release"),
+  );
 
   const skipBuild = resolveBooleanFlag(input.skipBuild, env.skipBuild);
   const keepStage = resolveBooleanFlag(input.keepStage, env.keepStage);
@@ -255,7 +334,9 @@ const commandOutputOptions = (verbose: boolean) =>
     stderr: "inherit",
   }) as const;
 
-const runCommand = Effect.fn("runCommand")(function* (command: ChildProcess.Command) {
+const runCommand = Effect.fn("runCommand")(function* (
+  command: ChildProcess.Command,
+) {
   const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const child = yield* commandSpawner.spawn(command);
   const exitCode = yield* child.exitCode;
@@ -377,8 +458,16 @@ function validateBundledClientAssets(clientDir: string) {
     for (const ref of refs) {
       const normalizedRef = ref.split("#")[0]?.split("?")[0] ?? "";
       if (!normalizedRef) continue;
-      if (normalizedRef.startsWith("http://") || normalizedRef.startsWith("https://")) continue;
-      if (normalizedRef.startsWith("data:") || normalizedRef.startsWith("mailto:")) continue;
+      if (
+        normalizedRef.startsWith("http://") ||
+        normalizedRef.startsWith("https://")
+      )
+        continue;
+      if (
+        normalizedRef.startsWith("data:") ||
+        normalizedRef.startsWith("mailto:")
+      )
+        continue;
 
       const ext = path.extname(normalizedRef);
       if (!ext) continue;
@@ -409,10 +498,16 @@ function resolveDesktopRuntimeDependencies(
   }
 
   const runtimeDependencies = Object.fromEntries(
-    Object.entries(dependencies).filter(([dependencyName]) => dependencyName !== "electron"),
+    Object.entries(dependencies).filter(
+      ([dependencyName]) => dependencyName !== "electron",
+    ),
   );
 
-  return resolveCatalogDependencies(runtimeDependencies, catalog, "apps/desktop");
+  return resolveCatalogDependencies(
+    runtimeDependencies,
+    catalog,
+    "apps/desktop",
+  );
 }
 
 function resolveGitHubPublishConfig():
@@ -446,6 +541,11 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   productName: string,
   signed: boolean,
 ) {
+  const metadata = yield* BuildMetadataConfig.asEffect();
+  const linuxMaintainer = Option.getOrElse(
+    metadata.linuxMaintainer,
+    () => `${metadata.authorName} <${metadata.authorEmail}>`,
+  );
   const buildConfig: Record<string, unknown> = {
     appId: "com.t3tools.t3code",
     productName,
@@ -472,6 +572,7 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       target: [target],
       icon: "icon.png",
       category: "Development",
+      maintainer: linuxMaintainer,
     };
   }
 
@@ -489,25 +590,27 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   return buildConfig;
 });
 
-const assertPlatformBuildResources = Effect.fn("assertPlatformBuildResources")(function* (
-  platform: typeof BuildPlatform.Type,
-  stageResourcesDir: string,
-  verbose: boolean,
-) {
-  if (platform === "mac") {
-    yield* stageMacIcons(stageResourcesDir, verbose);
-    return;
-  }
+const assertPlatformBuildResources = Effect.fn("assertPlatformBuildResources")(
+  function* (
+    platform: typeof BuildPlatform.Type,
+    stageResourcesDir: string,
+    verbose: boolean,
+  ) {
+    if (platform === "mac") {
+      yield* stageMacIcons(stageResourcesDir, verbose);
+      return;
+    }
 
-  if (platform === "linux") {
-    yield* stageLinuxIcons(stageResourcesDir);
-    return;
-  }
+    if (platform === "linux") {
+      yield* stageLinuxIcons(stageResourcesDir);
+      return;
+    }
 
-  if (platform === "win") {
-    yield* stageWindowsIcons(stageResourcesDir);
-  }
-});
+    if (platform === "win") {
+      yield* stageWindowsIcons(stageResourcesDir);
+    }
+  },
+);
 
 const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   options: ResolvedBuildOptions,
@@ -528,7 +631,8 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const serverDependencies = serverPackageJson.dependencies;
   if (!serverDependencies || Object.keys(serverDependencies).length === 0) {
     return yield* new BuildScriptError({
-      message: "Could not resolve production dependencies from apps/server/package.json.",
+      message:
+        "Could not resolve production dependencies from apps/server/package.json.",
     });
   }
 
@@ -541,7 +645,8 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       ),
     catch: (cause) =>
       new BuildScriptError({
-        message: "Could not resolve production dependencies from apps/server/package.json.",
+        message:
+          "Could not resolve production dependencies from apps/server/package.json.",
         cause,
       }),
   });
@@ -553,14 +658,18 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       ),
     catch: (cause) =>
       new BuildScriptError({
-        message: "Could not resolve desktop runtime dependencies from apps/desktop/package.json.",
+        message:
+          "Could not resolve desktop runtime dependencies from apps/desktop/package.json.",
         cause,
       }),
   });
+  const buildMetadata = yield* BuildMetadataConfig.asEffect();
 
   const appVersion = options.version ?? serverPackageJson.version;
   const commitHash = resolveGitCommitHash(repoRoot);
-  const mkdir = options.keepStage ? fs.makeTempDirectory : fs.makeTempDirectoryScoped;
+  const mkdir = options.keepStage
+    ? fs.makeTempDirectory
+    : fs.makeTempDirectoryScoped;
   const stageRoot = yield* mkdir({
     prefix: `t3code-desktop-${options.platform}-stage-`,
   });
@@ -572,10 +681,15 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     desktopResources: path.join(repoRoot, "apps/desktop/resources"),
     serverDist: path.join(repoRoot, "apps/server/dist"),
   };
-  const bundledClientEntry = path.join(distDirs.serverDist, "client/index.html");
+  const bundledClientEntry = path.join(
+    distDirs.serverDist,
+    "client/index.html",
+  );
 
   if (!options.skipBuild) {
-    yield* Effect.log("[desktop-artifact] Building desktop/server/web artifacts...");
+    yield* Effect.log(
+      "[desktop-artifact] Building desktop/server/web artifacts...",
+    );
     yield* runCommand(
       ChildProcess.make({
         cwd: repoRoot,
@@ -600,15 +714,29 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
 
   yield* validateBundledClientAssets(path.dirname(bundledClientEntry));
 
-  yield* fs.makeDirectory(path.join(stageAppDir, "apps/desktop"), { recursive: true });
-  yield* fs.makeDirectory(path.join(stageAppDir, "apps/server"), { recursive: true });
+  yield* fs.makeDirectory(path.join(stageAppDir, "apps/desktop"), {
+    recursive: true,
+  });
+  yield* fs.makeDirectory(path.join(stageAppDir, "apps/server"), {
+    recursive: true,
+  });
 
   yield* Effect.log("[desktop-artifact] Staging release app...");
-  yield* fs.copy(distDirs.desktopDist, path.join(stageAppDir, "apps/desktop/dist-electron"));
+  yield* fs.copy(
+    distDirs.desktopDist,
+    path.join(stageAppDir, "apps/desktop/dist-electron"),
+  );
   yield* fs.copy(distDirs.desktopResources, stageResourcesDir);
-  yield* fs.copy(distDirs.serverDist, path.join(stageAppDir, "apps/server/dist"));
+  yield* fs.copy(
+    distDirs.serverDist,
+    path.join(stageAppDir, "apps/server/dist"),
+  );
 
-  yield* assertPlatformBuildResources(options.platform, stageResourcesDir, options.verbose);
+  yield* assertPlatformBuildResources(
+    options.platform,
+    stageResourcesDir,
+    options.verbose,
+  );
 
   const stagePackageJson: StagePackageJson = {
     name: "t3-code-desktop",
@@ -617,7 +745,11 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     t3codeCommitHash: commitHash,
     private: true,
     description: "T3 Code desktop build",
-    author: "T3 Tools",
+    homepage: buildMetadata.homepage,
+    author: {
+      name: buildMetadata.authorName,
+      email: buildMetadata.authorEmail,
+    },
     main: "apps/desktop/dist-electron/main.js",
     build: yield* createBuildConfig(
       options.platform,
@@ -635,9 +767,14 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   };
 
   const stagePackageJsonString = yield* encodeJsonString(stagePackageJson);
-  yield* fs.writeFileString(path.join(stageAppDir, "package.json"), `${stagePackageJsonString}\n`);
+  yield* fs.writeFileString(
+    path.join(stageAppDir, "package.json"),
+    `${stagePackageJsonString}\n`,
+  );
 
-  yield* Effect.log("[desktop-artifact] Installing staged production dependencies...");
+  yield* Effect.log(
+    "[desktop-artifact] Installing staged production dependencies...",
+  );
   yield* runCommand(
     ChildProcess.make({
       cwd: stageAppDir,
@@ -668,7 +805,8 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       buildEnv.PYTHON = python;
       buildEnv.npm_config_python = python;
     }
-    buildEnv.npm_config_msvs_version = buildEnv.npm_config_msvs_version ?? "2022";
+    buildEnv.npm_config_msvs_version =
+      buildEnv.npm_config_msvs_version ?? "2022";
     buildEnv.GYP_MSVS_VERSION = buildEnv.GYP_MSVS_VERSION ?? "2022";
   }
 
@@ -696,7 +834,9 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const copiedArtifacts: string[] = [];
   for (const entry of stageEntries) {
     const from = path.join(stageDistDir, entry);
-    const stat = yield* fs.stat(from).pipe(Effect.catch(() => Effect.succeed(null)));
+    const stat = yield* fs
+      .stat(from)
+      .pipe(Effect.catch(() => Effect.succeed(null)));
     if (!stat || stat.type !== "File") continue;
 
     const to = path.join(options.outputDir, entry);
@@ -727,15 +867,21 @@ const buildDesktopArtifactCli = Command.make("build-desktop-artifact", {
     Flag.optional,
   ),
   arch: Flag.choice("arch", BuildArch.literals).pipe(
-    Flag.withDescription("Build arch, for example arm64/x64/universal (env: T3CODE_DESKTOP_ARCH)."),
+    Flag.withDescription(
+      "Build arch, for example arm64/x64/universal (env: T3CODE_DESKTOP_ARCH).",
+    ),
     Flag.optional,
   ),
   buildVersion: Flag.string("build-version").pipe(
-    Flag.withDescription("Artifact version metadata (env: T3CODE_DESKTOP_VERSION)."),
+    Flag.withDescription(
+      "Artifact version metadata (env: T3CODE_DESKTOP_VERSION).",
+    ),
     Flag.optional,
   ),
   outputDir: Flag.string("output-dir").pipe(
-    Flag.withDescription("Output directory for artifacts (env: T3CODE_DESKTOP_OUTPUT_DIR)."),
+    Flag.withDescription(
+      "Output directory for artifacts (env: T3CODE_DESKTOP_OUTPUT_DIR).",
+    ),
     Flag.optional,
   ),
   skipBuild: Flag.boolean("skip-build").pipe(
@@ -745,7 +891,9 @@ const buildDesktopArtifactCli = Command.make("build-desktop-artifact", {
     Flag.optional,
   ),
   keepStage: Flag.boolean("keep-stage").pipe(
-    Flag.withDescription("Keep temporary staging files (env: T3CODE_DESKTOP_KEEP_STAGE)."),
+    Flag.withDescription(
+      "Keep temporary staging files (env: T3CODE_DESKTOP_KEEP_STAGE).",
+    ),
     Flag.optional,
   ),
   signed: Flag.boolean("signed").pipe(
@@ -755,15 +903,22 @@ const buildDesktopArtifactCli = Command.make("build-desktop-artifact", {
     Flag.optional,
   ),
   verbose: Flag.boolean("verbose").pipe(
-    Flag.withDescription("Stream subprocess stdout (env: T3CODE_DESKTOP_VERBOSE)."),
+    Flag.withDescription(
+      "Stream subprocess stdout (env: T3CODE_DESKTOP_VERBOSE).",
+    ),
     Flag.optional,
   ),
 }).pipe(
   Command.withDescription("Build a desktop artifact for T3 Code."),
-  Command.withHandler((input) => Effect.flatMap(resolveBuildOptions(input), buildDesktopArtifact)),
+  Command.withHandler((input) =>
+    Effect.flatMap(resolveBuildOptions(input), buildDesktopArtifact),
+  ),
 );
 
-const cliRuntimeLayer = Layer.mergeAll(Logger.layer([Logger.consolePretty()]), NodeServices.layer);
+const cliRuntimeLayer = Layer.mergeAll(
+  Logger.layer([Logger.consolePretty()]),
+  NodeServices.layer,
+);
 
 Command.run(buildDesktopArtifactCli, { version: "0.0.0" }).pipe(
   Effect.scoped,


### PR DESCRIPTION
## Summary
- add a dedicated `dist:desktop:deb` command
- include the Debian metadata electron-builder requires for `.deb` packaging
- publish `.deb` artifacts from the desktop release workflow alongside AppImage builds

## Validation
- `bun run dist:desktop:deb -- --skip-build`
- `bun run lint`
- `bun run typecheck`

Closes #543

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Linux x64 Debian desktop packaging and publish .deb artifacts via CI in [release.yml](https://github.com/pingdotgg/t3code/pull/544/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34)
> Add a Linux x64 `deb` target to the CI matrix and release uploads, introduce `npm run dist:desktop:deb`, and inject `homepage`, structured `author`, and Linux `maintainer` metadata in [scripts/build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/544/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d).
>
> #### 📍Where to Start
> Start with `buildDesktopArtifact` and `BuildMetadataConfig` in [scripts/build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/544/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d), then review the CI matrix and artifact upload changes in [release.yml](https://github.com/pingdotgg/t3code/pull/544/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32eeaed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->