### PR TITLE
fix: settings in sidebar, better add project flow

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1397,7 +1397,7 @@ export default function Sidebar() {
               <SidebarMenuButton
                 size="sm"
                 className="gap-2 px-2 py-1.5 text-muted-foreground/70 hover:bg-accent hover:text-foreground"
-                onClick={() => void navigate({ to: "/" })}
+                onClick={() => window.history.back()}
               >
                 <ArrowLeftIcon className="size-3.5" />
                 <span className="text-xs">Back</span>


### PR DESCRIPTION
Before: (nothing to see here)

After:
<img width="952" height="734" alt="image" src="https://github.com/user-attachments/assets/d4e4da1f-dbe8-4202-9e07-e0e0a5124f41" />
<img width="952" height="734" alt="image" src="https://github.com/user-attachments/assets/1264fd34-8086-4c6f-9d5a-8a47be490172" />
<img width="952" height="734" alt="image" src="https://github.com/user-attachments/assets/09501176-fc00-4e59-bb10-e7fb581a6c6e" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move project creation to an inline panel in the Sidebar and add a Settings/Back footer control to support navigating to settings
> Rework the `Sidebar` UI in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/584/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1): add a header-level `+` toggle that opens an inline add-project panel with input, optional folder picker, loading state, cancel, and inline error text; replace footer add controls with a `Settings` button when not on settings and a `Back` button when on settings; route state uses `useLocation`; error handling in `Sidebar.addProjectFromPath` sets `addProjectError` instead of toasts and clears it on finish; focus returns to the input when folder picking is canceled.
>
> #### 📍Where to Start
> Start in the `Sidebar` component render and handlers in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/584/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), focusing on `addProjectFromPath` and the new header-level add-project panel logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6f0350.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->