### PR TITLE
Replace mode-toggle titles with styled tooltips

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -814,7 +814,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
     try {
       const initialModeButton = await waitForInteractionModeButton("Chat");
-      expect(initialModeButton.title).toContain("enter plan mode");
+      expect(initialModeButton.getAttribute("title")).toBeNull();
 
       window.dispatchEvent(
         new KeyboardEvent("keydown", {
@@ -826,7 +826,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
       await waitForLayout();
 
-      expect((await waitForInteractionModeButton("Chat")).title).toContain("enter plan mode");
+      expect(await waitForInteractionModeButton("Chat")).toBeTruthy();
 
       const composerEditor = await waitForComposerEditor();
       composerEditor.focus();
@@ -841,9 +841,8 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       await vi.waitFor(
         async () => {
-          expect((await waitForInteractionModeButton("Plan")).title).toContain(
-            "return to normal chat mode",
-          );
+          const planButton = await waitForInteractionModeButton("Plan");
+          expect(planButton.getAttribute("title")).toBeNull();
         },
         { timeout: 8_000, interval: 16 },
       );
@@ -859,7 +858,8 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       await vi.waitFor(
         async () => {
-          expect((await waitForInteractionModeButton("Chat")).title).toContain("enter plan mode");
+          const chatButton = await waitForInteractionModeButton("Chat");
+          expect(chatButton.getAttribute("title")).toBeNull();
         },
         { timeout: 8_000, interval: 16 },
       );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -31,6 +31,8 @@ import {
 } from "@t3tools/shared/model";
 import {
   memo,
+  type ComponentProps,
+  type ReactNode,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -250,6 +252,7 @@ function formatWorkingTimer(startIso: string, endIso: string): string | null {
 
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
+
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
 const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
@@ -3720,49 +3723,85 @@ export default function ChatView({ threadId }: ChatViewProps) {
                   <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
 
                   {/* Interaction mode toggle */}
-                  <Button
-                    variant="ghost"
-                    className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
-                    size="sm"
-                    type="button"
-                    onClick={toggleInteractionMode}
-                    title={
-                      interactionMode === "plan"
-                        ? "Plan mode — click to return to normal chat mode"
-                        : "Default mode — click to enter plan mode"
-                    }
-                  >
-                    <BotIcon />
-                    <span className="sr-only sm:not-sr-only">
-                      {interactionMode === "plan" ? "Plan" : "Chat"}
-                    </span>
-                  </Button>
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          variant="ghost"
+                          className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
+                          size="sm"
+                          type="button"
+                          onClick={toggleInteractionMode}
+                          aria-description={
+                            interactionMode === "plan"
+                              ? "Plan mode — click to return to normal chat mode"
+                              : "Default mode — click to enter plan mode"
+                          }
+                        >
+                          <BotIcon />
+                          <span className="sr-only sm:not-sr-only">
+                            {interactionMode === "plan" ? "Plan" : "Chat"}
+                          </span>
+                        </Button>
+                      }
+                    />
+                    <TooltipPopup
+                      side="top"
+                      className="max-w-72 whitespace-normal leading-tight"
+                    >
+                      <span className="flex flex-col items-center gap-1">
+                        <span>
+                          {interactionMode === "plan"
+                            ? "Plan mode — click to return to normal chat mode"
+                            : "Default mode — click to enter plan mode"}
+                        </span>
+                        <kbd className="inline-flex shrink-0 items-center gap-0.5 rounded bg-foreground/10 px-1 py-0.5 font-medium font-sans text-[10px]">
+                          <span>⇧</span>
+                          <span>Tab</span>
+                        </kbd>
+                      </span>
+                    </TooltipPopup>
+                  </Tooltip>
 
                   {/* Divider */}
                   <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
 
                   {/* Runtime mode toggle */}
-                  <Button
-                    variant="ghost"
-                    className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
-                    size="sm"
-                    type="button"
-                    onClick={() =>
-                      void handleRuntimeModeChange(
-                        runtimeMode === "full-access" ? "approval-required" : "full-access",
-                      )
-                    }
-                    title={
-                      runtimeMode === "full-access"
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <Button
+                          variant="ghost"
+                          className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
+                          size="sm"
+                          type="button"
+                          onClick={() =>
+                            void handleRuntimeModeChange(
+                              runtimeMode === "full-access" ? "approval-required" : "full-access",
+                            )
+                          }
+                          aria-description={
+                            runtimeMode === "full-access"
+                              ? "Full access — click to require approvals"
+                              : "Approval required — click for full access"
+                          }
+                        >
+                          {runtimeMode === "full-access" ? <LockOpenIcon /> : <LockIcon />}
+                          <span className="sr-only sm:not-sr-only">
+                            {runtimeMode === "full-access" ? "Full access" : "Supervised"}
+                          </span>
+                        </Button>
+                      }
+                    />
+                    <TooltipPopup
+                      side="top"
+                      className="max-w-72 whitespace-normal leading-tight"
+                    >
+                      {runtimeMode === "full-access"
                         ? "Full access — click to require approvals"
-                        : "Approval required — click for full access"
-                    }
-                  >
-                    {runtimeMode === "full-access" ? <LockOpenIcon /> : <LockIcon />}
-                    <span className="sr-only sm:not-sr-only">
-                      {runtimeMode === "full-access" ? "Full access" : "Supervised"}
-                    </span>
-                  </Button>
+                        : "Approval required — click for full access"}
+                    </TooltipPopup>
+                  </Tooltip>
 
                   {/* Plan sidebar toggle */}
                   {(activePlan || activeProposedPlan || planSidebarOpen) ? (

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -9,7 +9,16 @@ const TooltipProvider = TooltipPrimitive.Provider;
 const Tooltip = TooltipPrimitive.Root;
 
 function TooltipTrigger(props: TooltipPrimitive.Trigger.Props) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+  const { delay = 120, closeDelay = 80, ...restProps } = props;
+
+  return (
+    <TooltipPrimitive.Trigger
+      closeDelay={closeDelay}
+      data-slot="tooltip-trigger"
+      delay={delay}
+      {...restProps}
+    />
+  );
 }
 
 function TooltipPopup({
@@ -38,7 +47,7 @@ function TooltipPopup({
       >
         <TooltipPrimitive.Popup
           className={cn(
-            "relative flex h-(--popup-height,auto) w-(--popup-width,auto) origin-(--transform-origin) text-balance rounded-md border bg-popover not-dark:bg-clip-padding text-popover-foreground text-xs shadow-md/5 transition-[width,height,scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:duration-0 dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+            "relative flex h-(--popup-height,auto) w-(--popup-width,auto) origin-(--transform-origin) text-balance rounded-md border border-border/70 bg-background/95 not-dark:bg-clip-padding text-[11px] font-medium text-foreground/90 shadow-lg/10 shadow-black/15 backdrop-blur-md transition-[width,height,scale,opacity] before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-md)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] data-ending-style:scale-98 data-starting-style:scale-98 data-ending-style:opacity-0 data-starting-style:opacity-0 data-instant:duration-0 dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
             className,
           )}
           data-slot="tooltip-popup"


### PR DESCRIPTION
## What Changed

Replaces native browser `title` attributes on the Chat and Runtime mode buttons with a proper Tooltip component, improving both visual consistency and accessibility.

- Swap `title` attributes on Chat and Runtime mode buttons for the Tooltip UI component, including a keyboard shortcut hint for the plan toggle
- Use `aria-description` instead of `title` for accessibility text, avoiding native tooltip behavior
- Add default open/close delays and refresh tooltip popup styling for a more polished feel
- Update browser tests to assert that `title` attributes are no longer present

## Why

The app already had a styled tooltip component available, but these buttons were still using the default browser tooltip instead. I also wanted to surface the Shift+Tab shortcut more clearly, since it isn’t user-bindable and isn’t something people would discover unless they already use that shortcut elsewhere.

## UI Changes
Before:
<img width="838" height="202" alt="Ask anything @tar hesfoiders or use modi" src="https://github.com/user-attachments/assets/29cab66b-19ad-4d13-b9a1-047e6b605ca7" />

After:
<img width="804" height="172" alt="• Full access" src="https://github.com/user-attachments/assets/add95ffe-971e-48a4-9a08-6701da6945b4" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (I don't think it's needed for this)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace ChatView interaction and runtime toggle button `title` attributes with styled tooltips using `Tooltip`/`TooltipPopup` and default trigger delays (120ms open, 80ms close) in [tooltip.tsx](https://github.com/pingdotgg/t3code/pull/696/files#diff-97acc7c97f91957af019082b41210bb280e2dd2af1a011328a1549f5647431d9)
> Switch ChatView mode toggles to custom tooltips with `aria-description`, update tooltip trigger defaults (delay 120ms, closeDelay 80ms), and adjust tooltip styling; update tests to assert no `title` attributes.
>
> #### 📍Where to Start
> Start with the toggle render logic in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/696/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), then review tooltip trigger/popup behavior in [tooltip.tsx](https://github.com/pingdotgg/t3code/pull/696/files#diff-97acc7c97f91957af019082b41210bb280e2dd2af1a011328a1549f5647431d9), and finally the updated expectations in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/696/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5998d74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->