### PR TITLE
Improve sidebar thread state accuracy

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -5,6 +5,8 @@ import {
   getSlashModelOptions,
   normalizeCustomModelSlugs,
   resolveAppModelSelection,
+  resolveSidebarThreadOrder,
+  SIDEBAR_THREAD_ORDER_OPTIONS,
 } from "./appSettings";
 
 describe("normalizeCustomModelSlugs", () => {
@@ -80,5 +82,20 @@ describe("getSlashModelOptions", () => {
     );
 
     expect(options.map((option) => option.slug)).toEqual(["openai/gpt-oss-120b"]);
+  });
+});
+
+describe("resolveSidebarThreadOrder", () => {
+  it("defaults invalid values to recent-activity", () => {
+    expect(resolveSidebarThreadOrder("something-else")).toBe("recent-activity");
+  });
+
+  it("keeps the supported thread ordering preferences", () => {
+    expect(resolveSidebarThreadOrder("recent-activity")).toBe("recent-activity");
+    expect(resolveSidebarThreadOrder("created-at")).toBe("created-at");
+    expect(SIDEBAR_THREAD_ORDER_OPTIONS.map((option) => option.value)).toEqual([
+      "recent-activity",
+      "created-at",
+    ]);
   });
 });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -6,6 +6,20 @@ import { getDefaultModel, getModelOptions, normalizeModelSlug } from "@t3tools/s
 const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
 const MAX_CUSTOM_MODEL_COUNT = 32;
 export const MAX_CUSTOM_MODEL_LENGTH = 256;
+export const SIDEBAR_THREAD_ORDER_OPTIONS = [
+  {
+    value: "recent-activity",
+    label: "Recent activity",
+    description: "Sort chats by the latest user message, final assistant message, plan, or assistant question.",
+  },
+  {
+    value: "created-at",
+    label: "Created time",
+    description: "Sort chats by when the thread was originally created.",
+  },
+] as const;
+export type SidebarThreadOrder = (typeof SIDEBAR_THREAD_ORDER_OPTIONS)[number]["value"];
+const SidebarThreadOrderSchema = Schema.Literals(["recent-activity", "created-at"]);
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
 };
@@ -21,6 +35,9 @@ const AppSettingsSchema = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(
     Schema.withConstructorDefault(() => Option.some(false)),
   ),
+  sidebarThreadOrder: SidebarThreadOrderSchema.pipe(
+    Schema.withConstructorDefault(() => Option.some("recent-activity")),
+  ),
   customCodexModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
   ),
@@ -30,6 +47,10 @@ export interface AppModelOption {
   slug: string;
   name: string;
   isCustom: boolean;
+}
+
+export function resolveSidebarThreadOrder(value: string | null | undefined): SidebarThreadOrder {
+  return value === "created-at" ? "created-at" : "recent-activity";
 }
 
 const DEFAULT_APP_SETTINGS = AppSettingsSchema.makeUnsafe({});
