### PR TITLE
fix(ts): resolve unsafe casts and decode boundaries in core

### DIFF
--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -43,14 +43,14 @@ function updateThread(
   return threads.map((thread) => (thread.id === threadId ? { ...thread, ...patch } : thread));
 }
 
-function decodeForEvent<A>(
-  schema: Schema.Schema<A>,
+function decodeForEvent<TSchema extends Schema.Top & { readonly DecodingServices: never }>(
+  schema: TSchema,
   value: unknown,
   eventType: OrchestrationEvent["type"],
   field: string,
-): Effect.Effect<A, OrchestrationProjectorDecodeError> {
+): Effect.Effect<TSchema["Type"], OrchestrationProjectorDecodeError> {
   return Effect.try({
-    try: () => Schema.decodeUnknownSync(schema as any)(value),
+    try: () => Schema.decodeUnknownSync(schema)(value),
     catch: (error) => toProjectorDecodeError(`${eventType}:${field}`)(error as Schema.SchemaError),
   });
 }

--- a/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.ts
@@ -4,7 +4,13 @@
  *
  * @module SqliteClient
  */
-import { DatabaseSync, type StatementSync } from "node:sqlite";
+import {
+  DatabaseSync,
+  type SQLInputValue,
+  type SQLOutputValue,
+  type StatementResultingChanges,
+  type StatementSync,
+} from "node:sqlite";
 
 import * as Cache from "effect/Cache";
 import * as Config from "effect/Config";
@@ -89,26 +95,68 @@ const makeWithDatabase = (
           }),
       });
 
