### PR TITLE
Visually distinguish plan mode from chat mode in composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3638,7 +3638,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
               data-chat-composer-form="true"
             >
               <div
-                className={`group rounded-[20px] border bg-card transition-colors duration-200 ${
+                className={`group relative overflow-visible rounded-[20px] border bg-card transition-colors duration-200 ${
                   isDragOverComposer
                     ? "border-primary/70 bg-accent/30"
                     : interactionMode === "plan"
@@ -3650,6 +3650,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 onDragLeave={onComposerDragLeave}
                 onDrop={onComposerDrop}
               >
+                {interactionMode === "plan" && (
+                  <span className="absolute -top-3 left-5 rounded-full border border-border group-focus-within:border-ring-plan/45 bg-card transition-colors duration-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-ring-plan/50 group-focus-within:text-ring-plan">
+                    Plan
+                  </span>
+                )}
                 {activePendingApproval ? (
                   <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
                     <ComposerPendingApprovalPanel

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3882,29 +3882,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
                             size="sm"
                             type="button"
-                            onClick={toggleInteractionMode}
-                            title={
-                              interactionMode === "plan"
-                                ? "Plan mode — click to return to normal chat mode"
-                                : "Default mode — click to enter plan mode"
-                            }
-                          >
-                            <BotIcon />
-                            <span className="sr-only sm:not-sr-only">
-                              {interactionMode === "plan" ? "Plan" : "Chat"}
-                            </span>
-                          </Button>
-
-                          <Separator
-                            orientation="vertical"
-                            className="mx-0.5 hidden h-4 sm:block"
-                          />
-
-                          <Button
-                            variant="ghost"
-                            className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
-                            size="sm"
-                            type="button"
                             onClick={() =>
                               void handleRuntimeModeChange(
                                 runtimeMode === "full-access" ? "approval-required" : "full-access",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3642,7 +3642,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                   isDragOverComposer
                     ? "border-primary/70 bg-accent/30"
                     : interactionMode === "plan"
-                      ? "border-border focus-within:border-amber-500/45"
+                      ? "border-border focus-within:border-warning/45"
                       : "border-border focus-within:border-ring/45"
                 }`}
                 onDragEnter={onComposerDragEnter}
@@ -4054,7 +4054,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             type="submit"
                             className={`flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 disabled:opacity-30 disabled:hover:scale-100 sm:h-8 sm:w-8 ${
                               interactionMode === "plan"
-                                ? "bg-amber-500/90 text-white hover:bg-amber-500 hover:scale-105"
+                                ? "bg-warning/90 text-white hover:bg-warning hover:scale-105"
                                 : "bg-primary/90 text-primary-foreground hover:bg-primary hover:scale-105"
                             }`}
                             disabled={

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3642,7 +3642,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                   isDragOverComposer
                     ? "border-primary/70 bg-accent/30"
                     : interactionMode === "plan"
-                      ? "border-border focus-within:border-warning/45"
+                      ? "border-border focus-within:border-ring-plan/45"
                       : "border-border focus-within:border-ring/45"
                 }`}
                 onDragEnter={onComposerDragEnter}
@@ -4054,7 +4054,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             type="submit"
                             className={`flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 disabled:opacity-30 disabled:hover:scale-100 sm:h-8 sm:w-8 ${
                               interactionMode === "plan"
-                                ? "bg-warning/90 text-white hover:bg-warning hover:scale-105"
+                                ? "bg-ring-plan/90 text-white hover:bg-ring-plan hover:scale-105"
                                 : "bg-primary/90 text-primary-foreground hover:bg-primary hover:scale-105"
                             }`}
                             disabled={

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3638,8 +3638,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
               data-chat-composer-form="true"
             >
               <div
-                className={`group rounded-[20px] border bg-card transition-colors duration-200 focus-within:border-ring/45 ${
-                  isDragOverComposer ? "border-primary/70 bg-accent/30" : "border-border"
+                className={`group rounded-[20px] border bg-card transition-colors duration-200 ${
+                  isDragOverComposer
+                    ? "border-primary/70 bg-accent/30"
+                    : interactionMode === "plan"
+                      ? "border-border focus-within:border-amber-500/45"
+                      : "border-border focus-within:border-ring/45"
                 }`}
                 onDragEnter={onComposerDragEnter}
                 onDragOver={onComposerDragOver}
@@ -4048,7 +4052,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
                         ) : (
                           <button
                             type="submit"
-                            className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/90 text-primary-foreground transition-all duration-150 hover:bg-primary hover:scale-105 disabled:opacity-30 disabled:hover:scale-100 sm:h-8 sm:w-8"
+                            className={`flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 disabled:opacity-30 disabled:hover:scale-100 sm:h-8 sm:w-8 ${
+                              interactionMode === "plan"
+                                ? "bg-amber-500/90 text-white hover:bg-amber-500 hover:scale-105"
+                                : "bg-primary/90 text-primary-foreground hover:bg-primary hover:scale-105"
+                            }`}
                             disabled={
                               isSendBusy ||
                               isConnecting ||

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3640,7 +3640,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
               <div
                 className={`group relative overflow-visible rounded-[20px] border bg-card transition-colors duration-200 ${
                   isDragOverComposer
-                    ? "border-primary/70 bg-accent/30"
+                    ? interactionMode === "plan"
+                      ? "border-ring-plan/70 bg-accent/30"
+                      : "border-primary/70 bg-accent/30"
                     : interactionMode === "plan"
                       ? "border-border focus-within:border-ring-plan/45"
                       : "border-border focus-within:border-ring/45"
@@ -3651,7 +3653,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 onDrop={onComposerDrop}
               >
                 {interactionMode === "plan" && (
-                  <span className="absolute -top-3 left-5 rounded-full border border-border group-focus-within:border-ring-plan/45 bg-card transition-colors duration-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest text-ring-plan/50 group-focus-within:text-ring-plan">
+                  <span className={`absolute -top-3 left-5 rounded-full border bg-card transition-colors duration-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest ${isDragOverComposer ? "border-ring-plan/70 text-ring-plan" : "border-border group-focus-within:border-ring-plan/45 text-ring-plan/50 group-focus-within:text-ring-plan"}`}>
                     Plan
                   </span>
                 )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11,6 +11,7 @@
   --color-info-foreground: var(--info-foreground);
   --color-info: var(--info);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-ring-plan: var(--ring-plan);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -89,6 +90,7 @@
   --success-foreground: var(--color-emerald-700);
   --warning: var(--color-amber-500);
   --warning-foreground: var(--color-amber-700);
+  --ring-plan: var(--color-amber-500);
 
   @variant dark {
     color-scheme: dark;
@@ -117,6 +119,7 @@
     --success-foreground: var(--color-emerald-400);
     --warning: var(--color-amber-500);
     --warning-foreground: var(--color-amber-400);
+    --ring-plan: var(--color-amber-500);
   }
 }
 


### PR DESCRIPTION
## What Changed

Updated the composer container's border and send button styling in ChatView.tsx to visually distinguish "plan" mode from "chat" mode:

- Composer border: focused state uses border-amber-500/45 in plan mode, border-ring/45 in chat mode (unfocused remains border-border in both)

- Send button: uses bg-amber-500/90 in plan mode, bg-primary/90 in chat mode

## Why

When the composer is in plan mode, there is no visual cue on the composer itself to indicate the active interaction mode. Adding an amber accent to the border and send button provides immediate, at-a-glance feedback so users don't accidentally send messages in the wrong mode.

## UI Changes
| Before | After |
|--------|-------|
| <img width="850" height="223" alt="Screenshot 2026-03-10 at 18 57 50" src="https://github.com/user-attachments/assets/4aa547eb-6388-4ab0-93b0-fab1a53eba63" />| <img width="829" height="247" alt="Screenshot 2026-03-10 at 18 57 22" src="https://github.com/user-attachments/assets/981ad673-2cf6-4edc-93bb-e9871a9df0aa" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Visually distinguish plan mode from chat mode in the composer
> - Adds a 'Plan' badge above the composer and applies `ring-plan` amber color tokens to the focus ring, drag-over border, and send button when `interactionMode === 'plan'`.
> - Introduces a `--ring-plan` CSS color token (amber-500) in [index.css](https://github.com/pingdotgg/t3code/pull/828/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to support plan-specific styling.
> - Removes the inline Chat/Plan toggle button from the input bar in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/828/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45a7d5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->