@@ -70,6 +91,7 @@ export function normalizeCustomModelSlugs(
 function normalizeAppSettings(settings: AppSettings): AppSettings {
   return {
     ...settings,
+    sidebarThreadOrder: resolveSidebarThreadOrder(settings.sidebarThreadOrder),
     customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
   };
 }

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -8,6 +8,7 @@ import {
   type ProjectId,
   type ServerConfig,
   type ThreadId,
+  type TurnId,
   type WsWelcomePayload,
   WS_CHANNELS,
   WS_METHODS,
@@ -253,6 +254,69 @@ function createDraftOnlySnapshot(): OrchestrationReadModel {
   return {
     ...snapshot,
     threads: [],
+  };
+}
+
+function createSnapshotWithPendingUserInput(): OrchestrationReadModel {
+  const snapshot = createSnapshotForTargetUser({
+    targetMessageId: "msg-user-pending-input" as MessageId,
+    targetText: "pending input thread",
+  });
+  const turnId = "turn-pending-user-input" as TurnId;
+  const pendingUserInputActivity: OrchestrationReadModel["threads"][number]["activities"][number] = {
+    id: "activity-pending-user-input" as OrchestrationReadModel["threads"][number]["activities"][number]["id"],
+    createdAt: isoAt(102),
+    tone: "info",
+    kind: "user-input.requested",
+    summary: "User input requested",
+    turnId,
+    payload: {
+      requestId: "req-user-input-browser",
+      questions: [
+        {
+          id: "affected_course",
+          header: "Affected Course",
+          question: "Which student calendar is broken?",
+          options: [
+            {
+              label: "The Combine (Recommended)",
+              description: "Matches the report.",
+            },
+            {
+              label: "The Invitational",
+              description: "Alternative calendar.",
+            },
+          ],
+        },
+      ],
+    },
+  };
+  return {
+    ...snapshot,
+    threads: snapshot.threads.map((thread) =>
+      thread.id !== THREAD_ID
+        ? thread
+        : Object.assign({}, thread, {
+            latestTurn: {
+              turnId,
+              state: "running",
+              requestedAt: isoAt(100),
+              startedAt: isoAt(101),
+              completedAt: null,
+              assistantMessageId: null,
+            },
+            session: {
+              threadId: THREAD_ID,
+              status: "running",
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId: turnId,
+              lastError: null,
+              updatedAt: isoAt(101),
+            },
+            activities: [pendingUserInputActivity],
+          }),
+    ),
   };
 }
 
@@ -850,6 +914,43 @@ describe("ChatView timeline estimator parity (full app)", () => {
             cwd: "/repo/project",
             editor: "vscode",
           });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("submits structured user-input answers from a running thread", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotWithPendingUserInput(),
+    });
+
+    try {
+      const optionButton = page.getByRole("button", { name: /The Combine \(Recommended\)/i });
+      await expect.element(optionButton).toBeVisible();
+      await optionButton.click();
+
+      const submitButton = page.getByRole("button", { name: /Submit answers/i });
+      await expect.element(submitButton).toBeEnabled();
+      await submitButton.click();
+
+      await vi.waitFor(
+        () => {
+          const dispatches = wsRequests.filter(
+            (request) => request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand,
+          );
+          const userInputCommand = dispatches
+            .map((request) => request.command as { type?: string; requestId?: string } | undefined)
+            .find((command) => command?.type === "thread.user-input.respond");
+          expect(userInputCommand).toEqual(
+            expect.objectContaining({
+              type: "thread.user-input.respond",
+              requestId: "req-user-input-browser",
+            }),
+          );
         },
         { timeout: 8_000, interval: 16 },
       );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -872,13 +872,28 @@ export default function ChatView({ threadId }: ChatViewProps) {
     () => derivePendingApprovals(threadActivities),
     [threadActivities],
   );
+  const activeLatestTurnId = activeLatestTurn?.turnId ?? null;
+  const activeLatestTurnState = activeLatestTurn?.state ?? null;
+  const activeSessionStatus = activeThread?.session?.status ?? null;
+  const pendingUserInputContext = useMemo(
+    () => ({
+      latestTurn: activeLatestTurnId && activeLatestTurnState
+        ? {
+            turnId: activeLatestTurnId,
+            state: activeLatestTurnState,
+          }
+        : null,
+      session: activeSessionStatus
+        ? {
+            status: activeSessionStatus,
+          }
+        : null,
+    }),
+    [activeLatestTurnId, activeLatestTurnState, activeSessionStatus],
+  );
   const pendingUserInputs = useMemo(
-    () =>
-      derivePendingUserInputs(threadActivities, {
-        latestTurn: activeLatestTurn,
-        session: activeThread?.session ?? null,
-      }),
-    [activeLatestTurn, activeThread?.session, threadActivities],
+    () => derivePendingUserInputs(threadActivities, pendingUserInputContext),
+    [pendingUserInputContext, threadActivities],
   );
   const activePendingUserInput = pendingUserInputs[0] ?? null;
   const activePendingDraftAnswers = useMemo(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -873,8 +873,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [threadActivities],
   );
   const pendingUserInputs = useMemo(
-    () => derivePendingUserInputs(threadActivities),
-    [threadActivities],
+    () =>
+      derivePendingUserInputs(threadActivities, {
+        latestTurn: activeLatestTurn,
+        session: activeThread?.session ?? null,
+      }),
+    [activeLatestTurn, activeThread?.session, threadActivities],
   );
   const activePendingUserInput = pendingUserInputs[0] ?? null;
   const activePendingDraftAnswers = useMemo(

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -72,10 +72,23 @@ describe("resolveThreadStatusPill", () => {
         hasPendingApprovals: false,
         hasPendingUserInput: false,
       }),
+    ).toMatchObject({ label: "Planning", pulse: true });
+  });
+
+  it("shows working for non-plan threads that are actively running", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          interactionMode: "default",
+        },
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+      }),
     ).toMatchObject({ label: "Working", pulse: true });
   });
 
