### PR TITLE
Quote cwd when building editor command args

### DIFF
--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -212,8 +212,8 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
 
   if (editorDef.command) {
     return shouldUseGotoFlag(editorDef.id, input.cwd)
-      ? { command: editorDef.command, args: ["--goto", input.cwd] }
-      : { command: editorDef.command, args: [input.cwd] };
+      ? { command: editorDef.command, args: ["--goto", `"${input.cwd}"`] }
+      : { command: editorDef.command, args: [`"${input.cwd}"`] };
   }
 
   if (editorDef.id !== "file-manager") {


### PR DESCRIPTION
fixes [#754](https://github.com/pingdotgg/t3code/issues/757)

## What Changed
Quote cwd param when building editor command args in `resolveEditorLaunch`.

## Why

The buttons that should open an editor (Open project, open keybindings.json) instead open two blank buffers, because path spaces are not handled in `resolveEditorLaunch`.

## UI Changes

No UI changes have been made

## Before

https://github.com/user-attachments/assets/aff475f2-3697-4794-95d8-ee6787d5f5ed

## After

https://github.com/user-attachments/assets/509b15d5-be1d-4f2f-8727-d105822b98db


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Quote `cwd` path in editor command args built by `resolveEditorLaunch`
> Wraps the `cwd` argument in double quotes when building args for editors that define a `command`, covering both `--goto` and plain invocation paths in [open.ts](https://github.com/pingdotgg/t3code/pull/775/files#diff-67f3655f84064d89de7cec58f5e8d2b9d406dd21986dcefc77c335e3036b65be). This prevents path resolution issues when the working directory contains spaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b35e579. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->