### PR TITLE
Add settings.open shortcut with Mod+Shift+,

### DIFF
--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -69,6 +69,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
+  { key: "mod+shift+,", command: "settings.open" },
   { key: "mod+o", command: "editor.openFavorite" },
 ];
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -99,6 +99,7 @@ const DEFAULT_BINDINGS = compile([
   },
   { shortcut: modShortcut("o", { shiftKey: true }), command: "chat.new" },
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
+  { shortcut: modShortcut(",", { shiftKey: true }), command: "settings.open" },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
 ]);
 
@@ -238,6 +239,10 @@ describe("shortcutLabelForCommand", () => {
     assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "chat.new", "MacIntel"), "⇧⌘O");
     assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "diff.toggle", "Linux"), "Ctrl+D");
     assert.strictEqual(
+      shortcutLabelForCommand(DEFAULT_BINDINGS, "settings.open", "MacIntel"),
+      "⇧⌘,",
+    );
+    assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "editor.openFavorite", "Linux"),
       "Ctrl+O",
     );
@@ -268,6 +273,21 @@ describe("chat/editor shortcuts", () => {
       isChatNewLocalShortcut(event({ key: "n", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
         platform: "Linux",
       }),
+    );
+  });
+
+  it("matches settings.open shortcut", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: ",", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+      "settings.open",
+    );
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: ",", ctrlKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "Linux",
+      }),
+      "settings.open",
     );
   });
 

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,12 +1,20 @@
 import { Outlet, createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
 import { useEffect } from "react";
+import { type ResolvedKeybindingsConfig } from "@t3tools/contracts";
 
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
+import { resolveShortcutCommand } from "../keybindings";
+import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import ThreadSidebar from "../components/Sidebar";
 import { Sidebar, SidebarProvider } from "~/components/ui/sidebar";
 
+const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
+
 function ChatRouteLayout() {
   const navigate = useNavigate();
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
 
   useEffect(() => {
     const onMenuAction = window.desktopBridge?.onMenuAction;
@@ -23,6 +31,21 @@ function ChatRouteLayout() {
       unsubscribe?.();
     };
   }, [navigate]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (resolveShortcutCommand(event, keybindings) !== "settings.open") return;
+      event.preventDefault();
+      event.stopPropagation();
+      void navigate({ to: "/settings" });
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("keydown", handler);
+    };
+  }, [keybindings, navigate]);
 
   return (
     <SidebarProvider defaultOpen>

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -46,6 +46,12 @@ it.effect("parses keybinding rules", () =>
       command: "chat.newLocal",
     });
     assert.strictEqual(parsedLocal.command, "chat.newLocal");
+
+    const parsedSettings = yield* decode(KeybindingRule, {
+      key: "mod+shift+,",
+      command: "settings.open",
+    });
+    assert.strictEqual(parsedSettings.command, "settings.open");
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -15,6 +15,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "diff.toggle",
   "chat.new",
   "chat.newLocal",
+  "settings.open",
   "editor.openFavorite",
 ] as const;
 


### PR DESCRIPTION
- add `settings.open` to shared keybinding command contracts
- bind `Mod+Shift+,` in server defaults and web shortcut resolution
- handle shortcut in chat route to navigate to `/settings`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Mod+Shift+, to open settings and route Chat pages to /settings on the shortcut in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/561/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e) and [/_chat.tsx](https://github.com/pingdotgg/t3code/pull/561/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691)
> Introduce a `settings.open` command bound to `mod+shift+,`, validate it in contracts, and handle it in the chat route to navigate to `/settings`, with tests covering parsing, labeling, and resolution.
>
> #### 📍Where to Start
> Start with the keydown handling effect in `ChatRouteLayout` in [/_chat.tsx](https://github.com/pingdotgg/t3code/pull/561/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691), then review the new binding in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/561/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4ab7ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->