### PR TITLE
fix(web): restore terminal shortcuts in terminal

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2291,8 +2291,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
       event.stopPropagation();
       void runProjectScript(script);
     };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => window.removeEventListener("keydown", handler, { capture: true });
   }, [
     activeProject,
     terminalState.terminalOpen,


### PR DESCRIPTION
Closes #731

## What Changed

Fixed terminal shortcuts so `Ctrl/Cmd+N`, `Ctrl/Cmd+W`, and `Ctrl/Cmd+D` still work when the terminal is focused.

## Why

On Windows, terminal key events could be consumed before the app-level shortcut handler saw them. Listening in the capture phase keeps terminal shortcuts working reliably while the terminal is open and focused.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal keyboard shortcuts by registering keydown handler with capture phase
> The global `keydown` handler in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/753/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) was not intercepting keyboard events before the terminal consumed them. Adding `{ capture: true }` to both `addEventListener` and `removeEventListener` ensures the handler runs during the capture phase, restoring terminal shortcuts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d05af69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->