### PR TITLE
fix: prevent Codex overrides footer overflow with long binary paths

### DIFF
--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -279,14 +279,17 @@ function SettingsRouteView() {
                   </span>
                 </label>
 
-                <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
-                  <p>
-                    Binary source:{" "}
-                    <span className="font-medium text-foreground">{codexBinaryPath || "PATH"}</span>
-                  </p>
+                <div className="flex flex-col gap-3 text-xs text-muted-foreground sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0 flex-1">
+                    <p>Binary source</p>
+                    <p className="mt-1 break-all font-mono text-[11px] text-foreground">
+                      {codexBinaryPath || "PATH"}
+                    </p>
+                  </div>
                   <Button
                     size="xs"
                     variant="outline"
+                    className="self-start"
                     onClick={() =>
                       updateSettings({
                         codexBinaryPath: defaults.codexBinaryPath,


### PR DESCRIPTION
You can navigate my issues and PRs at https://pr-navigator.pages.dev/t3code-utkarsh. It will be helpful when I open more issues and PRs, and in situations like when there are multiple PRs for one issue.

## What Changed

Fixes #284.
Fix the Codex App Server settings footer layout so long Codex binary paths wrap inside the card instead of pushing the `Reset codex overrides` button out of the card.

## Why

Long override paths, especially WSL-style paths, could expand the footer row and push the reset button outside the card. This PR keeps the existing behavior unchanged and fixes the layout with a small UI change.

## UI Changes

In Settings > Codex App Server.
| Before | After |
| --- | --- |
| <img width="1275" height="520" alt="image" src="https://github.com/user-attachments/assets/fb848aa2-9b3f-46eb-bd82-ea806e5bcf2a" /> | <img width="1175" height="542" alt="image" src="https://github.com/user-attachments/assets/2badf698-b1ff-47a9-8a91-358b2e8b8126" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex overrides footer layout to keep binary path inside card
> Reworks the binary source display in [settings.tsx](https://github.com/pingdotgg/t3code/pull/707/files#diff-0707e8295d0df761e405e66f02211b55d56c6eaea1ac3cb99562525a9c589cc6) to prevent the path from overflowing the card. Switches from a single-row flex layout to a responsive column-to-row layout, displays the binary path on its own monospaced line with `break-all`, and aligns the reset button to the start on small screens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bc1cf3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->