### PR TITLE
Add project sidebar action to open in file manager

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -738,13 +738,21 @@ export default function Sidebar() {
       const api = readNativeApi();
       if (!api) return;
       const clicked = await api.contextMenu.show(
-        [{ id: "delete", label: "Delete", destructive: true }],
+        [
+          { id: "open-in-file-manager", label: "Open in File Manager" },
+          { id: "delete", label: "Delete", destructive: true },
+        ],
         position,
       );
-      if (clicked !== "delete") return;
 
       const project = projects.find((entry) => entry.id === projectId);
       if (!project) return;
+
+      if (clicked === "open-in-file-manager") {
+        void api.shell.openInEditor(project.cwd, "file-manager");
+        return;
+      }
+      if (clicked !== "delete") return;
 
       const projectThreads = threads.filter((thread) => thread.projectId === projectId);
       if (projectThreads.length > 0) {


### PR DESCRIPTION
## What Changed

- Added an `Open in File Manager` action to the project context menu in the left sidebar.
- Reused the existing `shell.openInEditor(..., "file-manager")` path instead of introducing a new open mechanism.
- Left the existing project delete flow unchanged apart from adding the new action above it.

## Why

This makes it possible to open a project's root folder directly from the sidebar without navigating elsewhere first.

The change is intentionally small:
- one file
- one new context menu action
- no change to the existing delete behavior

## UI Changes

Before:
<img width="300" height="250" alt="before" src="https://github.com/user-attachments/assets/4e858b22-026d-4b29-b6b1-94906919fb85" />

After:
<img width="300" height="250" alt="after" src="https://github.com/user-attachments/assets/3d42a305-7fd2-4e6d-92d3-23dc924a447c" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for the UI change
- [x] No video needed; this does not depend on animation or timing

## Verification

- `bun lint`
- `bun typecheck`
- Manual verification via desktop build on Windows

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Open in File Manager' context menu item to project sidebar
> Adds a new 'Open in File Manager' option to the project context menu in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/774/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1). When selected, it calls `api.shell.openInEditor(project.cwd, 'file-manager')` to open the project directory in the system file manager.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 039743d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->