### PR TITLE
fix(web): clear waiting state after completed turns

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -68,6 +68,7 @@ import {
   derivePhase,
   deriveTimelineEntries,
   deriveActiveWorkStartedAt,
+  shouldResetSendPhase,
   deriveActivePlanState,
   findLatestProposedPlan,
   type PendingApproval,
@@ -2170,20 +2171,26 @@ export default function ChatView({ threadId }: ChatViewProps) {
       return;
     }
     if (
-      phase === "running" ||
-      activePendingApproval !== null ||
-      activePendingUserInput !== null ||
-      activeThread?.error
+      shouldResetSendPhase({
+        latestTurn: activeLatestTurn,
+        session: activeThread?.session ?? null,
+        sendStartedAt,
+        hasPendingApproval: activePendingApproval !== null,
+        hasPendingUserInput: activePendingUserInput !== null,
+        hasThreadError: Boolean(activeThread?.error),
+      })
     ) {
       resetSendPhase();
     }
   }, [
+    activeLatestTurn,
     activePendingApproval,
     activePendingUserInput,
     activeThread?.error,
-    phase,
     resetSendPhase,
+    sendStartedAt,
     sendPhase,
+    activeThread?.session,
   ]);
 
   useEffect(() => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -12,6 +12,7 @@ import {
   findLatestProposedPlan,
   hasToolActivityForTurn,
   isLatestTurnSettled,
+  shouldResetSendPhase,
 } from "./session-logic";
 
 function makeActivity(overrides: {
@@ -636,6 +637,62 @@ describe("deriveActiveWorkStartedAt", () => {
         "2026-02-27T21:11:00.000Z",
       ),
     ).toBe("2026-02-27T21:11:00.000Z");
+  });
+});
+
+describe("shouldResetSendPhase", () => {
+  const latestTurn = {
+    turnId: TurnId.makeUnsafe("turn-1"),
+    startedAt: "2026-02-27T21:10:00.000Z",
+    completedAt: "2026-02-27T21:10:06.000Z",
+  } as const;
+
+  it("resets once a newly started turn has already settled", () => {
+    expect(
+      shouldResetSendPhase({
+        latestTurn,
+        session: {
+          orchestrationStatus: "ready",
+          activeTurnId: undefined,
+        },
+        sendStartedAt: "2026-02-27T21:10:01.000Z",
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        hasThreadError: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not reset from an older completed turn that finished before the new send started", () => {
+    expect(
+      shouldResetSendPhase({
+        latestTurn,
+        session: {
+          orchestrationStatus: "ready",
+          activeTurnId: undefined,
+        },
+        sendStartedAt: "2026-02-27T21:10:10.000Z",
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        hasThreadError: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("resets immediately when the session is actively running", () => {
+    expect(
+      shouldResetSendPhase({
+        latestTurn,
+        session: {
+          orchestrationStatus: "running",
+          activeTurnId: TurnId.makeUnsafe("turn-1"),
+        },
+        sendStartedAt: "2026-02-27T21:10:10.000Z",
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        hasThreadError: false,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -116,6 +116,15 @@ export function formatElapsed(startIso: string, endIso: string | undefined): str
 type LatestTurnTiming = Pick<OrchestrationLatestTurn, "turnId" | "startedAt" | "completedAt">;
 type SessionActivityState = Pick<ThreadSession, "orchestrationStatus" | "activeTurnId">;
 
+interface SendPhaseResetInput {
+  latestTurn: LatestTurnTiming | null;
+  session: SessionActivityState | null;
+  sendStartedAt: string | null;
+  hasPendingApproval: boolean;
+  hasPendingUserInput: boolean;
+  hasThreadError: boolean;
+}
+
 export function isLatestTurnSettled(
   latestTurn: LatestTurnTiming | null,
   session: SessionActivityState | null,
@@ -136,6 +145,29 @@ export function deriveActiveWorkStartedAt(
     return latestTurn?.startedAt ?? sendStartedAt;
   }
   return sendStartedAt;
+}
+
+export function shouldResetSendPhase({
+  latestTurn,
+  session,
+  sendStartedAt,
+  hasPendingApproval,
+  hasPendingUserInput,
+  hasThreadError,
+}: SendPhaseResetInput): boolean {
+  if (session?.orchestrationStatus === "running") return true;
+  if (hasPendingApproval || hasPendingUserInput || hasThreadError) return true;
+  if (!sendStartedAt) return false;
+  if (!isLatestTurnSettled(latestTurn, session)) return false;
+  if (!latestTurn?.completedAt) return false;
+
+  const sendStartedAtMs = Date.parse(sendStartedAt);
+  const completedAtMs = Date.parse(latestTurn.completedAt);
+  if (Number.isNaN(sendStartedAtMs) || Number.isNaN(completedAtMs)) {
+    return false;
+  }
+
+  return completedAtMs >= sendStartedAtMs;
 }
 
 function requestKindFromRequestType(


### PR DESCRIPTION
## Summary
Clear the waiting state once a turn has already completed.

## Why
The derived send/waiting phase can stay stuck after turn completion, leaving the thread in an incorrect UI state.

## Testing
- add regression coverage for completed-turn state transitions in `session-logic.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset ChatView send phase based on `session-logic.shouldResetSendPhase` and latest turn `completedAt >= sendStartedAt` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/679/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Move reset logic into `session-logic.shouldResetSendPhase`, update `useEffect` dependencies to `activeLatestTurn`, `sendStartedAt`, and `activeThread?.session`, and add tests for reset behavior in [session-logic.test.ts](https://github.com/pingdotgg/t3code/pull/679/files#diff-57adf4675e36941eb9badc7010414e9dae54f29534134a68c9e8808cda5c4e47).
>
> #### 📍Where to Start
> Start with the `shouldResetSendPhase` function in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/679/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6), then review its usage in the `useEffect` within [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/679/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0060a05.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
