### PR TITLE
refactor(contracts): remove unused OrchestrationPersistedEvent schema

### DIFF
--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -769,20 +769,6 @@ const EventBaseFields = {
   metadata: OrchestrationEventMetadata,
 } as const;
 
-const PersistedEventBaseFields = {
-  sequence: NonNegativeInt,
-  eventId: EventId,
-  aggregateKind: OrchestrationAggregateKind,
-  streamId: Schema.Union([ProjectId, ThreadId]),
-  streamVersion: NonNegativeInt,
-  occurredAt: IsoDateTime,
-  commandId: Schema.NullOr(CommandId),
-  causationEventId: Schema.NullOr(EventId),
-  correlationId: Schema.NullOr(CommandId),
-  actorKind: OrchestrationActorKind,
-  metadata: OrchestrationEventMetadata,
-} as const;
-
 export const OrchestrationEvent = Schema.Union([
   Schema.Struct({
     ...EventBaseFields,
@@ -886,110 +872,6 @@ export const OrchestrationEvent = Schema.Union([
   }),
 ]);
 export type OrchestrationEvent = typeof OrchestrationEvent.Type;
-
-export const OrchestrationPersistedEvent = Schema.Union([
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("project.created"),
-    payload: ProjectCreatedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("project.meta-updated"),
-    payload: ProjectMetaUpdatedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("project.deleted"),
-    payload: ProjectDeletedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.created"),
-    payload: ThreadCreatedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.deleted"),
-    payload: ThreadDeletedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.meta-updated"),
-    payload: ThreadMetaUpdatedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.runtime-mode-set"),
-    payload: ThreadRuntimeModeSetPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.interaction-mode-set"),
-    payload: ThreadInteractionModeSetPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.message-sent"),
-    payload: ThreadMessageSentPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.turn-start-requested"),
-    payload: ThreadTurnStartRequestedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.turn-interrupt-requested"),
-    payload: ThreadTurnInterruptRequestedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.approval-response-requested"),
-    payload: ThreadApprovalResponseRequestedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.user-input-response-requested"),
-    payload: ThreadUserInputResponseRequestedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.checkpoint-revert-requested"),
-    payload: ThreadCheckpointRevertRequestedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.reverted"),
-    payload: ThreadRevertedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.session-stop-requested"),
-    payload: ThreadSessionStopRequestedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.session-set"),
-    payload: ThreadSessionSetPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.proposed-plan-upserted"),
-    payload: ThreadProposedPlanUpsertedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.turn-diff-completed"),
-    payload: ThreadTurnDiffCompletedPayload,
-  }),
-  Schema.Struct({
-    ...PersistedEventBaseFields,
-    eventType: Schema.Literal("thread.activity-appended"),
-    payload: ThreadActivityAppendedPayload,
-  }),
-]);
-export type OrchestrationPersistedEvent = typeof OrchestrationPersistedEvent.Type;
 
 export const OrchestrationCommandReceiptStatus = Schema.Literals(["accepted", "rejected"]);
 export type OrchestrationCommandReceiptStatus = typeof OrchestrationCommandReceiptStatus.Type;


### PR DESCRIPTION
## Summary

`OrchestrationPersistedEvent` (a 20-member Schema.Union, ~100 lines) and its `PersistedEventBaseFields` helper (~14 lines) in `packages/contracts/src/orchestration.ts` are exported but never imported anywhere in the codebase.

The actual persistence layer (`apps/server/src/persistence/Layers/OrchestrationEventStore.ts`) defines its own local schema with different field names (`type` vs `eventType`, `aggregateId` vs `streamId`), confirming that `OrchestrationPersistedEvent` is dead code rather than unused-but-planned.

## Change

Remove `PersistedEventBaseFields` and `OrchestrationPersistedEvent` from `orchestration.ts`. Net: **-118 lines**.

## Verification

- `bun lint` — passes (only pre-existing warnings)
- `bun typecheck` — passes across all 7 packages
- `bun run test` — passes (pre-existing `terminalStateStore.test.ts` failures unrelated)
- `rg "OrchestrationPersistedEvent"` confirms zero remaining references

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `OrchestrationPersistedEvent` schema and `PersistedEventBaseFields` export from [orchestration.ts](https://github.com/pingdotgg/t3code/pull/601/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af)
> Delete the `OrchestrationPersistedEvent` union schema and its `OrchestrationPersistedEvent` type alias, and remove the `PersistedEventBaseFields` constant in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/601/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af).
>
> #### 📍Where to Start
> Start with the deleted exports in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/601/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af), focusing on the removed `PersistedEventBaseFields` and `OrchestrationPersistedEvent` definitions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fd3f652.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->