### PR TITLE
feat(web): add sidebar settings entry

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -409,6 +409,16 @@ async function waitForInteractionModeButton(expectedLabel: "Chat" | "Plan"): Pro
   );
 }
 
+async function waitForButtonByLabel(label: string): Promise<HTMLButtonElement> {
+  return waitForElement(
+    () =>
+      Array.from(document.querySelectorAll("button")).find(
+        (button) => button.textContent?.trim() === label,
+      ) as HTMLButtonElement | null,
+    `Unable to find ${label} button.`,
+  );
+}
+
 async function waitForImagesToLoad(scope: ParentNode): Promise<void> {
   const images = Array.from(scope.querySelectorAll("img"));
   if (images.length === 0) {
@@ -795,6 +805,40 @@ describe("ChatView timeline estimator parity (full app)", () => {
             cwd: "/repo/project",
             editor: "vscode",
           });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("opens settings from the sidebar footer", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-target-settings-nav" as MessageId,
+        targetText: "settings navigation target",
+      }),
+    });
+
+    try {
+      const settingsButton = await waitForButtonByLabel("Settings");
+      settingsButton.click();
+
+      await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("h1")).find(
+            (heading) => heading.textContent?.trim() === "Settings",
+          ) as HTMLHeadingElement | null,
+        "Unable to find Settings heading.",
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(document.body.textContent).toContain(
+            "Configure app-level preferences for this device.",
+          );
         },
         { timeout: 8_000, interval: 16 },
       );

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   FolderIcon,
   GitPullRequestIcon,
   RocketIcon,
+  SettingsIcon,
   SquarePenIcon,
   TerminalIcon,
 } from "lucide-react";
@@ -17,7 +18,7 @@ import {
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate, useParams } from "@tanstack/react-router";
+import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import { useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL } from "../branding";
@@ -57,6 +58,7 @@ import {
   SidebarMenuSubItem,
   SidebarSeparator,
   SidebarTrigger,
+  useSidebar,
 } from "./ui/sidebar";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
@@ -258,6 +260,7 @@ function ProjectFavicon({ cwd }: { cwd: string }) {
 }
 
 export default function Sidebar() {
+  const { isMobile, setOpenMobile } = useSidebar();
   const projects = useStore((store) => store.projects);
   const threads = useStore((store) => store.threads);
   const markThreadUnread = useStore((store) => store.markThreadUnread);
@@ -278,6 +281,7 @@ export default function Sidebar() {
     (store) => store.clearProjectDraftThreadById,
   );
   const navigate = useNavigate();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
   const { settings: appSettings } = useAppSettings();
   const routeThreadId = useParams({
     strict: false,
@@ -898,6 +902,7 @@ export default function Sidebar() {
       shortcutLabelForCommand(keybindings, "chat.new"),
     [keybindings],
   );
+  const isSettingsRoute = pathname === "/settings";
 
   const handleDesktopUpdateButtonClick = useCallback(() => {
     const bridge = window.desktopBridge;
@@ -974,6 +979,13 @@ export default function Sidebar() {
       return next;
     });
   }, []);
+
+  const handleOpenSettings = useCallback(() => {
+    if (isMobile) {
+      setOpenMobile(false);
+    }
+    void navigate({ to: "/settings" });
+  }, [isMobile, navigate, setOpenMobile]);
 
   const wordmark = (
     <div className="flex items-center gap-2">
@@ -1342,13 +1354,28 @@ export default function Sidebar() {
             </div>
           </>
         ) : (
-          <button
-            type="button"
-            className="flex w-full items-center justify-center gap-1 rounded-md border border-dashed border-border py-2 text-xs text-muted-foreground/70 transition-colors duration-150 hover:border-ring hover:text-muted-foreground"
-            onClick={() => setAddingProject(true)}
-          >
-            + Add project
-          </button>
+          <>
+            <button
+              type="button"
+              className="flex w-full items-center justify-center gap-1 rounded-md border border-dashed border-border py-2 text-xs text-muted-foreground/70 transition-colors duration-150 hover:border-ring hover:text-muted-foreground"
+              onClick={() => setAddingProject(true)}
+            >
+              + Add project
+            </button>
+            <button
+              type="button"
+              aria-current={isSettingsRoute ? "page" : undefined}
+              className={`flex w-full items-center justify-center gap-1.5 rounded-md border px-3 py-2 text-xs transition-colors duration-150 ${
+                isSettingsRoute
+                  ? "border-border/70 bg-accent/85 font-medium text-foreground ring-1 ring-border/70 dark:bg-accent/55 dark:ring-border/50"
+                  : "border-border text-muted-foreground/80 hover:bg-secondary hover:text-foreground"
+              }`}
+              onClick={handleOpenSettings}
+            >
+              <SettingsIcon className="size-3.5 shrink-0" />
+              <span>Settings</span>
+            </button>
+          </>
         )}
       </SidebarFooter>
     </>


### PR DESCRIPTION
## Summary
- add a visible `Settings` action below `+ Add project` in the sidebar footer
- reuse the existing `/settings` route and highlight the footer action when that page is active
- close the mobile sidebar sheet before navigating so the settings page opens cleanly on smaller screens
- add a browser test that mounts the full app shell and verifies footer navigation to settings

## Context
The settings page already existed, but the web UI had no visible way to reach it without the desktop menu or keybinding path. This change makes settings discoverable in the main app chrome without adding a new command, changing the route structure, or introducing extra header actions.

Keeping the entry in the sidebar footer preserves the existing navigation model, keeps the add-project flow intact, and works across desktop and mobile layouts.
<img width="259" height="926" alt="image" src="https://github.com/user-attachments/assets/22c1e41b-4cf5-4175-afb6-079f434c6184" />

## Testing
- `cd apps/web && bun run test:browser`
- `bun lint` (passes with existing unrelated server warnings)
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a Settings entry in the web sidebar footer that navigates to `/settings` and closes the mobile sidebar
> Add a Settings button to the sidebar footer in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/577/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) with active state via `aria-current`, mobile close behavior via `useSidebar`, and routing via `useRouterState`; add an integration test in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/577/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) using a new `waitForButtonByLabel` helper to open Settings and assert the page header and copy.
>
> #### 📍Where to Start
> Start with the `Sidebar` component changes in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/577/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), then review the test and helper additions in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/577/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6301f4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->