### PR TITLE
Move desktop update status into the sidebar footer

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -34,11 +34,12 @@ import { selectThreadTerminalState, useTerminalStateStore } from "../terminalSta
 import { toastManager } from "./ui/toast";
 import {
   getDesktopUpdateActionError,
+  getDesktopUpdateButtonSummary,
   getDesktopUpdateButtonTooltip,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldHighlightDesktopUpdateError,
-  shouldShowDesktopUpdateButton,
+  shouldShowDesktopUpdateStatus,
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
@@ -871,7 +872,11 @@ export default function Sidebar() {
     };
   }, []);
 
-  const showDesktopUpdateButton = isElectron && shouldShowDesktopUpdateButton(desktopUpdateState);
+  const showDesktopUpdateStatusControl =
+    isElectron && shouldShowDesktopUpdateStatus(desktopUpdateState);
+  const desktopUpdateSummary = desktopUpdateState
+    ? getDesktopUpdateButtonSummary(desktopUpdateState)
+    : null;
 
   const desktopUpdateTooltip = desktopUpdateState
     ? getDesktopUpdateButtonTooltip(desktopUpdateState)
@@ -881,17 +886,45 @@ export default function Sidebar() {
   const desktopUpdateButtonAction = desktopUpdateState
     ? resolveDesktopUpdateButtonAction(desktopUpdateState)
     : "none";
-  const desktopUpdateButtonInteractivityClasses = desktopUpdateButtonDisabled
-    ? "cursor-not-allowed opacity-60"
-    : "hover:bg-accent hover:text-foreground";
+  const desktopUpdateButtonIsInteractive =
+    desktopUpdateButtonAction !== "none" && !desktopUpdateButtonDisabled;
+  const desktopUpdateButtonInteractivityClasses = desktopUpdateButtonIsInteractive
+    ? "cursor-pointer hover:border-ring hover:bg-accent/40"
+    : "cursor-default";
   const desktopUpdateButtonClasses =
     desktopUpdateState?.status === "downloaded"
-      ? "text-emerald-500"
+      ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
       : desktopUpdateState?.status === "downloading"
-        ? "text-sky-400"
-        : shouldHighlightDesktopUpdateError(desktopUpdateState)
-          ? "text-rose-500 animate-pulse"
-          : "text-amber-500 animate-pulse";
+        ? "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-300"
+        : desktopUpdateState?.status === "up-to-date"
+          ? "border-border bg-secondary/50 text-muted-foreground"
+          : desktopUpdateState?.status === "error"
+            ? shouldHighlightDesktopUpdateError(desktopUpdateState)
+              ? "border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300"
+              : "border-rose-500/20 bg-rose-500/10 text-rose-700 dark:text-rose-300"
+            : desktopUpdateState?.status === "available"
+              ? "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+              : "border-border bg-secondary/50 text-muted-foreground";
+  const desktopUpdateActionLabel =
+    desktopUpdateButtonAction === "download"
+      ? "Update"
+      : desktopUpdateButtonAction === "install"
+        ? "Install"
+        : null;
+  const desktopUpdateControlContent = desktopUpdateSummary ? (
+    <>
+      <RocketIcon className="size-3.5 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium">{desktopUpdateSummary.label}</p>
+        <p className="truncate text-[10px] opacity-70">{desktopUpdateSummary.detail}</p>
+      </div>
+      {desktopUpdateActionLabel ? (
+        <span className="shrink-0 rounded-full border border-current/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.16em]">
+          {desktopUpdateActionLabel}
+        </span>
+      ) : null}
+    </>
+  ) : null;
   const newThreadShortcutLabel = useMemo(
     () =>
       shortcutLabelForCommand(keybindings, "chat.newLocal") ??
@@ -993,30 +1026,9 @@ export default function Sidebar() {
   return (
     <>
       {isElectron ? (
-        <>
-          <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[82px]">
-            {wordmark}
-            {showDesktopUpdateButton && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <button
-                      type="button"
-                      aria-label={desktopUpdateTooltip}
-                      aria-disabled={desktopUpdateButtonDisabled || undefined}
-                      disabled={desktopUpdateButtonDisabled}
-                      className={`inline-flex size-7 ml-auto mt-2 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
-                      onClick={handleDesktopUpdateButtonClick}
-                    >
-                      <RocketIcon className="size-3.5" />
-                    </button>
-                  }
-                />
-                <TooltipPopup side="bottom">{desktopUpdateTooltip}</TooltipPopup>
-              </Tooltip>
-            )}
-          </SidebarHeader>
-        </>
+        <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[82px]">
+          {wordmark}
+        </SidebarHeader>
       ) : (
         <SidebarHeader className="gap-3 px-3 py-2 sm:gap-2.5 sm:px-4 sm:py-3">
           {wordmark}
@@ -1349,6 +1361,33 @@ export default function Sidebar() {
           >
             + Add project
           </button>
+        )}
+        {showDesktopUpdateStatusControl && desktopUpdateControlContent && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                desktopUpdateButtonIsInteractive ? (
+                  <button
+                    type="button"
+                    aria-label={desktopUpdateTooltip}
+                    className={`mt-2 flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left transition-colors duration-150 ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
+                    onClick={handleDesktopUpdateButtonClick}
+                  >
+                    {desktopUpdateControlContent}
+                  </button>
+                ) : (
+                  <div
+                    role="status"
+                    aria-label={desktopUpdateTooltip}
+                    className={`mt-2 flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
+                  >
+                    {desktopUpdateControlContent}
+                  </div>
+                )
+              }
+            />
+            <TooltipPopup side="top">{desktopUpdateTooltip}</TooltipPopup>
+          </Tooltip>
         )}
       </SidebarFooter>
     </>

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -3,11 +3,13 @@ import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/con
 
 import {
   getDesktopUpdateActionError,
+  getDesktopUpdateButtonSummary,
   getDesktopUpdateButtonTooltip,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldHighlightDesktopUpdateError,
   shouldShowDesktopUpdateButton,
+  shouldShowDesktopUpdateStatus,
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
 
@@ -82,6 +84,20 @@ describe("desktop update button state", () => {
     expect(shouldShowDesktopUpdateButton(state)).toBe(true);
     expect(isDesktopUpdateButtonDisabled(state)).toBe(true);
     expect(getDesktopUpdateButtonTooltip(state)).toContain("42%");
+  });
+
+  it("shows updater status while already up to date", () => {
+    const state: DesktopUpdateState = {
+      ...baseState,
+      status: "up-to-date",
+      checkedAt: "2026-03-08T12:00:00.000Z",
+    };
+    expect(shouldShowDesktopUpdateButton(state)).toBe(false);
+    expect(shouldShowDesktopUpdateStatus(state)).toBe(true);
+    expect(getDesktopUpdateButtonSummary(state)).toEqual({
+      label: "Up to date",
+      detail: "Version 1.0.0 is installed.",
+    });
   });
 });
 

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -2,6 +2,11 @@ import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/con
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
+export interface DesktopUpdateButtonSummary {
+  label: string;
+  detail: string;
+}
+
 export function resolveDesktopUpdateButtonAction(
   state: DesktopUpdateState,
 ): DesktopUpdateButtonAction {
@@ -32,8 +37,71 @@ export function shouldShowDesktopUpdateButton(state: DesktopUpdateState | null):
   return resolveDesktopUpdateButtonAction(state) !== "none";
 }
 
+export function shouldShowDesktopUpdateStatus(state: DesktopUpdateState | null): boolean {
+  return state?.enabled === true;
+}
+
 export function isDesktopUpdateButtonDisabled(state: DesktopUpdateState | null): boolean {
   return state?.status === "downloading";
+}
+
+export function getDesktopUpdateButtonSummary(
+  state: DesktopUpdateState,
+): DesktopUpdateButtonSummary {
+  if (state.status === "available") {
+    return {
+      label: "Update available",
+      detail: `Version ${state.availableVersion ?? "available"} is ready to download.`,
+    };
+  }
+  if (state.status === "checking") {
+    return {
+      label: "Checking for updates",
+      detail: `Current version ${state.currentVersion}`,
+    };
+  }
+  if (state.status === "downloading") {
+    const progress =
+      typeof state.downloadPercent === "number" ? `${Math.floor(state.downloadPercent)}% complete` : "In progress";
+    return {
+      label: "Downloading update",
+      detail: progress,
+    };
+  }
+  if (state.status === "downloaded") {
+    return {
+      label: "Ready to install",
+      detail: `Restart into ${state.downloadedVersion ?? state.availableVersion ?? "the new version"}.`,
+    };
+  }
+  if (state.status === "up-to-date") {
+    return {
+      label: "Up to date",
+      detail: `Version ${state.currentVersion} is installed.`,
+    };
+  }
+  if (state.status === "error") {
+    if (state.errorContext === "download" && state.availableVersion) {
+      return {
+        label: "Update download failed",
+        detail: state.message?.trim() || `Retry downloading ${state.availableVersion}.`,
+      };
+    }
+    if (state.errorContext === "install" && state.downloadedVersion) {
+      return {
+        label: "Update install failed",
+        detail: state.message?.trim() || `Retry installing ${state.downloadedVersion}.`,
+      };
+    }
+    return {
+      label: "Update check failed",
+      detail: state.message?.trim() || "Unable to determine update status.",
+    };
+  }
+  return {
+    label: "Update status",
+    detail: `Current version ${state.currentVersion}`,
+  };
 }
 
 export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string {


### PR DESCRIPTION
## Summary
- move the desktop updater control from the sidebar header into the footer under the Add project action
- keep the updater visible when desktop updates are enabled, including an explicit "Up to date" state
- add shared sidebar updater summary helpers and test coverage for the new status rendering

## Testing
- bun lint
- bun typecheck


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move the Electron desktop update control from the header to the sidebar footer to show status and actionable chips in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/565/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1)
> Add `shouldShowDesktopUpdateStatus` and `getDesktopUpdateButtonSummary` in [desktopUpdate.logic.ts](https://github.com/pingdotgg/t3code/pull/565/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af); update `Sidebar` to render a footer status control with contextual label/detail and optional action chip; remove the header rocket button for Electron; extend tests for up-to-date state in [desktopUpdate.logic.test.ts](https://github.com/pingdotgg/t3code/pull/565/files#diff-96a4905c89d54ee90b7a7248f4cb0f60cfa640f6ff13da50864ae5dc47c0b028).
>
> #### 📍Where to Start
> Start with the footer rendering and status logic in `Sidebar` within [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/565/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), then review `getDesktopUpdateButtonSummary` and `shouldShowDesktopUpdateStatus` in [desktopUpdate.logic.ts](https://github.com/pingdotgg/t3code/pull/565/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1732ed4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->