### PR TITLE
fix: stop cursor from being pushed to the very end on each keystroke in custom question answer entry

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -33,6 +33,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useEffectEvent,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -938,23 +939,26 @@ export default function ChatView({ threadId }: ChatViewProps) {
     pendingUserInputs.length > 0 ||
     (showPlanFollowUpPrompt && activeProposedPlan !== null);
   const composerFooterHasWideActions = showPlanFollowUpPrompt || activePendingProgress !== null;
-  useEffect(() => {
-    if (!activePendingProgress) {
-      return;
-    }
-    promptRef.current = activePendingProgress.customAnswer;
-    setComposerCursor(activePendingProgress.customAnswer.length);
+  const activePendingRequestId = activePendingUserInput?.requestId ?? null;
+  const activePendingQuestionId = activePendingProgress?.activeQuestion?.id ?? null;
+  const activePendingCustomAnswer = activePendingProgress?.customAnswer ?? "";
+  const syncActivePendingQuestionComposer = useEffectEvent(() => {
+    promptRef.current = activePendingCustomAnswer;
+    setComposerCursor(activePendingCustomAnswer.length);
     setComposerTrigger(
       detectComposerTrigger(
-        activePendingProgress.customAnswer,
-        expandCollapsedComposerCursor(
-          activePendingProgress.customAnswer,
-          activePendingProgress.customAnswer.length,
-        ),
+        activePendingCustomAnswer,
+        expandCollapsedComposerCursor(activePendingCustomAnswer, activePendingCustomAnswer.length),
       ),
     );
     setComposerHighlightedItemId(null);
-  }, [activePendingProgress, activePendingUserInput?.requestId]);
+  });
+  useEffect(() => {
+    if (activePendingRequestId === null || activePendingQuestionId === null) {
+      return;
+    }
+    syncActivePendingQuestionComposer();
+  }, [activePendingQuestionId, activePendingRequestId]);
   useEffect(() => {
     attachmentPreviewHandoffByMessageIdRef.current = attachmentPreviewHandoffByMessageId;
   }, [attachmentPreviewHandoffByMessageId]);


### PR DESCRIPTION
## What Changed

This fixes a bug that disallowed moving the cursor around in a custom answer response. It was caused by an aggressive function that moved the cursor to the end being called on every keystroke. Now that function should only ever be called when changing questions. There is another bug in the Questions flow, though. I plan to open another PR that fixes that.

## Why

Users should expect to be able to move their cursor around in a text entry field as they normally can.

## UI Changes

### Before

I tried pressing Option+Left on macOS to move the cursor back a word but the cursor snaps back to the end.

https://github.com/user-attachments/assets/c0038dd9-08ec-4a54-8766-a776bc53b813

### After

I can now press Option+Left/Right and move my cursor around freely.

https://github.com/user-attachments/assets/f934f604-c583-4d95-9df4-2a7854e0baa1

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cursor jumping to end on each keystroke in custom question answer entry
> The composer-syncing effect in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/742/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) was re-running on every change to `activePendingProgress`, which reset the cursor position to the end of the input on each keystroke. The fix wraps the sync logic in a `useEffectEvent` callback (`syncActivePendingQuestionComposer`) so it always reads the latest custom answer without becoming a dependency, and narrows the effect trigger to only fire when both `activePendingRequestId` and `activePendingQuestionId` are non-null.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ae5aee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->