### PR TITLE
fix(server): preserve file-change metadata on completed tool calls

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -254,6 +254,61 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it("preserves file-change payload data on completed tool activities", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-file-change-completed"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-1"),
+      itemId: asItemId("item-file-change-1"),
+      payload: {
+        itemType: "file_change",
+        title: "File change",
+        detail: "Updated UI text",
+        data: {
+          item: {
+            changes: [
+              { path: "apps/web/src/components/ChatView.tsx" },
+              { filename: "apps/web/src/session-logic.ts" },
+            ],
+          },
+        },
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.activities.some(
+          (activity: ProviderRuntimeTestActivity) => activity.id === "evt-file-change-completed",
+        ),
+    );
+
+    const activity = thread.activities.find(
+      (entry: ProviderRuntimeTestActivity) => entry.id === "evt-file-change-completed",
+    );
+    const payload =
+      activity?.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : undefined;
+
+    expect(activity?.kind).toBe("tool.completed");
+    expect(payload?.itemType).toBe("file_change");
+    expect(payload?.data).toEqual({
+      item: {
+        changes: [
+          { path: "apps/web/src/components/ChatView.tsx" },
+          { filename: "apps/web/src/session-logic.ts" },
+        ],
+      },
+    });
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -448,6 +448,7 @@ function runtimeEventToActivities(
           payload: {
             itemType: event.payload.itemType,
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,


### PR DESCRIPTION
## Summary
Preserve file-change metadata on completed tool-call activities.

## Why
Completed tool-call ingestion can drop payload data that the UI uses to show edited files.

## Testing
- add regression coverage for completed tool-call ingestion in `ProviderRuntimeIngestion.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve file-change payload data on completed tool activities by extending `ProviderRuntimeIngestion.runtimeEventToActivities` in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/678/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7)
> Extend `runtimeEventToActivities` to include `payload.data` on `tool.completed` activities when present, and add a test covering file change metadata retention in [ProviderRuntimeIngestion.test.ts](https://github.com/pingdotgg/t3code/pull/678/files#diff-ea511ca36a45f5254c8f22ac107b5469fed67d652de6af2c5d2763bf00ce53c3).
>
> #### 📍Where to Start
> Start with the `runtimeEventToActivities` item.completed case in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/678/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dea946.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
