### PR TITLE
refactor(web): remove redundant double parse of diff route search params

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -757,11 +757,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     composerDraft.interactionMode ?? activeThread?.interactionMode ?? DEFAULT_INTERACTION_MODE;
   const isServerThread = serverThread !== undefined;
   const isLocalDraftThread = !isServerThread && localDraftThread !== undefined;
-  const diffSearch = useMemo(
-    () => parseDiffRouteSearch(rawSearch as Record<string, unknown>),
-    [rawSearch],
-  );
-  const diffOpen = diffSearch.diff === "1";
+  const diffOpen = rawSearch.diff === "1";
   const activeThreadId = activeThread?.id ?? null;
   const activeLatestTurn = activeThread?.latestTurn ?? null;
   const latestTurnSettled = isLatestTurnSettled(activeLatestTurn, activeThread?.session ?? null);


### PR DESCRIPTION
## Summary

`rawSearch` in `ChatView` is produced by `useSearch` with a `select` transform that runs `parseDiffRouteSearch`. A subsequent `useMemo` re-parsed the already-parsed result through the same function using an unsafe `as Record<string, unknown>` cast, producing an identical `DiffRouteSearch` object.

This removes the redundant `useMemo` + re-parse and reads `rawSearch.diff` directly, since `rawSearch` is already typed as `DiffRouteSearch`.

## Change

- Removed the `diffSearch` useMemo that called `parseDiffRouteSearch(rawSearch as Record<string, unknown>)`
- Replaced `diffSearch.diff === "1"` with `rawSearch.diff === "1"`
- Net: -5 lines, eliminates an unnecessary re-parse and an unsafe type cast

## Verification

- `bun lint` — passes (only pre-existing warnings)
- `bun typecheck` — passes across all 7 packages
- `bun run test` — passes (pre-existing `terminalStateStore.test.ts` failures unrelated)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant double parse of diff route search params by deriving `ChatView` diff state directly from `rawSearch.diff` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/598/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Remove `useMemo` for `diffSearch` and compute `diffOpen` directly from `rawSearch.diff` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/598/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> #### 📍Where to Start
> Start with the `ChatView` component changes in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/598/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7a2fae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->