### PR TITLE
Sort sidebar threads by most recent user message

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -196,6 +196,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const syncServerReadModel = useStore((store) => store.syncServerReadModel);
   const setStoreThreadError = useStore((store) => store.setError);
   const setStoreThreadBranch = useStore((store) => store.setThreadBranch);
+  const markStoreThreadOptimisticUserSend = useStore((store) => store.markThreadOptimisticUserSend);
+  const clearStoreThreadOptimisticUserSend = useStore(
+    (store) => store.clearThreadOptimisticUserSend,
+  );
   const { settings } = useAppSettings();
   const timestampFormat = settings.timestampFormat;
   const navigate = useNavigate();
@@ -2276,6 +2280,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       sizeBytes: image.sizeBytes,
       previewUrl: image.previewUrl,
     }));
+    markStoreThreadOptimisticUserSend(threadIdForSend, messageCreatedAt);
     setOptimisticUserMessages((existing) => [
       ...existing,
       {
@@ -2435,6 +2440,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       });
       turnStartSucceeded = true;
     })().catch(async (err: unknown) => {
+      clearStoreThreadOptimisticUserSend(threadIdForSend);
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
         await api.orchestration
           .dispatchCommand({

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -89,6 +89,7 @@ import {
   resolveThreadStatusPill,
   shouldClearThreadSelectionOnMouseDown,
 } from "./Sidebar.logic";
+import { compareThreadsForSidebar } from "../lib/threadRecency";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
@@ -254,6 +255,7 @@ function SortableProjectItem({
 export default function Sidebar() {
   const projects = useStore((store) => store.projects);
   const threads = useStore((store) => store.threads);
+  const optimisticUserSendAtByThreadId = useStore((store) => store.optimisticUserSendAtByThreadId);
   const markThreadUnread = useStore((store) => store.markThreadUnread);
   const toggleProject = useStore((store) => store.toggleProject);
   const reorderProjects = useStore((store) => store.reorderProjects);
@@ -385,11 +387,7 @@ export default function Sidebar() {
     (projectId: ProjectId) => {
       const latestThread = threads
         .filter((thread) => thread.projectId === projectId)
-        .toSorted((a, b) => {
-          const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-          if (byDate !== 0) return byDate;
-          return b.id.localeCompare(a.id);
-        })[0];
+        .toSorted((a, b) => compareThreadsForSidebar(a, b, optimisticUserSendAtByThreadId))[0];
       if (!latestThread) return;
 
       void navigate({
@@ -397,7 +395,7 @@ export default function Sidebar() {
         params: { threadId: latestThread.id },
       });
     },
-    [navigate, threads],
+    [navigate, optimisticUserSendAtByThreadId, threads],
   );
 
   const addProjectFromPath = useCallback(
@@ -1295,12 +1293,9 @@ export default function Sidebar() {
                 {projects.map((project) => {
                   const projectThreads = threads
                     .filter((thread) => thread.projectId === project.id)
-                    .toSorted((a, b) => {
-                      const byDate =
-                        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-                      if (byDate !== 0) return byDate;
-                      return b.id.localeCompare(a.id);
-                    });
+                    .toSorted((a, b) =>
+                      compareThreadsForSidebar(a, b, optimisticUserSendAtByThreadId),
+                    );
                   const isThreadListExpanded = expandedThreadListsByProject.has(project.id);
                   const hasHiddenThreads = projectThreads.length > THREAD_PREVIEW_LIMIT;
                   const visibleThreads =

--- a/apps/web/src/lib/threadRecency.test.ts
+++ b/apps/web/src/lib/threadRecency.test.ts
@@ -1,0 +1,170 @@
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  compareThreadsForSidebar,
+  getLatestUserMessageAt,
+  getThreadSidebarRecency,
+} from "./threadRecency";
+import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "../types";
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread",
+    model: "gpt-5-codex",
+    runtimeMode: DEFAULT_RUNTIME_MODE,
+    interactionMode: DEFAULT_INTERACTION_MODE,
+    session: null,
+    messages: [],
+    turnDiffSummaries: [],
+    activities: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-03-10T10:00:00.000Z",
+    latestTurn: null,
+    branch: null,
+    worktreePath: null,
+    ...overrides,
+  };
+}
+
+describe("threadRecency", () => {
+  it("returns the latest user message timestamp", () => {
+    const thread = makeThread({
+      messages: [
+        {
+          id: "assistant-1" as never,
+          role: "assistant",
+          text: "assistant",
+          createdAt: "2026-03-10T10:10:00.000Z",
+          streaming: false,
+        },
+        {
+          id: "user-1" as never,
+          role: "user",
+          text: "first",
+          createdAt: "2026-03-10T10:05:00.000Z",
+          streaming: false,
+        },
+        {
+          id: "user-2" as never,
+          role: "user",
+          text: "latest",
+          createdAt: "2026-03-10T10:15:00.000Z",
+          streaming: false,
+        },
+      ],
+    });
+
+    expect(getLatestUserMessageAt(thread)).toBe("2026-03-10T10:15:00.000Z");
+  });
+
+  it("ignores assistant-only activity when deriving recency", () => {
+    const thread = makeThread({
+      messages: [
+        {
+          id: "assistant-1" as never,
+          role: "assistant",
+          text: "assistant",
+          createdAt: "2026-03-10T10:20:00.000Z",
+          streaming: false,
+        },
+      ],
+    });
+
+    expect(getThreadSidebarRecency(thread)).toBe("2026-03-10T10:00:00.000Z");
+  });
+
+  it("prefers optimistic recency over confirmed user-message recency", () => {
+    const thread = makeThread({
+      messages: [
+        {
+          id: "user-1" as never,
+          role: "user",
+          text: "first",
+          createdAt: "2026-03-10T10:05:00.000Z",
+          streaming: false,
+        },
+      ],
+    });
+
+    expect(getThreadSidebarRecency(thread, "2026-03-10T10:06:00.000Z")).toBe(
+      "2026-03-10T10:06:00.000Z",
+    );
+  });
+
+  it("does not allow an older optimistic timestamp to lower confirmed recency", () => {
+    const thread = makeThread({
+      messages: [
+        {
+          id: "user-1" as never,
+          role: "user",
+          text: "newest",
+          createdAt: "2026-03-10T10:07:00.000Z",
+          streaming: false,
+        },
+      ],
+    });
+
+    expect(getThreadSidebarRecency(thread, "2026-03-10T10:06:00.000Z")).toBe(
+      "2026-03-10T10:07:00.000Z",
+    );
+  });
+
+  it("sorts by sidebar recency with deterministic tiebreakers", () => {
+    const optimisticThread = makeThread({
+      id: ThreadId.makeUnsafe("thread-optimistic"),
+      createdAt: "2026-03-10T09:00:00.000Z",
+      messages: [
+        {
+          id: "user-1" as never,
+          role: "user",
+          text: "older",
+          createdAt: "2026-03-10T10:01:00.000Z",
+          streaming: false,
+        },
+      ],
+    });
+    const newerCreatedThread = makeThread({
+      id: ThreadId.makeUnsafe("thread-newer-created"),
+      createdAt: "2026-03-10T10:00:00.000Z",
+      messages: [
+        {
+          id: "user-2" as never,
+          role: "user",
+          text: "same time",
+          createdAt: "2026-03-10T10:02:00.000Z",
+          streaming: false,
+        },
+      ],
+    });
+    const olderCreatedThread = makeThread({
+      id: ThreadId.makeUnsafe("thread-older-created"),
+      createdAt: "2026-03-10T08:00:00.000Z",
+      messages: [
+        {
+          id: "user-3" as never,
+          role: "user",
+          text: "same time",
+          createdAt: "2026-03-10T10:02:00.000Z",
+          streaming: false,
+        },
+      ],
+    });
+
+    const ordered = [olderCreatedThread, newerCreatedThread, optimisticThread].toSorted((a, b) =>
+      compareThreadsForSidebar(a, b, {
+        [optimisticThread.id]: "2026-03-10T10:03:00.000Z",
+      }),
+    );
+
+    expect(ordered.map((thread) => thread.id)).toEqual([
+      ThreadId.makeUnsafe("thread-optimistic"),
+      ThreadId.makeUnsafe("thread-newer-created"),
+      ThreadId.makeUnsafe("thread-older-created"),
+    ]);
+  });
+});

--- a/apps/web/src/lib/threadRecency.ts
+++ b/apps/web/src/lib/threadRecency.ts
@@ -1,0 +1,41 @@
+import type { ThreadId } from "@t3tools/contracts";
+
+import type { Thread } from "../types";
+
+export type OptimisticUserSendAtByThreadId = Partial<Record<ThreadId, string>>;
+
+export function getLatestUserMessageAt(thread: Thread): string | null {
+  let latestUserMessageAt: string | null = null;
+  for (const message of thread.messages) {
+    if (message.role !== "user") continue;
+    if (latestUserMessageAt === null || message.createdAt.localeCompare(latestUserMessageAt) > 0) {
+      latestUserMessageAt = message.createdAt;
+    }
+  }
+  return latestUserMessageAt;
+}
+
+export function getThreadSidebarRecency(thread: Thread, optimisticAt?: string | null): string {
+  const confirmedRecency = getLatestUserMessageAt(thread) ?? thread.createdAt;
+  if (optimisticAt == null) {
+    return confirmedRecency;
+  }
+  return optimisticAt.localeCompare(confirmedRecency) > 0 ? optimisticAt : confirmedRecency;
+}
+
+export function compareThreadsForSidebar(
+  left: Thread,
+  right: Thread,
+  optimisticUserSendAtByThreadId: OptimisticUserSendAtByThreadId,
+): number {
+  const byRecency = getThreadSidebarRecency(
+    right,
+    optimisticUserSendAtByThreadId[right.id],
+  ).localeCompare(getThreadSidebarRecency(left, optimisticUserSendAtByThreadId[left.id]));
+  if (byRecency !== 0) return byRecency;
+
+  const byCreatedAt = right.createdAt.localeCompare(left.createdAt);
+  if (byCreatedAt !== 0) return byCreatedAt;
+
+  return right.id.localeCompare(left.id);
+}

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -7,7 +7,14 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { markThreadUnread, reorderProjects, syncServerReadModel, type AppState } from "./store";
+import {
+  clearThreadOptimisticUserSend,
+  markThreadOptimisticUserSend,
+  markThreadUnread,
+  reorderProjects,
+  syncServerReadModel,
+  type AppState,
+} from "./store";
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "./types";
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
@@ -47,6 +54,7 @@ function makeState(thread: Thread): AppState {
     ],
     threads: [thread],
     threadsHydrated: true,
+    optimisticUserSendAtByThreadId: {},
   };
 }
 
@@ -182,11 +190,56 @@ describe("store pure functions", () => {
       ],
       threads: [],
       threadsHydrated: true,
+      optimisticUserSendAtByThreadId: {},
     };
 
     const next = reorderProjects(state, project1, project3);
 
     expect(next.projects.map((project) => project.id)).toEqual([project2, project3, project1]);
+  });
+
+  it("markThreadOptimisticUserSend stores the optimistic timestamp", () => {
+    const state = makeState(makeThread());
+
+    const next = markThreadOptimisticUserSend(
+      state,
+      ThreadId.makeUnsafe("thread-1"),
+      "2026-03-10T12:00:00.000Z",
+    );
+
+    expect(next.optimisticUserSendAtByThreadId[ThreadId.makeUnsafe("thread-1")]).toBe(
+      "2026-03-10T12:00:00.000Z",
+    );
+  });
+
+  it("markThreadOptimisticUserSend keeps the newest timestamp for a thread", () => {
+    const state = {
+      ...makeState(makeThread()),
+      optimisticUserSendAtByThreadId: {
+        [ThreadId.makeUnsafe("thread-1")]: "2026-03-10T12:00:01.000Z",
+      },
+    } satisfies AppState;
+
+    const next = markThreadOptimisticUserSend(
+      state,
+      ThreadId.makeUnsafe("thread-1"),
+      "2026-03-10T12:00:00.000Z",
+    );
+
+    expect(next).toBe(state);
+  });
+
+  it("clearThreadOptimisticUserSend removes the optimistic timestamp", () => {
+    const state = {
+      ...makeState(makeThread()),
+      optimisticUserSendAtByThreadId: {
+        [ThreadId.makeUnsafe("thread-1")]: "2026-03-10T12:00:00.000Z",
+      },
+    } satisfies AppState;
+
+    const next = clearThreadOptimisticUserSend(state, ThreadId.makeUnsafe("thread-1"));
+
+    expect(next.optimisticUserSendAtByThreadId[ThreadId.makeUnsafe("thread-1")]).toBeUndefined();
   });
 });
 
@@ -229,6 +282,7 @@ describe("store read model sync", () => {
       ],
       threads: [],
       threadsHydrated: true,
+      optimisticUserSendAtByThreadId: {},
     };
     const readModel: OrchestrationReadModel = {
       snapshotSequence: 2,
@@ -256,5 +310,90 @@ describe("store read model sync", () => {
     const next = syncServerReadModel(initialState, readModel);
 
     expect(next.projects.map((project) => project.id)).toEqual([project2, project1, project3]);
+  });
+
+  it("clears optimistic user send timestamps once the confirmed user message catches up", () => {
+    const initialState: AppState = {
+      ...makeState(makeThread()),
+      optimisticUserSendAtByThreadId: {
+        [ThreadId.makeUnsafe("thread-1")]: "2026-03-10T12:00:00.000Z",
+      },
+    };
+    const readModel = makeReadModel(
+      makeReadModelThread({
+        messages: [
+          {
+            id: "message-1" as never,
+            role: "user",
+            text: "Hello",
+            attachments: [],
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-03-10T12:00:00.000Z",
+            updatedAt: "2026-03-10T12:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.optimisticUserSendAtByThreadId[ThreadId.makeUnsafe("thread-1")]).toBeUndefined();
+  });
+
+  it("keeps optimistic user send timestamps when the confirmed thread has not caught up", () => {
+    const initialState: AppState = {
+      ...makeState(makeThread()),
+      optimisticUserSendAtByThreadId: {
+        [ThreadId.makeUnsafe("thread-1")]: "2026-03-10T12:00:01.000Z",
+      },
+    };
+    const readModel = makeReadModel(
+      makeReadModelThread({
+        messages: [
+          {
+            id: "message-1" as never,
+            role: "user",
+            text: "Hello",
+            attachments: [],
+            turnId: null,
+            streaming: false,
+            createdAt: "2026-03-10T12:00:00.000Z",
+            updatedAt: "2026-03-10T12:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.optimisticUserSendAtByThreadId[ThreadId.makeUnsafe("thread-1")]).toBe(
+      "2026-03-10T12:00:01.000Z",
+    );
+  });
+
+  it("drops optimistic user send timestamps for threads missing from the latest snapshot", () => {
+    const initialState: AppState = {
+      ...makeState(makeThread()),
+      optimisticUserSendAtByThreadId: {
+        [ThreadId.makeUnsafe("thread-1")]: "2026-03-10T12:00:01.000Z",
+      },
+    };
+    const readModel: OrchestrationReadModel = {
+      snapshotSequence: 2,
+      updatedAt: "2026-02-27T00:00:00.000Z",
+      projects: [
+        makeReadModelProject({
+          id: ProjectId.makeUnsafe("project-1"),
+          title: "Project 1",
+          workspaceRoot: "/tmp/project-1",
+        }),
+      ],
+      threads: [],
+    };
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.optimisticUserSendAtByThreadId).toEqual({});
   });
 });

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -15,6 +15,7 @@ import {
 import { create } from "zustand";
 import { type ChatMessage, type Project, type Thread } from "./types";
 import { Debouncer } from "@tanstack/react-pacer";
+import { getLatestUserMessageAt, type OptimisticUserSendAtByThreadId } from "./lib/threadRecency";
 
 // ── State ────────────────────────────────────────────────────────────
 
@@ -22,6 +23,7 @@ export interface AppState {
   projects: Project[];
   threads: Thread[];
   threadsHydrated: boolean;
+  optimisticUserSendAtByThreadId: OptimisticUserSendAtByThreadId;
 }
 
 const PERSISTED_STATE_KEY = "t3code:renderer-state:v8";
@@ -41,6 +43,7 @@ const initialState: AppState = {
   projects: [],
   threads: [],
   threadsHydrated: false,
+  optimisticUserSendAtByThreadId: {},
 };
 const persistedExpandedProjectCwds = new Set<string>();
 const persistedProjectOrderCwds: string[] = [];
@@ -325,11 +328,26 @@ export function syncServerReadModel(state: AppState, readModel: OrchestrationRea
         activities: thread.activities.map((activity) => ({ ...activity })),
       };
     });
+  const threadById = new Map(threads.map((thread) => [thread.id, thread] as const));
+  const optimisticUserSendAtByThreadId = Object.fromEntries(
+    Object.entries(state.optimisticUserSendAtByThreadId).filter(([threadId, optimisticAt]) => {
+      if (typeof optimisticAt !== "string") {
+        return false;
+      }
+      const thread = threadById.get(threadId as ThreadId);
+      if (!thread) {
+        return false;
+      }
+      const latestUserMessageAt = getLatestUserMessageAt(thread);
+      return latestUserMessageAt === null || latestUserMessageAt.localeCompare(optimisticAt) < 0;
+    }),
+  ) as OptimisticUserSendAtByThreadId;
   return {
     ...state,
     projects,
     threads,
     threadsHydrated: true,
+    optimisticUserSendAtByThreadId,
   };
 }
 
@@ -430,6 +448,36 @@ export function setThreadBranch(
   return threads === state.threads ? state : { ...state, threads };
 }
 
+export function markThreadOptimisticUserSend(
+  state: AppState,
+  threadId: ThreadId,
+  at?: string,
+): AppState {
+  const nextAt = at ?? new Date().toISOString();
+  const previousAt = state.optimisticUserSendAtByThreadId[threadId];
+  if (previousAt !== undefined && previousAt.localeCompare(nextAt) >= 0) {
+    return state;
+  }
+  return {
+    ...state,
+    optimisticUserSendAtByThreadId: {
+      ...state.optimisticUserSendAtByThreadId,
+      [threadId]: nextAt,
+    },
+  };
+}
+
+export function clearThreadOptimisticUserSend(state: AppState, threadId: ThreadId): AppState {
+  if (state.optimisticUserSendAtByThreadId[threadId] === undefined) {
+    return state;
+  }
+  const { [threadId]: _cleared, ...rest } = state.optimisticUserSendAtByThreadId;
+  return {
+    ...state,
+    optimisticUserSendAtByThreadId: rest as OptimisticUserSendAtByThreadId,
+  };
+}
+
 // ── Zustand store ────────────────────────────────────────────────────
 
 interface AppStore extends AppState {
@@ -441,6 +489,8 @@ interface AppStore extends AppState {
   reorderProjects: (draggedProjectId: Project["id"], targetProjectId: Project["id"]) => void;
   setError: (threadId: ThreadId, error: string | null) => void;
   setThreadBranch: (threadId: ThreadId, branch: string | null, worktreePath: string | null) => void;
+  markThreadOptimisticUserSend: (threadId: ThreadId, at?: string) => void;
+  clearThreadOptimisticUserSend: (threadId: ThreadId) => void;
 }
 
 export const useStore = create<AppStore>((set) => ({
@@ -457,6 +507,10 @@ export const useStore = create<AppStore>((set) => ({
   setError: (threadId, error) => set((state) => setError(state, threadId, error)),
   setThreadBranch: (threadId, branch, worktreePath) =>
     set((state) => setThreadBranch(state, threadId, branch, worktreePath)),
+  markThreadOptimisticUserSend: (threadId, at) =>
+    set((state) => markThreadOptimisticUserSend(state, threadId, at)),
+  clearThreadOptimisticUserSend: (threadId) =>
+    set((state) => clearThreadOptimisticUserSend(state, threadId)),
 }));
 
 // Persist state changes with debouncing to avoid localStorage thrashing


### PR DESCRIPTION
Makes the left sidebar feel more natural by moving threads up when you send a message in them.

Instead of sorting by creation date, the sidebar now uses your latest user prompt to determine recency. It updates immediately when you hit send, then settles back onto confirmed server state.

Tests added:

- thread recency derivation and comparator behavior
- ignoring assistant-only messages for sorting
- optimistic recency winning immediately after send
- snapshot reconciliation clearing optimistic state once confirmed messages catch up
- dropping stale optimistic state for missing threads

## What Changed

Updated sidebar thread ordering so threads are no longer sorted by creation date. The sidebar now uses the latest user prompt as the recency signal, and it moves a thread up immediately when you send a message in it. That optimistic move then settles back onto confirmed server state once the message appears in the synced snapshot.

## Why

Fixes #805 and #804, which I agree is a nicer user flow and more fits the expectations of how using ChatGPT like systems and Codex App itself by bringing most recent chats to the top. 

## UI Changes

The left sidebar now reorders threads when you send a message, rather than keeping them fixed by original creation time.

Video:
https://github.com/user-attachments/assets/3570d19c-a10f-4481-abf4-9507af096289


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort sidebar threads by most recent user message using optimistic timestamps
> - Adds a `compareThreadsForSidebar` utility in [threadRecency.ts](https://github.com/pingdotgg/t3code/pull/827/files#diff-7ce1e1b6a1276b406169fe7b469cea6ad722039ad2f0ee12f4cb48774150f61d) that sorts threads by the latest confirmed user message time, falling back to thread creation time, with deterministic tiebreakers.
> - Introduces `optimisticUserSendAtByThreadId` to the Zustand store to track per-thread optimistic timestamps when a user sends a message, so the sidebar reorders immediately without waiting for a server response.
> - `syncServerReadModel` prunes optimistic timestamps when the server-confirmed user message time catches up or the thread no longer exists.
> - The [Sidebar](https://github.com/pingdotgg/t3code/pull/827/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) now uses `compareThreadsForSidebar` with the optimistic map, replacing previous inline sort comparators.
> - Behavioral Change: threads previously sorted by assistant activity or creation time will now sort by user message recency, which may reorder existing thread lists.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6406df.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->