### PR TITLE
fix(web): guard persisted stores when localStorage is unavailable

### DIFF
--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -14,6 +14,7 @@ import {
   DEFAULT_RUNTIME_MODE,
   type ChatImageAttachment,
 } from "./types";
+import { getSafeLocalStorage } from "./lib/browserStorage";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
@@ -439,7 +440,7 @@ function readPersistedAttachmentIdsFromStorage(threadId: ThreadId): string[] {
     return [];
   }
   try {
-    const raw = localStorage.getItem(COMPOSER_DRAFT_STORAGE_KEY);
+    const raw = getSafeLocalStorage().getItem(COMPOSER_DRAFT_STORAGE_KEY);
     const persisted = parsePersistedDraftStateRaw(raw);
     return (persisted.draftsByThreadId[threadId]?.attachments ?? []).map(
       (attachment) => attachment.id,
@@ -1169,7 +1170,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
     {
       name: COMPOSER_DRAFT_STORAGE_KEY,
       version: 1,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(getSafeLocalStorage),
       partialize: (state) => {
         const persistedDraftsByThreadId: PersistedComposerDraftStoreState["draftsByThreadId"] = {};
         for (const [threadId, draft] of Object.entries(state.draftsByThreadId)) {

--- a/apps/web/src/lib/browserStorage.test.ts
+++ b/apps/web/src/lib/browserStorage.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getSafeLocalStorage } from "./browserStorage";
+
+const localStorageDescriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+afterEach(() => {
+  if (localStorageDescriptor) {
+    Object.defineProperty(globalThis, "localStorage", localStorageDescriptor);
+  } else {
+    // @ts-expect-error cleanup for environments without a configurable localStorage.
+    delete globalThis.localStorage;
+  }
+});
+
+describe("getSafeLocalStorage", () => {
+  it("falls back to in-memory storage when reading localStorage throws", () => {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get() {
+        throw new Error("blocked");
+      },
+    });
+
+    const storage = getSafeLocalStorage();
+
+    storage.setItem("key", "value");
+
+    expect(storage.getItem("key")).toBe("value");
+    expect(getSafeLocalStorage().getItem("key")).toBe("value");
+  });
+});

--- a/apps/web/src/lib/browserStorage.test.ts
+++ b/apps/web/src/lib/browserStorage.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 });
 
 describe("getSafeLocalStorage", () => {
-  it("falls back to in-memory storage when reading localStorage throws", () => {
+  it("falls back to isolated in-memory storage when reading localStorage throws", () => {
     Object.defineProperty(globalThis, "localStorage", {
       configurable: true,
       get() {
@@ -22,11 +22,51 @@ describe("getSafeLocalStorage", () => {
       },
     });
 
+    const firstStorage = getSafeLocalStorage();
+    const secondStorage = getSafeLocalStorage();
+
+    firstStorage.setItem("key", "value");
+
+    expect(firstStorage.getItem("key")).toBe("value");
+    expect(secondStorage.getItem("key")).toBeNull();
+  });
+
+  it("falls back when storage methods throw at call time", () => {
+    let reads = 0;
+    const throwingStorage = {
+      get length() {
+        throw new Error("blocked length");
+      },
+      clear() {
+        throw new Error("blocked clear");
+      },
+      getItem() {
+        reads += 1;
+        throw new Error("blocked get");
+      },
+      key() {
+        throw new Error("blocked key");
+      },
+      removeItem() {
+        throw new Error("blocked remove");
+      },
+      setItem() {
+        throw new Error("blocked set");
+      },
+    };
+
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: throwingStorage,
+    });
+
     const storage = getSafeLocalStorage();
 
     storage.setItem("key", "value");
-
     expect(storage.getItem("key")).toBe("value");
-    expect(getSafeLocalStorage().getItem("key")).toBe("value");
+    storage.removeItem("key");
+    expect(storage.getItem("key")).toBeNull();
+    expect(storage.length).toBe(0);
+    expect(reads).toBe(0);
   });
 });

--- a/apps/web/src/lib/browserStorage.ts
+++ b/apps/web/src/lib/browserStorage.ts
@@ -1,0 +1,65 @@
+const memoryStorageEntries = new Map<string, string>();
+
+const memoryStorage: Storage = {
+  get length() {
+    return memoryStorageEntries.size;
+  },
+  clear() {
+    memoryStorageEntries.clear();
+  },
+  getItem(key) {
+    return memoryStorageEntries.get(key) ?? null;
+  },
+  key(index) {
+    return Array.from(memoryStorageEntries.keys())[index] ?? null;
+  },
+  removeItem(key) {
+    memoryStorageEntries.delete(key);
+  },
+  setItem(key, value) {
+    memoryStorageEntries.set(key, String(value));
+  },
+};
+
+function isStorageLike(value: unknown): value is Storage {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<Storage>;
+
+  return (
+    typeof candidate.getItem === "function" &&
+    typeof candidate.setItem === "function" &&
+    typeof candidate.removeItem === "function" &&
+    typeof candidate.clear === "function" &&
+    typeof candidate.key === "function"
+  );
+}
+
+export function getSafeLocalStorage(): Storage {
+  const candidate = (() => {
+    try {
+      return globalThis.localStorage;
+    } catch {
+      return undefined;
+    }
+  })();
+
+  if (isStorageLike(candidate)) {
+    return candidate;
+  }
+
+  try {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: memoryStorage,
+    });
+  } catch {
+    // Ignore assignment failures and keep the in-memory fallback local to callers.
+  }
+
+  return memoryStorage;
+}

