### PR TITLE
Add Linux Ctrl+= alias for Zoom In shortcut

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -587,6 +587,16 @@ function configureApplicationMenu(): void {
     },
     { role: "editMenu" },
     { role: "viewMenu" },
+    ...(process.platform === "linux"
+      ? [
+          {
+            label: "Zoom In Alias",
+            accelerator: "Ctrl+=",
+            role: "zoomIn" as const,
+            visible: false,
+          },
+        ]
+      : []),
     { role: "windowMenu" },
     {
       role: "help",


### PR DESCRIPTION
Closes #852 


## What Changed
- added a Linux-only menu item to register Ctrl+= as a zoom-in alias

## Why

- Ctrl + = is expected as the keybind to zoom-in without having to press Ctrl and shift at the same time.

## Checklist

- [ x ] This PR is small and focused
- [ x ] I explained what changed and why
- [ N/A ] I included before/after screenshots for any UI changes
- [ N/A ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `Ctrl+=` as a Linux alias for the Zoom In shortcut
> On Linux, `Ctrl++` and `Ctrl+=` are distinct key combinations, so the standard zoom-in accelerator misses the `=` key. A hidden menu item with `role: zoomIn` and `accelerator: Ctrl+=` is conditionally added in [main.ts](https://github.com/pingdotgg/t3code/pull/854/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb) when `process.platform === 'linux'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b48f99d. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->