### PR TITLE
fix: avoid duplicating streamed assistant text on completion

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -850,6 +850,96 @@ describe("ProviderRuntimeIngestion", () => {
     expect(finalMessage?.streaming).toBe(false);
   });
 
+  it("does not duplicate streamed assistant text when completion includes full detail", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-streaming-detail"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("message-streaming-detail"),
+          role: "user",
+          text: "stream please",
+          attachments: [],
+        },
+        assistantDeliveryMode: "streaming",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(Effect.sleep("30 millis"));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-detail"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-streaming-detail"),
+    });
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-detail-1"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-streaming-detail"),
+      itemId: asItemId("item-streaming-detail"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "I checked this carefully before generating junk data.",
+      },
+    });
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-detail-2"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-streaming-detail"),
+      itemId: asItemId("item-streaming-detail"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "\n\nWhat’s true right now:",
+      },
+    });
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-streaming-detail"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-streaming-detail"),
+      itemId: asItemId("item-streaming-detail"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+        detail: "I checked this carefully before generating junk data.\n\nWhat’s true right now:",
+      },
+    });
+
+    const finalThread = await waitForThread(harness.engine, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-detail" && !message.streaming,
+      ),
+    );
+    const finalMessage = finalThread.messages.find(
+      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-streaming-detail",
+    );
+    expect(finalMessage?.text).toBe(
+      "I checked this carefully before generating junk data.\n\nWhat’s true right now:",
+    );
+    expect(finalMessage?.streaming).toBe(false);
+  });
+
   it("spills oversized buffered deltas and still finalizes full assistant text", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -32,6 +32,8 @@ const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
 const BUFFERED_PROPOSED_PLAN_BY_ID_CACHE_CAPACITY = 10_000;
 const BUFFERED_PROPOSED_PLAN_BY_ID_TTL = Duration.minutes(120);
+const ASSISTANT_TEXT_SEEN_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
+const ASSISTANT_TEXT_SEEN_BY_MESSAGE_ID_TTL = Duration.minutes(120);
 const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
 const STRICT_PROVIDER_LIFECYCLE_GUARD = process.env.T3CODE_STRICT_PROVIDER_LIFECYCLE_GUARD !== "0";
 
@@ -509,6 +511,12 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed({ text: "", createdAt: "" }),
   });
 
+  const assistantTextSeenByMessageId = yield* Cache.make<MessageId, boolean>({
+    capacity: ASSISTANT_TEXT_SEEN_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: ASSISTANT_TEXT_SEEN_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(false),
+  });
+
   const isGitRepoForThread = Effect.fnUntraced(function* (threadId: ThreadId) {
     const readModel = yield* orchestrationEngine.getReadModel();
     const thread = readModel.threads.find((entry) => entry.id === threadId);
@@ -610,6 +618,17 @@ const make = Effect.gen(function* () {
   const clearBufferedAssistantText = (messageId: MessageId) =>
     Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
 
+  const markAssistantTextSeen = (messageId: MessageId) =>
+    Cache.set(assistantTextSeenByMessageId, messageId, true);
+
+  const hasSeenAssistantText = (messageId: MessageId) =>
+    Cache.getOption(assistantTextSeenByMessageId, messageId).pipe(
+      Effect.map((existing) => Option.getOrElse(existing, () => false)),
+    );
+
+  const clearAssistantTextSeen = (messageId: MessageId) =>
+    Cache.invalidate(assistantTextSeenByMessageId, messageId);
+
   const appendBufferedProposedPlan = (planId: string, delta: string, createdAt: string) =>
     Cache.getOption(bufferedProposedPlanById, planId).pipe(
       Effect.flatMap((existingEntry) => {
@@ -647,10 +666,11 @@ const make = Effect.gen(function* () {
   }) =>
     Effect.gen(function* () {
       const bufferedText = yield* takeBufferedAssistantText(input.messageId);
+      const sawAssistantText = yield* hasSeenAssistantText(input.messageId);
       const text =
         bufferedText.length > 0
           ? bufferedText
-          : (input.fallbackText?.trim().length ?? 0) > 0
+          : !sawAssistantText && (input.fallbackText?.trim().length ?? 0) > 0
             ? input.fallbackText!
             : "";
 
@@ -675,6 +695,7 @@ const make = Effect.gen(function* () {
         createdAt: input.createdAt,
       });
       yield* clearAssistantMessageState(input.messageId);
+      yield* clearAssistantTextSeen(input.messageId);
     });
 
   const upsertProposedPlan = (input: {
@@ -755,6 +776,7 @@ const make = Effect.gen(function* () {
       const proposedPlanPrefix = `plan:${threadId}:`;
       const turnKeys = Array.from(yield* Cache.keys(turnMessageIdsByTurnKey));
       const proposedPlanKeys = Array.from(yield* Cache.keys(bufferedProposedPlanById));
+      const assistantTextSeenKeys = Array.from(yield* Cache.keys(assistantTextSeenByMessageId));
       yield* Effect.forEach(
         turnKeys,
         (key) =>
@@ -780,6 +802,11 @@ const make = Effect.gen(function* () {
           key.startsWith(proposedPlanPrefix)
             ? Cache.invalidate(bufferedProposedPlanById, key)
             : Effect.void,
+        { concurrency: 1 },
+      ).pipe(Effect.asVoid);
+      yield* Effect.forEach(
+        assistantTextSeenKeys,
+        (messageId) => clearAssistantTextSeen(messageId),
         { concurrency: 1 },
       ).pipe(Effect.asVoid);
     });
@@ -895,6 +922,7 @@ const make = Effect.gen(function* () {
         const assistantMessageId = MessageId.makeUnsafe(
           `assistant:${event.itemId ?? event.turnId ?? event.eventId}`,
         );
+        yield* markAssistantTextSeen(assistantMessageId);
         const turnId = toTurnId(event.turnId);
         if (turnId) {
           yield* rememberAssistantMessageId(thread.id, turnId, assistantMessageId);


### PR DESCRIPTION
## Summary

Fixes a streaming-mode bug where assistant text could be duplicated in the final rendered response.

## Root cause

During runtime ingestion:
- `content.delta` events stream assistant text incrementally
- later, `item.completed` may include `payload.detail` containing the full final assistant text
- finalization treated that `detail` as fallback text even when the message had already received streamed assistant deltas

That could append the same content twice in one assistant message.

## Fix

In `ProviderRuntimeIngestion.ts`:
- track whether assistant text has already been seen for each message
- only use `item.completed.payload.detail` as fallback text if **no assistant text was seen earlier**
- clear that state after finalization

## Tests

Added a regression test covering:
- streaming mode enabled
- assistant emits multiple `content.delta` chunks
- `item.completed` includes the full final text in `detail`
- final message should contain the text **once**, not duplicated

## Validation

Ran:
- `npx vitest run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts`

Fixes #546

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent duplicated assistant text in server orchestration by tracking streamed `assistant_text` per message and suppressing fallback completion text in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/547/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7)
> Add a per-message cache with TTL/capacity to record seen `assistant_text` deltas, mark on `content.delta`, consult during `finalizeAssistantTextFromBuffer` to skip fallback text, and clear on completion and session cleanup; add a test covering streaming followed by full detail in [ProviderRuntimeIngestion.test.ts](https://github.com/pingdotgg/t3code/pull/547/files#diff-ea511ca36a45f5254c8f22ac107b5469fed67d652de6af2c5d2763bf00ce53c3).
>
> #### 📍Where to Start
> Start in `processRuntimeEvent` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/547/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7), then review `finalizeAssistantTextFromBuffer` and the new cache helpers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b40f0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->