### PR TITLE
Fix Codex chat startup for WSL UNC workspaces on Windows

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -10,6 +10,7 @@ import { DEVELOPMENT_ICON_OVERRIDES, PUBLISH_ICON_OVERRIDES } from "../../../scr
 import { resolveCatalogDependencies } from "../../../scripts/lib/resolve-catalog.ts";
 import rootPackageJson from "../../../package.json" with { type: "json" };
 import serverPackageJson from "../package.json" with { type: "json" };
+import { resolveShellCommand } from "../src/windowsShell.ts";
 
 class CliError extends Data.TaggedError("CliError")<{
   readonly message: string;
@@ -125,16 +126,16 @@ const buildCmd = Command.make(
       const fs = yield* FileSystem.FileSystem;
       const repoRoot = yield* RepoRoot;
       const serverDir = path.join(repoRoot, "apps/server");
+      const tsdownCommand = resolveShellCommand("bun", ["tsdown"], { cwd: serverDir });
 
       yield* Effect.log("[cli] Running tsdown...");
       yield* runCommand(
-        ChildProcess.make({
-          cwd: serverDir,
+        ChildProcess.make(tsdownCommand.command, [...tsdownCommand.args], {
+          cwd: tsdownCommand.cwd,
           stdout: config.verbose ? "inherit" : "ignore",
           stderr: "inherit",
-          // Windows needs shell mode to resolve .cmd shims (e.g. bun.cmd).
-          shell: process.platform === "win32",
-        })`bun tsdown`,
+          shell: tsdownCommand.shell,
+        }),
       );
 
       const webDist = path.join(repoRoot, "apps/web/dist");
@@ -220,15 +221,15 @@ const publishCmd = Command.make(
             const args = ["publish", "--access", config.access, "--tag", config.tag];
             if (config.provenance) args.push("--provenance");
             if (config.dryRun) args.push("--dry-run");
+            const publishCommand = resolveShellCommand("npm", args, { cwd: serverDir });
 
             yield* Effect.log(`[cli] Running: npm ${args.join(" ")}`);
             yield* runCommand(
-              ChildProcess.make("npm", [...args], {
-                cwd: serverDir,
+              ChildProcess.make(publishCommand.command, [...publishCommand.args], {
+                cwd: publishCommand.cwd,
                 stdout: config.verbose ? "inherit" : "ignore",
                 stderr: "inherit",
-                // Windows needs shell mode to resolve .cmd shims.
-                shell: process.platform === "win32",
+                shell: publishCommand.shell,
               }),
             );
           }),

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -132,6 +132,7 @@ const buildCmd = Command.make(
       yield* runCommand(
         ChildProcess.make(tsdownCommand.command, [...tsdownCommand.args], {
           cwd: tsdownCommand.cwd,
+          ...(tsdownCommand.env ? { env: { ...process.env, ...tsdownCommand.env } } : {}),
           stdout: config.verbose ? "inherit" : "ignore",
           stderr: "inherit",
           shell: tsdownCommand.shell,
@@ -227,6 +228,7 @@ const publishCmd = Command.make(
             yield* runCommand(
               ChildProcess.make(publishCommand.command, [...publishCommand.args], {
                 cwd: publishCommand.cwd,
+                ...(publishCommand.env ? { env: { ...process.env, ...publishCommand.env } } : {}),
                 stdout: config.verbose ? "inherit" : "ignore",
                 stderr: "inherit",
                 shell: publishCommand.shell,

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -495,7 +495,7 @@ describe("sendTurn", () => {
       ],
       model: "gpt-5.3-codex",
       collaborationMode: {
-        mode: "default",
+        mode: "code",
         settings: {
           model: "gpt-5.3-codex",
           reasoning_effort: "medium",

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -27,6 +27,7 @@ import {
   isCodexCliVersionSupported,
   parseCodexCliVersion,
 } from "./provider/codexCliVersion";
+import { resolveShellCommand } from "./windowsShell";
 
 type PendingRequestKey = string;
 
@@ -548,14 +549,17 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         cwd: resolvedCwd,
         ...(codexHomePath ? { homePath: codexHomePath } : {}),
       });
-      const child = spawn(codexBinaryPath, ["app-server"], {
+      const launchCommand = resolveShellCommand(codexBinaryPath, ["app-server"], {
         cwd: resolvedCwd,
+      });
+      const child = spawn(launchCommand.command, launchCommand.args, {
+        cwd: launchCommand.cwd,
         env: {
           ...process.env,
           ...(codexHomePath ? { CODEX_HOME: codexHomePath } : {}),
         },
         stdio: ["pipe", "pipe", "pipe"],
-        shell: process.platform === "win32",
+        shell: launchCommand.shell,
       });
       const output = readline.createInterface({ input: child.stdout });
 
@@ -1526,14 +1530,17 @@ function assertSupportedCodexCliVersion(input: {
   readonly cwd: string;
   readonly homePath?: string;
 }): void {
-  const result = spawnSync(input.binaryPath, ["--version"], {
+  const versionCommand = resolveShellCommand(input.binaryPath, ["--version"], {
     cwd: input.cwd,
+  });
+  const result = spawnSync(versionCommand.command, versionCommand.args, {
+    cwd: versionCommand.cwd,
     env: {
       ...process.env,
       ...(input.homePath ? { CODEX_HOME: input.homePath } : {}),
     },
     encoding: "utf8",
-    shell: process.platform === "win32",
+    shell: versionCommand.shell,
     stdio: ["ignore", "pipe", "pipe"],
     timeout: CODEX_VERSION_CHECK_TIMEOUT_MS,
     maxBuffer: 1024 * 1024,

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -421,7 +421,7 @@ function buildCodexCollaborationMode(input: {
   readonly effort?: string;
 }):
   | {
-      mode: "default" | "plan";
+      mode: "code" | "plan";
       settings: {
         model: string;
         reasoning_effort: string;
@@ -434,7 +434,7 @@ function buildCodexCollaborationMode(input: {
   }
   const model = normalizeCodexModelSlug(input.model) ?? "gpt-5.3-codex";
   return {
-    mode: input.interactionMode,
+    mode: input.interactionMode === "plan" ? "plan" : "code",
     settings: {
       model,
       reasoning_effort: input.effort ?? "medium",
@@ -557,6 +557,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         env: {
           ...process.env,
           ...(codexHomePath ? { CODEX_HOME: codexHomePath } : {}),
+          ...(launchCommand.env ?? {}),
         },
         stdio: ["pipe", "pipe", "pipe"],
         shell: launchCommand.shell,
@@ -1538,6 +1539,7 @@ function assertSupportedCodexCliVersion(input: {
     env: {
       ...process.env,
       ...(input.homePath ? { CODEX_HOME: input.homePath } : {}),
+      ...(versionCommand.env ?? {}),
     },
     encoding: "utf8",
     shell: versionCommand.shell,

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -230,6 +230,7 @@ const makeCodexTextGeneration = Effect.gen(function* () {
           [...resolvedCommand.args],
           {
             cwd: resolvedCommand.cwd,
+            ...(resolvedCommand.env ? { env: resolvedCommand.env } : {}),
             shell: resolvedCommand.shell,
             stdin: {
               stream: Stream.make(new TextEncoder().encode(prompt)),

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -230,7 +230,9 @@ const makeCodexTextGeneration = Effect.gen(function* () {
           [...resolvedCommand.args],
           {
             cwd: resolvedCommand.cwd,
-            ...(resolvedCommand.env ? { env: resolvedCommand.env } : {}),
+            ...(resolvedCommand.env
+              ? { env: { ...process.env, ...resolvedCommand.env } }
+              : {}),
             shell: resolvedCommand.shell,
             stdin: {
               stream: Stream.make(new TextEncoder().encode(prompt)),

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -7,6 +7,7 @@ import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shar
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
+import { resolveShellCommand } from "../../windowsShell.ts";
 import { TextGenerationError } from "../Errors.ts";
 import {
   type BranchNameGenerationInput,
@@ -204,7 +205,7 @@ const makeCodexTextGeneration = Effect.gen(function* () {
       const outputPath = yield* writeTempFile(operation, "codex-output", "");
 
       const runCodexCommand = Effect.gen(function* () {
-        const command = ChildProcess.make(
+        const resolvedCommand = resolveShellCommand(
           "codex",
           [
             "exec",
@@ -222,9 +223,14 @@ const makeCodexTextGeneration = Effect.gen(function* () {
             ...imagePaths.flatMap((imagePath) => ["--image", imagePath]),
             "-",
           ],
+          { cwd },
+        );
+        const command = ChildProcess.make(
+          resolvedCommand.command,
+          [...resolvedCommand.args],
           {
-            cwd,
-            shell: process.platform === "win32",
+            cwd: resolvedCommand.cwd,
+            shell: resolvedCommand.shell,
             stdin: {
               stream: Stream.make(new TextEncoder().encode(prompt)),
             },

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -12,6 +12,7 @@ import { extname, join } from "node:path";
 
 import { EDITORS, type EditorId } from "@t3tools/contracts";
 import { ServiceMap, Schema, Effect, Layer } from "effect";
+import { resolveShellCommand } from "./windowsShell";
 
 // ==============================
 // Definitions
@@ -232,10 +233,12 @@ export const launchDetached = (launch: EditorLaunch) =>
     yield* Effect.callback<void, OpenError>((resume) => {
       let child;
       try {
-        child = spawn(launch.command, [...launch.args], {
+        const resolvedCommand = resolveShellCommand(launch.command, launch.args);
+        child = spawn(resolvedCommand.command, [...resolvedCommand.args], {
+          cwd: resolvedCommand.cwd,
           detached: true,
           stdio: "ignore",
-          shell: process.platform === "win32",
+          shell: resolvedCommand.shell,
         });
       } catch (error) {
         return resume(

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -140,7 +140,9 @@ export async function runProcess(
     const resolvedCommand = resolveShellCommand(command, args, { cwd: options.cwd });
     const child = spawn(resolvedCommand.command, resolvedCommand.args, {
       cwd: resolvedCommand.cwd,
-      env: options.env,
+      env: resolvedCommand.env
+        ? { ...(options.env ?? process.env), ...resolvedCommand.env }
+        : options.env,
       stdio: "pipe",
       shell: resolvedCommand.shell,
     });

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -1,5 +1,7 @@
 import { type ChildProcess as ChildProcessHandle, spawn, spawnSync } from "node:child_process";
 
+import { resolveShellCommand } from "./windowsShell";
+
 export interface ProcessRunOptions {
   cwd?: string | undefined;
   timeoutMs?: number | undefined;
@@ -135,11 +137,12 @@ export async function runProcess(
   const outputMode = options.outputMode ?? "error";
 
   return new Promise<ProcessRunResult>((resolve, reject) => {
-    const child = spawn(command, args, {
-      cwd: options.cwd,
+    const resolvedCommand = resolveShellCommand(command, args, { cwd: options.cwd });
+    const child = spawn(resolvedCommand.command, resolvedCommand.args, {
+      cwd: resolvedCommand.cwd,
       env: options.env,
       stdio: "pipe",
-      shell: process.platform === "win32",
+      shell: resolvedCommand.shell,
     });
 
     let stdout = "";

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -183,6 +183,7 @@ const runCodexCommand = (args: ReadonlyArray<string>) =>
     const resolvedCommand = resolveShellCommand("codex", args);
     const command = ChildProcess.make(resolvedCommand.command, [...resolvedCommand.args], {
       cwd: resolvedCommand.cwd,
+      ...(resolvedCommand.env ? { env: resolvedCommand.env } : {}),
       shell: resolvedCommand.shell,
     });
 

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -21,6 +21,7 @@ import {
   isCodexCliVersionSupported,
   parseCodexCliVersion,
 } from "../codexCliVersion";
+import { resolveShellCommand } from "../windowsShell";
 import { ProviderHealth, type ProviderHealthShape } from "../Services/ProviderHealth";
 
 const DEFAULT_TIMEOUT_MS = 4_000;
@@ -179,8 +180,10 @@ const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.
 const runCodexCommand = (args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-    const command = ChildProcess.make("codex", [...args], {
-      shell: process.platform === "win32",
+    const resolvedCommand = resolveShellCommand("codex", args);
+    const command = ChildProcess.make(resolvedCommand.command, [...resolvedCommand.args], {
+      cwd: resolvedCommand.cwd,
+      shell: resolvedCommand.shell,
     });
 
     const child = yield* spawner.spawn(command);

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -21,7 +21,7 @@ import {
   isCodexCliVersionSupported,
   parseCodexCliVersion,
 } from "../codexCliVersion";
-import { resolveShellCommand } from "../windowsShell";
+import { resolveShellCommand } from "../../windowsShell.ts";
 import { ProviderHealth, type ProviderHealthShape } from "../Services/ProviderHealth";
 
 const DEFAULT_TIMEOUT_MS = 4_000;

--- a/apps/server/src/windowsShell.test.ts
+++ b/apps/server/src/windowsShell.test.ts
@@ -14,6 +14,10 @@ describe("isWindowsUncPath", () => {
   it("ignores UNC-looking paths on non-Windows platforms", () => {
     expect(isWindowsUncPath("\\\\wsl.localhost\\Ubuntu\\home\\user\\repo", "linux")).toBe(false);
   });
+
+  it("ignores Windows verbatim paths on Windows", () => {
+    expect(isWindowsUncPath("\\\\?\\C:\\Users\\user\\repo", "win32")).toBe(false);
+  });
 });
 
 describe("resolveShellCommand", () => {

--- a/apps/server/src/windowsShell.test.ts
+++ b/apps/server/src/windowsShell.test.ts
@@ -41,12 +41,38 @@ describe("resolveShellCommand", () => {
       command: "cmd.exe",
       args: [
         "/d",
-        "/v:on",
-        "/s",
         "/c",
-        'pushd "\\\\wsl.localhost\\Ubuntu\\home\\user\\repo" && ("codex" "app-server" & set "T3CODE_EXIT_CODE=!ERRORLEVEL!" & popd & exit /b !T3CODE_EXIT_CODE!)',
+        'pushd %__T3CODE_WINDOWS_UNC_CWD% && %__T3CODE_WINDOWS_UNC_COMMAND% %__T3CODE_WINDOWS_UNC_ARG_0%',
       ],
       cwd: undefined,
+      env: {
+        __T3CODE_WINDOWS_UNC_COMMAND: '"codex"',
+        __T3CODE_WINDOWS_UNC_CWD: '"\\\\wsl.localhost\\Ubuntu\\home\\user\\repo"',
+        __T3CODE_WINDOWS_UNC_ARG_0: '"app-server"',
+      },
+      shell: false,
+    });
+  });
+
+  it("quotes command paths with spaces for UNC cwd values", () => {
+    expect(
+      resolveShellCommand("C:\\Users\\user\\AppData\\Roaming\\npm\\codex.cmd", ["--version"], {
+        cwd: "\\\\wsl.localhost\\Ubuntu\\home\\user\\repo",
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "cmd.exe",
+      args: [
+        "/d",
+        "/c",
+        "pushd %__T3CODE_WINDOWS_UNC_CWD% && call %__T3CODE_WINDOWS_UNC_COMMAND% %__T3CODE_WINDOWS_UNC_ARG_0%",
+      ],
+      cwd: undefined,
+      env: {
+        __T3CODE_WINDOWS_UNC_COMMAND: '"C:\\Users\\user\\AppData\\Roaming\\npm\\codex.cmd"',
+        __T3CODE_WINDOWS_UNC_CWD: '"\\\\wsl.localhost\\Ubuntu\\home\\user\\repo"',
+        __T3CODE_WINDOWS_UNC_ARG_0: '"--version"',
+      },
       shell: false,
     });
   });

--- a/apps/server/src/windowsShell.test.ts
+++ b/apps/server/src/windowsShell.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { isWindowsUncPath, resolveShellCommand } from "./windowsShell";
+
+describe("isWindowsUncPath", () => {
+  it("detects UNC paths on Windows", () => {
+    expect(isWindowsUncPath("\\\\wsl.localhost\\Ubuntu\\home\\user\\repo", "win32")).toBe(true);
+  });
+
+  it("ignores drive-letter paths on Windows", () => {
+    expect(isWindowsUncPath("C:\\Users\\user\\repo", "win32")).toBe(false);
+  });
+
+  it("ignores UNC-looking paths on non-Windows platforms", () => {
+    expect(isWindowsUncPath("\\\\wsl.localhost\\Ubuntu\\home\\user\\repo", "linux")).toBe(false);
+  });
+});
+
+describe("resolveShellCommand", () => {
+  it("keeps the normal Windows shell path for drive-letter cwd values", () => {
+    expect(
+      resolveShellCommand("codex", ["app-server"], {
+        cwd: "C:\\Users\\user\\repo",
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "codex",
+      args: ["app-server"],
+      cwd: "C:\\Users\\user\\repo",
+      shell: true,
+    });
+  });
+
+  it("wraps UNC cwd values through cmd pushd on Windows", () => {
+    expect(
+      resolveShellCommand("codex", ["app-server"], {
+        cwd: "\\\\wsl.localhost\\Ubuntu\\home\\user\\repo",
+        platform: "win32",
+      }),
+    ).toEqual({
+      command: "cmd.exe",
+      args: [
+        "/d",
+        "/v:on",
+        "/s",
+        "/c",
+        'pushd "\\\\wsl.localhost\\Ubuntu\\home\\user\\repo" && ("codex" "app-server" & set "T3CODE_EXIT_CODE=!ERRORLEVEL!" & popd & exit /b !T3CODE_EXIT_CODE!)',
+      ],
+      cwd: undefined,
+      shell: false,
+    });
+  });
+});

--- a/apps/server/src/windowsShell.ts
+++ b/apps/server/src/windowsShell.ts
@@ -2,6 +2,7 @@ export interface ResolvedShellCommand {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
   readonly cwd: string | undefined;
+  readonly env?: Readonly<Record<string, string>>;
   readonly shell: boolean;
 }
 
@@ -20,9 +21,36 @@ function quoteForCmd(value: string): string {
   return `"${value.replaceAll('"', '""')}"`;
 }
 
-function buildWindowsUncCommand(command: string, args: ReadonlyArray<string>, cwd: string): string {
-  const commandLine = [command, ...args].map(quoteForCmd).join(" ");
-  return `pushd ${quoteForCmd(cwd)} && (${commandLine} & set "T3CODE_EXIT_CODE=!ERRORLEVEL!" & popd & exit /b !T3CODE_EXIT_CODE!)`;
+function isBatchScriptCommand(command: string): boolean {
+  return /\.(cmd|bat)$/i.test(command);
+}
+
+const WINDOWS_UNC_ENV_PREFIX = "__T3CODE_WINDOWS_UNC";
+
+function buildWindowsUncCommand(
+  command: string,
+  args: ReadonlyArray<string>,
+  cwd: string,
+): {
+  readonly script: string;
+  readonly env: Readonly<Record<string, string>>;
+} {
+  const env: Record<string, string> = {
+    [`${WINDOWS_UNC_ENV_PREFIX}_CWD`]: quoteForCmd(cwd),
+    [`${WINDOWS_UNC_ENV_PREFIX}_COMMAND`]: quoteForCmd(command),
+  };
+  const argRefs = args.map((arg, index) => {
+    const key = `${WINDOWS_UNC_ENV_PREFIX}_ARG_${index}`;
+    env[key] = quoteForCmd(arg);
+    return `%${key}%`;
+  });
+  const commandRef = `%${WINDOWS_UNC_ENV_PREFIX}_COMMAND%`;
+  const cwdRef = `%${WINDOWS_UNC_ENV_PREFIX}_CWD%`;
+  const commandPrefix = isBatchScriptCommand(command) ? "call " : "";
+  return {
+    script: `pushd ${cwdRef} && ${commandPrefix}${commandRef}${argRefs.length > 0 ? ` ${argRefs.join(" ")}` : ""}`,
+    env,
+  };
 }
 
 export function resolveShellCommand(
@@ -37,10 +65,12 @@ export function resolveShellCommand(
   const cwd = options.cwd;
 
   if (isWindowsUncPath(cwd, platform)) {
+    const wrappedCommand = buildWindowsUncCommand(command, args, cwd);
     return {
       command: "cmd.exe",
-      args: ["/d", "/v:on", "/s", "/c", buildWindowsUncCommand(command, args, cwd)],
+      args: ["/d", "/c", wrappedCommand.script],
       cwd: undefined,
+      env: wrappedCommand.env,
       shell: false,
     };
   }

--- a/apps/server/src/windowsShell.ts
+++ b/apps/server/src/windowsShell.ts
@@ -14,7 +14,7 @@ export function isWindowsUncPath(
     return false;
   }
 
-  return /^[/\\]{2}/.test(cwd);
+  return /^[/\\]{2}(?!\?\\)/.test(cwd);
 }
 
 function quoteForCmd(value: string): string {

--- a/apps/server/src/windowsShell.ts
+++ b/apps/server/src/windowsShell.ts
@@ -1,0 +1,54 @@
+export interface ResolvedShellCommand {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly cwd: string | undefined;
+  readonly shell: boolean;
+}
+
+export function isWindowsUncPath(
+  cwd: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform !== "win32" || !cwd) {
+    return false;
+  }
+
+  return /^[/\\]{2}/.test(cwd);
+}
+
+function quoteForCmd(value: string): string {
+  return `"${value.replaceAll('"', '""')}"`;
+}
+
+function buildWindowsUncCommand(command: string, args: ReadonlyArray<string>, cwd: string): string {
+  const commandLine = [command, ...args].map(quoteForCmd).join(" ");
+  return `pushd ${quoteForCmd(cwd)} && (${commandLine} & set "T3CODE_EXIT_CODE=!ERRORLEVEL!" & popd & exit /b !T3CODE_EXIT_CODE!)`;
+}
+
+export function resolveShellCommand(
+  command: string,
+  args: ReadonlyArray<string>,
+  options: {
+    readonly cwd?: string;
+    readonly platform?: NodeJS.Platform;
+  } = {},
+): ResolvedShellCommand {
+  const platform = options.platform ?? process.platform;
+  const cwd = options.cwd;
+
+  if (isWindowsUncPath(cwd, platform)) {
+    return {
+      command: "cmd.exe",
+      args: ["/d", "/v:on", "/s", "/c", buildWindowsUncCommand(command, args, cwd)],
+      cwd: undefined,
+      shell: false,
+    };
+  }
+
+  return {
+    command,
+    args,
+    cwd,
+    shell: platform === "win32",
+  };
+}


### PR DESCRIPTION
## Summary

This fixes Windows Codex chat startup when the workspace lives under a WSL UNC path such as:

`\\wsl.localhost\Ubuntu\home\<user>\project`

## What changed

- Added UNC-aware Windows shell command resolution for Codex-related subprocess launches.
- Switched UNC wrapping to an env-expanded `cmd.exe /c pushd ...` strategy to avoid Windows quoting/path parsing issues with direct embedded UNC and command-path quoting.
- Threaded the wrapper env through Codex launch/version-check and shared process execution paths.
- Updated Codex collaboration mode mapping so T3's default chat mode is sent as Codex app-server mode `code` instead of the outdated `default`.

## Why

Two separate issues were blocking chat in WSL-backed Windows workspaces:

1. Windows `cmd.exe` cannot safely start with a UNC current working directory, which caused Codex startup/version-check failures.
2. After fixing startup, Codex app-server rejected `turn/start` because it no longer accepts collaboration mode `default` and now expects values like `code` and `plan`.

## Result

- Codex CLI startup and version checks work for WSL UNC workspace paths on Windows.
- Chat now starts successfully in the Windows desktop app for WSL-backed projects.

## Validation

- `bun test apps/server/src/windowsShell.test.ts`
- `bun test apps/server/src/codexAppServerManager.test.ts`
- Manual desktop-app validation on Windows with a WSL UNC workspace path

## Related

- Fixes / follows up on #716


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex chat startup for WSL UNC workspaces on Windows
> - Introduces [windowsShell.ts](https://github.com/pingdotgg/t3code/pull/724/files#diff-4de33c1801066702bdaecb5b6cc2f6a00372968d0f3459484c5bb61dc22df934) with `resolveShellCommand`, which detects Windows UNC paths and routes process spawning through `cmd.exe /d /c pushd ... && <command>` to work around Node's inability to spawn processes with UNC working directories.
> - Applies `resolveShellCommand` across all spawn sites: session startup, CLI version checks, text generation, provider health checks, process runner, and editor launches.
> - Changes `buildCodexCollaborationMode` to return `'code'` instead of `'default'` for non-plan interaction modes.
> - Behavioral Change: shell mode, `cwd`, and environment variable composition now differ on Windows vs. non-Windows for every spawned child process in the server.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0952c5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->