### PR TITLE
Fix: Add tooltip to locked sandbox mode toggle

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -121,7 +121,7 @@ export default function BranchToolbar({
                 />
               }
             >
-              Local
+              {activeWorktreePath ? "Worktree" : "Local"}
             </PopoverTrigger>
             <PopoverPopup tooltipStyle side="bottom" align="start">
               Start a new thread to use worktrees


### PR DESCRIPTION
I wanted to create a worktree but was confused why clicking on "main" didn't do anything. It also didnt show a lock or anything.

I then realised you cant change an existing thread, and needed to start a new thread. This PR fixes the lock icon and also shows a tooltip. (If you prefer just the lock to work and no tooltip, happy to change that also).

Before
<img width="793" height="163" alt="image" src="https://github.com/user-attachments/assets/1a91a957-5d1e-4607-910c-c15d10d57de2" />

After
<img width="793" height="179" alt="image" src="https://github.com/user-attachments/assets/f81c6ae9-0c29-4603-898d-4f259cfe8e71" />

Built with 4.6, reviewed (and corrected) with 5.4.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tooltip to disabled sandbox mode toggle in `BranchToolbar`
> When the environment is locked and no worktree is active, the 'Local' button now renders as a disabled-styled button wrapped in a `Popover` that shows a tooltip on hover ('Start a new thread to use worktrees'). Previously this state rendered plain text with no user guidance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f71e9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->