-  it("shows plan ready when a settled plan turn has a proposed plan ready for follow-up", () => {
+  it("shows plan submitted when a settled plan turn has a proposed plan ready for follow-up", () => {
     expect(
       resolveThreadStatusPill({
         thread: {
@@ -99,7 +112,34 @@ describe("resolveThreadStatusPill", () => {
         hasPendingApprovals: false,
         hasPendingUserInput: false,
       }),
-    ).toMatchObject({ label: "Plan Ready", pulse: false });
+    ).toMatchObject({ label: "Plan Submitted", pulse: false });
+  });
+
+  it("shows errored when the latest turn failed after the thread was last visited", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          latestTurn: {
+            turnId: "turn-1" as never,
+            state: "error",
+            assistantMessageId: null,
+            requestedAt: "2026-03-09T10:00:00.000Z",
+            startedAt: "2026-03-09T10:00:00.000Z",
+            completedAt: "2026-03-09T10:05:00.000Z",
+          },
+          lastVisitedAt: "2026-03-09T10:04:00.000Z",
+          session: {
+            ...baseThread.session,
+            status: "error",
+            updatedAt: "2026-03-09T10:05:00.000Z",
+            orchestrationStatus: "error",
+          },
+        },
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+      }),
+    ).toMatchObject({ label: "Errored", pulse: false });
   });
 
   it("shows completed when there is an unseen completion and no active blocker", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -4,11 +4,13 @@ import { findLatestProposedPlan, isLatestTurnSettled } from "../session-logic";
 export interface ThreadStatusPill {
   label:
     | "Working"
+    | "Planning"
     | "Connecting"
     | "Completed"
     | "Pending Approval"
     | "Awaiting Input"
-    | "Plan Ready";
+    | "Plan Submitted"
+    | "Errored";
   colorClass: string;
   dotClass: string;
   pulse: boolean;
@@ -18,6 +20,28 @@ type ThreadStatusInput = Pick<
   Thread,
   "interactionMode" | "latestTurn" | "lastVisitedAt" | "proposedPlans" | "session"
 >;
+
+function hasUnreadAt(timestamp: string | undefined, lastVisitedAt: string | undefined): boolean {
+  if (!timestamp) {
+    return false;
+  }
+
+  const updatedAt = Date.parse(timestamp);
+  if (Number.isNaN(updatedAt)) {
+    return false;
+  }
+
+  if (!lastVisitedAt) {
+    return true;
+  }
+
+  const visitedAt = Date.parse(lastVisitedAt);
+  if (Number.isNaN(visitedAt)) {
+    return true;
+  }
+
+  return updatedAt > visitedAt;
+}
 
 export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
   if (!thread.latestTurn?.completedAt) return false;
@@ -55,6 +79,15 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
+  if (thread.session?.status === "running" && thread.interactionMode === "plan") {
+    return {
+      label: "Planning",
+      colorClass: "text-cyan-600 dark:text-cyan-300/90",
+      dotClass: "bg-cyan-500 dark:bg-cyan-300/90",
+      pulse: true,
+    };
+  }
+
   if (thread.session?.status === "running") {
     return {
       label: "Working",
@@ -80,9 +113,33 @@ export function resolveThreadStatusPill(input: {
     findLatestProposedPlan(thread.proposedPlans, thread.latestTurn?.turnId ?? null) !== null;
   if (hasPlanReadyPrompt) {
     return {
-      label: "Plan Ready",
-      colorClass: "text-violet-600 dark:text-violet-300/90",
-      dotClass: "bg-violet-500 dark:bg-violet-300/90",
+      label: "Plan Submitted",
+      colorClass: "text-teal-600 dark:text-teal-300/90",
+      dotClass: "bg-teal-500 dark:bg-teal-300/90",
+      pulse: false,
+    };
+  }
+
+  if (
+    thread.latestTurn?.state === "error" &&
+    hasUnreadAt(thread.latestTurn.completedAt ?? undefined, thread.lastVisitedAt)
+  ) {
+    return {
+      label: "Errored",
+      colorClass: "text-rose-600 dark:text-rose-300/90",
+      dotClass: "bg-rose-500 dark:bg-rose-300/90",
+      pulse: false,
+    };
+  }
+
+  if (
+    thread.session?.status === "error" &&
+    hasUnreadAt(thread.session.updatedAt, thread.lastVisitedAt)
+  ) {
+    return {
+      label: "Errored",
+      colorClass: "text-rose-600 dark:text-rose-300/90",
+      dotClass: "bg-rose-500 dark:bg-rose-300/90",
       pulse: false,
     };
   }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -48,6 +48,7 @@ import { gitRemoveWorktreeMutationOptions, gitStatusQueryOptions } from "../lib/
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { type DraftThreadEnvMode, useComposerDraftStore } from "../composerDraftStore";
+import { sortSidebarThreadEntries } from "../sidebarThreadOrder";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { toastManager } from "./ui/toast";
 import {
@@ -1270,13 +1271,16 @@ export default function Sidebar() {
                 strategy={verticalListSortingStrategy}
               >
                 {projects.map((project) => {
-                  const projectThreads = threads
-                    .filter((thread) => thread.projectId === project.id)
-                    .toSorted((a, b) => {
-                      const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-                      if (byDate !== 0) return byDate;
-                      return b.id.localeCompare(a.id);
-                    });
+                  const projectThreads = sortSidebarThreadEntries(
+                    threads
+                      .filter((thread) => thread.projectId === project.id)
+                      .map((thread) => ({
+                        id: thread.id,
+                        createdAt: thread.createdAt,
+                        thread,
+                      })),
+                    appSettings.sidebarThreadOrder,
+                  ).map((entry) => entry.thread);
                   const isThreadListExpanded = expandedThreadListsByProject.has(project.id);
                   const hasHiddenThreads = projectThreads.length > THREAD_PREVIEW_LIMIT;
                   const visibleThreads =

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -313,7 +313,13 @@ export default function Sidebar() {
   const pendingUserInputByThreadId = useMemo(() => {
     const map = new Map<ThreadId, boolean>();
     for (const thread of threads) {
-      map.set(thread.id, derivePendingUserInputs(thread.activities).length > 0);
+      map.set(
+        thread.id,
+        derivePendingUserInputs(thread.activities, {
+          latestTurn: thread.latestTurn,
+          session: thread.session,
+        }).length > 0,
+      );
     }
     return map;
   }, [threads]);

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -4,7 +4,11 @@ import { useCallback, useState } from "react";
 import { type ProviderKind } from "@t3tools/contracts";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 
-import { MAX_CUSTOM_MODEL_LENGTH, useAppSettings } from "../appSettings";
+import {
+  MAX_CUSTOM_MODEL_LENGTH,
+  SIDEBAR_THREAD_ORDER_OPTIONS,
+  useAppSettings,
+} from "../appSettings";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
@@ -12,6 +16,13 @@ import { ensureNativeApi } from "../nativeApi";
 import { preferredTerminalEditor } from "../terminal-links";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
 import { Switch } from "../components/ui/switch";
 import { SidebarInset } from "~/components/ui/sidebar";
 
@@ -96,6 +107,7 @@ function SettingsRouteView() {
 
   const codexBinaryPath = settings.codexBinaryPath;
   const codexHomePath = settings.codexHomePath;
+  const sidebarThreadOrder = settings.sidebarThreadOrder;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
 
   const openKeybindingsFile = useCallback(() => {
@@ -232,6 +244,45 @@ function SettingsRouteView() {
               <p className="mt-4 text-xs text-muted-foreground">
                 Active theme: <span className="font-medium text-foreground">{resolvedTheme}</span>
               </p>
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <div className="mb-4">
+                <h2 className="text-sm font-medium text-foreground">Sidebar</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Choose how chats are ordered in each project.
+                </p>
+              </div>
+
+              <label className="block space-y-1">
+                <span className="text-xs font-medium text-foreground">Chat ordering</span>
+                <Select
+                  items={SIDEBAR_THREAD_ORDER_OPTIONS.map((option) => ({
+                    label: option.label,
+                    value: option.value,
+                  }))}
+                  value={sidebarThreadOrder}
+                  onValueChange={(value) => {
+                    if (!value) return;
+                    updateSettings({ sidebarThreadOrder: value });
+                  }}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {SIDEBAR_THREAD_ORDER_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+                <span className="text-xs text-muted-foreground">
+                  {SIDEBAR_THREAD_ORDER_OPTIONS.find((option) => option.value === sidebarThreadOrder)
+                    ?.description ?? ""}
+                </span>
+              </label>
             </section>
 
             <section className="rounded-2xl border border-border bg-card p-5">

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -220,6 +220,120 @@ describe("derivePendingUserInputs", () => {
       },
     ]);
   });
+
+  it("removes prompts when the provider reports an unknown pending user input request", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-1",
+          questions: [
+            {
+              id: "sandbox_mode",
+              header: "Sandbox",
+              question: "Which mode should be used?",
+              options: [
+                {
+                  label: "workspace-write",
+                  description: "Allow workspace writes only",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      makeActivity({
+        id: "user-input-failed",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "provider.user-input.respond.failed",
+        summary: "Provider user input response failed",
+        tone: "error",
+        payload: {
+          requestId: "req-user-input-1",
+          detail:
+            "Provider adapter request failed (codex) for item/tool/requestUserInput: Unknown pending user input request: req-user-input-1",
+        },
+      }),
+    ];
+
+    expect(derivePendingUserInputs(activities)).toEqual([]);
+  });
+
+  it("removes prompts when the thread session is already in error", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-1",
+          questions: [
+            {
+              id: "sandbox_mode",
+              header: "Sandbox",
+              question: "Which mode should be used?",
+              options: [
+                {
+                  label: "workspace-write",
+                  description: "Allow workspace writes only",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(
+      derivePendingUserInputs(activities, {
+        session: { status: "error" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("removes prompts when their turn has already settled", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        turnId: "turn-1",
+        payload: {
+          requestId: "req-user-input-1",
+          questions: [
+            {
+              id: "sandbox_mode",
+              header: "Sandbox",
+              question: "Which mode should be used?",
+              options: [
+                {
+                  label: "workspace-write",
+                  description: "Allow workspace writes only",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(
+      derivePendingUserInputs(activities, {
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-1"),
+          state: "error",
+        },
+      }),
+    ).toEqual([]);
+  });
 });
 
 describe("deriveActivePlanState", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -45,6 +45,11 @@ export interface PendingUserInput {
   questions: ReadonlyArray<UserInputQuestion>;
 }
 
+interface PendingUserInputContext {
+  latestTurn?: Pick<OrchestrationLatestTurn, "turnId" | "state"> | null;
+  session?: Pick<ThreadSession, "status"> | null;
+}
+
 export interface ActivePlanState {
   createdAt: string;
   turnId: TurnId | null;
@@ -262,8 +267,12 @@ function parseUserInputQuestions(
 
 export function derivePendingUserInputs(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
+  context?: PendingUserInputContext,
 ): PendingUserInput[] {
-  const openByRequestId = new Map<ApprovalRequestId, PendingUserInput>();
+  const openByRequestId = new Map<
+    ApprovalRequestId,
+    PendingUserInput & { turnId: TurnId | null }
+  >();
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
 
   for (const activity of ordered) {
@@ -285,18 +294,42 @@ export function derivePendingUserInputs(
         requestId,
         createdAt: activity.createdAt,
         questions,
+        turnId: activity.turnId,
       });
       continue;
     }
 
     if (activity.kind === "user-input.resolved" && requestId) {
       openByRequestId.delete(requestId);
+      continue;
+    }
+
+    const detail = payload && typeof payload.detail === "string" ? payload.detail : undefined;
+    if (
+      activity.kind === "provider.user-input.respond.failed" &&
+      requestId &&
+      detail?.includes("Unknown pending user input request")
+    ) {
+      openByRequestId.delete(requestId);
     }
   }
 
-  return [...openByRequestId.values()].toSorted((left, right) =>
-    left.createdAt.localeCompare(right.createdAt),
-  );
+  if (context?.session?.status === "error" || context?.session?.status === "closed") {
+    return [];
+  }
+
+  const latestTurn = context?.latestTurn;
+  if (latestTurn && latestTurn.state !== "running") {
+    for (const [requestId, pending] of openByRequestId.entries()) {
+      if (pending.turnId === latestTurn.turnId) {
+        openByRequestId.delete(requestId);
+      }
+    }
+  }
+
+  return [...openByRequestId.values()]
+    .map(({ turnId: _turnId, ...pending }) => pending)
+    .toSorted((left, right) => left.createdAt.localeCompare(right.createdAt));
 }
 
 export function deriveActivePlanState(

--- a/apps/web/src/sidebarThreadOrder.test.ts
+++ b/apps/web/src/sidebarThreadOrder.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import { sortSidebarThreadEntries } from "./sidebarThreadOrder";
+import { type Thread } from "./types";
+
+function makeThread(overrides: Partial<Thread>): Thread {
+  return {
+    id: "thread" as Thread["id"],
+    codexThreadId: null,
+    projectId: "project" as Thread["projectId"],
+    title: "Thread",
+    model: "gpt-5.4",
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    session: null,
+    messages: [],
+    turnDiffSummaries: [],
+    activities: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-03-09T12:00:00.000Z",
+    latestTurn: null,
+    branch: null,
+    worktreePath: null,
+    ...overrides,
+  };
+}
+
+describe("sortSidebarThreadEntries", () => {
+  it("sorts by recent activity when configured", () => {
+    const olderThread = makeThread({
+      id: "thread-older" as Thread["id"],
+      createdAt: "2026-03-09T11:00:00.000Z",
+      messages: [
+        {
+          id: "older-user" as Thread["messages"][number]["id"],
+          role: "user",
+          text: "hello",
+          streaming: false,
+          createdAt: "2026-03-09T11:01:00.000Z",
+        },
+      ],
+    });
+    const newerActivityThread = makeThread({
+      id: "thread-new-activity" as Thread["id"],
+      createdAt: "2026-03-09T10:00:00.000Z",
+      messages: [
+        {
+          id: "new-user" as Thread["messages"][number]["id"],
+          role: "user",
+          text: "latest",
+          streaming: false,
+          createdAt: "2026-03-09T12:30:00.000Z",
+        },
+      ],
+    });
+
+    const ordered = sortSidebarThreadEntries(
+      [
+        { id: olderThread.id, createdAt: olderThread.createdAt, thread: olderThread },
+        {
+          id: newerActivityThread.id,
+          createdAt: newerActivityThread.createdAt,
+          thread: newerActivityThread,
+        },
+      ],
+      "recent-activity",
+    );
+
+    expect(ordered.map((entry) => entry.id)).toEqual([
+      newerActivityThread.id,
+      olderThread.id,
+    ]);
+  });
+
+  it("sorts by created-at when configured", () => {
+    const olderThread = makeThread({
+      id: "thread-older" as Thread["id"],
+      createdAt: "2026-03-09T11:00:00.000Z",
+      messages: [
+        {
+          id: "older-user" as Thread["messages"][number]["id"],
+          role: "user",
+          text: "latest",
+          streaming: false,
+          createdAt: "2026-03-09T12:30:00.000Z",
+        },
+      ],
+    });
+    const newerThread = makeThread({
+      id: "thread-newer" as Thread["id"],
+      createdAt: "2026-03-09T12:00:00.000Z",
+    });
+
+    const ordered = sortSidebarThreadEntries(
+      [
+        { id: olderThread.id, createdAt: olderThread.createdAt, thread: olderThread },
+        { id: newerThread.id, createdAt: newerThread.createdAt, thread: newerThread },
+      ],
+      "created-at",
+    );
+
+    expect(ordered.map((entry) => entry.id)).toEqual([newerThread.id, olderThread.id]);
+  });
+
+  it("treats proposed plans and pending questions as recent activity", () => {
+    const planThread = makeThread({
+      id: "thread-plan" as Thread["id"],
+      createdAt: "2026-03-09T08:00:00.000Z",
+      proposedPlans: [
+        {
+          id: "plan-1" as Thread["proposedPlans"][number]["id"],
+          turnId: null,
+          planMarkdown: "# plan",
+          createdAt: "2026-03-09T09:00:00.000Z",
+          updatedAt: "2026-03-09T12:15:00.000Z",
+        },
+      ],
+    });
+    const questionThread = makeThread({
+      id: "thread-question" as Thread["id"],
+      createdAt: "2026-03-09T07:00:00.000Z",
+      activities: [
+        {
+          id: "act-1" as Thread["activities"][number]["id"],
+          createdAt: "2026-03-09T12:20:00.000Z",
+          kind: "user-input.requested",
+          summary: "Need input",
+          tone: "info",
+          payload: {
+            requestId: "req-1",
+            questions: [
+              {
+                id: "answer",
+                header: "Answer",
+                question: "Need input",
+                options: [
+                  {
+                    label: "continue",
+                    description: "Continue execution",
+                  },
+                ],
+              },
+            ],
+          },
+          turnId: null,
+          sequence: 1,
+        },
+      ],
+    });
+
+    const ordered = sortSidebarThreadEntries(
+      [
+        { id: planThread.id, createdAt: planThread.createdAt, thread: planThread },
+        { id: questionThread.id, createdAt: questionThread.createdAt, thread: questionThread },
+      ],
+      "recent-activity",
+    );
+
+    expect(ordered.map((entry) => entry.id)).toEqual([questionThread.id, planThread.id]);
+  });
+});

--- a/apps/web/src/sidebarThreadOrder.ts
+++ b/apps/web/src/sidebarThreadOrder.ts
@@ -1,0 +1,68 @@
+import { derivePendingUserInputs } from "./session-logic";
+import type { Thread } from "./types";
+import type { SidebarThreadOrder } from "./appSettings";
+
+export interface SidebarThreadEntryLike {
+  id: string;
+  createdAt: string;
+  thread: Thread | null;
+}
+
+function latestIso(left: string, right: string): string {
+  return left.localeCompare(right) >= 0 ? left : right;
+}
+
+export function getSidebarThreadRecentActivityAt(entry: SidebarThreadEntryLike): string {
+  const thread = entry.thread;
+  if (thread === null) {
+    return entry.createdAt;
+  }
+
+  let latestActivityAt = latestIso(entry.createdAt, thread.createdAt);
+
+  for (const message of thread.messages) {
+    if (message.role === "user") {
+      latestActivityAt = latestIso(latestActivityAt, message.createdAt);
+      continue;
+    }
+
+    if (message.role === "assistant" && !message.streaming && message.completedAt) {
+      latestActivityAt = latestIso(latestActivityAt, message.completedAt);
+    }
+  }
+
+  for (const proposedPlan of thread.proposedPlans) {
+    latestActivityAt = latestIso(latestActivityAt, proposedPlan.updatedAt);
+  }
+
+  for (const pendingUserInput of derivePendingUserInputs(thread.activities)) {
+    latestActivityAt = latestIso(latestActivityAt, pendingUserInput.createdAt);
+  }
+
+  return latestActivityAt;
+}
+
+export function getSidebarThreadSortTimestamp(
+  entry: SidebarThreadEntryLike,
+  order: SidebarThreadOrder,
+): string {
+  return order === "created-at" ? entry.createdAt : getSidebarThreadRecentActivityAt(entry);
+}
+
+export function sortSidebarThreadEntries<T extends SidebarThreadEntryLike>(
+  entries: readonly T[],
+  order: SidebarThreadOrder,
+): T[] {
+  return [...entries].toSorted((left, right) => {
+    const bySortTimestamp =
+      getSidebarThreadSortTimestamp(right, order).localeCompare(
+        getSidebarThreadSortTimestamp(left, order),
+      );
+    if (bySortTimestamp !== 0) return bySortTimestamp;
+
+    const byCreatedAt = right.createdAt.localeCompare(left.createdAt);
+    if (byCreatedAt !== 0) return byCreatedAt;
+
+    return right.id.localeCompare(left.id);
+  });
+}

--- a/apps/web/src/sidebarThreadOrder.ts
+++ b/apps/web/src/sidebarThreadOrder.ts
@@ -35,7 +35,12 @@ export function getSidebarThreadRecentActivityAt(entry: SidebarThreadEntryLike):
     latestActivityAt = latestIso(latestActivityAt, proposedPlan.updatedAt);
   }
 
-  for (const pendingUserInput of derivePendingUserInputs(thread.activities)) {
+  for (
+    const pendingUserInput of derivePendingUserInputs(thread.activities, {
+      latestTurn: thread.latestTurn,
+      session: thread.session,
+    })
+  ) {
     latestActivityAt = latestIso(latestActivityAt, pendingUserInput.createdAt);
   }
 


### PR DESCRIPTION
## What Changed

- clean up stale pending-input state so thread ordering and status derivation stop treating old user-input prompts as active blockers
- tighten sidebar thread state handling for plan and error flows
- add a thread ordering preference in settings for busy groups

## Why

- the sidebar could collapse distinct thread states or keep showing stale pending-input state after the underlying thread had moved on
- thread ordering becomes less trustworthy when stale state keeps affecting sort timestamps

## UI Changes

- screenshots and video are attached in the PR asset comment

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes, if applicable


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve sidebar thread state accuracy with status pills, ordering, and pending input suppression
> - Adds `sidebarThreadOrder` to app settings (`'recent-activity'` or `'created-at'`), with a new Settings UI control and normalization via [`appSettings.ts`](https://github.com/pingdotgg/t3code/pull/814/files#diff-4f500b80c5f743d5b39d3f07498169da0c26f4bf9b5a2127453a90c04a4c49cc)
> - Implements [`sortSidebarThreadEntries`](https://github.com/pingdotgg/t3code/pull/814/files#diff-7f0ca9b15ddf5168345460b8a6f2313c1c5f143aa92373f7e8046c82adf06700) to sort threads by recent activity (considering user messages, assistant completions, proposed plans, and pending questions) or creation time
> - Updates [`resolveThreadStatusPill`](https://github.com/pingdotgg/t3code/pull/814/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to show `'Planning'` for plan-mode running threads, rename `'Plan Ready'` to `'Plan Submitted'`, and surface unseen errors as `'Errored'`
> - Extends [`derivePendingUserInputs`](https://github.com/pingdotgg/t3code/pull/814/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) to suppress prompts for errored/closed sessions, drop prompts tied to settled turns, and clean up on provider rejection of unknown requests
> - Behavioral Change: pending user input badges in both the sidebar and chat view are now hidden when the session has errored or the latest turn has settled
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17740a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
