### PR TITLE
Feature: add link actions to context menu

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -4,7 +4,7 @@ import * as FS from "node:fs";
 import * as OS from "node:os";
 import * as Path from "node:path";
 
-import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, protocol, shell } from "electron";
+import { app, BrowserWindow, dialog, ipcMain, Menu, nativeImage, protocol, shell, clipboard } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
 import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
@@ -1169,6 +1169,15 @@ function createWindow(): BrowserWindow {
         menuTemplate.push({ label: "No suggestions", enabled: false });
       }
       menuTemplate.push({ type: "separator" });
+    }
+
+    const externalUrl = getSafeExternalUrl(params.linkURL);
+    if (externalUrl) {
+      menuTemplate.push(
+        { label: "Open Link", click: () => void shell.openExternal(externalUrl) },
+        { label: "Copy Link Address", click: () => clipboard.writeText(externalUrl) },
+        { type: "separator" },
+      );
     }
 
     menuTemplate.push(


### PR DESCRIPTION
## What Changed

Added 2 new link-specific elements in the context menu when right-clicking a link in chat:

- Open Link
- Copy Link Address

Image:
<img width="400" height="310" alt="Screenshot 2026-03-09 at 9 08 20 AM" src="https://github.com/user-attachments/assets/9f5308fa-72a9-4a21-80c3-c903868f7d8f" />

This was part of the request from #677. I confirmed that the main issue for #677 of links not working on Windows was resolved previously by #599, but added the quality of life improvement of the extra attributes to the context menu.

Added an if statement to the context menu event to check if what is being right clicked on is a link or not, and if so, add the 2 elements and a separator. This required adding 'clipboard' to the electron import as well. 

## Why

This makes link behavior more closely resemble standard UX.

## UI Changes

This is a UI change specifically. 

Before:
<img width="245" height="185" alt="Screenshot 2026-03-09 at 9 10 37 AM" src="https://github.com/user-attachments/assets/2cca4784-893f-498f-8070-b7d19af6638b" />

After:
<img width="400" height="310" alt="Screenshot 2026-03-09 at 9 08 20 AM" src="https://github.com/user-attachments/assets/199b9930-197c-45cd-8d0e-30bb46bf115f" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Open Link' and 'Copy Link Address' entries to the desktop context menu
> When right-clicking a link in the desktop app, two new items appear in the context menu: 'Open Link' (opens via `shell.openExternal`) and 'Copy Link Address' (writes to clipboard). Both items are only shown when `getSafeExternalUrl` returns a valid URL, followed by a separator before the standard edit items.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 956c18d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->