--- a/apps/web/src/lib/browserStorage.ts
+++ b/apps/web/src/lib/browserStorage.ts
@@ -1,25 +1,27 @@
-const memoryStorageEntries = new Map<string, string>();
+function createMemoryStorage(): Storage {
+  const memoryStorageEntries = new Map<string, string>();
 
-const memoryStorage: Storage = {
-  get length() {
-    return memoryStorageEntries.size;
-  },
-  clear() {
-    memoryStorageEntries.clear();
-  },
-  getItem(key) {
-    return memoryStorageEntries.get(key) ?? null;
-  },
-  key(index) {
-    return Array.from(memoryStorageEntries.keys())[index] ?? null;
-  },
-  removeItem(key) {
-    memoryStorageEntries.delete(key);
-  },
-  setItem(key, value) {
-    memoryStorageEntries.set(key, String(value));
-  },
-};
+  return {
+    get length() {
+      return memoryStorageEntries.size;
+    },
+    clear() {
+      memoryStorageEntries.clear();
+    },
+    getItem(key) {
+      return memoryStorageEntries.get(key) ?? null;
+    },
+    key(index) {
+      return Array.from(memoryStorageEntries.keys())[index] ?? null;
+    },
+    removeItem(key) {
+      memoryStorageEntries.delete(key);
+    },
+    setItem(key, value) {
+      memoryStorageEntries.set(key, String(value));
+    },
+  };
+}
 
 function isStorageLike(value: unknown): value is Storage {
   if (!value || typeof value !== "object") {
@@ -46,20 +48,40 @@ export function getSafeLocalStorage(): Storage {
     }
   })();
 
-  if (isStorageLike(candidate)) {
-    return candidate;
+  if (!isStorageLike(candidate)) {
+    return createMemoryStorage();
   }
 
-  try {
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      enumerable: true,
-      writable: true,
-      value: memoryStorage,
-    });
-  } catch {
-    // Ignore assignment failures and keep the in-memory fallback local to callers.
-  }
+  const fallbackStorage = createMemoryStorage();
+  let activeStorage: Storage = candidate;
 
-  return memoryStorage;
+  const withStorage = <T>(operation: (storage: Storage) => T): T => {
+    try {
+      return operation(activeStorage);
+    } catch {
+      activeStorage = fallbackStorage;
+      return operation(activeStorage);
+    }
+  };
+
+  return {
+    get length() {
+      return withStorage((storage) => storage.length);
+    },
+    clear() {
+      withStorage((storage) => storage.clear());
+    },
+    getItem(key) {
+      return withStorage((storage) => storage.getItem(key));
+    },
+    key(index) {
+      return withStorage((storage) => storage.key(index));
+    },
+    removeItem(key) {
+      withStorage((storage) => storage.removeItem(key));
+    },
+    setItem(key, value) {
+      withStorage((storage) => storage.setItem(key, value));
+    },
+  };
 }

--- a/apps/web/src/terminalStateStore.ts
+++ b/apps/web/src/terminalStateStore.ts
@@ -14,6 +14,7 @@ import {
   MAX_THREAD_TERMINAL_COUNT,
   type ThreadTerminalGroup,
 } from "./types";
+import { getSafeLocalStorage } from "./lib/browserStorage";
 
 interface ThreadTerminalState {
   terminalOpen: boolean;
@@ -523,7 +524,7 @@ export const useTerminalStateStore = create<TerminalStateStoreState>()(
     {
       name: TERMINAL_STATE_STORAGE_KEY,
       version: 1,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(getSafeLocalStorage),
       partialize: (state) => ({
         terminalStateByThreadId: state.terminalStateByThreadId,
       }),


### PR DESCRIPTION
## Summary
Guard persisted web stores when `localStorage` is unavailable or unusable.

## Why
Some environments throw either when reading `localStorage` or when calling its methods. The original fallback also used a module-level in-memory store, which can leak state across server-side requests. This update switches to per-call in-memory fallback storage and permanently falls back after the first storage access failure.

## Testing
- `bun x vitest run apps/web/src/lib/browserStorage.test.ts`
- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard web composer and terminal persisted stores by using `getSafeLocalStorage` to handle unavailable `localStorage`
> Introduce `getSafeLocalStorage` with in-memory failover and update zustand persist stores to use it; add tests and a `createMemoryStorage` utility.
>
> #### 📍Where to Start
> Start with `getSafeLocalStorage` in [apps/web/src/lib/browserStorage.ts](https://github.com/pingdotgg/t3code/pull/692/files#diff-503e404ef381ee0c0b2a71727d2d584ba00ff66fa8655eaeee268aa5d61e18ec).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1964131.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
