### PR TITLE
[codex] show workspace folder paths in sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  type ContextMenuItem,
   DEFAULT_RUNTIME_MODE,
   DEFAULT_MODEL_BY_PROVIDER,
   type DesktopUpdateState,
@@ -66,6 +67,14 @@ import { isNonEmpty as isNonEmptyString } from "effect/String";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_PREVIEW_LIMIT = 6;
+
+type ProjectContextMenuAction = "copy-folder-path" | "change-folder" | "delete";
+
+const PROJECT_CONTEXT_MENU_ITEMS: readonly ContextMenuItem<ProjectContextMenuAction>[] = [
+  { id: "copy-folder-path", label: "Copy folder path" },
+  { id: "change-folder", label: "Change folder..." },
+  { id: "delete", label: "Delete", destructive: true },
+];
 
 async function copyTextToClipboard(text: string): Promise<void> {
   if (typeof navigator === "undefined" || navigator.clipboard?.writeText === undefined) {
@@ -758,14 +767,82 @@ export default function Sidebar() {
     async (projectId: ProjectId, position: { x: number; y: number }) => {
       const api = readNativeApi();
       if (!api) return;
-      const clicked = await api.contextMenu.show(
-        [{ id: "delete", label: "Delete", destructive: true }],
-        position,
-      );
-      if (clicked !== "delete") return;
-
       const project = projects.find((entry) => entry.id === projectId);
       if (!project) return;
+      const clicked = await api.contextMenu.show(PROJECT_CONTEXT_MENU_ITEMS, position);
+      if (clicked === null) return;
+
+      if (clicked === "copy-folder-path") {
+        try {
+          await copyTextToClipboard(project.cwd);
+          toastManager.add({
+            type: "success",
+            title: "Folder path copied",
+            description: project.cwd,
+          });
+        } catch (error) {
+          toastManager.add({
+            type: "error",
+            title: "Could not copy folder path",
+            description:
+              error instanceof Error ? error.message : "Clipboard is unavailable right now.",
+          });
+        }
+        return;
+      }
+
+      if (clicked === "change-folder") {
+        const pickedPath = isElectron
+          ? await api.dialogs.pickFolder()
+          : typeof window !== "undefined"
+            ? window.prompt(`Enter a new folder for "${project.name}"`, project.cwd)?.trim() ??
+              null
+            : null;
+        const nextWorkspaceRoot = pickedPath?.trim() ?? "";
+        if (!nextWorkspaceRoot || nextWorkspaceRoot === project.cwd) {
+          return;
+        }
+
+        const duplicateProject = projects.find(
+          (entry) => entry.id !== projectId && entry.cwd === nextWorkspaceRoot,
+        );
+        if (duplicateProject) {
+          toastManager.add({
+            type: "warning",
+            title: "Folder already added",
+            description: `"${duplicateProject.name}" already uses ${nextWorkspaceRoot}.`,
+          });
+          return;
+        }
+
+        const nextTitle =
+          nextWorkspaceRoot.split(/[/\\]/).findLast(isNonEmptyString) ?? project.name;
+        try {
+          await api.orchestration.dispatchCommand({
+            type: "project.meta.update",
+            commandId: newCommandId(),
+            projectId,
+            title: nextTitle,
+            workspaceRoot: nextWorkspaceRoot,
+          });
+          toastManager.add({
+            type: "success",
+            title: "Project folder updated",
+            description: nextWorkspaceRoot,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "Unknown error updating project folder.";
+          toastManager.add({
+            type: "error",
+            title: `Failed to update "${project.name}"`,
+            description: message,
+          });
+        }
+        return;
+      }
+
+      if (clicked !== "delete") return;
 
       const projectThreads = threads.filter((thread) => thread.projectId === projectId);
       if (projectThreads.length > 0) {
@@ -1169,9 +1246,28 @@ export default function Sidebar() {
                           }`}
                         />
                         <ProjectFavicon cwd={project.cwd} />
-                        <span className="flex-1 truncate text-xs font-medium text-foreground/90">
-                          {project.name}
-                        </span>
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <span className="flex-1 truncate text-xs font-medium text-foreground/90" />
+                            }
+                          >
+                            {project.name}
+                          </TooltipTrigger>
+                          <TooltipPopup side="right" className="max-w-sm">
+                            <div className="flex flex-col gap-1.5 py-0.5">
+                              <span className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground/70">
+                                Workspace folder
+                              </span>
+                              <code className="whitespace-normal break-all font-mono text-[11px] leading-relaxed text-foreground/90">
+                                {project.cwd}
+                              </code>
+                              <span className="text-[10px] text-muted-foreground/70">
+                                Right-click to copy or change it.
+                              </span>
+                            </div>
+                          </TooltipPopup>
+                        </Tooltip>
                       </CollapsibleTrigger>
                       <Tooltip>
                         <TooltipTrigger


### PR DESCRIPTION
This fixes a project sidebar visibility gap: there was no quick way to see where a workspace lived on disk without going through the `Open` flow. That makes it hard to confirm which folder a project actually points at, especially when multiple similarly named workspaces exist or when a project has been moved locally.

The change adds two pieces of project-level workspace affordance in the sidebar. Hovering a project name now shows a tooltip with the absolute workspace folder path. Right-clicking a project now exposes `Copy folder path` and `Change folder...`, so the path is not only visible but actionable. `Change folder...` updates the project via `project.meta.update`; in Electron it uses the native folder picker, and in browser mode it falls back to a prompt so the behavior still works in web development.

I checked the current open PR queue before opening this. There are nearby sidebar PRs, including `#280` (context menu rendering), `#515` (sidebar favicon support), and `#185` (project reordering), but none of them add workspace-path hover visibility or folder reassignment. This PR is therefore not duplicating an existing in-flight implementation, though `Sidebar.tsx` is a shared touchpoint and may require a routine merge conflict resolution if those land first.

Validation was done in three ways. First, `bun lint` completed successfully on the rebased branch, with only two pre-existing upstream warnings unrelated to this change. Second, `bun typecheck` passed across the monorepo. Third, I ran a real browser validation against the rebased branch: the test verified that hovering the project name showed the expected absolute path, then used `Change folder...` to repoint the project and confirmed that both the displayed project name and the tooltip path updated accordingly.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add project workspace folder paths and context menu actions to the Sidebar in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/610/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1)
> Introduce a tooltip that shows each project's workspace folder path and replace the project context menu with typed items for `copy-folder-path`, `change-folder`, and `delete`, including clipboard copy and a `project.meta.update` dispatch when changing folders.
>
> #### 📍Where to Start
> Start with the `handleProjectContextMenu` logic and `PROJECT_CONTEXT_MENU_ITEMS` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/610/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2e8668.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->