### PR TITLE
fix(web): fix native scrollbar being intercepted by sidebar rail on windows and linux

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -566,7 +566,8 @@ function SidebarRail({
     <button
       aria-label={railLabel}
       className={cn(
-        "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex",
+        /* disable pointer events only when offcanvas sidebar is collapsed, that's when the rail sits over the native scrollbar on windows and linux. icon mode stays fully clickable. */
+        "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex [[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
         "group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full",


### PR DESCRIPTION
fixes #548

the sidebar rail is a 16px wide invisible button sitting at z-20 along the
edge of the sidebar. when the sidebar is offcanvas and collapsed, that hit
area ends up exactly where the native os scrollbar lives, so clicks and drags
on the scrollbar were toggling the sidebar instead.

one css class added to SidebarRail:
[[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none

scoped to offcanvas+collapsed only so icon mode (where the rail stays visible
and needs to be clickable to expand) is completely unaffected.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent sidebar rail button from intercepting native scrollbar on Windows and Linux by applying `pointer-events-none` when `SidebarRail` is offcanvas and collapsed in [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/618/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd)
> Add a state-selective `pointer-events-none` to the `SidebarRail` button when `data-collapsible=offcanvas` and `data-state=collapsed` in [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/618/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd); include an inline comment documenting the condition.
>
> #### 📍Where to Start
> Start with the `SidebarRail` component’s button `className` logic in [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/618/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d3d46c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->