### PR TITLE
fix: auto-dismiss toast notifications after timeout

### DIFF
--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -27,6 +27,8 @@ const anchoredToastManager = Toast.createToastManager<ThreadToastData>();
 type ToastId = ReturnType<typeof toastManager.add>;
 const threadToastVisibleTimeoutRemainingMs = new Map<ToastId, number>();
 
+const DEFAULT_DISMISS_AFTER_VISIBLE_MS = 5_000;
+
 const TOAST_ICONS = {
   error: CircleAlertIcon,
   info: InfoIcon,
@@ -263,7 +265,7 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
               toast={toast}
             >
               <ThreadToastVisibleAutoDismiss
-                dismissAfterVisibleMs={toast.data?.dismissAfterVisibleMs}
+                dismissAfterVisibleMs={toast.data?.dismissAfterVisibleMs ?? (toast.type === "loading" ? undefined : DEFAULT_DISMISS_AFTER_VISIBLE_MS)}
                 toastId={toast.id}
               />
               <Toast.Content


### PR DESCRIPTION
### Summary
- Fixes #792

### Changes
- Added a `DEFAULT_DISMISS_AFTER_VISIBLE_MS = 5_000` constant in `apps/web/src/components/ui/toast.tsx`
- Applied it as a fallback when `dismissAfterVisibleMs` is not explicitly set by the caller
- The existing `ThreadToastVisibleAutoDismiss` component already had visibility-aware pause/resume logic, but only 1 of ~15 call sites opted in — this makes 5s auto-dismiss the default

### Test plan
- [ ] Trigger various toasts (session start, errors, git actions) and verify they dismiss after ~5s
- [ ] Verify toasts still pause countdown when tab is hidden or window loses focus
- [ ] Verify `GitActionsControl.tsx` still uses its custom 10s timeout

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-dismiss non-loading toast notifications after 5 seconds
> Adds a `DEFAULT_DISMISS_AFTER_VISIBLE_MS` constant (5,000 ms) in [toast.tsx](https://github.com/pingdotgg/t3code/pull/847/files#diff-dbb38a4f02a67491223157a9f1aba388365f4cd55652e1f32847ffda53aee7f2) and passes it as the default `dismissAfterVisibleMs` to `ThreadToastVisibleAutoDismiss` for all non-loading toasts. Loading toasts continue to persist until explicitly dismissed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88ed0ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->