### PR TITLE
Fix terminal resize when diff layout changes

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -135,10 +135,42 @@ function TerminalViewport({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const onSessionExitedRef = useRef(onSessionExited);
   const hasHandledExitRef = useRef(false);
+  const viewportSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
     onSessionExitedRef.current = onSessionExited;
   }, [onSessionExited]);
+
+  const syncViewportSize = useCallback(() => {
+    const api = readNativeApi();
+    const terminal = terminalRef.current;
+    const fitAddon = fitAddonRef.current;
+    const container = containerRef.current;
+    if (!api || !terminal || !fitAddon || !container) return;
+
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+    if (width <= 0 || height <= 0) return;
+
+    const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
+    fitAddon.fit();
+    if (wasAtBottom) {
+      terminal.scrollToBottom();
+    }
+
+    const nextSignature = `${width}x${height}:${terminal.cols}x${terminal.rows}`;
+    if (viewportSignatureRef.current === nextSignature) return;
+    viewportSignatureRef.current = nextSignature;
+
+    void api.terminal
+      .resize({
+        threadId,
+        terminalId,
+        cols: terminal.cols,
+        rows: terminal.rows,
+      })
+      .catch(() => undefined);
+  }, [terminalId, threadId]);
 
   useEffect(() => {
     const mount = containerRef.current;
@@ -358,23 +390,7 @@ function TerminalViewport({
     });
 
     const fitTimer = window.setTimeout(() => {
-      const activeTerminal = terminalRef.current;
-      const activeFitAddon = fitAddonRef.current;
-      if (!activeTerminal || !activeFitAddon) return;
-      const wasAtBottom =
-        activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
-      activeFitAddon.fit();
-      if (wasAtBottom) {
-        activeTerminal.scrollToBottom();
-      }
-      void api.terminal
-        .resize({
-          threadId,
-          terminalId,
-          cols: activeTerminal.cols,
-          rows: activeTerminal.rows,
-        })
-        .catch(() => undefined);
+      syncViewportSize();
     }, 30);
     void openTerminal();
 
@@ -392,7 +408,7 @@ function TerminalViewport({
     // autoFocus is intentionally omitted;
     // it is only read at mount time and must not trigger terminal teardown/recreation.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cwd, runtimeEnv, terminalId, threadId]);
+  }, [cwd, runtimeEnv, syncViewportSize, terminalId, threadId]);
 
   useEffect(() => {
     if (!autoFocus) return;
@@ -407,29 +423,34 @@ function TerminalViewport({
   }, [autoFocus, focusRequestId]);
 
   useEffect(() => {
-    const api = readNativeApi();
-    const terminal = terminalRef.current;
-    const fitAddon = fitAddonRef.current;
-    if (!api || !terminal || !fitAddon) return;
-    const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
-    const frame = window.requestAnimationFrame(() => {
-      fitAddon.fit();
-      if (wasAtBottom) {
-        terminal.scrollToBottom();
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") return;
+
+    let frame = 0;
+    const scheduleSync = () => {
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame);
       }
-      void api.terminal
-        .resize({
-          threadId,
-          terminalId,
-          cols: terminal.cols,
-          rows: terminal.rows,
-        })
-        .catch(() => undefined);
-    });
-    return () => {
-      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        syncViewportSize();
+      });
     };
-  }, [drawerHeight, resizeEpoch, terminalId, threadId]);
+
+    scheduleSync();
+
+    const observer = new ResizeObserver(() => {
+      scheduleSync();
+    });
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, [drawerHeight, resizeEpoch, syncViewportSize]);
   return <div ref={containerRef} className="h-full w-full overflow-hidden rounded-[4px]" />;
 }
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -158,7 +158,7 @@ function TerminalViewport({
       terminal.scrollToBottom();
     }
 
-    const nextSignature = `${width}x${height}:${terminal.cols}x${terminal.rows}`;
+    const nextSignature = `${terminal.cols}x${terminal.rows}`;
     if (viewportSignatureRef.current === nextSignature) return;
     viewportSignatureRef.current = nextSignature;
 


### PR DESCRIPTION
## What Changed

Sync the terminal viewport with layout-driven size changes from the inline diff sidebar.

The terminal now observes its own container size, refits xterm when that size changes, and sends updated `cols`/`rows` to the backend PTY. This keeps the frontend terminal grid and backend PTY dimensions aligned when the diff panel opens, closes, or resizes.

## Why

Interactive terminal prompts that redraw the screen could become corrupted on Windows when the diff panel was open. The root cause was stale terminal sizing: the diff sidebar changed the terminal width without triggering a PTY resize.

By resizing from actual container changes instead of only window resize or drawer height changes, the terminal stays in sync and redraw-heavy prompts remain stable.

## Related

Fixes #445

## UI Changes

No visual redesign. Behavioral fix for terminal rendering while the diff panel is open.

Video:

https://github.com/user-attachments/assets/031beeb3-e8b8-4ed0-836d-f3143fdd0b4a

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal resize in `ThreadTerminalDrawer.TerminalViewport` when diff layout changes by centralizing fit/resize in `syncViewportSize` and suppressing unchanged `cols x rows` updates
> Introduce `viewportSignatureRef` and a memoized `syncViewportSize` that fits the terminal, preserves bottom scroll, validates non-zero container size, and only calls `api.terminal.resize` when `cols x rows` changes; replace inline mount/resize logic with a `ResizeObserver`-driven `requestAnimationFrame` schedule in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/620/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636).
>
> #### 📍Where to Start
> Start with the `syncViewportSize` callback and its usages in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/620/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c33acc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->