### PR TITLE
Treat retryable Codex error notifications as runtime warnings

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1091,6 +1091,50 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("runtime exploded");
   });
 
+  it("keeps the session running when a runtime.warning arrives during an active turn", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-warning-turn-started"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-warning"),
+      payload: {},
+    });
+
+    harness.emit({
+      type: "runtime.warning",
+      eventId: asEventId("evt-warning-runtime"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-warning"),
+      payload: {
+        message: "Reconnecting... 2/5",
+        detail: {
+          willRetry: true,
+        },
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.session?.status === "running" &&
+        entry.session?.activeTurnId === "turn-warning" &&
+        entry.activities.some(
+          (activity: ProviderRuntimeTestActivity) =>
+            activity.id === "evt-warning-runtime" && activity.kind === "runtime.warning",
+        ),
+    );
+    expect(thread.session?.status).toBe("running");
+    expect(thread.session?.activeTurnId).toBe("turn-warning");
+    expect(thread.session?.lastError).toBeNull();
+  });
+
   it("maps session/thread lifecycle and item.started into session/activity projections", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -407,6 +407,42 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("maps retryable Codex error notifications to runtime.warning", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      lifecycleManager.emit("event", {
+        id: asEventId("evt-retryable-error"),
+        kind: "notification",
+        provider: "codex",
+        threadId: asThreadId("thread-1"),
+        createdAt: new Date().toISOString(),
+        method: "error",
+        turnId: asTurnId("turn-1"),
+        payload: {
+          error: {
+            message: "Reconnecting... 2/5",
+          },
+          willRetry: true,
+        },
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      assert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      assert.equal(firstEvent.value.type, "runtime.warning");
+      if (firstEvent.value.type !== "runtime.warning") {
+        return;
+      }
+      assert.equal(firstEvent.value.turnId, "turn-1");
+      assert.equal(firstEvent.value.payload.message, "Reconnecting... 2/5");
+    }),
+  );
+
   it.effect("preserves request type when mapping serverRequest/resolved", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1192,13 +1192,14 @@ function mapToRuntimeEvents(
   if (event.method === "error") {
     const message =
       asString(asObject(payload?.error)?.message) ?? event.message ?? "Provider runtime error";
+    const willRetry = payload?.willRetry === true;
     return [
       {
-        type: "runtime.error",
+        type: willRetry ? "runtime.warning" : "runtime.error",
         ...runtimeEventBase(event, canonicalThreadId),
         payload: {
           message,
-          class: "provider_error",
+          ...(!willRetry ? { class: "provider_error" as const } : {}),
           ...(event.payload !== undefined ? { detail: event.payload } : {}),
         },
       },


### PR DESCRIPTION
## Summary
- Map Codex `error` notifications with `willRetry: true` to `runtime.warning` instead of `runtime.error`.
- Keep non-retryable errors mapped to `runtime.error` with `class: provider_error` unchanged.
- Add adapter coverage to verify retryable error notifications emit `runtime.warning` with the expected turn/message.
- Add ingestion coverage to ensure an active session remains `running` (with active turn preserved and no `lastError`) when `runtime.warning` is received.

## Testing
- Added test: `apps/server/src/provider/Layers/CodexAdapter.test.ts` (`maps retryable Codex error notifications to runtime.warning`).
- Added test: `apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts` (`keeps the session running when a runtime.warning arrives during an active turn`).
- Not run: `bun lint`.
- Not run: `bun typecheck`.
- Not run: `bun run test`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Codex `error` notifications are classified, which can affect session erroring/alerting behavior if `willRetry` is set incorrectly. Scope is small and covered by new adapter + ingestion tests.
> 
> **Overview**
> Treats Codex `method: "error"` notifications with `payload.willRetry: true` as `runtime.warning` instead of `runtime.error`, while keeping non-retryable errors mapped to `runtime.error` with `class: "provider_error"`.
> 
> Adds coverage to verify the adapter emits `runtime.warning` for retryable errors, and that ingestion records the warning activity without flipping an in-flight session to `error` or setting `lastError`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d2b0df06f131f2769acb0a1262d6789c77239d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Treat retryable Codex error notifications as `runtime.warning` instead of `runtime.error`
> In [`CodexAdapter.ts`](https://github.com/pingdotgg/t3code/pull/758/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d), the `mapToRuntimeEvents` function now checks `payload.willRetry` on `error` method notifications. When `true`, it emits a `runtime.warning` event (without `class: provider_error`) rather than a `runtime.error`, keeping the session in a running state. New tests cover both the adapter mapping and the downstream session behavior in `ProviderRuntimeIngestion`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d2b0df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->