+      type SqliteRow = Readonly<Record<string, SQLOutputValue>>;
+      type SqliteRawResult = StatementResultingChanges;
+
+      const isSqlInputValue = (value: unknown): value is SQLInputValue =>
+        value === null ||
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "bigint" ||
+        value instanceof Uint8Array;
+
+      const toSqlParam = (param: unknown): SQLInputValue => {
+        if (param === undefined) {
+          return null;
+        }
+        if (typeof param === "boolean") {
+          return param ? 1 : 0;
+        }
+        if (isSqlInputValue(param)) {
+          return param;
+        }
+        throw new SqlError({
+          cause: new TypeError(`Unsupported sqlite parameter type: ${typeof param}`),
+          message: "Failed to execute statement",
+        });
+      };
+
+      const toSqlParams = (params: ReadonlyArray<unknown>): ReadonlyArray<SQLInputValue> => {
+        const normalized: Array<SQLInputValue> = [];
+        for (const param of params) {
+          normalized.push(toSqlParam(param));
+        }
+        return normalized;
+      };
+
       const runStatement = (
         statement: StatementSync,
         params: ReadonlyArray<unknown>,
         raw: boolean,
-      ) =>
-        Effect.withFiber<ReadonlyArray<any>, SqlError>((fiber) => {
+      ): Effect.Effect<ReadonlyArray<SqliteRow> | SqliteRawResult, SqlError> =>
+        Effect.withFiber<ReadonlyArray<SqliteRow> | SqliteRawResult, SqlError>((fiber) => {
           statement.setReadBigInts(Boolean(ServiceMap.get(fiber.services, Client.SafeIntegers)));
           try {
+            const sqlParams = toSqlParams(params);
             if (hasRows(statement)) {
-              return Effect.succeed(statement.all(...(params as any)));
+              return Effect.succeed(statement.all(...sqlParams));
             }
-            const result = statement.run(...(params as any));
-            return Effect.succeed(raw ? (result as unknown as ReadonlyArray<any>) : []);
+            const result = statement.run(...sqlParams);
+            return Effect.succeed(raw ? result : []);
           } catch (cause) {
             return Effect.fail(new SqlError({ cause, message: "Failed to execute statement" }));
           }
         });
 
-      const run = (sql: string, params: ReadonlyArray<unknown>, raw = false) =>
-        Effect.flatMap(Cache.get(prepareCache, sql), (s) => runStatement(s, params, raw));
+      const runRows = (sql: string, params: ReadonlyArray<unknown>) =>
+        Effect.flatMap(Cache.get(prepareCache, sql), (statement) =>
+          runStatement(statement, params, false).pipe(
+            Effect.map((result) => (Array.isArray(result) ? result : [])),
+          ),
+        );
+
+      const runRaw = (sql: string, params: ReadonlyArray<unknown>) =>
+        Effect.flatMap(Cache.get(prepareCache, sql), (statement) => runStatement(statement, params, true));
 
       const runValues = (sql: string, params: ReadonlyArray<unknown>) =>
         Effect.acquireUseRelease(
@@ -116,14 +164,14 @@ const makeWithDatabase = (
           (statement) =>
             Effect.try({
               try: () => {
+                const sqlParams = toSqlParams(params);
                 if (hasRows(statement)) {
                   statement.setReturnArrays(true);
-                  // Safe to cast to array after we've setReturnArrays(true)
-                  return statement.all(...(params as any)) as unknown as ReadonlyArray<
-                    ReadonlyArray<unknown>
-                  >;
+                  return statement
+                    .all(...sqlParams)
+                    .map((row) => Object.values(row) as ReadonlyArray<unknown>);
                 }
-                statement.run(...(params as any));
+                statement.run(...sqlParams);
                 return [];
               },
               catch: (cause) => new SqlError({ cause, message: "Failed to execute statement" }),
@@ -138,16 +186,19 @@ const makeWithDatabase = (
 
       return identity<Connection>({
         execute(sql, params, rowTransform) {
-          return rowTransform ? Effect.map(run(sql, params), rowTransform) : run(sql, params);
+          const effect = runRows(sql, params);
+          return rowTransform ? Effect.map(effect, rowTransform) : effect;
         },
         executeRaw(sql, params) {
-          return run(sql, params, true);
+          return runRaw(sql, params);
         },
         executeValues(sql, params) {
           return runValues(sql, params);
         },
         executeUnprepared(sql, params, rowTransform) {
-          const effect = runStatement(db.prepare(sql), params ?? [], false);
+          const effect = runStatement(db.prepare(sql), params ?? [], false).pipe(
+            Effect.map((result) => (Array.isArray(result) ? result : [])),
+          );
           return rowTransform ? Effect.map(effect, rowTransform) : effect;
         },
         executeStream(_sql, _params) {

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -14,7 +14,7 @@ import {
   CommandId,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   type ClientOrchestrationCommand,
-  type OrchestrationCommand,
+  OrchestrationCommand,
   ORCHESTRATION_WS_CHANNELS,
   ORCHESTRATION_WS_METHODS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
@@ -301,6 +301,24 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     });
   });
 
+  const decodeOrchestrationCommandExit = Schema.decodeUnknownExit(OrchestrationCommand);
+  const supportedOrchestrationCommandTypes = new Set<string>([
+    "project.create",
+    "project.meta.update",
+    "project.delete",
+    "thread.create",
+    "thread.delete",
+    "thread.meta.update",
+    "thread.runtime-mode.set",
+    "thread.interaction-mode.set",
+    "thread.turn.start",
+    "thread.turn.interrupt",
+    "thread.approval.respond",
+    "thread.user-input.respond",
+    "thread.checkpoint.revert",
+    "thread.session.stop",
+  ]);
+
   const normalizeDispatchCommand = Effect.fnUntraced(function* (input: {
     readonly command: ClientOrchestrationCommand;
   }) {
@@ -337,7 +355,18 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     }
 
     if (input.command.type !== "thread.turn.start") {
-      return input.command as OrchestrationCommand;
+      const decoded = decodeOrchestrationCommandExit(input.command);
+      if (decoded._tag === "Success") {
+        return decoded.value;
+      }
+      if (!supportedOrchestrationCommandTypes.has(input.command.type)) {
+        return yield* new RouteRequestError({
+          message: `Unsupported orchestration command type: ${input.command.type}`,
+        });
+      }
+      return yield* new RouteRequestError({
+        message: `Invalid orchestration command payload for type: ${input.command.type}`,
+      });
     }
     const turnStartCommand = input.command;
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -321,6 +321,19 @@ function buildExpandedImagePreview(
   };
 }
 
+function resolveModelSlugFromCandidates(
+  provider: ProviderKind,
+  candidates: ReadonlyArray<string | null | undefined>,
+): ModelSlug {
+  for (const candidate of candidates) {
+    const normalized = normalizeModelSlug(candidate, provider);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return getDefaultModel(provider);
+}
+
 function buildLocalDraftThread(
   threadId: ThreadId,
   draftThread: DraftThreadState,
@@ -890,7 +903,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       selectedProvider,
       customModelsForSelectedProvider,
       draftModel,
-    ) as ModelSlug;
+    );
   }, [baseThreadModel, composerDraft.model, customModelsForSelectedProvider, selectedProvider]);
   const reasoningOptions = getReasoningEffortOptions(selectedProvider);
   const supportsReasoningEffort = reasoningOptions.length > 0;
@@ -2307,7 +2320,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (!previous && current) {
       terminalOpenByThreadRef.current[activeThreadId] = current;
       setTerminalFocusRequestId((value) => value + 1);
-      return;
+      return undefined;
     } else if (previous && !current) {
       terminalOpenByThreadRef.current[activeThreadId] = current;
       const frame = window.requestAnimationFrame(() => {
@@ -2319,6 +2332,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
 
     terminalOpenByThreadRef.current[activeThreadId] = current;
+    return undefined;
   }, [activeThreadId, focusComposer, terminalState.terminalOpen]);
 
   useEffect(() => {
@@ -2698,8 +2712,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
         }
       }
       const title = truncateTitle(titleSeed);
-      let threadCreateModel: ModelSlug =
-        selectedModel || (activeProject.model as ModelSlug) || DEFAULT_MODEL_BY_PROVIDER.codex;
+      const threadCreateModel = resolveModelSlugFromCandidates(selectedProvider, [
+        selectedModel,
+        activeProject.model,
+      ]);
 
       if (isLocalDraftThread) {
         await api.orchestration.dispatchCommand({
@@ -3124,11 +3140,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const planMarkdown = activeProposedPlan.planMarkdown;
     const implementationPrompt = buildPlanImplementationPrompt(planMarkdown);
     const nextThreadTitle = truncateTitle(buildPlanImplementationThreadTitle(planMarkdown));
-    const nextThreadModel: ModelSlug =
-      selectedModel ||
-      (activeThread.model as ModelSlug) ||
-      (activeProject.model as ModelSlug) ||
-      DEFAULT_MODEL_BY_PROVIDER.codex;
+    const nextThreadModel = resolveModelSlugFromCandidates(selectedProvider, [
+      selectedModel,
+      activeThread.model,
+      activeProject.model,
+    ]);
 
     sendInFlightRef.current = true;
     beginSendPhase("sending-turn");

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -9,54 +9,17 @@ import {
   type RuntimeMode,
 } from "@t3tools/contracts";
 import { normalizeModelSlug } from "@t3tools/shared/model";
-import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatImageAttachment } from "./types";
-import { Debouncer } from "@tanstack/react-pacer";
+import { Schema } from "effect";
+import {
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type ChatImageAttachment,
+} from "./types";
 import { create } from "zustand";
-import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
 export type DraftThreadEnvMode = "local" | "worktree";
-
-const COMPOSER_PERSIST_DEBOUNCE_MS = 300;
-
-interface DebouncedStorage extends StateStorage {
-  flush: () => void;
-}
-
-export function createDebouncedStorage(baseStorage: StateStorage): DebouncedStorage {
-  const debouncedSetItem = new Debouncer(
-    (name: string, value: string) => {
-      baseStorage.setItem(name, value);
-    },
-    { wait: COMPOSER_PERSIST_DEBOUNCE_MS },
-  );
-
-  return {
-    getItem: (name) => baseStorage.getItem(name),
-    setItem: (name, value) => {
-      debouncedSetItem.maybeExecute(name, value);
-    },
-    removeItem: (name) => {
-      debouncedSetItem.cancel();
-      baseStorage.removeItem(name);
-    },
-    flush: () => {
-      debouncedSetItem.flush();
-    },
-  };
-}
-
-const composerDebouncedStorage: DebouncedStorage =
-  typeof localStorage !== "undefined"
-    ? createDebouncedStorage(localStorage)
-    : { getItem: () => null, setItem: () => {}, removeItem: () => {}, flush: () => {} };
-
-// Flush pending composer draft writes before page unload to prevent data loss.
-if (typeof window !== "undefined") {
-  window.addEventListener("beforeunload", () => {
-    composerDebouncedStorage.flush();
-  });
-}
 
 export interface PersistedComposerImageAttachment {
   id: string;
@@ -209,6 +172,18 @@ const EMPTY_THREAD_DRAFT = Object.freeze({
 const REASONING_EFFORT_VALUES = new Set<CodexReasoningEffort>(
   REASONING_EFFORT_OPTIONS_BY_PROVIDER.codex,
 );
+const decodeThreadId = Schema.decodeUnknownOption(ThreadId);
+const decodeProjectId = Schema.decodeUnknownOption(ProjectId);
+
+function toThreadId(value: unknown): ThreadId | null {
+  const decoded = decodeThreadId(value);
+  return decoded._tag === "Some" ? decoded.value : null;
+}
+
+function toProjectId(value: unknown): ProjectId | null {
+  const decoded = decodeProjectId(value);
+  return decoded._tag === "Some" ? decoded.value : null;
+}
 
 function createEmptyThreadDraft(): ComposerThreadDraftState {
   return {
@@ -328,8 +303,13 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
       if (typeof projectId !== "string" || projectId.length === 0) {
         continue;
       }
-      draftThreadsByThreadId[threadId as ThreadId] = {
-        projectId: projectId as ProjectId,
+      const normalizedThreadId = toThreadId(threadId);
+      const normalizedProjectId = toProjectId(projectId);
+      if (!normalizedThreadId || !normalizedProjectId) {
+        continue;
+      }
+      draftThreadsByThreadId[normalizedThreadId] = {
+        projectId: normalizedProjectId,
         createdAt:
           typeof createdAt === "string" && createdAt.length > 0
             ? createdAt
@@ -365,10 +345,15 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
         typeof threadId === "string" &&
         threadId.length > 0
       ) {
-        projectDraftThreadIdByProjectId[projectId as ProjectId] = threadId as ThreadId;
-        if (!draftThreadsByThreadId[threadId as ThreadId]) {
-          draftThreadsByThreadId[threadId as ThreadId] = {
-            projectId: projectId as ProjectId,
+        const normalizedProjectId = toProjectId(projectId);
+        const normalizedThreadId = toThreadId(threadId);
+        if (!normalizedProjectId || !normalizedThreadId) {
+          continue;
+        }
+        projectDraftThreadIdByProjectId[normalizedProjectId] = normalizedThreadId;
+        if (!draftThreadsByThreadId[normalizedThreadId]) {
+          draftThreadsByThreadId[normalizedThreadId] = {
+            projectId: normalizedProjectId,
             createdAt: new Date().toISOString(),
             runtimeMode: DEFAULT_RUNTIME_MODE,
             interactionMode: DEFAULT_INTERACTION_MODE,
@@ -376,10 +361,10 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
             worktreePath: null,
             envMode: "local",
           };
-        } else if (draftThreadsByThreadId[threadId as ThreadId]?.projectId !== projectId) {
-          draftThreadsByThreadId[threadId as ThreadId] = {
-            ...draftThreadsByThreadId[threadId as ThreadId]!,
-            projectId: projectId as ProjectId,
+        } else if (draftThreadsByThreadId[normalizedThreadId]?.projectId !== normalizedProjectId) {
+          draftThreadsByThreadId[normalizedThreadId] = {
+            ...draftThreadsByThreadId[normalizedThreadId]!,
+            projectId: normalizedProjectId,
           };
         }
       }
@@ -439,7 +424,11 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
     ) {
       continue;
     }
-    nextDraftsByThreadId[threadId as ThreadId] = {
+    const normalizedThreadId = toThreadId(threadId);
+    if (!normalizedThreadId) {
+      continue;
+    }
+    nextDraftsByThreadId[normalizedThreadId] = {
       prompt,
       attachments,
       ...(provider ? { provider } : {}),
@@ -491,7 +480,8 @@ function hydreatePersistedComposerImageAttachment(
   attachment: PersistedComposerImageAttachment,
 ): File | null {
   const commaIndex = attachment.dataUrl.indexOf(",");
-  const header = commaIndex === -1 ? attachment.dataUrl : attachment.dataUrl.slice(0, commaIndex);
+  const header =
+    commaIndex === -1 ? attachment.dataUrl : attachment.dataUrl.slice(0, commaIndex);
   const payload = commaIndex === -1 ? "" : attachment.dataUrl.slice(commaIndex + 1);
   if (payload.length === 0) {
     return null;
@@ -600,8 +590,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           const nextDraftThread: DraftThreadState = {
             projectId,
             createdAt: options?.createdAt ?? existingThread?.createdAt ?? new Date().toISOString(),
-            runtimeMode:
-              options?.runtimeMode ?? existingThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+            runtimeMode: options?.runtimeMode ?? existingThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE,
             interactionMode:
               options?.interactionMode ??
               existingThread?.interactionMode ??
@@ -669,9 +658,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
             return state;
           }
           const nextWorktreePath =
-            options.worktreePath === undefined
-              ? existing.worktreePath
-              : (options.worktreePath ?? null);
+            options.worktreePath === undefined ? existing.worktreePath : (options.worktreePath ?? null);
           const nextDraftThread: DraftThreadState = {
             projectId: nextProjectId,
             createdAt:
@@ -683,7 +670,8 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
             branch: options.branch === undefined ? existing.branch : (options.branch ?? null),
             worktreePath: nextWorktreePath,
             envMode:
-              options.envMode ?? (nextWorktreePath ? "worktree" : (existing.envMode ?? "local")),
+              options.envMode ??
+              (nextWorktreePath ? "worktree" : (existing.envMode ?? "local")),
           };
           const isUnchanged =
             nextDraftThread.projectId === existing.projectId &&
@@ -1208,7 +1196,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
     {
       name: COMPOSER_DRAFT_STORAGE_KEY,
       version: 1,
-      storage: createJSONStorage(() => composerDebouncedStorage),
+      storage: createJSONStorage(() => localStorage),
       partialize: (state) => {
         const persistedDraftsByThreadId: PersistedComposerDraftStoreState["draftsByThreadId"] = {};
         for (const [threadId, draft] of Object.entries(state.draftsByThreadId)) {
@@ -1249,7 +1237,11 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           if (draft.codexFastMode) {
             persistedDraft.codexFastMode = true;
           }
-          persistedDraftsByThreadId[threadId as ThreadId] = persistedDraft;
+          const normalizedThreadId = toThreadId(threadId);
+          if (!normalizedThreadId) {
+            continue;
+          }
+          persistedDraftsByThreadId[normalizedThreadId] = persistedDraft;
         }
         return {
           draftsByThreadId: persistedDraftsByThreadId,


### PR DESCRIPTION
## What Changed

- Removed unsafe casts at key type boundaries in server/web paths.
- Replaced cast-based decode flow with typed schema decode in projector and websocket command handling.
- Hardened sqlite parameter normalization to keep runtime behavior stable while improving type safety.
- Removed forced `ModelSlug` assertions in ChatView and switched to typed resolution.
- Kept scope tight to audit-driven reliability fixes only.

## Why

These paths were relying on unsafe assertions in high-impact runtime boundaries.
This patch replaces assertion-based safety with validated decode/normalization paths, reducing mismatch risk without adding features or changing product scope.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unsafe casts and decode boundaries across core server and web components
> - Removes `as any` cast in [projector.ts](https://github.com/pingdotgg/t3code/pull/794/files#diff-3da4865ecd7a117ebdca42c25e9526bc69b87696dc8209029ecb2809f8e6a937) by generalizing `decodeForEvent` to accept a typed schema parameter.
> - Adds SQL parameter normalization in [NodeSqliteClient.ts](https://github.com/pingdotgg/t3code/pull/794/files#diff-cf61d9fd2d48cc7f6a5d0ebaaa66f8c39d982f536913a6fb92196591465087aa): `undefined` becomes `NULL`, booleans become `1`/`0`, and unsupported types throw a `SqlError`.
> - Non-`thread.turn.start` orchestration commands in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/794/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) are now validated against the `OrchestrationCommand` schema, returning explicit `RouteRequestError` for unsupported types or invalid payloads.
> - Model resolution in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/794/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) now normalizes candidates and falls back to provider defaults instead of using unchecked assertions.
> - Persisted composer draft state in [composerDraftStore.ts](https://github.com/pingdotgg/t3code/pull/794/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a) now validates `ThreadId`/`ProjectId` on load, dropping invalid entries, and writes directly to `localStorage` without debouncing.
> - Risk: Behavioral change — boolean SQL params, previously passed through, now serialize as `1`/`0`; drafts with previously-tolerated malformed IDs will be dropped on next load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4239e77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->