### PR TITLE
fix: return 404 for missing static assets

### DIFF
--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -565,6 +565,36 @@ describe("WebSocket Server", () => {
     expect(await response.text()).toContain("static-root");
   });
 
+  it("falls back to static index for missing route paths without an extension", async () => {
+    const stateDir = makeTempDir("t3code-state-static-route-fallback-");
+    const staticDir = makeTempDir("t3code-static-route-fallback-");
+    fs.writeFileSync(path.join(staticDir, "index.html"), "<h1>static-route-fallback</h1>", "utf8");
+
+    server = await createTestServer({ cwd: "/test/project", stateDir, staticDir });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+    expect(port).toBeGreaterThan(0);
+
+    const response = await requestPath(port, "/chat/thread-123");
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain("static-route-fallback");
+  });
+
+  it("returns 404 for missing static asset paths with an extension", async () => {
+    const stateDir = makeTempDir("t3code-state-static-assets-");
+    const staticDir = makeTempDir("t3code-static-assets-");
+    fs.writeFileSync(path.join(staticDir, "index.html"), "<h1>static-assets</h1>", "utf8");
+
+    server = await createTestServer({ cwd: "/test/project", stateDir, staticDir });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+    expect(port).toBeGreaterThan(0);
+
+    const response = await requestPath(port, "/assets/missing.js");
+    expect(response.statusCode).toBe(404);
+    expect(response.body).toBe("Not Found");
+  });
+
   it("rejects static path traversal attempts", async () => {
     const stateDir = makeTempDir("t3code-state-static-traversal-");
     const staticDir = makeTempDir("t3code-static-traversal-");

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -555,6 +555,10 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
           .stat(filePath)
           .pipe(Effect.catch(() => Effect.succeed(null)));
         if (!fileInfo || fileInfo.type !== "File") {
+          if (ext) {
+            respond(404, { "Content-Type": "text/plain" }, "Not Found");
+            return;
+          }
           const indexPath = path.resolve(staticRoot, "index.html");
           const indexData = yield* fileSystem
             .readFile(indexPath)


### PR DESCRIPTION
## What Changed

This PR tightens static file serving so missing asset-like requests return `404 Not Found` instead of falling back to `index.html`.

## Why

The current server always falls back to `index.html` when a static file lookup misses. That is correct for client-side routes like `/chat/thread-123`, but it is incorrect for concrete asset requests like `/assets/missing.js`.

When an asset request gets HTML with a `200 OK` response, the browser tries to treat that HTML as JavaScript, CSS, or an image. That hides the real failure behind confusing frontend errors and makes broken builds or stale asset references harder to diagnose.

This change keeps SPA routing behavior intact while making missing static assets fail loudly and correctly.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Validation

- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run test src/wsServer.test.ts` (from `apps/server`)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return 404 for missing static asset requests with extensions in `createServer` HTTP handler in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/655/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679)
> Update `createServer` request handling to send 404 'Not Found' for missing paths with extensions and continue serving `index.html` for missing extension-less routes; add tests in [wsServer.test.ts](https://github.com/pingdotgg/t3code/pull/655/files#diff-30ed28ff3e0b23441a1395ccab21d3c0ddf523513084c6d69abef88fc03ca7b3).
>
> #### 📍Where to Start
> Start with the HTTP request handler in `createServer` in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/655/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 835c387.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->