### PR TITLE
fix editor launch fallback when saved editor is unavailable

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -14,6 +14,23 @@ import { Effect } from "effect";
 import { assertSuccess } from "@effect/vitest/utils";
 
 describe("resolveEditorLaunch", () => {
+  function withTempDirEnv(
+    files: ReadonlyArray<{ name: string; contents: string; mode?: number }>,
+    run: (env: NodeJS.ProcessEnv) => void,
+  ): void {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-open-launch-"));
+    try {
+      for (const file of files) {
+        fs.writeFileSync(path.join(dir, file.name), file.contents, {
+          mode: file.mode ?? 0o755,
+        });
+      }
+      run({ PATH: dir });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
   it.effect("returns commands for command-based editors", () =>
     Effect.gen(function* () {
       const cursorLaunch = yield* resolveEditorLaunch(
@@ -25,23 +42,23 @@ describe("resolveEditorLaunch", () => {
         args: ["/tmp/workspace"],
       });
 
-      const vscodeLaunch = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace", editor: "vscode" },
-        "darwin",
+      yield* Effect.sync(() =>
+        withTempDirEnv([{ name: "code", contents: "#!/bin/sh\nexit 0\n" }], (env) => {
+          assert.deepEqual(
+            Effect.runSync(resolveEditorLaunch({ cwd: "/tmp/workspace", editor: "vscode" }, "darwin", env)),
+            { command: "code", args: ["/tmp/workspace"] },
+          );
+        }),
       );
-      assert.deepEqual(vscodeLaunch, {
-        command: "code",
-        args: ["/tmp/workspace"],
-      });
 
-      const zedLaunch = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace", editor: "zed" },
-        "darwin",
+      yield* Effect.sync(() =>
+        withTempDirEnv([{ name: "zed", contents: "#!/bin/sh\nexit 0\n" }], (env) => {
+          assert.deepEqual(
+            Effect.runSync(resolveEditorLaunch({ cwd: "/tmp/workspace", editor: "zed" }, "darwin", env)),
+            { command: "zed", args: ["/tmp/workspace"] },
+          );
+        }),
       );
-      assert.deepEqual(zedLaunch, {
-        command: "zed",
-        args: ["/tmp/workspace"],
-      });
     }),
   );
 
@@ -65,53 +82,82 @@ describe("resolveEditorLaunch", () => {
         args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
       });
 
-      const vscodeLineAndColumn = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "vscode" },
-        "darwin",
+      yield* Effect.sync(() =>
+        withTempDirEnv([{ name: "code", contents: "#!/bin/sh\nexit 0\n" }], (env) => {
+          assert.deepEqual(
+            Effect.runSync(
+              resolveEditorLaunch({ cwd: "/tmp/workspace/src/open.ts:71:5", editor: "vscode" }, "darwin", env),
+            ),
+            { command: "code", args: ["--goto", "/tmp/workspace/src/open.ts:71:5"] },
+          );
+        }),
       );
-      assert.deepEqual(vscodeLineAndColumn, {
-        command: "code",
-        args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
-      });
 
-      const zedLineAndColumn = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "zed" },
-        "darwin",
+      yield* Effect.sync(() =>
+        withTempDirEnv([{ name: "zed", contents: "#!/bin/sh\nexit 0\n" }], (env) => {
+          assert.deepEqual(
+            Effect.runSync(
+              resolveEditorLaunch({ cwd: "/tmp/workspace/src/open.ts:71:5", editor: "zed" }, "darwin", env),
+            ),
+            { command: "zed", args: ["/tmp/workspace/src/open.ts:71:5"] },
+          );
+        }),
       );
-      assert.deepEqual(zedLineAndColumn, {
-        command: "zed",
-        args: ["/tmp/workspace/src/open.ts:71:5"],
-      });
     }),
   );
 
   it.effect("maps file-manager editor to OS open commands", () =>
-    Effect.gen(function* () {
-      const launch1 = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace", editor: "file-manager" },
-        "darwin",
-      );
-      assert.deepEqual(launch1, {
-        command: "open",
-        args: ["/tmp/workspace"],
+    Effect.sync(() => {
+      withTempDirEnv([{ name: "open", contents: "#!/bin/sh\nexit 0\n" }], (env) => {
+        assert.deepEqual(
+          Effect.runSync(resolveEditorLaunch({ cwd: "/tmp/workspace", editor: "file-manager" }, "darwin", env)),
+          { command: "open", args: ["/tmp/workspace"] },
+        );
       });
-
-      const launch2 = yield* resolveEditorLaunch(
-        { cwd: "C:\\workspace", editor: "file-manager" },
-        "win32",
-      );
-      assert.deepEqual(launch2, {
-        command: "explorer",
-        args: ["C:\\workspace"],
+      withTempDirEnv([{ name: "explorer.EXE", contents: "MZ", mode: 0o755 }], (env) => {
+        assert.deepEqual(
+          Effect.runSync(
+            resolveEditorLaunch(
+              { cwd: "C:\\workspace", editor: "file-manager" },
+              "win32",
+              { ...env, PATHEXT: ".COM;.EXE;.BAT;.CMD" },
+            ),
+          ),
+          { command: "explorer", args: ["C:\\workspace"] },
+        );
       });
+      withTempDirEnv([{ name: "xdg-open", contents: "#!/bin/sh\nexit 0\n" }], (env) => {
+        assert.deepEqual(
+          Effect.runSync(resolveEditorLaunch({ cwd: "/tmp/workspace", editor: "file-manager" }, "linux", env)),
+          { command: "xdg-open", args: ["/tmp/workspace"] },
+        );
+      });
+    }),
+  );
 
-      const launch3 = yield* resolveEditorLaunch(
-        { cwd: "/tmp/workspace", editor: "file-manager" },
-        "linux",
+  it.effect("falls back to the file manager when the requested editor is not on PATH", () =>
+    Effect.sync(() => {
+      withTempDirEnv([{ name: "xdg-open", contents: "#!/bin/sh\nexit 0\n" }], (env) =>
+        assert.deepEqual(
+          Effect.runSync(
+            resolveEditorLaunch({ cwd: "/tmp/keybindings.json", editor: "cursor" }, "linux", env),
+          ),
+          { command: "xdg-open", args: ["/tmp/keybindings.json"] },
+        ),
       );
-      assert.deepEqual(launch3, {
-        command: "xdg-open",
-        args: ["/tmp/workspace"],
+    }),
+  );
+
+  it.effect("strips line and column when falling back to the file manager", () =>
+    Effect.sync(() => {
+      withTempDirEnv([{ name: "xdg-open", contents: "#!/bin/sh\nexit 0\n" }], (env) => {
+        const launch = Effect.runSync(
+          resolveEditorLaunch({ cwd: "/tmp/src/open.ts:71:5", editor: "cursor" }, "linux", env),
+        );
+        assert.deepEqual(launch, {
+          command: "xdg-open",
+          args: ["/tmp/src/open.ts"],
+        });
       });
     }),
   );

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -32,6 +32,29 @@ interface EditorLaunch {
   readonly args: ReadonlyArray<string>;
 }
 
+function stripLineColumnSuffix(target: string): string {
+  return target.replace(LINE_COLUMN_SUFFIX_PATTERN, "");
+}
+
+function resolveLaunchEditor(
+  requestedEditor: EditorId,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): EditorId | null {
+  const availableEditors = resolveAvailableEditors(platform, env);
+  if (availableEditors.includes(requestedEditor)) {
+    return requestedEditor;
+  }
+
+  for (const editor of EDITORS) {
+    if (editor.command && availableEditors.includes(editor.id)) {
+      return editor.id;
+    }
+  }
+
+  return availableEditors.includes("file-manager") ? "file-manager" : null;
+}
+
 interface CommandAvailabilityOptions {
   readonly platform?: NodeJS.Platform;
   readonly env?: NodeJS.ProcessEnv;
@@ -206,23 +229,29 @@ export class Open extends ServiceMap.Service<Open, OpenShape>()("t3/open") {}
 export const resolveEditorLaunch = Effect.fnUntraced(function* (
   input: OpenInEditorInput,
   platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
 ): Effect.fn.Return<EditorLaunch, OpenError> {
-  const editorDef = EDITORS.find((editor) => editor.id === input.editor);
+  const editorId = resolveLaunchEditor(input.editor, platform, env);
+  if (!editorId) {
+    return yield* new OpenError({ message: "No supported editor command is available" });
+  }
+
+  const editorDef = EDITORS.find((editor) => editor.id === editorId);
   if (!editorDef) {
-    return yield* new OpenError({ message: `Unknown editor: ${input.editor}` });
+    return yield* new OpenError({ message: `Unknown editor: ${editorId}` });
   }
 
   if (editorDef.command) {
-    return shouldUseGotoFlag(editorDef.id, input.cwd)
+    return shouldUseGotoFlag(editorId, input.cwd)
       ? { command: editorDef.command, args: ["--goto", input.cwd] }
       : { command: editorDef.command, args: [input.cwd] };
   }
 
-  if (editorDef.id !== "file-manager") {
-    return yield* new OpenError({ message: `Unsupported editor: ${input.editor}` });
+  if (editorId !== "file-manager") {
+    return yield* new OpenError({ message: `Unsupported editor: ${editorId}` });
   }
 
-  return { command: fileManagerCommandForPlatform(platform), args: [input.cwd] };
+  return { command: fileManagerCommandForPlatform(platform), args: [stripLineColumnSuffix(input.cwd)] };
 });
 
 export const launchDetached = (launch: EditorLaunch) =>


### PR DESCRIPTION



<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

- `apps/server/src/open.ts`
    - now checks the requested editor against the editors actually available in the current process environment
    - it keeps the requested editor when it is available, otherwise falls back to another supported command editor in the existing editor order, or file-manager when no command editor is available
    - for file-manager: strips `:line[:column]`, so it opens the base file path instead of failing.


- `apps/server/src/open.test.ts`
    - adds deterministic environment-based coverage for editor launch resolution.
    - adds focused regression tests for:
		- falling back to file-manager when the requested editor is unavailable for a plain file path
		- stripping line/column suffixes when falling back to file-manager for line- targeted paths

## Why


Issue https://github.com/pingdotgg/t3code/issues/209:
- Opening a file could fail when the requested editor command was no longer installed, even if another supported launcher was available in the current environment.

Cause:
- The server launch path resolved the requested editor id directly and only discovered command availability later, so it never reconciled the request against the editors actually available on PATH.

Fix:
- Resolve the requested editor against the current environment before building the launch command.
- Keep the requested editor when it is available, otherwise fall back to another supported command editor, then to the file manager.
- When the file manager is the only option for a line-targeted path, strip the line and column suffix and open the base file instead.
- Add focused server tests for the fallback behavior.

<!-- Explain the problem being solved and why this approach is the right one. -->

### before 
- attempting to open cursor when cursor is not installed

https://github.com/user-attachments/assets/449a298f-9b7c-4ea8-bdba-8692f980f228


## after

- open default file-manager 

https://github.com/user-attachments/assets/4a14a54f-14a1-47f4-8c1e-5e2973138296





## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->
No UI changes



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix editor launch fallback when saved editor is unavailable on PATH
> - `resolveEditorLaunch` in [open.ts](https://github.com/pingdotgg/t3code/pull/681/files#diff-67f3655f84064d89de7cec58f5e8d2b9d406dd21986dcefc77c335e3036b65be) now checks PATH at runtime to determine which editors are available, falling back to another command-based editor or the file manager when the requested editor is not found.
> - Adds `resolveLaunchEditor` to encapsulate editor selection logic, and `stripLineColumnSuffix` to strip `:line:column` from paths passed to the file manager on fallback.
> - Returns an `OpenError` with a clear message when no supported editor command is available at all.
> - New tests in [open.test.ts](https://github.com/pingdotgg/t3code/pull/681/files#diff-8461679cd410b8ed7a51a0d456bc119318c2d6bea6e58b14b57bf6176220d22b) use a `withTempDirEnv` helper to simulate editor binaries on PATH and cover the fallback and suffix-stripping behavior.
> - Behavioral Change: previously unresolved editors may now silently fall back to the file manager instead of using the saved editor preference.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46dad54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->