### PR TITLE
Fix desktop chat markdown external links

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -20,6 +20,7 @@ import React, {
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { isElectron } from "../env";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
 import { fnv1a32 } from "../lib/diffRendering";
 import { LRUCache } from "../lib/lruCache";
@@ -240,7 +241,31 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
       a({ node: _node, href, ...props }) {
         const targetPath = resolveMarkdownFileLinkTarget(href, cwd);
         if (!targetPath) {
-          return <a {...props} href={href} target="_blank" rel="noreferrer" />;
+          if (!isElectron) {
+            return <a {...props} href={href} target="_blank" rel="noreferrer" />;
+          }
+
+          return (
+            <a
+              {...props}
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => {
+                if (!href) {
+                  return;
+                }
+                const api = readNativeApi();
+                if (api) {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  void api.shell.openExternal(href);
+                } else {
+                  console.warn("Unable to open external link.");
+                }
+              }}
+            />
+          );
         }
 
         return (


### PR DESCRIPTION
## What Changed

- Route external markdown links in chat through the native desktop external-open path when running in Electron.
- Keep the regular web app on plain anchor behavior with no desktop-specific click interception.
- Limit the change to chat markdown external links only.

## Why

In v0.0.8, clicking external links in chat did not work on Windows in the desktop app. I confirmed the broken behavior on Windows before this change and verified the fix there.

I have not confirmed whether macOS was affected, so this PR is intentionally scoped to the Windows-confirmed bug rather than claiming a broader regression.

This approach keeps the PR small and avoids changing browser behavior for the web build.

## UI Changes

None. This is a behavior-only fix for external link handling in the desktop app.

## Verification

- `bun lint`
- `bun typecheck`
- Manual verification on Windows desktop app

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No visual UI changes, so screenshots are not applicable
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle ChatMarkdown external link clicks in Electron by invoking `readNativeApi().shell.openExternal` in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/623/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to fix desktop chat markdown external links
> Add environment-aware anchor rendering in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/623/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05), importing `isElectron` and wiring `onClick` to `readNativeApi().shell.openExternal(href)` in Electron; keep `_blank` with `rel='noreferrer'` elsewhere.
>
> #### 📍Where to Start
> Start with the `markdownComponents.a` renderer in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/623/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e957bbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->