### PR TITLE
perf(web): debounce root snapshot syncs

### DIFF
--- a/apps/web/src/lib/snapshotSyncScheduler.test.ts
+++ b/apps/web/src/lib/snapshotSyncScheduler.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createSnapshotSyncScheduler } from "./snapshotSyncScheduler";
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+describe("createSnapshotSyncScheduler", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces repeated debounced requests into a single sync", async () => {
+    vi.useFakeTimers();
+    const run = vi.fn(async () => undefined);
+    const scheduler = createSnapshotSyncScheduler({
+      debounceMs: 75,
+      run,
+    });
+
+    scheduler.requestDebounced();
+    scheduler.requestDebounced();
+    scheduler.requestDebounced();
+
+    expect(run).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(74);
+    expect(run).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs one debounced follow-up sync for events that arrive during an active sync", async () => {
+    vi.useFakeTimers();
+    const firstRun = createDeferred();
+    let callCount = 0;
+    const run = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        await firstRun.promise;
+      }
+    });
+    const scheduler = createSnapshotSyncScheduler({
+      debounceMs: 75,
+      run,
+    });
+
+    scheduler.requestDebounced();
+    await vi.advanceTimersByTimeAsync(75);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    scheduler.requestDebounced();
+    scheduler.requestDebounced();
+
+    firstRun.resolve();
+    await Promise.resolve();
+    expect(run).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(75);
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("promotes a waiting sync to immediate and waits until the queue is idle", async () => {
+    vi.useFakeTimers();
+    const firstRun = createDeferred();
+    const secondRun = createDeferred();
+    let callCount = 0;
+    const run = vi.fn(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        await firstRun.promise;
+        return;
+      }
+      if (callCount === 2) {
+        await secondRun.promise;
+      }
+    });
+    const scheduler = createSnapshotSyncScheduler({
+      debounceMs: 75,
+      run,
+    });
+
+    scheduler.requestDebounced();
+    await vi.advanceTimersByTimeAsync(75);
+    expect(run).toHaveBeenCalledTimes(1);
+
+    let settled = false;
+    const immediateSync = scheduler.requestImmediate().then(() => {
+      settled = true;
+    });
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    firstRun.resolve();
+    await flushMicrotasks();
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(settled).toBe(false);
+
+    secondRun.resolve();
+    await immediateSync;
+    expect(settled).toBe(true);
+  });
+});

--- a/apps/web/src/lib/snapshotSyncScheduler.ts
+++ b/apps/web/src/lib/snapshotSyncScheduler.ts
@@ -1,0 +1,136 @@
+type QueueMode = "none" | "debounced" | "immediate";
+
+interface IdleWaiter {
+  resolve: () => void;
+  reject: (error: Error) => void;
+}
+
+export interface SnapshotSyncScheduler {
+  requestDebounced(): void;
+  requestImmediate(): Promise<void>;
+  dispose(): void;
+}
+
+export interface SnapshotSyncSchedulerOptions {
+  debounceMs: number;
+  run: () => Promise<void>;
+}
+
+export function createSnapshotSyncScheduler(
+  options: SnapshotSyncSchedulerOptions,
+): SnapshotSyncScheduler {
+  let disposed = false;
+  let syncing = false;
+  let queuedMode: QueueMode = "none";
+  let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  let idleWaiters: IdleWaiter[] = [];
+
+  const clearScheduledRun = () => {
+    if (timer === null) {
+      return;
+    }
+    globalThis.clearTimeout(timer);
+    timer = null;
+  };
+
+  const resolveIdleWaiters = () => {
+    if (syncing || queuedMode !== "none" || timer !== null) {
+      return;
+    }
+    const waiters = idleWaiters;
+    idleWaiters = [];
+    for (const waiter of waiters) {
+      waiter.resolve();
+    }
+  };
+
+  const rejectIdleWaiters = (error: Error) => {
+    const waiters = idleWaiters;
+    idleWaiters = [];
+    for (const waiter of waiters) {
+      waiter.reject(error);
+    }
+  };
+
+  const runNext = async (): Promise<void> => {
+    if (disposed || syncing || queuedMode === "none") {
+      resolveIdleWaiters();
+      return;
+    }
+
+    clearScheduledRun();
+    syncing = true;
+    queuedMode = "none";
+
+    try {
+      await options.run();
+    } finally {
+      syncing = false;
+      scheduleNextRun();
+      resolveIdleWaiters();
+    }
+  };
+
+  const scheduleNextRun = () => {
+    if (disposed || syncing || queuedMode === "none") {
+      return;
+    }
+    if (timer !== null) {
+      return;
+    }
+
+    if (queuedMode === "immediate") {
+      void runNext();
+      return;
+    }
+
+    timer = globalThis.setTimeout(() => {
+      timer = null;
+      void runNext();
+    }, options.debounceMs);
+  };
+
+  const queueRun = (mode: Exclude<QueueMode, "none">) => {
+    if (disposed) {
+      return;
+    }
+
+    if (mode === "immediate") {
+      if (queuedMode !== "immediate") {
+        queuedMode = "immediate";
+      }
+      clearScheduledRun();
+    } else if (queuedMode === "none") {
+      queuedMode = "debounced";
+    }
+
+    scheduleNextRun();
+  };
+
+  return {
+    requestDebounced() {
+      queueRun("debounced");
+    },
+    requestImmediate() {
+      if (disposed) {
+        return Promise.resolve();
+      }
+
+      queueRun("immediate");
+
+      return new Promise<void>((resolve, reject) => {
+        idleWaiters.push({ resolve, reject });
+        resolveIdleWaiters();
+      });
+    },
+    dispose() {
+      if (disposed) {
+        return;
+      }
+
+      disposed = true;
+      clearScheduledRun();
+      rejectIdleWaiters(new Error("Snapshot sync scheduler disposed"));
+    },
+  };
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { APP_DISPLAY_NAME } from "../branding";
 import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
 import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQuery";
+import { createSnapshotSyncScheduler } from "../lib/snapshotSyncScheduler";
 import { readNativeApi } from "../nativeApi";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useStore } from "../store";
