### PR TITLE
fix: Update project name styling in chat header for better readability

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4145,7 +4145,7 @@ const ChatHeader = memo(function ChatHeader({
           {activeThreadTitle}
         </h2>
         {activeProjectName && (
-          <Badge variant="outline" className="max-w-28 shrink-0 truncate">
+          <Badge variant="outline" className="justify-start shrink truncate">
             {activeProjectName}
           </Badge>
         )}


### PR DESCRIPTION
## What Changed

I added `justify-start` so it only truncates the right side, removed the `max-w-28` so it can grow if there is space, and changed `shrink-0` to `shrink` so if the screen does get small it shrinks with everything else (like the thread title).

Fixes #713 

## Why

If a project name was long enough, it would be cut off even if there was room to see the whole thing. Also, due to the default styling for the Badge component, it would truncate both the left and right side leaving only the middle to be read. 

## UI Changes

Before (large screen)
<img width="1059" height="96" alt="before" src="https://github.com/user-attachments/assets/18a10519-da07-4862-84b0-d6fd951e6569" />

After (large screen)
<img width="1025" height="96" alt="after" src="https://github.com/user-attachments/assets/5db14826-0dc1-446f-b2e3-0ae362f23c73" />

Before (small screen)
<img width="582" height="95" alt="before-small" src="https://github.com/user-attachments/assets/2d1fbc25-78f5-47fb-909a-30e20529f52b" />

Before (small screen)
<img width="582" height="96" alt="after-small" src="https://github.com/user-attachments/assets/25c91b29-5961-4149-b15d-314ed9535d99" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adjust ChatHeader project name Badge flex styling to improve readability in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/691/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e)
> Update the `ChatHeader` Badge showing `activeProjectName`: remove `max-w-28` and `shrink-0`; add `justify-start` and `shrink` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/691/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> #### 📍Where to Start
> Start with the `ChatHeader` component in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/691/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6f349e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->