### PR TITLE
Fix: Fixed the menu opening for text in-between sentences of the prompt.

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -923,6 +923,42 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("keeps slash command suggestions active while typing before a suffix mention", async () => {
+    useComposerDraftStore.getState().setPrompt(THREAD_ID, "@AGENTS.md ");
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-target-prefix-typing" as MessageId,
+        targetText: "prefix typing target",
+      }),
+    });
+
+    try {
+      const composerEditor = await waitForComposerEditor();
+      composerEditor.focus();
+
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(composerEditor);
+      range.collapse(true);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+
+      await waitForLayout();
+      document.execCommand("insertText", false, "/mo");
+
+      await vi.waitFor(
+        () => {
+          expect(document.body.textContent).toContain("/model");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("keeps long proposed plans lightweight until the user expands them", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -57,7 +57,9 @@ import {
   type ComposerSlashCommand,
   type ComposerTrigger,
   type ComposerTriggerKind,
+  collapseExpandedComposerCursor,
   detectComposerTrigger,
+  detectComposerTriggerInPrefix,
   expandCollapsedComposerCursor,
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
@@ -215,7 +217,12 @@ import {
 import { shouldUseCompactComposerFooter } from "./composerFooterLayout";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { clamp } from "effect/Number";
-import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./ComposerPromptEditor";
+import {
+  ComposerPromptEditor,
+  type ComposerPromptEditorChangeMeta,
+  type ComposerPromptEditorHandle,
+  type ComposerPromptEditorSnapshot,
+} from "./ComposerPromptEditor";
 import { estimateTimelineMessageHeight } from "./timelineHeight";
 
 function formatMessageMeta(createdAt: string, duration: string | null): string {
@@ -244,6 +251,33 @@ function formatWorkingTimer(startIso: string, endIso: string): string | null {
   }
 
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+function detectComposerTriggerFromChange(
+  value: string,
+  cursor: number,
+  metadata: ComposerPromptEditorChangeMeta,
+): ComposerTrigger | null {
+  if (metadata.changeKind === "content-edit") {
+    return detectComposerTriggerInPrefix(metadata.prefixText);
+  }
+  if (metadata.cursorAdjacentToMention) {
+    return null;
+  }
+  return detectComposerTrigger(value, expandCollapsedComposerCursor(value, cursor));
+}
+
+function detectComposerTriggerFromSnapshot(snapshot: ComposerPromptEditorSnapshot): ComposerTrigger | null {
+  if (snapshot.changeKind === "content-edit") {
+    return detectComposerTriggerInPrefix(snapshot.prefixText);
+  }
+  if (snapshot.cursorAdjacentToMention) {
+    return null;
+  }
+  return detectComposerTrigger(
+    snapshot.value,
+    expandCollapsedComposerCursor(snapshot.value, snapshot.cursor),
+  );
 }
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
@@ -2836,7 +2870,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
 
   const onChangeActivePendingUserInputCustomAnswer = useCallback(
-    (questionId: string, value: string, nextCursor: number, cursorAdjacentToMention: boolean) => {
+    (questionId: string, value: string, nextCursor: number, metadata: ComposerPromptEditorChangeMeta) => {
       if (!activePendingUserInput) {
         return;
       }
@@ -2852,11 +2886,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         },
       }));
       setComposerCursor(nextCursor);
-      setComposerTrigger(
-        cursorAdjacentToMention
-          ? null
-          : detectComposerTrigger(value, expandCollapsedComposerCursor(value, nextCursor)),
-      );
+      setComposerTrigger(detectComposerTriggerFromChange(value, nextCursor, metadata));
     },
     [activePendingUserInput],
   );
@@ -3191,6 +3221,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
         return false;
       }
       const next = replaceTextRange(promptRef.current, rangeStart, rangeEnd, replacement);
+      const nextExpandedCursor = next.cursor;
+      const nextCollapsedCursor = collapseExpandedComposerCursor(next.text, nextExpandedCursor);
       promptRef.current = next.text;
       const activePendingQuestion = activePendingProgress?.activeQuestion;
       if (activePendingQuestion && activePendingUserInput) {
@@ -3207,33 +3239,38 @@ export default function ChatView({ threadId }: ChatViewProps) {
       } else {
         setPrompt(next.text);
       }
-      setComposerCursor(next.cursor);
-      setComposerTrigger(detectComposerTrigger(next.text, next.cursor));
+      setComposerCursor(nextCollapsedCursor);
+      setComposerTrigger(detectComposerTriggerInPrefix(next.text.slice(0, nextExpandedCursor)));
       window.requestAnimationFrame(() => {
-        composerEditorRef.current?.focusAt(next.cursor);
+        composerEditorRef.current?.focusAt(nextCollapsedCursor);
       });
       return true;
     },
     [activePendingProgress?.activeQuestion, activePendingUserInput, setPrompt],
   );
 
-  const readComposerSnapshot = useCallback((): { value: string; cursor: number } => {
+  const readComposerSnapshot = useCallback((): ComposerPromptEditorSnapshot => {
     const editorSnapshot = composerEditorRef.current?.readSnapshot();
     if (editorSnapshot) {
       return editorSnapshot;
     }
-    return { value: promptRef.current, cursor: composerCursor };
+    return {
+      value: promptRef.current,
+      cursor: composerCursor,
+      prefixText: promptRef.current,
+      changeKind: "selection-move",
+      cursorAdjacentToMention: false,
+    };
   }, [composerCursor]);
 
   const resolveActiveComposerTrigger = useCallback((): {
-    snapshot: { value: string; cursor: number };
+    snapshot: ComposerPromptEditorSnapshot;
     trigger: ComposerTrigger | null;
   } => {
     const snapshot = readComposerSnapshot();
-    const expandedCursor = expandCollapsedComposerCursor(snapshot.value, snapshot.cursor);
     return {
       snapshot,
-      trigger: detectComposerTrigger(snapshot.value, expandedCursor),
+      trigger: detectComposerTriggerFromSnapshot(snapshot),
     };
   }, [readComposerSnapshot]);
 
@@ -3321,27 +3358,20 @@ export default function ChatView({ threadId }: ChatViewProps) {
       workspaceEntriesQuery.isFetching);
 
   const onPromptChange = useCallback(
-    (nextPrompt: string, nextCursor: number, cursorAdjacentToMention: boolean) => {
+    (nextPrompt: string, nextCursor: number, metadata: ComposerPromptEditorChangeMeta) => {
       if (activePendingProgress?.activeQuestion && activePendingUserInput) {
         onChangeActivePendingUserInputCustomAnswer(
           activePendingProgress.activeQuestion.id,
           nextPrompt,
           nextCursor,
-          cursorAdjacentToMention,
+          metadata,
         );
         return;
       }
       promptRef.current = nextPrompt;
       setPrompt(nextPrompt);
       setComposerCursor(nextCursor);
-      setComposerTrigger(
-        cursorAdjacentToMention
-          ? null
-          : detectComposerTrigger(
-              nextPrompt,
-              expandCollapsedComposerCursor(nextPrompt, nextCursor),
-            ),
-      );
+      setComposerTrigger(detectComposerTriggerFromChange(nextPrompt, nextCursor, metadata));
     },
     [
       activePendingProgress?.activeQuestion,

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -354,6 +354,62 @@ function $readSelectionOffsetFromEditorState(fallback: number): number {
   return Math.max(0, Math.min(offset, composerLength));
 }
 
+function readTextPrefixForComposerOffset(
+  node: LexicalNode,
+  remainingRef: { value: number },
+): string {
+  if (remainingRef.value <= 0) {
+    return "";
+  }
+
+  if (node instanceof ComposerMentionNode) {
+    remainingRef.value -= 1;
+    return node.getTextContent();
+  }
+
+  if ($isTextNode(node)) {
+    const size = node.getTextContentSize();
+    const take = Math.min(remainingRef.value, size);
+    remainingRef.value -= take;
+    return node.getTextContent().slice(0, take);
+  }
+
+  if ($isLineBreakNode(node)) {
+    remainingRef.value -= 1;
+    return "\n";
+  }
+
+  if ($isElementNode(node)) {
+    let prefix = "";
+    for (const child of node.getChildren()) {
+      prefix += readTextPrefixForComposerOffset(child, remainingRef);
+      if (remainingRef.value <= 0) {
+        break;
+      }
+    }
+    return prefix;
+  }
+
+  return "";
+}
+
+function $readComposerPrefixTextAtOffset(offset: number): string {
+  const root = $getRoot();
+  const composerLength = $getComposerRootLength();
+  const boundedOffset = Math.max(0, Math.min(offset, composerLength));
+  const remainingRef = { value: boundedOffset };
+  let prefix = "";
+
+  for (const child of root.getChildren()) {
+    prefix += readTextPrefixForComposerOffset(child, remainingRef);
+    if (remainingRef.value <= 0) {
+      break;
+    }
+  }
+
+  return prefix;
+}
+
 function $appendTextWithLineBreaks(parent: ElementNode, text: string): void {
   const lines = text.split("\n");
   for (let index = 0; index < lines.length; index += 1) {
@@ -387,7 +443,28 @@ export interface ComposerPromptEditorHandle {
   focus: () => void;
   focusAt: (cursor: number) => void;
   focusAtEnd: () => void;
-  readSnapshot: () => { value: string; cursor: number };
+  readSnapshot: () => ComposerPromptEditorSnapshot;
+}
+
+export type ComposerPromptEditorChangeKind = "content-edit" | "selection-move";
+
+export type ComposerPromptEditorChangeMeta =
+  | {
+      changeKind: "content-edit";
+      cursorAdjacentToMention: boolean;
+      prefixText: string;
+    }
+  | {
+      changeKind: "selection-move";
+      cursorAdjacentToMention: boolean;
+    };
+
+export interface ComposerPromptEditorSnapshot {
+  value: string;
+  cursor: number;
+  prefixText: string;
+  changeKind: ComposerPromptEditorChangeKind;
+  cursorAdjacentToMention: boolean;
 }
 
 interface ComposerPromptEditorProps {
@@ -396,7 +473,11 @@ interface ComposerPromptEditorProps {
   disabled: boolean;
   placeholder: string;
   className?: string;
-  onChange: (nextValue: string, nextCursor: number, cursorAdjacentToMention: boolean) => void;
+  onChange: (
+    nextValue: string,
+    nextCursor: number,
+    metadata: ComposerPromptEditorChangeMeta,
+  ) => void;
   onCommandKeyDown?: (
     key: "ArrowDown" | "ArrowUp" | "Enter" | "Tab",
     event: KeyboardEvent,
@@ -632,7 +713,14 @@ function ComposerPromptEditorInner({
 }: ComposerPromptEditorInnerProps) {
   const [editor] = useLexicalComposerContext();
   const onChangeRef = useRef(onChange);
-  const snapshotRef = useRef({ value, cursor: clampCursor(value, cursor) });
+  const initialCursor = clampCursor(value, cursor);
+  const snapshotRef = useRef<ComposerPromptEditorSnapshot>({
+    value,
+    cursor: initialCursor,
+    prefixText: value.slice(0, initialCursor),
+    changeKind: "selection-move",
+    cursorAdjacentToMention: false,
+  });
 
   useEffect(() => {
     onChangeRef.current = onChange;
@@ -655,7 +743,16 @@ function ComposerPromptEditorInner({
       });
     }
 
-    snapshotRef.current = { value, cursor: normalizedCursor };
+    snapshotRef.current = {
+      value,
+      cursor: normalizedCursor,
+      prefixText:
+        previousSnapshot.value === value
+          ? previousSnapshot.prefixText
+          : value.slice(0, normalizedCursor),
+      changeKind: previousSnapshot.changeKind,
+      cursorAdjacentToMention: previousSnapshot.cursorAdjacentToMention,
+    };
 
     const rootElement = editor.getRootElement();
     if (!rootElement || document.activeElement !== rootElement) {
@@ -676,16 +773,29 @@ function ComposerPromptEditorInner({
       editor.update(() => {
         $setSelectionAtComposerOffset(boundedCursor);
       });
+      let prefixText = snapshotRef.current.prefixText;
+      editor.getEditorState().read(() => {
+        prefixText = $readComposerPrefixTextAtOffset(boundedCursor);
+      });
+      const cursorAdjacentToMention =
+        isCollapsedCursorAdjacentToMention(snapshotRef.current.value, boundedCursor, "left") ||
+        isCollapsedCursorAdjacentToMention(snapshotRef.current.value, boundedCursor, "right");
       snapshotRef.current = {
         value: snapshotRef.current.value,
         cursor: boundedCursor,
+        prefixText,
+        changeKind: "selection-move",
+        cursorAdjacentToMention,
       };
-      onChangeRef.current(snapshotRef.current.value, boundedCursor, false);
+      onChangeRef.current(snapshotRef.current.value, boundedCursor, {
+        changeKind: "selection-move",
+        cursorAdjacentToMention,
+      });
     },
     [editor],
   );
 
-  const readSnapshot = useCallback((): { value: string; cursor: number } => {
+  const readSnapshot = useCallback((): ComposerPromptEditorSnapshot => {
     let snapshot = snapshotRef.current;
     editor.getEditorState().read(() => {
       const nextValue = $getRoot().getTextContent();
@@ -697,6 +807,9 @@ function ComposerPromptEditorInner({
       snapshot = {
         value: nextValue,
         cursor: nextCursor,
+        prefixText: $readComposerPrefixTextAtOffset(nextCursor),
+        changeKind: snapshotRef.current.changeKind,
+        cursorAdjacentToMention: snapshotRef.current.cursorAdjacentToMention,
       };
     });
     snapshotRef.current = snapshot;
@@ -725,18 +838,35 @@ function ComposerPromptEditorInner({
       const nextValue = $getRoot().getTextContent();
       const fallbackCursor = clampCursor(nextValue, snapshotRef.current.cursor);
       const nextCursor = clampCursor(nextValue, $readSelectionOffsetFromEditorState(fallbackCursor));
+      const nextPrefixText = $readComposerPrefixTextAtOffset(nextCursor);
       const previousSnapshot = snapshotRef.current;
       if (previousSnapshot.value === nextValue && previousSnapshot.cursor === nextCursor) {
         return;
       }
-      snapshotRef.current = {
-        value: nextValue,
-        cursor: nextCursor,
-      };
+      const changeKind: ComposerPromptEditorChangeKind =
+        previousSnapshot.value === nextValue ? "selection-move" : "content-edit";
       const cursorAdjacentToMention =
         isCollapsedCursorAdjacentToMention(nextValue, nextCursor, "left") ||
         isCollapsedCursorAdjacentToMention(nextValue, nextCursor, "right");
-      onChangeRef.current(nextValue, nextCursor, cursorAdjacentToMention);
+      snapshotRef.current = {
+        value: nextValue,
+        cursor: nextCursor,
+        prefixText: nextPrefixText,
+        changeKind,
+        cursorAdjacentToMention,
+      };
+      if (changeKind === "content-edit") {
+        onChangeRef.current(nextValue, nextCursor, {
+          changeKind,
+          cursorAdjacentToMention,
+          prefixText: nextPrefixText,
+        });
+        return;
+      }
+      onChangeRef.current(nextValue, nextCursor, {
+        changeKind,
+        cursorAdjacentToMention,
+      });
     });
   }, []);
 

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  collapseExpandedComposerCursor,
   detectComposerTrigger,
+  detectComposerTriggerInPrefix,
   expandCollapsedComposerCursor,
   isCollapsedCursorAdjacentToMention,
   parseStandaloneComposerSlashCommand,
@@ -68,6 +70,18 @@ describe("replaceTextRange", () => {
   });
 });
 
+describe("collapseExpandedComposerCursor", () => {
+  it("maps expanded mention cursor to collapsed cursor", () => {
+    const text = "what's in my @AGENTS.md fsfdas";
+    const expandedCursorAfterMention = "what's in my @AGENTS.md ".length;
+    const collapsedCursorAfterMention = "what's in my ".length + 2;
+
+    expect(collapseExpandedComposerCursor(text, expandedCursorAfterMention)).toBe(
+      collapsedCursorAfterMention,
+    );
+  });
+});
+
 describe("expandCollapsedComposerCursor", () => {
   it("keeps cursor unchanged when no mention segment is present", () => {
     expect(expandCollapsedComposerCursor("plain text", 5)).toBe(5);
@@ -122,6 +136,17 @@ describe("isCollapsedCursorAdjacentToMention", () => {
     expect(isCollapsedCursorAdjacentToMention(text, mentionStart, "right")).toBe(true);
     expect(isCollapsedCursorAdjacentToMention(text, mentionEnd, "right")).toBe(false);
     expect(isCollapsedCursorAdjacentToMention(text, mentionStart - 1, "right")).toBe(false);
+  });
+});
+
+describe("detectComposerTriggerInPrefix", () => {
+  it("ignores suffix text after the caret during edit-time trigger detection", () => {
+    expect(detectComposerTriggerInPrefix("/mo")).toEqual({
+      kind: "slash-command",
+      query: "mo",
+      rangeStart: 0,
+      rangeEnd: 3,
+    });
   });
 });
 

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -61,6 +61,38 @@ export function expandCollapsedComposerCursor(text: string, cursorInput: number)
   return expandedCursor;
 }
 
+export function collapseExpandedComposerCursor(text: string, cursorInput: number): number {
+  const expandedCursor = clampCursor(text, cursorInput);
+  const segments = splitPromptIntoComposerSegments(text);
+  if (segments.length === 0) {
+    return expandedCursor;
+  }
+
+  let remaining = expandedCursor;
+  let collapsedCursor = 0;
+
+  for (const segment of segments) {
+    if (segment.type === "mention") {
+      const expandedLength = segment.path.length + 1;
+      if (remaining <= expandedLength) {
+        return collapsedCursor + (remaining === 0 ? 0 : 1);
+      }
+      remaining -= expandedLength;
+      collapsedCursor += 1;
+      continue;
+    }
+
+    const segmentLength = segment.text.length;
+    if (remaining <= segmentLength) {
+      return collapsedCursor + remaining;
+    }
+    remaining -= segmentLength;
+    collapsedCursor += segmentLength;
+  }
+
+  return collapsedCursor;
+}
+
 function collapsedSegmentLength(segment: { type: "text"; text: string } | { type: "mention" }): number {
   return segment.type === "mention" ? 1 : segment.text.length;
 }
@@ -158,6 +190,10 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
     rangeStart: tokenStart,
     rangeEnd: cursor,
   };
+}
+
+export function detectComposerTriggerInPrefix(prefixText: string): ComposerTrigger | null {
+  return detectComposerTrigger(prefixText, prefixText.length);
 }
 
 export function parseStandaloneComposerSlashCommand(text: string): Exclude<


### PR DESCRIPTION
Issue: 
Can't open file selector menu when adding text in-between sentences:

https://github.com/user-attachments/assets/49d01bcb-c8b8-4825-9a8a-6aff25249fd9

After this fix:


https://github.com/user-attachments/assets/468d8105-2dd0-43d5-b328-d3390c329182





Changes:

  - Prefix-bounded trigger detection while typing: composer edits now resolve triggers using only the text before the caret, so suffix mentions no longer interfere.
  
  - Preserved full-text caret navigation: mention jump / cursor movement behavior still uses the full prompt.
  
  - Editor change handling split: ComposerPromptEditor.tsx now distinguishes content-edit vs selection-move, and sends prefix text on content edits.
  
  - Composer logic updates: added helpers for prefix trigger detection and for converting replacement cursors back to collapsed editor positions.
  
  - Mid-prompt replacement fix: inserting mentions/slash commands in the middle of a prompt now keeps trailing text and restores the cursor correctly.
  
  - Coverage: added unit tests plus a browser regression for typing before a suffix mention.
  
  - Validation: bun lint and bun typecheck passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix slash command menu not opening when typing before a suffix mention in the composer
> - Adds prefix-only trigger detection so slash command suggestions are computed from text before the caret, ignoring any suffix (e.g. a trailing mention).
> - Introduces `detectComposerTriggerInPrefix` and `collapseExpandedComposerCursor` in [composer-logic.ts](https://github.com/pingdotgg/t3code/pull/783/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6) to support this.
> - Extends [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/783/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4) to report `prefixText`, `changeKind` (`content-edit` vs `selection-move`), and `cursorAdjacentToMention` in change callbacks.
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/783/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to use the new metadata for trigger detection, suppressing suggestions when the caret is adjacent to a mention.
> - Behavioral Change: trigger detection for the composer now ignores text after the caret; menus will no longer open when the cursor is immediately adjacent to a mention.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20a7a9a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->