### PR TITLE
feat(web): add configurable app font settings

### DIFF
--- a/apps/web/src/appFonts.test.ts
+++ b/apps/web/src/appFonts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_APP_FONT_FAMILIES,
+  getAppFontOptions,
+  normalizeAppFontSetting,
+  normalizeSystemFontFamilies,
+} from "./appFonts";
+
+describe("normalizeAppFontSetting", () => {
+  it("trims stored values and falls back when blank", () => {
+    expect(normalizeAppFontSetting("interfaceFontFamily", '  "Avenir Next", sans-serif  ')).toBe(
+      '"Avenir Next", sans-serif',
+    );
+    expect(normalizeAppFontSetting("interfaceFontFamily", "   ")).toBe(
+      DEFAULT_APP_FONT_FAMILIES.interfaceFontFamily,
+    );
+  });
+});
+
+describe("normalizeSystemFontFamilies", () => {
+  it("deduplicates and sorts families", () => {
+    expect(
+      normalizeSystemFontFamilies([" Menlo ", "SF Pro", "Menlo", "", null, "Avenir Next"]),
+    ).toEqual(["Avenir Next", "Menlo", "SF Pro"]);
+  });
+});
+
+describe("getAppFontOptions", () => {
+  it("includes built-in presets and requested system font families", () => {
+    const options = getAppFontOptions("headingFontFamily", ["Avenir Next"], null);
+
+    expect(options.map((option) => option.label)).toEqual([
+      "T3 Code Sans",
+      "System UI",
+      "Avenir Next",
+    ]);
+    expect(options.at(-1)?.value).toContain('"Avenir Next"');
+  });
+
+  it("keeps an existing selection visible even if it is not in the current option list", () => {
+    const options = getAppFontOptions(
+      "monoFontFamily",
+      [],
+      '"JetBrains Mono", "SF Mono", monospace',
+    );
+
+    expect(options.at(-1)).toMatchObject({
+      label: "JetBrains Mono",
+      source: "current",
+      value: '"JetBrains Mono", "SF Mono", monospace',
+    });
+  });
+});

