### PR TITLE
feat: add weekly usage limit pill in sidebar

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -601,6 +601,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       } catch (error) {
         console.log("codex account/read failed", error);
       }
+      this.fetchAndEmitRateLimits(context);
 
       const normalizedModel = resolveCodexModelForAccount(
         normalizeCodexModelSlug(input.model),
@@ -1168,6 +1169,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         activeTurnId: undefined,
         lastError: errorMessage ?? context.session.lastError,
       });
+      this.fetchAndEmitRateLimits(context);
       return;
     }
 
@@ -1303,6 +1305,24 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     context.child.stdin.write(`${encoded}\n`);
+  }
+
+  private fetchAndEmitRateLimits(context: CodexSessionContext): void {
+    this.sendRequest(context, "account/rateLimits/read", {})
+      .then((rateLimitsResponse) => {
+        this.emitEvent({
+          id: EventId.makeUnsafe(randomUUID()),
+          kind: "notification",
+          provider: "codex",
+          threadId: context.session.threadId,
+          createdAt: new Date().toISOString(),
+          method: "account/rateLimits/updated",
+          payload: rateLimitsResponse,
+        });
+      })
+      .catch(() => {
+        // Rate limits may not be available for all auth modes.
+      });
   }
 
   private emitLifecycleEvent(context: CodexSessionContext, method: string, message: string): void {

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1106,9 +1106,7 @@ function mapToRuntimeEvents(
       {
         type: "account.rate-limits.updated",
         ...runtimeEventBase(event, canonicalThreadId),
-        payload: {
-          rateLimits: event.payload ?? {},
-        },
+        payload: event.payload ?? {},
       },
     ];
   }

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -636,6 +636,20 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     }),
   ).pipe(Effect.forkIn(subscriptionsScope));
 
+  const providerService = yield* ProviderService;
+  yield* Stream.runForEach(
+    Stream.filter(
+      providerService.streamEvents,
+      (event) => event.type === "account.rate-limits.updated",
+    ),
+    (event) =>
+      broadcastPush({
+        type: "push",
+        channel: WS_CHANNELS.providerRateLimitsUpdated,
+        data: (event as { payload?: unknown }).payload ?? {},
+      }),
+  ).pipe(Effect.forkIn(subscriptionsScope));
+
   yield* Scope.provide(orchestrationReactor.start, subscriptionsScope);
 
   let welcomeBootstrapProjectId: ProjectId | undefined;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -33,6 +33,7 @@ import { derivePendingApprovals } from "../session-logic";
 import { gitRemoveWorktreeMutationOptions, gitStatusQueryOptions } from "../lib/gitReactQuery";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
+import { WeeklyLimitPill } from "./WeeklyLimitPill";
 import { type DraftThreadEnvMode, useComposerDraftStore } from "../composerDraftStore";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { toastManager } from "./ui/toast";
