### PR TITLE
fix(web): add missing v7 key to legacy localStorage cleanup list

### DIFF
--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -25,6 +25,7 @@ export interface AppState {
 
 const PERSISTED_STATE_KEY = "t3code:renderer-state:v8";
 const LEGACY_PERSISTED_STATE_KEYS = [
+  "t3code:renderer-state:v7",
   "t3code:renderer-state:v6",
   "t3code:renderer-state:v5",
   "t3code:renderer-state:v4",


### PR DESCRIPTION
## Summary

When the persisted state key was bumped from `v7` to `v8` in [`689dda59`](https://github.com/pingdotgg/t3code/commit/689dda59), the outgoing `v7` key was not added to `LEGACY_PERSISTED_STATE_KEYS`. Users who ran the app during the ~3-week window where `v7` was the active key retain a stale `t3code:renderer-state:v7` entry in localStorage that is never cleaned up.

## Change

One-line addition: add `"t3code:renderer-state:v7"` to the legacy key cleanup array in `apps/web/src/store.ts`.

## Verification

- `bun lint` — passes (only pre-existing warnings)
- `bun typecheck` — passes
- `bun run test` — passes (2 pre-existing `terminalStateStore.test.ts` failures on `main` unrelated to this change)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add missing "t3code:renderer-state:v7" key to legacy localStorage cleanup list in `LEGACY_PERSISTED_STATE_KEYS` within [store.ts](https://github.com/pingdotgg/t3code/pull/594/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82)
> Add the string "t3code:renderer-state:v7" to `LEGACY_PERSISTED_STATE_KEYS` in [store.ts](https://github.com/pingdotgg/t3code/pull/594/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82).
>
> #### 📍Where to Start
> Start with the `LEGACY_PERSISTED_STATE_KEYS` definition in [store.ts](https://github.com/pingdotgg/t3code/pull/594/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 759f6e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->