### PR TITLE
Discover project favicons recursively for monorepos

### DIFF
--- a/apps/server/src/projectFaviconRoute.test.ts
+++ b/apps/server/src/projectFaviconRoute.test.ts
@@ -1,9 +1,11 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
+
 import { tryHandleProjectFaviconRequest } from "./projectFaviconRoute";
 
 interface HttpResponse {
@@ -20,9 +22,20 @@ function makeTempDir(prefix: string): string {
   return dir;
 }
 
-async function withRouteServer(
-  run: (baseUrl: string) => Promise<void>,
-): Promise<void> {
+function writeFile(cwd: string, relativePath: string, contents = ""): void {
+  const absolutePath = path.join(cwd, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, "utf8");
+}
+
+function runGit(cwd: string, args: string[]): void {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  }
+}
+
+async function withRouteServer(run: (baseUrl: string) => Promise<void>): Promise<void> {
   const server = http.createServer((req, res) => {
     const url = new URL(req.url ?? "/", "http://127.0.0.1");
     if (tryHandleProjectFaviconRequest(url, res)) {
@@ -72,6 +85,10 @@ async function request(baseUrl: string, pathname: string): Promise<HttpResponse>
   };
 }
 
+async function requestProjectFavicon(baseUrl: string, cwd: string): Promise<HttpResponse> {
+  return request(baseUrl, `/api/project-favicon?cwd=${encodeURIComponent(cwd)}`);
+}
+
 describe("tryHandleProjectFaviconRequest", () => {
   afterEach(() => {
     for (const dir of tempDirs.splice(0, tempDirs.length)) {
@@ -89,43 +106,59 @@ describe("tryHandleProjectFaviconRequest", () => {
 
   it("serves a well-known favicon file from the project root", async () => {
     const projectDir = makeTempDir("t3code-favicon-route-root-");
-    fs.writeFileSync(path.join(projectDir, "favicon.svg"), "<svg>favicon</svg>", "utf8");
+    writeFile(projectDir, "favicon.svg", "<svg>favicon</svg>");
 
     await withRouteServer(async (baseUrl) => {
-      const pathname = `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}`;
-      const response = await request(baseUrl, pathname);
+      const response = await requestProjectFavicon(baseUrl, projectDir);
       expect(response.statusCode).toBe(200);
       expect(response.contentType).toContain("image/svg+xml");
       expect(response.body).toBe("<svg>favicon</svg>");
     });
   });
 
-  it("resolves icon href from source files when no well-known favicon exists", async () => {
-    const projectDir = makeTempDir("t3code-favicon-route-source-");
-    const iconPath = path.join(projectDir, "public", "brand", "logo.svg");
-    fs.mkdirSync(path.dirname(iconPath), { recursive: true });
-    fs.writeFileSync(path.join(projectDir, "index.html"), '<link rel="icon" href="/brand/logo.svg">');
-    fs.writeFileSync(iconPath, "<svg>brand</svg>", "utf8");
+  it("keeps the root fast path ahead of recursive app matches", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-root-priority-");
+    writeFile(projectDir, "favicon.svg", "<svg>root</svg>");
+    writeFile(projectDir, "apps/web/public/favicon.svg", "<svg>nested-app</svg>");
 
     await withRouteServer(async (baseUrl) => {
-      const pathname = `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}`;
-      const response = await request(baseUrl, pathname);
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>root</svg>");
+    });
+  });
+
+  it("resolves icon href from source files when no well-known favicon exists", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-source-");
+    writeFile(projectDir, "index.html", '<link rel="icon" href="/brand/logo.svg">');
+    writeFile(projectDir, "public/brand/logo.svg", "<svg>brand</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
       expect(response.statusCode).toBe(200);
       expect(response.contentType).toContain("image/svg+xml");
       expect(response.body).toBe("<svg>brand</svg>");
     });
   });
 
-  it("resolves icon link when href appears before rel in HTML", async () => {
-    const projectDir = makeTempDir("t3code-favicon-route-html-order-");
-    const iconPath = path.join(projectDir, "public", "brand", "logo.svg");
-    fs.mkdirSync(path.dirname(iconPath), { recursive: true });
-    fs.writeFileSync(path.join(projectDir, "index.html"), '<link href="/brand/logo.svg" rel="icon">');
-    fs.writeFileSync(iconPath, "<svg>brand-html-order</svg>", "utf8");
+  it("keeps source-declared icons ahead of recursive app matches", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-source-priority-");
+    writeFile(projectDir, "index.html", '<link rel="icon" href="/brand/logo.svg">');
+    writeFile(projectDir, "public/brand/logo.svg", "<svg>brand</svg>");
+    writeFile(projectDir, "apps/web/public/favicon.svg", "<svg>nested-app</svg>");
 
     await withRouteServer(async (baseUrl) => {
-      const pathname = `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}`;
-      const response = await request(baseUrl, pathname);
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>brand</svg>");
+    });
+  });
+
+  it("resolves icon link when href appears before rel in HTML", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-html-order-");
+    writeFile(projectDir, "index.html", '<link href="/brand/logo.svg" rel="icon">');
+    writeFile(projectDir, "public/brand/logo.svg", "<svg>brand-html-order</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
       expect(response.statusCode).toBe(200);
       expect(response.contentType).toContain("image/svg+xml");
       expect(response.body).toBe("<svg>brand-html-order</svg>");
@@ -134,22 +167,112 @@ describe("tryHandleProjectFaviconRequest", () => {
 
   it("resolves object-style icon metadata when href appears before rel", async () => {
     const projectDir = makeTempDir("t3code-favicon-route-obj-order-");
-    const iconPath = path.join(projectDir, "public", "brand", "obj.svg");
-    fs.mkdirSync(path.dirname(iconPath), { recursive: true });
-    fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
-    fs.writeFileSync(
-      path.join(projectDir, "src", "root.tsx"),
+    writeFile(
+      projectDir,
+      "src/root.tsx",
       'const links = [{ href: "/brand/obj.svg", rel: "icon" }];',
-      "utf8",
     );
-    fs.writeFileSync(iconPath, "<svg>brand-obj-order</svg>", "utf8");
+    writeFile(projectDir, "public/brand/obj.svg", "<svg>brand-obj-order</svg>");
 
     await withRouteServer(async (baseUrl) => {
-      const pathname = `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}`;
-      const response = await request(baseUrl, pathname);
+      const response = await requestProjectFavicon(baseUrl, projectDir);
       expect(response.statusCode).toBe(200);
       expect(response.contentType).toContain("image/svg+xml");
       expect(response.body).toBe("<svg>brand-obj-order</svg>");
+    });
+  });
+
+  it("finds a nested favicon under apps when fast paths miss", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-apps-scan-");
+    writeFile(projectDir, "apps/web/public/favicon.svg", "<svg>apps-public</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>apps-public</svg>");
+    });
+  });
+
+  it("prefers apps over non-app recursive matches", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-apps-priority-");
+    writeFile(projectDir, "shared/logo.svg", "<svg>shared</svg>");
+    writeFile(projectDir, "apps/web/public/favicon.svg", "<svg>app</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>app</svg>");
+    });
+  });
+
+  it("prefers public and app roots over less-specific paths inside the same app", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-app-location-");
+    writeFile(projectDir, "apps/web/assets/favicon.svg", "<svg>assets</svg>");
+    writeFile(projectDir, "apps/web/public/favicon.svg", "<svg>public</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>public</svg>");
+    });
+  });
+
+  it("prefers shallower same-priority recursive matches before alphabetical tie-breaks", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-depth-order-");
+    writeFile(projectDir, "apps/web/alpha/favicon.svg", "<svg>alpha-deep</svg>");
+    writeFile(projectDir, "apps/web/zeta/favicon.svg", "<svg>zeta-deep</svg>");
+    writeFile(projectDir, "apps/web/favicon.svg", "<svg>root-shallow</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>root-shallow</svg>");
+    });
+  });
+
+  it("uses alphabetical order for same-depth recursive ties", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-alpha-order-");
+    writeFile(projectDir, "apps/web/alpha/favicon.svg", "<svg>alpha</svg>");
+    writeFile(projectDir, "apps/web/zeta/favicon.svg", "<svg>zeta</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>alpha</svg>");
+    });
+  });
+
+  it("excludes gitignored recursive favicon files", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-gitignore-");
+    runGit(projectDir, ["init"]);
+    writeFile(projectDir, ".gitignore", "apps/web/public/\n");
+    writeFile(projectDir, "apps/web/public/favicon.svg", "<svg>ignored</svg>");
+    writeFile(projectDir, "apps/docs/favicon.svg", "<svg>kept</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>kept</svg>");
+    });
+  });
+
+  it("excludes tracked files that now match gitignore rules", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-gitignore-tracked-");
+    runGit(projectDir, ["init"]);
+    writeFile(projectDir, "apps/web/public/favicon.svg", "<svg>tracked-ignored</svg>");
+    writeFile(projectDir, "apps/docs/favicon.svg", "<svg>kept</svg>");
+    runGit(projectDir, ["add", "apps/web/public/favicon.svg", "apps/docs/favicon.svg"]);
+    writeFile(projectDir, ".gitignore", "apps/web/public/\n");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>kept</svg>");
+    });
+  });
+
+  it("walks non-git workspaces recursively while skipping heavy directories", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-non-git-scan-");
+    writeFile(projectDir, "node_modules/pkg/favicon.svg", "<svg>ignored-node-modules</svg>");
+    writeFile(projectDir, ".cache/favicon.svg", "<svg>ignored-cache</svg>");
+    writeFile(projectDir, "apps/web/public/favicon.svg", "<svg>kept</svg>");
+
+    await withRouteServer(async (baseUrl) => {
+      const response = await requestProjectFavicon(baseUrl, projectDir);
+      expect(response.body).toBe("<svg>kept</svg>");
     });
   });
 
