### PR TITLE
Fix checkpoint diff history corruption from provider preview events

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
@@ -20,8 +20,10 @@ function makeSnapshot(input: {
   readonly threadId: ThreadId;
   readonly workspaceRoot: string;
   readonly worktreePath: string | null;
-  readonly checkpointTurnCount: number;
-  readonly checkpointRef: CheckpointRef;
+  readonly checkpoints: ReadonlyArray<{
+    readonly checkpointTurnCount: number;
+    readonly checkpointRef: CheckpointRef;
+  }>;
 }): OrchestrationReadModel {
   return {
     snapshotSequence: 0,
@@ -62,17 +64,15 @@ function makeSnapshot(input: {
         messages: [],
         activities: [],
         proposedPlans: [],
-        checkpoints: [
-          {
-            turnId: TurnId.makeUnsafe("turn-1"),
-            checkpointTurnCount: input.checkpointTurnCount,
-            checkpointRef: input.checkpointRef,
-            status: "ready",
-            files: [],
-            assistantMessageId: null,
-            completedAt: "2026-01-01T00:00:00.000Z",
-          },
-        ],
+        checkpoints: input.checkpoints.map((checkpoint) => ({
+          turnId: TurnId.makeUnsafe(`turn-${checkpoint.checkpointTurnCount}`),
+          checkpointTurnCount: checkpoint.checkpointTurnCount,
+          checkpointRef: checkpoint.checkpointRef,
+          status: "ready" as const,
+          files: [],
+          assistantMessageId: null,
+          completedAt: "2026-01-01T00:00:00.000Z",
+        })),
         session: null,
       },
     ],
@@ -96,8 +96,12 @@ describe("CheckpointDiffQueryLive", () => {
       threadId,
       workspaceRoot: "/tmp/workspace",
       worktreePath: null,
-      checkpointTurnCount: 1,
-      checkpointRef: toCheckpointRef,
+      checkpoints: [
+        {
+          checkpointTurnCount: 1,
+          checkpointRef: toCheckpointRef,
+        },
+      ],
     });
 
     const checkpointStore: CheckpointStoreShape = {
@@ -193,5 +197,58 @@ describe("CheckpointDiffQueryLive", () => {
         }).pipe(Effect.provide(layer)),
       ),
     ).rejects.toThrow("Thread 'thread-missing' not found.");
+  });
+
+  it("fails with an invariant error when checkpoint turn counts are non-contiguous", async () => {
+    const projectId = ProjectId.makeUnsafe("project-gap");
+    const threadId = ThreadId.makeUnsafe("thread-gap");
+
+    const snapshot = makeSnapshot({
+      projectId,
+      threadId,
+      workspaceRoot: "/tmp/workspace",
+      worktreePath: null,
+      checkpoints: [
+        {
+          checkpointTurnCount: 1,
+          checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+        },
+        {
+          checkpointTurnCount: 3,
+          checkpointRef: checkpointRefForThreadTurn(threadId, 3),
+        },
+      ],
+    });
+
+    const checkpointStore: CheckpointStoreShape = {
+      isGitRepository: () => Effect.succeed(true),
+      captureCheckpoint: () => Effect.void,
+      hasCheckpointRef: () => Effect.succeed(true),
+      restoreCheckpoint: () => Effect.succeed(true),
+      diffCheckpoints: () => Effect.succeed(""),
+      deleteCheckpointRefs: () => Effect.void,
+    };
+
+    const layer = CheckpointDiffQueryLive.pipe(
+      Layer.provideMerge(Layer.succeed(CheckpointStore, checkpointStore)),
+      Layer.provideMerge(
+        Layer.succeed(ProjectionSnapshotQuery, {
+          getSnapshot: () => Effect.succeed(snapshot),
+        }),
+      ),
+    );
+
+    await expect(
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const query = yield* CheckpointDiffQuery;
+          return yield* query.getTurnDiff({
+            threadId,
+            fromTurnCount: 0,
+            toTurnCount: 3,
+          });
+        }).pipe(Effect.provide(layer)),
+      ),
+    ).rejects.toThrow("missing checkpoint row for turn 2");
   });
 });

--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts
@@ -199,9 +199,83 @@ describe("CheckpointDiffQueryLive", () => {
     ).rejects.toThrow("Thread 'thread-missing' not found.");
   });
 
