### PR TITLE
Use local tsdown binary for server build command

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -32,27 +32,6 @@ const runCommand = Effect.fn("runCommand")(function* (command: ChildProcess.Comm
   }
 });
 
-const resolveLocalTsdownCommand = Effect.fn("resolveLocalTsdownCommand")(function* (
-  serverDir: string,
-) {
-  const path = yield* Path.Path;
-  const fs = yield* FileSystem.FileSystem;
-  const binDir = path.join(serverDir, "node_modules/.bin");
-  const candidates =
-    process.platform === "win32" ? ["tsdown.exe", "tsdown.cmd", "tsdown"] : ["tsdown"];
-
-  for (const candidate of candidates) {
-    const commandPath = path.join(binDir, candidate);
-    if (yield* fs.exists(commandPath)) {
-      return commandPath;
-    }
-  }
-
-  return yield* new CliError({
-    message: `Missing tsdown binary in ${binDir}. Install dependencies and try again.`,
-  });
-});
-
 interface PublishIconBackup {
   readonly targetPath: string;
   readonly backupPath: string;
@@ -146,15 +125,15 @@ const buildCmd = Command.make(
       const fs = yield* FileSystem.FileSystem;
       const repoRoot = yield* RepoRoot;
       const serverDir = path.join(repoRoot, "apps/server");
-      const tsdownCommand = yield* resolveLocalTsdownCommand(serverDir);
 
       yield* Effect.log("[cli] Running tsdown...");
       yield* runCommand(
-        ChildProcess.make(tsdownCommand, [], {
+        ChildProcess.make({
           cwd: serverDir,
+          shell: process.platform === "win32",
           stdout: config.verbose ? "inherit" : "ignore",
           stderr: "inherit",
-        }),
+        })`bun tsdown`,
       );
 
       const webDist = path.join(repoRoot, "apps/web/dist");


### PR DESCRIPTION
## Summary
- resolve `tsdown` from `apps/server/node_modules/.bin` instead of invoking `bun tsdown`
- support Windows binary variants (`tsdown.exe`, `tsdown.cmd`) before falling back to `tsdown`
- fail with a clear error when the local `tsdown` binary is missing

Closes #568.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `bun tsdown` via a shell on Windows in `apps/server/scripts/cli.ts` to use the local tsdown binary
> Add `shell: process.platform === "win32"` to the `ChildProcess.make` invocation in [cli.ts](https://github.com/pingdotgg/t3code/pull/569/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) for the `buildCmd` command.
>
> #### 📍Where to Start
> Start with the `buildCmd` implementation and its `ChildProcess.make` call in [cli.ts](https://github.com/pingdotgg/t3code/pull/569/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a720ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->