### PR TITLE
feat: use static appimage runtime for Linux

### DIFF
--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -473,6 +473,8 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       icon: "icon.png",
       category: "Development",
     };
+    // TODO: Remove this once electron-builder defaults to the static AppImage runtime.
+    // Ubuntu 22.04+ does not install libfuse2 by default, so we pin the static runtime here.
     buildConfig.toolsets = {
       appimage: "1.0.2",
     };

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -473,6 +473,9 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       icon: "icon.png",
       category: "Development",
     };
+    buildConfig.toolsets = {
+      appimage: "1.0.2",
+    };
   }
 
   if (platform === "win") {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

uses https://github.com/electron-userland/electron-builder/pull/9558 to use static appimage runtime

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

Problem: libfuse2 is not installed on Ubuntu 22.04 and later

https://github.com/electron-userland/electron-builder/issues/9632
- electron-builder doesn't enable this by default yet (as of 26.8.1)

When electron-builder enables this by default, this workaround should be removed

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use static AppImage runtime for Linux desktop builds
> Sets `toolsets.appimage` to `"1.0.2"` in the Linux branch of `createBuildConfig` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/715/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d), switching Linux builds to use a static AppImage runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f847d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Linux desktop build configuration updated to pin the AppImage static runtime to version 1.0.2, improving consistency and reliability of Linux desktop artifacts across builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->