### PR TITLE
fix(web): queue websocket requests until connect

### DIFF
--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -84,6 +84,43 @@ afterEach(() => {
 });
 
 describe("WsTransport", () => {
+  it("queues requests until the socket opens without starting per-request polling timers", async () => {
+    const intervalSpy = vi.spyOn(globalThis, "setInterval");
+    const transport = new WsTransport("ws://localhost:3020");
+    const socket = getSocket();
+
+    const firstRequest = transport.request("projects.list");
+    const secondRequest = transport.request("server.config");
+
+    expect(socket.sent).toEqual([]);
+    expect(intervalSpy).not.toHaveBeenCalled();
+
+    socket.open();
+
+    expect(socket.sent).toHaveLength(2);
+
+    const firstEnvelope = JSON.parse(socket.sent[0] ?? "") as { id: string };
+    const secondEnvelope = JSON.parse(socket.sent[1] ?? "") as { id: string };
+
+    socket.serverMessage(
+      JSON.stringify({
+        id: firstEnvelope.id,
+        result: { projects: [] },
+      }),
+    );
+    socket.serverMessage(
+      JSON.stringify({
+        id: secondEnvelope.id,
+        result: { ok: true },
+      }),
+    );
+
+    await expect(firstRequest).resolves.toEqual({ projects: [] });
+    await expect(secondRequest).resolves.toEqual({ ok: true });
+
+    transport.dispose();
+  });
+
   it("routes valid push envelopes to channel listeners", () => {
     const transport = new WsTransport("ws://localhost:3020");
     const socket = getSocket();
@@ -171,5 +208,26 @@ describe("WsTransport", () => {
     });
 
     transport.dispose();
+  });
+
+  it("rejects queued requests when the transport is disposed before connect", async () => {
+    const transport = new WsTransport("ws://localhost:3020");
+
+    const requestPromise = transport.request("projects.list");
+
+    transport.dispose();
+
+    await expect(requestPromise).rejects.toThrow("Transport disposed");
+  });
+
+  it("does not flush queued requests if a socket opens after dispose", () => {
+    const transport = new WsTransport("ws://localhost:3020");
+    const socket = getSocket();
+
+    void transport.request("projects.list").catch(() => undefined);
+    transport.dispose();
+    socket.open();
+
+    expect(socket.sent).toEqual([]);
   });
 });

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -27,6 +27,7 @@ export class WsTransport {
   private ws: WebSocket | null = null;
   private nextId = 1;
   private readonly pending = new Map<string, PendingRequest>();
+  private readonly queuedRequestsById = new Map<string, string>();
   private readonly listeners = new Map<string, Set<PushListener>>();
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -59,6 +60,7 @@ export class WsTransport {
     return new Promise<T>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.pending.delete(id);
+        this.queuedRequestsById.delete(id);
         reject(new Error(`Request timed out: ${method}`));
       }, REQUEST_TIMEOUT_MS);
 
@@ -68,7 +70,7 @@ export class WsTransport {
         timeout,
       });
 
-      this.send(message);
+      this.sendOrQueueRequest(id, JSON.stringify(message));
     });
   }
 
@@ -99,6 +101,7 @@ export class WsTransport {
       pending.reject(new Error("Transport disposed"));
     }
     this.pending.clear();
+    this.queuedRequestsById.clear();
     this.ws?.close();
     this.ws = null;
   }
@@ -109,8 +112,13 @@ export class WsTransport {
     const ws = new WebSocket(this.url);
 
     ws.addEventListener("open", () => {
+      if (this.disposed) {
+        ws.close();
+        return;
+      }
       this.ws = ws;
       this.reconnectAttempt = 0;
+      this.flushQueuedRequests();
     });
 
     ws.addEventListener("message", (event) => {
@@ -118,7 +126,9 @@ export class WsTransport {
     });
 
     ws.addEventListener("close", () => {
-      this.ws = null;
+      if (this.ws === ws) {
+        this.ws = null;
+      }
       this.scheduleReconnect();
     });
 
@@ -172,29 +182,28 @@ export class WsTransport {
     }
   }
 
-  private send(message: WsRequestEnvelope) {
+  private sendOrQueueRequest(requestId: string, encodedMessage: string) {
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(message));
+      this.ws.send(encodedMessage);
+      return;
+    }
+    this.queuedRequestsById.set(requestId, encodedMessage);
+  }
+
+  private flushQueuedRequests() {
+    if (this.ws?.readyState !== WebSocket.OPEN) {
       return;
     }
 
-    // If not connected, wait for connection
-    const waitForOpen = () => {
-      const check = setInterval(() => {
-        if (this.disposed) {
-          clearInterval(check);
-          return;
-        }
-        if (this.ws?.readyState === WebSocket.OPEN) {
-          clearInterval(check);
-          this.ws.send(JSON.stringify(message));
-        }
-      }, 50);
+    for (const [requestId, encodedMessage] of this.queuedRequestsById) {
+      if (!this.pending.has(requestId)) {
+        this.queuedRequestsById.delete(requestId);
+        continue;
+      }
 
-      // Give up after timeout (the pending request will time out on its own)
-      setTimeout(() => clearInterval(check), REQUEST_TIMEOUT_MS);
-    };
-    waitForOpen();
+      this.ws.send(encodedMessage);
+      this.queuedRequestsById.delete(requestId);
+    }
   }
 
   private scheduleReconnect() {


### PR DESCRIPTION
## Summary
Queue outbound WebSocket requests until the socket is open.

## Why
The previous implementation started a polling interval per request while the socket was still connecting. This replaces that with explicit request queueing and flush-on-open behavior.

## Testing
- `bun x vitest run apps/web/src/wsTransport.test.ts`
- add regression coverage for queued send and dispose behavior in `wsTransport.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Queue pre-connection requests in `WsTransport` to avoid per-request polling and flush them on WebSocket open in [wsTransport.ts](https://github.com/pingdotgg/t3code/pull/680/files#diff-2129bf8b884f9eac0205e2de5672354ffe759743b6538d8dee077fb1944d1506)
> Add `queuedRequestsById`, route `request` through `sendOrQueueRequest`, flush in `open` via `flushQueuedRequests`, guard dispose, and adjust `close` handling; add tests in [wsTransport.test.ts](https://github.com/pingdotgg/t3code/pull/680/files#diff-7c6ed9129e00d65af355f5c56dbbace125d2af92ee10372a5479c1907600adee).
>
> #### 📍Where to Start
> Start with `WsTransport.sendOrQueueRequest` and `WsTransport.flushQueuedRequests` in [wsTransport.ts](https://github.com/pingdotgg/t3code/pull/680/files#diff-2129bf8b884f9eac0205e2de5672354ffe759743b6538d8dee077fb1944d1506).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0739488.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
