### PR TITLE
fix(web): align sidebar logo with macOS traffic light buttons

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -978,7 +978,7 @@ export default function Sidebar() {
   const wordmark = (
     <div className="flex items-center gap-2">
       <SidebarTrigger className="shrink-0 md:hidden" />
-      <div className="flex min-w-0 flex-1 items-center gap-1 mt-2 ml-1">
+      <div className="flex min-w-0 flex-1 items-center gap-1 mt-1.5 ml-1">
         <T3Wordmark />
         <span className="truncate text-sm font-medium tracking-tight text-muted-foreground">
           Code
@@ -994,7 +994,7 @@ export default function Sidebar() {
     <>
       {isElectron ? (
         <>
-          <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[82px]">
+          <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}
             {showDesktopUpdateButton && (
               <Tooltip>
@@ -1005,7 +1005,7 @@ export default function Sidebar() {
                       aria-label={desktopUpdateTooltip}
                       aria-disabled={desktopUpdateButtonDisabled || undefined}
                       disabled={desktopUpdateButtonDisabled}
-                      className={`inline-flex size-7 ml-auto mt-2 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
+                      className={`inline-flex size-7 ml-auto mt-1.5 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
                       onClick={handleDesktopUpdateButtonClick}
                     >
                       <RocketIcon className="size-3.5" />


### PR DESCRIPTION
## Summary

Fixes the sidebar logo alignment in the Electron desktop app on macOS. The T3 wordmark was not vertically centered with the native window traffic light buttons — it sat ~2px too low and ~8px too close to the traffic lights.

Closes #564

## Changes

- **Vertical alignment:** Reduced wordmark container top margin from `mt-2` (8px) to `mt-1.5` (6px), shifting the logo up ~2px to better center with the traffic light buttons.
- **Horizontal clearance:** Increased Electron `SidebarHeader` left padding from `pl-[82px]` to `pl-[90px]`, adding 8px of breathing room from the traffic light buttons.
- **Update button alignment:** Matched the desktop update button's top margin (`mt-2` → `mt-1.5`) so it stays vertically aligned with the wordmark.

All three changes are scoped to `apps/web/src/components/Sidebar.tsx`. Only Tailwind class adjustments — no logic changes.

## Before / After

| Before | After |
|--------|-------|
| Logo sits slightly below traffic light center, too close horizontally | Logo vertically centered with traffic lights, proper horizontal clearance  |



**Before**
<img width="186" height="32" alt="before" src="https://github.com/user-attachments/assets/7f599991-41f8-417d-be7a-b5adbaab31e6" />
**After**
<img width="217" height="42" alt="after" src="https://github.com/user-attachments/assets/bd3e68b5-650c-4183-adfd-b235eb2c6348" />

## Testing

- `bun lint` — 0 errors
- `bun typecheck` — 0 errors
- Verified visually in Electron desktop app on macOS