### PR TITLE
fix: Pending user input displays with "Pending Approval" status

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,0 +1,142 @@
+import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+import type { Thread } from "../types";
+import { resolveThreadStatusPill } from "./Sidebar.logic";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread",
+    model: "gpt-5-codex",
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    session: null,
+    messages: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-03-09T00:00:00.000Z",
+    latestTurn: null,
+    branch: null,
+    worktreePath: null,
+    turnDiffSummaries: [],
+    activities: [],
+    ...overrides,
+  };
+}
+
+describe("resolveThreadStatusPill", () => {
+  it("returns Pending Approval when an approval request is open", () => {
+    expect(
+      resolveThreadStatusPill(
+        makeThread({
+          session: {
+            provider: "codex",
+            status: "running",
+            orchestrationStatus: "running",
+            createdAt: "2026-03-09T00:00:00.000Z",
+            updatedAt: "2026-03-09T00:00:00.000Z",
+          },
+        }),
+        { hasPendingApproval: true, hasPendingUserInput: false },
+      ),
+    ).toMatchObject({ label: "Pending Approval", pulse: false });
+  });
+
+  it("returns Pending Approval when a user-input request is open", () => {
+    expect(
+      resolveThreadStatusPill(
+        makeThread({
+          session: {
+            provider: "codex",
+            status: "running",
+            orchestrationStatus: "running",
+            createdAt: "2026-03-09T00:00:00.000Z",
+            updatedAt: "2026-03-09T00:00:00.000Z",
+          },
+        }),
+        { hasPendingApproval: false, hasPendingUserInput: true },
+      ),
+    ).toMatchObject({ label: "Pending Approval", pulse: false });
+  });
+
+  it("returns Pending Approval when both request types are open", () => {
+    expect(
+      resolveThreadStatusPill(
+        makeThread({
+          session: {
+            provider: "codex",
+            status: "running",
+            orchestrationStatus: "running",
+            createdAt: "2026-03-09T00:00:00.000Z",
+            updatedAt: "2026-03-09T00:00:00.000Z",
+          },
+        }),
+        { hasPendingApproval: true, hasPendingUserInput: true },
+      ),
+    ).toMatchObject({ label: "Pending Approval", pulse: false });
+  });
+
+  it("returns Working when the session is running without blocking requests", () => {
+    expect(
+      resolveThreadStatusPill(
+        makeThread({
+          session: {
+            provider: "codex",
+            status: "running",
+            orchestrationStatus: "running",
+            createdAt: "2026-03-09T00:00:00.000Z",
+            updatedAt: "2026-03-09T00:00:00.000Z",
+          },
+        }),
+        { hasPendingApproval: false, hasPendingUserInput: false },
+      ),
+    ).toMatchObject({ label: "Working", pulse: true });
+  });
+
+  it("returns Connecting when the session is connecting without blocking requests", () => {
+    expect(
+      resolveThreadStatusPill(
+        makeThread({
+          session: {
+            provider: "codex",
+            status: "connecting",
+            orchestrationStatus: "starting",
+            createdAt: "2026-03-09T00:00:00.000Z",
+            updatedAt: "2026-03-09T00:00:00.000Z",
+          },
+        }),
+        { hasPendingApproval: false, hasPendingUserInput: false },
+      ),
+    ).toMatchObject({ label: "Connecting", pulse: true });
+  });
+
+  it("returns Completed when there is unseen completion and no stronger status", () => {
+    expect(
+      resolveThreadStatusPill(
+        makeThread({
+          latestTurn: {
+            turnId: TurnId.makeUnsafe("turn-1"),
+            state: "completed",
+            requestedAt: "2026-03-09T00:00:00.000Z",
+            startedAt: "2026-03-09T00:00:01.000Z",
+            completedAt: "2026-03-09T00:00:02.000Z",
+            assistantMessageId: null,
+          },
+          lastVisitedAt: "2026-03-09T00:00:01.500Z",
+        }),
+        { hasPendingApproval: false, hasPendingUserInput: false },
+      ),
+    ).toMatchObject({ label: "Completed", pulse: false });
+  });
+
+  it("returns null when no status applies", () => {
+    expect(
+      resolveThreadStatusPill(makeThread(), {
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,0 +1,67 @@
+import type { Thread } from "../types";
+
+export interface ThreadStatusPill {
+  label: "Working" | "Connecting" | "Completed" | "Pending Approval";
+  colorClass: string;
+  dotClass: string;
+  pulse: boolean;
+}
+
+interface ResolveThreadStatusPillOptions {
+  hasPendingApproval: boolean;
+  hasPendingUserInput: boolean;
+}
+
+export function hasUnseenCompletion(thread: Thread): boolean {
+  if (!thread.latestTurn?.completedAt) return false;
+  const completedAt = Date.parse(thread.latestTurn.completedAt);
+  if (Number.isNaN(completedAt)) return false;
+  if (!thread.lastVisitedAt) return true;
+
+  const lastVisitedAt = Date.parse(thread.lastVisitedAt);
+  if (Number.isNaN(lastVisitedAt)) return true;
+  return completedAt > lastVisitedAt;
+}
+
+export function resolveThreadStatusPill(
+  thread: Thread,
+  options: ResolveThreadStatusPillOptions,
+): ThreadStatusPill | null {
+  if (options.hasPendingApproval || options.hasPendingUserInput) {
+    return {
+      label: "Pending Approval",
+      colorClass: "text-amber-600 dark:text-amber-300/90",
+      dotClass: "bg-amber-500 dark:bg-amber-300/90",
+      pulse: false,
+    };
+  }
+
+  if (thread.session?.status === "running") {
+    return {
+      label: "Working",
+      colorClass: "text-sky-600 dark:text-sky-300/80",
+      dotClass: "bg-sky-500 dark:bg-sky-300/80",
+      pulse: true,
+    };
+  }
+
+  if (thread.session?.status === "connecting") {
+    return {
+      label: "Connecting",
+      colorClass: "text-sky-600 dark:text-sky-300/80",
+      dotClass: "bg-sky-500 dark:bg-sky-300/80",
+      pulse: true,
+    };
+  }
+
+  if (hasUnseenCompletion(thread)) {
+    return {
+      label: "Completed",
+      colorClass: "text-emerald-600 dark:text-emerald-300/90",
+      dotClass: "bg-emerald-500 dark:bg-emerald-300/90",
+      pulse: false,
+    };
+  }
+
+  return null;
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -28,8 +28,7 @@ import { APP_STAGE_LABEL } from "../branding";
 import { newCommandId, newProjectId, newThreadId } from "../lib/utils";
 import { useStore } from "../store";
 import { isChatNewLocalShortcut, isChatNewShortcut, shortcutLabelForCommand } from "../keybindings";
-import { type Thread } from "../types";
-import { derivePendingApprovals } from "../session-logic";
+import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
 import { gitRemoveWorktreeMutationOptions, gitStatusQueryOptions } from "../lib/gitReactQuery";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
@@ -66,6 +65,7 @@ import {
   SidebarSeparator,
   SidebarTrigger,
 } from "./ui/sidebar";
+import { resolveThreadStatusPill } from "./Sidebar.logic";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
 
@@ -89,13 +89,6 @@ function formatRelativeTime(iso: string): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
-interface ThreadStatusPill {
-  label: "Working" | "Connecting" | "Completed" | "Pending Approval";
-  colorClass: string;
-  dotClass: string;
-  pulse: boolean;
-}
-
 interface TerminalStatusIndicator {
   label: "Terminal process running";
   colorClass: string;
@@ -110,57 +103,6 @@ interface PrStatusIndicator {
 }
 
 type ThreadPr = GitStatusResult["pr"];
-
-function hasUnseenCompletion(thread: Thread): boolean {
-  if (!thread.latestTurn?.completedAt) return false;
-  const completedAt = Date.parse(thread.latestTurn.completedAt);
-  if (Number.isNaN(completedAt)) return false;
-  if (!thread.lastVisitedAt) return true;
-
-  const lastVisitedAt = Date.parse(thread.lastVisitedAt);
-  if (Number.isNaN(lastVisitedAt)) return true;
-  return completedAt > lastVisitedAt;
-}
-
-function threadStatusPill(thread: Thread, hasPendingApprovals: boolean): ThreadStatusPill | null {
-  if (hasPendingApprovals) {
-    return {
-      label: "Pending Approval",
-      colorClass: "text-amber-600 dark:text-amber-300/90",
-      dotClass: "bg-amber-500 dark:bg-amber-300/90",
-      pulse: false,
-    };
-  }
-
-  if (thread.session?.status === "running") {
-    return {
-      label: "Working",
-      colorClass: "text-sky-600 dark:text-sky-300/80",
-      dotClass: "bg-sky-500 dark:bg-sky-300/80",
-      pulse: true,
-    };
-  }
-
-  if (thread.session?.status === "connecting") {
-    return {
-      label: "Connecting",
-      colorClass: "text-sky-600 dark:text-sky-300/80",
-      dotClass: "bg-sky-500 dark:bg-sky-300/80",
-      pulse: true,
-    };
-  }
-
-  if (hasUnseenCompletion(thread)) {
-    return {
-      label: "Completed",
-      colorClass: "text-emerald-600 dark:text-emerald-300/90",
-      dotClass: "bg-emerald-500 dark:bg-emerald-300/90",
-      pulse: false,
-    };
-  }
-
-  return null;
-}
 
 function terminalStatusFromRunningIds(
   runningTerminalIds: string[],
@@ -316,6 +258,13 @@ export default function Sidebar() {
     const map = new Map<ThreadId, boolean>();
     for (const thread of threads) {
       map.set(thread.id, derivePendingApprovals(thread.activities).length > 0);
+    }
+    return map;
+  }, [threads]);
+  const pendingUserInputByThreadId = useMemo(() => {
+    const map = new Map<ThreadId, boolean>();
+    for (const thread of threads) {
+      map.set(thread.id, derivePendingUserInputs(thread.activities).length > 0);
     }
     return map;
   }, [threads]);
@@ -1241,10 +1190,10 @@ export default function Sidebar() {
                       <SidebarMenuSub className="mx-1 my-0 w-full translate-x-0 gap-0 px-1.5 py-0">
                         {visibleThreads.map((thread) => {
                           const isActive = routeThreadId === thread.id;
-                          const threadStatus = threadStatusPill(
-                            thread,
-                            pendingApprovalByThreadId.get(thread.id) === true,
-                          );
+                          const threadStatus = resolveThreadStatusPill(thread, {
+                            hasPendingApproval: pendingApprovalByThreadId.get(thread.id) === true,
+                            hasPendingUserInput: pendingUserInputByThreadId.get(thread.id) === true,
+                          });
                           const prStatus = prStatusIndicator(prByThreadId.get(thread.id) ?? null);
                           const terminalStatus = terminalStatusFromRunningIds(
                             selectThreadTerminalState(terminalStateByThreadId, thread.id)


### PR DESCRIPTION
## What Changed

- show `Pending Approval` when either approvals or user input are pending
- move thread status pill derivation into `Sidebar.logic.ts`
- add unit tests for status priority and unseen completion behavior

## Why

Issue https://github.com/pingdotgg/t3code/issues/442:

* If an agent in plan mode asks a question, there is no visual indicator for that in the sidebar. This makes knowing that the user needs to take some action impossible without opening up the thread.

Cause:

* `pendingUserInput` was not being considered for the "Pending Approval" status.

## UI Changes

### Before

https://github.com/user-attachments/assets/3b35c93a-09a8-40e5-a1b4-bf2efd621b43

### After

https://github.com/user-attachments/assets/33ac9455-20c7-43d6-8ab8-030213fa0863

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat pending user-input as "Pending Approval" and centralize status pill resolution via `Sidebar.logic.resolveThreadStatusPill` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/688/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1)
> Move status pill logic into `Sidebar.logic.resolveThreadStatusPill` and add `hasUnseenCompletion`; update `Sidebar.tsx` to use the resolver and derive pending user input; add tests in [Sidebar.logic.test.ts](https://github.com/pingdotgg/t3code/pull/688/files#diff-32549f6f09ae3a1d9d846a62727c17b9f9ec246030982995fd972b497a87335a).
>
> #### 📍Where to Start
> Start with `resolveThreadStatusPill` and `hasUnseenCompletion` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/688/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2259aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->