### PR TITLE
fix: sync desktop window theme with theme changes

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -4,10 +4,23 @@ import * as FS from "node:fs";
 import * as OS from "node:os";
 import * as Path from "node:path";
 
-import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, protocol, shell } from "electron";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  Menu,
+  nativeImage,
+  nativeTheme,
+  protocol,
+  shell,
+} from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
-import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
+import type {
+  DesktopUpdateActionResult,
+  DesktopUpdateState,
+} from "@t3tools/contracts";
 import { autoUpdater } from "electron-updater";
 
 import type { ContextMenuItem } from "@t3tools/contracts";
@@ -38,6 +51,7 @@ const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
+const SET_WINDOW_THEME_CHANNEL = "desktop:set-window-theme";
 const MENU_ACTION_CHANNEL = "desktop:menu-action";
 const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
@@ -1095,6 +1109,19 @@ function registerIpcHandlers(): void {
     }
   });
 
+  ipcMain.removeHandler(SET_WINDOW_THEME_CHANNEL);
+  ipcMain.handle(SET_WINDOW_THEME_CHANNEL, async (_event, rawTheme: unknown) => {
+    if (process.platform !== "win32") {
+      return;
+    }
+
+    if (rawTheme !== "light" && rawTheme !== "dark" && rawTheme !== "system") {
+      return;
+    }
+
+    nativeTheme.themeSource = rawTheme;
+  });
+
   ipcMain.removeHandler(UPDATE_GET_STATE_CHANNEL);
   ipcMain.handle(UPDATE_GET_STATE_CHANNEL, async () => updateState);
 
@@ -1193,6 +1220,7 @@ function createWindow(): BrowserWindow {
     event.preventDefault();
     window.setTitle(APP_DISPLAY_NAME);
   });
