### PR TITLE
Preserve draft thread identity across draft env changes

### DIFF
--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -113,8 +113,8 @@ describe("resolveDraftContextForEnvModeChange", () => {
       }),
     ).toEqual({
       envMode: "local",
-      branch: "feature/base",
-      worktreePath: "/repo/.t3/worktrees/feature-base",
+      branch: null,
+      worktreePath: null,
     });
   });
 });

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   dedupeRemoteBranchesWithLocalMatches,
   deriveLocalBranchNameFromRemoteRef,
+  resolveDraftContextForEnvModeChange,
   resolveDraftEnvModeAfterBranchChange,
   resolveBranchToolbarValue,
 } from "./BranchToolbar.logic";
@@ -71,6 +72,50 @@ describe("resolveBranchToolbarValue", () => {
         currentGitBranch: "main",
       }),
     ).toBe("main");
+  });
+});
+
+describe("resolveDraftContextForEnvModeChange", () => {
+  it("clears staged branch and worktree identity when switching a draft back to local", () => {
+    expect(
+      resolveDraftContextForEnvModeChange({
+        nextMode: "local",
+        currentBranch: "main",
+        currentWorktreePath: null,
+      }),
+    ).toEqual({
+      envMode: "local",
+      branch: null,
+      worktreePath: null,
+    });
+  });
+
+  it("preserves the draft branch when switching from local to new-worktree mode", () => {
+    expect(
+      resolveDraftContextForEnvModeChange({
+        nextMode: "worktree",
+        currentBranch: "feature/base",
+        currentWorktreePath: null,
+      }),
+    ).toEqual({
+      envMode: "worktree",
+      branch: "feature/base",
+      worktreePath: null,
+    });
+  });
+
+  it("does not clear a realized worktree path when resolving a local toggle", () => {
+    expect(
+      resolveDraftContextForEnvModeChange({
+        nextMode: "local",
+        currentBranch: "feature/base",
+        currentWorktreePath: "/repo/.t3/worktrees/feature-base",
+      }),
+    ).toEqual({
+      envMode: "local",
+      branch: "feature/base",
+      worktreePath: "/repo/.t3/worktrees/feature-base",
+    });
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -40,7 +40,7 @@ export function resolveDraftContextForEnvModeChange(input: {
   currentWorktreePath: string | null;
 }): DraftContextForEnvModeChange {
   const { nextMode, currentBranch, currentWorktreePath } = input;
-  if (nextMode === "local" && currentWorktreePath === null) {
+  if (nextMode === "local") {
     return {
       envMode: "local",
       branch: null,

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -2,6 +2,12 @@ import type { GitBranch } from "@t3tools/contracts";
 
 export type EnvMode = "local" | "worktree";
 
+export interface DraftContextForEnvModeChange {
+  envMode: EnvMode;
+  branch: string | null;
+  worktreePath: string | null;
+}
+
 export function resolveEffectiveEnvMode(input: {
   activeWorktreePath: string | null;
   hasServerThread: boolean;
@@ -26,6 +32,26 @@ export function resolveDraftEnvModeAfterBranchChange(input: {
     return "worktree";
   }
   return "local";
+}
+
+export function resolveDraftContextForEnvModeChange(input: {
+  nextMode: EnvMode;
+  currentBranch: string | null;
+  currentWorktreePath: string | null;
+}): DraftContextForEnvModeChange {
+  const { nextMode, currentBranch, currentWorktreePath } = input;
+  if (nextMode === "local" && currentWorktreePath === null) {
+    return {
+      envMode: "local",
+      branch: null,
+      worktreePath: null,
+    };
+  }
+  return {
+    envMode: nextMode,
+    branch: currentBranch,
+    worktreePath: currentWorktreePath,
+  };
 }
 
 export function resolveBranchToolbarValue(input: {

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -85,6 +85,7 @@ interface MountedChatView {
   cleanup: () => Promise<void>;
   measureUserRow: (targetMessageId: MessageId) => Promise<UserRowMeasurement>;
   setViewport: (viewport: ViewportSpec) => Promise<void>;
+  syncSnapshot: (snapshot: OrchestrationReadModel) => Promise<void>;
 }
 
 function isoAt(offsetSeconds: number): string {
@@ -590,6 +591,10 @@ async function mountChatView(options: {
       await setViewport(viewport);
       await waitForProductionStyles();
     },
+    syncSnapshot: async (snapshot: OrchestrationReadModel) => {
+      useStore.getState().syncServerReadModel(snapshot);
+      await waitForLayout();
+    },
   };
 }
 
@@ -802,6 +807,73 @@ describe("ChatView timeline estimator parity (full app)", () => {
       }
     },
   );
+
+  it("keeps a local draft thread registered until the synced server thread arrives", async () => {
+    useComposerDraftStore.setState({
+      draftThreadsByThreadId: {
+        [THREAD_ID]: {
+          projectId: PROJECT_ID,
+          createdAt: NOW_ISO,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          envMode: "local",
+        },
+      },
+      projectDraftThreadIdByProjectId: {
+        [PROJECT_ID]: THREAD_ID,
+      },
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+    });
+
+    try {
+      useComposerDraftStore.getState().setPrompt(THREAD_ID, "draft send regression");
+      await waitForLayout();
+
+      const composerForm = await waitForElement(
+        () => document.querySelector<HTMLFormElement>('[data-chat-composer-form="true"]'),
+        "Unable to find composer form.",
+      );
+      composerForm.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
+
+      await vi.waitFor(
+        () => {
+          const commandTags = wsRequests
+            .filter((request) => request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand)
+            .map((request) => {
+              const command = request.command as { type?: string } | undefined;
+              return command?.type ?? null;
+            });
+          expect(commandTags).toContain("thread.create");
+          expect(commandTags).toContain("thread.turn.start");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      expect(useComposerDraftStore.getState().getDraftThread(THREAD_ID)).not.toBeNull();
+
+      await mounted.syncSnapshot(
+        createSnapshotForTargetUser({
+          targetMessageId: "msg-user-target-created-thread" as MessageId,
+          targetText: "draft send regression",
+        }),
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(useComposerDraftStore.getState().getDraftThread(THREAD_ID)).toBeNull();
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
 
   it("opens the project cwd for draft threads without a worktree path", async () => {
     useComposerDraftStore.setState({

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -20,6 +20,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { render } from "vitest-browser-react";
 
 import { useComposerDraftStore } from "../composerDraftStore";
+import { readNativeApi } from "../nativeApi";
 import { getRouter } from "../router";
 import { useStore } from "../store";
 import { estimateTimelineMessageHeight } from "./timelineHeight";
@@ -592,6 +593,7 @@ async function mountChatView(options: {
       await waitForProductionStyles();
     },
     syncSnapshot: async (snapshot: OrchestrationReadModel) => {
+      fixture.snapshot = snapshot;
       useStore.getState().syncServerReadModel(snapshot);
       await waitForLayout();
     },
@@ -870,6 +872,29 @@ describe("ChatView timeline estimator parity (full app)", () => {
         },
         { timeout: 8_000, interval: 16 },
       );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("serves the latest synced snapshot through the browser fixture RPC", async () => {
+    const targetMessageId = "msg-user-target-synced-snapshot" as MessageId;
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+    });
+
+    try {
+      const nextSnapshot = createSnapshotForTargetUser({
+        targetMessageId,
+        targetText: "synced snapshot regression",
+      });
+
+      await mounted.syncSnapshot(nextSnapshot);
+
+      const api = readNativeApi();
+      expect(api).toBeTruthy();
+      await expect(api!.orchestration.getSnapshot()).resolves.toEqual(nextSnapshot);
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -750,6 +750,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const activeProject = projects.find((p) => p.id === activeThread?.projectId);
 
   useEffect(() => {
+    if (!serverThread || !draftThread) {
+      return;
+    }
+
+    clearDraftThread(threadId);
+  }, [clearDraftThread, draftThread, serverThread, threadId]);
+
+  useEffect(() => {
     if (!activeThread?.id) return;
     if (!latestTurnSettled) return;
     if (!activeLatestTurn?.completedAt) return;
@@ -2690,9 +2698,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
         createdAt: messageCreatedAt,
       });
       turnStartSucceeded = true;
-      if (isFirstMessage) {
-        clearDraftThread(threadIdForSend);
-      }
     })().catch(async (err: unknown) => {
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
         await api.orchestration

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -118,6 +118,7 @@ import {
   summarizeTurnDiffStats,
   type TurnDiffTreeNode,
 } from "../lib/turnDiffTree";
+import { resolveDraftContextForEnvModeChange } from "./BranchToolbar.logic";
 import BranchToolbar from "./BranchToolbar";
 import GitActionsControl from "./GitActionsControl";
 import {
@@ -3172,11 +3173,25 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const onEnvModeChange = useCallback(
     (mode: DraftThreadEnvMode) => {
       if (isLocalDraftThread) {
-        setDraftThreadContext(threadId, { envMode: mode });
+        setDraftThreadContext(
+          threadId,
+          resolveDraftContextForEnvModeChange({
+            nextMode: mode,
+            currentBranch: draftThread?.branch ?? null,
+            currentWorktreePath: draftThread?.worktreePath ?? null,
+          }),
+        );
       }
       scheduleComposerFocus();
     },
-    [isLocalDraftThread, scheduleComposerFocus, setDraftThreadContext, threadId],
+    [
+      draftThread?.branch,
+      draftThread?.worktreePath,
+      isLocalDraftThread,
+      scheduleComposerFocus,
+      setDraftThreadContext,
+      threadId,
+    ],
   );
 
   const applyPromptReplacement = useCallback(

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -310,6 +310,32 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 
+  it("clears staged branch identity when a project draft switches back to local mode", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectId, threadId, {
+      branch: "main",
+      worktreePath: null,
+      envMode: "worktree",
+    });
+    store.setPrompt(threadId, "keep draft content");
+
+    store.setDraftThreadContext(threadId, {
+      branch: null,
+      worktreePath: null,
+      envMode: "local",
+    });
+
+    expect(useComposerDraftStore.getState().getDraftThreadByProjectId(projectId)).toMatchObject({
+      threadId,
+      branch: null,
+      worktreePath: null,
+      envMode: "local",
+    });
+    expect(useComposerDraftStore.getState().draftsByThreadId[threadId]?.prompt).toBe(
+      "keep draft content",
+    );
+  });
+
   it("preserves worktree env mode without a worktree path", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectId, threadId, {


### PR DESCRIPTION
## What Changed

- clear stale staged branch state when toggling draft env mode
- keep draft thread state attached to the correct draft context during branch and env transitions
- add regression coverage around draft identity and staged-branch cleanup

## Why

- draft state could become detached or overwritten when moving between local and worktree draft flows
- the draft context should stay stable across normal branch and env-mode transitions

## UI Changes

- None

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve draft thread identity across draft env mode changes
> - Draft threads now persist after the first message is sent and are only cleared once the corresponding server thread arrives in the synced snapshot.
> - Switching a draft thread's env mode to `local` now clears `branch` and `worktreePath`; switching to `worktree` preserves existing values via the new `resolveDraftContextForEnvModeChange` helper in [BranchToolbar.logic.ts](https://github.com/pingdotgg/t3code/pull/813/files#diff-22eaeeb6cc7f6e680a66d29924a8aa6c56a51450578462389a4b649102ea655f).
> - The `mountChatView` test utility gains a `syncSnapshot` method to simulate server snapshot delivery in browser tests.
> - Behavioral Change: draft threads are no longer cleared on message send — they remain visible until the server confirms the thread, which changes what users see between submission and server acknowledgment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 116c8e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->