### PR TITLE
fix(git): preserve full target path for brace-style renames in numstat parsing

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -1270,6 +1270,31 @@ it.layer(TestLayer)("git integration", (it) => {
         yield* writeTextFile(path.join(tmp, "README.md"), "updated\n");
         const dirty = yield* core.statusDetails(tmp);
         expect(dirty.hasWorkingTreeChanges).toBe(true);
+      }),
+    );
+
+    it.effect("preserves full target path for brace-style renames in numstat output", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const core = yield* GitCore;
+
+        const oldDir = path.join(tmp, "src", "old");
+        yield* Effect.sync(() => {
+          mkdirSync(oldDir, { recursive: true });
+        });
+
+        yield* writeTextFile(path.join(oldDir, "file.ts"), "export const value = 1;\n");
+        yield* git(tmp, ["add", "."]);
+        yield* git(tmp, ["commit", "-m", "add old path"]);
+
+        yield* git(tmp, ["mv", "src/old", "src/new"]);
+
+        const details = yield* core.statusDetails(tmp);
+        const filePaths = details.workingTree.files.map((file) => file.path);
+
+        expect(filePaths).toContain("src/new/file.ts");
+        expect(filePaths).not.toContain("new}/file.ts");
       }),
     );
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -31,6 +31,28 @@ function parseBranchAb(value: string): { ahead: number; behind: number } {
   };
 }
 
+function normalizeNumstatPath(rawPath: string): string {
+  const trimmedPath = rawPath.trim();
+  if (trimmedPath.length === 0) {
+    return trimmedPath;
+  }
+
+  const braceExpandedPath = trimmedPath.replace(/\{([^{}]*?) => ([^{}]*?)\}/g, "$2");
+  if (braceExpandedPath !== trimmedPath && braceExpandedPath.trim().length > 0) {
+    return braceExpandedPath.trim();
+  }
+
+  const renameArrowIndex = trimmedPath.indexOf(" => ");
+  if (renameArrowIndex >= 0) {
+    const renamedPath = trimmedPath.slice(renameArrowIndex + " => ".length).trim();
+    if (renamedPath.length > 0) {
+      return renamedPath;
+    }
+  }
+
+  return trimmedPath;
+}
+
 function parseNumstatEntries(
   stdout: string,
 ): Array<{ path: string; insertions: number; deletions: number }> {
@@ -41,11 +63,11 @@ function parseNumstatEntries(
     const rawPath =
       pathParts.length > 1 ? (pathParts.at(-1) ?? "").trim() : pathParts.join("\t").trim();
     if (rawPath.length === 0) continue;
+
     const added = Number.parseInt(addedRaw ?? "0", 10);
     const deleted = Number.parseInt(deletedRaw ?? "0", 10);
-    const renameArrowIndex = rawPath.indexOf(" => ");
-    const normalizedPath =
-      renameArrowIndex >= 0 ? rawPath.slice(renameArrowIndex + " => ".length).trim() : rawPath;
+    const normalizedPath = normalizeNumstatPath(rawPath);
+
     entries.push({
       path: normalizedPath.length > 0 ? normalizedPath : rawPath,
       insertions: Number.isFinite(added) ? added : 0,


### PR DESCRIPTION
## Summary

Fixes Git numstat path parsing for brace-style renames such as:

src/{old => new}/file.ts

Previously the parser sliced everything after ` => `, which produced an invalid path like:

new}/file.ts

This patch preserves the full target path by expanding brace-style renames first, while keeping the existing behavior for simple rename outputs like:

old.ts => new.ts

## What changed

- Added `normalizeNumstatPath()` to normalize git numstat paths
- Handle brace-style renames before the simple `old => new` fallback
- Added an integration test covering staged brace-style renames in `statusDetails()`

## Why this matters

`statusDetails()` uses numstat output to build the working tree file list and per-file insertions/deletions. For brace-style renames, the old parsing could attribute stats to a bogus truncated path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix numstat parsing to preserve full target path for brace-style git renames
> Git numstat output for renamed files can use brace-style notation (e.g. `src/{old => new}/file.ts`), which was not handled correctly, causing the reported path to be `new}/file.ts` instead of `src/new/file.ts`.
>
> - Adds `normalizeNumstatPath` in [GitCore.ts](https://github.com/pingdotgg/t3code/pull/776/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865) to expand brace-style `{old => new}` segments into the full post-rename path, with a fallback for plain ` => ` arrow format.
> - Updates `parseNumstatEntries` to call `normalizeNumstatPath` instead of the previous inline ` => `-only normalization.
> - Adds a regression test in [GitCore.test.ts](https://github.com/pingdotgg/t3code/pull/776/files#diff-49e9b5a653566cf07288b6f6d553d942f05d7f26eba74c4e0f94a9e2a144f986) that performs a `git mv` across subdirectories and asserts the correct path is returned by `statusDetails`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 908f3e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->