### PR TITLE
fix: use available editor as fallback before lastEditor is set

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1,3 +1,4 @@
+import { type EditorId } from "@t3tools/contracts";
 import {
   getSharedHighlighter,
   type DiffsHighlighter,
@@ -23,10 +24,10 @@ import remarkGfm from "remark-gfm";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
 import { fnv1a32 } from "../lib/diffRendering";
 import { LRUCache } from "../lib/lruCache";
+import { getPreferredEditor } from "../editorPreferences";
 import { useTheme } from "../hooks/useTheme";
 import { resolveMarkdownFileLinkTarget } from "../markdown-links";
 import { readNativeApi } from "../nativeApi";
-import { preferredTerminalEditor } from "../terminal-links";
 
 class CodeHighlightErrorBoundary extends React.Component<
   { fallback: ReactNode; children: ReactNode },
@@ -52,6 +53,7 @@ class CodeHighlightErrorBoundary extends React.Component<
 interface ChatMarkdownProps {
   text: string;
   cwd: string | undefined;
+  availableEditors: ReadonlyArray<EditorId>;
   isStreaming?: boolean;
 }
 
@@ -232,7 +234,7 @@ function SuspenseShikiCodeBlock({
   );
 }
 
-function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
+function ChatMarkdown({ text, cwd, availableEditors, isStreaming = false }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
   const markdownComponents = useMemo<Components>(
@@ -251,11 +253,16 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
               event.preventDefault();
               event.stopPropagation();
               const api = readNativeApi();
-              if (api) {
-                void api.shell.openInEditor(targetPath, preferredTerminalEditor());
-              } else {
+              if (!api) {
                 console.warn("Native API not found. Unable to open file in editor.");
+                return;
               }
+              const preferredEditor = getPreferredEditor(availableEditors);
+              if (!preferredEditor) {
+                console.warn("No available editor found. Unable to open file in editor.");
+                return;
+              }
+              void api.shell.openInEditor(targetPath, preferredEditor);
             }}
           />
         );
@@ -282,7 +289,7 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
         );
       },
     }),