+
   window.webContents.on("did-finish-load", () => {
     window.setTitle(APP_DISPLAY_NAME);
     emitUpdateState();

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -5,6 +5,7 @@ const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
+const SET_WINDOW_THEME_CHANNEL = "desktop:set-window-theme";
 const MENU_ACTION_CHANNEL = "desktop:menu-action";
 const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
@@ -18,6 +19,9 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   showContextMenu: (items, position) => ipcRenderer.invoke(CONTEXT_MENU_CHANNEL, items, position),
   openExternal: (url: string) => ipcRenderer.invoke(OPEN_EXTERNAL_CHANNEL, url),
+  setWindowTheme: (theme) => {
+    void ipcRenderer.invoke(SET_WINDOW_THEME_CHANNEL, theme);
+  },
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useSyncExternalStore } from "react";
 
+import type { DesktopWindowTheme } from "@t3tools/contracts";
+
 type Theme = "light" | "dark" | "system";
 type ThemeSnapshot = {
   theme: Theme;
@@ -25,11 +27,23 @@ function getStored(): Theme {
   return "system";
 }
 
+function resolveTheme(theme: Theme): DesktopWindowTheme {
+  return theme === "system" ? (getSystemDark() ? "dark" : "light") : theme;
+}
+
+function syncDesktopWindowTheme(theme: Theme) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.desktopBridge?.setWindowTheme?.(theme);
+}
+
 function applyTheme(theme: Theme, suppressTransitions = false) {
   if (suppressTransitions) {
     document.documentElement.classList.add("no-transitions");
   }
-  const isDark = theme === "dark" || (theme === "system" && getSystemDark());
+  const isDark = resolveTheme(theme) === "dark";
   document.documentElement.classList.toggle("dark", isDark);
   if (suppressTransitions) {
     // Force a reflow so the no-transitions class takes effect before removal
@@ -43,6 +57,7 @@ function applyTheme(theme: Theme, suppressTransitions = false) {
 
 // Apply immediately on module load to prevent flash
 applyTheme(getStored());
+syncDesktopWindowTheme(getStored());
 
 function getSnapshot(): ThemeSnapshot {
   const theme = getStored();
@@ -62,7 +77,10 @@ function subscribe(listener: () => void): () => void {
   // Listen for system preference changes
   const mq = window.matchMedia(MEDIA_QUERY);
   const handleChange = () => {
-    if (getStored() === "system") applyTheme("system", true);
+    if (getStored() === "system") {
+      applyTheme("system", true);
+      syncDesktopWindowTheme("system");
+    }
     emitChange();
   };
   mq.addEventListener("change", handleChange);
@@ -70,7 +88,9 @@ function subscribe(listener: () => void): () => void {
   // Listen for storage changes from other tabs
   const handleStorage = (e: StorageEvent) => {
     if (e.key === STORAGE_KEY) {
-      applyTheme(getStored(), true);
+      const nextTheme = getStored();
+      applyTheme(nextTheme, true);
+      syncDesktopWindowTheme(nextTheme);
       emitChange();
     }
   };
@@ -93,13 +113,15 @@ export function useTheme() {
   const setTheme = useCallback((next: Theme) => {
     localStorage.setItem(STORAGE_KEY, next);
     applyTheme(next, true);
+    syncDesktopWindowTheme(next);
     emitChange();
   }, []);
 
   // Keep DOM in sync on mount/change
   useEffect(() => {
     applyTheme(theme);
-  }, [theme]);
+    syncDesktopWindowTheme(theme);
+  }, [resolvedTheme, theme]);
 
   return { theme, setTheme, resolvedTheme } as const;
 }

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -77,6 +77,8 @@ export interface DesktopUpdateActionResult {
   state: DesktopUpdateState;
 }
 
+export type DesktopWindowTheme = "light" | "dark" | "system";
+
 export interface DesktopBridge {
   getWsUrl: () => string | null;
   pickFolder: () => Promise<string | null>;
@@ -86,6 +88,7 @@ export interface DesktopBridge {
     position?: { x: number; y: number },
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
+  setWindowTheme?: (theme: DesktopWindowTheme) => void;
   onMenuAction: (listener: (action: string) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   downloadUpdate: () => Promise<DesktopUpdateActionResult>;


### PR DESCRIPTION
## What Changed

Changed the electron header/nav bar to respect theme changes on Windows. I don't know if this issue affects macOS and/or Linux because I did not have a Mac and my Linux environment is currently broken. This says only being built and tested as a Windows EXE, specifically on Windows 10; however, it should work perfectly fine on Windows 11.

#### Specifics:
- Add desktop IPC channel and preload bridge method to set native window theme
- Propagate theme updates from `useTheme` on init, user changes, system changes, and storage sync
- Add shared `DesktopWindowTheme` contract type and optional `setWindowTheme` bridge API

## Why

Because when in dark mode instead of light mode the electron header was still following light mode (it was still white) on Windows 10. Not necessarily a bug, however, I didn't like the way that it looked and it was annoying me. 

Kind of a throwaway PR, it's just a bit of a pet peeve of mine and I didn't like how it looked against the rest of the UI.

## UI Changes

#### Before:

<img width="2558" height="133" alt="image" src="https://github.com/user-attachments/assets/2db32083-e916-46ff-bfdc-f3d4cc9a82e2" />

#### After:

<img width="2561" height="131" alt="image" src="https://github.com/user-attachments/assets/03e9b7f1-8e73-4299-8ca5-ad144ef1ec54" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes - N/A Not animated - screenshots included.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync the Electron desktop window theme on Windows via `apps/desktop/src/main.ts` IPC handler and `apps/web/src/hooks/useTheme.ts` renderer calls to match theme changes
> Add `desktop:set-window-theme` IPC channel and `window.desktopBridge.setWindowTheme` wiring, update `useTheme` to resolve system to concrete theme and call the bridge on init and changes. Types are added in `packages/contracts/src/ipc.ts`.
>
> #### 📍Where to Start
> Start with the IPC registration in `registerIpcHandlers` in [apps/desktop/src/main.ts](https://github.com/pingdotgg/t3code/pull/648/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb), then review `syncDesktopWindowTheme` and `useTheme` changes in [apps/web/src/hooks/useTheme.ts](https://github.com/pingdotgg/t3code/pull/648/files#diff-57ecb397fe0e1618fa00c5e68da8f87d74b28fa80bbe3278328f195bc91505c4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d91cbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->