### PR TITLE
fix: use configured editor instead of hardcoded Cursor for keybindings

### DIFF
--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -1,18 +1,60 @@
 import { EDITORS, EditorId, NativeApi } from "@t3tools/contracts";
-import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "./hooks/useLocalStorage";
-import { useMemo } from "react";
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+  useLocalStorage,
+} from "./hooks/useLocalStorage";
+import { useCallback, useMemo } from "react";
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
+const LAST_OPEN_TARGET_KEY = "t3code:last-open-target";
+
+function resolveDefaultOpenTarget(availableEditors: ReadonlyArray<EditorId>): EditorId | null {
+  if (availableEditors.includes("file-manager")) {
+    return "file-manager";
+  }
+
+  return EDITORS.find((editor) => availableEditors.includes(editor.id))?.id ?? null;
+}
+
+function resolveDefaultPreferredEditor(availableEditors: ReadonlyArray<EditorId>): EditorId | null {
+  return (
+    EDITORS.find((editor) => editor.id !== "file-manager" && availableEditors.includes(editor.id))
+      ?.id ?? (availableEditors.includes("file-manager") ? "file-manager" : null)
+  );
+}
 
 export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
-  const [lastEditor, setLastEditor] = useLocalStorage(LAST_EDITOR_KEY, null, EditorId);
+  const [lastOpenTarget, setLastOpenTarget] = useLocalStorage(
+    LAST_OPEN_TARGET_KEY,
+    getLocalStorageItem(LAST_EDITOR_KEY, EditorId),
+    EditorId,
+  );
 
   const effectiveEditor = useMemo(() => {
-    if (lastEditor && availableEditors.includes(lastEditor)) return lastEditor;
-    return EDITORS.find((editor) => availableEditors.includes(editor.id))?.id ?? null;
-  }, [lastEditor, availableEditors]);
+    if (lastOpenTarget && availableEditors.includes(lastOpenTarget)) return lastOpenTarget;
+    return resolveDefaultOpenTarget(availableEditors);
+  }, [lastOpenTarget, availableEditors]);
 
-  return [effectiveEditor, setLastEditor] as const;
+  const setPreferredEditor = useCallback(
+    (value: EditorId | null | ((val: EditorId | null) => EditorId | null)) => {
+      setLastOpenTarget((prev) => {
+        const next = typeof value === "function" ? value(prev) : value;
+        if (next === null) {
+          removeLocalStorageItem(LAST_EDITOR_KEY);
+          return next;
+        }
+        if (next !== "file-manager") {
+          setLocalStorageItem(LAST_EDITOR_KEY, next, EditorId);
+        }
+        return next;
+      });
+    },
+    [setLastOpenTarget],
+  );
+
+  return [effectiveEditor, setPreferredEditor] as const;
 }
 
 export function resolveAndPersistPreferredEditor(
@@ -21,7 +63,7 @@ export function resolveAndPersistPreferredEditor(
   const availableEditorIds = new Set(availableEditors);
   const stored = getLocalStorageItem(LAST_EDITOR_KEY, EditorId);
   if (stored && availableEditorIds.has(stored)) return stored;
-  const editor = EDITORS.find((editor) => availableEditorIds.has(editor.id))?.id ?? null;
+  const editor = resolveDefaultPreferredEditor(availableEditors);
   if (editor) setLocalStorageItem(LAST_EDITOR_KEY, editor, EditorId);
   return editor ?? null;
 }


### PR DESCRIPTION
### Summary
- Fixes #209
- Fixes #261
- Fixes #746

### Changes
- In `apps/web/src/terminal-links.ts`, changed the fallback editor from a chain that always resolved to `"cursor"` to `"file-manager"`, which maps server-side to OS-native open commands (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows)
- Relaxed the stored-preference validation from `!configured?.command` to `!configured` so that `file-manager` (which has `command: null`) is accepted as a valid stored preference

### Test plan
- [ ] Without Cursor installed: click "Open keybindings.json" in Settings — should open in OS default handler
- [ ] With a stored editor preference (e.g., VS Code): verify it still uses the stored preference
- [ ] Click file links in chat, diff panel, terminal drawer — verify they open correctly

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `usePreferredEditor` to use the configured editor instead of hardcoded Cursor for keybindings
> - Replaces inline default resolution logic in [editorPreferences.ts](https://github.com/pingdotgg/t3code/pull/850/files#diff-b95642bd2ec02008455dc34d764b6b380dc3cb63bf4eb8fc249e0a105220efdd) with two new helpers: `resolveDefaultOpenTarget` (prefers `file-manager` when available) and `resolveDefaultPreferredEditor` (deprioritizes `file-manager` unless it's the only option).
> - The `usePreferredEditor` hook now stores selections under a new `t3code:last-open-target` key, seeded from the legacy `t3code:last-editor` key, so the effective open target defaults to `file-manager` when available.
> - Non-`file-manager` selections are still mirrored to the legacy `t3code:last-editor` key; that key is cleared when the selection is set to null.
> - Behavioral Change: the default open target now resolves to `file-manager` (not the first available editor) when `file-manager` is installed, which affects users who have not explicitly set a preference.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7c9a87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->