### PR TITLE
fix: adjust padding in composer to remove unnecessary gap

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3630,7 +3630,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           </div>
 
           {/* Input bar */}
-          <div className={cn("px-3 pt-1.5 sm:px-5 sm:pt-2", isGitRepo ? "pb-1" : "pb-3 sm:pb-4")}>
+          <div className={cn("px-3 sm:px-5", isGitRepo ? "pb-1" : "pb-3 sm:pb-4")}>
             <form
               ref={composerFormRef}
               onSubmit={onSend}


### PR DESCRIPTION
## What Changed
Removed the top padding from the chat composer container to eliminate the gap above the composer.

## Why
The extra gap looked visually wrong. Removing the padding fixes it with a minimal, low-risk change.

## UI Changes
Before:
<img width="789" height="211" alt="image" src="https://github.com/user-attachments/assets/4ce3f5e7-6013-466c-b804-cb67e573973c" />

After:
<img width="789" height="196" alt="image" src="https://github.com/user-attachments/assets/939b6764-144d-4ab7-8350-00deebaa1ef0" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove top padding from chat composer input bar container
> Removes `pt-1.5` and `sm:pt-2` Tailwind classes from the input bar container in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/803/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), eliminating the unnecessary vertical gap above the composer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a291e11.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->