### PR TITLE
Extend Git Action failure Visibility

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -408,7 +408,10 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
           type: "error",
           title: "Action failed",
           description: err instanceof Error ? err.message : "An error occurred.",
-          data: threadToastData,
+          data: {
+            ...threadToastData,
+            dismissAfterVisibleMs: 10_000,
+          },
         });
       }
     },


### PR DESCRIPTION
## What Changed

Updated the Git action error toast so it now auto-dismisses after 10 seconds of visible time, matching the existing success toast behavior.

## Why

Git action failures were reusing a persistent progress toast created with timeout: 0, but unlike the success path, the error path never opted back into auto-dismiss behavior. That made failed action toasts stay on screen indefinitely, which was inconsistent with successful action toasts and looked like an accidental sticky state rather than an intentional UX choice.

This change fixes that inconsistency with the smallest possible scope and no broader toast-system behavior changes.

This fix resolves the issue #390 and #419 

## UI Changes

### Before the fix
the toast would stick forever, only way to dismiss it was by sliding it off. 

https://github.com/user-attachments/assets/e9c74bce-980b-4adc-8cde-c2dc785c2b5b

### After the fix
the toast now auto-dismisses after 10 seconds of visible time.

https://github.com/user-attachments/assets/074c4afb-ce88-490c-b484-722d8121c3a4



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set error toast dismissal to 10,000 ms in `GitActionsControl` to extend Git Action failure visibility in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/672/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f)
> On mutation failure in `GitActionsControl`, update `toastManager.update` to spread `threadToastData` and add `dismissAfterVisibleMs: 10_000` in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/672/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f).
>
> #### 📍Where to Start
> Start with the error path in the `runImmediateGitActionMutation` handler within `GitActionsControl` in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/672/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c757e9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->