### PR TITLE
fix(ci): handle draft PR conversions in pr-vouch

### DIFF
--- a/.github/workflows/pr-vouch.yml
+++ b/.github/workflows/pr-vouch.yml
@@ -2,7 +2,7 @@ name: PR Vouch
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
   issue_comment:
     types: [created]
   push:


### PR DESCRIPTION
## Summary
- add the missing `converted_to_draft` `pull_request_target` trigger to `pr-vouch`
- ensure trust labels are refreshed when an open PR is moved back into draft state
- keep the workflow behavior unchanged for every other PR lifecycle event

## Verification
- ran `bun lint`
- ran `bun typecheck`
- verified the branch diff only changes `.github/workflows/pr-vouch.yml`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger the `pr-vouch` `pull_request_target` workflow on `converted_to_draft` events in [.github/workflows/pr-vouch.yml](https://github.com/pingdotgg/t3code/pull/611/files#diff-52e4809f3c60b4b97db97a19e1dc7ace0f6a0b8f063e66712a2b504b14fd6445)
> Add `converted_to_draft` to the `on.pull_request_target.types` list in [.github/workflows/pr-vouch.yml](https://github.com/pingdotgg/t3code/pull/611/files#diff-52e4809f3c60b4b97db97a19e1dc7ace0f6a0b8f063e66712a2b504b14fd6445) so the workflow runs when a pull request is converted to draft.
>
> #### 📍Where to Start
> Start in [.github/workflows/pr-vouch.yml](https://github.com/pingdotgg/t3code/pull/611/files#diff-52e4809f3c60b4b97db97a19e1dc7ace0f6a0b8f063e66712a2b504b14fd6445) at the `on.pull_request_target.types` configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1aaf095.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->