-    [cwd, diffThemeName, isStreaming],
+    [availableEditors, cwd, diffThemeName, isStreaming],
   );
 
   return (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -52,6 +52,7 @@ import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
 
 import { isElectron } from "../env";
+import { EMPTY_AVAILABLE_EDITORS } from "../editorPreferences";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import {
   type ComposerSlashCommand,
@@ -258,7 +259,6 @@ const IMAGE_ONLY_BOOTSTRAP_PROMPT =
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
-const EMPTY_AVAILABLE_EDITORS: EditorId[] = [];
 const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
 const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
@@ -3624,6 +3624,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
               isRevertingCheckpoint={isRevertingCheckpoint}
               onImageExpand={onExpandTimelineImage}
               markdownCwd={gitCwd ?? undefined}
+              availableEditors={availableEditors}
               resolvedTheme={resolvedTheme}
               workspaceRoot={activeProject?.cwd ?? undefined}
             />
@@ -4144,6 +4145,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
             activePlan={activePlan}
             activeProposedPlan={activeProposedPlan}
             markdownCwd={gitCwd ?? undefined}
+            availableEditors={availableEditors}
             workspaceRoot={activeProject?.cwd ?? undefined}
             onClose={() => {
               setPlanSidebarOpen(false);
@@ -4869,10 +4871,12 @@ const ChangedFilesTree = memo(function ChangedFilesTree(props: {
 const ProposedPlanCard = memo(function ProposedPlanCard({
   planMarkdown,
   cwd,
+  availableEditors,
   workspaceRoot,
 }: {
   planMarkdown: string;
   cwd: string | undefined;
+  availableEditors: ReadonlyArray<EditorId>;
   workspaceRoot: string | undefined;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -4977,9 +4981,19 @@ const ProposedPlanCard = memo(function ProposedPlanCard({
       <div className="mt-4">
         <div className={cn("relative", canCollapse && !expanded && "max-h-104 overflow-hidden")}>
           {canCollapse && !expanded ? (
-            <ChatMarkdown text={collapsedPreview ?? ""} cwd={cwd} isStreaming={false} />
+            <ChatMarkdown
+              text={collapsedPreview ?? ""}
+              cwd={cwd}
+              availableEditors={availableEditors}
+              isStreaming={false}
+            />
           ) : (
-            <ChatMarkdown text={displayedPlanMarkdown} cwd={cwd} isStreaming={false} />
+            <ChatMarkdown
+              text={displayedPlanMarkdown}
+              cwd={cwd}
+              availableEditors={availableEditors}
+              isStreaming={false}
+            />
           )}
           {canCollapse && !expanded ? (
             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-linear-to-t from-card/95 via-card/80 to-transparent" />
@@ -5069,6 +5083,7 @@ interface MessagesTimelineProps {
   isRevertingCheckpoint: boolean;
   onImageExpand: (preview: ExpandedImagePreview) => void;
   markdownCwd: string | undefined;
+  availableEditors: ReadonlyArray<EditorId>;
   resolvedTheme: "light" | "dark";
   workspaceRoot: string | undefined;
 }
@@ -5123,6 +5138,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
   isRevertingCheckpoint,
   onImageExpand,
   markdownCwd,
+  availableEditors,
   resolvedTheme,
   workspaceRoot,
 }: MessagesTimelineProps) {
@@ -5503,6 +5519,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
                 <ChatMarkdown
                   text={messageText}
                   cwd={markdownCwd}
+                  availableEditors={availableEditors}
                   isStreaming={Boolean(row.message.streaming)}
                 />
                 {(() => {
@@ -5579,6 +5596,7 @@ const MessagesTimeline = memo(function MessagesTimeline({
           <ProposedPlanCard
             planMarkdown={row.proposedPlan.planMarkdown}
             cwd={markdownCwd}
+            availableEditors={availableEditors}
             workspaceRoot={workspaceRoot}
           />
         </div>

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -12,11 +12,12 @@ import {
   useRef,
   useState,
 } from "react";
+import { getPreferredEditor, useAvailableEditors } from "~/editorPreferences";
 import { gitBranchesQueryOptions } from "~/lib/gitReactQuery";
 import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
 import { cn } from "~/lib/utils";
 import { readNativeApi } from "../nativeApi";
-import { preferredTerminalEditor, resolvePathLinkTarget } from "../terminal-links";
+import { resolvePathLinkTarget } from "../terminal-links";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
@@ -162,6 +163,7 @@ interface DiffPanelProps {
 export { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
 
 export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
+  const availableEditors = useAvailableEditors();
   const navigate = useNavigate();
   const { resolvedTheme } = useTheme();
   const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("stacked");
@@ -310,12 +312,17 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     (filePath: string) => {
       const api = readNativeApi();
       if (!api) return;
+      const preferredEditor = getPreferredEditor(availableEditors);
+      if (!preferredEditor) {
+        console.warn("No available editor found. Unable to open diff file in editor.");
+        return;
+      }
       const targetPath = activeCwd ? resolvePathLinkTarget(filePath, activeCwd) : filePath;
-      void api.shell.openInEditor(targetPath, preferredTerminalEditor()).catch((error) => {
+      void api.shell.openInEditor(targetPath, preferredEditor).catch((error) => {
         console.warn("Failed to open diff file in editor.", error);
       });
     },
-    [activeCwd],
+    [activeCwd, availableEditors],
   );
 
   const selectTurn = (turnId: TurnId) => {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -2,6 +2,7 @@ import type { GitStackedAction, GitStatusResult, ThreadId } from "@t3tools/contr
 import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ChevronDownIcon, CloudUploadIcon, GitCommitIcon, InfoIcon } from "lucide-react";
+import { getPreferredEditor, useAvailableEditors } from "~/editorPreferences";
 import { GitHubIcon } from "./Icons";
 import {
   buildGitActionProgressStages,
@@ -40,7 +41,7 @@ import {
   gitStatusQueryOptions,
   invalidateGitQueries,
 } from "~/lib/gitReactQuery";
-import { preferredTerminalEditor, resolvePathLinkTarget } from "~/terminal-links";
+import { resolvePathLinkTarget } from "~/terminal-links";
 import { readNativeApi } from "~/nativeApi";
 
 interface GitActionsControlProps {
@@ -151,6 +152,7 @@ function GitQuickActionIcon({ quickAction }: { quickAction: GitQuickAction }) {
 }
 
 export default function GitActionsControl({ gitCwd, activeThreadId }: GitActionsControlProps) {
+  const availableEditors = useAvailableEditors();
   const threadToastData = useMemo(
     () => (activeThreadId ? { threadId: activeThreadId } : undefined),
     [activeThreadId],
@@ -218,7 +220,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
 
   const openExistingPr = useCallback(async () => {
     const api = readNativeApi();
-    if (!api) {
+      if (!api) {
       toastManager.add({
         type: "error",
         title: "Link opening is unavailable.",
@@ -582,8 +584,17 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
         });
         return;
       }
+      const preferredEditor = getPreferredEditor(availableEditors);
+      if (!preferredEditor) {
+        toastManager.add({
+          type: "error",
+          title: "No available editor found.",
+          data: threadToastData,
+        });
+        return;
+      }
       const target = resolvePathLinkTarget(filePath, gitCwd);
-      void api.shell.openInEditor(target, preferredTerminalEditor()).catch((error) => {
+      void api.shell.openInEditor(target, preferredEditor).catch((error) => {
         toastManager.add({
           type: "error",
           title: "Unable to open file",
@@ -592,7 +603,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
         });
       });
     },
-    [gitCwd, threadToastData],
+    [availableEditors, gitCwd, threadToastData],
   );
 
   if (!gitCwd) return null;

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -1,3 +1,4 @@
+import { type EditorId } from "@t3tools/contracts";
 import { memo, useState, useCallback } from "react";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
@@ -52,6 +53,7 @@ interface PlanSidebarProps {
   activePlan: ActivePlanState | null;
   activeProposedPlan: LatestProposedPlanState | null;
   markdownCwd: string | undefined;
+  availableEditors: ReadonlyArray<EditorId>;
   workspaceRoot: string | undefined;
   onClose: () => void;
 }
@@ -60,6 +62,7 @@ const PlanSidebar = memo(function PlanSidebar({
   activePlan,
   activeProposedPlan,
   markdownCwd,
+  availableEditors,
   workspaceRoot,
   onClose,
 }: PlanSidebarProps) {
@@ -238,6 +241,7 @@ const PlanSidebar = memo(function PlanSidebar({
                   <ChatMarkdown
                     text={displayedPlanMarkdown ?? ""}
                     cwd={markdownCwd}
+                    availableEditors={availableEditors}
                     isStreaming={false}
                   />
                 </div>

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1,6 +1,6 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Plus, SquareSplitHorizontal, TerminalSquare, Trash2, XIcon } from "lucide-react";
-import { type ThreadId } from "@t3tools/contracts";
+import { type EditorId, type ThreadId } from "@t3tools/contracts";
 import { Terminal, type ITheme } from "@xterm/xterm";
 import {
   type PointerEvent as ReactPointerEvent,
@@ -12,10 +12,10 @@ import {
   useState,
 } from "react";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
+import { getPreferredEditor, useAvailableEditors } from "~/editorPreferences";
 import {
   extractTerminalLinks,
   isTerminalLinkActivation,
-  preferredTerminalEditor,
   resolvePathLinkTarget,
 } from "../terminal-links";
 import { isTerminalClearShortcut, terminalNavigationShortcutData } from "../keybindings";
@@ -111,6 +111,7 @@ interface TerminalViewportProps {
   threadId: ThreadId;
   terminalId: string;
   cwd: string;
+  availableEditors: ReadonlyArray<EditorId>;
   runtimeEnv?: Record<string, string>;
   onSessionExited: () => void;
   focusRequestId: number;
@@ -123,6 +124,7 @@ function TerminalViewport({
   threadId,
   terminalId,
   cwd,
+  availableEditors,
   runtimeEnv,
   onSessionExited,
   focusRequestId,
@@ -135,10 +137,15 @@ function TerminalViewport({
   const fitAddonRef = useRef<FitAddon | null>(null);
   const onSessionExitedRef = useRef(onSessionExited);
   const hasHandledExitRef = useRef(false);
+  const availableEditorsRef = useRef<ReadonlyArray<EditorId>>(availableEditors);
 
   useEffect(() => {
     onSessionExitedRef.current = onSessionExited;
   }, [onSessionExited]);
+
+  useEffect(() => {
+    availableEditorsRef.current = availableEditors;
+  }, [availableEditors]);
 
   useEffect(() => {
     const mount = containerRef.current;
@@ -236,7 +243,12 @@ function TerminalViewport({
               }
 
               const target = resolvePathLinkTarget(match.text, cwd);
-              void api.shell.openInEditor(target, preferredTerminalEditor()).catch((error) => {
+              const editor = getPreferredEditor(availableEditorsRef.current);
+              if (!editor) {
+                writeSystemMessage(latestTerminal, "No available editor found.");
+                return;
+              }
+              void api.shell.openInEditor(target, editor).catch((error) => {
                 writeSystemMessage(
                   latestTerminal,
                   error instanceof Error ? error.message : "Unable to open path",
@@ -501,6 +513,7 @@ export default function ThreadTerminalDrawer({
   onCloseTerminal,
   onHeightChange,
 }: ThreadTerminalDrawerProps) {
+  const availableEditors = useAvailableEditors();
   const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height));
   const [resizeEpoch, setResizeEpoch] = useState(0);
   const drawerHeightRef = useRef(drawerHeight);
@@ -804,6 +817,7 @@ export default function ThreadTerminalDrawer({
                         threadId={threadId}
                         terminalId={terminalId}
                         cwd={cwd}
+                        availableEditors={availableEditors}
                         {...(runtimeEnv ? { runtimeEnv } : {})}
                         onSessionExited={() => onCloseTerminal(terminalId)}
                         focusRequestId={focusRequestId}
@@ -822,6 +836,7 @@ export default function ThreadTerminalDrawer({
                   threadId={threadId}
                   terminalId={resolvedActiveTerminalId}
                   cwd={cwd}
+                  availableEditors={availableEditors}
                   {...(runtimeEnv ? { runtimeEnv } : {})}
                   onSessionExited={() => onCloseTerminal(resolvedActiveTerminalId)}
                   focusRequestId={focusRequestId}

--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -1,0 +1,43 @@
+import { type EditorId, EDITORS } from "@t3tools/contracts";
+import { useQuery } from "@tanstack/react-query";
+
+import { serverConfigQueryOptions } from "./lib/serverReactQuery";
+
+export const LAST_EDITOR_KEY = "t3code:last-editor";
+export const EMPTY_AVAILABLE_EDITORS: EditorId[] = [];
+const EDITOR_IDS_WITH_COMMAND = new Set(
+  EDITORS.filter((editor) => editor.command).map((editor) => editor.id),
+);
+
+function isFileOpenEditor(editorId: EditorId): boolean {
+  return EDITOR_IDS_WITH_COMMAND.has(editorId);
+}
+
+function readStoredEditorPreference(): EditorId | null {
+  if (typeof window === "undefined") return null;
+
+  const stored = window.localStorage.getItem(LAST_EDITOR_KEY);
+  return EDITORS.some((editor) => editor.id === stored) ? (stored as EditorId) : null;
+}
+
+function resolvePreferredEditor(
+  availableEditors: ReadonlyArray<EditorId>,
+  storedEditor: EditorId | null,
+): EditorId | null {
+  const eligibleEditors = availableEditors.filter(isFileOpenEditor);
+
+  if (storedEditor && eligibleEditors.includes(storedEditor)) {
+    return storedEditor;
+  }
+
+  return eligibleEditors[0] ?? null;
+}
+
+export function getPreferredEditor(availableEditors: ReadonlyArray<EditorId>): EditorId | null {
+  return resolvePreferredEditor(availableEditors, readStoredEditorPreference());
+}
+
+export function useAvailableEditors(): ReadonlyArray<EditorId> {
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  return serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -13,12 +13,12 @@ import { Throttler } from "@tanstack/react-pacer";
 import { APP_DISPLAY_NAME } from "../branding";
 import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
+import { getPreferredEditor } from "../editorPreferences";
 import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useStore } from "../store";
 import { useTerminalStateStore } from "../terminalStateStore";
-import { preferredTerminalEditor } from "../terminal-links";
 import { terminalRunningSubprocessFromEvent } from "../terminalActivity";
 import { onServerConfigUpdated, onServerWelcome } from "../wsNativeApi";
 import { providerQueryKeys } from "../lib/providerReactQuery";
@@ -278,9 +278,13 @@ function EventRouter() {
           onClick: () => {
             void queryClient
               .ensureQueryData(serverConfigQueryOptions())
-              .then((config) =>
-                api.shell.openInEditor(config.keybindingsConfigPath, preferredTerminalEditor()),
-              )
+              .then((config) => {
+                const preferredEditor = getPreferredEditor(config.availableEditors);
+                if (!preferredEditor) {
+                  throw new Error("No available editor found.");
+                }
+                return api.shell.openInEditor(config.keybindingsConfigPath, preferredEditor);
+              })
               .catch((error) => {
                 toastManager.add({
                   type: "error",

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -5,11 +5,11 @@ import { type ProviderKind } from "@t3tools/contracts";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 
 import { MAX_CUSTOM_MODEL_LENGTH, useAppSettings } from "../appSettings";
+import { EMPTY_AVAILABLE_EDITORS, getPreferredEditor } from "../editorPreferences";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { ensureNativeApi } from "../nativeApi";
-import { preferredTerminalEditor } from "../terminal-links";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Switch } from "../components/ui/switch";
@@ -49,7 +49,6 @@ const MODEL_PROVIDER_SETTINGS: Array<{
     example: "gpt-6.7-codex-ultra-preview",
   },
 ] as const;
-
 function getCustomModelsForProvider(
   settings: ReturnType<typeof useAppSettings>["settings"],
   provider: ProviderKind,
@@ -98,14 +97,22 @@ function SettingsRouteView() {
   const codexBinaryPath = settings.codexBinaryPath;
   const codexHomePath = settings.codexHomePath;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
+  const availableEditors = serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
+  const preferredEditor = getPreferredEditor(availableEditors);
 
   const openKeybindingsFile = useCallback(() => {
     if (!keybindingsConfigPath) return;
     setOpenKeybindingsError(null);
     setIsOpeningKeybindings(true);
+    const preferredEditor = getPreferredEditor(availableEditors);
+    if (!preferredEditor) {
+      setOpenKeybindingsError("No available editor found.");
+      setIsOpeningKeybindings(false);
+      return;
+    }
     const api = ensureNativeApi();
     void api.shell
-      .openInEditor(keybindingsConfigPath, preferredTerminalEditor())
+      .openInEditor(keybindingsConfigPath, preferredEditor)
       .catch((error) => {
         setOpenKeybindingsError(
           error instanceof Error ? error.message : "Unable to open keybindings file.",
@@ -114,7 +121,7 @@ function SettingsRouteView() {
       .finally(() => {
         setIsOpeningKeybindings(false);
       });
-  }, [keybindingsConfigPath]);
+  }, [availableEditors, keybindingsConfigPath]);
 
   const addCustomModel = useCallback(
     (provider: ProviderKind) => {
@@ -497,7 +504,7 @@ function SettingsRouteView() {
                   <Button
                     size="xs"
                     variant="outline"
-                    disabled={!keybindingsConfigPath || isOpeningKeybindings}
+                    disabled={!keybindingsConfigPath || !preferredEditor || isOpeningKeybindings}
                     onClick={openKeybindingsFile}
                   >
                     {isOpeningKeybindings ? "Opening..." : "Open keybindings.json"}

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -1,4 +1,3 @@
-import { EDITORS, type EditorId } from "@t3tools/contracts";
 import { isMacPlatform } from "./lib/utils";
 
 export type TerminalLinkKind = "url" | "path";
@@ -14,8 +13,6 @@ const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/g;
 const FILE_PATH_PATTERN =
   /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:\\|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}/g;
 const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/;
-const LAST_EDITOR_KEY = "t3code:last-editor";
-
 function trimClosingDelimiters(value: string): string {
   let output = value.replace(TRAILING_PUNCTUATION_PATTERN, "");
   if (output.length === 0) return output;
@@ -174,24 +171,4 @@ export function resolvePathLinkTarget(rawPath: string, cwd: string): string {
 
   if (!line) return resolvedPath;
   return `${resolvedPath}:${line}${column ? `:${column}` : ""}`;
-}
-
-export function preferredTerminalEditor(): EditorId {
-  const fallback = EDITORS.find((editor) => editor.command)?.id ?? EDITORS[0]?.id ?? "cursor";
-
-  if (typeof window === "undefined") {
-    return fallback;
-  }
-
-  const storedEditor = window.localStorage.getItem(LAST_EDITOR_KEY);
-  if (!storedEditor) {
-    return fallback;
-  }
-
-  const configured = EDITORS.find((editor) => editor.id === storedEditor);
-  if (!configured?.command) {
-    return fallback;
-  }
-
-  return configured.id;
 }


### PR DESCRIPTION
## What Changed

* Replace `preferredTerminalEditor` function with available editor aware `getPreferredEditor`.
* Update uses of `getPreferredTerminal` to either call `getPreferredEditor` with available editors directly, when available, or to use a new hook `useAvailableEditors` first, to ensure up to date state.
  * Specifically used prop drilling for ChatView's ChatMarkdown to avoid repeated useQuery calls. 
  * For terminal drawer, specifically used a ref to keep it up to date and to avoid reinstantiating the terminal.

If accepted, should close #746 

## Why

When i first installed t3 code, i immediately went to open `keybindings.json` but that failed with 'cursor not found', since i don't have cursor installed on this machine and had yet to set my last used editor storage key. The ChatHeader UI correctly gave me the option to open Zed (an available editor) but this button didn't, which feels like unintentional, inconsistent behavior.

## UI Changes

There are no UI changes, well besides hopefully preventing some errors to be shown, which here is an example of the error I got when opening `keybindings.json`:

### Before

<img width="1212" height="892" alt="image" src="https://github.com/user-attachments/assets/20df7645-4897-4b0e-bcf9-be04d79ff2ba" />

### After

<img width="1212" height="892" alt="image" src="https://github.com/user-attachments/assets/7c93815c-b8e6-4e1c-b512-0852d5aab662" />

(note the zed editor did open, and you can see there is no error)

### Quick Video Comparison

https://github.com/user-attachments/assets/98cc97ca-d876-48c8-9832-3850e2d266b4

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes

## Future Considerations

It may be desirable to lift last used editor into zustand app state store to encapsulate the local storage usage to clean up the code more and better unify the code paths in OpenInPicker, which has been left alone for now, as it wasn't causing problems and these changes are already compatible.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use available editors as fallback before last editor preference is set
> - Adds a new [editorPreferences.ts](https://github.com/pingdotgg/t3code/pull/825/files#diff-b95642bd2ec02008455dc34d764b6b380dc3cb63bf4eb8fc249e0a105220efdd) module with `getPreferredEditor(availableEditors)` and `useAvailableEditors` hook, replacing the removed `preferredTerminalEditor()` from [terminal-links.ts](https://github.com/pingdotgg/t3code/pull/825/files#diff-5f57eb38e8e99e705308a736729815ef1ec005cf2f20cca912a9f7abcf28c110).
> - Updates file-opening in `DiffPanel`, `GitActionsControl`, `ChatMarkdown`, `TerminalViewport`, and the settings/root routes to resolve the preferred editor from server-reported availability before falling back to the last-used localStorage preference.
> - When no editor is available, each call site now fails gracefully: terminal shows a system message, git actions show a toast, settings disables the button, and others log a warning.
> - Behavioral Change: `preferredTerminalEditor()` is removed; all callers must use `getPreferredEditor(availableEditors)` from the new module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c017eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->