### PR TITLE
fix: handle spaces in file paths for Open in Editor

### DIFF
--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -236,7 +236,7 @@ export const launchDetached = (launch: EditorLaunch) =>
       try {
         const useShell = process.platform === "win32";
         const args = useShell
-          ? launch.args.map((a) => (a.includes(" ") ? `"${a}"` : a))
+          ? launch.args.map((a) => `"${a}"`)
           : [...launch.args];
         child = spawn(launch.command, args, {
           detached: true,


### PR DESCRIPTION
### Summary
- Fixes #757
- Fixes #603

### Changes
- In `apps/server/src/open.ts`, when `shell: true` (Windows), wrap spawn args containing spaces in double quotes before passing to `spawn()`
- On Windows, `spawn()` with `shell: true` joins args with spaces for `cmd.exe`, splitting paths like `C:\Users\John Doe\project` into separate tokens
- Non-Windows platforms use `shell: false` where args are passed as proper `argv` entries, so no quoting is needed

### Test plan
- [ ] On Windows: open a file with spaces in its path via "Open in Editor" — should open correctly in one buffer
- [ ] On macOS/Linux: verify "Open in Editor" still works normally (no behavior change expected)
- [ ] Verify editor launch still works for paths without spaces on all platforms

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spaces in file paths for Open in Editor on Windows
> In [open.ts](https://github.com/pingdotgg/t3code/pull/849/files#diff-67f3655f84064d89de7cec58f5e8d2b9d406dd21986dcefc77c335e3036b65be), `launchDetached` now wraps each argument in double quotes when spawning on Windows, and sets the `shell` option accordingly. Non-Windows behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 443b4e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->