### PR TITLE
Add 'select-none' class to message prompt paragraph

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5426,7 +5426,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
   if (!hasMessages && !isWorking) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-sm text-muted-foreground/30">
+        <p className="text-sm text-muted-foreground/30 select-none">
           Send a message to start the conversation.
         </p>
       </div>


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

The initial prompt was selectable, which makes the app feels like a website instead of a real app. This PR marks it as non-selectable.

<img width="3344" height="2190" alt="CleanShot 2026-03-09 at 10 35 02@2x" src="https://github.com/user-attachments/assets/0cd895a3-d972-437e-abc8-6023a53bd53f" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `select-none` to empty-state prompt paragraph in `MessagesTimeline`
> Adds the Tailwind `select-none` utility to the empty-state hint text ('Send a message to start the conversation.') in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/714/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), preventing text selection when no messages are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ade3a02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->