### PR TITLE
Disable add project button for empty path.

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -503,6 +503,8 @@ export default function Sidebar() {
     void addProjectFromPath(newCwd);
   };
 
+  const canAddProject = newCwd.trim().length > 0 && !isAddingProject;
+
   const handlePickFolder = async () => {
     const api = readNativeApi();
     if (!api || isPickingFolder) return;
@@ -1105,7 +1107,7 @@ export default function Sidebar() {
                   type="button"
                   className="shrink-0 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-colors duration-150 hover:bg-primary/90 disabled:opacity-60"
                   onClick={handleAddProject}
-                  disabled={isAddingProject}
+                  disabled={!canAddProject}
                 >
                   {isAddingProject ? "Adding..." : "Add"}
                 </button>


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Disables the 'Add' button in the 'Add Projects' section when the entered path is empty.

## Why

Can be misleading sometines.

## UI Changes

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
<img width="514" height="216" alt="image" src="https://github.com/user-attachments/assets/994afaad-1da0-4060-bbc6-e8d64fb6f91b" />
 <td>
<img width="514" height="216" alt="image" src="https://github.com/user-attachments/assets/7f5e3544-3ce2-413e-8202-f8dca7681f5a" />

</table>

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable 'Add' project button when path input is empty
> Adds a `canAddProject` check in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/725/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that requires the path input (`newCwd`) to be non-empty after trimming before enabling the button. Previously, the button was only disabled while an add operation was in progress.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f86620.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->