### PR TITLE
fix(web): only use VITE_WS_URL in dev mode

### DIFF
--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -37,7 +37,7 @@ export class WsTransport {
     const bridgeUrl = window.desktopBridge?.getWsUrl();
     // In dev mode, VITE_WS_URL points to the server's WebSocket endpoint.
     // In production, the page is served by the WS server on the same host:port.
-    const envUrl = import.meta.env.VITE_WS_URL as string | undefined;
+    const envUrl = import.meta.env.DEV ? (import.meta.env.VITE_WS_URL as string | undefined) : undefined;
     this.url =
       url ??
       (bridgeUrl && bridgeUrl.length > 0


### PR DESCRIPTION
In production, the page is served by the WS server on the same host:port, so the WebSocket URL should be derived from window.location. VITE_WS_URL is baked in at build time and would override the window.location fallback, pointing the browser to the wrong host (e.g. localhost instead of the actual server host).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `WsTransport` to ignore `VITE_WS_URL` in production builds
> In [wsTransport.ts](https://github.com/pingdotgg/t3code/pull/740/files#diff-2129bf8b884f9eac0205e2de5672354ffe759743b6538d8dee077fb1944d1506), `VITE_WS_URL` is now only read when `import.meta.env.DEV` is true. In production, the WebSocket URL falls back to the provided `url`, the desktop bridge URL, or the default `ws(s)://host:port`. This prevents dev-only environment variables from leaking into production builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ca0261.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->