### PR TITLE
fix(server): stop existing codex session before restarting for same thread

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -523,6 +523,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
   async startSession(input: CodexAppServerStartSessionInput): Promise<ProviderSession> {
     const threadId = input.threadId;
+    if (this.sessions.has(threadId)) {
+      this.stopSession(threadId);
+    }
     const now = new Date().toISOString();
     let context: CodexSessionContext | undefined;
 


### PR DESCRIPTION
Summary:

- Prevent stale Codex session state from leaking when runtime mode changes trigger a restart.

Root cause:

- startSession() overwrote sessions by threadId without shutting down an existing context, leaving old child processes, readline streams, listeners, and pending request maps alive.

- Old process exit handlers could later mutate/delete state for the new session sharing the same threadId.

Fix:

- Add preflight cleanup in startSession(): if this.sessions.has(threadId), call stopSession(threadId) before creating a new session context.

- Ensures full cleanup via stop path (set stopping flag, kill child/IO, clear pending state) before re-binding to the same threadId.



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop existing codex session before restarting for the same thread
> In [`CodexAppServerManager.startSession`](https://github.com/pingdotgg/t3code/pull/722/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9), a check is added at the start of the method that calls `stopSession(threadId)` if a session with the same `threadId` already exists. This prevents duplicate sessions from running concurrently for the same thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23d13b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->