### PR TITLE
Open desktop folder picker immediately when adding projects in Electron

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -525,15 +525,29 @@ export default function Sidebar() {
         });
         await handleNewThread(projectId).catch(() => undefined);
       } catch (error) {
+        const description =
+          error instanceof Error ? error.message : "An error occurred while adding the project.";
         setIsAddingProject(false);
-        setAddProjectError(
-          error instanceof Error ? error.message : "An error occurred while adding the project.",
-        );
+        if (shouldBrowseForProjectImmediately) {
+          toastManager.add({
+            type: "error",
+            title: "Failed to add project",
+            description,
+          });
+        } else {
+          setAddProjectError(description);
+        }
         return;
       }
       finishAddingProject();
     },
-    [focusMostRecentThreadForProject, handleNewThread, isAddingProject, projects],
+    [
+      focusMostRecentThreadForProject,
+      handleNewThread,
+      isAddingProject,
+      projects,
+      shouldBrowseForProjectImmediately,
+    ],
   );
 
   const handleAddProject = () => {


### PR DESCRIPTION
## Summary
- Open the native folder picker immediately when the Add Project action is triggered in desktop Electron (`isElectron && !isMobile`).
- Keep existing manual path-entry behavior for mobile Electron layouts and non-Electron environments.
- Add `Sidebar.logic.ts` to isolate the picker decision logic for easier testing and reuse.
- Add unit tests for `shouldOpenProjectFolderPickerImmediately` covering desktop Electron, mobile Electron, and non-Electron cases.
- Update Sidebar UI state handling so the inline path entry only appears when manual entry is intended, including icon rotation/pressed state updates.

## Testing
- `apps/web/src/components/Sidebar.logic.test.ts` added with 3 Vitest cases for the new decision logic.
- `bun lint` — Not run.
- `bun typecheck` — Not run.
- `bun run test` — Not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the project-creation UX and error surfacing in `Sidebar`, which could affect Electron users’ ability to add projects if the picker flow or state transitions misbehave.
> 
> **Overview**
> Clicking **Add project** in `Sidebar` now immediately opens the native folder picker on Electron, instead of toggling the inline path-entry UI.
> 
> The inline path entry (and related empty-state text) is now gated behind `shouldShowProjectPathEntry`, while failures during add-project in the immediate-picker flow are surfaced via an error toast rather than inline form error state; the add button also reflects state via `aria-pressed` and a rotating `PlusIcon`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b6e01164e160ac23e9c22d4b4ac663236cac91f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open the native folder picker immediately in Electron when clicking Add project in `Sidebar` and adjust web UX in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/697/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1)
> Introduce `shouldBrowseForProjectImmediately` and `shouldShowProjectPathEntry`, add `handleStartAddProject`, route errors to toasts in Electron, skip refocus after canceled pick in Electron, and update Projects section JSX and button state.
>
> #### 📍Where to Start
> Start with the `handleStartAddProject` handler and related state logic in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/697/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b6e011.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->