### PR TITLE
fix(contracts): align terminal restart input type across IPC, WS, and server

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.test.ts
+++ b/apps/server/src/terminal/Layers/Manager.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_TERMINAL_ID,
   type TerminalEvent,
   type TerminalOpenInput,
+  type TerminalRestartInput,
 } from "@t3tools/contracts";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -125,6 +126,16 @@ function waitFor(predicate: () => boolean, timeoutMs = 800): Promise<void> {
 }
 
 function openInput(overrides: Partial<TerminalOpenInput> = {}): TerminalOpenInput {
+  return {
+    threadId: "thread-1",
+    cwd: process.cwd(),
+    cols: 100,
+    rows: 24,
+    ...overrides,
+  };
+}
+
+function restartInput(overrides: Partial<TerminalRestartInput> = {}): TerminalRestartInput {
   return {
     threadId: "thread-1",
     cwd: process.cwd(),
@@ -361,7 +372,7 @@ describe("TerminalManager", () => {
     firstProcess.emitData("before restart\n");
     await waitFor(() => fs.existsSync(historyLogPath(logsDir)));
 
-    const snapshot = await manager.restart(openInput());
+    const snapshot = await manager.restart(restartInput());
     expect(snapshot.history).toBe("");
     expect(snapshot.status).toBe("running");
     expect(ptyAdapter.spawnInputs).toHaveLength(2);

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -8,6 +8,7 @@ import {
   TerminalCloseInput,
   TerminalOpenInput,
   TerminalResizeInput,
+  TerminalRestartInput,
   TerminalWriteInput,
   type TerminalEvent,
   type TerminalSessionSnapshot,
@@ -37,6 +38,7 @@ const DEFAULT_OPEN_ROWS = 30;
 const TERMINAL_ENV_BLOCKLIST = new Set(["PORT", "ELECTRON_RENDERER_PORT", "ELECTRON_RUN_AS_NODE"]);
 
 const decodeTerminalOpenInput = Schema.decodeUnknownSync(TerminalOpenInput);
+const decodeTerminalRestartInput = Schema.decodeUnknownSync(TerminalRestartInput);
 const decodeTerminalWriteInput = Schema.decodeUnknownSync(TerminalWriteInput);
 const decodeTerminalResizeInput = Schema.decodeUnknownSync(TerminalResizeInput);
 const decodeTerminalClearInput = Schema.decodeUnknownSync(TerminalClearInput);
@@ -478,8 +480,8 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     });
   }
 
-  async restart(raw: TerminalOpenInput): Promise<TerminalSessionSnapshot> {
-    const input = decodeTerminalOpenInput(raw);
+  async restart(raw: TerminalRestartInput): Promise<TerminalSessionSnapshot> {
+    const input = decodeTerminalRestartInput(raw);
     return this.runWithThreadLock(input.threadId, async () => {
       await this.assertValidCwd(input.cwd);
 

--- a/apps/server/src/terminal/Services/Manager.ts
+++ b/apps/server/src/terminal/Services/Manager.ts
@@ -12,6 +12,7 @@ import {
   TerminalEvent,
   TerminalOpenInput,
   TerminalResizeInput,
+  TerminalRestartInput,
   TerminalSessionSnapshot,
   TerminalSessionStatus,
   TerminalWriteInput,
@@ -88,7 +89,7 @@ export interface TerminalManagerShape {
    * Always resets history before spawning the new process.
    */
   readonly restart: (
-    input: TerminalOpenInput,
+    input: TerminalRestartInput,
   ) => Effect.Effect<TerminalSessionSnapshot, TerminalError>;
 
   /**

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -27,6 +27,7 @@ import type {
   TerminalEvent,
   TerminalOpenInput,
   TerminalResizeInput,
+  TerminalRestartInput,
   TerminalSessionSnapshot,
   TerminalWriteInput,
 } from "./terminal";
@@ -103,7 +104,7 @@ export interface NativeApi {
     write: (input: TerminalWriteInput) => Promise<void>;
     resize: (input: TerminalResizeInput) => Promise<void>;
     clear: (input: TerminalClearInput) => Promise<void>;
-    restart: (input: TerminalOpenInput) => Promise<TerminalSessionSnapshot>;
+    restart: (input: TerminalRestartInput) => Promise<TerminalSessionSnapshot>;
     close: (input: TerminalCloseInput) => Promise<void>;
     onEvent: (callback: (event: TerminalEvent) => void) => () => void;
   };

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -60,12 +60,13 @@ export const TerminalClearInput = TerminalSessionInput;
 export type TerminalClearInput = Schema.Codec.Encoded<typeof TerminalClearInput>;
 
 export const TerminalRestartInput = Schema.Struct({
-  ...TerminalThreadInput.fields,
+  ...TerminalSessionInput.fields,
   cwd: TrimmedNonEmptyStringSchema,
   cols: TerminalColsSchema,
   rows: TerminalRowsSchema,
   env: Schema.optional(TerminalEnvSchema),
 });
+export type TerminalRestartInput = Schema.Codec.Encoded<typeof TerminalRestartInput>;
 
 export const TerminalCloseInput = Schema.Struct({
   ...TerminalThreadInput.fields,


### PR DESCRIPTION
## Summary

The `terminal.restart` operation had three different type expectations depending on the layer:

| Layer | Type used | cols/rows | terminalId |
|-------|-----------|-----------|------------|
| NativeApi IPC (`ipc.ts`) | `TerminalOpenInput` | optional | yes (with default) |
| WS schema (`ws.ts`) | `TerminalRestartInput` | **required** | **no** |
| Server impl (`Manager.ts`) | `TerminalOpenInput` decode | optional | yes (with default) |

The server accessed `input.terminalId` after decode, but the WS schema never validated it — the field silently fell through to the `withDecodingDefault` fallback. Meanwhile the IPC type allowed callers to omit `cols`/`rows`, but the WS schema would reject the request at validation time.

## Changes

1. **`TerminalRestartInput`** now extends `TerminalSessionInput` (adds `terminalId` with decoding default) instead of `TerminalThreadInput`. Also exports the type alias.
2. **`NativeApi.terminal.restart`** in `ipc.ts` now accepts `TerminalRestartInput` instead of `TerminalOpenInput`.
3. **`TerminalManagerShape.restart`** and **`TerminalManagerRuntime.restart`** updated to accept and decode `TerminalRestartInput`.
4. **Test** updated with a dedicated `restartInput()` helper.

The change is **backward-compatible on the wire** — `terminalId` uses `withDecodingDefault` and defaults to `"default"` when omitted by existing clients.

## Verification

- `bun lint` — passes (only pre-existing warnings)
- `bun typecheck` — passes across all 7 packages
- `bun run test` — passes (pre-existing failures in `terminalStateStore.test.ts` and one shell-resolver test unrelated to this change)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align terminal restart input to use `TerminalRestartInput` across `packages/contracts`, IPC, WS, and server runtime
> Switch restart flows to `TerminalRestartInput`, update schema to derive from `TerminalSessionInput`, change `TerminalManagerRuntime.restart` to decode the new type, and update tests and service interfaces accordingly. See [packages/contracts/src/terminal.ts](https://github.com/pingdotgg/t3code/pull/597/files#diff-68613534653e19cf33dc0ddf6c6bf01ac3c4848b8fbfdd29363100dd6a7c2a89) and [apps/server/src/terminal/Layers/Manager.ts](https://github.com/pingdotgg/t3code/pull/597/files#diff-51f9668a4493e7cf6ec7c836a4af9946110091ee50cd822c9c4a4d5bdcedf496).
>
> #### 📍Where to Start
> Start at `TerminalManagerRuntime.restart` in [apps/server/src/terminal/Layers/Manager.ts](https://github.com/pingdotgg/t3code/pull/597/files#diff-51f9668a4493e7cf6ec7c836a4af9946110091ee50cd822c9c4a4d5bdcedf496), then review the `TerminalRestartInput` schema in [packages/contracts/src/terminal.ts](https://github.com/pingdotgg/t3code/pull/597/files#diff-68613534653e19cf33dc0ddf6c6bf01ac3c4848b8fbfdd29363100dd6a7c2a89).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized beda3de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->