### PR TITLE
Stabilize visible toast layout offsets to prevent hover flicker

### DIFF
--- a/apps/web/src/components/ui/toast.logic.test.ts
+++ b/apps/web/src/components/ui/toast.logic.test.ts
@@ -1,5 +1,5 @@
 import { assert, describe, it } from "vitest";
-import { shouldHideCollapsedToastContent } from "./toast.logic";
+import { buildVisibleToastLayout, shouldHideCollapsedToastContent } from "./toast.logic";
 
 describe("shouldHideCollapsedToastContent", () => {
   it("keeps a single visible toast readable", () => {
@@ -12,5 +12,44 @@ describe("shouldHideCollapsedToastContent", () => {
 
   it("hides non-front toasts until the stack is expanded", () => {
     assert.equal(shouldHideCollapsedToastContent(1, 3), true);
+  });
+});
+
+describe("buildVisibleToastLayout", () => {
+  it("computes indices and offsets from the visible subset", () => {
+    const visibleToasts = [{ id: "a", height: 48 }, { id: "b", height: 72 }, { id: "c", height: 24 }];
+
+    const layout = buildVisibleToastLayout(visibleToasts);
+
+    assert.equal(layout.frontmostHeight, 48);
+    assert.deepEqual(
+      layout.items.map(({ toast, visibleIndex, offsetY }) => ({
+        id: toast.id,
+        visibleIndex,
+        offsetY,
+      })),
+      [
+        { id: "a", visibleIndex: 0, offsetY: 0 },
+        { id: "b", visibleIndex: 1, offsetY: 48 },
+        { id: "c", visibleIndex: 2, offsetY: 120 },
+      ],
+    );
+  });
+
+  it("treats missing heights as zero", () => {
+    const layout = buildVisibleToastLayout([{ id: "a" }, { id: "b", height: undefined }, { id: "c", height: 30 }]);
+
+    assert.equal(layout.frontmostHeight, 0);
+    assert.deepEqual(
+      layout.items.map(({ toast, offsetY }) => ({
+        id: toast.id,
+        offsetY,
+      })),
+      [
+        { id: "a", offsetY: 0 },
+        { id: "b", offsetY: 0 },
+        { id: "c", offsetY: 0 },
+      ],
+    );
   });
 });

--- a/apps/web/src/components/ui/toast.logic.ts
+++ b/apps/web/src/components/ui/toast.logic.ts
@@ -7,3 +7,40 @@ export function shouldHideCollapsedToastContent(
   if (visibleToastCount <= 1) return false;
   return visibleToastIndex > 0;
 }
+
+type ToastWithHeight = {
+  height?: number | null | undefined;
+};
+
+type VisibleToastLayoutItem<TToast extends object> = {
+  toast: TToast;
+  visibleIndex: number;
+  offsetY: number;
+};
+
+export function buildVisibleToastLayout<TToast extends object>(
+  visibleToasts: readonly (TToast & ToastWithHeight)[],
+): {
+  frontmostHeight: number;
+  items: VisibleToastLayoutItem<TToast & ToastWithHeight>[];
+} {
+  let offsetY = 0;
+
+  return {
+    frontmostHeight: normalizeToastHeight(visibleToasts[0]?.height),
+    items: visibleToasts.map((toast, visibleIndex) => {
+      const item = {
+        toast,
+        visibleIndex,
+        offsetY,
+      };
+
+      offsetY += normalizeToastHeight(toast.height);
+      return item;
+    }),
+  };
+}
+
+function normalizeToastHeight(height: number | null | undefined): number {
+  return typeof height === "number" && Number.isFinite(height) && height > 0 ? height : 0;
+}

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Toast } from "@base-ui/react/toast";
-import { useEffect } from "react";
+import { useEffect, type CSSProperties } from "react";
 import { useParams } from "@tanstack/react-router";
 import { ThreadId } from "@t3tools/contracts";
 import {
@@ -14,7 +14,7 @@ import {
 
 import { cn } from "~/lib/utils";
 import { buttonVariants } from "~/components/ui/button";
-import { shouldHideCollapsedToastContent } from "./toast.logic";
+import { buildVisibleToastLayout, shouldHideCollapsedToastContent } from "./toast.logic";
 
 type ThreadToastData = {
   threadId?: ThreadId | null;
@@ -158,6 +158,7 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
   const visibleToasts = toasts.filter((toast) =>
     shouldRenderForActiveThread(toast.data, activeThreadId),
   );
+  const visibleToastLayout = buildVisibleToastLayout(visibleToasts);
 
   useEffect(() => {
     const activeToastIds = new Set(toasts.map((toast) => toast.id));
@@ -183,12 +184,17 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
         )}
         data-position={position}
         data-slot="toast-viewport"
+        style={
+          {
+            "--toast-frontmost-height": `${visibleToastLayout.frontmostHeight}px`,
+          } as CSSProperties
+        }
       >
-        {visibleToasts.map((toast, visibleIndex) => {
+        {visibleToastLayout.items.map(({ toast, visibleIndex, offsetY }) => {
           const Icon = toast.type ? TOAST_ICONS[toast.type as keyof typeof TOAST_ICONS] : null;
           const hideCollapsedContent = shouldHideCollapsedToastContent(
             visibleIndex,
-            visibleToasts.length,
+            visibleToastLayout.items.length,
           );
 
           return (
@@ -241,6 +247,12 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
               )}
               data-position={position}
               key={toast.id}
+              style={
+                {
+                  "--toast-index": visibleIndex,
+                  "--toast-offset-y": `${offsetY}px`,
+                } as CSSProperties
+              }
               swipeDirection={
                 position.includes("center")
                   ? [isTop ? "up" : "down"]


### PR DESCRIPTION
## Summary
- add `buildVisibleToastLayout` to compute stable per-toast `visibleIndex` and cumulative `offsetY` from the currently visible toast subset
- normalize toast heights (invalid/missing heights become `0`) so layout math remains predictable
- update toast rendering to use precomputed layout values and CSS variables (`--toast-frontmost-height`, `--toast-index`, `--toast-offset-y`)
- keep collapsed-content visibility logic intact while switching to layout-derived visible counts
- add unit tests for layout computation, including mixed heights and missing-height cases

## Testing
- `apps/web/src/components/ui/toast.logic.test.ts`: verifies visible-index and offset stacking for multiple toast heights
- `apps/web/src/components/ui/toast.logic.test.ts`: verifies missing/undefined heights are treated as `0`
- Lint/typecheck: Not run
- Manual UI verification of hover flicker regression: Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes toast stacking/positioning logic and CSS variables, which could cause visual regressions (overlap/jump/flicker) across all toast notifications. Risk is mitigated by added unit tests but still needs quick manual UI verification.
> 
> **Overview**
> **Stabilizes toast stack layout calculations** by introducing `buildVisibleToastLayout`, which derives a per-visible-toast `visibleIndex` and cumulative `offsetY` while normalizing missing/invalid heights to `0`.
> 
> Updates `toast.tsx` to render from this computed layout and to pass layout-derived CSS variables (`--toast-frontmost-height`, `--toast-index`, `--toast-offset-y`) into the viewport/toasts, keeping the existing collapsed-content visibility behavior but using the layout’s visible count. Adds unit tests covering offset stacking and missing-height cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95a5ce4cf5ea2c6b35e58247150ca4112eaff5cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compute toast stack CSS layout variables to stabilize hover offsets in `Toasts` using `buildVisibleToastLayout` in [toast.tsx](https://github.com/pingdotgg/t3code/pull/702/files#diff-dbb38a4f02a67491223157a9f1aba388365f4cd55652e1f32847ffda53aee7f2)
> Add `buildVisibleToastLayout` in [toast.logic.ts](https://github.com/pingdotgg/t3code/pull/702/files#diff-c3182d6685311defeefe9d1e131cb06f1f9a264fd0ef3528190accd7212a5e9f) to compute `frontmostHeight`, `--toast-index`, and `--toast-offset-y`, and update `Toasts` to consume these values and set CSS variables.
>
> #### 📍Where to Start
> Start with `buildVisibleToastLayout` in [toast.logic.ts](https://github.com/pingdotgg/t3code/pull/702/files#diff-c3182d6685311defeefe9d1e131cb06f1f9a264fd0ef3528190accd7212a5e9f), then see its usage in `Toasts` in [toast.tsx](https://github.com/pingdotgg/t3code/pull/702/files#diff-dbb38a4f02a67491223157a9f1aba388365f4cd55652e1f32847ffda53aee7f2).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95a5ce4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->