@@ -1424,7 +1425,9 @@ export default function Sidebar() {
       </SidebarContent>
 
       <SidebarSeparator />
-      <SidebarFooter className="p-2">
+      <SidebarFooter className="gap-0 p-2">
+        <WeeklyLimitPill />
+        <SidebarSeparator className="my-1.5" />
         <SidebarMenu>
           <SidebarMenuItem>
             {isOnSettings ? (

--- a/apps/web/src/components/WeeklyLimitPill.tsx
+++ b/apps/web/src/components/WeeklyLimitPill.tsx
@@ -1,0 +1,49 @@
+import { memo } from "react";
+import { useRateLimits } from "../rateLimitsStore";
+
+function formatResetsAt(resetsAt: number | undefined): string | null {
+  if (!resetsAt) return null;
+  const now = Date.now() / 1000;
+  const diff = resetsAt - now;
+  if (diff <= 0) return null;
+  const days = Math.floor(diff / 86400);
+  const hours = Math.floor((diff % 86400) / 3600);
+  if (days > 0) return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  if (hours > 0) return `${hours}h`;
+  return `${Math.ceil(diff / 60)}m`;
+}
+
+export const WeeklyLimitPill = memo(function WeeklyLimitPill() {
+  const rateLimits = useRateLimits();
+
+  const primary = rateLimits?.rateLimits?.primary;
+  if (!primary || primary.usedPercent === undefined) return null;
+
+  const usedPercent = Math.min(100, Math.max(0, primary.usedPercent));
+  const remainingPercent = 100 - usedPercent;
+  const resetsIn = formatResetsAt(primary.resetsAt);
+
+  return (
+    <div className="group flex flex-col gap-1 rounded-lg border border-border/50 px-2.5 py-1.5">
+      <span className="text-[11px] font-medium text-muted-foreground/70">
+        Weekly usage
+      </span>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-border/40">
+        <div
+          className="h-full rounded-full bg-ring/50 transition-all duration-500"
+          style={{ width: `${usedPercent}%` }}
+        />
+      </div>
+      <div className="flex items-center">
+        <span className="text-[10px] tabular-nums text-muted-foreground/50">
+          {remainingPercent}% left
+        </span>
+        {resetsIn && (
+          <span className="ml-auto text-[10px] tabular-nums text-muted-foreground/40 opacity-0 transition-opacity group-hover:opacity-100">
+            resets in {resetsIn}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/rateLimitsStore.ts
+++ b/apps/web/src/rateLimitsStore.ts
@@ -1,0 +1,37 @@
+import { useSyncExternalStore } from "react";
+import { onRateLimitsUpdated, type RateLimitsPayload } from "./wsNativeApi";
+
+let snapshot: RateLimitsPayload | null = null;
+let listeners: Array<() => void> = [];
+
+function emitChange(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+let unsubWs: (() => void) | null = null;
+
+function ensureSubscription(): void {
+  if (unsubWs) return;
+  unsubWs = onRateLimitsUpdated((payload) => {
+    snapshot = payload;
+    emitChange();
+  });
+}
+
+function subscribe(listener: () => void): () => void {
+  ensureSubscription();
+  listeners.push(listener);
+  return () => {
+    listeners = listeners.filter((entry) => entry !== listener);
+  };
+}
+
+function getSnapshot(): RateLimitsPayload | null {
+  return snapshot;
+}
+
+export function useRateLimits(): RateLimitsPayload | null {
+  return useSyncExternalStore(subscribe, getSnapshot, () => null);
+}

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -15,11 +15,39 @@ import { Cause, Schema } from "effect";
 import { showContextMenuFallback } from "./contextMenuFallback";
 import { WsTransport } from "./wsTransport";
 
+export interface RateLimitsPayload {
+  readonly rateLimits?: {
+    readonly limitId?: string;
+    readonly limitName?: string | null;
+    readonly primary?: {
+      readonly usedPercent?: number;
+      readonly windowDurationMins?: number;
+      readonly resetsAt?: number;
+    } | null;
+    readonly secondary?: unknown;
+  };
+  readonly rateLimitsByLimitId?: Record<
+    string,
+    {
+      readonly limitId?: string;
+      readonly limitName?: string | null;
+      readonly primary?: {
+        readonly usedPercent?: number;
+        readonly windowDurationMins?: number;
+        readonly resetsAt?: number;
+      } | null;
+      readonly secondary?: unknown;
+    }
+  >;
+}
+
 let instance: { api: NativeApi; transport: WsTransport } | null = null;
 const welcomeListeners = new Set<(payload: WsWelcomePayload) => void>();
 const serverConfigUpdatedListeners = new Set<(payload: ServerConfigUpdatedPayload) => void>();
+const rateLimitsListeners = new Set<(payload: RateLimitsPayload) => void>();
 let lastWelcome: WsWelcomePayload | null = null;
 let lastServerConfigUpdated: ServerConfigUpdatedPayload | null = null;
+let lastRateLimits: RateLimitsPayload | null = null;
 
 const decodeAndWarnOnFailure = <T>(
   schema: Schema.Schema<T> & { readonly DecodingServices: never },
@@ -81,6 +109,24 @@ export function onServerConfigUpdated(
   };
 }
 
+export function onRateLimitsUpdated(
+  listener: (payload: RateLimitsPayload) => void,
+): () => void {
+  rateLimitsListeners.add(listener);
+
+  if (lastRateLimits) {
+    try {
+      listener(lastRateLimits);
+    } catch {
+      // Swallow listener errors
+    }
+  }
+
+  return () => {
+    rateLimitsListeners.delete(listener);
+  };
+}
+
 export function createWsNativeApi(): NativeApi {
   if (instance) return instance.api;
 
@@ -105,6 +151,17 @@ export function createWsNativeApi(): NativeApi {
     if (!payload) return;
     lastServerConfigUpdated = payload;
     for (const listener of serverConfigUpdatedListeners) {
+      try {
+        listener(payload);
+      } catch {
+        // Swallow listener errors
+      }
+    }
+  });
+  transport.subscribe(WS_CHANNELS.providerRateLimitsUpdated, (data) => {
+    const payload = data as RateLimitsPayload;
+    lastRateLimits = payload;
+    for (const listener of rateLimitsListeners) {
       try {
         listener(payload);
       } catch {

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -75,6 +75,7 @@ export const WS_CHANNELS = {
   terminalEvent: "terminal.event",
   serverWelcome: "server.welcome",
   serverConfigUpdated: "server.configUpdated",
+  providerRateLimitsUpdated: "provider.rateLimitsUpdated",
 } as const;
 
 // -- Tagged Union of all request body schemas ─────────────────────────


### PR DESCRIPTION
## What Changed

Added a "Weekly usage" pill to the sidebar footer (above Settings) that shows the Codex rate limit — percentage remaining, progress bar, and reset time on hover.

**Server:**
- `codexAppServerManager.ts` — added `fetchAndEmitRateLimits()` that calls `account/rateLimits/read` on session start and after each completed turn
- `CodexAdapter.ts` — fixed payload wrapping so the rate limits object passes through without double-nesting
- `wsServer.ts` — subscribed to `account.rate-limits.updated` events and broadcasts them to clients
- `packages/contracts/src/ws.ts` — added `providerRateLimitsUpdated` channel

**Web:**
- `wsNativeApi.ts` — added `RateLimitsPayload` type and `onRateLimitsUpdated` listener
- `rateLimitsStore.ts` — new store using `useSyncExternalStore` to expose rate limits to React
- `WeeklyLimitPill.tsx` — new component: title, progress bar, percentage left, reset time (hover only)
- `Sidebar.tsx` — renders the pill in the footer with a separator above Settings

## Why

Codex CLI shows weekly usage limits but the T3 Code GUI had no way to see them. This surfaces the same data from the Codex app-server without requiring users to check the CLI separately. The pill self-hides when no rate limit data is available, so it won't affect future providers.

## UI Changes

### Before
<img width="1035" height="372" alt="Screenshot 2026-03-09 111943" src="https://github.com/user-attachments/assets/80b5fa23-bef5-4d64-bd3a-389ddb5bc0f3" />

### After
<img width="1138" height="333" alt="Screenshot 2026-03-09 111828" src="https://github.com/user-attachments/assets/4eb26348-b531-48ba-8c63-373f7c486dfd" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a weekly usage limit pill in the web sidebar and emit `account.rate-limits.updated` over websockets from server rate limit reads
> Emit provider rate limit updates after session start and turn completion, map them to a flattened runtime event, broadcast on a new websocket channel, and render a sidebar pill sourced from a client store.
>
> #### 📍Where to Start
> Start with `CodexAppServerManager.startSession` and `CodexAppServerManager.fetchAndEmitRateLimits` in [codexAppServerManager.ts](https://github.com/pingdotgg/t3code/pull/667/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9), then follow the event mapping in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/667/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) and websocket broadcast in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/667/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679), and finally review the client store and UI in [rateLimitsStore.ts](https://github.com/pingdotgg/t3code/pull/667/files#diff-522732f549568da77d901c792d71475181f818f084be7cacdcf0b918edefd208) and [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/667/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3d6acbe. 8 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Layers/CodexAdapter.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 574](https://github.com/pingdotgg/t3code/blob/3d6acbe4a6beb1ed3b6e262773fc2133f31ce7eb/apps/server/src/provider/Layers/CodexAdapter.ts#L574): The `item/requestApproval/decision` event handler uses `Schema.decodeUnknownSync` to parse the `decision` payload. If the payload is invalid or missing (e.g. due to a provider error or schema mismatch), this function throws a synchronous exception. This call occurs inside an `Effect.gen` block that is executed via `Effect.runPromiseWith`. The synchronous throw causes the Effect to fail, resulting in a rejected Promise. Since the event listener (attached to `manager`) does not await or handle this Promise, the rejection is unhandled, which will cause the Node.js process to crash. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->