-  it("fails with an invariant error when checkpoint turn counts are non-contiguous", async () => {
+  it("allows partial checkpoint history when the requested turn range exists", async () => {
     const projectId = ProjectId.makeUnsafe("project-gap");
     const threadId = ThreadId.makeUnsafe("thread-gap");
+    const diffCheckpointsCalls: Array<{
+      readonly fromCheckpointRef: CheckpointRef;
+      readonly toCheckpointRef: CheckpointRef;
+      readonly cwd: string;
+    }> = [];
+
+    const snapshot = makeSnapshot({
+      projectId,
+      threadId,
+      workspaceRoot: "/tmp/workspace",
+      worktreePath: null,
+      checkpoints: [
+        {
+          checkpointTurnCount: 1,
+          checkpointRef: checkpointRefForThreadTurn(threadId, 1),
+        },
+        {
+          checkpointTurnCount: 3,
+          checkpointRef: checkpointRefForThreadTurn(threadId, 3),
+        },
+      ],
+    });
+
+    const checkpointStore: CheckpointStoreShape = {
+      isGitRepository: () => Effect.succeed(true),
+      captureCheckpoint: () => Effect.void,
+      hasCheckpointRef: () => Effect.succeed(true),
+      restoreCheckpoint: () => Effect.succeed(true),
+      diffCheckpoints: ({ fromCheckpointRef, toCheckpointRef, cwd }) =>
+        Effect.sync(() => {
+          diffCheckpointsCalls.push({ fromCheckpointRef, toCheckpointRef, cwd });
+          return "partial-history diff";
+        }),
+      deleteCheckpointRefs: () => Effect.void,
+    };
+
+    const layer = CheckpointDiffQueryLive.pipe(
+      Layer.provideMerge(Layer.succeed(CheckpointStore, checkpointStore)),
+      Layer.provideMerge(
+        Layer.succeed(ProjectionSnapshotQuery, {
+          getSnapshot: () => Effect.succeed(snapshot),
+        }),
+      ),
+    );
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const query = yield* CheckpointDiffQuery;
+        return yield* query.getTurnDiff({
+          threadId,
+          fromTurnCount: 0,
+          toTurnCount: 3,
+        });
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(diffCheckpointsCalls).toEqual([
+      {
+        cwd: "/tmp/workspace",
+        fromCheckpointRef: checkpointRefForThreadTurn(threadId, 0),
+        toCheckpointRef: checkpointRefForThreadTurn(threadId, 3),
+      },
+    ]);
+    expect(result).toEqual({
+      threadId,
+      fromTurnCount: 0,
+      toTurnCount: 3,
+      diff: "partial-history diff",
+    });
+  });
+
+  it("fails when a specifically requested checkpoint row is missing", async () => {
+    const projectId = ProjectId.makeUnsafe("project-missing-turn");
+    const threadId = ThreadId.makeUnsafe("thread-missing-turn");
 
     const snapshot = makeSnapshot({
       projectId,
@@ -244,7 +318,7 @@ describe("CheckpointDiffQueryLive", () => {
           const query = yield* CheckpointDiffQuery;
           return yield* query.getTurnDiff({
             threadId,
-            fromTurnCount: 0,
+            fromTurnCount: 2,
             toTurnCount: 3,
           });
         }).pipe(Effect.provide(layer)),

--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
@@ -1,5 +1,6 @@
 import {
   OrchestrationGetTurnDiffResult,
+  type CheckpointRef,
   type OrchestrationGetFullThreadDiffInput,
   type OrchestrationGetFullThreadDiffResult,
   type OrchestrationGetTurnDiffResult as OrchestrationGetTurnDiffResultType,
@@ -16,6 +17,49 @@ import {
 } from "../Services/CheckpointDiffQuery.ts";
 
 const isTurnDiffResult = Schema.is(OrchestrationGetTurnDiffResult);
+
+function buildCheckpointIndex(input: {
+  readonly operation: string;
+  readonly threadId: string;
+  readonly checkpoints: ReadonlyArray<{
+    readonly checkpointTurnCount: number;
+    readonly checkpointRef: CheckpointRef;
+  }>;
+}): Effect.Effect<
+  Map<number, (typeof input.checkpoints)[number]>,
+  CheckpointInvariantError
+> {
+  const checkpointByTurnCount = new Map<number, (typeof input.checkpoints)[number]>();
+
+  for (const checkpoint of input.checkpoints) {
+    if (checkpointByTurnCount.has(checkpoint.checkpointTurnCount)) {
+      return Effect.fail(
+        new CheckpointInvariantError({
+          operation: input.operation,
+          detail: `Checkpoint turn-count sequence is inconsistent for thread '${input.threadId}': duplicate checkpoint row for turn ${checkpoint.checkpointTurnCount}.`,
+        }),
+      );
+    }
+    checkpointByTurnCount.set(checkpoint.checkpointTurnCount, checkpoint);
+  }
+
+  const maxTurnCount = input.checkpoints.reduce(
+    (max, checkpoint) => Math.max(max, checkpoint.checkpointTurnCount),
+    0,
+  );
+  for (let expectedTurnCount = 1; expectedTurnCount <= maxTurnCount; expectedTurnCount += 1) {
+    if (!checkpointByTurnCount.has(expectedTurnCount)) {
+      return Effect.fail(
+        new CheckpointInvariantError({
+          operation: input.operation,
+          detail: `Checkpoint turn-count sequence is inconsistent for thread '${input.threadId}': missing checkpoint row for turn ${expectedTurnCount}.`,
+        }),
+      );
+    }
+  }
+
+  return Effect.succeed(checkpointByTurnCount);
+}
 
 const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
@@ -50,6 +94,12 @@ const make = Effect.gen(function* () {
         });
       }
 
+      const checkpointByTurnCount = yield* buildCheckpointIndex({
+        operation,
+        threadId: input.threadId,
+        checkpoints: thread.checkpoints,
+      });
+
       const maxTurnCount = thread.checkpoints.reduce(
         (max, checkpoint) => Math.max(max, checkpoint.checkpointTurnCount),
         0,
@@ -76,25 +126,19 @@ const make = Effect.gen(function* () {
       const fromCheckpointRef =
         input.fromTurnCount === 0
           ? checkpointRefForThreadTurn(input.threadId, 0)
-          : thread.checkpoints.find(
-              (checkpoint) => checkpoint.checkpointTurnCount === input.fromTurnCount,
-            )?.checkpointRef;
+          : checkpointByTurnCount.get(input.fromTurnCount)?.checkpointRef;
       if (!fromCheckpointRef) {
-        return yield* new CheckpointUnavailableError({
-          threadId: input.threadId,
-          turnCount: input.fromTurnCount,
-          detail: `Checkpoint ref is unavailable for turn ${input.fromTurnCount}.`,
+        return yield* new CheckpointInvariantError({
+          operation,
+          detail: `Checkpoint turn-count sequence is inconsistent for thread '${input.threadId}': missing checkpoint row for turn ${input.fromTurnCount}.`,
         });
       }
 
-      const toCheckpointRef = thread.checkpoints.find(
-        (checkpoint) => checkpoint.checkpointTurnCount === input.toTurnCount,
-      )?.checkpointRef;
+      const toCheckpointRef = checkpointByTurnCount.get(input.toTurnCount)?.checkpointRef;
       if (!toCheckpointRef) {
-        return yield* new CheckpointUnavailableError({
-          threadId: input.threadId,
-          turnCount: input.toTurnCount,
-          detail: `Checkpoint ref is unavailable for turn ${input.toTurnCount}.`,
+        return yield* new CheckpointInvariantError({
+          operation,
+          detail: `Checkpoint turn-count sequence is inconsistent for thread '${input.threadId}': missing checkpoint row for turn ${input.toTurnCount}.`,
         });
       }
 

--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
@@ -26,7 +26,10 @@ function buildCheckpointIndex(input: {
     readonly checkpointRef: CheckpointRef;
   }>;
 }): Effect.Effect<
-  Map<number, (typeof input.checkpoints)[number]>,
+  {
+    readonly checkpointByTurnCount: Map<number, (typeof input.checkpoints)[number]>;
+    readonly maxTurnCount: number;
+  },
   CheckpointInvariantError
 > {
   const checkpointByTurnCount = new Map<number, (typeof input.checkpoints)[number]>();
@@ -47,18 +50,11 @@ function buildCheckpointIndex(input: {
     (max, checkpoint) => Math.max(max, checkpoint.checkpointTurnCount),
     0,
   );
-  for (let expectedTurnCount = 1; expectedTurnCount <= maxTurnCount; expectedTurnCount += 1) {
-    if (!checkpointByTurnCount.has(expectedTurnCount)) {
-      return Effect.fail(
-        new CheckpointInvariantError({
-          operation: input.operation,
-          detail: `Checkpoint turn-count sequence is inconsistent for thread '${input.threadId}': missing checkpoint row for turn ${expectedTurnCount}.`,
-        }),
-      );
-    }
-  }
 
-  return Effect.succeed(checkpointByTurnCount);
+  return Effect.succeed({
+    checkpointByTurnCount,
+    maxTurnCount,
+  });
 }
 
 const make = Effect.gen(function* () {
@@ -94,16 +90,12 @@ const make = Effect.gen(function* () {
         });
       }
 
-      const checkpointByTurnCount = yield* buildCheckpointIndex({
+      const { checkpointByTurnCount, maxTurnCount } = yield* buildCheckpointIndex({
         operation,
         threadId: input.threadId,
         checkpoints: thread.checkpoints,
       });
 
-      const maxTurnCount = thread.checkpoints.reduce(
-        (max, checkpoint) => Math.max(max, checkpoint.checkpointTurnCount),
-        0,
-      );
       if (input.toTurnCount > maxTurnCount) {
         return yield* new CheckpointUnavailableError({
           threadId: input.threadId,

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -400,6 +400,78 @@ describe("CheckpointReactor", () => {
     ).toBe("v2\n");
   });
 
+  it("treats duplicate turn completion events for the same turn as idempotent", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const createdAt = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-duplicate-capture"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.makeUnsafe("evt-turn-started-duplicate"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-duplicate"),
+    });
+    await waitForGitRefExists(
+      harness.cwd,
+      checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 0),
+    );
+
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "v2\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.makeUnsafe("evt-turn-completed-duplicate-1"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-duplicate"),
+      payload: { state: "completed" },
+    });
+
+    await waitForEvent(harness.engine, (event) => event.type === "thread.turn-diff-completed");
+    const firstThread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.latestTurn?.turnId === "turn-duplicate" && entry.checkpoints.length === 1,
+    );
+    expect(firstThread.checkpoints[0]?.checkpointTurnCount).toBe(1);
+
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.makeUnsafe("evt-turn-completed-duplicate-2"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-duplicate"),
+      payload: { state: "completed" },
+    });
+
+    await Effect.runPromise(Effect.sleep("40 millis"));
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+
+    expect(thread?.checkpoints).toHaveLength(1);
+    expect(thread?.checkpoints[0]?.checkpointTurnCount).toBe(1);
+  });
+
   it("ignores auxiliary thread turn completion while primary turn is active", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });
     const createdAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -166,7 +166,13 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    if (thread.checkpoints.some((checkpoint) => checkpoint.turnId === turnId)) {
+    const existingCheckpoint = thread.checkpoints.find((checkpoint) => checkpoint.turnId === turnId);
+    if (existingCheckpoint) {
+      yield* Effect.logDebug("checkpoint completion ignored: checkpoint already exists for turn", {
+        threadId: thread.id,
+        turnId,
+        checkpointTurnCount: existingCheckpoint.checkpointTurnCount,
+      });
       return;
     }
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -108,7 +108,6 @@ type ProviderRuntimeTestThread = ProviderRuntimeTestReadModel["threads"][number]
 type ProviderRuntimeTestMessage = ProviderRuntimeTestThread["messages"][number];
 type ProviderRuntimeTestProposedPlan = ProviderRuntimeTestThread["proposedPlans"][number];
 type ProviderRuntimeTestActivity = ProviderRuntimeTestThread["activities"][number];
-type ProviderRuntimeTestCheckpoint = ProviderRuntimeTestThread["checkpoints"][number];
 
 describe("ProviderRuntimeIngestion", () => {
   let runtime: ManagedRuntime.ManagedRuntime<
@@ -1230,8 +1229,8 @@ describe("ProviderRuntimeIngestion", () => {
         entry.activities.some(
           (activity: ProviderRuntimeTestActivity) => activity.kind === "runtime.warning",
         ) &&
-        entry.checkpoints.some(
-          (checkpoint: ProviderRuntimeTestCheckpoint) => checkpoint.turnId === "turn-p1",
+        entry.activities.some(
+          (activity: ProviderRuntimeTestActivity) => activity.kind === "turn.diff.preview.updated",
         ),
     );
 
@@ -1268,12 +1267,63 @@ describe("ProviderRuntimeIngestion", () => {
     expect(warning?.kind).toBe("runtime.warning");
     expect(warningPayload?.message).toBe("Provider got slow");
 
-    const checkpoint = thread.checkpoints.find(
-      (entry: ProviderRuntimeTestCheckpoint) => entry.turnId === "turn-p1",
+    const diffPreview = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) => activity.id === "evt-turn-diff-updated",
     );
-    expect(checkpoint?.status).toBe("missing");
-    expect(checkpoint?.assistantMessageId).toBe("assistant:item-p1-assistant");
-    expect(checkpoint?.checkpointRef).toBe("provider-diff:evt-turn-diff-updated");
+    const diffPreviewPayload =
+      diffPreview?.payload && typeof diffPreview.payload === "object"
+        ? (diffPreview.payload as Record<string, unknown>)
+        : undefined;
+    expect(diffPreview?.kind).toBe("turn.diff.preview.updated");
+    expect(diffPreviewPayload?.itemId).toBe("item-p1-assistant");
+    expect(diffPreviewPayload?.unifiedDiff).toBe("diff --git a/file.txt b/file.txt\n+hello\n");
+    expect(thread.checkpoints).toHaveLength(0);
+  });
+
+  it("keeps repeated turn diff preview updates out of checkpoint history", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.diff.updated",
+      eventId: asEventId("evt-turn-diff-updated-1"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-preview"),
+      itemId: asItemId("item-preview-1"),
+      payload: {
+        unifiedDiff: "diff --git a/file.txt b/file.txt\n+hello\n",
+      },
+    });
+
+    harness.emit({
+      type: "turn.diff.updated",
+      eventId: asEventId("evt-turn-diff-updated-2"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-preview"),
+      itemId: asItemId("item-preview-2"),
+      payload: {
+        unifiedDiff: "diff --git a/file.txt b/file.txt\n+hello again\n",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.activities.filter(
+          (activity: ProviderRuntimeTestActivity) => activity.kind === "turn.diff.preview.updated",
+        ).length === 2,
+    );
+
+    expect(thread.checkpoints).toHaveLength(0);
+    expect(
+      thread.activities.filter(
+        (activity: ProviderRuntimeTestActivity) => activity.kind === "turn.diff.preview.updated",
+      ),
+    ).toHaveLength(2);
   });
 
   it("projects Codex task lifecycle chunks into thread activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -4,7 +4,6 @@ import {
   CommandId,
   MessageId,
   type OrchestrationEvent,
-  CheckpointRef,
   ThreadId,
   TurnId,
   type OrchestrationThreadActivity,
@@ -13,8 +12,6 @@ import {
 import { Cache, Cause, Duration, Effect, Layer, Option, Queue, Ref, Stream } from "effect";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
-import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
-import { isGitRepository } from "../../git/isRepo.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import {
   ProviderRuntimeIngestionService,
@@ -306,6 +303,24 @@ function runtimeEventToActivities(
       ];
     }
 
+    case "turn.diff.updated": {
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "turn.diff.preview.updated",
+          summary: "Diff preview updated",
+          payload: {
+            unifiedDiff: event.payload.unifiedDiff,
+            ...(event.itemId ? { itemId: event.itemId } : {}),
+          },
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
     case "user-input.requested": {
       return [
         {
@@ -507,22 +522,6 @@ const make = Effect.gen(function* () {
     capacity: BUFFERED_PROPOSED_PLAN_BY_ID_CACHE_CAPACITY,
     timeToLive: BUFFERED_PROPOSED_PLAN_BY_ID_TTL,
     lookup: () => Effect.succeed({ text: "", createdAt: "" }),
-  });
-
-  const isGitRepoForThread = Effect.fnUntraced(function* (threadId: ThreadId) {
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const thread = readModel.threads.find((entry) => entry.id === threadId);
-    if (!thread) {
-      return false;
-    }
-    const workspaceCwd = resolveThreadWorkspaceCwd({
-      thread,
-      projects: readModel.projects,
-    });
-    if (!workspaceCwd) {
-      return false;
-    }
-    return isGitRepository(workspaceCwd);
   });
 
   const rememberAssistantMessageId = (
@@ -1055,28 +1054,6 @@ const make = Effect.gen(function* () {
           threadId: thread.id,
           title: event.payload.name,
         });
-      }
-
-      if (event.type === "turn.diff.updated") {
-        const turnId = toTurnId(event.turnId);
-        if (turnId && (yield* isGitRepoForThread(thread.id))) {
-          const assistantMessageId = MessageId.makeUnsafe(
-            `assistant:${event.itemId ?? event.turnId ?? event.eventId}`,
-          );
-          yield* orchestrationEngine.dispatch({
-            type: "thread.turn.diff.complete",
-            commandId: providerCommandId(event, "thread-turn-diff-complete"),
-            threadId: thread.id,
-            turnId,
-            completedAt: now,
-            checkpointRef: CheckpointRef.makeUnsafe(`provider-diff:${event.eventId}`),
-            status: "missing",
-            files: [],
-            assistantMessageId,
-            checkpointTurnCount: thread.checkpoints.length + 1,
-            createdAt: now,
-          });
-        }
       }
 
       const activities = runtimeEventToActivities(event);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -52,7 +52,7 @@ import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
 
 import { isElectron } from "../env";
-import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import { buildOpenDiffSearch, parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import {
   type ComposerSlashCommand,
   type ComposerTrigger,
@@ -69,6 +69,7 @@ import {
   deriveTimelineEntries,
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
+  findLatestDiffableTurnDiffSummary,
   findLatestProposedPlan,
   type PendingApproval,
   type PendingUserInput,
@@ -1083,6 +1084,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
+  const latestTurnDiffSummary = useMemo(
+    () => findLatestDiffableTurnDiffSummary(turnDiffSummaries),
+    [turnDiffSummaries],
+  );
   const turnDiffSummaryByAssistantMessageId = useMemo(() => {
     const byMessageId = new Map<MessageId, TurnDiffSummary>();
     for (const summary of turnDiffSummaries) {
@@ -1314,10 +1319,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
       replace: true,
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return diffOpen ? rest : { ...rest, diff: "1" };
+        return diffOpen ? rest : buildOpenDiffSearch(rest, latestTurnDiffSummary?.turnId);
       },
     });
-  }, [diffOpen, navigate, threadId]);
+  }, [diffOpen, latestTurnDiffSummary?.turnId, navigate, threadId]);
 
   const envLocked = Boolean(
     activeThread &&

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -1,21 +1,31 @@
 import { parsePatchFiles } from "@pierre/diffs";
 import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { ThreadId, type TurnId } from "@t3tools/contracts";
 import { ChevronLeftIcon, ChevronRightIcon, Columns2Icon, Rows3Icon } from "lucide-react";
 import { type WheelEvent as ReactWheelEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { gitBranchesQueryOptions } from "~/lib/gitReactQuery";
-import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
+import {
+  checkpointDiffQueryOptions,
+  isCheckpointRecoverableSelectionError,
+  providerQueryKeys,
+} from "~/lib/providerReactQuery";
 import { cn } from "~/lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { preferredTerminalEditor, resolvePathLinkTarget } from "../terminal-links";
-import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import { buildOpenDiffSearch, parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
 import { buildPatchCacheKey } from "../lib/diffRendering";
 import { resolveDiffThemeName } from "../lib/diffRendering";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
+import {
+  findLatestDiffableTurnDiffSummary,
+  findLatestReadyCheckpointTurnCount,
+  listDiffableTurnIds,
+  orderTurnDiffSummariesByRecency,
+} from "../session-logic";
 import { useStore } from "../store";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
@@ -156,10 +166,12 @@ export { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
 
 export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { resolvedTheme } = useTheme();
   const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("stacked");
   const patchViewportRef = useRef<HTMLDivElement>(null);
   const turnStripRef = useRef<HTMLDivElement>(null);
+  const recoveryKeyRef = useRef<string | null>(null);
   const [canScrollTurnStripLeft, setCanScrollTurnStripLeft] = useState(false);
   const [canScrollTurnStripRight, setCanScrollTurnStripRight] = useState(false);
   const routeThreadId = useParams({
@@ -181,29 +193,31 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
   const orderedTurnDiffSummaries = useMemo(
-    () =>
-      [...turnDiffSummaries].toSorted((left, right) => {
-        const leftTurnCount =
-          left.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[left.turnId] ?? 0;
-        const rightTurnCount =
-          right.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[right.turnId] ?? 0;
-        if (leftTurnCount !== rightTurnCount) {
-          return rightTurnCount - leftTurnCount;
-        }
-        return right.completedAt.localeCompare(left.completedAt);
-      }),
-    [inferredCheckpointTurnCountByTurnId, turnDiffSummaries],
+    () => orderTurnDiffSummariesByRecency(turnDiffSummaries),
+    [turnDiffSummaries],
+  );
+  const diffableTurnIds = useMemo(() => listDiffableTurnIds(turnDiffSummaries), [turnDiffSummaries]);
+  const diffableTurnIdSet = useMemo(() => new Set(diffableTurnIds), [diffableTurnIds]);
+  const latestDiffableTurnSummary = useMemo(
+    () => findLatestDiffableTurnDiffSummary(turnDiffSummaries),
+    [turnDiffSummaries],
   );
 
   const selectedTurnId = diffSearch.diffTurnId ?? null;
   const selectedFilePath = selectedTurnId !== null ? (diffSearch.diffFilePath ?? null) : null;
-  const selectedTurn =
+  const selectedTurn = useMemo(
+    () =>
+      selectedTurnId === null
+        ? undefined
+        : orderedTurnDiffSummaries.find((summary) => summary.turnId === selectedTurnId),
+    [orderedTurnDiffSummaries, selectedTurnId],
+  );
+  const selectedTurnIsDiffable = selectedTurn ? diffableTurnIdSet.has(selectedTurn.turnId) : false;
+  const selectedCheckpointTurnCount =
     selectedTurnId === null
       ? undefined
-      : (orderedTurnDiffSummaries.find((summary) => summary.turnId === selectedTurnId) ??
-        orderedTurnDiffSummaries[0]);
-  const selectedCheckpointTurnCount =
-    selectedTurn &&
+      : selectedTurn &&
+        selectedTurnIsDiffable &&
     (selectedTurn.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[selectedTurn.turnId]);
   const selectedCheckpointRange = useMemo(
     () =>
@@ -215,19 +229,10 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         : null,
     [selectedCheckpointTurnCount],
   );
-  const conversationCheckpointTurnCount = useMemo(() => {
-    const turnCounts = orderedTurnDiffSummaries
-      .map(
-        (summary) =>
-          summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId],
-      )
-      .filter((value): value is number => typeof value === "number");
-    if (turnCounts.length === 0) {
-      return undefined;
-    }
-    const latest = Math.max(...turnCounts);
-    return latest > 0 ? latest : undefined;
-  }, [inferredCheckpointTurnCountByTurnId, orderedTurnDiffSummaries]);
+  const conversationCheckpointTurnCount = useMemo(
+    () => findLatestReadyCheckpointTurnCount(turnDiffSummaries),
+    [turnDiffSummaries],
+  );
   const conversationCheckpointRange = useMemo(
     () =>
       !selectedTurn && typeof conversationCheckpointTurnCount === "number"
@@ -238,9 +243,12 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         : null,
     [conversationCheckpointTurnCount, selectedTurn],
   );
-  const activeCheckpointRange = selectedTurn
-    ? selectedCheckpointRange
-    : conversationCheckpointRange;
+  const activeCheckpointRange =
+    selectedTurn === undefined
+      ? conversationCheckpointRange
+      : selectedTurnIsDiffable
+        ? selectedCheckpointRange
+        : null;
   const conversationCacheScope = useMemo(() => {
     if (selectedTurn || orderedTurnDiffSummaries.length === 0) {
       return null;
@@ -269,6 +277,116 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       : activeCheckpointDiffQuery.error
         ? "Failed to load checkpoint diff."
         : null;
+
+  const navigateToBestAvailableDiff = useCallback(
+    (input?: { replace?: boolean }) => {
+      if (!activeThread) {
+        return false;
+      }
+
+      if (latestDiffableTurnSummary) {
+        void navigate({
+          to: "/$threadId",
+          params: { threadId: activeThread.id },
+          replace: input?.replace ?? false,
+          search: (previous) => buildOpenDiffSearch(previous, latestDiffableTurnSummary.turnId),
+        });
+        return true;
+      }
+
+      if (typeof conversationCheckpointTurnCount === "number") {
+        void navigate({
+          to: "/$threadId",
+          params: { threadId: activeThread.id },
+          replace: input?.replace ?? false,
+          search: (previous) => buildOpenDiffSearch(previous),
+        });
+        return true;
+      }
+
+      return false;
+    },
+    [activeThread, conversationCheckpointTurnCount, latestDiffableTurnSummary, navigate],
+  );
+
+  useEffect(() => {
+    if (selectedTurnId === null) {
+      return;
+    }
+    if (selectedTurn && selectedTurnIsDiffable) {
+      return;
+    }
+
+    void navigateToBestAvailableDiff({ replace: true });
+  }, [navigateToBestAvailableDiff, selectedTurn, selectedTurnId, selectedTurnIsDiffable]);
+
+  useEffect(() => {
+    if (!activeThreadId || !activeCheckpointDiffQuery.error) {
+      recoveryKeyRef.current = null;
+      return;
+    }
+    if (!isCheckpointRecoverableSelectionError(activeCheckpointDiffQuery.error)) {
+      return;
+    }
+
+    const message =
+      activeCheckpointDiffQuery.error instanceof Error
+        ? activeCheckpointDiffQuery.error.message
+        : String(activeCheckpointDiffQuery.error);
+    const recoveryKey = `${activeThreadId}:${selectedTurnId ?? "all"}:${message}`;
+    if (recoveryKeyRef.current === recoveryKey) {
+      return;
+    }
+    recoveryKeyRef.current = recoveryKey;
+
+    const api = readNativeApi();
+    if (!api) {
+      return;
+    }
+
+    void (async () => {
+      try {
+        const snapshot = await api.orchestration.getSnapshot();
+        useStore.getState().syncServerReadModel(snapshot);
+      } catch {
+        // Keep prior state; best-effort refresh only.
+      }
+
+      await queryClient.invalidateQueries({ queryKey: providerQueryKeys.all });
+
+      const refreshedThread = useStore
+        .getState()
+        .threads.find((thread) => thread.id === activeThreadId);
+      const refreshedSummaries = refreshedThread?.turnDiffSummaries ?? [];
+      const fallbackTurn = findLatestDiffableTurnDiffSummary(refreshedSummaries);
+      const fallbackConversationTurnCount = findLatestReadyCheckpointTurnCount(refreshedSummaries);
+
+      if (refreshedThread && fallbackTurn) {
+        void navigate({
+          to: "/$threadId",
+          params: { threadId: refreshedThread.id },
+          replace: true,
+          search: (previous) => buildOpenDiffSearch(previous, fallbackTurn.turnId),
+        });
+        return;
+      }
+
+      if (refreshedThread && typeof fallbackConversationTurnCount === "number") {
+        void navigate({
+          to: "/$threadId",
+          params: { threadId: refreshedThread.id },
+          replace: true,
+          search: (previous) => buildOpenDiffSearch(previous),
+        });
+      }
+    })().catch(() => undefined);
+  }, [
+    activeCheckpointDiffQuery.error,
+    activeThreadId,
+    queryClient,
+    selectedTurnId,
+    navigate,
+  ]);
 
   const selectedPatch = selectedTurn ? selectedTurnCheckpointDiff : conversationCheckpointDiff;
   const hasResolvedPatch = typeof selectedPatch === "string";
@@ -312,7 +430,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   );
 
   const selectTurn = (turnId: TurnId) => {
-    if (!activeThread) return;
+    if (!activeThread || !diffableTurnIdSet.has(turnId)) return;
     void navigate({
       to: "/$threadId",
       params: { threadId: activeThread.id },
@@ -454,37 +572,47 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
               <div className="text-[10px] leading-tight font-medium">All turns</div>
             </div>
           </button>
-          {orderedTurnDiffSummaries.map((summary) => (
-            <button
-              key={summary.turnId}
-              type="button"
-              className="shrink-0 rounded-md"
-              onClick={() => selectTurn(summary.turnId)}
-              title={summary.turnId}
-              data-turn-chip-selected={summary.turnId === selectedTurn?.turnId}
-            >
-              <div
-                className={cn(
-                  "rounded-md border px-2 py-1 text-left transition-colors",
-                  summary.turnId === selectedTurn?.turnId
-                    ? "border-border bg-accent text-accent-foreground"
-                    : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80",
-                )}
+          {orderedTurnDiffSummaries.map((summary) => {
+            const isDiffable = diffableTurnIdSet.has(summary.turnId);
+
+            return (
+              <button
+                key={summary.turnId}
+                type="button"
+                className="shrink-0 rounded-md"
+                onClick={() => selectTurn(summary.turnId)}
+                title={
+                  isDiffable ? summary.turnId : "Checkpoint diff unavailable for this turn."
+                }
+                disabled={!isDiffable}
+                aria-disabled={!isDiffable}
+                data-turn-chip-selected={summary.turnId === selectedTurn?.turnId}
               >
-                <div className="flex items-center gap-1">
-                  <span className="text-[10px] leading-tight font-medium">
-                    Turn{" "}
-                    {summary.checkpointTurnCount ??
-                      inferredCheckpointTurnCountByTurnId[summary.turnId] ??
-                      "?"}
-                  </span>
-                  <span className="text-[9px] leading-tight opacity-70">
-                    {formatTurnChipTimestamp(summary.completedAt)}
-                  </span>
+                <div
+                  className={cn(
+                    "rounded-md border px-2 py-1 text-left transition-colors",
+                    summary.turnId === selectedTurn?.turnId
+                      ? "border-border bg-accent text-accent-foreground"
+                      : isDiffable
+                        ? "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80"
+                        : "cursor-not-allowed border-border/40 bg-background/50 text-muted-foreground/45",
+                  )}
+                >
+                  <div className="flex items-center gap-1">
+                    <span className="text-[10px] leading-tight font-medium">
+                      Turn{" "}
+                      {summary.checkpointTurnCount ??
+                        inferredCheckpointTurnCountByTurnId[summary.turnId] ??
+                        "?"}
+                    </span>
+                    <span className="text-[9px] leading-tight opacity-70">
+                      {formatTurnChipTimestamp(summary.completedAt)}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </button>
-          ))}
+              </button>
+            );
+          })}
         </div>
       </div>
       <ToggleGroup

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -321,8 +321,11 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   }, [navigateToBestAvailableDiff, selectedTurn, selectedTurnId, selectedTurnIsDiffable]);
 
   useEffect(() => {
+    recoveryKeyRef.current = null;
+  }, [activeThreadId, selectedTurnId]);
+
+  useEffect(() => {
     if (!activeThreadId || !activeCheckpointDiffQuery.error) {
-      recoveryKeyRef.current = null;
       return;
     }
     if (!isCheckpointRecoverableSelectionError(activeCheckpointDiffQuery.error)) {

--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { TurnId } from "@t3tools/contracts";
 
-import { parseDiffRouteSearch } from "./diffRouteSearch";
+import { buildOpenDiffSearch, parseDiffRouteSearch, stripDiffSearchParams } from "./diffRouteSearch";
 
 describe("parseDiffRouteSearch", () => {
   it("parses valid diff search values", () => {
@@ -69,6 +70,54 @@ describe("parseDiffRouteSearch", () => {
 
     expect(parsed).toEqual({
       diff: "1",
+    });
+  });
+});
+
+describe("buildOpenDiffSearch", () => {
+  it("strips stale diff params and seeds the latest turn id when available", () => {
+    expect(
+      buildOpenDiffSearch(
+        {
+          tab: "chat",
+          diff: "1",
+          diffTurnId: "turn-old",
+          diffFilePath: "src/old.ts",
+        },
+        TurnId.makeUnsafe("turn-latest"),
+      ),
+    ).toEqual({
+      tab: "chat",
+      diff: "1",
+      diffTurnId: "turn-latest",
+    });
+  });
+
+  it("opens aggregate diff when no latest turn id is available", () => {
+    expect(
+      buildOpenDiffSearch({
+        tab: "chat",
+        diffTurnId: "turn-old",
+        diffFilePath: "src/old.ts",
+      }),
+    ).toEqual({
+      tab: "chat",
+      diff: "1",
+    });
+  });
+});
+
+describe("stripDiffSearchParams", () => {
+  it("supports the diff toggle close path by clearing all diff params", () => {
+    expect(
+      stripDiffSearchParams({
+        tab: "chat",
+        diff: "1",
+        diffTurnId: "turn-latest",
+        diffFilePath: "src/file.ts",
+      }),
+    ).toEqual({
+      tab: "chat",
     });
   });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -25,6 +25,15 @@ export function stripDiffSearchParams<T extends Record<string, unknown>>(
   return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
 }
 
+export function buildOpenDiffSearch<T extends Record<string, unknown>>(
+  params: T,
+  latestTurnId?: TurnId | null,
+): Omit<T, "diff" | "diffTurnId" | "diffFilePath"> & DiffRouteSearch {
+  const rest = stripDiffSearchParams(params);
+
+  return latestTurnId ? { ...rest, diff: "1", diffTurnId: latestTurnId } : { ...rest, diff: "1" };
+}
+
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
   const diff = isDiffOpenValue(search.diff) ? "1" : undefined;
   const diffTurnIdRaw = diff ? normalizeSearchString(search.diffTurnId) : undefined;

--- a/apps/web/src/lib/providerReactQuery.test.ts
+++ b/apps/web/src/lib/providerReactQuery.test.ts
@@ -1,7 +1,13 @@
 import { ThreadId, type NativeApi } from "@t3tools/contracts";
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { checkpointDiffQueryOptions, providerQueryKeys } from "./providerReactQuery";
+import {
+  checkpointDiffQueryOptions,
+  isCheckpointRecoverableSelectionError,
+  isCheckpointTemporarilyUnavailable,
+  normalizeCheckpointErrorMessage,
+  providerQueryKeys,
+} from "./providerReactQuery";
 import * as nativeApi from "../nativeApi";
 
 const threadId = ThreadId.makeUnsafe("thread-id");
@@ -157,5 +163,40 @@ describe("checkpointDiffQueryOptions", () => {
     expect(typeof checkpointDelay).toBe("number");
     expect(typeof genericDelay).toBe("number");
     expect((checkpointDelay ?? 0) > (genericDelay ?? 0)).toBe(true);
+  });
+});
+
+describe("normalizeCheckpointErrorMessage", () => {
+  it("rephrases missing checkpoint ref errors for recovery UX", () => {
+    expect(normalizeCheckpointErrorMessage("Checkpoint ref is unavailable for turn 5.")).toBe(
+      "This turn's checkpoint diff is no longer available. Showing the latest available diff when possible.",
+    );
+  });
+
+  it("rephrases checkpoint continuity errors", () => {
+    expect(
+      normalizeCheckpointErrorMessage(
+        "Checkpoint invariant violation in thread thread-1: Checkpoint turn-count sequence is inconsistent for thread 'thread-1': missing checkpoint row for turn 5.",
+      ),
+    ).toBe("This thread's diff history is out of sync. Showing the latest available diff when possible.");
+  });
+});
+
+describe("checkpoint error classification", () => {
+  it("keeps temporary unavailability retryable", () => {
+    expect(
+      isCheckpointTemporarilyUnavailable(
+        new Error("Filesystem checkpoint is unavailable for turn 2 in thread thread-1."),
+      ),
+    ).toBe(true);
+  });
+
+  it("marks continuity mismatches as recoverable but not temporary", () => {
+    const error = new Error(
+      "Checkpoint invariant violation in thread thread-1: Checkpoint turn-count sequence is inconsistent for thread 'thread-1': missing checkpoint row for turn 5.",
+    );
+
+    expect(isCheckpointRecoverableSelectionError(error)).toBe(true);
+    expect(isCheckpointTemporarilyUnavailable(error)).toBe(false);
   });
 });

--- a/apps/web/src/lib/providerReactQuery.ts
+++ b/apps/web/src/lib/providerReactQuery.ts
@@ -53,7 +53,7 @@ function asCheckpointErrorMessage(error: unknown): string {
   return "";
 }
 
-function normalizeCheckpointErrorMessage(error: unknown): string {
+export function normalizeCheckpointErrorMessage(error: unknown): string {
   const message = asCheckpointErrorMessage(error).trim();
   if (message.length === 0) {
     return "Failed to load checkpoint diff.";
@@ -62,6 +62,20 @@ function normalizeCheckpointErrorMessage(error: unknown): string {
   const lower = message.toLowerCase();
   if (lower.includes("not a git repository")) {
     return "Turn diffs are unavailable because this project is not a git repository.";
+  }
+
+  if (
+    lower.includes("checkpoint ref is unavailable for turn") ||
+    lower.includes("filesystem checkpoint is unavailable for turn")
+  ) {
+    return "This turn's checkpoint diff is no longer available. Showing the latest available diff when possible.";
+  }
+
+  if (
+    lower.includes("checkpoint turn-count sequence is inconsistent") ||
+    lower.includes("missing checkpoint row for turn")
+  ) {
+    return "This thread's diff history is out of sync. Showing the latest available diff when possible.";
   }
 
   if (
@@ -80,12 +94,22 @@ function normalizeCheckpointErrorMessage(error: unknown): string {
   return message;
 }
 
-function isCheckpointTemporarilyUnavailable(error: unknown): boolean {
+export function isCheckpointTemporarilyUnavailable(error: unknown): boolean {
   const message = asCheckpointErrorMessage(error).toLowerCase();
   return (
     message.includes("exceeds current turn count") ||
     message.includes("checkpoint is unavailable for turn") ||
     message.includes("filesystem checkpoint is unavailable")
+  );
+}
+
+export function isCheckpointRecoverableSelectionError(error: unknown): boolean {
+  const message = asCheckpointErrorMessage(error).toLowerCase();
+  return (
+    isCheckpointTemporarilyUnavailable(error) ||
+    message.includes("checkpoint turn-count sequence is inconsistent") ||
+    message.includes("missing checkpoint row for turn") ||
+    message.includes("checkpoint ref is unavailable for turn")
   );
 }
 

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,11 +1,12 @@
 import { ThreadId } from "@t3tools/contracts";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Suspense, lazy, type ReactNode, useCallback, useEffect } from "react";
+import { Suspense, lazy, type ReactNode, useCallback, useEffect, useMemo } from "react";
 
 import ChatView from "../components/ChatView";
 import { useComposerDraftStore } from "../composerDraftStore";
-import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import { buildOpenDiffSearch, parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import { findLatestDiffableTurnDiffSummary } from "../session-logic";
 import { useStore } from "../store";
 import { Sheet, SheetPopup } from "../components/ui/sheet";
 import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
@@ -139,13 +140,18 @@ function ChatThreadRouteView() {
     select: (params) => ThreadId.makeUnsafe(params.threadId),
   });
   const search = Route.useSearch();
-  const threadExists = useStore((store) => store.threads.some((thread) => thread.id === threadId));
+  const activeThread = useStore((store) => store.threads.find((thread) => thread.id === threadId));
+  const threadExists = activeThread !== undefined;
   const draftThreadExists = useComposerDraftStore(
     (store) => Object.hasOwn(store.draftThreadsByThreadId, threadId),
   );
   const routeThreadExists = threadExists || draftThreadExists;
   const diffOpen = search.diff === "1";
   const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
+  const latestTurnDiffSummary = useMemo(
+    () => findLatestDiffableTurnDiffSummary(activeThread?.turnDiffSummaries ?? []),
+    [activeThread?.turnDiffSummaries],
+  );
   const closeDiff = useCallback(() => {
     void navigate({
       to: "/$threadId",
@@ -160,11 +166,10 @@ function ChatThreadRouteView() {
       to: "/$threadId",
       params: { threadId },
       search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
+        return buildOpenDiffSearch(previous, latestTurnDiffSummary?.turnId);
       },
     });
-  }, [navigate, threadId]);
+  }, [latestTurnDiffSummary?.turnId, navigate, threadId]);
 
   useEffect(() => {
     if (!threadsHydrated) {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -9,10 +9,17 @@ import {
   derivePendingUserInputs,
   deriveTimelineEntries,
   deriveWorkLogEntries,
+  findLatestDiffableTurnDiffSummary,
+  findLatestReadyCheckpointTurnCount,
   findLatestProposedPlan,
+  findLatestTurnDiffSummary,
   hasToolActivityForTurn,
+  isTurnDiffSummaryDiffable,
   isLatestTurnSettled,
+  listDiffableTurnIds,
+  orderTurnDiffSummariesByRecency,
 } from "./session-logic";
+import type { TurnDiffSummary } from "./types";
 
 function makeActivity(overrides: {
   id?: string;
@@ -133,6 +140,205 @@ describe("derivePendingApprovals", () => {
     ];
 
     expect(derivePendingApprovals(activities)).toEqual([]);
+  });
+});
+
+describe("orderTurnDiffSummariesByRecency", () => {
+  it("prefers higher explicit checkpoint turn counts over recency", () => {
+    const summaries: TurnDiffSummary[] = [
+      {
+        turnId: TurnId.makeUnsafe("turn-older-higher-count"),
+        completedAt: "2026-02-23T00:00:01.000Z",
+        files: [],
+        checkpointTurnCount: 3,
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-newer-lower-count"),
+        completedAt: "2026-02-23T00:00:09.000Z",
+        files: [],
+        checkpointTurnCount: 2,
+      },
+    ];
+
+    expect(orderTurnDiffSummariesByRecency(summaries).map((summary) => summary.turnId)).toEqual([
+      "turn-older-higher-count",
+      "turn-newer-lower-count",
+    ]);
+  });
+
+  it("falls back to inferred checkpoint turn counts when explicit values are missing", () => {
+    const summaries: TurnDiffSummary[] = [
+      {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        completedAt: "2026-02-23T00:00:01.000Z",
+        files: [],
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-2"),
+        completedAt: "2026-02-23T00:00:02.000Z",
+        files: [],
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-3"),
+        completedAt: "2026-02-23T00:00:03.000Z",
+        files: [],
+      },
+    ];
+
+    expect(orderTurnDiffSummariesByRecency(summaries).map((summary) => summary.turnId)).toEqual([
+      "turn-3",
+      "turn-2",
+      "turn-1",
+    ]);
+  });
+
+  it("uses completion time to break turn-count ties", () => {
+    const summaries: TurnDiffSummary[] = [
+      {
+        turnId: TurnId.makeUnsafe("turn-earlier"),
+        completedAt: "2026-02-23T00:00:01.000Z",
+        files: [],
+        checkpointTurnCount: 2,
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-later"),
+        completedAt: "2026-02-23T00:00:02.000Z",
+        files: [],
+        checkpointTurnCount: 2,
+      },
+    ];
+
+    expect(orderTurnDiffSummariesByRecency(summaries).map((summary) => summary.turnId)).toEqual([
+      "turn-later",
+      "turn-earlier",
+    ]);
+  });
+});
+
+describe("findLatestTurnDiffSummary", () => {
+  it("returns the latest ordered turn summary", () => {
+    const summaries: TurnDiffSummary[] = [
+      {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        completedAt: "2026-02-23T00:00:01.000Z",
+        files: [],
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-2"),
+        completedAt: "2026-02-23T00:00:02.000Z",
+        files: [],
+      },
+    ];
+
+    expect(findLatestTurnDiffSummary(summaries)?.turnId).toBe("turn-2");
+  });
+
+  it("returns null when no turn summaries exist", () => {
+    expect(findLatestTurnDiffSummary([])).toBeNull();
+  });
+});
+
+describe("isTurnDiffSummaryDiffable", () => {
+  it("treats the first ready checkpoint as diffable", () => {
+    const summary: TurnDiffSummary = {
+      turnId: TurnId.makeUnsafe("turn-1"),
+      completedAt: "2026-02-23T00:00:01.000Z",
+      files: [],
+      checkpointTurnCount: 1,
+      status: "ready",
+    };
+
+    expect(isTurnDiffSummaryDiffable(summary, [summary])).toBe(true);
+  });
+
+  it("requires the previous checkpoint count for later turns", () => {
+    const summaries: TurnDiffSummary[] = [
+      {
+        turnId: TurnId.makeUnsafe("turn-2"),
+        completedAt: "2026-02-23T00:00:02.000Z",
+        files: [],
+        checkpointTurnCount: 2,
+        status: "ready",
+      },
+    ];
+
+    expect(isTurnDiffSummaryDiffable(summaries[0]!, summaries)).toBe(false);
+  });
+
+  it("rejects non-ready checkpoint summaries", () => {
+    const summaries: TurnDiffSummary[] = [
+      {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        completedAt: "2026-02-23T00:00:01.000Z",
+        files: [],
+        checkpointTurnCount: 1,
+        status: "missing",
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-2"),
+        completedAt: "2026-02-23T00:00:02.000Z",
+        files: [],
+        checkpointTurnCount: 2,
+        status: "error",
+      },
+    ];
+
+    expect(isTurnDiffSummaryDiffable(summaries[0]!, summaries)).toBe(false);
+    expect(isTurnDiffSummaryDiffable(summaries[1]!, summaries)).toBe(false);
+  });
+});
+
+describe("findLatestDiffableTurnDiffSummary", () => {
+  it("skips newer unusable summaries and returns the latest diffable turn", () => {
+    const summaries: TurnDiffSummary[] = [
+      {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        completedAt: "2026-02-23T00:00:01.000Z",
+        files: [],
+        checkpointTurnCount: 1,
+        status: "ready",
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-3"),
+        completedAt: "2026-02-23T00:00:03.000Z",
+        files: [],
+        checkpointTurnCount: 3,
+        status: "ready",
+      },
+    ];
+
+    expect(findLatestDiffableTurnDiffSummary(summaries)?.turnId).toBe("turn-1");
+    expect(listDiffableTurnIds(summaries)).toEqual(["turn-1"]);
+  });
+});
+
+describe("findLatestReadyCheckpointTurnCount", () => {
+  it("returns the latest ready count even when the newest summary is unusable", () => {
+    const summaries: TurnDiffSummary[] = [
+      {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        completedAt: "2026-02-23T00:00:01.000Z",
+        files: [],
+        checkpointTurnCount: 1,
+        status: "ready",
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-2"),
+        completedAt: "2026-02-23T00:00:02.000Z",
+        files: [],
+        checkpointTurnCount: 2,
+        status: "ready",
+      },
+      {
+        turnId: TurnId.makeUnsafe("turn-3"),
+        completedAt: "2026-02-23T00:00:03.000Z",
+        files: [],
+        checkpointTurnCount: 3,
+        status: "missing",
+      },
+    ];
+
+    expect(findLatestReadyCheckpointTurnCount(summaries)).toBe(2);
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -613,6 +613,109 @@ export function inferCheckpointTurnCountByTurnId(
   return result;
 }
 
+function resolveTurnDiffSummaryCheckpointTurnCount(
+  summary: TurnDiffSummary,
+  inferredCheckpointTurnCountByTurnId: Record<TurnId, number>,
+): number | undefined {
+  return summary.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[summary.turnId];
+}
+
+function buildTurnDiffSummaryResolution(summaries: TurnDiffSummary[]) {
+  const inferredCheckpointTurnCountByTurnId = inferCheckpointTurnCountByTurnId(summaries);
+  const availableCheckpointTurnCounts = new Set<number>();
+  const readyCheckpointTurnCounts = new Set<number>();
+
+  for (const summary of summaries) {
+    const checkpointTurnCount = resolveTurnDiffSummaryCheckpointTurnCount(
+      summary,
+      inferredCheckpointTurnCountByTurnId,
+    );
+    if (checkpointTurnCount === undefined) {
+      continue;
+    }
+    availableCheckpointTurnCounts.add(checkpointTurnCount);
+    if (summary.status === undefined || summary.status === "ready") {
+      readyCheckpointTurnCounts.add(checkpointTurnCount);
+    }
+  }
+
+  return {
+    inferredCheckpointTurnCountByTurnId,
+    availableCheckpointTurnCounts,
+    readyCheckpointTurnCounts,
+  };
+}
+
+export function orderTurnDiffSummariesByRecency(
+  summaries: TurnDiffSummary[],
+): TurnDiffSummary[] {
+  const inferredCheckpointTurnCountByTurnId = inferCheckpointTurnCountByTurnId(summaries);
+
+  return [...summaries].toSorted((left, right) => {
+    const leftTurnCount =
+      left.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[left.turnId] ?? 0;
+    const rightTurnCount =
+      right.checkpointTurnCount ?? inferredCheckpointTurnCountByTurnId[right.turnId] ?? 0;
+
+    if (leftTurnCount !== rightTurnCount) {
+      return rightTurnCount - leftTurnCount;
+    }
+
+    return right.completedAt.localeCompare(left.completedAt);
+  });
+}
+
+export function findLatestTurnDiffSummary(summaries: TurnDiffSummary[]): TurnDiffSummary | null {
+  return orderTurnDiffSummariesByRecency(summaries)[0] ?? null;
+}
+
+export function isTurnDiffSummaryDiffable(
+  summary: TurnDiffSummary,
+  summaries: TurnDiffSummary[],
+): boolean {
+  if (summary.status !== undefined && summary.status !== "ready") {
+    return false;
+  }
+
+  const { inferredCheckpointTurnCountByTurnId, availableCheckpointTurnCounts } =
+    buildTurnDiffSummaryResolution(summaries);
+  const checkpointTurnCount = resolveTurnDiffSummaryCheckpointTurnCount(
+    summary,
+    inferredCheckpointTurnCountByTurnId,
+  );
+  if (checkpointTurnCount === undefined) {
+    return false;
+  }
+
+  return checkpointTurnCount === 1 || availableCheckpointTurnCounts.has(checkpointTurnCount - 1);
+}
+
+export function listDiffableTurnIds(summaries: TurnDiffSummary[]): TurnId[] {
+  return orderTurnDiffSummariesByRecency(summaries)
+    .filter((summary) => isTurnDiffSummaryDiffable(summary, summaries))
+    .map((summary) => summary.turnId);
+}
+
+export function findLatestDiffableTurnDiffSummary(
+  summaries: TurnDiffSummary[],
+): TurnDiffSummary | null {
+  return (
+    orderTurnDiffSummariesByRecency(summaries).find((summary) =>
+      isTurnDiffSummaryDiffable(summary, summaries),
+    ) ?? null
+  );
+}
+
+export function findLatestReadyCheckpointTurnCount(
+  summaries: TurnDiffSummary[],
+): number | undefined {
+  const { readyCheckpointTurnCounts } = buildTurnDiffSummaryResolution(summaries);
+  if (readyCheckpointTurnCounts.size === 0) {
+    return undefined;
+  }
+  return Math.max(...readyCheckpointTurnCounts);
+}
+
 export function derivePhase(session: ThreadSession | null): SessionPhase {
   if (!session || session.status === "closed") return "disconnected";
   if (session.status === "connecting") return "connecting";


### PR DESCRIPTION
## Summary
- stop projecting `turn.diff.updated` runtime events as `thread.turn.diff.complete` checkpoint entries
- keep provider diff previews as separate `turn.diff.preview.updated` activities so they stay associated with the correct turn without consuming checkpoint turn counts
- add duplicate-turn idempotency guards on the server and validate only the specific checkpoint rows needed for a requested diff
- harden the web diff panel so default-open prefers the latest diffable checkpoint turn and recovers cleanly when a selected diff target becomes invalid

## Context
The intermittent `Checkpoint ref is unavailable for turn X` error was caused by mixing provider preview diff updates into canonical checkpoint history. `turn.diff.updated` events were being assigned synthetic checkpoint refs and `checkpointTurnCount` values, which could distort the checkpoint-turn timeline and leave later per-turn diff requests targeting counts with no real filesystem-backed checkpoint behind them.

This change keeps `thread.checkpoints` canonical and checkpoint-backed, moves preview diffs onto a separate per-turn activity path, and keeps the web diff UI aligned with real diffable checkpoint history only.

On the query side, the invariant check now stays narrow: it rejects duplicate checkpoint rows and missing requested rows, but still allows reading diffs from threads with partial checkpoint history when the specific `fromTurnCount` and `toTurnCount` needed for the diff are present.

## Screenshot
<img width="496" height="796" alt="image" src="https://github.com/user-attachments/assets/e5cf1fcc-b82d-4b35-9a4e-7f5e926aa376" />

## Testing
- `bun x vitest run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts apps/server/src/orchestration/Layers/CheckpointReactor.test.ts apps/server/src/checkpointing/Layers/CheckpointDiffQuery.test.ts apps/web/src/session-logic.test.ts apps/web/src/lib/providerReactQuery.test.ts apps/web/src/diffRouteSearch.test.ts`
- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent provider preview events from corrupting checkpoint history and update `CheckpointDiffQueryLive.getTurnDiff` to tolerate gaps while enforcing duplicate and missing turn-count invariants in [CheckpointDiffQuery.ts](https://github.com/pingdotgg/t3code/pull/572/files#diff-a7f6357814d1957a562de3ea25f26bd4dc2f18e4ccf790082ae04e2bc484da51)
> Server adds `buildCheckpointIndex` and refactors `CheckpointDiffQueryLive.getTurnDiff` for map-based lookups and strict invariants; orchestration stops creating checkpoints from `turn.diff.updated` and logs duplicate turn completions; web routes and panels navigate to the latest diffable turn and constrain selection to diffable checkpoints.
>
> #### 📍Where to Start
> Start with `CheckpointDiffQueryLive.getTurnDiff` and `buildCheckpointIndex` in [CheckpointDiffQuery.ts](https://github.com/pingdotgg/t3code/pull/572/files#diff-a7f6357814d1957a562de3ea25f26bd4dc2f18e4ccf790082ae04e2bc484da51).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cae17c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->