### PR TITLE
fix: fix external link opening in desktop

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -112,6 +112,25 @@ function formatErrorMessage(error: unknown): string {
   return String(error);
 }
 
+function getSafeExternalUrl(rawUrl: unknown): string | null {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0) {
+    return null;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+    return null;
+  }
+
+  return parsedUrl.toString();
+}
+
 function writeDesktopStreamChunk(
   streamName: "stdout" | "stderr",
   chunk: unknown,
@@ -1033,23 +1052,13 @@ function registerIpcHandlers(): void {
 
   ipcMain.removeHandler(OPEN_EXTERNAL_CHANNEL);
   ipcMain.handle(OPEN_EXTERNAL_CHANNEL, async (_event, rawUrl: unknown) => {
-    if (typeof rawUrl !== "string" || rawUrl.length === 0) {
-      return false;
-    }
-
-    let parsedUrl: URL;
-    try {
-      parsedUrl = new URL(rawUrl);
-    } catch {
-      return false;
-    }
-
-    if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+    const externalUrl = getSafeExternalUrl(rawUrl);
+    if (!externalUrl) {
       return false;
     }
 
     try {
-      await shell.openExternal(parsedUrl.toString());
+      await shell.openExternal(externalUrl);
       return true;
     } catch {
       return false;
@@ -1142,7 +1151,14 @@ function createWindow(): BrowserWindow {
     Menu.buildFromTemplate(menuTemplate).popup({ window });
   });
 
-  window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  window.webContents.setWindowOpenHandler(({ url }) => {
+    const externalUrl = getSafeExternalUrl(url);
+    if (externalUrl) {
+      void shell.openExternal(externalUrl);
+    }
+    return { action: "deny" };
+  });
+
   window.on("page-title-updated", (event) => {
     event.preventDefault();
     window.setTitle(APP_DISPLAY_NAME);


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Added electron link handling for safe links so they open in an external browser.

I have validated that file links still open in Cursor, and that external links work in both the browser and desktop environment.

## Why

Clicking on external links in the agent response was doing nothing rather than opening in an external browser.

Fixes #434

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate and open http/https external links from desktop by routing `main.createWindow` window-open requests and `main.registerIpcHandlers` `OPEN_EXTERNAL` through `main.getSafeExternalUrl` in [main.ts](https://github.com/pingdotgg/t3code/pull/599/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb)
> Add `main.getSafeExternalUrl` to normalize and guard URLs; update `OPEN_EXTERNAL` IPC handler and `webContents.setWindowOpenHandler` to use it and open validated links via `shell.openExternal` in [main.ts](https://github.com/pingdotgg/t3code/pull/599/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb).
>
> #### 📍Where to Start
> Start with `getSafeExternalUrl` and its use in the `OPEN_EXTERNAL` IPC handler and `webContents.setWindowOpenHandler` in [main.ts](https://github.com/pingdotgg/t3code/pull/599/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 015ee56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->