### PR TITLE
fix(desktop): use filesystem-friendly userData directory name

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -50,6 +50,8 @@ const ROOT_DIR = Path.resolve(__dirname, "../../..");
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
 const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
 const APP_USER_MODEL_ID = "com.t3tools.t3code";
+const USER_DATA_DIR_NAME = isDevelopment ? "t3code-dev" : "t3code";
+const LEGACY_USER_DATA_DIR_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
 const COMMIT_HASH_PATTERN = /^[0-9a-f]{7,40}$/i;
 const COMMIT_HASH_DISPLAY_LENGTH = 12;
 const LOG_DIR = Path.join(STATE_DIR, "logs");
@@ -572,6 +574,34 @@ function resolveResourcePath(fileName: string): string | null {
 
 function resolveIconPath(ext: "ico" | "icns" | "png"): string | null {
   return resolveResourcePath(`icon.${ext}`);
+}
+
+/**
+ * Resolve the Electron userData directory path.
+ *
+ * Electron derives the default userData path from `productName` in
+ * package.json, which currently produces directories with spaces and
+ * parentheses (e.g. `~/.config/T3 Code (Alpha)` on Linux). This is
+ * unfriendly for shell usage and violates Linux naming conventions.
+ *
+ * We override it to a clean lowercase name (`t3code`). If the legacy
+ * directory already exists we keep using it so existing users don't
+ * lose their Chromium profile data (localStorage, cookies, sessions).
+ */
+function resolveUserDataPath(): string {
+  const appDataBase =
+    process.platform === "win32"
+      ? process.env.APPDATA || Path.join(OS.homedir(), "AppData", "Roaming")
+      : process.platform === "darwin"
+        ? Path.join(OS.homedir(), "Library", "Application Support")
+        : process.env.XDG_CONFIG_HOME || Path.join(OS.homedir(), ".config");
+
+  const legacyPath = Path.join(appDataBase, LEGACY_USER_DATA_DIR_NAME);
+  if (FS.existsSync(legacyPath)) {
+    return legacyPath;
+  }
+
+  return Path.join(appDataBase, USER_DATA_DIR_NAME);
 }
 
 function configureAppIdentity(): void {
@@ -1170,6 +1200,11 @@ function createWindow(): BrowserWindow {
 
   return window;
 }
+
+// Override Electron's userData path before the `ready` event so that
+// Chromium session data uses a filesystem-friendly directory name.
+// Must be called synchronously at the top level — before `app.whenReady()`.
+app.setPath("userData", resolveUserDataPath());
 
 configureAppIdentity();
 


### PR DESCRIPTION
## Summary

- Override Electron's `userData` directory path to use a clean, lowercase name (`t3code`) instead of the `productName`-derived `T3 Code (Alpha)`.
- Existing users with the legacy directory are automatically detected and continue using it — no data loss.

Closes #578

## Problem

Electron derives the `userData` path from `productName` in `package.json`. With `"T3 Code (Alpha)"` this produces:

| Platform | Path |
|----------|------|
| Linux | `~/.config/T3 Code (Alpha)/` |
| macOS | `~/Library/Application Support/T3 Code (Alpha)/` |
| Windows | `%APPDATA%/T3 Code (Alpha)/` |

Spaces and parentheses in directory names are hostile to shell usage and violate Linux XDG naming conventions.

## Solution

Call `app.setPath("userData", ...)` synchronously at the top level (before Electron's `ready` event) to override the path with a clean name. This is the same pattern [VS Code uses](https://github.com/microsoft/vscode/blob/main/src/main.ts#L56-L62) — `productName` stays as-is for display purposes (window titles, About panel) while the data directory gets an explicit filesystem-friendly path.

**New users** get `~/.config/t3code/` (or platform equivalent).

**Existing users** are detected via `fs.existsSync` on the legacy path. If the old directory exists, it is used as-is so Chromium profile data (localStorage, cookies, sessions, cache) is preserved.

The `userData` directory is purely for Electron/Chromium internals — T3 Code's own state directory (`~/.t3/userdata`) is unaffected.

## Changes

- `apps/desktop/src/main.ts`: Add `resolveUserDataPath()` function + `app.setPath("userData", ...)` call (+35 lines)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set Electron desktop app userData path to a filesystem-friendly directory at startup to preserve legacy data when present
> Add `resolveUserDataPath` to compute platform-specific app data paths and call `app.setPath("userData", resolveUserDataPath())` in [main.ts](https://github.com/pingdotgg/t3code/pull/607/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb) to prefer a legacy Electron productName directory if it exists, otherwise use a sanitized lowercase directory.
>
> #### 📍Where to Start
> Start with the `resolveUserDataPath` function and its invocation before `app.whenReady()` in [main.ts](https://github.com/pingdotgg/t3code/pull/607/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81a5efe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->