### PR TITLE
Add contributor trust check on PRs

### DIFF
--- a/.github/workflows/brin-check.yml
+++ b/.github/workflows/brin-check.yml
@@ -1,0 +1,116 @@
+name: Contributor Trust Check
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    name: Scan PR author
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: brin-check-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Query Brin API
+        id: brin
+        run: |
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          RESPONSE=$(curl -sf "https://api.brin.sh/contributor/${AUTHOR}?details=true&mode=full" || echo '{}')
+          echo "response<<BRIN_EOF" >> "$GITHUB_OUTPUT"
+          echo "$RESPONSE" >> "$GITHUB_OUTPUT"
+          echo "BRIN_EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Post or update comment
+        uses: actions/github-script@v7
+        env:
+          BRIN_RESPONSE: ${{ steps.brin.outputs.response }}
+        with:
+          script: |
+            const marker = "<!-- brin-check -->";
+            const pr = context.payload.pull_request;
+            let data;
+            try {
+              data = JSON.parse(process.env.BRIN_RESPONSE);
+            } catch {
+              core.warning("Failed to parse Brin API response");
+              return;
+            }
+
+            if (!data.score && data.score !== 0) {
+              core.warning("Brin API returned no score");
+              return;
+            }
+
+            const score = data.score;
+            const verdict = data.verdict ?? "unknown";
+            const confidence = data.confidence ?? "unknown";
+
+            const verdictEmoji = {
+              safe: "\u2705",
+              caution: "\u26A0\uFE0F",
+              suspicious: "\u26D4",
+              dangerous: "\uD83D\uDEA8",
+            }[verdict] ?? "\u2753";
+
+            const sub = data.sub_scores ?? {};
+            const fmt = (v) => (v != null ? String(Math.round(v)) : "—");
+
+            let body = `${marker}\n`;
+            body += `### ${verdictEmoji} Contributor Trust Check\n\n`;
+            body += `| | |\n|---|---|\n`;
+            body += `| **Author** | [@${data.name}](https://github.com/${data.name}) |\n`;
+            body += `| **Score** | **${score}**/100 |\n`;
+            body += `| **Verdict** | ${verdict} |\n`;
+            body += `| **Confidence** | ${confidence} |\n\n`;
+
+            body += `<details>\n<summary>Dimension breakdown</summary>\n\n`;
+            body += `| Dimension | Score |\n|-----------|-------|\n`;
+            body += `| Identity | ${fmt(sub.identity)} |\n`;
+            body += `| Behavior | ${fmt(sub.behavior)} |\n`;
+            body += `| Content | ${fmt(sub.content)} |\n`;
+            body += `| Graph | ${fmt(sub.graph)} |\n`;
+            body += `</details>\n\n`;
+
+            if (data.threats && data.threats.length > 0) {
+              body += `#### Detected threats\n\n`;
+              body += `| Type | Severity | Detail |\n|------|----------|--------|\n`;
+              for (const t of data.threats) {
+                body += `| ${t.type} | ${t.severity} | ${t.detail} |\n`;
+              }
+              body += `\n`;
+            }
+
+            body += `<sub>Scanned by [Brin](https://brin.sh) — analyzes GitHub identity, behavior, and contribution patterns to help maintainers assess contributor trust. `;
+            body += `[Full profile](${data.url}?details=true)</sub>\n`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated comment ${existing.id} on PR #${pr.number}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+              core.info(`Created comment on PR #${pr.number}`);
+            }


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically checks the trust profile of PR authors using the [Brin](https://brin.sh) API. On every PR (opened, reopened, or updated), it posts an informational comment with:

- **Trust score** (0–100) with verdict (safe / caution / suspicious / dangerous)
- **Dimension breakdown** — identity, behavior, content, and graph scores
- **Detected threats** — if any suspicious patterns are found (e.g. PR spray, unsolicited contributions, low-effort PRs)

### Why

With the volume of AI-agent-generated PRs increasing, it's helpful for maintainers to have automated signals about contributor trustworthiness beyond the existing vouch system. This check analyzes the contributor's GitHub profile, activity patterns, and contribution history to surface potential red flags.

### How it works

- Triggers on `pull_request_target` (same as the existing vouch workflow)
- Calls the public Brin API (`api.brin.sh`) for the PR author — no secrets, tokens, or GitHub App required
- Posts a single comment per PR (updates on subsequent pushes instead of creating new comments)
- Purely informational — does not add labels or block merges

### What it checks

| Signal | What it measures |
|--------|-----------------|
| Identity | Account age, contribution history, GPG keys, org memberships |
| Behavior | PR spray velocity, unsolicited PR ratio, close-without-merge patterns |
| Content | PR body substance, issue linkage, low-effort detection |
| Graph | Cross-repo trust, co-contributor relationships |

### Complements the existing vouch system

The vouch workflow answers "is this person on a trusted list?" — this check answers "what does their actual contribution behavior look like?" Together they give maintainers a more complete picture.

### Tested

Verified end-to-end on a fork — the workflow triggers correctly, the API responds with full scores, and the comment renders cleanly on the PR.

## Test plan

- [x] Workflow triggers on `pull_request_target` events
- [x] Brin API returns contributor score with dimension breakdown
- [x] Comment is posted with correct formatting
- [x] Comment updates (not duplicates) on subsequent pushes

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a Contributor Trust Check workflow to post Brin trust metrics on pull_request_target events in [.github/workflows/brin-check.yml](https://github.com/pingdotgg/t3code/pull/686/files#diff-e4892559bd87cb8882ea5148e8e806af3f8619f6332af8639b8f233c0f927cb4)
> Introduce a GitHub Actions job that queries the Brin API for the PR author and posts or updates a structured comment with verdict, confidence, sub-scores, and threats, using `pull_request_target` triggers and `github-script` for comment management.
>
> #### 📍Where to Start
> Start with the workflow definition in [.github/workflows/brin-check.yml](https://github.com/pingdotgg/t3code/pull/686/files#diff-e4892559bd87cb8882ea5148e8e806af3f8619f6332af8639b8f233c0f927cb4), focusing on the `check` job steps and the `github-script` comment logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a62ea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->