### PR TITLE
fix: update installation command in README to use npx t3@alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ T3 Code is a minimal web GUI for coding agents. Currently Codex-first, with Clau
 > You need to have [Codex CLI](https://github.com/openai/codex) installed and authorized for T3 Code to work.
 
 ```bash
-npx t3
+npx t3@alpha
 ```
 
 You can also just install the desktop app. It's cooler.


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed
Updated the installation command in the README to use:
```bash
npx t3@alpha
```
instead of:
```bash
npx t3
```

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->
The `npx t3` command no longer works because the package is currently published under the alpha tag.

Several users were attempting to run `npx t3` and encountering errors during project creation. Updating the README ensures the command matches the currently available package version and prevents confusion during setup.

## UI Changes
N/A – documentation change only.

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update README installation command to use `npx t3@alpha`
> Changes the example CLI command in [README.md](https://github.com/pingdotgg/t3code/pull/837/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) from `npx t3` to `npx t3@alpha` to reflect the current alpha release tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c3a906.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->