### PR TITLE
apps/server: Fix potential command injection on Windows

### DIFF
--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -7,11 +7,10 @@
  * @module Open
  */
 import { spawn } from "node:child_process";
-import { accessSync, constants, statSync } from "node:fs";
-import { extname, join } from "node:path";
 
 import { EDITORS, type EditorId } from "@t3tools/contracts";
 import { ServiceMap, Schema, Effect, Layer } from "effect";
+import { isCommandAvailable, resolveCommandPath } from "./pathUtils";
 
 // ==============================
 // Definitions
@@ -32,11 +31,6 @@ interface EditorLaunch {
   readonly args: ReadonlyArray<string>;
 }
 
-interface CommandAvailabilityOptions {
-  readonly platform?: NodeJS.Platform;
-  readonly env?: NodeJS.ProcessEnv;
-}
-
 const LINE_COLUMN_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
 
 function shouldUseGotoFlag(editorId: EditorId, target: string): boolean {
@@ -54,110 +48,7 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
   }
 }
 
-function stripWrappingQuotes(value: string): string {
-  return value.replace(/^"+|"+$/g, "");
-}
-
-function resolvePathEnvironmentVariable(env: NodeJS.ProcessEnv): string {
-  return env.PATH ?? env.Path ?? env.path ?? "";
-}
-
-function resolveWindowsPathExtensions(env: NodeJS.ProcessEnv): ReadonlyArray<string> {
-  const rawValue = env.PATHEXT;
-  const fallback = [".COM", ".EXE", ".BAT", ".CMD"];
-  if (!rawValue) return fallback;
-
-  const parsed = rawValue
-    .split(";")
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0)
-    .map((entry) => (entry.startsWith(".") ? entry.toUpperCase() : `.${entry.toUpperCase()}`));
-  return parsed.length > 0 ? Array.from(new Set(parsed)) : fallback;
-}
-
-function resolveCommandCandidates(
-  command: string,
-  platform: NodeJS.Platform,
-  windowsPathExtensions: ReadonlyArray<string>,
-): ReadonlyArray<string> {
-  if (platform !== "win32") return [command];
-  const extension = extname(command);
-  const normalizedExtension = extension.toUpperCase();
-
-  if (extension.length > 0 && windowsPathExtensions.includes(normalizedExtension)) {
-    const commandWithoutExtension = command.slice(0, -extension.length);
-    return Array.from(
-      new Set([
-        command,
-        `${commandWithoutExtension}${normalizedExtension}`,
-        `${commandWithoutExtension}${normalizedExtension.toLowerCase()}`,
-      ]),
-    );
-  }
-
-  const candidates: string[] = [];
-  for (const extension of windowsPathExtensions) {
-    candidates.push(`${command}${extension}`);
-    candidates.push(`${command}${extension.toLowerCase()}`);
-  }
-  return Array.from(new Set(candidates));
-}
-
-function isExecutableFile(
-  filePath: string,
-  platform: NodeJS.Platform,
-  windowsPathExtensions: ReadonlyArray<string>,
-): boolean {
-  try {
-    const stat = statSync(filePath);
-    if (!stat.isFile()) return false;
-    if (platform === "win32") {
-      const extension = extname(filePath);
-      if (extension.length === 0) return false;
-      return windowsPathExtensions.includes(extension.toUpperCase());
-    }
-    accessSync(filePath, constants.X_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function resolvePathDelimiter(platform: NodeJS.Platform): string {
-  return platform === "win32" ? ";" : ":";
-}
-
-export function isCommandAvailable(
-  command: string,
-  options: CommandAvailabilityOptions = {},
-): boolean {
-  const platform = options.platform ?? process.platform;
-  const env = options.env ?? process.env;
-  const windowsPathExtensions = platform === "win32" ? resolveWindowsPathExtensions(env) : [];
-  const commandCandidates = resolveCommandCandidates(command, platform, windowsPathExtensions);
-
-  if (command.includes("/") || command.includes("\\")) {
-    return commandCandidates.some((candidate) =>
-      isExecutableFile(candidate, platform, windowsPathExtensions),
-    );
-  }
-
-  const pathValue = resolvePathEnvironmentVariable(env);
-  if (pathValue.length === 0) return false;
-  const pathEntries = pathValue
-    .split(resolvePathDelimiter(platform))
-    .map((entry) => stripWrappingQuotes(entry.trim()))
-    .filter((entry) => entry.length > 0);
-
-  for (const pathEntry of pathEntries) {
-    for (const candidate of commandCandidates) {
-      if (isExecutableFile(join(pathEntry, candidate), platform, windowsPathExtensions)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
+export { isCommandAvailable, resolveCommandPath };
 
 export function resolveAvailableEditors(
   platform: NodeJS.Platform = process.platform,
@@ -225,17 +116,28 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
 
 export const launchDetached = (launch: EditorLaunch) =>
   Effect.gen(function* () {
-    if (!isCommandAvailable(launch.command)) {
+    const commandPath = resolveCommandPath(launch.command);
+    if (!commandPath) {
       return yield* new OpenError({ message: `Editor command not found: ${launch.command}` });
     }
 
     yield* Effect.callback<void, OpenError>((resume) => {
       let child;
       try {
-        child = spawn(launch.command, [...launch.args], {
+        const isWindows = process.platform === "win32";
+        const isBatchFile = isWindows && /\.(bat|cmd)$/i.test(commandPath);
+
+        // If it's a batch file on Windows, we use cmd.exe /c to launch it
+        // and we use shell: false to avoid command injection in the arguments.
+        const spawnCommand = isBatchFile ? (process.env.comspec || "cmd.exe") : commandPath;
+        const spawnArgs = isBatchFile
+          ? ["/d", "/s", "/c", commandPath, ...launch.args]
+          : [...launch.args];
+
+        child = spawn(spawnCommand, spawnArgs, {
           detached: true,
           stdio: "ignore",
-          shell: process.platform === "win32",
+          shell: false,
         });
       } catch (error) {
         return resume(

--- a/apps/server/src/pathUtils.ts
+++ b/apps/server/src/pathUtils.ts
@@ -1,0 +1,120 @@
+import { accessSync, constants, statSync } from "node:fs";
+import { extname, join } from "node:path";
+
+export interface CommandAvailabilityOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+function stripWrappingQuotes(value: string): string {
+  return value.replace(/^"+|"+$/g, "");
+}
+
+function resolvePathEnvironmentVariable(env: NodeJS.ProcessEnv): string {
+  return env.PATH ?? env.Path ?? env.path ?? "";
+}
+
+function resolveWindowsPathExtensions(env: NodeJS.ProcessEnv): ReadonlyArray<string> {
+  const rawValue = env.PATHEXT;
+  const fallback = [".COM", ".EXE", ".BAT", ".CMD"];
+  if (!rawValue) return fallback;
+
+  const parsed = rawValue
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .map((entry) => (entry.startsWith(".") ? entry.toUpperCase() : `.${entry.toUpperCase()}`));
+  return parsed.length > 0 ? Array.from(new Set(parsed)) : fallback;
+}
+
+function resolveCommandCandidates(
+  command: string,
+  platform: NodeJS.Platform,
+  windowsPathExtensions: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  if (platform !== "win32") return [command];
+  const extension = extname(command);
+  const normalizedExtension = extension.toUpperCase();
+
+  if (extension.length > 0 && windowsPathExtensions.includes(normalizedExtension)) {
+    const commandWithoutExtension = command.slice(0, -extension.length);
+    return Array.from(
+      new Set([
+        command,
+        `${commandWithoutExtension}${normalizedExtension}`,
+        `${commandWithoutExtension}${normalizedExtension.toLowerCase()}`,
+      ]),
+    );
+  }
+
+  const candidates: string[] = [];
+  for (const extension of windowsPathExtensions) {
+    candidates.push(`${command}${extension}`);
+    candidates.push(`${command}${extension.toLowerCase()}`);
+  }
+  return Array.from(new Set(candidates));
+}
+
+function isExecutableFile(
+  filePath: string,
+  platform: NodeJS.Platform,
+  windowsPathExtensions: ReadonlyArray<string>,
+): boolean {
+  try {
+    const stat = statSync(filePath);
+    if (!stat.isFile()) return false;
+    if (platform === "win32") {
+      const extension = extname(filePath);
+      if (extension.length === 0) return false;
+      return windowsPathExtensions.includes(extension.toUpperCase());
+    }
+    accessSync(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolvePathDelimiter(platform: NodeJS.Platform): string {
+  return platform === "win32" ? ";" : ":";
+}
+
+export function resolveCommandPath(
+  command: string,
+  options: CommandAvailabilityOptions = {},
+): string | undefined {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const windowsPathExtensions = platform === "win32" ? resolveWindowsPathExtensions(env) : [];
+  const commandCandidates = resolveCommandCandidates(command, platform, windowsPathExtensions);
+
+  if (command.includes("/") || command.includes("\\")) {
+    return commandCandidates.find((candidate) =>
+      isExecutableFile(candidate, platform, windowsPathExtensions),
+    );
+  }
+
+  const pathValue = resolvePathEnvironmentVariable(env);
+  if (pathValue.length === 0) return undefined;
+  const pathEntries = pathValue
+    .split(resolvePathDelimiter(platform))
+    .map((entry) => stripWrappingQuotes(entry.trim()))
+    .filter((entry) => entry.length > 0);
+
+  for (const pathEntry of pathEntries) {
+    for (const candidate of commandCandidates) {
+      const fullPath = join(pathEntry, candidate);
+      if (isExecutableFile(fullPath, platform, windowsPathExtensions)) {
+        return fullPath;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function isCommandAvailable(
+  command: string,
+  options: CommandAvailabilityOptions = {},
+): boolean {
+  return !!resolveCommandPath(command, options);
+}

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -1,4 +1,6 @@
 import { type ChildProcess as ChildProcessHandle, spawn, spawnSync } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+import { resolveCommandPath } from "./pathUtils";
 
 export interface ProcessRunOptions {
   cwd?: string | undefined;
@@ -102,6 +104,7 @@ function appendChunkWithinLimit(
   currentBytes: number,
   chunk: Buffer,
   maxBytes: number,
+  decoder: StringDecoder,
 ): {
   next: string;
   nextBytes: number;
@@ -113,13 +116,13 @@ function appendChunkWithinLimit(
   }
   if (chunk.length <= remaining) {
     return {
-      next: `${target}${chunk.toString()}`,
+      next: `${target}${decoder.write(chunk)}`,
       nextBytes: currentBytes + chunk.length,
       truncated: false,
     };
   }
   return {
-    next: `${target}${chunk.subarray(0, remaining).toString()}`,
+    next: `${target}${decoder.write(chunk.subarray(0, remaining))}`,
     nextBytes: currentBytes + remaining,
     truncated: true,
   };
@@ -134,12 +137,32 @@ export async function runProcess(
   const maxBufferBytes = options.maxBufferBytes ?? DEFAULT_MAX_BUFFER_BYTES;
   const outputMode = options.outputMode ?? "error";
 
+  const commandPath = resolveCommandPath(command, { env: options.env });
+
   return new Promise<ProcessRunResult>((resolve, reject) => {
-    const child = spawn(command, args, {
+    if (!commandPath) {
+      reject(new Error(`Command not found: ${command}`));
+      return;
+    }
+
+    const isWindows = process.platform === "win32";
+    const isBatchFile = isWindows && /\.(bat|cmd)$/i.test(commandPath);
+
+    const spawnCommand = isBatchFile ? (process.env.comspec || "cmd.exe") : commandPath;
+
+    // On Windows, when executing a .bat or .cmd file via cmd.exe, arguments must be
+    // manually quoted because Node's default spawn escaping (C-runtime) is incompatible
+    // with cmd.exe's parsing rules.
+    const spawnArgs = isBatchFile
+      ? ["/d", "/s", "/c", `"${commandPath}"`, ...args.map(arg => `"${arg.replace(/"/g, '""')}"`)]
+      : args;
+
+    const child = spawn(spawnCommand, spawnArgs as string[], {
       cwd: options.cwd,
       env: options.env,
       stdio: "pipe",
-      shell: process.platform === "win32",
+      shell: false,
+      windowsVerbatimArguments: isBatchFile,
     });
 
     let stdout = "";
@@ -151,6 +174,9 @@ export async function runProcess(
     let timedOut = false;
     let settled = false;
     let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const stdoutDecoder = new StringDecoder("utf8");
+    const stderrDecoder = new StringDecoder("utf8");
 
     const timeoutTimer = setTimeout(() => {
       timedOut = true;
@@ -179,30 +205,43 @@ export async function runProcess(
 
     const appendOutput = (stream: "stdout" | "stderr", chunk: Buffer | string): Error | null => {
       const chunkBuffer = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
-      const text = chunkBuffer.toString();
+      const decoder = stream === "stdout" ? stdoutDecoder : stderrDecoder;
       const byteLength = chunkBuffer.length;
+
       if (stream === "stdout") {
         if (outputMode === "truncate") {
-          const appended = appendChunkWithinLimit(stdout, stdoutBytes, chunkBuffer, maxBufferBytes);
+          const appended = appendChunkWithinLimit(
+            stdout,
+            stdoutBytes,
+            chunkBuffer,
+            maxBufferBytes,
+            decoder,
+          );
           stdout = appended.next;
           stdoutBytes = appended.nextBytes;
           stdoutTruncated = stdoutTruncated || appended.truncated;
           return null;
         }
-        stdout += text;
+        stdout += decoder.write(chunkBuffer);
         stdoutBytes += byteLength;
         if (stdoutBytes > maxBufferBytes) {
           return normalizeBufferError(command, args, "stdout", maxBufferBytes);
         }
       } else {
         if (outputMode === "truncate") {
-          const appended = appendChunkWithinLimit(stderr, stderrBytes, chunkBuffer, maxBufferBytes);
+          const appended = appendChunkWithinLimit(
+            stderr,
+            stderrBytes,
+            chunkBuffer,
+            maxBufferBytes,
+            decoder,
+          );
           stderr = appended.next;
           stderrBytes = appended.nextBytes;
           stderrTruncated = stderrTruncated || appended.truncated;
           return null;
         }
-        stderr += text;
+        stderr += decoder.write(chunkBuffer);
         stderrBytes += byteLength;
         if (stderrBytes > maxBufferBytes) {
           return normalizeBufferError(command, args, "stderr", maxBufferBytes);
@@ -232,6 +271,9 @@ export async function runProcess(
     });
 
     child.once("close", (code, signal) => {
+      stdout += stdoutDecoder.end();
+      stderr += stderrDecoder.end();
+
       const result: ProcessRunResult = {
         stdout,
         stderr,


### PR DESCRIPTION
## What Changed
This update eliminates a command injection vulnerability in both the editor launch service and the general process runner by avoiding `shell: true` when spawning processes on Windows.

Centralized the executable resolution logic into a new `pathUtils.ts` utility. Both `open.ts` and `processRunner.ts` now resolve the absolute path of the target command before spawning. On Windows, if a batch file (.cmd or .bat) is identified, it is explicitly wrapped using the system's `comspec` shell while maintaining `shell: false`. This ensures that arguments are correctly escaped by the Node.js runtime's process creation logic instead of being interpreted as raw command components by the shell.

## Why
Using `shell: true` on Windows with unescaped arguments allows attackers to inject arbitrary commands via workspace paths or other user-influenced arguments. By moving to `shell: false` and manually resolving the executable path, the system gains the built-in safety of the `spawn` API for argument handling.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (Not applicable)
- [ ] I included a video for animation/interaction changes (Not applicable)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent command injection on Windows by resolving absolute command paths and executing `.bat`/`.cmd` via `cmd.exe` in `apps/server` using `open.launchDetached` and `processRunner.runProcess`
> Introduce `pathUtils` for command resolution and executable detection, rework spawning to use `shell: false`, and add UTF-8 safe output decoding with `StringDecoder`.
>
> #### 📍Where to Start
> Start with `resolveCommandPath` in [pathUtils.ts](https://github.com/pingdotgg/t3code/pull/675/files#diff-058aca8c738765d3a62d68d37521b1cc3be49b42339cb7751a7810f393ab3c43), then review its use in `open.launchDetached` in [open.ts](https://github.com/pingdotgg/t3code/pull/675/files#diff-67f3655f84064d89de7cec58f5e8d2b9d406dd21986dcefc77c335e3036b65be) and `processRunner.runProcess` in [processRunner.ts](https://github.com/pingdotgg/t3code/pull/675/files#diff-5a47a42313dddcd1d898b2fd498aab076e20a9447c1fc581a0eaa174b917068c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97d15b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->