### PR TITLE
fix: ensure Homebrew paths are on PATH for Codex CLI detection (#777)

### DIFF
--- a/apps/desktop/src/fixPath.ts
+++ b/apps/desktop/src/fixPath.ts
@@ -1,4 +1,4 @@
-import { readPathFromLoginShell } from "@t3tools/shared/shell";
+import { ensureCommonMacPaths, readPathFromLoginShell } from "@t3tools/shared/shell";
 
 export function fixPath(): void {
   if (process.platform !== "darwin") return;
@@ -12,4 +12,8 @@ export function fixPath(): void {
   } catch {
     // Keep inherited PATH if shell lookup fails.
   }
+
+  // Ensure well-known macOS binary directories (e.g. Homebrew) are on PATH
+  // even when the login-shell probe fails or returns a partial result.
+  ensureCommonMacPaths();
 }

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -1,6 +1,6 @@
 import * as OS from "node:os";
 import { Effect, Path } from "effect";
-import { readPathFromLoginShell } from "@t3tools/shared/shell";
+import { ensureCommonMacPaths, readPathFromLoginShell } from "@t3tools/shared/shell";
 
 export function fixPath(): void {
   if (process.platform !== "darwin") return;
@@ -14,6 +14,10 @@ export function fixPath(): void {
   } catch {
     // Silently ignore — keep default PATH
   }
+
+  // Ensure well-known macOS binary directories (e.g. Homebrew) are on PATH
+  // even when the login-shell probe fails or returns a partial result.
+  ensureCommonMacPaths();
 }
 
 export const expandHomePath = Effect.fn(function* (input: string) {

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { extractPathFromShellOutput, readPathFromLoginShell } from "./shell";
+import { COMMON_MACOS_PATHS, ensureCommonMacPaths, extractPathFromShellOutput, readPathFromLoginShell } from "./shell";
 
 describe("extractPathFromShellOutput", () => {
   it("extracts the path between capture markers", () => {
@@ -51,5 +51,63 @@ describe("readPathFromLoginShell", () => {
     expect(args?.[1]).toContain("__T3CODE_PATH_START__");
     expect(args?.[1]).toContain("__T3CODE_PATH_END__");
     expect(options).toEqual({ encoding: "utf8", timeout: 5000 });
+  });
+});
+
+describe("ensureCommonMacPaths", () => {
+  const originalPlatform = process.platform;
+  const originalPath = process.env.PATH;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    process.env.PATH = originalPath;
+  });
+
+  it("appends missing Homebrew paths on darwin", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    process.env.PATH = "/usr/bin:/bin";
+
+    ensureCommonMacPaths();
+
+    const dirs = process.env.PATH!.split(":");
+    for (const p of COMMON_MACOS_PATHS) {
+      expect(dirs).toContain(p);
+    }
+    // Original paths are still present at the start
+    expect(dirs[0]).toBe("/usr/bin");
+    expect(dirs[1]).toBe("/bin");
+  });
+
+  it("does not duplicate paths already present", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    process.env.PATH = `/usr/bin:/bin:${COMMON_MACOS_PATHS.join(":")}`;
+
+    ensureCommonMacPaths();
+
+    const dirs = process.env.PATH!.split(":");
+    for (const p of COMMON_MACOS_PATHS) {
+      expect(dirs.filter((d) => d === p)).toHaveLength(1);
+    }
+  });
+
+  it("handles empty PATH", () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    process.env.PATH = "";
+
+    ensureCommonMacPaths();
+
+    const dirs = process.env.PATH!.split(":");
+    for (const p of COMMON_MACOS_PATHS) {
+      expect(dirs).toContain(p);
+    }
+  });
+
+  it("is a no-op on non-darwin platforms", () => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    process.env.PATH = "/usr/bin:/bin";
+
+    ensureCommonMacPaths();
+
+    expect(process.env.PATH).toBe("/usr/bin:/bin");
   });
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -36,3 +36,31 @@ export function readPathFromLoginShell(
   });
   return extractPathFromShellOutput(output) ?? undefined;
 }
+
+/**
+ * Well-known macOS binary directories that should always be on PATH
+ * so that tools installed via Homebrew are discoverable even when the
+ * app is launched from the Dock / Finder (which inherits a minimal PATH).
+ */
+export const COMMON_MACOS_PATHS = [
+  "/opt/homebrew/bin", // Apple Silicon Homebrew
+  "/opt/homebrew/sbin",
+  "/usr/local/bin", // Intel Homebrew / user binaries
+  "/usr/local/sbin",
+] as const;
+
+/**
+ * Append any missing well-known macOS binary directories to
+ * `process.env.PATH`.  This is a no-op on non-darwin platforms.
+ */
+export function ensureCommonMacPaths(): void {
+  if (process.platform !== "darwin") return;
+
+  const currentPath = process.env.PATH ?? "";
+  const currentDirs = new Set(currentPath.split(":").filter(Boolean));
+  const missing = COMMON_MACOS_PATHS.filter((p) => !currentDirs.has(p));
+
+  if (missing.length > 0) {
+    process.env.PATH = [currentPath, ...missing].filter(Boolean).join(":");
+  }
+}


### PR DESCRIPTION
On macOS, GUI-launched apps inherit a minimal PATH that excludes Homebrew directories (/opt/homebrew/bin, /usr/local/bin, etc.).

The existing fixPath() attempts to read PATH from a login shell, but if this fails (timeout, shell error, etc.), the Codex CLI installed via Homebrew is not found.

This adds ensureCommonMacPaths() which appends well-known macOS binary directories to process.env.PATH if they are missing, ensuring tools installed via Homebrew are always discoverable.

Closes #777

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Append Homebrew and common macOS binary paths to PATH for CLI detection
> - Adds `ensureCommonMacPaths()` to [`packages/shared/src/shell.ts`](https://github.com/pingdotgg/t3code/pull/790/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce), which appends any missing entries from `/opt/homebrew/bin`, `/opt/homebrew/sbin`, `/usr/local/bin`, and `/usr/local/sbin` to `process.env.PATH` on darwin, and is a no-op on other platforms.
> - Calls `ensureCommonMacPaths()` at the end of `fixPath()` in both [`apps/desktop/src/fixPath.ts`](https://github.com/pingdotgg/t3code/pull/790/files#diff-b5a16ed958b8e407001f062cf0edea569a7adceeb262d35d520692991a3c3a11) and [`apps/server/src/os-jank.ts`](https://github.com/pingdotgg/t3code/pull/790/files#diff-01387cb8f0521a1e152ae377c15805f328384e404ccf93da7a82c02d30cf694c), so Homebrew-installed binaries like the Codex CLI are discoverable even when the login-shell PATH probe fails or returns incomplete results.
> - Existing PATH entries are preserved; only missing directories are appended.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0d9020.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->