### PR TITLE
fix(web): add dismiss button to thread error banner

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -123,7 +123,7 @@ import {
 } from "../keybindings";
 import ChatMarkdown from "./ChatMarkdown";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
-import { Alert, AlertDescription, AlertTitle } from "./ui/alert";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import {
   BotIcon,
   ChevronDownIcon,
@@ -3434,7 +3434,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
       {/* Error banner */}
       <ProviderHealthBanner status={activeProviderStatus} />
-      <ThreadErrorBanner error={activeThread.error} />
+      <ThreadErrorBanner
+        error={activeThread.error}
+        onDismiss={() => setThreadError(activeThread.id, null)}
+      />
       <PlanModePanel activePlan={activePlan} />
 
       {/* Messages */}
@@ -4095,7 +4098,13 @@ const ChatHeader = memo(function ChatHeader({
   );
 });
 
-const ThreadErrorBanner = memo(function ThreadErrorBanner({ error }: { error: string | null }) {
+const ThreadErrorBanner = memo(function ThreadErrorBanner({
+  error,
+  onDismiss,
+}: {
+  error: string | null;
+  onDismiss?: () => void;
+}) {
   if (!error) return null;
   return (
     <div className="pt-3 mx-auto max-w-3xl">
@@ -4104,6 +4113,18 @@ const ThreadErrorBanner = memo(function ThreadErrorBanner({ error }: { error: st
         <AlertDescription className="line-clamp-3" title={error}>
           {error}
         </AlertDescription>
+        {onDismiss && (
+          <AlertAction>
+            <button
+              type="button"
+              aria-label="Dismiss error"
+              className="inline-flex size-6 items-center justify-center rounded-md text-destructive/60 transition-colors hover:text-destructive"
+              onClick={onDismiss}
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          </AlertAction>
+        )}
       </Alert>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds a dismiss button to the thread error banner so users can clear errors that would otherwise persist indefinitely.

Closes #496

## Problem

`ThreadErrorBanner` rendered an `Alert` with no close button. The only way to clear an error was to send a new message (which resets the error to `null`). If the thread was in a broken state (e.g. missing `gh` CLI during PR creation), the user was stuck with a persistent, undismissable error banner.

## Changes

### `apps/web/src/components/ChatView.tsx`
- Added `onDismiss` prop to `ThreadErrorBanner`, rendering an `AlertAction` with a close button (`XIcon`) that clears the thread error.
- Imported the existing `AlertAction` component from `./ui/alert` (was exported but unused).
- Wired the dismiss callback at the call site: `() => setThreadError(activeThread.id, null)`.

Single file changed. No store or contract changes.

## Testing

- `bun lint` — 0 errors
- `bun typecheck` — 0 errors
- `bun run test` — no regressions

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a dismiss button to the chat thread error banner in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/588/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to clear the active thread error
> Introduce an optional `onDismiss` prop to `ThreadErrorBanner` and wire it in `ChatView` to call `setThreadError(activeThread.id, null)`; render an `AlertAction` with an `XIcon` button when the callback is provided.
>
> #### 📍Where to Start
> Start with the `ThreadErrorBanner` prop changes and dismiss handling in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/588/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b8c294.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->