### PR TITLE
fix(web): clear pending ws send timers on dispose

### DIFF
--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -80,10 +80,26 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.WebSocket = originalWebSocket;
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
 describe("WsTransport", () => {
+  it("clears send wait timers when disposed before the socket opens", async () => {
+    vi.useFakeTimers();
+
+    const transport = new WsTransport("ws://localhost:3020");
+    const requestPromise = transport.request("projects.list");
+    const rejection = expect(requestPromise).rejects.toThrow("Transport disposed");
+
+    expect(vi.getTimerCount()).toBe(3);
+
+    transport.dispose();
+
+    expect(vi.getTimerCount()).toBe(0);
+    await rejection;
+  });
+
   it("routes valid push envelopes to channel listeners", () => {
     const transport = new WsTransport("ws://localhost:3020");
     const socket = getSocket();

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -9,6 +9,8 @@ interface PendingRequest {
   timeout: ReturnType<typeof setTimeout>;
 }
 
+type SendTimer = ReturnType<typeof setTimeout>;
+
 const REQUEST_TIMEOUT_MS = 60_000;
 const RECONNECT_DELAYS_MS = [500, 1_000, 2_000, 4_000, 8_000];
 const decodeWsResponseFromJson = Schema.decodeUnknownExit(Schema.fromJsonString(WsResponse));
@@ -27,6 +29,7 @@ export class WsTransport {
   private ws: WebSocket | null = null;
   private nextId = 1;
   private readonly pending = new Map<string, PendingRequest>();
+  private readonly pendingSendTimers = new Set<SendTimer>();
   private readonly listeners = new Map<string, Set<PushListener>>();
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -94,6 +97,11 @@ export class WsTransport {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    for (const timer of this.pendingSendTimers) {
+      clearTimeout(timer);
+      clearInterval(timer);
+    }
+    this.pendingSendTimers.clear();
     for (const pending of this.pending.values()) {
       clearTimeout(pending.timeout);
       pending.reject(new Error("Transport disposed"));
@@ -180,19 +188,31 @@ export class WsTransport {
 
     // If not connected, wait for connection
     const waitForOpen = () => {
+      const clearPendingSendWait = () => {
+        clearInterval(check);
+        clearTimeout(timeoutId);
+        this.pendingSendTimers.delete(check);
+        this.pendingSendTimers.delete(timeoutId);
+      };
+
       const check = setInterval(() => {
         if (this.disposed) {
-          clearInterval(check);
+          clearPendingSendWait();
           return;
         }
         if (this.ws?.readyState === WebSocket.OPEN) {
-          clearInterval(check);
+          clearPendingSendWait();
           this.ws.send(JSON.stringify(message));
         }
       }, 50);
+      this.pendingSendTimers.add(check);
 
       // Give up after timeout (the pending request will time out on its own)
-      setTimeout(() => clearInterval(check), REQUEST_TIMEOUT_MS);
+      const timeoutId = setTimeout(() => {
+        clearPendingSendWait();
+      }, REQUEST_TIMEOUT_MS);
+
+      this.pendingSendTimers.add(timeoutId);
     };
     waitForOpen();
   }


### PR DESCRIPTION
Summary:
Prevent timer leaks in the web WebSocket transport when requests are sent while the socket is disconnected.

Root cause:
`WsTransport.send()` started a polling interval plus a backup timeout for disconnected sends, but those timers were not tracked. If the transport was disposed before reconnecting, the request timeout was cleared but the send-wait timers kept running until their own timeout elapsed.

Fix:
- Track disconnected send timers in `WsTransport`
- Remove tracked timers when the socket opens or the send wait times out
- Clear all remaining send-wait timers during `dispose()`
- Add a regression test with fake timers that reproduces the leak and verifies `dispose()` leaves no timers behind

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear pending send-wait timers in `WsTransport.dispose` to prevent stray timer activity
> When `WsTransport` is disposed before the WebSocket opens, any in-flight send-wait intervals and timeouts were left running. This fix tracks all send-wait timer handles in a new `pendingSendTimers` set and clears them all on dispose, causing pending requests to reject with "Transport disposed". A new test in [wsTransport.test.ts](https://github.com/pingdotgg/t3code/pull/747/files#diff-7c6ed9129e00d65af355f5c56dbbace125d2af92ee10372a5479c1907600adee) verifies this behavior using fake timers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a285da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->