### PR TITLE
Fix project name badge truncation in chat header

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4132,7 +4132,7 @@ const ChatHeader = memo(function ChatHeader({
           {activeThreadTitle}
         </h2>
         {activeProjectName && (
-          <Badge variant="outline" className="max-w-28 shrink-0 truncate">
+          <Badge variant="outline" className="min-w-0 shrink truncate">
             {activeProjectName}
           </Badge>
         )}


### PR DESCRIPTION
## Summary
- The project name badge in the chat header was aggressively truncating due to a hard `max-w-28` (112px) cap and `shrink-0`
- Replaced with `min-w-0 shrink` so the badge uses available flex space and only truncates when the header is truly out of room

## Before
<img width="1420" height="81" alt="Screenshot 2026-03-09 at 1 54 11 PM" src="https://github.com/user-attachments/assets/e82e2b7d-7108-4ed1-9a5e-635064ae1773" />


## After
<img width="1086" height="49" alt="Screenshot 2026-03-09 at 1 53 57 PM" src="https://github.com/user-attachments/assets/4c050257-b027-46b3-b17f-4a7deac9746e" />



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project name badge truncation in chat header
> Replaces fixed Tailwind classes `max-w-28 shrink-0` with `min-w-0 shrink` on the project name `Badge` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/723/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), so the badge shrinks within available space instead of reserving a fixed width.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 796293d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->