### PR TITLE
Fix web UUID fallback handling

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0",
+    "uuid": "^13.0.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -187,6 +187,7 @@ import {
 import { toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "./ProjectScriptsControl";
+import { v4 as uuidv4 } from "uuid";
 import {
   commandForProjectScript,
   nextProjectScriptId,
@@ -444,7 +445,7 @@ function readFileAsDataUrl(file: File): Promise<string> {
 
 function buildTemporaryWorktreeBranchName(): string {
   // Keep the 8-hex suffix shape for backend temporary-branch detection.
-  const token = crypto.randomUUID().slice(0, 8).toLowerCase();
+  const token = uuidv4().slice(0, 8).toLowerCase();
   return `${WORKTREE_BRANCH_PREFIX}/${token}`;
 }
 
@@ -1373,13 +1374,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
   }, [activeThreadId, setTerminalOpen, terminalState.terminalOpen]);
   const splitTerminal = useCallback(() => {
     if (!activeThreadId || hasReachedTerminalLimit) return;
-    const terminalId = `terminal-${crypto.randomUUID()}`;
+    const terminalId = `terminal-${uuidv4()}`;
     storeSplitTerminal(activeThreadId, terminalId);
     setTerminalFocusRequestId((value) => value + 1);
   }, [activeThreadId, storeSplitTerminal, hasReachedTerminalLimit]);
   const createNewTerminal = useCallback(() => {
     if (!activeThreadId || hasReachedTerminalLimit) return;
-    const terminalId = `terminal-${crypto.randomUUID()}`;
+    const terminalId = `terminal-${uuidv4()}`;
     storeNewTerminal(activeThreadId, terminalId);
     setTerminalFocusRequestId((value) => value + 1);
   }, [activeThreadId, storeNewTerminal, hasReachedTerminalLimit]);
@@ -1447,9 +1448,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       const wantsNewTerminal = Boolean(options?.preferNewTerminal) || isBaseTerminalBusy;
       const shouldCreateNewTerminal =
         wantsNewTerminal && terminalState.terminalIds.length < MAX_THREAD_TERMINAL_COUNT;
-      const targetTerminalId = shouldCreateNewTerminal
-        ? `terminal-${crypto.randomUUID()}`
-        : baseTerminalId;
+      const targetTerminalId = shouldCreateNewTerminal ? `terminal-${uuidv4()}` : baseTerminalId;
 
       setTerminalOpen(true);
       if (shouldCreateNewTerminal) {
@@ -2274,7 +2273,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       const previewUrl = URL.createObjectURL(file);
       nextImages.push({
         type: "image",
-        id: crypto.randomUUID(),
+        id: uuidv4(),
         name: file.name || "image",
         mimeType: file.type,
         sizeBytes: file.size,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -483,23 +483,25 @@ export default function Sidebar() {
       if (!api) return;
 
       setIsAddingProject(true);
-      const finishAddingProject = () => {
+      const finishAddingProject = (resetInput: boolean) => {
         setIsAddingProject(false);
+        if (!resetInput) return;
         setNewCwd("");
         setAddingProject(false);
       };
 
-      const existing = projects.find((project) => project.cwd === cwd);
-      if (existing) {
-        focusMostRecentThreadForProject(existing.id);
-        finishAddingProject();
-        return;
-      }
-
-      const projectId = newProjectId();
-      const createdAt = new Date().toISOString();
-      const title = cwd.split(/[/\\]/).findLast(isNonEmptyString) ?? cwd;
+      let shouldResetInput = false;
       try {
+        const existing = projects.find((project) => project.cwd === cwd);
+        if (existing) {
+          focusMostRecentThreadForProject(existing.id);
+          shouldResetInput = true;
+          return;
+        }
+
+        const projectId = newProjectId();
+        const createdAt = new Date().toISOString();
+        const title = cwd.split(/[/\\]/).findLast(isNonEmptyString) ?? cwd;
         await api.orchestration.dispatchCommand({
           type: "project.create",
           commandId: newCommandId(),
@@ -510,17 +512,17 @@ export default function Sidebar() {
           createdAt,
         });
         await handleNewThread(projectId).catch(() => undefined);
+        shouldResetInput = true;
       } catch (error) {
-        setIsAddingProject(false);
         toastManager.add({
           type: "error",
           title: "Unable to add project",
           description:
             error instanceof Error ? error.message : "An error occurred while adding the project.",
         });
-        return;
+      } finally {
+        finishAddingProject(shouldResetInput);
       }
-      finishAddingProject();
     },
     [focusMostRecentThreadForProject, handleNewThread, isAddingProject, projects],
   );

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -1,15 +1,24 @@
-import { assert, describe, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { isWindowsPlatform } from "./utils";
+const uuidV4Mock = vi.hoisted(() => vi.fn());
 
-describe("isWindowsPlatform", () => {
-  it("matches Windows platform identifiers", () => {
-    assert.isTrue(isWindowsPlatform("Win32"));
-    assert.isTrue(isWindowsPlatform("Windows"));
-    assert.isTrue(isWindowsPlatform("windows_nt"));
+vi.mock("uuid", () => ({
+  v4: uuidV4Mock,
+}));
+
+import { newCommandId, newMessageId, newProjectId, newThreadId } from "./utils";
+
+describe("utils", () => {
+  beforeEach(() => {
+    uuidV4Mock.mockReset();
+    uuidV4Mock.mockReturnValue("00010203-0405-4607-8809-0a0b0c0d0e0f");
   });
 
-  it("does not match darwin", () => {
-    assert.isFalse(isWindowsPlatform("darwin"));
+  it("delegates ID generation to uuid.v4", () => {
+    expect(newCommandId()).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+    expect(newProjectId()).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+    expect(newThreadId()).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+    expect(newMessageId()).toBe("00010203-0405-4607-8809-0a0b0c0d0e0f");
+    expect(uuidV4Mock).toHaveBeenCalledTimes(4);
   });
 });

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { CommandId, MessageId, ProjectId, ThreadId } from "@t3tools/contracts";
 import { type CxOptions, cx } from "class-variance-authority";
 import { twMerge } from "tailwind-merge";
+import { v4 as uuidv4 } from "uuid";
 
 export function cn(...inputs: CxOptions) {
   return twMerge(cx(inputs));
@@ -14,10 +15,10 @@ export function isWindowsPlatform(platform: string): boolean {
   return /^win(dows)?/i.test(platform);
 }
 
-export const newCommandId = (): CommandId => CommandId.makeUnsafe(crypto.randomUUID());
+export const newCommandId = (): CommandId => CommandId.makeUnsafe(uuidv4());
 
-export const newProjectId = (): ProjectId => ProjectId.makeUnsafe(crypto.randomUUID());
+export const newProjectId = (): ProjectId => ProjectId.makeUnsafe(uuidv4());
 
-export const newThreadId = (): ThreadId => ThreadId.makeUnsafe(crypto.randomUUID());
+export const newThreadId = (): ThreadId => ThreadId.makeUnsafe(uuidv4());
 
-export const newMessageId = (): MessageId => MessageId.makeUnsafe(crypto.randomUUID());
+export const newMessageId = (): MessageId => MessageId.makeUnsafe(uuidv4());

--- a/bun.lock
+++ b/bun.lock
@@ -94,6 +94,7 @@
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.4.0",
+        "uuid": "^13.0.0",
         "zustand": "^5.0.11",
       },
       "devDependencies": {


### PR DESCRIPTION
While testing out the project in dev mode, I found I couldn't add new projects to my workspace because the `crypto.randomUUID` function wasn't available on non-secured sites (I was tailscale'd in to a devbox and using the http transport). So I updated it to use the `uuid` package which has a sane and trustworthy fallback for making UUIDs when that API isn't available.

Also hardened the add-project UI so synchronous client-side failures clear the loading state instead of leaving the dialog stuck on "Adding..."

Should make it easier for local deployments :)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace web ID generation with `uuid.v4` to fix UUID fallback across `ChatView` and `utils`
> Switch ID generation from `crypto.randomUUID()` to `uuid.v4`, add `uuid@^13.0.0`, update tests to mock `uuid.v4`, and adjust `Sidebar` project-add cleanup flow.
>
> #### 📍Where to Start
> Start with ID helpers in `newCommandId`, `newProjectId`, `newThreadId`, and `newMessageId` in [utils.ts](https://github.com/pingdotgg/t3code/pull/554/files#diff-a77b1983abf81ad3ac9e3d762f4ea683e77399fc446a1f34a6c0d57cde0ab767).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89c68d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->