### PR TITLE
Fix UI Overflow when Github Action is 'Commit, Create & Push PR'

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -344,7 +344,7 @@ describe("when: working tree has local changes", () => {
     assert.deepInclude(quick, {
       kind: "run_action",
       action: "commit_push_pr",
-      label: "Commit, push & create PR",
+      label: "Commit, push & PR",
     });
   });
 
@@ -440,7 +440,7 @@ describe("when: working tree has local changes and branch is behind upstream", (
     assert.deepInclude(quick, {
       kind: "run_action",
       action: "commit_push_pr",
-      label: "Commit, push & create PR",
+      label: "Commit, push & PR",
     });
   });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -206,7 +206,7 @@ export function resolveQuickAction(
       return { label: "Commit & push", disabled: false, kind: "run_action", action: "commit_push" };
     }
     return {
-      label: "Commit, push & create PR",
+      label: "Commit, push & PR",
       disabled: false,
       kind: "run_action",
       action: "commit_push_pr",


### PR DESCRIPTION
## What Changed

[edited post comments]

Updated the label for 'Commit, create & push PR' to be 'Commit, create & PR' to allow the overlap to no longer happen, but still fit within the default window size without force collapsing all the icons by default. Brings the text closer to the size of the other labels and I believe is still clear instructions.

## Why

Fixes: #769, the problem with the 'Commit, push & create PR' overflowing behind the + in the title bar.

## UI Changes

Before:
<img width="413" height="128" alt="Screenshot 2026-03-09 at 10 17 09 AM" src="https://github.com/user-attachments/assets/88756966-79c8-4114-b30a-4457ff784409" />

After:
<img width="423" height="84" alt="Screenshot 2026-03-09 at 10 09 27 PM" src="https://github.com/user-attachments/assets/b1a54910-b8cb-4ebd-98a0-f8e6813e30a9" />



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Shorten 'Commit, push & create PR' label to 'Commit, push & PR' to fix UI overflow
> The quick action label in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/771/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) is shortened to prevent text overflow in the UI when the action is to commit, push, and create a PR.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7750bc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->