### PR TITLE
Fix snapshot handling for unfinished checkpoint rows

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -296,4 +296,124 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       ]);
     }),
   );
+  it.effect("ignores in-progress checkpoint rows with null completedAt", () =>
+    Effect.gen(function* () {
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`DELETE FROM projection_projects`;
+      yield* sql`DELETE FROM projection_threads`;
+      yield* sql`DELETE FROM projection_turns`;
+      yield* sql`DELETE FROM projection_state`;
+
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model,
+          scripts_json,
+          thread_group_order_json,
+          sort_order,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (
+          'project-1',
+          'Project 1',
+          '/tmp/project-1',
+          'gpt-5-codex',
+          '[]',
+          '[]',
+          0,
+          '2026-03-09T12:00:00.000Z',
+          '2026-03-09T12:00:00.000Z',
+          NULL
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_threads (
+          thread_id,
+          project_id,
+          title,
+          model,
+          branch,
+          worktree_path,
+          latest_turn_id,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (
+          'thread-1',
+          'project-1',
+          'Thread 1',
+          'gpt-5-codex',
+          NULL,
+          NULL,
+          'turn-1',
+          '2026-03-09T12:00:01.000Z',
+          '2026-03-09T12:00:04.000Z',
+          NULL
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_turns (
+          thread_id,
+          turn_id,
+          pending_message_id,
+          assistant_message_id,
+          state,
+          requested_at,
+          started_at,
+          completed_at,
+          checkpoint_turn_count,
+          checkpoint_ref,
+          checkpoint_status,
+          checkpoint_files_json
+        )
+        VALUES (
+          'thread-1',
+          'turn-1',
+          NULL,
+          'message-1',
+          'running',
+          '2026-03-09T12:00:02.000Z',
+          '2026-03-09T12:00:03.000Z',
+          NULL,
+          7,
+          'checkpoint-7',
+          'missing',
+          '[]'
+        )
+      `;
+
+      for (const projector of Object.values(ORCHESTRATION_PROJECTOR_NAMES)) {
+        yield* sql`
+          INSERT INTO projection_state (
+            projector,
+            last_applied_sequence,
+            updated_at
+          )
+          VALUES (
+            ${projector},
+            7,
+            '2026-03-09T12:00:04.000Z'
+          )
+        `;
+      }
+
+      const snapshot = yield* snapshotQuery.getSnapshot();
+
+      assert.equal(snapshot.snapshotSequence, 7);
+      assert.equal(snapshot.threads.length, 1);
+      assert.deepEqual(snapshot.threads[0]?.checkpoints, []);
+      assert.equal(snapshot.threads[0]?.latestTurn?.turnId, asTurnId("turn-1"));
+      assert.equal(snapshot.threads[0]?.latestTurn?.state, "running");
+      assert.equal(snapshot.updatedAt, "2026-03-09T12:00:04.000Z");
+    }),
+  );
 });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -268,6 +268,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           completed_at AS "completedAt"
         FROM projection_turns
         WHERE checkpoint_turn_count IS NOT NULL
+          AND completed_at IS NOT NULL
         ORDER BY thread_id ASC, checkpoint_turn_count ASC
       `,
   });


### PR DESCRIPTION
## What Changed

- ignore unfinished checkpoint rows when reconstructing projection snapshots
- add regression coverage for snapshot reconstruction when checkpoint rows exist without `completedAt`

## Why

- snapshot reconstruction should not treat an unfinished checkpoint row as a completed checkpoint
- letting incomplete rows through can produce invalid downstream thread state

## UI Changes

- None

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `listCheckpointRows` to exclude in-progress checkpoints with null `completed_at`
> Adds `AND completed_at IS NOT NULL` to the SQL query in `listCheckpointRows` in [ProjectionSnapshotQuery.ts](https://github.com/pingdotgg/t3code/pull/811/files#diff-7f517291c1a9a2bf839691915f2f1c92d2553a298bd2d6144574615878e82209), so only fully completed checkpoints are returned. A new test in [ProjectionSnapshotQuery.test.ts](https://github.com/pingdotgg/t3code/pull/811/files#diff-6700451c66a6218b04e163b8349fc062291a7e50974a4061952bb5b3e16e47b3) verifies that turns with a non-null `checkpoint_turn_count` but null `completed_at` are excluded from the snapshot's `checkpoints` array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 828354d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->