### PR TITLE
Add downloads page and shared marketing layout

### DIFF
--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -1,0 +1,228 @@
+---
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const {
+  title = "T3 Code",
+  description = "T3 Code — The best way to code with AI.",
+} = Astro.props;
+---
+
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" href="/favicon.ico" sizes="48x48" />
+    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <div class="page">
+      <nav class="nav">
+        <a href="/" class="nav-brand">
+          <img src="/icon.png" alt="T3" class="nav-icon" />
+        </a>
+        <a
+          href="https://github.com/pingdotgg/t3code"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="nav-github"
+        >
+          GitHub
+          <span class="nav-github-arrow" aria-hidden="true">&#8599;</span>
+        </a>
+      </nav>
+
+      <main class="main">
+        <slot />
+      </main>
+
+      <footer class="footer">
+        <span class="footer-copy">&copy; {new Date().getFullYear()} T3 Tools Inc</span>
+        <div class="footer-links">
+          <a href="https://github.com/pingdotgg/t3code" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://discord.gg/jn4EGJjrvv" target="_blank" rel="noopener noreferrer">Discord</a>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>
+
+<style is:global>
+  :root {
+    --bg: #09090b;
+    --fg: #fafafa;
+    --fg-muted: #a1a1aa;
+    --fg-dim: #71717a;
+    --border: rgba(255, 255, 255, 0.08);
+  }
+
+  * {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+  }
+
+  html {
+    color-scheme: dark;
+  }
+
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: "DM Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+    overflow-x: hidden;
+  }
+
+  body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0.035;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-repeat: repeat;
+    background-size: 256px 256px;
+    z-index: 9999;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  img {
+    display: block;
+    max-width: 100%;
+  }
+
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+</style>
+
+<style>
+  /* ── Page ── */
+
+  .page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+  }
+
+  /* ── Navbar ── */
+
+  .nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem 2.5rem;
+    opacity: 0.5;
+    transition: opacity 0.4s ease;
+  }
+
+  .nav:hover {
+    opacity: 1;
+  }
+
+  .nav-brand {
+    display: flex;
+    align-items: center;
+  }
+
+  .nav-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+  }
+
+  .nav-github {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--fg-muted);
+    font-size: 0.875rem;
+    transition: color 0.3s ease;
+  }
+
+  .nav-github:hover {
+    color: var(--fg);
+  }
+
+  .nav-github-arrow {
+    display: inline-block;
+    transition: transform 0.3s ease;
+  }
+
+  .nav-github:hover .nav-github-arrow {
+    transform: translateX(2px) translateY(-1px);
+  }
+
+  /* ── Main content ── */
+
+  .main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  /* ── Footer ── */
+
+  .footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.5rem 2.5rem;
+    font-size: 0.8rem;
+    color: var(--fg-dim);
+  }
+
+  .footer-links {
+    display: flex;
+    gap: 1.25rem;
+  }
+
+  .footer-links a {
+    color: var(--fg-dim);
+    transition: color 0.3s ease;
+  }
+
+  .footer-links a:hover {
+    color: var(--fg);
+  }
+
+  /* ── Mobile ── */
+
+  @media (max-width: 640px) {
+    .nav {
+      padding: 1.25rem;
+    }
+
+    .footer {
+      padding: 1.25rem;
+    }
+  }
+</style>

--- a/apps/marketing/src/lib/releases.ts
+++ b/apps/marketing/src/lib/releases.ts
@@ -1,0 +1,30 @@
+const REPO = "pingdotgg/t3code";
+
+export const RELEASES_URL = `https://github.com/${REPO}/releases`;
+
+const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
+const CACHE_KEY = "t3code-latest-release";
+
+export interface ReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
+
+export interface Release {
+  tag_name: string;
+  html_url: string;
+  assets: ReleaseAsset[];
+}
+
+export async function fetchLatestRelease(): Promise<Release> {
+  const cached = sessionStorage.getItem(CACHE_KEY);
+  if (cached) return JSON.parse(cached);
+
+  const data = await fetch(API_URL).then((r) => r.json());
+
+  if (data?.assets) {
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(data));
+  }
+
+  return data;
+}

