### PR TITLE
Make worktree branch prefix configurable

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -165,7 +165,7 @@ describe("ProviderCommandReactor", () => {
             : "renamed-branch",
       }),
     );
-    const generateBranchName = vi.fn(() =>
+    const generateBranchName = vi.fn<TextGenerationShape["generateBranchName"]>(() =>
       Effect.fail(
         new TextGenerationError({
           operation: "generateBranchName",
@@ -290,6 +290,101 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("renames first-turn temporary worktree branches with the configured prefix", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    harness.generateBranchName.mockImplementation(() =>
+      Effect.succeed({
+        branch: "Bugfix/Verify Poland weight fix merge https://github.com/pingdotgg/t3code/pull/123",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-thread-meta-worktree"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        branch: "bugfix/1234abcd",
+        worktreePath: "/tmp/provider-project/worktrees/bugfix-1234abcd",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-worktree-rename"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-worktree-rename"),
+          role: "user",
+          text: "verify polish merge",
+          attachments: [],
+        },
+        worktreeBranchPrefix: "bugfix",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.renameBranch.mock.calls.length === 1);
+    expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+      cwd: "/tmp/provider-project/worktrees/bugfix-1234abcd",
+      oldBranch: "bugfix/1234abcd",
+      newBranch: "bugfix/verify-poland-weight-fix-merge",
+    });
+
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+      return thread?.branch === "bugfix/verify-poland-weight-fix-merge";
+    });
+  });
+
+  it("migrates legacy t3code temporary worktree branches onto the configured prefix", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+    harness.generateBranchName.mockImplementation(() =>
+      Effect.succeed({
+        branch: "feature/refine-toolbar-actions",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.makeUnsafe("cmd-thread-meta-worktree-legacy"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        branch: "t3code/1234abcd",
+        worktreePath: "/tmp/provider-project/worktrees/t3code-1234abcd",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-worktree-legacy"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-worktree-legacy"),
+          role: "user",
+          text: "refine toolbar actions",
+          attachments: [],
+        },
+        worktreeBranchPrefix: "feature",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.renameBranch.mock.calls.length === 1);
+    expect(harness.renameBranch.mock.calls[0]?.[0]).toMatchObject({
+      oldBranch: "t3code/1234abcd",
+      newBranch: "feature/refine-toolbar-actions",
+    });
   });
 
   it("forwards codex model options through session start and turn send", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,6 +12,10 @@ import {
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
+import {
+  buildWorktreeBranchName,
+  isTemporaryWorktreeBranch,
+} from "@t3tools/shared/git";
 import { Cache, Cause, Duration, Effect, Layer, Option, Queue, Schema, Stream } from "effect";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
@@ -70,8 +74,7 @@ const serverCommandId = (tag: string): CommandId =>
 const HANDLED_TURN_START_KEY_MAX = 10_000;
 const HANDLED_TURN_START_KEY_TTL = Duration.minutes(30);
 const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
-const WORKTREE_BRANCH_PREFIX = "t3code";
-const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(`^${WORKTREE_BRANCH_PREFIX}\\/[0-9a-f]{8}$`);
+const LEGACY_WORKTREE_BRANCH_PREFIX = "t3code";
 
 function toErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message.trim().length > 0) {
@@ -99,31 +102,14 @@ function isUnknownPendingApprovalRequestError(error: unknown): boolean {
   );
 }
 
-function isTemporaryWorktreeBranch(branch: string): boolean {
-  return TEMP_WORKTREE_BRANCH_PATTERN.test(branch.trim().toLowerCase());
-}
-
-function buildGeneratedWorktreeBranchName(raw: string): string {
-  const normalized = raw
-    .trim()
-    .toLowerCase()
-    .replace(/^refs\/heads\//, "")
-    .replace(/['"`]/g, "");
-
-  const withoutPrefix = normalized.startsWith(`${WORKTREE_BRANCH_PREFIX}/`)
-    ? normalized.slice(`${WORKTREE_BRANCH_PREFIX}/`.length)
-    : normalized;
-
-  const branchFragment = withoutPrefix
-    .replace(/[^a-z0-9/_-]+/g, "-")
-    .replace(/\/+/g, "/")
-    .replace(/-+/g, "-")
-    .replace(/^[./_-]+|[./_-]+$/g, "")
-    .slice(0, 64)
-    .replace(/[./_-]+$/g, "");
-
-  const safeFragment = branchFragment.length > 0 ? branchFragment : "update";
-  return `${WORKTREE_BRANCH_PREFIX}/${safeFragment}`;
+function isKnownTemporaryWorktreeBranch(
+  branch: string,
+  worktreeBranchPrefix: string | undefined,
+): boolean {
+  return (
+    isTemporaryWorktreeBranch(branch, worktreeBranchPrefix) ||
+    isTemporaryWorktreeBranch(branch, LEGACY_WORKTREE_BRANCH_PREFIX)
+  );
 }
 
 const make = Effect.gen(function* () {
@@ -369,6 +355,7 @@ const make = Effect.gen(function* () {
     readonly threadId: ThreadId;
     readonly branch: string | null;
     readonly worktreePath: string | null;
+    readonly worktreeBranchPrefix?: string;
     readonly messageId: string;
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
@@ -376,7 +363,7 @@ const make = Effect.gen(function* () {
     if (!input.branch || !input.worktreePath) {
       return;
     }
-    if (!isTemporaryWorktreeBranch(input.branch)) {
+    if (!isKnownTemporaryWorktreeBranch(input.branch, input.worktreeBranchPrefix)) {
       return;
     }
 
@@ -409,7 +396,10 @@ const make = Effect.gen(function* () {
         Effect.flatMap((generated) => {
           if (!generated) return Effect.void;
 
-          const targetBranch = buildGeneratedWorktreeBranchName(generated.branch);
+          const targetBranch = buildWorktreeBranchName(
+            input.worktreeBranchPrefix,
+            generated.branch,
+          );
           if (targetBranch === oldBranch) return Effect.void;
 
           return Effect.flatMap(
@@ -463,6 +453,9 @@ const make = Effect.gen(function* () {
       threadId: event.payload.threadId,
       branch: thread.branch,
       worktreePath: thread.worktreePath,
+      ...(event.payload.worktreeBranchPrefix !== undefined
+        ? { worktreeBranchPrefix: event.payload.worktreeBranchPrefix }
+        : {}),
       messageId: message.id,
       messageText: message.text,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -303,6 +303,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           ...(command.model !== undefined ? { model: command.model } : {}),
           ...(command.modelOptions !== undefined ? { modelOptions: command.modelOptions } : {}),
           ...(command.providerOptions !== undefined ? { providerOptions: command.providerOptions } : {}),
+          ...(command.worktreeBranchPrefix !== undefined
+            ? { worktreeBranchPrefix: command.worktreeBranchPrefix }
+            : {}),
           assistantDeliveryMode: command.assistantDeliveryMode ?? DEFAULT_ASSISTANT_DELIVERY_MODE,
           runtimeMode:
             readModel.threads.find((entry) => entry.id === command.threadId)?.runtimeMode ??

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -4,7 +4,9 @@ import {
   getAppModelOptions,
   getSlashModelOptions,
   normalizeCustomModelSlugs,
+  normalizeWorktreeBranchPrefixSetting,
   resolveAppModelSelection,
+  resolveWorktreeBranchPrefixSetting,
 } from "./appSettings";
 
 describe("normalizeCustomModelSlugs", () => {
@@ -80,5 +82,16 @@ describe("getSlashModelOptions", () => {
     );
 
     expect(options.map((option) => option.slug)).toEqual(["openai/gpt-oss-120b"]);
+  });
+});
+
+describe("worktree branch prefix settings", () => {
+  it("stores blank values as default-backed empty strings", () => {
+    expect(normalizeWorktreeBranchPrefixSetting("  ")).toBe("");
+    expect(resolveWorktreeBranchPrefixSetting("  ")).toBe("feature");
+  });
+
+  it("normalizes custom prefixes before persisting them", () => {
+    expect(normalizeWorktreeBranchPrefixSetting(" Bugfix/Hotfix/ ")).toBe("bugfix/hotfix");
   });
 });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1,11 +1,16 @@
 import { useCallback, useSyncExternalStore } from "react";
 import { Option, Schema } from "effect";
 import { type ProviderKind } from "@t3tools/contracts";
+import {
+  DEFAULT_WORKTREE_BRANCH_PREFIX,
+  sanitizeWorktreeBranchPrefix,
+} from "@t3tools/shared/git";
 import { getDefaultModel, getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 
 const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
 const MAX_CUSTOM_MODEL_COUNT = 32;
 export const MAX_CUSTOM_MODEL_LENGTH = 256;
+export const MAX_WORKTREE_BRANCH_PREFIX_LENGTH = 128;
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
 };
@@ -21,6 +26,9 @@ const AppSettingsSchema = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(
     Schema.withConstructorDefault(() => Option.some(false)),
   ),
+  worktreeBranchPrefix: Schema.String.check(
+    Schema.isMaxLength(MAX_WORKTREE_BRANCH_PREFIX_LENGTH),
+  ).pipe(Schema.withConstructorDefault(() => Option.some(""))),
   customCodexModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
   ),
@@ -67,9 +75,23 @@ export function normalizeCustomModelSlugs(
   return normalizedModels;
 }
 
+export function normalizeWorktreeBranchPrefixSetting(value: string | null | undefined): string {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return "";
+  }
+  return sanitizeWorktreeBranchPrefix(trimmed);
+}
+
+export function resolveWorktreeBranchPrefixSetting(value: string | null | undefined): string {
+  const normalized = normalizeWorktreeBranchPrefixSetting(value);
+  return normalized.length > 0 ? normalized : DEFAULT_WORKTREE_BRANCH_PREFIX;
+}
+
 function normalizeAppSettings(settings: AppSettings): AppSettings {
   return {
     ...settings,
+    worktreeBranchPrefix: normalizeWorktreeBranchPrefixSetting(settings.worktreeBranchPrefix),
     customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
   };
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -22,6 +22,7 @@ import {
   RuntimeMode,
   ProviderInteractionMode,
 } from "@t3tools/contracts";
+import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import {
   getDefaultModel,
   getDefaultReasoningEffort,
@@ -203,7 +204,12 @@ import { Toggle } from "./ui/toggle";
 import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
-import { getAppModelOptions, resolveAppModelSelection, useAppSettings } from "../appSettings";
+import {
+  getAppModelOptions,
+  resolveAppModelSelection,
+  resolveWorktreeBranchPrefixSetting,
+  useAppSettings,
+} from "../appSettings";
 import {
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
@@ -263,7 +269,6 @@ const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnsw
 const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
-const WORKTREE_BRANCH_PREFIX = "t3code";
 
 function readLastInvokedScriptByProjectFromStorage(): Record<string, string> {
   const stored = localStorage.getItem(LAST_INVOKED_SCRIPT_BY_PROJECT_KEY);
@@ -424,12 +429,6 @@ function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
-function buildTemporaryWorktreeBranchName(): string {
-  // Keep the 8-hex suffix shape for backend temporary-branch detection.
-  const token = crypto.randomUUID().slice(0, 8).toLowerCase();
-  return `${WORKTREE_BRANCH_PREFIX}/${token}`;
-}
-
 function cloneComposerImageForRetry(image: ComposerImageAttachment): ComposerImageAttachment {
   if (typeof URL === "undefined" || !image.previewUrl.startsWith("blob:")) {
     return image;
@@ -576,6 +575,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const setStoreThreadError = useStore((store) => store.setError);
   const setStoreThreadBranch = useStore((store) => store.setThreadBranch);
   const { settings } = useAppSettings();
+  const worktreeBranchPrefix = resolveWorktreeBranchPrefixSetting(settings.worktreeBranchPrefix);
   const navigate = useNavigate();
   const rawSearch = useSearch({
     strict: false,
@@ -2562,7 +2562,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       // On first message: lock in branch + create worktree if needed.
       if (baseBranchForWorktree) {
         beginSendPhase("preparing-worktree");
-        const newBranch = buildTemporaryWorktreeBranchName();
+        const newBranch = buildTemporaryWorktreeBranchName(worktreeBranchPrefix);
         const result = await createWorktreeMutation.mutateAsync({
           cwd: activeProject.cwd,
           branch: baseBranchForWorktree,
@@ -2683,6 +2683,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           ? { modelOptions: selectedModelOptionsForDispatch }
           : {}),
         ...(providerOptionsForDispatch ? { providerOptions: providerOptionsForDispatch } : {}),
+        worktreeBranchPrefix,
         provider: selectedProvider,
         assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
         runtimeMode,
@@ -2961,6 +2962,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
             ? { modelOptions: selectedModelOptionsForDispatch }
             : {}),
           ...(providerOptionsForDispatch ? { providerOptions: providerOptionsForDispatch } : {}),
+          worktreeBranchPrefix,
           assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
           runtimeMode,
           interactionMode: nextInteractionMode,
@@ -3003,6 +3005,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setComposerDraftInteractionMode,
       setThreadError,
       settings.enableAssistantStreaming,
+      worktreeBranchPrefix,
     ],
   );
 
@@ -3070,6 +3073,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
             ? { modelOptions: selectedModelOptionsForDispatch }
             : {}),
           ...(providerOptionsForDispatch ? { providerOptions: providerOptionsForDispatch } : {}),
+          worktreeBranchPrefix,
           assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
           runtimeMode,
           interactionMode: "default",
@@ -3125,6 +3129,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     selectedProvider,
     settings.enableAssistantStreaming,
     syncServerReadModel,
+    worktreeBranchPrefix,
   ]);
 
   const onProviderModelSelect = useCallback(

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -2,9 +2,18 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import { type ProviderKind } from "@t3tools/contracts";
+import {
+  buildWorktreeBranchName,
+  DEFAULT_WORKTREE_BRANCH_PREFIX,
+} from "@t3tools/shared/git";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 
-import { MAX_CUSTOM_MODEL_LENGTH, useAppSettings } from "../appSettings";
+import {
+  MAX_CUSTOM_MODEL_LENGTH,
+  MAX_WORKTREE_BRANCH_PREFIX_LENGTH,
+  resolveWorktreeBranchPrefixSetting,
+  useAppSettings,
+} from "../appSettings";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
@@ -96,6 +105,9 @@ function SettingsRouteView() {
 
   const codexBinaryPath = settings.codexBinaryPath;
   const codexHomePath = settings.codexHomePath;
+  const effectiveWorktreeBranchPrefix = resolveWorktreeBranchPrefixSetting(
+    settings.worktreeBranchPrefix,
+  );
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
 
   const openKeybindingsFile = useCallback(() => {
@@ -467,6 +479,72 @@ function SettingsRouteView() {
                   </Button>
                 </div>
               ) : null}
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <div className="mb-4">
+                <h2 className="text-sm font-medium text-foreground">Git</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Configure how the New worktree flow names its temporary and generated branches.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                <label htmlFor="worktree-branch-prefix" className="block space-y-1">
+                  <span className="text-xs font-medium text-foreground">Worktree branch prefix</span>
+                  <Input
+                    id="worktree-branch-prefix"
+                    value={settings.worktreeBranchPrefix}
+                    onChange={(event) =>
+                      updateSettings({ worktreeBranchPrefix: event.target.value })
+                    }
+                    placeholder={DEFAULT_WORKTREE_BRANCH_PREFIX}
+                    maxLength={MAX_WORKTREE_BRANCH_PREFIX_LENGTH}
+                    spellCheck={false}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    Blank falls back to <code>{DEFAULT_WORKTREE_BRANCH_PREFIX}</code>. Slashes are
+                    allowed for namespaces.
+                  </span>
+                </label>
+
+                <div className="rounded-lg border border-border bg-background px-3 py-2 text-xs text-muted-foreground">
+                  <p>
+                    Effective prefix:{" "}
+                    <code className="font-medium text-foreground">{effectiveWorktreeBranchPrefix}</code>
+                  </p>
+                  <p className="mt-1">
+                    Temporary branch:{" "}
+                    <code className="font-medium text-foreground">
+                      {`${effectiveWorktreeBranchPrefix}/a1b2c3d4`}
+                    </code>
+                  </p>
+                  <p className="mt-1">
+                    Generated branch:{" "}
+                    <code className="font-medium text-foreground">
+                      {buildWorktreeBranchName(effectiveWorktreeBranchPrefix, "fix-timeout-loop")}
+                    </code>
+                  </p>
+                </div>
+
+                {settings.worktreeBranchPrefix !== defaults.worktreeBranchPrefix ? (
+                  <div className="flex justify-end">
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      onClick={() =>
+                        updateSettings({
+                          worktreeBranchPrefix: defaults.worktreeBranchPrefix,
+                        })
+                      }
+                    >
+                      Restore default
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
             </section>
 
             <section className="rounded-2xl border border-border bg-card p-5">

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -186,6 +186,25 @@ it.effect("accepts provider-scoped model options in thread.turn.start", () =>
   }),
 );
 
+it.effect("preserves worktree branch prefix in thread.turn.start", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeThreadTurnStartCommand({
+      type: "thread.turn.start",
+      commandId: "cmd-turn-prefix",
+      threadId: "thread-1",
+      message: {
+        messageId: "msg-prefix",
+        role: "user",
+        text: "hello",
+        attachments: [],
+      },
+      worktreeBranchPrefix: "bugfix",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.strictEqual(parsed.worktreeBranchPrefix, "bugfix");
+  }),
+);
+
 it.effect(
   "decodes thread.turn-start-requested defaults for provider, runtime mode, and interaction mode",
   () =>
@@ -196,6 +215,7 @@ it.effect(
         createdAt: "2026-01-01T00:00:00.000Z",
       });
       assert.strictEqual(parsed.provider, undefined);
+      assert.strictEqual(parsed.worktreeBranchPrefix, undefined);
       assert.strictEqual(parsed.runtimeMode, DEFAULT_RUNTIME_MODE);
       assert.strictEqual(parsed.interactionMode, DEFAULT_PROVIDER_INTERACTION_MODE);
     }),

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -371,6 +371,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
   model: Schema.optional(TrimmedNonEmptyString),
   modelOptions: Schema.optional(ProviderModelOptions),
   providerOptions: Schema.optional(ProviderStartOptions),
+  worktreeBranchPrefix: Schema.optional(TrimmedNonEmptyString),
   assistantDeliveryMode: Schema.optional(AssistantDeliveryMode),
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(() => DEFAULT_RUNTIME_MODE)),
   interactionMode: ProviderInteractionMode.pipe(
@@ -393,6 +394,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
   model: Schema.optional(TrimmedNonEmptyString),
   modelOptions: Schema.optional(ProviderModelOptions),
   providerOptions: Schema.optional(ProviderStartOptions),
+  worktreeBranchPrefix: Schema.optional(TrimmedNonEmptyString),
   assistantDeliveryMode: Schema.optional(AssistantDeliveryMode),
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode,
@@ -673,6 +675,7 @@ export const ThreadTurnStartRequestedPayload = Schema.Struct({
   model: Schema.optional(TrimmedNonEmptyString),
   modelOptions: Schema.optional(ProviderModelOptions),
   providerOptions: Schema.optional(ProviderStartOptions),
+  worktreeBranchPrefix: Schema.optional(TrimmedNonEmptyString),
   assistantDeliveryMode: Schema.optional(AssistantDeliveryMode),
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(() => DEFAULT_RUNTIME_MODE)),
   interactionMode: ProviderInteractionMode.pipe(

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildTemporaryWorktreeBranchName,
+  buildWorktreeBranchName,
+  DEFAULT_WORKTREE_BRANCH_PREFIX,
+  isTemporaryWorktreeBranch,
+  sanitizeBranchFragment,
+  sanitizeWorktreeBranchPrefix,
+} from "./git";
+
+describe("sanitizeBranchFragment", () => {
+  it("strips URLs before normalizing branch fragments", () => {
+    expect(
+      sanitizeBranchFragment(
+        "Verify Poland weight fix merge https://github.com/pingdotgg/t3code/pull/123",
+      ),
+    ).toBe("verify-poland-weight-fix-merge");
+  });
+});
+
+describe("sanitizeWorktreeBranchPrefix", () => {
+  it("falls back to the default prefix when the input is empty", () => {
+    expect(sanitizeWorktreeBranchPrefix("")).toBe(DEFAULT_WORKTREE_BRANCH_PREFIX);
+  });
+
+  it("normalizes slash-separated custom prefixes", () => {
+    expect(sanitizeWorktreeBranchPrefix(" Team/Feature/ ")).toBe("team/feature");
+  });
+});
+
+describe("buildWorktreeBranchName", () => {
+  it("avoids duplicating the configured prefix", () => {
+    expect(buildWorktreeBranchName("feature", " Feature/refine-toolbar-actions ")).toBe(
+      "feature/refine-toolbar-actions",
+    );
+  });
+});
+
+describe("temporary worktree branches", () => {
+  it("builds temporary branches under the configured prefix", () => {
+    const branch = buildTemporaryWorktreeBranchName("Bugfix/");
+
+    expect(branch).toMatch(/^bugfix\/[0-9a-f]{8}$/);
+    expect(isTemporaryWorktreeBranch(branch, "bugfix")).toBe(true);
+  });
+});

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -1,13 +1,28 @@
-/**
- * Sanitize an arbitrary string into a valid, lowercase git branch fragment.
- * Strips quotes, collapses separators, limits to 64 chars.
- */
-export function sanitizeBranchFragment(raw: string): string {
-  const normalized = raw
+export const DEFAULT_WORKTREE_BRANCH_PREFIX = "feature";
+const TEMP_WORKTREE_BRANCH_TOKEN_PATTERN = /^[0-9a-f]{8}$/;
+
+function stripBranchNoise(raw: string): string {
+  return raw
     .trim()
     .toLowerCase()
+    .replace(/^refs\/heads\//, "")
+    .replace(/\bhttps?:\/\/\S+/g, " ")
+    .replace(/\bwww\.\S+/g, " ")
+    .replace(/\b(?:github|gitlab|bitbucket)\.com\/\S+/g, " ")
     .replace(/['"`]/g, "")
     .replace(/^[./\s_-]+|[./\s_-]+$/g, "");
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Sanitize an arbitrary string into a valid, lowercase git branch fragment.
+ * Strips quotes and URLs, collapses separators, limits to 64 chars.
+ */
+export function sanitizeBranchFragment(raw: string): string {
+  const normalized = stripBranchNoise(raw);
 
   const branchFragment = normalized
     .replace(/[^a-z0-9/_-]+/g, "-")
@@ -18,6 +33,15 @@ export function sanitizeBranchFragment(raw: string): string {
     .replace(/[./_-]+$/g, "");
 
   return branchFragment.length > 0 ? branchFragment : "update";
+}
+
+export function sanitizeWorktreeBranchPrefix(raw: string | null | undefined): string {
+  const trimmed = raw?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return DEFAULT_WORKTREE_BRANCH_PREFIX;
+  }
+  const normalized = sanitizeBranchFragment(trimmed);
+  return normalized.length > 0 ? normalized : DEFAULT_WORKTREE_BRANCH_PREFIX;
 }
 
 /**
@@ -33,6 +57,37 @@ export function sanitizeFeatureBranchName(raw: string): string {
 }
 
 const AUTO_FEATURE_BRANCH_FALLBACK = "feature/update";
+
+export function buildWorktreeBranchName(
+  prefixRaw: string | null | undefined,
+  rawFragment: string,
+): string {
+  const prefix = sanitizeWorktreeBranchPrefix(prefixRaw);
+  const sanitizedFragment = sanitizeBranchFragment(rawFragment);
+  const branchFragment =
+    sanitizedFragment === prefix
+      ? ""
+      : sanitizedFragment.startsWith(`${prefix}/`)
+        ? sanitizedFragment.slice(prefix.length + 1)
+        : sanitizedFragment;
+  return `${prefix}/${branchFragment.length > 0 ? branchFragment : "update"}`;
+}
+
+export function buildTemporaryWorktreeBranchName(prefixRaw: string | null | undefined): string {
+  return `${sanitizeWorktreeBranchPrefix(prefixRaw)}/${crypto.randomUUID().slice(0, 8).toLowerCase()}`;
+}
+
+export function isTemporaryWorktreeBranch(
+  branch: string,
+  prefixRaw: string | null | undefined,
+): boolean {
+  const prefix = sanitizeWorktreeBranchPrefix(prefixRaw);
+  const match = branch.trim().toLowerCase().match(new RegExp(`^${escapeRegExp(prefix)}\\/(.+)$`));
+  if (!match) {
+    return false;
+  }
+  return TEMP_WORKTREE_BRANCH_TOKEN_PATTERN.test(match[1] ?? "");
+}
 
 /**
  * Resolve a unique `feature/…` branch name that doesn't collide with


### PR DESCRIPTION
## What changed

This change makes the New worktree flow use a configurable branch prefix instead of hardcoding `t3code/...`. The setting is available on the settings screen, and both the UI worktree creation step and the server-side first-message rename step now use the same prefix.

## Why it matters

- Teams can switch the worktree flow to `feature/...` or another namespace without patching the code.
- Generated worktree branch names stop dragging pasted GitHub URLs into the branch slug.
- Existing temporary `t3code/<hex>` worktree branches still get renamed on first use after the upgrade.

## Technical background

- Shared git utilities now own worktree branch prefix sanitizing, temporary branch generation, final branch generation, and temporary-branch detection.
- `thread.turn.start` now carries an optional `worktreeBranchPrefix` so the browser and server stay in sync for the first-turn rename flow.
- The server keeps a small legacy detection path for old `t3code/<hex>` temporary branches to avoid stranding in-progress worktrees.

## Implementation details

- Added a new app setting plus a settings-screen preview for the effective temporary and generated branch names.
- Replaced the duplicated hardcoded prefix logic in `ChatView` and `ProviderCommandReactor` with shared helpers.
- Added tests for shared branch sanitizing, orchestration contract decoding, app settings normalization, and the provider reactor rename flow.

## Validation

- `npx -y bun@1.3.9 run --cwd packages/shared test src/git.test.ts`
- `npx -y bun@1.3.9 run --cwd packages/contracts test src/orchestration.test.ts`
- `npx -y bun@1.3.9 run --cwd apps/server test src/orchestration/Layers/ProviderCommandReactor.test.ts`
- `npx -y bun@1.3.9 run --cwd apps/web test src/appSettings.test.ts`
- `npx -y bun@1.3.9 run lint`
- `npx -y bun@1.3.9 run typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make worktree branch prefix configurable via app settings
> - Adds a `worktreeBranchPrefix` field to app settings, defaulting to `'feature'` when unset, with normalization and sanitization logic in [appSettings.ts](https://github.com/pingdotgg/t3code/pull/778/files#diff-4f500b80c5f743d5b39d3f07498169da0c26f4bf9b5a2127453a90c04a4c49cc).
> - Introduces shared git utilities (`sanitizeWorktreeBranchPrefix`, `buildWorktreeBranchName`, `buildTemporaryWorktreeBranchName`, `isTemporaryWorktreeBranch`) in [git.ts](https://github.com/pingdotgg/t3code/pull/778/files#diff-e52ee60f55e13d4ce4a00279168044882e11385edf15a01ad8073cd1442f5785) to replace duplicated in-file implementations.
> - Exposes a Git settings section in [_chat.settings.tsx](https://github.com/pingdotgg/t3code/pull/778/files#diff-0707e8295d0df761e405e66f02211b55d56c6eaea1ac3cb99562525a9c589cc6) where users can set the prefix, with live examples of generated and temporary branch names.
> - Threads `worktreeBranchPrefix` through the orchestration pipeline: `ThreadTurnStartCommand` → `thread.turn-start-requested` event → `ProviderCommandReactor`, replacing the previously hardcoded `t3code` prefix.
> - Behavioral Change: existing temporary branches created under the legacy `t3code` prefix will no longer be detected as temporary worktree branches by `isTemporaryWorktreeBranch` unless the prefix is explicitly set to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e544127.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->