### PR TITLE
fix(server): use waitForPush in terminal event broadcast test to prevent flaky failure

### DIFF
--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -1333,9 +1333,7 @@ describe("WebSocket Server", () => {
     };
     terminalManager.emitEvent(manualEvent);
 
-    const push = (await waitForMessage(ws)) as WsPush;
-    expect(push.type).toBe("push");
-    expect(push.channel).toBe(WS_CHANNELS.terminalEvent);
+    const push = await waitForPush(ws, WS_CHANNELS.terminalEvent);
     expect((push.data as TerminalEvent).type).toBe("output");
   });
 


### PR DESCRIPTION
## Summary

- Fix flaky test `"routes terminal RPC methods and broadcasts terminal events"` in `wsServer.test.ts` by replacing raw `waitForMessage` with the existing `waitForPush` helper.

## Root Cause

On server startup, `syncDefaultKeybindingsOnStartup` writes a default keybindings file when none exists. A file watcher (`fs.watch`) on the keybindings config directory detects this write and triggers a `server.configUpdated` push to all connected WebSocket clients.

The terminal broadcast test used `waitForMessage(ws)` (which returns the **next** message regardless of type) to receive the expected `terminal.event` push. When the `server.configUpdated` push arrived in the narrow window between the last RPC response and the `waitForMessage` call, it was dequeued first — causing the channel assertion to fail:

```
Expected: "terminal.event"
Received: "server.configUpdated"
```

Observed in CI run [22836192988](https://github.com/pingdotgg/t3code/actions/runs/22836192988/job/66232949882?pr=602) (attempt 1 failed, retry passed).

## Fix

Replace the raw `waitForMessage` + manual channel assertion with `waitForPush(ws, WS_CHANNELS.terminalEvent)` — an existing test helper (line 293) that drains non-matching messages until the expected channel arrives. This is the same pattern used elsewhere in the test file (e.g., the `server.configUpdated` tests at lines 895/910).

**Note:** #488 addresses this same class of issues more comprehensively by restructuring the entire test harness. This PR is a minimal targeted fix in case that larger effort takes time to land.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `waitForPush` to assert terminal event broadcasts in `WebSocket Server` test in [wsServer.test.ts](https://github.com/pingdotgg/t3code/pull/606/files#diff-30ed28ff3e0b23441a1395ccab21d3c0ddf523513084c6d69abef88fc03ca7b3) to prevent flaky failure
> Replace `waitForMessage` plus channel/type assertions with a single `waitForPush(ws, WS_CHANNELS.terminalEvent)` call in [wsServer.test.ts](https://github.com/pingdotgg/t3code/pull/606/files#diff-30ed28ff3e0b23441a1395ccab21d3c0ddf523513084c6d69abef88fc03ca7b3), retaining the assertion on `(push.data as TerminalEvent).type`.
>
> #### 📍Where to Start
> Start in the `describe("WebSocket Server")` test, focusing on the terminal event push assertion in [wsServer.test.ts](https://github.com/pingdotgg/t3code/pull/606/files#diff-30ed28ff3e0b23441a1395ccab21d3c0ddf523513084c6d69abef88fc03ca7b3).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe37f58.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->