--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -1,0 +1,271 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="Download — T3 Code" description="Download T3 Code for macOS, Windows, or Linux.">
+  <h1 class="heading">Download T3 Code</h1>
+  <p class="subheading">
+    <span id="version-label">Loading latest release&hellip;</span>
+    <a id="changelog-link" class="changelog-link" href="#" target="_blank" rel="noopener noreferrer" style="display:none">View changelog<span aria-hidden="true"> &#8599;</span></a>
+  </p>
+
+  <div class="platforms" id="platforms">
+    <!-- macOS -->
+    <section class="platform-section">
+      <div class="platform-header">
+        <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 814 1000" aria-hidden="true"><path fill="currentColor" d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg>
+        <h2 class="platform-name">macOS</h2>
+      </div>
+      <div class="download-cards">
+        <a class="download-card" data-asset="arm64.dmg" href="#">
+          <span class="card-arch">Apple Silicon (arm64)</span>
+          <span class="card-format">.dmg</span>
+        </a>
+        <a class="download-card" data-asset="x64.dmg" href="#">
+          <span class="card-arch">Intel (x64)</span>
+          <span class="card-format">.dmg</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- Windows -->
+    <section class="platform-section">
+      <div class="platform-header">
+        <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88" aria-hidden="true"><path fill="currentColor" d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"/></svg>
+        <h2 class="platform-name">Windows</h2>
+      </div>
+      <div class="download-cards">
+        <a class="download-card" data-asset="x64.exe" href="#">
+          <span class="card-arch">Windows 10, 11</span>
+          <span class="card-format">.exe</span>
+        </a>
+      </div>
+    </section>
+
+    <!-- Linux -->
+    <section class="platform-section">
+      <div class="platform-header">
+        <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 295" aria-hidden="true"><defs><linearGradient id="lt0" x1="48.548%" x2="51.047%" y1="115.276%" y2="41.364%"><stop offset="0%" stop-color="#FFEED7"/><stop offset="100%" stop-color="#BDBFC2"/></linearGradient><linearGradient id="lt6" x1="49.984%" x2="49.984%" y1="89.845%" y2="40.632%"><stop offset="0%" stop-color="#FFEED7"/><stop offset="100%" stop-color="#BDBFC2"/></linearGradient><linearGradient id="lt8" x1="49.841%" x2="50.241%" y1="13.229%" y2="94.673%"><stop offset="0%" stop-color="#FFF" stop-opacity=".8"/><stop offset="100%" stop-color="#FFF" stop-opacity="0"/></linearGradient><linearGradient id="ltc" x1="53.467%" x2="38.949%" y1="48.921%" y2="98.1%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient><linearGradient id="lte" x1="30.581%" x2="65.887%" y1="34.024%" y2="89.175%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient><linearGradient id="lti" x1="49.733%" x2="50.558%" y1="17.609%" y2="99.385%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient></defs><g fill="none"><path fill="#000" d="M63.213 215.474c-11.387-16.346-13.591-69.606 12.947-102.39C89.292 97.383 92.69 86.455 93.7 71.67c.734-16.805-11.846-66.851 35.537-70.616 48.027-3.857 45.364 43.526 45.088 68.596-.183 21.12 15.52 33.15 26.355 49.68 19.927 30.303 18.274 82.461-3.765 110.745-27.916 35.354-51.791 20.018-67.678 21.304-29.752 1.745-30.762 17.54-66.024-35.905"/><path fill="url(#lt6)" d="M81.027 145.684c6.52-14.785 20.386-40.772 20.662-60.883 0-15.978 47.843-19.835 51.7-3.856 3.856 15.978 13.59 39.853 19.834 51.424 6.245 11.478 24.335 48.118 5.051 80.074-17.356 28.284-69.973 50.69-98.073-3.856-9.55-18.917-7.806-42.333.826-62.903"/><path fill="url(#lt8)" d="M166.428 151.285c0 16.162-15.519 37.1-42.15 36.916-27.456.183-39.118-20.754-39.118-36.916 0-16.161 18.182-29.293 40.588-29.293 22.498.092 40.68 13.132 40.68 29.293"/><path fill="#000" stroke="#000" stroke-width=".977" d="M176.805 117.86c13.59 11.02 38.292 49.587 2.204 74.748-11.846 7.806 10.468 32.508 23.049 19.927 43.618-43.894-1.102-94.308-16.53-111.664-13.774-15.151-25.987 3.49-8.723 16.989z"/><path fill="#000" stroke="#000" stroke-width="1.25" d="M79.925 122.727c-8.907 14.509-30.211 48.669-1.652 66.484 38.384 23.6 27.548 47.108-7.53 25.895-49.404-29.568-5.97-89.257 13.774-112.03 22.59-25.529 4.316 4.683-4.592 19.65z"/><path fill="url(#ltc)" stroke="#E68C3F" stroke-width="6.25" d="M51.835 258.542c-20.57-10.928-50.414 2.112-39.578-27.457 2.204-6.704-3.214-16.805.275-23.325 4.133-7.989 13.04-6.244 18.366-11.57 5.234-5.51 8.54-15.06 18.366-13.59 9.734 1.468 16.254 13.406 23.049 28.099 5.05 10.468 22.865 25.253 21.672 37.007-1.47 17.998-21.948 21.396-42.15 10.836z" transform="translate(10)"/><path fill="url(#lte)" stroke="#E68C3F" stroke-width="6.251" d="M194.445 253.49c15.06-18.273 48.578-14.508 25.988-39.577-4.775-5.418-3.306-16.989-9.183-21.947-6.887-6.061-14.509-1.102-21.488-4.224-6.979-3.398-14.325-9.918-22.865-5.327-8.54 4.684-9.459 16.805-10.285 32.783-.735 11.479-11.203 30.671-5.602 41.231 8.081 16.346 29.11 14.142 43.435-2.938z" transform="translate(10)"/><path fill="url(#lti)" stroke="#E68C3F" stroke-width="3.75" d="M97.107 66.344c3.673-3.398 12.58-13.774 29.477-2.939 3.122 2.02 5.693 2.204 11.662 4.775 12.03 4.96 6.336 16.897-6.52 20.937-5.51 1.745-10.468 8.449-20.386 7.806-8.54-.46-10.744-6.06-15.978-9.091-9.275-5.234-10.652-12.305-5.602-16.07 5.051-3.765 6.98-5.143 7.347-5.418z" transform="translate(10)"/><path fill="#000" d="M133.186 57.712c-.092 5.234 2.48 9.458 5.877 9.458 3.306 0 6.153-4.224 6.245-9.366.091-5.234-2.48-9.459-5.878-9.459-3.397 0-6.152 4.225-6.244 9.367m-21.212.092c.459 4.316-1.194 7.989-3.582 8.356-2.387.276-4.683-2.938-5.142-7.254-.46-4.316 1.194-7.99 3.581-8.357 2.388-.275 4.684 2.939 5.143 7.255"/></g></svg>
+        <h2 class="platform-name">Linux</h2>
+      </div>
+      <div class="download-cards">
+        <a class="download-card" data-asset="x86_64.AppImage" href="#">
+          <span class="card-arch">x86_64</span>
+          <span class="card-format">AppImage</span>
+        </a>
+      </div>
+    </section>
+  </div>
+
+  <p class="releases-link">
+    Looking for older versions? Check the
+    <a href="https://github.com/pingdotgg/t3code/releases" target="_blank" rel="noopener noreferrer">
+      GitHub releases page<span aria-hidden="true"> &#8599;</span>
+    </a>
+  </p>
+</Layout>
+
+<script>
+  import { fetchLatestRelease, RELEASES_URL } from "../lib/releases";
+
+  async function init() {
+    const versionLabel = document.getElementById("version-label");
+    const cards = document.querySelectorAll<HTMLAnchorElement>(".download-card");
+
+    try {
+      const release = await fetchLatestRelease();
+
+      if (versionLabel && release.tag_name) {
+        versionLabel.textContent = `Latest (${release.tag_name})`;
+      }
+
+      const changelogLink = document.getElementById("changelog-link") as HTMLAnchorElement | null;
+      if (changelogLink && release.html_url) {
+        changelogLink.href = release.html_url;
+        changelogLink.style.display = "";
+      }
+
+      cards.forEach((card) => {
+        const suffix = card.dataset.asset;
+        if (!suffix) return;
+
+        const match = (release.assets ?? []).find((a) => a.name.endsWith(`-${suffix}`));
+        if (match) {
+          card.href = match.browser_download_url;
+        } else {
+          card.href = RELEASES_URL;
+        }
+      });
+    } catch {
+      if (versionLabel) {
+        versionLabel.textContent = "Could not load release info.";
+      }
+      cards.forEach((card) => {
+        card.href = RELEASES_URL;
+      });
+    }
+  }
+
+  init();
+</script>
+
+<style>
+  .main {
+    padding: 8vh 1.5rem 4rem;
+  }
+
+  /* ── Heading ── */
+
+  .heading {
+    font-weight: 500;
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    letter-spacing: -0.035em;
+    line-height: 1.15;
+    text-align: center;
+    margin-bottom: 0.5rem;
+    opacity: 0;
+    animation: fade-in 1s ease-out forwards;
+  }
+
+  .subheading {
+    font-size: 0.9rem;
+    color: var(--fg-dim);
+    margin-bottom: 3.5rem;
+    opacity: 0;
+    animation: fade-in 1s ease-out 0.1s forwards;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .changelog-link {
+    color: var(--fg-muted);
+    font-size: 0.8rem;
+    text-decoration: underline;
+    text-decoration-color: rgba(161, 161, 170, 0.4);
+    text-underline-offset: 3px;
+    transition: color 0.3s ease, text-decoration-color 0.3s ease;
+  }
+
+  .changelog-link:hover {
+    color: var(--fg);
+    text-decoration-color: var(--fg);
+  }
+
+  /* ── Platforms ── */
+
+  .platforms {
+    width: 100%;
+    max-width: 720px;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+    opacity: 0;
+    animation: fade-in 1s ease-out 0.2s forwards;
+  }
+
+  .platform-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  .platform-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .platform-icon {
+    width: 1.15em;
+    height: 1.15em;
+    color: var(--fg-muted);
+    flex-shrink: 0;
+  }
+
+  .platform-name {
+    font-weight: 500;
+    font-size: 1.1rem;
+    letter-spacing: -0.01em;
+  }
+
+  /* ── Download cards ── */
+
+  .download-cards {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+  }
+
+  .download-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: 0.85rem 1rem;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.02);
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .download-card:hover {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.15);
+    transform: translateY(-1px);
+  }
+
+  .download-card:active {
+    transform: translateY(0);
+  }
+
+  .card-arch {
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+
+  .card-format {
+    font-size: 0.8rem;
+    color: var(--fg-dim);
+  }
+
+  /* ── Releases link ── */
+
+  .releases-link {
+    margin-top: 3rem;
+    font-size: 0.825rem;
+    color: var(--fg-dim);
+    opacity: 0;
+    animation: fade-in 1s ease-out 0.35s forwards;
+  }
+
+  .releases-link a {
+    color: var(--fg-muted);
+    text-decoration: underline;
+    text-decoration-color: rgba(161, 161, 170, 0.4);
+    text-underline-offset: 3px;
+    transition: color 0.3s ease, text-decoration-color 0.3s ease;
+  }
+
+  .releases-link a:hover {
+    color: var(--fg);
+    text-decoration-color: var(--fg);
+  }
+
+  /* ── Mobile ── */
+
+  @media (max-width: 640px) {
+    .main {
+      padding: 5vh 1.25rem 4rem;
+    }
+
+    .platforms {
+      padding: 0 0.25rem;
+    }
+
+    .download-cards {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -1,75 +1,30 @@
 ---
+import Layout from "../layouts/Layout.astro";
 ---
 
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="T3 Code — The best way to code with AI." />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600&display=swap"
-      rel="stylesheet"
-    />
-    <link rel="icon" href="/favicon.ico" sizes="48x48" />
-    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <title>T3 Code</title>
-  </head>
-  <body>
-    <div class="page">
-      <nav class="nav">
-        <a href="/" class="nav-brand">
-          <img src="/icon.png" alt="T3" class="nav-icon" />
-        </a>
-        <a
-          href="https://github.com/pingdotgg/t3code"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="nav-github"
-        >
-          GitHub
-          <span class="nav-github-arrow" aria-hidden="true">&#8599;</span>
-        </a>
-      </nav>
+<Layout>
+  <h1 class="tagline">T3 Code is the best way to code with AI.</h1>
 
-      <main class="main">
-        <h1 class="tagline">T3 Code is the best way to code with AI.</h1>
+  <a
+    id="download-btn"
+    href="https://github.com/pingdotgg/t3code/releases"
+    class="hero-button"
+  >
+    <svg class="hero-button-icon hero-button-icon--apple" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 814 1000" aria-hidden="true"><path fill="currentColor" d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg>
+    <svg class="hero-button-icon hero-button-icon--windows" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88" aria-hidden="true"><path fill="currentColor" d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"/></svg>
+    <svg class="hero-button-icon hero-button-icon--linux" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 295" aria-hidden="true"><defs><linearGradient id="lt0" x1="48.548%" x2="51.047%" y1="115.276%" y2="41.364%"><stop offset="0%" stop-color="#FFEED7"/><stop offset="100%" stop-color="#BDBFC2"/></linearGradient><linearGradient id="lt6" x1="49.984%" x2="49.984%" y1="89.845%" y2="40.632%"><stop offset="0%" stop-color="#FFEED7"/><stop offset="100%" stop-color="#BDBFC2"/></linearGradient><linearGradient id="lt8" x1="49.841%" x2="50.241%" y1="13.229%" y2="94.673%"><stop offset="0%" stop-color="#FFF" stop-opacity=".8"/><stop offset="100%" stop-color="#FFF" stop-opacity="0"/></linearGradient><linearGradient id="ltc" x1="53.467%" x2="38.949%" y1="48.921%" y2="98.1%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient><linearGradient id="lte" x1="30.581%" x2="65.887%" y1="34.024%" y2="89.175%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient><linearGradient id="lti" x1="49.733%" x2="50.558%" y1="17.609%" y2="99.385%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient></defs><g fill="none"><path fill="#000" d="M63.213 215.474c-11.387-16.346-13.591-69.606 12.947-102.39C89.292 97.383 92.69 86.455 93.7 71.67c.734-16.805-11.846-66.851 35.537-70.616 48.027-3.857 45.364 43.526 45.088 68.596-.183 21.12 15.52 33.15 26.355 49.68 19.927 30.303 18.274 82.461-3.765 110.745-27.916 35.354-51.791 20.018-67.678 21.304-29.752 1.745-30.762 17.54-66.024-35.905"/><path fill="url(#lt6)" d="M81.027 145.684c6.52-14.785 20.386-40.772 20.662-60.883 0-15.978 47.843-19.835 51.7-3.856 3.856 15.978 13.59 39.853 19.834 51.424 6.245 11.478 24.335 48.118 5.051 80.074-17.356 28.284-69.973 50.69-98.073-3.856-9.55-18.917-7.806-42.333.826-62.903"/><path fill="url(#lt8)" d="M166.428 151.285c0 16.162-15.519 37.1-42.15 36.916-27.456.183-39.118-20.754-39.118-36.916 0-16.161 18.182-29.293 40.588-29.293 22.498.092 40.68 13.132 40.68 29.293"/><path fill="#000" stroke="#000" stroke-width=".977" d="M176.805 117.86c13.59 11.02 38.292 49.587 2.204 74.748-11.846 7.806 10.468 32.508 23.049 19.927 43.618-43.894-1.102-94.308-16.53-111.664-13.774-15.151-25.987 3.49-8.723 16.989z"/><path fill="#000" stroke="#000" stroke-width="1.25" d="M79.925 122.727c-8.907 14.509-30.211 48.669-1.652 66.484 38.384 23.6 27.548 47.108-7.53 25.895-49.404-29.568-5.97-89.257 13.774-112.03 22.59-25.529 4.316 4.683-4.592 19.65z"/><path fill="url(#ltc)" stroke="#E68C3F" stroke-width="6.25" d="M51.835 258.542c-20.57-10.928-50.414 2.112-39.578-27.457 2.204-6.704-3.214-16.805.275-23.325 4.133-7.989 13.04-6.244 18.366-11.57 5.234-5.51 8.54-15.06 18.366-13.59 9.734 1.468 16.254 13.406 23.049 28.099 5.05 10.468 22.865 25.253 21.672 37.007-1.47 17.998-21.948 21.396-42.15 10.836z" transform="translate(10)"/><path fill="url(#lte)" stroke="#E68C3F" stroke-width="6.251" d="M194.445 253.49c15.06-18.273 48.578-14.508 25.988-39.577-4.775-5.418-3.306-16.989-9.183-21.947-6.887-6.061-14.509-1.102-21.488-4.224-6.979-3.398-14.325-9.918-22.865-5.327-8.54 4.684-9.459 16.805-10.285 32.783-.735 11.479-11.203 30.671-5.602 41.231 8.081 16.346 29.11 14.142 43.435-2.938z" transform="translate(10)"/><path fill="url(#lti)" stroke="#E68C3F" stroke-width="3.75" d="M97.107 66.344c3.673-3.398 12.58-13.774 29.477-2.939 3.122 2.02 5.693 2.204 11.662 4.775 12.03 4.96 6.336 16.897-6.52 20.937-5.51 1.745-10.468 8.449-20.386 7.806-8.54-.46-10.744-6.06-15.978-9.091-9.275-5.234-10.652-12.305-5.602-16.07 5.051-3.765 6.98-5.143 7.347-5.418z" transform="translate(10)"/><path fill="#000" d="M133.186 57.712c-.092 5.234 2.48 9.458 5.877 9.458 3.306 0 6.153-4.224 6.245-9.366.091-5.234-2.48-9.459-5.878-9.459-3.397 0-6.152 4.225-6.244 9.367m-21.212.092c.459 4.316-1.194 7.989-3.582 8.356-2.387.276-4.683-2.938-5.142-7.254-.46-4.316 1.194-7.99 3.581-8.357 2.388-.275 4.684 2.939 5.143 7.255"/></g></svg>
+    <span id="download-label">Download now</span>
+  </a>
 
-        <a
-          id="download-btn"
-          href="https://github.com/pingdotgg/t3code/releases"
-          class="hero-button"
-        >
-          <svg class="hero-button-icon hero-button-icon--apple" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 814 1000" aria-hidden="true"><path fill="currentColor" d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg>
-          <svg class="hero-button-icon hero-button-icon--windows" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88" aria-hidden="true"><path fill="currentColor" d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"/></svg>
-          <svg class="hero-button-icon hero-button-icon--linux" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 295" aria-hidden="true"><defs><linearGradient id="lt0" x1="48.548%" x2="51.047%" y1="115.276%" y2="41.364%"><stop offset="0%" stop-color="#FFEED7"/><stop offset="100%" stop-color="#BDBFC2"/></linearGradient><linearGradient id="lt6" x1="49.984%" x2="49.984%" y1="89.845%" y2="40.632%"><stop offset="0%" stop-color="#FFEED7"/><stop offset="100%" stop-color="#BDBFC2"/></linearGradient><linearGradient id="lt8" x1="49.841%" x2="50.241%" y1="13.229%" y2="94.673%"><stop offset="0%" stop-color="#FFF" stop-opacity=".8"/><stop offset="100%" stop-color="#FFF" stop-opacity="0"/></linearGradient><linearGradient id="ltc" x1="53.467%" x2="38.949%" y1="48.921%" y2="98.1%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient><linearGradient id="lte" x1="30.581%" x2="65.887%" y1="34.024%" y2="89.175%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient><linearGradient id="lti" x1="49.733%" x2="50.558%" y1="17.609%" y2="99.385%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient></defs><g fill="none"><path fill="#000" d="M63.213 215.474c-11.387-16.346-13.591-69.606 12.947-102.39C89.292 97.383 92.69 86.455 93.7 71.67c.734-16.805-11.846-66.851 35.537-70.616 48.027-3.857 45.364 43.526 45.088 68.596-.183 21.12 15.52 33.15 26.355 49.68 19.927 30.303 18.274 82.461-3.765 110.745-27.916 35.354-51.791 20.018-67.678 21.304-29.752 1.745-30.762 17.54-66.024-35.905"/><path fill="url(#lt6)" d="M81.027 145.684c6.52-14.785 20.386-40.772 20.662-60.883 0-15.978 47.843-19.835 51.7-3.856 3.856 15.978 13.59 39.853 19.834 51.424 6.245 11.478 24.335 48.118 5.051 80.074-17.356 28.284-69.973 50.69-98.073-3.856-9.55-18.917-7.806-42.333.826-62.903"/><path fill="url(#lt8)" d="M166.428 151.285c0 16.162-15.519 37.1-42.15 36.916-27.456.183-39.118-20.754-39.118-36.916 0-16.161 18.182-29.293 40.588-29.293 22.498.092 40.68 13.132 40.68 29.293"/><path fill="#000" stroke="#000" stroke-width=".977" d="M176.805 117.86c13.59 11.02 38.292 49.587 2.204 74.748-11.846 7.806 10.468 32.508 23.049 19.927 43.618-43.894-1.102-94.308-16.53-111.664-13.774-15.151-25.987 3.49-8.723 16.989z"/><path fill="#000" stroke="#000" stroke-width="1.25" d="M79.925 122.727c-8.907 14.509-30.211 48.669-1.652 66.484 38.384 23.6 27.548 47.108-7.53 25.895-49.404-29.568-5.97-89.257 13.774-112.03 22.59-25.529 4.316 4.683-4.592 19.65z"/><path fill="url(#ltc)" stroke="#E68C3F" stroke-width="6.25" d="M51.835 258.542c-20.57-10.928-50.414 2.112-39.578-27.457 2.204-6.704-3.214-16.805.275-23.325 4.133-7.989 13.04-6.244 18.366-11.57 5.234-5.51 8.54-15.06 18.366-13.59 9.734 1.468 16.254 13.406 23.049 28.099 5.05 10.468 22.865 25.253 21.672 37.007-1.47 17.998-21.948 21.396-42.15 10.836z" transform="translate(10)"/><path fill="url(#lte)" stroke="#E68C3F" stroke-width="6.251" d="M194.445 253.49c15.06-18.273 48.578-14.508 25.988-39.577-4.775-5.418-3.306-16.989-9.183-21.947-6.887-6.061-14.509-1.102-21.488-4.224-6.979-3.398-14.325-9.918-22.865-5.327-8.54 4.684-9.459 16.805-10.285 32.783-.735 11.479-11.203 30.671-5.602 41.231 8.081 16.346 29.11 14.142 43.435-2.938z" transform="translate(10)"/><path fill="url(#lti)" stroke="#E68C3F" stroke-width="3.75" d="M97.107 66.344c3.673-3.398 12.58-13.774 29.477-2.939 3.122 2.02 5.693 2.204 11.662 4.775 12.03 4.96 6.336 16.897-6.52 20.937-5.51 1.745-10.468 8.449-20.386 7.806-8.54-.46-10.744-6.06-15.978-9.091-9.275-5.234-10.652-12.305-5.602-16.07 5.051-3.765 6.98-5.143 7.347-5.418z" transform="translate(10)"/><path fill="#000" d="M133.186 57.712c-.092 5.234 2.48 9.458 5.877 9.458 3.306 0 6.153-4.224 6.245-9.366.091-5.234-2.48-9.459-5.878-9.459-3.397 0-6.152 4.225-6.244 9.367m-21.212.092c.459 4.316-1.194 7.989-3.582 8.356-2.387.276-4.683-2.938-5.142-7.254-.46-4.316 1.194-7.99 3.581-8.357 2.388-.275 4.684 2.939 5.143 7.255"/></g></svg>
-          <span id="download-label">Download now</span>
-        </a>
+  <a href="/download" class="other-platforms">Other platforms</a>
 
-        <div class="screenshot-wrap">
-          <img src="/screenshot.jpeg" alt="T3 Code" class="screenshot" />
-        </div>
-
-      </main>
-
-      <footer class="footer">
-        <span class="footer-copy">&copy; {new Date().getFullYear()} T3 Tools Inc</span>
-        <div class="footer-links">
-          <a href="https://github.com/pingdotgg/t3code" target="_blank" rel="noopener noreferrer">GitHub</a>
-          <a href="https://discord.gg/jn4EGJjrvv" target="_blank" rel="noopener noreferrer">Discord</a>
-        </div>
-      </footer>
-    </div>
-  </body>
-</html>
+  <div class="screenshot-wrap">
+    <img src="/screenshot.jpeg" alt="T3 Code" class="screenshot" />
+  </div>
+</Layout>
 
 <script>
-  const REPO = "pingdotgg/t3code";
-  const RELEASES_URL = `https://github.com/${REPO}/releases`;
-  const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
+  import { fetchLatestRelease, RELEASES_URL, type ReleaseAsset } from "../lib/releases";
 
   type Platform = { os: "mac" | "win" | "linux"; label: string; arch?: string };
 
@@ -87,10 +42,7 @@
     return null;
   }
 
-  function pickAsset(
-    assets: Array<{ name: string; browser_download_url: string }>,
-    platform: Platform,
-  ): string | null {
+  function pickAsset(assets: ReleaseAsset[], platform: Platform): string | null {
     if (platform.os === "win") {
       return (
         assets.find((a) => a.name.endsWith("-x64.exe"))
@@ -125,16 +77,8 @@
     label.textContent = platform.label;
 
     try {
-      const cached = sessionStorage.getItem("t3code-latest-release");
-      const data = cached
-        ? JSON.parse(cached)
-        : await fetch(API_URL).then((r) => r.json());
-
-      if (!cached && data?.assets) {
-        sessionStorage.setItem("t3code-latest-release", JSON.stringify(data));
-      }
-
-      const url = pickAsset(data.assets ?? [], platform);
+      const release = await fetchLatestRelease();
+      const url = pickAsset(release.assets ?? [], platform);
       if (url) {
         btn.href = url;
         btn.removeAttribute("target");
@@ -149,120 +93,7 @@
 </script>
 
 <style>
-  :root {
-    --bg: #09090b;
-    --fg: #fafafa;
-    --fg-muted: #a1a1aa;
-    --fg-dim: #71717a;
-    --border: rgba(255, 255, 255, 0.08);
-  }
-
-  * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-  }
-
-  html {
-    color-scheme: dark;
-  }
-
-  body {
-    background: var(--bg);
-    color: var(--fg);
-    font-family: "DM Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    min-height: 100vh;
-    overflow-x: hidden;
-  }
-
-  body::after {
-    content: "";
-    position: fixed;
-    inset: 0;
-    pointer-events: none;
-    opacity: 0.035;
-    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-    background-repeat: repeat;
-    background-size: 256px 256px;
-    z-index: 9999;
-  }
-
-  a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  img {
-    display: block;
-    max-width: 100%;
-  }
-
-  /* ── Page ── */
-
-  .page {
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    overflow-x: hidden;
-  }
-
-  /* ── Navbar ── */
-
-  .nav {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1.5rem 2.5rem;
-    opacity: 0.5;
-    transition: opacity 0.4s ease;
-  }
-
-  .nav:hover {
-    opacity: 1;
-  }
-
-  .nav-brand {
-    display: flex;
-    align-items: center;
-  }
-
-  .nav-icon {
-    width: 28px;
-    height: 28px;
-    border-radius: 6px;
-  }
-
-  .nav-github {
-    display: flex;
-    align-items: center;
-    gap: 0.35rem;
-    color: var(--fg-muted);
-    font-size: 0.875rem;
-    transition: color 0.3s ease;
-  }
-
-  .nav-github:hover {
-    color: var(--fg);
-  }
-
-  .nav-github-arrow {
-    display: inline-block;
-    transition: transform 0.3s ease;
-  }
-
-  .nav-github:hover .nav-github-arrow {
-    transform: translateX(2px) translateY(-1px);
-  }
-
-  /* ── Main content ── */
-
   .main {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
     padding-top: 10vh;
   }
 
@@ -291,7 +122,7 @@
     border-radius: 999px;
     font-weight: 600;
     font-size: 0.9rem;
-    margin-bottom: 5vh;
+    margin-bottom: 1.25rem;
     opacity: 0;
     animation: fade-in 1s ease-out 0.15s forwards;
     transition: transform 0.25s ease, box-shadow 0.25s ease;
@@ -323,6 +154,25 @@
 
   :global([data-platform="linux"]) .hero-button-icon--linux {
     display: block;
+  }
+
+  /* ── Other platforms link ── */
+
+  .other-platforms {
+    font-size: 0.825rem;
+    color: var(--fg-dim);
+    margin-bottom: 5vh;
+    opacity: 0;
+    animation: fade-in 1s ease-out 0.3s forwards;
+    transition: color 0.3s ease;
+    text-decoration: underline;
+    text-decoration-color: rgba(113, 113, 122, 0.4);
+    text-underline-offset: 3px;
+  }
+
+  .other-platforms:hover {
+    color: var(--fg-muted);
+    text-decoration-color: var(--fg-muted);
   }
 
   /* ── Screenshot ── */
@@ -358,44 +208,6 @@
     pointer-events: none;
   }
 
-  /* ── Footer ── */
-
-  .footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1.5rem 2.5rem;
-    font-size: 0.8rem;
-    color: var(--fg-dim);
-  }
-
-  .footer-links {
-    display: flex;
-    gap: 1.25rem;
-  }
-
-  .footer-links a {
-    color: var(--fg-dim);
-    transition: color 0.3s ease;
-  }
-
-  .footer-links a:hover {
-    color: var(--fg);
-  }
-
-  /* ── Animations ── */
-
-  @keyframes fade-in {
-    from {
-      opacity: 0;
-      transform: translateY(8px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
   @keyframes screenshot-in {
     from {
       opacity: 0;
@@ -410,10 +222,6 @@
   /* ── Mobile ── */
 
   @media (max-width: 640px) {
-    .nav {
-      padding: 1.25rem 1.25rem;
-    }
-
     .main {
       padding-top: 7vh;
     }
@@ -424,10 +232,6 @@
 
     .screenshot-wrap {
       width: 95vw;
-    }
-
-    .footer {
-      padding: 1.25rem;
     }
   }
 </style>


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Adds a downloads page to view downloads for all platforms.
- Moves some shared UI into a Layout an JS folder to share the code.

Ended up being slightly larger than I wanted with the refactoring to share code, so feel free to close :)

AI summary:
- add `/download` with OS-specific release asset links and changelog link
- extract shared marketing shell/styles into `Layout.astro`
- centralize GitHub latest-release fetching/caching in `lib/releases`
- update homepage to reuse shared layout and link to other platforms


## Why

I wanted a friend to try out the app but they have an Intel Mac and were unable to download the Intel Mac version without going to GitHub.

## UI Changes

https://github.com/user-attachments/assets/f1527024-d3bf-46fd-9bf0-fd6ea7e6a7b7

![image](https://github.com/user-attachments/assets/82e53a63-01ee-48b7-99cf-cc045da8c9e7)

![image](https://github.com/user-attachments/assets/a3b54cba-9abb-4d1c-9bdb-d3ba6ce56d8f)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add downloads page and shared marketing layout with dynamic GitHub release links
> - Adds a new [`/download` page](https://github.com/pingdotgg/t3code/pull/802/files#diff-9ac8ff1be0976fe42db086d1efaff539e58c29a5da4e782816188ed3cd0c8926) with platform sections (macOS, Windows, Linux) that dynamically resolve architecture-specific installer links from the latest GitHub release.
> - Introduces a shared [Layout component](https://github.com/pingdotgg/t3code/pull/802/files#diff-cd40546c5d1667e6a791b4befdf6583020a7cfd7a6bbe78583471acd1618eaba) with navbar, footer, global dark theme styles, and a background texture overlay, replacing inline markup in the homepage.
> - Adds a [`fetchLatestRelease` utility](https://github.com/pingdotgg/t3code/pull/802/files#diff-01deaab28341046401c124174a7c33beb1aab175eb2c15ccd14a0d35d47bd827) that fetches and caches the latest GitHub release in `sessionStorage`, now shared between the homepage and download page.
> - Updates the [homepage](https://github.com/pingdotgg/t3code/pull/802/files#diff-44a2946e1eacc7096aee1ba8a172800aa7d94150585e21ff8486d94f4776677a) to use the shared layout and adds an 'Other platforms' link pointing to `/download`.
> - Behavioral Change: download links fall back to the GitHub releases page when asset filenames don't match or the fetch fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ba98a2a. 4 files reviewed, 3 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->