### PR TITLE
fix: use thread updatedAt for sidebar activity ordering

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -54,6 +54,16 @@ describe("resolveThreadActivityAt", () => {
       }),
     ).toBe("2026-03-09T10:00:00.000Z");
   });
+
+  it("falls back to createdAt when updatedAt is invalid", () => {
+    expect(
+      resolveThreadActivityAt({
+        id: "thread-1" as never,
+        createdAt: "2026-03-09T10:00:00.000Z",
+        updatedAt: "not-a-date",
+      }),
+    ).toBe("2026-03-09T10:00:00.000Z");
+  });
 });
 
 describe("compareThreadsByRecentActivity", () => {
@@ -68,6 +78,42 @@ describe("compareThreadsByRecentActivity", () => {
         id: "thread-2" as never,
         createdAt: "2026-03-09T09:00:00.000Z",
         updatedAt: "2026-03-09T10:05:00.000Z",
+      },
+    ];
+
+    expect(threads.toSorted(compareThreadsByRecentActivity).map((thread) => thread.id)).toEqual([
+      "thread-2",
+      "thread-1",
+    ]);
+  });
+
+  it("sorts a valid activity timestamp ahead of an invalid one", () => {
+    const threads = [
+      {
+        id: "thread-1" as never,
+        createdAt: "not-a-date",
+      },
+      {
+        id: "thread-2" as never,
+        createdAt: "2026-03-09T10:05:00.000Z",
+      },
+    ];
+
+    expect(threads.toSorted(compareThreadsByRecentActivity).map((thread) => thread.id)).toEqual([
+      "thread-2",
+      "thread-1",
+    ]);
+  });
+
+  it("sorts two invalid timestamps by id as a stable fallback", () => {
+    const threads = [
+      {
+        id: "thread-1" as never,
+        createdAt: "not-a-date",
+      },
+      {
+        id: "thread-2" as never,
+        createdAt: "still-not-a-date",
       },
     ];
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { hasUnseenCompletion, resolveThreadStatusPill } from "./Sidebar.logic";
+import {
+  compareThreadsByRecentActivity,
+  hasUnseenCompletion,
+  resolveThreadActivityAt,
+  resolveThreadStatusPill,
+} from "./Sidebar.logic";
 
 function makeLatestTurn(overrides?: {
   completedAt?: string | null;
@@ -27,6 +32,49 @@ describe("hasUnseenCompletion", () => {
         session: null,
       }),
     ).toBe(true);
+  });
+});
+
+describe("resolveThreadActivityAt", () => {
+  it("prefers updatedAt over createdAt when present", () => {
+    expect(
+      resolveThreadActivityAt({
+        id: "thread-1" as never,
+        createdAt: "2026-03-09T10:00:00.000Z",
+        updatedAt: "2026-03-09T10:05:00.000Z",
+      }),
+    ).toBe("2026-03-09T10:05:00.000Z");
+  });
+
+  it("falls back to createdAt when updatedAt is missing", () => {
+    expect(
+      resolveThreadActivityAt({
+        id: "thread-1" as never,
+        createdAt: "2026-03-09T10:00:00.000Z",
+      }),
+    ).toBe("2026-03-09T10:00:00.000Z");
+  });
+});
+
+describe("compareThreadsByRecentActivity", () => {
+  it("sorts threads by most recent activity first", () => {
+    const threads = [
+      {
+        id: "thread-1" as never,
+        createdAt: "2026-03-09T10:00:00.000Z",
+        updatedAt: "2026-03-09T10:01:00.000Z",
+      },
+      {
+        id: "thread-2" as never,
+        createdAt: "2026-03-09T09:00:00.000Z",
+        updatedAt: "2026-03-09T10:05:00.000Z",
+      },
+    ];
+
+    expect(threads.toSorted(compareThreadsByRecentActivity).map((thread) => thread.id)).toEqual([
+      "thread-2",
+      "thread-1",
+    ]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -29,9 +29,12 @@ function parseIsoDate(value: string | undefined): number {
 }
 
 export function resolveThreadActivityAt(thread: ThreadActivityInput): string {
-  const updatedAtMs = parseIsoDate(thread.updatedAt);
-  if (!Number.isNaN(updatedAtMs)) {
-    return thread.updatedAt as string;
+  const { updatedAt } = thread;
+  if (updatedAt) {
+    const updatedAtMs = parseIsoDate(updatedAt);
+    if (!Number.isNaN(updatedAtMs)) {
+      return updatedAt;
+    }
   }
   return thread.createdAt;
 }

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -19,6 +19,45 @@ type ThreadStatusInput = Pick<
   "interactionMode" | "latestTurn" | "lastVisitedAt" | "proposedPlans" | "session"
 >;
 
+type ThreadActivityInput = Pick<Thread, "createdAt" | "id"> & {
+  updatedAt?: string | undefined;
+};
+
+function parseIsoDate(value: string | undefined): number {
+  if (!value) return Number.NaN;
+  return Date.parse(value);
+}
+
+export function resolveThreadActivityAt(thread: ThreadActivityInput): string {
+  const updatedAtMs = parseIsoDate(thread.updatedAt);
+  if (!Number.isNaN(updatedAtMs)) {
+    return thread.updatedAt as string;
+  }
+  return thread.createdAt;
+}
+
+export function compareThreadsByRecentActivity(
+  left: ThreadActivityInput,
+  right: ThreadActivityInput,
+): number {
+  const rightActivityAt = parseIsoDate(resolveThreadActivityAt(right));
+  const leftActivityAt = parseIsoDate(resolveThreadActivityAt(left));
+  if (
+    !Number.isNaN(rightActivityAt) &&
+    !Number.isNaN(leftActivityAt) &&
+    rightActivityAt !== leftActivityAt
+  ) {
+    return rightActivityAt - leftActivityAt;
+  }
+  if (!Number.isNaN(rightActivityAt) && Number.isNaN(leftActivityAt)) {
+    return 1;
+  }
+  if (Number.isNaN(rightActivityAt) && !Number.isNaN(leftActivityAt)) {
+    return -1;
+  }
+  return right.id.localeCompare(left.id);
+}
+
 export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   if (!thread.latestTurn?.completedAt) return false;
   const completedAt = Date.parse(thread.latestTurn.completedAt);

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -67,7 +67,11 @@ import {
 } from "./ui/sidebar";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
-import { resolveThreadStatusPill } from "./Sidebar.logic";
+import {
+  compareThreadsByRecentActivity,
+  resolveThreadActivityAt,
+  resolveThreadStatusPill,
+} from "./Sidebar.logic";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_PREVIEW_LIMIT = 6;
@@ -422,11 +426,7 @@ export default function Sidebar() {
     (projectId: ProjectId) => {
       const latestThread = threads
         .filter((thread) => thread.projectId === projectId)
-        .toSorted((a, b) => {
-          const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-          if (byDate !== 0) return byDate;
-          return b.id.localeCompare(a.id);
-        })[0];
+        .toSorted(compareThreadsByRecentActivity)[0];
       if (!latestThread) return;
 
       void navigate({
@@ -1134,11 +1134,7 @@ export default function Sidebar() {
             {projects.map((project) => {
               const projectThreads = threads
                 .filter((thread) => thread.projectId === project.id)
-                .toSorted((a, b) => {
-                  const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-                  if (byDate !== 0) return byDate;
-                  return b.id.localeCompare(a.id);
-                });
+                .toSorted(compareThreadsByRecentActivity);
               const isThreadListExpanded = expandedThreadListsByProject.has(project.id);
               const hasHiddenThreads = projectThreads.length > THREAD_PREVIEW_LIMIT;
               const visibleThreads =
@@ -1348,7 +1344,7 @@ export default function Sidebar() {
                                       isActive ? "text-foreground/65" : "text-muted-foreground/40"
                                     }`}
                                   >
-                                    {formatRelativeTime(thread.createdAt)}
+                                    {formatRelativeTime(resolveThreadActivityAt(thread))}
                                   </span>
                                 </div>
                               </SidebarMenuSubButton>

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -26,6 +26,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     proposedPlans: [],
     error: null,
     createdAt: "2026-02-13T00:00:00.000Z",
+    updatedAt: "2026-02-13T00:00:00.000Z",
     latestTurn: null,
     branch: null,
     worktreePath: null,
@@ -146,5 +147,18 @@ describe("store read model sync", () => {
     const next = syncServerReadModel(initialState, readModel);
 
     expect(next.threads[0]?.model).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
+  });
+
+  it("preserves thread updatedAt from the orchestration read model", () => {
+    const initialState = makeState(makeThread());
+    const readModel = makeReadModel(
+      makeReadModelThread({
+        updatedAt: "2026-02-27T00:05:00.000Z",
+      }),
+    );
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.threads[0]?.updatedAt).toBe("2026-02-27T00:05:00.000Z");
   });
 });

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -264,6 +264,7 @@ export function syncServerReadModel(state: AppState, readModel: OrchestrationRea
         })),
         error: thread.session?.lastError ?? null,
         createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
         latestTurn: thread.latestTurn,
         lastVisitedAt: existing?.lastVisitedAt ?? thread.updatedAt,
         branch: thread.branch,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -96,6 +96,7 @@ export interface Thread {
   proposedPlans: ProposedPlan[];
   error: string | null;
   createdAt: string;
+  updatedAt?: string | undefined;
   latestTurn: OrchestrationLatestTurn | null;
   lastVisitedAt?: string | undefined;
   branch: string | null;


### PR DESCRIPTION
## What Changed

Sidebar thread activity now uses the thread's latest activity timestamp instead of its creation timestamp.

- sorts project threads by most recent activity using `updatedAt`, with `createdAt` as a fallback
- displays the sidebar relative time from that resolved activity timestamp instead of always using `createdAt`
- preserves `updatedAt` during web store read-model sync
- adds tests for the activity timestamp helper, sidebar sorting, and store sync coverage

## Why

The sidebar was showing thread age based on creation time, which produced misleading timestamps and ordering.

In practice this meant:
- a thread could show an old relative time even if the first message or latest activity happened much later
- project thread lists were ordered by creation time instead of recent activity
- Example reference from my issue #466 where it shows 20h ago on the thread even though the first message was sent at 4pm which was 10 minutes ago

Using `updatedAt` with a `createdAt` fallback keeps the sidebar behavior aligned with actual thread activity while remaining safe for incomplete data.

## UI Changes

Before: sidebar thread timestamps and ordering reflected thread creation time

After: sidebar thread timestamps and ordering reflect latest known thread activity

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar thread ordering to use `updatedAt` instead of `createdAt`
> - Adds `updatedAt` to the `Thread` interface and maps it from the orchestration read model in `syncServerReadModel`.
> - Introduces `resolveThreadActivityAt` to return `updatedAt` when valid, falling back to `createdAt`, and `compareThreadsByRecentActivity` for deterministic sorting (falls back to `id` when timestamps are equal or invalid).
> - Replaces ad-hoc `createdAt`-based sorting in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/741/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) with the new comparator, and updates relative time display and "focus most recent thread" to use the resolved activity timestamp.
> - Behavioral Change: threads now sort by last activity rather than creation time, so recently updated threads appear at the top of the sidebar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbb1f7e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->