### PR TITLE
Add sidebar focus mode

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -49,6 +49,12 @@ import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { type DraftThreadEnvMode, useComposerDraftStore } from "../composerDraftStore";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+import {
+  FOCUS_MODE_GRACE_MS,
+  deriveFocusThreadVisibility,
+  resolveFocusProjectExpanded,
+  toggleFocusProjectOverride,
+} from "../sidebarFocusMode";
 import { toastManager } from "./ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
@@ -296,6 +302,14 @@ export default function Sidebar() {
   const [expandedThreadListsByProject, setExpandedThreadListsByProject] = useState<
     ReadonlySet<ProjectId>
   >(() => new Set());
+  const [isFocusMode, setIsFocusMode] = useState(false);
+  const [focusNow, setFocusNow] = useState(() => Date.now());
+  const [focusProjectExpandedSnapshot, setFocusProjectExpandedSnapshot] = useState<
+    ReadonlyMap<ProjectId, boolean> | null
+  >(null);
+  const [focusCollapsedProjectIds, setFocusCollapsedProjectIds] = useState<ReadonlySet<ProjectId>>(
+    () => new Set(),
+  );
   const renamingCommittedRef = useRef(false);
   const renamingInputRef = useRef<HTMLInputElement | null>(null);
   const dragInProgressRef = useRef(false);
@@ -317,6 +331,62 @@ export default function Sidebar() {
     }
     return map;
   }, [threads]);
+  const { focusVisibilityByThreadId, nextFocusExpiryAt } = useMemo(() => {
+    const visibilityByThreadId = new Map<
+      ThreadId,
+      ReturnType<typeof deriveFocusThreadVisibility>
+    >();
+    let nearestExpiryAt: number | null = null;
+
+    for (const thread of threads) {
+      const visibility = deriveFocusThreadVisibility({
+        thread,
+        hasPendingApprovals: pendingApprovalByThreadId.get(thread.id) === true,
+        hasPendingUserInputs: pendingUserInputByThreadId.get(thread.id) === true,
+        now: focusNow,
+        graceMs: FOCUS_MODE_GRACE_MS,
+      });
+      visibilityByThreadId.set(thread.id, visibility);
+      if (
+        visibility.isVisible &&
+        visibility.graceExpiresAt !== null &&
+        (nearestExpiryAt === null || visibility.graceExpiresAt < nearestExpiryAt)
+      ) {
+        nearestExpiryAt = visibility.graceExpiresAt;
+      }
+    }
+
+    return {
+      focusVisibilityByThreadId: visibilityByThreadId,
+      nextFocusExpiryAt: nearestExpiryAt,
+    };
+  }, [focusNow, pendingApprovalByThreadId, pendingUserInputByThreadId, threads]);
+  const activeFocusProjectId = useMemo(() => {
+    if (!routeThreadId) {
+      return null;
+    }
+
+    const activeThread = threads.find((thread) => thread.id === routeThreadId);
+    if (!activeThread) {
+      return null;
+    }
+
+    return focusVisibilityByThreadId.get(activeThread.id)?.isVisible === true
+      ? activeThread.projectId
+      : null;
+  }, [focusVisibilityByThreadId, routeThreadId, threads]);
+  const displayedProjects = useMemo(() => {
+    if (!isFocusMode) {
+      return projects;
+    }
+
+    return projects.filter((project) =>
+      threads.some(
+        (thread) =>
+          thread.projectId === project.id && focusVisibilityByThreadId.get(thread.id)?.isVisible === true,
+      ),
+    );
+  }, [focusVisibilityByThreadId, isFocusMode, projects, threads]);
   const projectCwdById = useMemo(
     () => new Map(projects.map((project) => [project.id, project.cwd] as const)),
     [projects],
@@ -881,7 +951,7 @@ export default function Sidebar() {
   }, []);
 
   const handleProjectTitleClick = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>, projectId: ProjectId) => {
+    (event: React.MouseEvent<HTMLButtonElement>, onToggle: () => void) => {
       if (dragInProgressRef.current) {
         event.preventDefault();
         event.stopPropagation();
@@ -894,22 +964,61 @@ export default function Sidebar() {
         event.stopPropagation();
         return;
       }
-      toggleProject(projectId);
+      onToggle();
     },
-    [toggleProject],
+    [],
   );
 
   const handleProjectTitleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLButtonElement>, projectId: ProjectId) => {
+    (event: React.KeyboardEvent<HTMLButtonElement>, onToggle: () => void) => {
       if (event.key !== "Enter" && event.key !== " ") return;
       event.preventDefault();
       if (dragInProgressRef.current) {
         return;
       }
-      toggleProject(projectId);
+      onToggle();
     },
-    [toggleProject],
+    [],
   );