@@ -157,8 +280,7 @@ describe("tryHandleProjectFaviconRequest", () => {
     const projectDir = makeTempDir("t3code-favicon-route-fallback-");
 
     await withRouteServer(async (baseUrl) => {
-      const pathname = `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}`;
-      const response = await request(baseUrl, pathname);
+      const response = await requestProjectFavicon(baseUrl, projectDir);
       expect(response.statusCode).toBe(200);
       expect(response.contentType).toContain("image/svg+xml");
       expect(response.body).toContain('data-fallback="project-favicon"');

--- a/apps/server/src/projectFaviconRoute.ts
+++ b/apps/server/src/projectFaviconRoute.ts
@@ -1,6 +1,8 @@
-import fs from "node:fs";
+import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
+
+import { listProjectFilePaths } from "./projectFiles";
 
 const FAVICON_MIME_TYPES: Record<string, string> = {
   ".png": "image/png",
@@ -11,7 +13,6 @@ const FAVICON_MIME_TYPES: Record<string, string> = {
 
 const FALLBACK_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 
-// Well-known favicon paths checked in order.
 const FAVICON_CANDIDATES = [
   "favicon.svg",
   "favicon.ico",
@@ -33,9 +34,8 @@ const FAVICON_CANDIDATES = [
   "assets/icon.png",
   "assets/logo.svg",
   "assets/logo.png",
-];
+] as const;
 
-// Files that may contain a <link rel="icon"> or icon metadata declaration.
 const ICON_SOURCE_FILES = [
   "index.html",
   "public/index.html",
@@ -44,13 +44,28 @@ const ICON_SOURCE_FILES = [
   "app/root.tsx",
   "src/root.tsx",
   "src/index.html",
-];
+] as const;
 
-// Matches <link ...> tags or object-like icon metadata where rel/href can appear in any order.
+const RECURSIVE_FAVICON_FILENAMES = [
+  "favicon.svg",
+  "favicon.ico",
+  "favicon.png",
+  "icon.svg",
+  "icon.png",
+  "icon.ico",
+  "logo.svg",
+  "logo.png",
+] as const;
+
 const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
 const LINK_ICON_OBJ_RE =
   /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i;
+
+const RECURSIVE_FAVICON_FILENAME_SET = new Set<string>(RECURSIVE_FAVICON_FILENAMES);
+const RECURSIVE_FAVICON_PRIORITY = new Map<string, number>(
+  RECURSIVE_FAVICON_FILENAMES.map((filename, index) => [filename, index]),
+);
 
 function extractIconHref(source: string): string | null {
   const htmlMatch = source.match(LINK_ICON_HTML_RE);
@@ -70,24 +85,37 @@ function isPathWithinProject(projectCwd: string, candidatePath: string): boolean
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
-function serveFaviconFile(filePath: string, res: http.ServerResponse): void {
+async function isFile(filePath: string): Promise<boolean> {
+  try {
+    const stats = await fs.stat(filePath);
+    return stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+async function serveFaviconFile(filePath: string, res: http.ServerResponse): Promise<void> {
   const ext = path.extname(filePath).toLowerCase();
   const contentType = FAVICON_MIME_TYPES[ext] ?? "application/octet-stream";
-  fs.readFile(filePath, (readErr, data) => {
-    if (readErr) {
-      res.writeHead(500, { "Content-Type": "text/plain" });
-      res.end("Read error");
-      return;
-    }
+  try {
+    const data = await fs.readFile(filePath);
     res.writeHead(200, {
       "Content-Type": contentType,
       "Cache-Control": "public, max-age=3600",
     });
     res.end(data);
-  });
+  } catch {
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Read error");
+    }
+  }
 }
 
 function serveFallbackFavicon(res: http.ServerResponse): void {
+  if (res.headersSent) {
+    return;
+  }
   res.writeHead(200, {
     "Content-Type": "image/svg+xml",
     "Cache-Control": "public, max-age=3600",
@@ -95,77 +123,163 @@ function serveFallbackFavicon(res: http.ServerResponse): void {
   res.end(FALLBACK_FAVICON_SVG);
 }
 
+function basenameOfPosixPath(relativePath: string): string {
+  const segments = relativePath.split("/");
+  return segments[segments.length - 1] ?? relativePath;
+}
+
+function relativePathWithinApp(relativePath: string): string | null {
+  const segments = relativePath.split("/");
+  if (segments.length < 3 || segments[0] !== "apps") {
+    return null;
+  }
+  return segments.slice(2).join("/");
+}
+
+function recursiveFaviconLocationRank(relativePath: string): number {
+  const appRelativePath = relativePathWithinApp(relativePath);
+  if (!appRelativePath) {
+    return 4;
+  }
+  if (appRelativePath.startsWith("public/")) {
+    return 0;
+  }
+  if (appRelativePath.startsWith("app/")) {
+    return 1;
+  }
+  if (appRelativePath.startsWith("src/app/")) {
+    return 2;
+  }
+  if (!appRelativePath.includes("/")) {
+    return 3;
+  }
+  return 4;
+}
+
+function recursiveFaviconDepth(relativePath: string): number {
+  const scopedPath = relativePathWithinApp(relativePath) ?? relativePath;
+  return Math.max(0, scopedPath.split("/").length - 1);
+}
+
+function recursiveFaviconFilenamePriority(relativePath: string): number {
+  return (
+    RECURSIVE_FAVICON_PRIORITY.get(basenameOfPosixPath(relativePath)) ?? Number.MAX_SAFE_INTEGER
+  );
+}
+
+function compareRecursiveFaviconPaths(left: string, right: string): number {
+  const leftInApps = relativePathWithinApp(left) ? 0 : 1;
+  const rightInApps = relativePathWithinApp(right) ? 0 : 1;
+  if (leftInApps !== rightInApps) {
+    return leftInApps - rightInApps;
+  }
+
+  const locationDelta = recursiveFaviconLocationRank(left) - recursiveFaviconLocationRank(right);
+  if (locationDelta !== 0) {
+    return locationDelta;
+  }
+
+  const depthDelta = recursiveFaviconDepth(left) - recursiveFaviconDepth(right);
+  if (depthDelta !== 0) {
+    return depthDelta;
+  }
+
+  const filenameDelta =
+    recursiveFaviconFilenamePriority(left) - recursiveFaviconFilenamePriority(right);
+  if (filenameDelta !== 0) {
+    return filenameDelta;
+  }
+
+  return left.localeCompare(right);
+}
+
+async function tryServeResolvedPaths(
+  projectCwd: string,
+  candidatePaths: readonly string[],
+  res: http.ServerResponse,
+): Promise<boolean> {
+  for (const candidatePath of candidatePaths) {
+    if (!isPathWithinProject(projectCwd, candidatePath) || !(await isFile(candidatePath))) {
+      continue;
+    }
+    await serveFaviconFile(candidatePath, res);
+    return true;
+  }
+  return false;
+}
+
+async function findRecursiveFaviconPath(projectCwd: string): Promise<string | null> {
+  const relativeFilePaths = await listProjectFilePaths(projectCwd);
+  const bestCandidate = relativeFilePaths
+    .filter((relativePath) => RECURSIVE_FAVICON_FILENAME_SET.has(basenameOfPosixPath(relativePath)))
+    .toSorted(compareRecursiveFaviconPaths)[0];
+  if (!bestCandidate) {
+    return null;
+  }
+
+  const absolutePath = path.join(projectCwd, bestCandidate);
+  if (!isPathWithinProject(projectCwd, absolutePath)) {
+    return null;
+  }
+  return absolutePath;
+}
+
+async function handleProjectFaviconRequest(url: URL, res: http.ServerResponse): Promise<void> {
+  const projectCwd = url.searchParams.get("cwd");
+  if (!projectCwd) {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end("Missing cwd parameter");
+    return;
+  }
+
+  for (const relativeCandidate of FAVICON_CANDIDATES) {
+    const candidatePath = path.join(projectCwd, relativeCandidate);
+    if (await tryServeResolvedPaths(projectCwd, [candidatePath], res)) {
+      return;
+    }
+  }
+
+  for (const sourceRelativePath of ICON_SOURCE_FILES) {
+    const sourceFilePath = path.join(projectCwd, sourceRelativePath);
+    let content: string;
+    try {
+      content = await fs.readFile(sourceFilePath, "utf8");
+    } catch {
+      continue;
+    }
+
+    const href = extractIconHref(content);
+    if (!href) {
+      continue;
+    }
+
+    if (await tryServeResolvedPaths(projectCwd, resolveIconHref(projectCwd, href), res)) {
+      return;
+    }
+  }
+
+  try {
+    const recursiveFaviconPath = await findRecursiveFaviconPath(projectCwd);
+    if (
+      recursiveFaviconPath &&
+      (await tryServeResolvedPaths(projectCwd, [recursiveFaviconPath], res))
+    ) {
+      return;
+    }
+  } catch {
+    // Fall back to the generated icon if recursive discovery fails.
+  }
+
+  serveFallbackFavicon(res);
+}
+
 export function tryHandleProjectFaviconRequest(url: URL, res: http.ServerResponse): boolean {
   if (url.pathname !== "/api/project-favicon") {
     return false;
   }
 
-  const projectCwd = url.searchParams.get("cwd");
-  if (!projectCwd) {
-    res.writeHead(400, { "Content-Type": "text/plain" });
-    res.end("Missing cwd parameter");
-    return true;
-  }
-
-  const tryResolvedPaths = (paths: string[], index: number, onExhausted: () => void): void => {
-    if (index >= paths.length) {
-      onExhausted();
-      return;
-    }
-    const candidate = paths[index]!;
-    if (!isPathWithinProject(projectCwd, candidate)) {
-      tryResolvedPaths(paths, index + 1, onExhausted);
-      return;
-    }
-    fs.stat(candidate, (err, stats) => {
-      if (err || !stats?.isFile()) {
-        tryResolvedPaths(paths, index + 1, onExhausted);
-        return;
-      }
-      serveFaviconFile(candidate, res);
-    });
-  };
-
-  const trySourceFiles = (index: number): void => {
-    if (index >= ICON_SOURCE_FILES.length) {
-      serveFallbackFavicon(res);
-      return;
-    }
-    const sourceFile = path.join(projectCwd, ICON_SOURCE_FILES[index]!);
-    fs.readFile(sourceFile, "utf8", (err, content) => {
-      if (err) {
-        trySourceFiles(index + 1);
-        return;
-      }
-      const href = extractIconHref(content);
-      if (!href) {
-        trySourceFiles(index + 1);
-        return;
-      }
-      const candidates = resolveIconHref(projectCwd, href);
-      tryResolvedPaths(candidates, 0, () => trySourceFiles(index + 1));
-    });
-  };
-
-  const tryCandidates = (index: number): void => {
-    if (index >= FAVICON_CANDIDATES.length) {
-      trySourceFiles(0);
-      return;
-    }
-    const candidate = path.join(projectCwd, FAVICON_CANDIDATES[index]!);
-    if (!isPathWithinProject(projectCwd, candidate)) {
-      tryCandidates(index + 1);
-      return;
-    }
-    fs.stat(candidate, (err, stats) => {
-      if (err || !stats?.isFile()) {
-        tryCandidates(index + 1);
-        return;
-      }
-      serveFaviconFile(candidate, res);
-    });
-  };
-
-  tryCandidates(0);
+  void handleProjectFaviconRequest(url, res).catch(() => {
+    serveFallbackFavicon(res);
+  });
   return true;
 }

--- a/apps/server/src/projectFiles.ts
+++ b/apps/server/src/projectFiles.ts
@@ -1,0 +1,275 @@
+import fs from "node:fs/promises";
+import type { Dirent } from "node:fs";
+import path from "node:path";
+
+import { runProcess } from "./processRunner";
+
+const PROJECT_SCAN_READDIR_CONCURRENCY = 32;
+const GIT_CHECK_IGNORE_MAX_STDIN_BYTES = 256 * 1024;
+
+export const IGNORED_DIRECTORY_NAMES = new Set([
+  ".git",
+  ".convex",
+  "node_modules",
+  ".next",
+  ".turbo",
+  "dist",
+  "build",
+  "out",
+  ".cache",
+]);
+
+export function toPosixPath(input: string): string {
+  return input.split(path.sep).join("/");
+}
+
+function splitNullSeparatedPaths(input: string, truncated: boolean): string[] {
+  const parts = input.split("\0");
+  if (parts.length === 0) return [];
+
+  if (truncated && parts[parts.length - 1]?.length) {
+    parts.pop();
+  }
+
+  return parts.filter((value) => value.length > 0);
+}
+
+export function isPathInIgnoredDirectory(relativePath: string): boolean {
+  const firstSegment = relativePath.split("/")[0];
+  if (!firstSegment) return false;
+  return IGNORED_DIRECTORY_NAMES.has(firstSegment);
+}
+
+export async function mapWithConcurrency<TInput, TOutput>(
+  items: readonly TInput[],
+  concurrency: number,
+  mapper: (item: TInput, index: number) => Promise<TOutput>,
+): Promise<TOutput[]> {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const boundedConcurrency = Math.max(1, Math.min(concurrency, items.length));
+  const results = Array.from({ length: items.length }) as TOutput[];
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: boundedConcurrency }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(items[currentIndex] as TInput, currentIndex);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+export async function isInsideGitWorkTree(cwd: string): Promise<boolean> {
+  const insideWorkTree = await runProcess("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd,
+    allowNonZeroExit: true,
+    timeoutMs: 5_000,
+    maxBufferBytes: 4_096,
+  }).catch(() => null);
+  return Boolean(
+    insideWorkTree && insideWorkTree.code === 0 && insideWorkTree.stdout.trim() === "true",
+  );
+}
+
+export async function filterGitIgnoredPaths(
+  cwd: string,
+  relativePaths: string[],
+): Promise<string[]> {
+  if (relativePaths.length === 0) {
+    return relativePaths;
+  }
+
+  const ignoredPaths = new Set<string>();
+  let chunk: string[] = [];
+  let chunkBytes = 0;
+
+  const flushChunk = async (): Promise<boolean> => {
+    if (chunk.length === 0) {
+      return true;
+    }
+
+    const checkIgnore = await runProcess("git", ["check-ignore", "--no-index", "-z", "--stdin"], {
+      cwd,
+      allowNonZeroExit: true,
+      timeoutMs: 20_000,
+      maxBufferBytes: 16 * 1024 * 1024,
+      outputMode: "truncate",
+      stdin: `${chunk.join("\0")}\0`,
+    }).catch(() => null);
+    chunk = [];
+    chunkBytes = 0;
+
+    if (!checkIgnore) {
+      return false;
+    }
+
+    // git-check-ignore exits with 1 when no paths match.
+    if (checkIgnore.code !== 0 && checkIgnore.code !== 1) {
+      return false;
+    }
+
+    const matchedIgnoredPaths = splitNullSeparatedPaths(
+      checkIgnore.stdout,
+      Boolean(checkIgnore.stdoutTruncated),
+    );
+    for (const ignoredPath of matchedIgnoredPaths) {
+      ignoredPaths.add(ignoredPath);
+    }
+    return true;
+  };
+
+  for (const relativePath of relativePaths) {
+    const relativePathBytes = Buffer.byteLength(relativePath) + 1;
+    if (
+      chunk.length > 0 &&
+      chunkBytes + relativePathBytes > GIT_CHECK_IGNORE_MAX_STDIN_BYTES &&
+      !(await flushChunk())
+    ) {
+      return relativePaths;
+    }
+
+    chunk.push(relativePath);
+    chunkBytes += relativePathBytes;
+
+    if (chunkBytes >= GIT_CHECK_IGNORE_MAX_STDIN_BYTES && !(await flushChunk())) {
+      return relativePaths;
+    }
+  }
+
+  if (!(await flushChunk())) {
+    return relativePaths;
+  }
+
+  if (ignoredPaths.size === 0) {
+    return relativePaths;
+  }
+
+  return relativePaths.filter((relativePath) => !ignoredPaths.has(relativePath));
+}
+
+export interface GitVisibleFilePathsResult {
+  paths: string[];
+  truncated: boolean;
+}
+
+export async function listGitVisibleFilePathsResult(
+  cwd: string,
+): Promise<GitVisibleFilePathsResult | null> {
+  if (!(await isInsideGitWorkTree(cwd))) {
+    return null;
+  }
+
+  const listedFiles = await runProcess(
+    "git",
+    ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+    {
+      cwd,
+      allowNonZeroExit: true,
+      timeoutMs: 20_000,
+      maxBufferBytes: 16 * 1024 * 1024,
+      outputMode: "truncate",
+    },
+  ).catch(() => null);
+  if (!listedFiles || listedFiles.code !== 0) {
+    return null;
+  }
+
+  const listedPaths = splitNullSeparatedPaths(
+    listedFiles.stdout,
+    Boolean(listedFiles.stdoutTruncated),
+  )
+    .map((entry) => toPosixPath(entry))
+    .filter((entry) => entry.length > 0 && !isPathInIgnoredDirectory(entry));
+  return {
+    paths: await filterGitIgnoredPaths(cwd, listedPaths),
+    truncated: Boolean(listedFiles.stdoutTruncated),
+  };
+}
+
+export async function listGitVisibleFilePaths(cwd: string): Promise<string[] | null> {
+  const result = await listGitVisibleFilePathsResult(cwd);
+  return result?.paths ?? null;
+}
+
+export async function listProjectFilePaths(cwd: string): Promise<string[]> {
+  const gitVisibleFiles = await listGitVisibleFilePaths(cwd);
+  if (gitVisibleFiles) {
+    return gitVisibleFiles;
+  }
+
+  let pendingDirectories: string[] = [""];
+  const filePaths: string[] = [];
+
+  while (pendingDirectories.length > 0) {
+    const currentDirectories = pendingDirectories;
+    pendingDirectories = [];
+
+    const directoryEntries = await mapWithConcurrency(
+      currentDirectories,
+      PROJECT_SCAN_READDIR_CONCURRENCY,
+      async (relativeDir) => {
+        const absoluteDir = relativeDir ? path.join(cwd, relativeDir) : cwd;
+        try {
+          const dirents = await fs.readdir(absoluteDir, { withFileTypes: true });
+          return { relativeDir, dirents };
+        } catch (error) {
+          if (!relativeDir) {
+            throw new Error(
+              `Unable to scan project files at '${cwd}': ${error instanceof Error ? error.message : "unknown error"}`,
+              { cause: error },
+            );
+          }
+          return { relativeDir, dirents: null };
+        }
+      },
+    );
+
+    for (const directoryEntry of directoryEntries) {
+      const dirents = directoryEntry.dirents?.toSorted((left, right) =>
+        left.name.localeCompare(right.name),
+      );
+      if (!dirents) {
+        continue;
+      }
+
+      for (const dirent of dirents) {
+        const relativePath = toPosixPath(
+          directoryEntry.relativeDir
+            ? path.join(directoryEntry.relativeDir, dirent.name)
+            : dirent.name,
+        );
+        if (!shouldIncludeDirent(relativePath, dirent)) {
+          continue;
+        }
+
+        if (dirent.isDirectory()) {
+          pendingDirectories.push(relativePath);
+          continue;
+        }
+
+        filePaths.push(relativePath);
+      }
+    }
+  }
+
+  return filePaths;
+}
+
+function shouldIncludeDirent(relativePath: string, dirent: Dirent): boolean {
+  if (!dirent.name || dirent.name === "." || dirent.name === "..") {
+    return false;
+  }
+  if (!dirent.isDirectory() && !dirent.isFile()) {
+    return false;
+  }
+  if (isPathInIgnoredDirectory(relativePath)) {
+    return false;
+  }
+  return true;
+}

--- a/apps/server/src/workspaceEntries.ts
+++ b/apps/server/src/workspaceEntries.ts
@@ -1,7 +1,15 @@
 import fs from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import path from "node:path";
-import { runProcess } from "./processRunner";
+import {
+  filterGitIgnoredPaths,
+  IGNORED_DIRECTORY_NAMES,
+  isInsideGitWorkTree,
+  isPathInIgnoredDirectory,
+  listGitVisibleFilePathsResult,
+  mapWithConcurrency,
+  toPosixPath,
+} from "./projectFiles";
 
 import {
   ProjectEntry,
@@ -13,18 +21,6 @@ const WORKSPACE_CACHE_TTL_MS = 15_000;
 const WORKSPACE_CACHE_MAX_KEYS = 4;
 const WORKSPACE_INDEX_MAX_ENTRIES = 25_000;
 const WORKSPACE_SCAN_READDIR_CONCURRENCY = 32;
-const GIT_CHECK_IGNORE_MAX_STDIN_BYTES = 256 * 1024;
-const IGNORED_DIRECTORY_NAMES = new Set([
-  ".git",
-  ".convex",
-  "node_modules",
-  ".next",
-  ".turbo",
-  "dist",
-  "build",
-  "out",
-  ".cache",
-]);
 
 interface WorkspaceIndex {
   scannedAt: number;
@@ -34,10 +30,6 @@ interface WorkspaceIndex {
 
 const workspaceIndexCache = new Map<string, WorkspaceIndex>();
 const inFlightWorkspaceIndexBuilds = new Map<string, Promise<WorkspaceIndex>>();
-
-function toPosixPath(input: string): string {
-  return input.split(path.sep).join("/");
-}
 
 function parentPathOf(input: string): string | undefined {
   const separatorIndex = input.lastIndexOf("/");
@@ -78,24 +70,6 @@ function scoreEntry(entry: ProjectEntry, query: string): number {
   return 5;
 }
 
-function isPathInIgnoredDirectory(relativePath: string): boolean {
-  const firstSegment = relativePath.split("/")[0];
-  if (!firstSegment) return false;
-  return IGNORED_DIRECTORY_NAMES.has(firstSegment);
-}
-
-function splitNullSeparatedPaths(input: string, truncated: boolean): string[] {
-  const parts = input.split("\0");
-  if (parts.length === 0) return [];
-
-  // If output was truncated, the final token can be partial.
-  if (truncated && parts[parts.length - 1]?.length) {
-    parts.pop();
-  }
-
-  return parts.filter((value) => value.length > 0);
-}
-
 function directoryAncestorsOf(relativePath: string): string[] {
   const segments = relativePath.split("/").filter((segment) => segment.length > 0);
   if (segments.length <= 1) return [];
@@ -106,143 +80,12 @@ function directoryAncestorsOf(relativePath: string): string[] {
   return directories;
 }
 
-async function mapWithConcurrency<TInput, TOutput>(
-  items: readonly TInput[],
-  concurrency: number,
-  mapper: (item: TInput, index: number) => Promise<TOutput>,
-): Promise<TOutput[]> {
-  if (items.length === 0) {
-    return [];
-  }
-
-  const boundedConcurrency = Math.max(1, Math.min(concurrency, items.length));
-  const results = Array.from({ length: items.length }) as TOutput[];
-  let nextIndex = 0;
-
-  const workers = Array.from({ length: boundedConcurrency }, async () => {
-    while (nextIndex < items.length) {
-      const currentIndex = nextIndex;
-      nextIndex += 1;
-      results[currentIndex] = await mapper(items[currentIndex] as TInput, currentIndex);
-    }
-  });
-
-  await Promise.all(workers);
-  return results;
-}
-
-async function isInsideGitWorkTree(cwd: string): Promise<boolean> {
-  const insideWorkTree = await runProcess("git", ["rev-parse", "--is-inside-work-tree"], {
-    cwd,
-    allowNonZeroExit: true,
-    timeoutMs: 5_000,
-    maxBufferBytes: 4_096,
-  }).catch(() => null);
-  return Boolean(
-    insideWorkTree && insideWorkTree.code === 0 && insideWorkTree.stdout.trim() === "true",
-  );
-}
-
-async function filterGitIgnoredPaths(cwd: string, relativePaths: string[]): Promise<string[]> {
-  if (relativePaths.length === 0) {
-    return relativePaths;
-  }
-
-  const ignoredPaths = new Set<string>();
-  let chunk: string[] = [];
-  let chunkBytes = 0;
-
-  const flushChunk = async (): Promise<boolean> => {
-    if (chunk.length === 0) {
-      return true;
-    }
-
-    const checkIgnore = await runProcess("git", ["check-ignore", "--no-index", "-z", "--stdin"], {
-      cwd,
-      allowNonZeroExit: true,
-      timeoutMs: 20_000,
-      maxBufferBytes: 16 * 1024 * 1024,
-      outputMode: "truncate",
-      stdin: `${chunk.join("\0")}\0`,
-    }).catch(() => null);
-    chunk = [];
-    chunkBytes = 0;
-
-    if (!checkIgnore) {
-      return false;
-    }
-
-    // git-check-ignore exits with 1 when no paths match.
-    if (checkIgnore.code !== 0 && checkIgnore.code !== 1) {
-      return false;
-    }
-
-    const matchedIgnoredPaths = splitNullSeparatedPaths(
-      checkIgnore.stdout,
-      Boolean(checkIgnore.stdoutTruncated),
-    );
-    for (const ignoredPath of matchedIgnoredPaths) {
-      ignoredPaths.add(ignoredPath);
-    }
-    return true;
-  };
-
-  for (const relativePath of relativePaths) {
-    const relativePathBytes = Buffer.byteLength(relativePath) + 1;
-    if (
-      chunk.length > 0 &&
-      chunkBytes + relativePathBytes > GIT_CHECK_IGNORE_MAX_STDIN_BYTES &&
-      !(await flushChunk())
-    ) {
-      return relativePaths;
-    }
-
-    chunk.push(relativePath);
-    chunkBytes += relativePathBytes;
-
-    if (chunkBytes >= GIT_CHECK_IGNORE_MAX_STDIN_BYTES && !(await flushChunk())) {
-      return relativePaths;
-    }
-  }
-
-  if (!(await flushChunk())) {
-    return relativePaths;
-  }
-
-  if (ignoredPaths.size === 0) {
-    return relativePaths;
-  }
-
-  return relativePaths.filter((relativePath) => !ignoredPaths.has(relativePath));
-}
-
 async function buildWorkspaceIndexFromGit(cwd: string): Promise<WorkspaceIndex | null> {
-  if (!(await isInsideGitWorkTree(cwd))) {
+  const gitVisibleFiles = await listGitVisibleFilePathsResult(cwd);
+  if (!gitVisibleFiles) {
     return null;
   }
-
-  const listedFiles = await runProcess(
-    "git",
-    ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
-    {
-      cwd,
-      allowNonZeroExit: true,
-      timeoutMs: 20_000,
-      maxBufferBytes: 16 * 1024 * 1024,
-      outputMode: "truncate",
-    },
-  ).catch(() => null);
-  if (!listedFiles || listedFiles.code !== 0) {
-    return null;
-  }
-
-  const listedPaths = splitNullSeparatedPaths(
-    listedFiles.stdout,
-    Boolean(listedFiles.stdoutTruncated),
-  )
-    .map((entry) => toPosixPath(entry))
-    .filter((entry) => entry.length > 0 && !isPathInIgnoredDirectory(entry));
-  const filePaths = await filterGitIgnoredPaths(cwd, listedPaths);
+  const { paths: filePaths, truncated: gitPathsTruncated } = gitVisibleFiles;
 
   const directorySet = new Set<string>();
   for (const filePath of filePaths) {
@@ -272,7 +115,7 @@ async function buildWorkspaceIndexFromGit(cwd: string): Promise<WorkspaceIndex |
   return {
     scannedAt: Date.now(),
     entries: entries.slice(0, WORKSPACE_INDEX_MAX_ENTRIES),
-    truncated: Boolean(listedFiles.stdoutTruncated) || entries.length > WORKSPACE_INDEX_MAX_ENTRIES,
+    truncated: gitPathsTruncated || entries.length > WORKSPACE_INDEX_MAX_ENTRIES,
   };
 }
 


### PR DESCRIPTION
In monorepos where applications life in a own namespace called apps, the favicon search fails. I updated how the favicon discovering works.

I only added the `apps` namespace for now but maybe it makes sense to add other common patterns too

## Summary
- keep the existing root and source-declared favicon fast paths
- add recursive project favicon discovery with apps/*-first ranking for monorepos
- reuse the workspace git-ignore file listing logic and extend route coverage for ranking and ignore cases

## Testing
- bun run --cwd apps/server test src/projectFaviconRoute.test.ts src/workspaceEntries.test.ts src/workspaceEntries.chunking.test.ts
- bun lint
- bun typecheck