### PR TITLE
fix: block image uploads during plan mode questions

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2034,6 +2034,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const addComposerImages = (files: File[]) => {
     if (!activeThreadId || files.length === 0) return;
 
+    if (pendingUserInputs.length > 0) {
+      toastManager.add({
+        type: "error",
+        title: "Attach images after answering plan questions.",
+      });
+      return;
+    }
+
     const nextImages: ComposerImageAttachment[] = [];
     let nextImageCount = composerImagesRef.current.length;
     let error: string | null = null;


### PR DESCRIPTION
## What Changed

Block image uploads while the user answers plan mode questions. Show an error message instead of silently accepting images with no visual feedback.

## Why

When a user drags or pastes an image during plan mode questions, the image is added to the composer draft store but the thumbnail is hidden behind a `pendingUserInputs.length === 0` guard. The upload appears to fail silently. Users only discover the image after finishing all questions.

The Codex `requestUserInput` protocol accepts only `{ answers: {...} }` with no support for attachments, so there is no way to send images with plan question answers. This fix rejects the upload at the source and tells the user to attach images after answering, when `turn/start` (which supports images) handles the next message.

## UI Changes

- Dragging or pasting an image during plan questions now shows: "Attach images after answering plan questions."

### Before

https://github.com/user-attachments/assets/8662d16a-b096-475a-a743-ecbb7a10382f

### After

https://github.com/user-attachments/assets/7d4d27e9-4101-4a77-8204-a9edf9bb522b

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Closes #499

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block image uploads in `ChatView` when plan mode questions are pending
> Adds a guard in the `addComposerImages` handler in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/621/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) that rejects image attachments while there are unanswered plan questions. An error toast is shown with the message "Attach images after answering plan questions." and no images are added.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b19e2db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->