--- a/apps/web/src/appFonts.ts
+++ b/apps/web/src/appFonts.ts
@@ -1,0 +1,231 @@
+const SYSTEM_FONT_CACHE_KEY = "t3code:system-font-families:v1";
+const MAX_SYSTEM_FONT_FAMILY_COUNT = 512;
+export const MAX_APP_FONT_FAMILY_LENGTH = 512;
+
+export const DEFAULT_APP_FONT_FAMILIES = {
+  interfaceFontFamily:
+    '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  headingFontFamily:
+    '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  monoFontFamily: '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+} as const;
+
+const SYSTEM_FONT_FAMILY_PRESETS = {
+  sans: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+  mono: 'ui-monospace, "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+} as const;
+
+export const APP_FONT_ROLE_DEFINITIONS = [
+  {
+    key: "interfaceFontFamily",
+    label: "Interface",
+    description: "Used for body copy, labels, buttons, and most app chrome.",
+    sampleText: "Aa Bb Cc 012345 The quick brown fox jumps over the lazy dog.",
+    fallbackKind: "sans",
+  },
+  {
+    key: "headingFontFamily",
+    label: "Headings",
+    description: "Used for page titles, section headings, dialogs, and display text.",
+    sampleText: "Design the shape of the workspace.",
+    fallbackKind: "sans",
+  },
+  {
+    key: "monoFontFamily",
+    label: "Monospace",
+    description: "Used for code, paths, inputs, and the terminal. Pick a monospace family here.",
+    sampleText: '{} => const file = "/src/index.ts"; ls -la',
+    fallbackKind: "mono",
+  },
+] as const;
+
+export type AppFontSettingKey = (typeof APP_FONT_ROLE_DEFINITIONS)[number]["key"];
+export type AppFontFallbackKind = (typeof APP_FONT_ROLE_DEFINITIONS)[number]["fallbackKind"];
+
+export interface AppFontOption {
+  value: string;
+  label: string;
+  previewFontFamily: string;
+  source: "default" | "system" | "current";
+}
+
+function normalizeStoredFontFamily(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.length > MAX_APP_FONT_FAMILY_LENGTH) {
+    return fallback;
+  }
+  return trimmed;
+}
+
+function quoteFontFamily(family: string): string {
+  return `"${family.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+function systemFontValue(family: string, fallbackKind: AppFontFallbackKind): string {
+  const fallback =
+    fallbackKind === "mono" ? SYSTEM_FONT_FAMILY_PRESETS.mono : SYSTEM_FONT_FAMILY_PRESETS.sans;
+  return `${quoteFontFamily(family)}, ${fallback}`;
+}
+
+export function normalizeAppFontSetting(
+  key: AppFontSettingKey,
+  value: string | null | undefined,
+): string {
+  return normalizeStoredFontFamily(value, DEFAULT_APP_FONT_FAMILIES[key]);
+}
+
+export function normalizeSystemFontFamilies(
+  families: Iterable<string | null | undefined>,
+): string[] {
+  const deduped = new Set<string>();
+
+  for (const family of families) {
+    const trimmed = family?.trim();
+    if (!trimmed) {
+      continue;
+    }
+    deduped.add(trimmed);
+    if (deduped.size >= MAX_SYSTEM_FONT_FAMILY_COUNT) {
+      break;
+    }
+  }
+
+  return [...deduped].toSorted((left, right) => left.localeCompare(right));
+}
+
+function fontLabelFromValue(value: string): string {
+  const [firstSegment = value] = value.split(",", 1);
+  const normalized = firstSegment.trim().replace(/^['"]|['"]$/g, "");
+  return normalized.length > 0 ? normalized : "Current selection";
+}
+
+export function getAppFontOptions(
+  key: AppFontSettingKey,
+  systemFontFamilies: readonly string[],
+  selectedValue?: string | null,
+): AppFontOption[] {
+  const role = APP_FONT_ROLE_DEFINITIONS.find((definition) => definition.key === key);
+  if (!role) {
+    return [];
+  }
+
+  const options: AppFontOption[] = [
+    {
+      value: DEFAULT_APP_FONT_FAMILIES[key],
+      label: key === "monoFontFamily" ? "T3 Code Mono" : "T3 Code Sans",
+      previewFontFamily: DEFAULT_APP_FONT_FAMILIES[key],
+      source: "default",
+    },
+    {
+      value:
+        role.fallbackKind === "mono"
+          ? SYSTEM_FONT_FAMILY_PRESETS.mono
+          : SYSTEM_FONT_FAMILY_PRESETS.sans,
+      label: role.fallbackKind === "mono" ? "System Mono" : "System UI",
+      previewFontFamily:
+        role.fallbackKind === "mono"
+          ? SYSTEM_FONT_FAMILY_PRESETS.mono
+          : SYSTEM_FONT_FAMILY_PRESETS.sans,
+      source: "default",
+    },
+  ];
+  const seen = new Set(options.map((option) => option.value));
+
+  for (const family of normalizeSystemFontFamilies(systemFontFamilies)) {
+    const value = systemFontValue(family, role.fallbackKind);
+    if (seen.has(value)) {
+      continue;
+    }
+    seen.add(value);
+    options.push({
+      value,
+      label: family,
+      previewFontFamily: value,
+      source: "system",
+    });
+  }
+
+  const normalizedSelectedValue = normalizeAppFontSetting(key, selectedValue);
+  if (!seen.has(normalizedSelectedValue)) {
+    options.push({
+      value: normalizedSelectedValue,
+      label: fontLabelFromValue(normalizedSelectedValue),
+      previewFontFamily: normalizedSelectedValue,
+      source: "current",
+    });
+  }
+
+  return options;
+}
+
+export function getCachedSystemFontFamilies(): string[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SYSTEM_FONT_CACHE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? normalizeSystemFontFamilies(parsed) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistSystemFontFamilies(families: readonly string[]): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      SYSTEM_FONT_CACHE_KEY,
+      JSON.stringify(normalizeSystemFontFamilies(families)),
+    );
+  } catch {
+    // Best-effort cache only.
+  }
+}
+
+export function supportsSystemFontAccess(): boolean {
+  return typeof window !== "undefined" && typeof window.queryLocalFonts === "function";
+}
+
+export async function requestSystemFontFamilies(): Promise<string[]> {
+  const queryLocalFonts = window.queryLocalFonts;
+  if (typeof queryLocalFonts !== "function") {
+    throw new Error("System font access is not available in this browser.");
+  }
+
+  const fonts = await queryLocalFonts.call(window);
+  const families = normalizeSystemFontFamilies(fonts.map((font) => font.family));
+  persistSystemFontFamilies(families);
+  return families;
+}
+
+export function applyAppFontSettings(settings: {
+  interfaceFontFamily: string;
+  headingFontFamily: string;
+  monoFontFamily: string;
+}): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty(
+    "--app-font-sans",
+    normalizeAppFontSetting("interfaceFontFamily", settings.interfaceFontFamily),
+  );
+  rootStyle.setProperty(
+    "--app-font-heading",
+    normalizeAppFontSetting("headingFontFamily", settings.headingFontFamily),
+  );
+  rootStyle.setProperty(
+    "--app-font-mono",
+    normalizeAppFontSetting("monoFontFamily", settings.monoFontFamily),
+  );
+}

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -3,6 +3,12 @@ import { Option, Schema } from "effect";
 import { type ProviderKind, type ProviderServiceTier } from "@t3tools/contracts";
 import { getDefaultModel, getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 
+import {
+  DEFAULT_APP_FONT_FAMILIES,
+  MAX_APP_FONT_FAMILY_LENGTH,
+  normalizeAppFontSetting,
+} from "./appFonts";
+
 const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
 const MAX_CUSTOM_MODEL_COUNT = 32;
 export const MAX_CUSTOM_MODEL_LENGTH = 256;
@@ -41,9 +47,20 @@ const AppSettingsSchema = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(
     Schema.withConstructorDefault(() => Option.some(false)),
   ),
-  codexServiceTier: AppServiceTierSchema.pipe(Schema.withConstructorDefault(() => Option.some("auto"))),
+  codexServiceTier: AppServiceTierSchema.pipe(
+    Schema.withConstructorDefault(() => Option.some("auto")),
+  ),
   customCodexModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
+  ),
+  interfaceFontFamily: Schema.String.check(Schema.isMaxLength(MAX_APP_FONT_FAMILY_LENGTH)).pipe(
+    Schema.withConstructorDefault(() => Option.some(DEFAULT_APP_FONT_FAMILIES.interfaceFontFamily)),
+  ),
+  headingFontFamily: Schema.String.check(Schema.isMaxLength(MAX_APP_FONT_FAMILY_LENGTH)).pipe(
+    Schema.withConstructorDefault(() => Option.some(DEFAULT_APP_FONT_FAMILIES.headingFontFamily)),
+  ),
+  monoFontFamily: Schema.String.check(Schema.isMaxLength(MAX_APP_FONT_FAMILY_LENGTH)).pipe(
+    Schema.withConstructorDefault(() => Option.some(DEFAULT_APP_FONT_FAMILIES.monoFontFamily)),
   ),
 });
 export type AppSettings = typeof AppSettingsSchema.Type;
@@ -108,6 +125,12 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
   return {
     ...settings,
     customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
+    interfaceFontFamily: normalizeAppFontSetting(
+      "interfaceFontFamily",
+      settings.interfaceFontFamily,
+    ),
+    headingFontFamily: normalizeAppFontSetting("headingFontFamily", settings.headingFontFamily),
+    monoFontFamily: normalizeAppFontSetting("monoFontFamily", settings.monoFontFamily),
   };
 }
 

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -25,6 +25,7 @@ import {
   MAX_THREAD_TERMINAL_COUNT,
   type ThreadTerminalGroup,
 } from "../types";
+import { useAppSettings } from "../appSettings";
 import { readNativeApi } from "~/nativeApi";
 
 const MIN_DRAWER_HEIGHT = 180;
@@ -130,11 +131,17 @@ function TerminalViewport({
   resizeEpoch,
   drawerHeight,
 }: TerminalViewportProps) {
+  const {
+    settings: { monoFontFamily },
+  } = useAppSettings();
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const onSessionExitedRef = useRef(onSessionExited);
   const hasHandledExitRef = useRef(false);
+  const monoFontFamilyRef = useRef(monoFontFamily);
+
+  monoFontFamilyRef.current = monoFontFamily;
 
   useEffect(() => {
     onSessionExitedRef.current = onSessionExited;
@@ -152,7 +159,7 @@ function TerminalViewport({
       lineHeight: 1.2,
       fontSize: 12,
       scrollback: 5_000,
-      fontFamily: '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+      fontFamily: monoFontFamilyRef.current,
       theme: terminalThemeFromApp(),
     });
     terminal.loadAddon(fitAddon);
@@ -393,6 +400,26 @@ function TerminalViewport({
     // it is only read at mount time and must not trigger terminal teardown/recreation.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cwd, runtimeEnv, terminalId, threadId]);
+
+  useEffect(() => {
+    const api = readNativeApi();
+    const terminal = terminalRef.current;
+    const fitAddon = fitAddonRef.current;
+    if (!api || !terminal || !fitAddon) {
+      return;
+    }
+
+    terminal.options.fontFamily = monoFontFamily;
+    fitAddon.fit();
+    void api.terminal
+      .resize({
+        threadId,
+        terminalId,
+        cols: terminal.cols,
+        rows: terminal.rows,
+      })
+      .catch(() => undefined);
+  }, [monoFontFamily, terminalId, threadId]);
 
   useEffect(() => {
     if (!autoFocus) return;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,6 +4,9 @@
 
 @theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;
+  --font-heading: var(--app-font-heading);
+  --font-mono: var(--app-font-mono);
+  --font-sans: var(--app-font-sans);
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);
   --color-success-foreground: var(--success-foreground);
@@ -64,6 +67,10 @@
 :root {
   color-scheme: light;
   --radius: 0.625rem;
+  --app-font-sans: "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --app-font-heading:
+    "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --app-font-mono: "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   --background: var(--color-white);
   --foreground: var(--color-neutral-800);
   --card: var(--color-white);
@@ -121,16 +128,19 @@
 }
 
 body {
-  font-family:
-    "DM Sans",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    system-ui,
-    sans-serif;
+  font-family: var(--app-font-sans);
   margin: 0;
   padding: 0;
   min-height: 100vh;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--app-font-heading);
 }
 
 html,
@@ -160,7 +170,7 @@ pre,
 code,
 textarea,
 input {
-  font-family: "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-family: var(--app-font-mono);
 }
 
 /* Window drag region (frameless titlebar) */

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,8 @@ import { createHashHistory, createBrowserHistory } from "@tanstack/react-router"
 import "@xterm/xterm/css/xterm.css";
 import "./index.css";
 
+import { applyAppFontSettings } from "./appFonts";
+import { getAppSettingsSnapshot } from "./appSettings";
 import { isElectron } from "./env";
 import { getRouter } from "./router";
 import { APP_DISPLAY_NAME } from "./branding";
@@ -15,6 +17,7 @@ const history = isElectron ? createHashHistory() : createBrowserHistory();
 const router = getRouter(history);
 
 document.title = APP_DISPLAY_NAME;
+applyAppFontSettings(getAppSettingsSnapshot());
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -9,6 +9,8 @@ import {
 import { useEffect, useRef } from "react";
 import { QueryClient, useQueryClient } from "@tanstack/react-query";
 
+import { applyAppFontSettings } from "../appFonts";
+import { useAppSettings } from "../appSettings";
 import { APP_DISPLAY_NAME } from "../branding";
 import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
@@ -34,6 +36,18 @@ export const Route = createRootRouteWithContext<{
 });
 
 function RootRouteView() {
+  const {
+    settings: { headingFontFamily, interfaceFontFamily, monoFontFamily },
+  } = useAppSettings();
+
+  useEffect(() => {
+    applyAppFontSettings({
+      headingFontFamily,
+      interfaceFontFamily,
+      monoFontFamily,
+    });
+  }, [headingFontFamily, interfaceFontFamily, monoFontFamily]);
+
   if (!readNativeApi()) {
     return (
       <div className="flex h-screen flex-col bg-background text-foreground">

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -1,12 +1,22 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { type ProviderKind } from "@t3tools/contracts";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
-import { ZapIcon } from "lucide-react";
+import { RefreshCcwIcon, TypeIcon, ZapIcon } from "lucide-react";
 
 import {
+  APP_FONT_ROLE_DEFINITIONS,
+  DEFAULT_APP_FONT_FAMILIES,
+  getAppFontOptions,
+  getCachedSystemFontFamilies,
+  requestSystemFontFamilies,
+  supportsSystemFontAccess,
+  type AppFontSettingKey,
+} from "../appFonts";
+import {
   APP_SERVICE_TIER_OPTIONS,
+  type AppSettings,
   MAX_CUSTOM_MODEL_LENGTH,
   shouldShowFastTierIcon,
   useAppSettings,
@@ -18,7 +28,13 @@ import { ensureNativeApi } from "../nativeApi";
 import { preferredTerminalEditor } from "../terminal-links";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
-import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../components/ui/select";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
 import { Switch } from "../components/ui/switch";
 import { SidebarInset } from "~/components/ui/sidebar";
 
@@ -86,6 +102,24 @@ function patchCustomModels(provider: ProviderKind, models: string[]) {
   }
 }
 
+function fontSettingsDifferFromDefaults(settings: AppSettings, defaults: AppSettings): boolean {
+  return (
+    settings.interfaceFontFamily !== defaults.interfaceFontFamily ||
+    settings.headingFontFamily !== defaults.headingFontFamily ||
+    settings.monoFontFamily !== defaults.monoFontFamily
+  );
+}
+
+function createFontDrafts(
+  settings: Pick<AppSettings, "interfaceFontFamily" | "headingFontFamily" | "monoFontFamily">,
+): Record<AppFontSettingKey, string> {
+  return {
+    interfaceFontFamily: settings.interfaceFontFamily,
+    headingFontFamily: settings.headingFontFamily,
+    monoFontFamily: settings.monoFontFamily,
+  };
+}
+
 function SettingsRouteView() {
   const { theme, setTheme, resolvedTheme } = useTheme();
   const { settings, defaults, updateSettings } = useAppSettings();
@@ -100,11 +134,34 @@ function SettingsRouteView() {
   const [customModelErrorByProvider, setCustomModelErrorByProvider] = useState<
     Partial<Record<ProviderKind, string | null>>
   >({});
+  const [systemFontFamilies, setSystemFontFamilies] = useState<string[]>(() =>
+    getCachedSystemFontFamilies(),
+  );
+  const [isRequestingSystemFonts, setIsRequestingSystemFonts] = useState(false);
+  const [systemFontMessage, setSystemFontMessage] = useState<string | null>(() =>
+    systemFontFamilies.length > 0
+      ? `Loaded ${systemFontFamilies.length} cached system font families.`
+      : null,
+  );
+  const [systemFontError, setSystemFontError] = useState<string | null>(null);
+  const [fontDrafts, setFontDrafts] = useState<Record<AppFontSettingKey, string>>(() =>
+    createFontDrafts(settings),
+  );
 
   const codexBinaryPath = settings.codexBinaryPath;
   const codexHomePath = settings.codexHomePath;
   const codexServiceTier = settings.codexServiceTier;
+  const interfaceFontFamily = settings.interfaceFontFamily;
+  const headingFontFamily = settings.headingFontFamily;
+  const monoFontFamily = settings.monoFontFamily;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
+  const canRequestSystemFonts = supportsSystemFontAccess();
+  const hasCustomTypography = fontSettingsDifferFromDefaults(settings, defaults);
+  const systemFontButtonLabel = isRequestingSystemFonts
+    ? "Requesting..."
+    : systemFontFamilies.length > 0
+      ? "Refresh system fonts"
+      : "Request system fonts";
 
   const openKeybindingsFile = useCallback(() => {
     if (!keybindingsConfigPath) return;
@@ -123,60 +180,113 @@ function SettingsRouteView() {
       });
   }, [keybindingsConfigPath]);
 
-  const addCustomModel = useCallback((provider: ProviderKind) => {
-    const customModelInput = customModelInputByProvider[provider];
-    const customModels = getCustomModelsForProvider(settings, provider);
-    const normalized = normalizeModelSlug(customModelInput, provider);
-    if (!normalized) {
-      setCustomModelErrorByProvider((existing) => ({
-        ...existing,
-        [provider]: "Enter a model slug.",
-      }));
-      return;
-    }
-    if (getModelOptions(provider).some((option) => option.slug === normalized)) {
-      setCustomModelErrorByProvider((existing) => ({
-        ...existing,
-        [provider]: "That model is already built in.",
-      }));
-      return;
-    }
-    if (normalized.length > MAX_CUSTOM_MODEL_LENGTH) {
-      setCustomModelErrorByProvider((existing) => ({
-        ...existing,
-        [provider]: `Model slugs must be ${MAX_CUSTOM_MODEL_LENGTH} characters or less.`,
-      }));
-      return;
-    }
-    if (customModels.includes(normalized)) {
-      setCustomModelErrorByProvider((existing) => ({
-        ...existing,
-        [provider]: "That custom model is already saved.",
-      }));
-      return;
-    }
+  const addCustomModel = useCallback(
+    (provider: ProviderKind) => {
+      const customModelInput = customModelInputByProvider[provider];
+      const customModels = getCustomModelsForProvider(settings, provider);
+      const normalized = normalizeModelSlug(customModelInput, provider);
+      if (!normalized) {
+        setCustomModelErrorByProvider((existing) => ({
+          ...existing,
+          [provider]: "Enter a model slug.",
+        }));
+        return;
+      }
+      if (getModelOptions(provider).some((option) => option.slug === normalized)) {
+        setCustomModelErrorByProvider((existing) => ({
+          ...existing,
+          [provider]: "That model is already built in.",
+        }));
+        return;
+      }
+      if (normalized.length > MAX_CUSTOM_MODEL_LENGTH) {
+        setCustomModelErrorByProvider((existing) => ({
+          ...existing,
+          [provider]: `Model slugs must be ${MAX_CUSTOM_MODEL_LENGTH} characters or less.`,
+        }));
+        return;
+      }
+      if (customModels.includes(normalized)) {
+        setCustomModelErrorByProvider((existing) => ({
+          ...existing,
+          [provider]: "That custom model is already saved.",
+        }));
+        return;
+      }
 
-    updateSettings(patchCustomModels(provider, [...customModels, normalized]));
-    setCustomModelInputByProvider((existing) => ({
-      ...existing,
-      [provider]: "",
-    }));
-    setCustomModelErrorByProvider((existing) => ({
-      ...existing,
-      [provider]: null,
-    }));
-  }, [customModelInputByProvider, settings, updateSettings]);
+      updateSettings(patchCustomModels(provider, [...customModels, normalized]));
+      setCustomModelInputByProvider((existing) => ({
+        ...existing,
+        [provider]: "",
+      }));
+      setCustomModelErrorByProvider((existing) => ({
+        ...existing,
+        [provider]: null,
+      }));
+    },
+    [customModelInputByProvider, settings, updateSettings],
+  );
 
   const removeCustomModel = useCallback(
     (provider: ProviderKind, slug: string) => {
       const customModels = getCustomModelsForProvider(settings, provider);
-      updateSettings(patchCustomModels(provider, customModels.filter((model) => model !== slug)));
+      updateSettings(
+        patchCustomModels(
+          provider,
+          customModels.filter((model) => model !== slug),
+        ),
+      );
       setCustomModelErrorByProvider((existing) => ({
         ...existing,
         [provider]: null,
       }));
     },
     [settings, updateSettings],
+  );
+
+  const requestFonts = useCallback(() => {
+    setSystemFontError(null);
+    setSystemFontMessage(null);
+    setIsRequestingSystemFonts(true);
+    void requestSystemFontFamilies()
+      .then((families) => {
+        setSystemFontFamilies(families);
+        setSystemFontMessage(
+          families.length > 0
+            ? `Loaded ${families.length} system font families from this device.`
+            : "No system font families were returned.",
+        );
+      })
+      .catch((error) => {
+        setSystemFontError(
+          error instanceof Error ? error.message : "Unable to request system fonts.",
+        );
+      })
+      .finally(() => {
+        setIsRequestingSystemFonts(false);
+      });
+  }, []);
+
+  const updateFontSetting = useCallback(
+    (key: AppFontSettingKey, value: string) => {
+      updateSettings({ [key]: value } as Partial<AppSettings>);
+    },
+    [updateSettings],
+  );
+
+  useEffect(() => {
+    setFontDrafts({
+      headingFontFamily,
+      interfaceFontFamily,
+      monoFontFamily,
+    });
+  }, [headingFontFamily, interfaceFontFamily, monoFontFamily]);
+
+  const applyFontDraft = useCallback(
+    (key: AppFontSettingKey) => {
+      updateFontSetting(key, fontDrafts[key]);
+    },
+    [fontDrafts, updateFontSetting],
   );
 
   return (
@@ -240,6 +350,191 @@ function SettingsRouteView() {
               <p className="mt-4 text-xs text-muted-foreground">
                 Active theme: <span className="font-medium text-foreground">{resolvedTheme}</span>
               </p>
+
+              <div className="mt-6 rounded-xl border border-border bg-background/55 p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0">
+                    <h3 className="flex items-center gap-2 text-sm font-medium text-foreground">
+                      <TypeIcon className="size-4 shrink-0" />
+                      Typography
+                    </h3>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Choose separate fonts for interface text, headings, and monospace surfaces.
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      System fonts come from the browser&apos;s Local Font Access API and may need
+                      permission.
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      disabled={!canRequestSystemFonts || isRequestingSystemFonts}
+                      onClick={requestFonts}
+                    >
+                      {systemFontButtonLabel}
+                    </Button>
+
+                    {hasCustomTypography ? (
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        onClick={() =>
+                          updateSettings({
+                            interfaceFontFamily: defaults.interfaceFontFamily,
+                            headingFontFamily: defaults.headingFontFamily,
+                            monoFontFamily: defaults.monoFontFamily,
+                          })
+                        }
+                      >
+                        Reset typography
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+
+                <div className="mt-3 space-y-1">
+                  {!canRequestSystemFonts ? (
+                    <p className="text-xs text-muted-foreground">
+                      System font requests are not available in this browser, so only built-in font
+                      stacks are shown.
+                    </p>
+                  ) : null}
+                  {systemFontMessage ? (
+                    <p className="text-xs text-muted-foreground">{systemFontMessage}</p>
+                  ) : null}
+                  {systemFontError ? (
+                    <p className="text-xs text-destructive">{systemFontError}</p>
+                  ) : null}
+                </div>
+
+                <div className="mt-4 grid gap-4">
+                  {APP_FONT_ROLE_DEFINITIONS.map((fontRole) => {
+                    const options = getAppFontOptions(
+                      fontRole.key,
+                      systemFontFamilies,
+                      settings[fontRole.key],
+                    );
+
+                    return (
+                      <div
+                        key={fontRole.key}
+                        className="rounded-lg border border-border bg-card/70 p-3"
+                      >
+                        <div className="flex flex-col gap-3 lg:flex-row lg:items-start">
+                          <label className="block min-w-0 flex-1 space-y-1">
+                            <span className="text-xs font-medium text-foreground">
+                              {fontRole.label}
+                            </span>
+                            <Select
+                              items={options.map((option) => ({
+                                label: option.label,
+                                value: option.value,
+                              }))}
+                              value={settings[fontRole.key]}
+                              onValueChange={(value) => {
+                                if (!value) return;
+                                updateFontSetting(fontRole.key, value);
+                              }}
+                            >
+                              <SelectTrigger>
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectPopup alignItemWithTrigger={false}>
+                                {options.map((option) => (
+                                  <SelectItem key={option.value} value={option.value}>
+                                    <div className="flex min-w-0 items-center justify-between gap-3">
+                                      <span
+                                        className="truncate"
+                                        style={{ fontFamily: option.previewFontFamily }}
+                                      >
+                                        {option.label}
+                                      </span>
+                                      {option.source === "system" ? (
+                                        <span className="shrink-0 text-[10px] uppercase tracking-wide text-muted-foreground">
+                                          Local
+                                        </span>
+                                      ) : null}
+                                    </div>
+                                  </SelectItem>
+                                ))}
+                              </SelectPopup>
+                            </Select>
+                            <span className="text-xs text-muted-foreground">
+                              {fontRole.description}
+                            </span>
+                          </label>
+
+                          <div className="min-w-0 flex-1 rounded-lg border border-border bg-background px-3 py-2">
+                            <div className="mb-1 flex items-center justify-between gap-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+                              <span>Preview</span>
+                              {settings[fontRole.key] !==
+                              DEFAULT_APP_FONT_FAMILIES[fontRole.key] ? (
+                                <button
+                                  type="button"
+                                  className="inline-flex items-center gap-1 text-[10px] text-muted-foreground transition-colors hover:text-foreground"
+                                  onClick={() =>
+                                    updateFontSetting(
+                                      fontRole.key,
+                                      DEFAULT_APP_FONT_FAMILIES[fontRole.key],
+                                    )
+                                  }
+                                >
+                                  <RefreshCcwIcon className="size-3" />
+                                  Restore
+                                </button>
+                              ) : null}
+                            </div>
+                            <p
+                              className="text-sm leading-relaxed text-foreground"
+                              style={{ fontFamily: settings[fontRole.key] }}
+                            >
+                              {fontRole.sampleText}
+                            </p>
+
+                            <div className="mt-3 space-y-1">
+                              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                                Manual font-family
+                              </span>
+                              <div className="flex flex-col gap-2 sm:flex-row">
+                                <Input
+                                  value={fontDrafts[fontRole.key]}
+                                  onChange={(event) =>
+                                    setFontDrafts((existing) => ({
+                                      ...existing,
+                                      [fontRole.key]: event.target.value,
+                                    }))
+                                  }
+                                  onKeyDown={(event) => {
+                                    if (event.key !== "Enter") return;
+                                    event.preventDefault();
+                                    applyFontDraft(fontRole.key);
+                                  }}
+                                  placeholder={DEFAULT_APP_FONT_FAMILIES[fontRole.key]}
+                                  spellCheck={false}
+                                />
+                                <Button
+                                  size="xs"
+                                  variant="outline"
+                                  onClick={() => applyFontDraft(fontRole.key)}
+                                >
+                                  Apply
+                                </Button>
+                              </div>
+                              <p className="text-xs text-muted-foreground">
+                                Paste a font name or full CSS stack, for example{" "}
+                                <code>"JetBrains Mono", monospace</code>.
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
             </section>
 
             <section className="rounded-2xl border border-border bg-card p-5">
@@ -426,10 +721,9 @@ function SettingsRouteView() {
                                 variant="outline"
                                 onClick={() =>
                                   updateSettings(
-                                    patchCustomModels(
-                                      provider,
-                                      [...getDefaultCustomModelsForProvider(defaults, provider)],
-                                    ),
+                                    patchCustomModels(provider, [
+                                      ...getDefaultCustomModelsForProvider(defaults, provider),
+                                    ]),
                                   )
                                 }
                               >
@@ -446,7 +740,8 @@ function SettingsRouteView() {
                                   className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2"
                                 >
                                   <div className="flex min-w-0 flex-1 items-center gap-2">
-                                    {provider === "codex" && shouldShowFastTierIcon(slug, codexServiceTier) ? (
+                                    {provider === "codex" &&
+                                    shouldShowFastTierIcon(slug, codexServiceTier) ? (
                                       <ZapIcon className="size-3.5 shrink-0 text-amber-500" />
                                     ) : null}
                                     <code className="min-w-0 flex-1 truncate text-xs text-foreground">

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -3,8 +3,17 @@
 import type { NativeApi, DesktopBridge } from "@t3tools/contracts";
 
 declare global {
+  interface LocalFontData {
+    readonly family: string;
+    readonly fullName: string;
+    readonly postscriptName: string;
+    readonly style: string;
+    blob(): Promise<Blob>;
+  }
+
   interface Window {
     nativeApi?: NativeApi;
     desktopBridge?: DesktopBridge;
+    queryLocalFonts?: () => Promise<LocalFontData[]>;
   }
 }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Added a settings section for configuring fonts used in the app. 

## Why

This feature is pretty crucial for having a custom app experience. 

## UI Changes

A new settings section. 

<img width="869" height="859" alt="image" src="https://github.com/user-attachments/assets/0bc45081-7107-44d5-83df-b6c21af09821" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable app font settings and apply `applyAppFontSettings` across global CSS variables and terminal font rendering in [main.tsx](https://github.com/pingdotgg/t3code/pull/629/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b), [__root.tsx](https://github.com/pingdotgg/t3code/pull/629/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100), and [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/629/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636)
> Introduce font role defaults and normalization utilities, persist three font-family settings in the app schema, generate system font options via Local Font Access, and update global CSS variables and terminal `fontFamily` on setting changes; add tests for font utilities in [appFonts.test.ts](https://github.com/pingdotgg/t3code/pull/629/files#diff-11a075ef70c9adafb61d55340f3bb823897e5ee92f5c7afe5b2ebb6f66229ca6).
>
> #### 📍Where to Start
> Start with font utilities in `apps/web/src/appFonts.ts`, focusing on `getAppFontOptions`, `applyAppFontSettings`, and `requestSystemFontFamilies`: [appFonts.ts](https://github.com/pingdotgg/t3code/pull/629/files#diff-9e576403977222a9929c83d238d9045db23762529e6f72cadb04c6244dbc731c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec3a595.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->