+
+  const setFocusProjectOpen = useCallback((projectId: ProjectId, open: boolean) => {
+    setFocusCollapsedProjectIds((current) => toggleFocusProjectOverride(current, projectId, open));
+  }, []);
+
+  const toggleFocusMode = useCallback(() => {
+    setFocusNow(Date.now());
+    setIsFocusMode((current) => {
+      if (current) {
+        setFocusProjectExpandedSnapshot(null);
+        setFocusCollapsedProjectIds(new Set());
+        return false;
+      }
+
+      setFocusProjectExpandedSnapshot(new Map(projects.map((project) => [project.id, project.expanded])));
+      setFocusCollapsedProjectIds(new Set());
+      return true;
+    });
+  }, [projects]);
+
+  useEffect(() => {
+    if (!isFocusMode) {
+      return;
+    }
+    setFocusNow(Date.now());
+  }, [isFocusMode, threads]);
+
+  useEffect(() => {
+    if (!isFocusMode || nextFocusExpiryAt === null) {
+      return;
+    }
+    const delay = Math.max(0, nextFocusExpiryAt - Date.now());
+    const timeout = window.setTimeout(() => {
+      setFocusNow(Date.now());
+    }, delay + 10);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [isFocusMode, nextFocusExpiryAt]);
 
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
@@ -1100,6 +1209,20 @@ export default function Sidebar() {
       </div>
     </div>
   );
+  const focusButton = (
+    <button
+      type="button"
+      aria-pressed={isFocusMode}
+      className={`inline-flex h-7 items-center justify-center rounded-md px-2.5 text-xs font-medium transition-colors ${
+        isFocusMode
+          ? "bg-sidebar-accent text-sidebar-accent-foreground"
+          : "text-muted-foreground hover:bg-accent hover:text-foreground"
+      }`}
+      onClick={toggleFocusMode}
+    >
+      Focus
+    </button>
+  );
 
   return (
     <>
@@ -1107,6 +1230,7 @@ export default function Sidebar() {
         <>
           <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}
+            <div className="mt-1.5">{focusButton}</div>
             {showDesktopUpdateButton && (
               <Tooltip>
                 <TooltipTrigger
@@ -1116,7 +1240,7 @@ export default function Sidebar() {
                       aria-label={desktopUpdateTooltip}
                       aria-disabled={desktopUpdateButtonDisabled || undefined}
                       disabled={desktopUpdateButtonDisabled}
-                      className={`inline-flex size-7 ml-auto mt-1.5 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
+                      className={`inline-flex size-7 mt-1.5 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
                       onClick={handleDesktopUpdateButtonClick}
                     >
                       <RocketIcon className="size-3.5" />
@@ -1131,6 +1255,7 @@ export default function Sidebar() {
       ) : (
         <SidebarHeader className="gap-3 px-3 py-2 sm:gap-2.5 sm:px-4 sm:py-3">
           {wordmark}
+          <div className="ml-auto">{focusButton}</div>
         </SidebarHeader>
       )}
 
@@ -1260,10 +1385,10 @@ export default function Sidebar() {
           >
             <SidebarMenu>
               <SortableContext
-                items={projects.map((project) => project.id)}
+                items={displayedProjects.map((project) => project.id)}
                 strategy={verticalListSortingStrategy}
               >
-                {projects.map((project) => {
+                {displayedProjects.map((project) => {
                   const projectThreads = threads
                     .filter((thread) => thread.projectId === project.id)
                     .toSorted((a, b) => {
@@ -1271,19 +1396,33 @@ export default function Sidebar() {
                       if (byDate !== 0) return byDate;
                       return b.id.localeCompare(a.id);
                     });
+                  const focusVisibleProjectThreads = projectThreads.filter(
+                    (thread) => focusVisibilityByThreadId.get(thread.id)?.isVisible === true,
+                  );
+                  const hasVisibleFocusThreadInProject = focusVisibleProjectThreads.length > 0;
+                  const projectBaseExpanded =
+                    focusProjectExpandedSnapshot?.get(project.id) ?? project.expanded;
+                  const isProjectOpen = resolveFocusProjectExpanded({
+                    isFocusMode,
+                    baseExpanded: projectBaseExpanded,
+                    containsVisibleThread: hasVisibleFocusThreadInProject,
+                    manuallyCollapsed: focusCollapsedProjectIds.has(project.id),
+                    activeVisibleThreadInContainer: activeFocusProjectId === project.id,
+                  });
+                  const displayThreads = isFocusMode ? focusVisibleProjectThreads : projectThreads;
                   const isThreadListExpanded = expandedThreadListsByProject.has(project.id);
-                  const hasHiddenThreads = projectThreads.length > THREAD_PREVIEW_LIMIT;
+                  const hasHiddenThreads = displayThreads.length > THREAD_PREVIEW_LIMIT;
                   const visibleThreads =
                     hasHiddenThreads && !isThreadListExpanded
-                      ? projectThreads.slice(0, THREAD_PREVIEW_LIMIT)
-                      : projectThreads;
+                      ? displayThreads.slice(0, THREAD_PREVIEW_LIMIT)
+                      : displayThreads;
 
                   return (
                     <SortableProjectItem key={project.id} projectId={project.id}>
                       {(dragHandleProps) => (
                         <Collapsible
                           className="group/collapsible"
-                          open={project.expanded}
+                          open={isProjectOpen}
                         >
                           <div className="group/project-header relative">
                             <SidebarMenuButton
@@ -1292,8 +1431,24 @@ export default function Sidebar() {
                               {...dragHandleProps.attributes}
                               {...dragHandleProps.listeners}
                               onPointerDownCapture={handleProjectTitlePointerDownCapture}
-                              onClick={(event) => handleProjectTitleClick(event, project.id)}
-                              onKeyDown={(event) => handleProjectTitleKeyDown(event, project.id)}
+                              onClick={(event) =>
+                                handleProjectTitleClick(event, () => {
+                                  if (isFocusMode) {
+                                    setFocusProjectOpen(project.id, !isProjectOpen);
+                                    return;
+                                  }
+                                  toggleProject(project.id);
+                                })
+                              }
+                              onKeyDown={(event) =>
+                                handleProjectTitleKeyDown(event, () => {
+                                  if (isFocusMode) {
+                                    setFocusProjectOpen(project.id, !isProjectOpen);
+                                    return;
+                                  }
+                                  toggleProject(project.id);
+                                })
+                              }
                               onContextMenu={(event) => {
                                 event.preventDefault();
                                 void handleProjectContextMenu(project.id, {
@@ -1304,7 +1459,7 @@ export default function Sidebar() {
                             >
                               <ChevronRightIcon
                                 className={`-ml-0.5 size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150 ${
-                                  project.expanded ? "rotate-90" : ""
+                                  isProjectOpen ? "rotate-90" : ""
                                 }`}
                               />
                               <ProjectFavicon cwd={project.cwd} />
@@ -1524,9 +1679,9 @@ export default function Sidebar() {
             </SidebarMenu>
           </DndContext>
 
-          {projects.length === 0 && !shouldShowProjectPathEntry && (
+          {displayedProjects.length === 0 && !shouldShowProjectPathEntry && (
             <div className="px-2 pt-4 text-center text-xs text-muted-foreground/60">
-              No projects yet
+              {projects.length === 0 ? "No projects yet" : "No chats need focus"}
             </div>
           )}
         </SidebarGroup>

--- a/apps/web/src/sidebarFocusMode.test.ts
+++ b/apps/web/src/sidebarFocusMode.test.ts
@@ -1,0 +1,238 @@
+import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  FOCUS_MODE_GRACE_MS,
+  deriveFocusThreadVisibility,
+  resolveFocusProjectExpanded,
+} from "./sidebarFocusMode";
+import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "./types";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread",
+    model: "gpt-5-codex",
+    runtimeMode: DEFAULT_RUNTIME_MODE,
+    interactionMode: DEFAULT_INTERACTION_MODE,
+    session: null,
+    messages: [],
+    turnDiffSummaries: [],
+    activities: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-03-01T00:00:00.000Z",
+    latestTurn: null,
+    lastVisitedAt: undefined,
+    branch: null,
+    worktreePath: null,
+    ...overrides,
+  };
+}
+
+describe("deriveFocusThreadVisibility", () => {
+  it("shows a running thread", () => {
+    const thread = makeThread({
+      session: {
+        provider: "codex",
+        status: "running",
+        orchestrationStatus: "running",
+        createdAt: "2026-03-09T12:00:00.000Z",
+        updatedAt: "2026-03-09T12:01:00.000Z",
+      },
+    });
+
+    expect(
+      deriveFocusThreadVisibility({
+        thread,
+        hasPendingApprovals: false,
+        hasPendingUserInputs: false,
+        now: Date.parse("2026-03-09T12:01:30.000Z"),
+        graceMs: FOCUS_MODE_GRACE_MS,
+      }),
+    ).toMatchObject({
+      hasCurrentStatus: true,
+      isVisible: true,
+    });
+  });
+
+  it("shows a thread with pending approval", () => {
+    expect(
+      deriveFocusThreadVisibility({
+        thread: makeThread(),
+        hasPendingApprovals: true,
+        hasPendingUserInputs: false,
+        now: Date.parse("2026-03-09T12:00:00.000Z"),
+        graceMs: FOCUS_MODE_GRACE_MS,
+      }),
+    ).toMatchObject({
+      hasCurrentStatus: true,
+      isVisible: true,
+    });
+  });
+
+  it("keeps a recently completed thread visible during the grace window", () => {
+    const thread = makeThread({
+      lastVisitedAt: "2026-03-09T12:12:00.000Z",
+      latestTurn: {
+        turnId: TurnId.makeUnsafe("turn-done"),
+        state: "completed",
+        requestedAt: "2026-03-09T12:00:00.000Z",
+        startedAt: "2026-03-09T12:00:02.000Z",
+        completedAt: "2026-03-09T12:10:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+
+    expect(
+      deriveFocusThreadVisibility({
+        thread,
+        hasPendingApprovals: false,
+        hasPendingUserInputs: false,
+        now: Date.parse("2026-03-09T12:11:00.000Z"),
+        graceMs: FOCUS_MODE_GRACE_MS,
+      }),
+    ).toMatchObject({
+      hasCurrentStatus: false,
+      isVisible: true,
+      graceExpiresAt: Date.parse("2026-03-09T12:12:00.000Z"),
+    });
+  });
+
+  it("hides a completed thread after the grace window expires", () => {
+    const thread = makeThread({
+      lastVisitedAt: "2026-03-09T12:12:00.000Z",
+      latestTurn: {
+        turnId: TurnId.makeUnsafe("turn-done"),
+        state: "completed",
+        requestedAt: "2026-03-09T12:00:00.000Z",
+        startedAt: "2026-03-09T12:00:02.000Z",
+        completedAt: "2026-03-09T12:10:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+
+    expect(
+      deriveFocusThreadVisibility({
+        thread,
+        hasPendingApprovals: false,
+        hasPendingUserInputs: false,
+        now: Date.parse("2026-03-09T12:12:01.000Z"),
+        graceMs: FOCUS_MODE_GRACE_MS,
+      }),
+    ).toMatchObject({
+      hasCurrentStatus: false,
+      isVisible: false,
+    });
+  });
+
+  it("treats a settled plan thread as focus-visible", () => {
+    const thread = makeThread({
+      interactionMode: "plan",
+      latestTurn: {
+        turnId: TurnId.makeUnsafe("turn-plan"),
+        state: "completed",
+        requestedAt: "2026-03-09T12:00:00.000Z",
+        startedAt: "2026-03-09T12:00:02.000Z",
+        completedAt: "2026-03-09T12:10:00.000Z",
+        assistantMessageId: null,
+      },
+      proposedPlans: [
+        {
+          id: "plan-1" as Thread["proposedPlans"][number]["id"],
+          turnId: TurnId.makeUnsafe("turn-plan"),
+          planMarkdown: "# Latest plan",
+          createdAt: "2026-03-09T12:09:00.000Z",
+          updatedAt: "2026-03-09T12:10:00.000Z",
+        },
+      ],
+      session: {
+        provider: "codex",
+        status: "ready",
+        orchestrationStatus: "ready",
+        createdAt: "2026-03-09T12:00:00.000Z",
+        updatedAt: "2026-03-09T12:10:00.000Z",
+      },
+    });
+
+    expect(
+      deriveFocusThreadVisibility({
+        thread,
+        hasPendingApprovals: false,
+        hasPendingUserInputs: false,
+        now: Date.parse("2026-03-09T12:10:30.000Z"),
+        graceMs: FOCUS_MODE_GRACE_MS,
+      }),
+    ).toMatchObject({
+      hasCurrentStatus: true,
+      isVisible: true,
+    });
+  });
+
+  it("treats errored threads as focus-visible", () => {
+    const thread = makeThread({
+      lastVisitedAt: "2026-03-09T12:05:00.000Z",
+      latestTurn: {
+        turnId: TurnId.makeUnsafe("turn-error"),
+        state: "error",
+        requestedAt: "2026-03-09T12:00:00.000Z",
+        startedAt: "2026-03-09T12:00:02.000Z",
+        completedAt: "2026-03-09T12:10:00.000Z",
+        assistantMessageId: null,
+      },
+    });
+
+    expect(
+      deriveFocusThreadVisibility({
+        thread,
+        hasPendingApprovals: false,
+        hasPendingUserInputs: false,
+        now: Date.parse("2026-03-09T12:10:30.000Z"),
+        graceMs: FOCUS_MODE_GRACE_MS,
+      }),
+    ).toMatchObject({
+      hasCurrentStatus: true,
+      isVisible: true,
+    });
+  });
+});
+
+describe("resolveFocusProjectExpanded", () => {
+  it("auto-reveals a project with visible focus work", () => {
+    expect(
+      resolveFocusProjectExpanded({
+        isFocusMode: true,
+        baseExpanded: false,
+        containsVisibleThread: true,
+        manuallyCollapsed: false,
+        activeVisibleThreadInContainer: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("lets a manual collapse win for non-active work", () => {
+    expect(
+      resolveFocusProjectExpanded({
+        isFocusMode: true,
+        baseExpanded: true,
+        containsVisibleThread: true,
+        manuallyCollapsed: true,
+        activeVisibleThreadInContainer: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("reopens the active project even after a manual collapse", () => {
+    expect(
+      resolveFocusProjectExpanded({
+        isFocusMode: true,
+        baseExpanded: true,
+        containsVisibleThread: true,
+        manuallyCollapsed: true,
+        activeVisibleThreadInContainer: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/sidebarFocusMode.ts
+++ b/apps/web/src/sidebarFocusMode.ts
@@ -1,0 +1,206 @@
+import type { ProjectId } from "@t3tools/contracts";
+
+import { findLatestProposedPlan, isLatestTurnSettled } from "./session-logic";
+import type { Thread } from "./types";
+import { resolveThreadStatusPill } from "./components/Sidebar.logic";
+
+export const FOCUS_MODE_GRACE_MS = 2 * 60_000;
+
+export type FocusVisibilityReason = "current-status" | "grace" | "hidden";
+
+export interface FocusThreadVisibilityInput {
+  thread: Thread;
+  hasPendingApprovals: boolean;
+  hasPendingUserInputs: boolean;
+  now: number;
+  graceMs: number;
+}
+
+export interface FocusThreadVisibility {
+  hasCurrentStatus: boolean;
+  isVisible: boolean;
+  graceExpiresAt: number | null;
+  lastFocusEligibleAt: number | null;
+  reason: FocusVisibilityReason;
+}
+
+interface ResolveFocusContainerOpenInput {
+  isFocusMode: boolean;
+  containsVisibleThread: boolean;
+  manuallyCollapsed: boolean;
+  activeVisibleThreadInContainer: boolean;
+}
+
+function parseIso(iso: string | null | undefined): number | null {
+  if (!iso) {
+    return null;
+  }
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function maxTimestamp(current: number | null, next: string | null | undefined): number | null {
+  const parsed = parseIso(next);
+  if (parsed === null) {
+    return current;
+  }
+  return current === null || parsed > current ? parsed : current;
+}
+
+function hasUnreadAt(timestamp: string | null | undefined, lastVisitedAt: string | undefined): boolean {
+  const updatedAt = parseIso(timestamp);
+  if (updatedAt === null) {
+    return false;
+  }
+
+  const visitedAt = parseIso(lastVisitedAt);
+  if (visitedAt === null) {
+    return true;
+  }
+
+  return updatedAt > visitedAt;
+}
+
+function hasUnreadError(thread: Thread): boolean {
+  if (
+    thread.latestTurn?.state === "error" &&
+    hasUnreadAt(thread.latestTurn.completedAt ?? undefined, thread.lastVisitedAt)
+  ) {
+    return true;
+  }
+
+  return thread.session?.status === "error" && hasUnreadAt(thread.session.updatedAt, thread.lastVisitedAt);
+}
+
+function deriveLastFocusEligibleAt(thread: Thread): number | null {
+  let latestAt: number | null = null;
+
+  for (const activity of thread.activities) {
+    if (
+      activity.kind === "approval.requested" ||
+      activity.kind === "approval.resolved" ||
+      activity.kind === "user-input.requested" ||
+      activity.kind === "user-input.resolved"
+    ) {
+      latestAt = maxTimestamp(latestAt, activity.createdAt);
+    }
+  }
+
+  if (thread.session?.status === "running" || thread.session?.status === "connecting") {
+    latestAt = maxTimestamp(latestAt, thread.session.updatedAt);
+  }
+
+  const latestTurnSettled = isLatestTurnSettled(thread.latestTurn, thread.session);
+  const latestTurnId = thread.latestTurn?.turnId ?? null;
+  const latestPlan = latestTurnSettled
+    ? findLatestProposedPlan(thread.proposedPlans, latestTurnId)
+    : null;
+
+  if (latestTurnId && latestPlan?.turnId === latestTurnId) {
+    latestAt = maxTimestamp(latestAt, latestPlan.updatedAt);
+  }
+
+  if (thread.latestTurn?.state === "completed" && latestTurnSettled) {
+    latestAt = maxTimestamp(latestAt, thread.latestTurn.completedAt);
+  }
+
+  if (thread.latestTurn?.state === "error") {
+    latestAt = maxTimestamp(latestAt, thread.latestTurn.completedAt);
+  }
+
+  if (thread.session?.status === "error") {
+    latestAt = maxTimestamp(latestAt, thread.session.updatedAt);
+  }
+
+  if (
+    latestAt !== null &&
+    thread.session &&
+    thread.session.status !== "running" &&
+    thread.session.status !== "connecting" &&
+    thread.session.status !== "error"
+  ) {
+    latestAt = maxTimestamp(latestAt, thread.session.updatedAt);
+  }
+
+  return latestAt;
+}
+
+export function deriveFocusThreadVisibility(
+  input: FocusThreadVisibilityInput,
+): FocusThreadVisibility {
+  const hasCurrentStatus =
+    resolveThreadStatusPill({
+      thread: input.thread,
+      hasPendingApprovals: input.hasPendingApprovals,
+      hasPendingUserInput: input.hasPendingUserInputs,
+    }) !== null || hasUnreadError(input.thread);
+
+  if (hasCurrentStatus) {
+    return {
+      hasCurrentStatus: true,
+      isVisible: true,
+      graceExpiresAt: null,
+      lastFocusEligibleAt: null,
+      reason: "current-status",
+    };
+  }
+
+  const lastFocusEligibleAt = deriveLastFocusEligibleAt(input.thread);
+  if (lastFocusEligibleAt === null) {
+    return {
+      hasCurrentStatus: false,
+      isVisible: false,
+      graceExpiresAt: null,
+      lastFocusEligibleAt: null,
+      reason: "hidden",
+    };
+  }
+
+  const graceExpiresAt = lastFocusEligibleAt + input.graceMs;
+  if (input.now < graceExpiresAt) {
+    return {
+      hasCurrentStatus: false,
+      isVisible: true,
+      graceExpiresAt,
+      lastFocusEligibleAt,
+      reason: "grace",
+    };
+  }
+
+  return {
+    hasCurrentStatus: false,
+    isVisible: false,
+    graceExpiresAt,
+    lastFocusEligibleAt,
+    reason: "hidden",
+  };
+}
+
+export function resolveFocusProjectExpanded(
+  input: ResolveFocusContainerOpenInput & { baseExpanded: boolean },
+): boolean {
+  if (!input.isFocusMode) {
+    return input.baseExpanded;
+  }
+  if (!input.containsVisibleThread) {
+    return false;
+  }
+  if (input.manuallyCollapsed && !input.activeVisibleThreadInContainer) {
+    return false;
+  }
+  return true;
+}
+
+export function toggleFocusProjectOverride(
+  previous: ReadonlySet<ProjectId>,
+  projectId: ProjectId,
+  open: boolean,
+): ReadonlySet<ProjectId> {
+  const next = new Set(previous);
+  if (open) {
+    next.delete(projectId);
+  } else {
+    next.add(projectId);
+  }
+  return next;
+}


### PR DESCRIPTION
## What Changed

- add a sidebar focus mode toggle
- filter sidebar visibility toward active, blocked, newly completed, and otherwise actionable threads
- add focused test coverage for the focus-mode filtering behavior

## Why

- busy sidebars get harder to scan as thread counts grow
- a focused view makes it easier to keep attention on threads that currently need action

## UI Changes

- screenshots are attached in the PR asset comment

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes, if applicable


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Focus mode to sidebar to filter projects and threads by recent activity
> - Adds a Focus button to the sidebar header that toggles a mode filtering the project/thread list to only items with current activity or within a 2-minute grace window after recent activity.
> - Introduces [sidebarFocusMode.ts](https://github.com/pingdotgg/t3code/pull/817/files#diff-0dcaaf2e0560a052350dff8ea48d5ea93f0eff5309037d74da68abdfb220777b) with `deriveFocusThreadVisibility`, `resolveFocusProjectExpanded`, and `toggleFocusProjectOverride` utilities to classify threads and manage per-session collapse overrides.
> - In focus mode, projects auto-expand when they contain visible threads; users can manually collapse projects, except the active project always stays open.
> - A timer is scheduled to recalculate visibility as grace windows expire, keeping the filtered list up to date without user interaction.
> - Behavioral Change: the sidebar empty state now shows 'No chats need focus' instead of the default message when focus mode is active and no threads are visible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17f0823.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