@@ -22,6 +23,8 @@ import { terminalRunningSubprocessFromEvent } from "../terminalActivity";
 import { onServerConfigUpdated, onServerWelcome } from "../wsNativeApi";
 import { providerQueryKeys } from "../lib/providerReactQuery";
 import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
+
+const SNAPSHOT_SYNC_DEBOUNCE_MS = 75;
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -148,10 +151,8 @@ function EventRouter() {
     if (!api) return;
     let disposed = false;
     let latestSequence = 0;
-    let syncing = false;
-    let pending = false;
 
-    const flushSnapshotSync = async (): Promise<void> => {
+    const syncSnapshot = async (): Promise<void> => {
       const snapshot = await api.orchestration.getSnapshot();
       if (disposed) return;
       latestSequence = Math.max(latestSequence, snapshot.snapshotSequence);
@@ -164,28 +165,20 @@ function EventRouter() {
         draftThreadIds,
       });
       removeOrphanedTerminalStates(activeThreadIds);
-      if (pending) {
-        pending = false;
-        await flushSnapshotSync();
-      }
     };
 
-    const syncSnapshot = async () => {
-      if (syncing) {
-        pending = true;
-        return;
-      }
-      syncing = true;
-      pending = false;
-      try {
-        await flushSnapshotSync();
-      } catch {
-        // Keep prior state and wait for next domain event to trigger a resync.
-      }
-      syncing = false;
-    };
+    const snapshotSync = createSnapshotSyncScheduler({
+      debounceMs: SNAPSHOT_SYNC_DEBOUNCE_MS,
+      run: async () => {
+        try {
+          await syncSnapshot();
+        } catch {
+          // Keep prior state and wait for the next trigger to retry.
+        }
+      },
+    });
 
-    void syncSnapshot().catch(() => undefined);
+    void snapshotSync.requestImmediate().catch(() => undefined);
 
     const unsubDomainEvent = api.orchestration.onDomainEvent((event) => {
       if (event.sequence <= latestSequence) {
@@ -195,7 +188,7 @@ function EventRouter() {
       if (event.type === "thread.turn-diff-completed" || event.type === "thread.reverted") {
         void queryClient.invalidateQueries({ queryKey: providerQueryKeys.all });
       }
-      void syncSnapshot();
+      snapshotSync.requestDebounced();
     });
     const unsubTerminalEvent = api.terminal.onEvent((event) => {
       const hasRunningSubprocess = terminalRunningSubprocessFromEvent(event);
@@ -212,7 +205,7 @@ function EventRouter() {
     });
     const unsubWelcome = onServerWelcome((payload) => {
       void (async () => {
-        await syncSnapshot();
+        await snapshotSync.requestImmediate();
         if (disposed) {
           return;
         }
@@ -280,6 +273,7 @@ function EventRouter() {
     });
     return () => {
       disposed = true;
+      snapshotSync.dispose();
       unsubDomainEvent();
       unsubTerminalEvent();
       unsubWelcome();


### PR DESCRIPTION
## What Changed
- Debounced root snapshot syncs triggered by orchestration domain events.
- Kept startup and welcome-driven syncs immediate.
- Added focused unit tests for the new scheduler behavior.

## Why
- The app was calling `orchestration.getSnapshot()` for every domain event.
- During streaming turns that caused redundant full snapshot refreshes in a hot path.
- This is a small, scoped performance fix that reduces unnecessary work without changing product behavior.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Debounce root snapshot syncs by 75ms in `EventRouter`
> - Introduces [`createSnapshotSyncScheduler`](https://github.com/pingdotgg/t3code/pull/705/files#diff-6cfac35594d4673b48da09739fe8f1c55fa7668a53170776b7ae7c13b345a717), a scheduler that manages async runs in debounced or immediate modes, coalescing concurrent requests so at most one follow-up run queues behind an active run.
> - Domain event handlers now call `requestDebounced()` (75ms debounce) instead of syncing directly; initial sync and server welcome use `requestImmediate()`, which returns a promise that resolves when the scheduler is idle.
> - The scheduler is disposed on effect cleanup, cancelling any pending timers and resolving outstanding idle waiters.
> - Behavioral Change: rapid domain events that previously triggered one sync per event now coalesce into a single sync after 75ms.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 04318d4. 2 files reviewed, 2 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/routes/__root.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 234](https://github.com/pingdotgg/t3code/blob/04318d4b256b1dfde3f4ea1bfa591e67363f0d4d/apps/web/src/routes/__root.tsx#L234): The `onServerConfigUpdated` handler deduplicates events based solely on `JSON.stringify(payload.issues)`. This prevents the application from reacting to consecutive valid configuration updates. If the user changes the configuration from one valid state to another, `payload.issues` remains empty (`[]`). The handler sees the signature `"[]"` matches the previous `lastConfigIssuesSignatureRef.current` and returns early. As a result, `queryClient.invalidateQueries` is skipped, and the new configuration is not loaded. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->