### PR TITLE
[codex] fix resume state drift

### DIFF
--- a/apps/server/integration/TestProviderAdapter.integration.ts
+++ b/apps/server/integration/TestProviderAdapter.integration.ts
@@ -477,6 +477,16 @@ export const makeTestProviderAdapterHarness = (options?: MakeTestProviderAdapter
         sessionModelSwitch: "in-session",
       },
       startSession,
+      recoverSession: (input) =>
+        startSession({
+          threadId: input.threadId,
+          provider: input.provider,
+          ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+          ...(input.model !== undefined ? { model: input.model } : {}),
+          resumeCursor: input.resumeCursor,
+          runtimeMode: input.runtimeMode,
+          ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
+        }),
       sendTurn,
       interruptTurn,
       respondToRequest,

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -465,6 +465,10 @@ describe("startSession", () => {
   it("returns a recovered session in running state when recovered turn metadata is present", async () => {
     const { manager, spawnSpy, assertSupportedCodexCliVersion, sendRequest } =
       createStartSessionHarness();
+    const events: string[] = [];
+    manager.on("event", (event) => {
+      events.push(event.method);
+    });
 
     try {
       const session = await manager.recoverSession({
@@ -489,6 +493,35 @@ describe("startSession", () => {
       expect(session.status).toBe("running");
       expect(session.activeTurnId).toBe("turn-resume-running");
       expect(session.resumeCursor).toEqual({ threadId: "provider-thread-1" });
+      expect(events).toContain("session/threadOpenResolved");
+      expect(events).not.toContain("session/ready");
+    } finally {
+      manager.stopAll();
+      spawnSpy.mockRestore();
+      assertSupportedCodexCliVersion.mockRestore();
+      sendRequest.mockRestore();
+    }
+  });
+
+  it("emits session/ready when a recovered session does not restore an active turn", async () => {
+    const { manager, spawnSpy, assertSupportedCodexCliVersion, sendRequest } =
+      createStartSessionHarness();
+    const events: string[] = [];
+    manager.on("event", (event) => {
+      events.push(event.method);
+    });
+
+    try {
+      const session = await manager.recoverSession({
+        threadId: asThreadId("thread-resume-ready"),
+        provider: "codex",
+        runtimeMode: "full-access",
+        resumeCursor: { threadId: "provider-thread-1" },
+      });
+
+      expect(session.status).toBe("ready");
+      expect(session.activeTurnId).toBeUndefined();
+      expect(events).toContain("session/ready");
     } finally {
       manager.stopAll();
       spawnSpy.mockRestore();
@@ -1081,6 +1114,52 @@ describe("runtime turn adoption", () => {
       method: "session/exited",
       params: {
         turnId: "turn-terminal",
+      },
+    });
+
+    expect(context.session.status).toBe("ready");
+    expect(context.session.activeTurnId).toBeUndefined();
+  });
+
+  it("clears the local active turn when turn/aborted arrives", () => {
+    const manager = new CodexAppServerManager();
+    type NotificationContext = {
+      session: {
+        provider: "codex";
+        status: "running";
+        threadId: ThreadId;
+        runtimeMode: "full-access";
+        resumeCursor: { threadId: string };
+        activeTurnId: TurnId | undefined;
+        lastError?: string;
+        createdAt: string;
+        updatedAt: string;
+      };
+    };
+    const context = {
+      session: {
+        provider: "codex" as const,
+        status: "running" as const,
+        threadId: asThreadId("thread_1"),
+        runtimeMode: "full-access" as const,
+        resumeCursor: { threadId: "thread_1" },
+        activeTurnId: asTurnId("turn-aborted"),
+        createdAt: "2026-02-10T00:00:00.000Z",
+        updatedAt: "2026-02-10T00:00:00.000Z",
+      },
+    };
+
+    (
+      manager as unknown as {
+        handleServerNotification: (
+          context: NotificationContext,
+          notification: { method: string; params?: unknown },
+        ) => void;
+      }
+    ).handleServerNotification(context, {
+      method: "turn/aborted",
+      params: {
+        turnId: "turn-aborted",
       },
     });
 

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { PassThrough } from "node:stream";
 import os from "node:os";
 import path from "node:path";
-import { ApprovalRequestId, ThreadId } from "@t3tools/contracts";
+import { ApprovalRequestId, ThreadId, TurnId } from "@t3tools/contracts";
 
 import {
   buildCodexInitializeParams,
@@ -18,6 +20,96 @@ import {
 } from "./codexAppServerManager";
 
 const asThreadId = (value: string): ThreadId => ThreadId.makeUnsafe(value);
+const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
+
+class FakeChildProcess extends EventEmitter {
+  readonly stdin = new PassThrough();
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly pid = 12345;
+
+  kill() {
+    return true;
+  }
+}
+
+function createStartSessionHarness(options?: {
+  readonly sendRequestImpl?: (method: string, params: unknown) => unknown;
+}) {
+  const manager = new CodexAppServerManager();
+  const child = new FakeChildProcess();
+  const spawnSpy = vi
+    .spyOn(
+      manager as unknown as {
+        spawnCodexAppServerProcess: (input: {
+          binaryPath: string;
+          cwd: string;
+          homePath?: string;
+        }) => FakeChildProcess;
+      },
+      "spawnCodexAppServerProcess",
+    )
+    .mockReturnValue(child);
+  const assertSupportedCodexCliVersion = vi
+    .spyOn(
+      manager as unknown as {
+        assertSupportedCodexCliVersion: (input: {
+          binaryPath: string;
+          cwd: string;
+          homePath?: string;
+        }) => void;
+      },
+      "assertSupportedCodexCliVersion",
+    )
+    .mockImplementation(() => {});
+  const sendRequest = vi
+    .spyOn(
+      manager as unknown as {
+        sendRequest: (
+          context: unknown,
+          method: string,
+          params: unknown,
+          timeoutMs?: number,
+        ) => Promise<unknown>;
+      },
+      "sendRequest",
+    )
+    .mockImplementation(async (_context, method, params) => {
+      if (options?.sendRequestImpl) {
+        return options.sendRequestImpl(method, params);
+      }
+      switch (method) {
+        case "initialize":
+          return {};
+        case "model/list":
+          return {};
+        case "account/read":
+          return {};
+        case "thread/start":
+          return {
+            thread: {
+              id: "provider-thread-1",
+            },
+          };
+        case "thread/resume":
+          return {
+            thread: {
+              id: "provider-thread-1",
+            },
+          };
+        default:
+          throw new Error(`Unexpected method: ${method}`);
+      }
+    });
+
+  return {
+    manager,
+    child,
+    spawnSpy,
+    assertSupportedCodexCliVersion,
+    sendRequest,
+  };
+}
 
 function createSendTurnHarness() {
   const manager = new CodexAppServerManager();
@@ -367,6 +459,86 @@ describe("startSession", () => {
     } finally {
       versionCheck.mockRestore();
       manager.stopAll();
+    }
+  });
+
+  it("returns a recovered session in running state when recovered turn metadata is present", async () => {
+    const { manager, spawnSpy, assertSupportedCodexCliVersion, sendRequest } =
+      createStartSessionHarness();
+
+    try {
+      const session = await manager.recoverSession({
+        threadId: asThreadId("thread-resume-running"),
+        provider: "codex",
+        runtimeMode: "full-access",
+        resumeCursor: { threadId: "provider-thread-1" },
+        recoveredTurn: {
+          activeTurnId: asTurnId("turn-resume-running"),
+        },
+      });
+
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(assertSupportedCodexCliVersion).toHaveBeenCalledTimes(1);
+      expect(sendRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        "thread/resume",
+        expect.objectContaining({
+          threadId: "provider-thread-1",
+        }),
+      );
+      expect(session.status).toBe("running");
+      expect(session.activeTurnId).toBe("turn-resume-running");
+      expect(session.resumeCursor).toEqual({ threadId: "provider-thread-1" });
+    } finally {
+      manager.stopAll();
+      spawnSpy.mockRestore();
+      assertSupportedCodexCliVersion.mockRestore();
+      sendRequest.mockRestore();
+    }
+  });
+
+  it("drops recovered turn state when resume falls back to a fresh thread start", async () => {
+    const { manager, spawnSpy, assertSupportedCodexCliVersion, sendRequest } =
+      createStartSessionHarness({
+        sendRequestImpl: (method) => {
+          switch (method) {
+            case "initialize":
+            case "model/list":
+            case "account/read":
+              return {};
+            case "thread/resume":
+              throw new Error("thread/resume failed: thread not found");
+            case "thread/start":
+              return {
+                thread: {
+                  id: "provider-thread-fresh",
+                },
+              };
+            default:
+              throw new Error(`Unexpected method: ${method}`);
+          }
+        },
+      });
+
+    try {
+      const session = await manager.recoverSession({
+        threadId: asThreadId("thread-resume-fallback"),
+        provider: "codex",
+        runtimeMode: "full-access",
+        resumeCursor: { threadId: "provider-thread-stale" },
+        recoveredTurn: {
+          activeTurnId: asTurnId("turn-stale"),
+        },
+      });
+
+      expect(session.status).toBe("ready");
+      expect(session.activeTurnId).toBeUndefined();
+      expect(session.resumeCursor).toEqual({ threadId: "provider-thread-fresh" });
+    } finally {
+      manager.stopAll();
+      spawnSpy.mockRestore();
+      assertSupportedCodexCliVersion.mockRestore();
+      sendRequest.mockRestore();
     }
   });
 });
@@ -745,6 +917,175 @@ describe("respondToUserInput", () => {
     const request = Array.from(context.pendingApprovals.values())[0];
     expect(request?.requestKind).toBe("file-read");
     expect(request?.method).toBe("item/fileRead/requestApproval");
+  });
+});
+
+describe("runtime turn adoption", () => {
+  it("adopts route.turnId from turn-scoped notifications when no active turn is tracked", () => {
+    const manager = new CodexAppServerManager();
+    type NotificationContext = {
+      session: {
+        provider: "codex";
+        status: "ready";
+        threadId: ThreadId;
+        runtimeMode: "full-access";
+        resumeCursor: { threadId: string };
+        activeTurnId: TurnId | undefined;
+        createdAt: string;
+        updatedAt: string;
+      };
+    };
+    const context = {
+      session: {
+        provider: "codex" as const,
+        status: "ready" as const,
+        threadId: asThreadId("thread_1"),
+        runtimeMode: "full-access" as const,
+        resumeCursor: { threadId: "thread_1" },
+        activeTurnId: undefined as TurnId | undefined,
+        createdAt: "2026-02-10T00:00:00.000Z",
+        updatedAt: "2026-02-10T00:00:00.000Z",
+      },
+    };
+
+    (
+      manager as unknown as {
+        handleServerNotification: (
+          context: NotificationContext,
+          notification: { method: string; params?: unknown },
+        ) => void;
+      }
+    ).handleServerNotification(context, {
+      method: "item/agentMessage/delta",
+      params: {
+        turnId: "turn-adopted-notification",
+        delta: "hi",
+      },
+    });
+
+    expect(context.session.status).toBe("running");
+    expect(context.session.activeTurnId).toBe("turn-adopted-notification");
+  });
+
+  it("adopts route.turnId from turn-scoped server requests when no active turn is tracked", () => {
+    const manager = new CodexAppServerManager();
+    type RequestContext = {
+      session: {
+        provider: "codex";
+        status: "ready";
+        threadId: ThreadId;
+        runtimeMode: "full-access";
+        resumeCursor: { threadId: string };
+        activeTurnId: TurnId | undefined;
+        createdAt: string;
+        updatedAt: string;
+      };
+      pendingApprovals: Map<unknown, unknown>;
+      pendingUserInputs: Map<unknown, unknown>;
+    };
+    const context = {
+      session: {
+        provider: "codex" as const,
+        status: "ready" as const,
+        threadId: asThreadId("thread_1"),
+        runtimeMode: "full-access" as const,
+        resumeCursor: { threadId: "thread_1" },
+        activeTurnId: undefined as TurnId | undefined,
+        createdAt: "2026-02-10T00:00:00.000Z",
+        updatedAt: "2026-02-10T00:00:00.000Z",
+      },
+      pendingApprovals: new Map(),
+      pendingUserInputs: new Map(),
+    };
+
+    (
+      manager as unknown as {
+        handleServerRequest: (
+          context: RequestContext,
+          request: { id: number; method: string; params?: unknown },
+        ) => void;
+      }
+    ).handleServerRequest(context, {
+      id: 42,
+      method: "item/tool/requestUserInput",
+      params: {
+        turnId: "turn-adopted-request",
+      },
+    });
+
+    expect(context.session.status).toBe("running");
+    expect(context.session.activeTurnId).toBe("turn-adopted-request");
+  });
+
+  it("does not re-enter running state for terminal lifecycle methods", () => {
+    const manager = new CodexAppServerManager();
+    type NotificationContext = {
+      session: {
+        provider: "codex";
+        status: "ready";
+        threadId: ThreadId;
+        runtimeMode: "full-access";
+        resumeCursor: { threadId: string };
+        activeTurnId: TurnId | undefined;
+        createdAt: string;
+        updatedAt: string;
+      };
+    };
+    const context = {
+      session: {
+        provider: "codex" as const,
+        status: "ready" as const,
+        threadId: asThreadId("thread_1"),
+        runtimeMode: "full-access" as const,
+        resumeCursor: { threadId: "thread_1" },
+        activeTurnId: undefined as TurnId | undefined,
+        createdAt: "2026-02-10T00:00:00.000Z",
+        updatedAt: "2026-02-10T00:00:00.000Z",
+      },
+    };
+
+    const handleServerNotification = (
+      manager as unknown as {
+        handleServerNotification: (
+          context: NotificationContext,
+          notification: { method: string; params?: unknown },
+        ) => void;
+      }
+    ).handleServerNotification.bind(manager);
+
+    handleServerNotification(context, {
+      method: "turn/completed",
+      params: {
+        turn: {
+          id: "turn-terminal",
+          status: "completed",
+        },
+      },
+    });
+    expect(context.session.status).toBe("ready");
+    expect(context.session.activeTurnId).toBeUndefined();
+
+    handleServerNotification(context, {
+      method: "turn/aborted",
+      params: {
+        turnId: "turn-terminal",
+      },
+    });
+    handleServerNotification(context, {
+      method: "session/closed",
+      params: {
+        turnId: "turn-terminal",
+      },
+    });
+    handleServerNotification(context, {
+      method: "session/exited",
+      params: {
+        turnId: "turn-terminal",
+      },
+    });
+
+    expect(context.session.status).toBe("ready");
+    expect(context.session.activeTurnId).toBeUndefined();
   });
 });
 

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -729,7 +729,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         resolvedThreadId: providerThreadId,
         requestedRuntimeMode: input.runtimeMode,
       }).pipe(this.runPromise);
-      this.emitLifecycleEvent(context, "session/ready", `Connected to thread ${providerThreadId}`);
+      if (restoredActiveTurnId === undefined) {
+        this.emitLifecycleEvent(context, "session/ready", `Connected to thread ${providerThreadId}`);
+      }
       return { ...context.session };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start Codex session.";
@@ -1191,6 +1193,21 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const errorMessage = this.readString(this.readObject(turn, "error"), "message");
       this.updateSession(context, {
         status: status === "failed" ? "error" : "ready",
+        activeTurnId: undefined,
+        lastError: errorMessage ?? context.session.lastError,
+      });
+      return;
+    }
+
+    if (notification.method === "turn/aborted") {
+      const params = this.readObject(notification.params);
+      const turn = this.readObject(params, "turn");
+      const errorMessage =
+        this.readString(this.readObject(turn, "error"), "message") ??
+        this.readString(this.readObject(params, "error"), "message") ??
+        this.readString(params, "message");
+      this.updateSession(context, {
+        status: "ready",
         activeTurnId: undefined,
         lastError: errorMessage ?? context.session.lastError,
       });

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -134,6 +134,20 @@ export interface CodexAppServerStartSessionInput {
   readonly runtimeMode: RuntimeMode;
 }
 
+export interface CodexAppServerRecoverSessionInput {
+  readonly threadId: ThreadId;
+  readonly provider?: "codex";
+  readonly cwd?: string;
+  readonly model?: string;
+  readonly serviceTier?: string;
+  readonly resumeCursor: unknown;
+  readonly providerOptions?: ProviderSessionStartInput["providerOptions"];
+  readonly runtimeMode: RuntimeMode;
+  readonly recoveredTurn?: {
+    readonly activeTurnId?: TurnId;
+  };
+}
+
 export interface CodexThreadTurnSnapshot {
   id: TurnId;
   items: unknown[];
@@ -522,6 +536,16 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
   }
 
   async startSession(input: CodexAppServerStartSessionInput): Promise<ProviderSession> {
+    return this.openSession(input);
+  }
+
+  async recoverSession(input: CodexAppServerRecoverSessionInput): Promise<ProviderSession> {
+    return this.openSession(input);
+  }
+
+  private async openSession(
+    input: CodexAppServerStartSessionInput | CodexAppServerRecoverSessionInput,
+  ): Promise<ProviderSession> {
     const threadId = input.threadId;
     const now = new Date().toISOString();
     let context: CodexSessionContext | undefined;
@@ -548,14 +572,10 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         cwd: resolvedCwd,
         ...(codexHomePath ? { homePath: codexHomePath } : {}),
       });
-      const child = spawn(codexBinaryPath, ["app-server"], {
+      const child = this.spawnCodexAppServerProcess({
+        binaryPath: codexBinaryPath,
         cwd: resolvedCwd,
-        env: {
-          ...process.env,
-          ...(codexHomePath ? { CODEX_HOME: codexHomePath } : {}),
-        },
-        stdio: ["pipe", "pipe", "pipe"],
-        shell: process.platform === "win32",
+        ...(codexHomePath ? { homePath: codexHomePath } : {}),
       });
       const output = readline.createInterface({ input: child.stdout });
 
@@ -688,8 +708,13 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       }
       const providerThreadId = threadIdRaw;
 
+      const restoredActiveTurnId =
+        threadOpenMethod === "thread/resume" && "recoveredTurn" in input
+          ? input.recoveredTurn?.activeTurnId
+          : undefined;
       this.updateSession(context, {
-        status: "ready",
+        status: restoredActiveTurnId !== undefined ? "running" : "ready",
+        activeTurnId: restoredActiveTurnId,
         resumeCursor: { threadId: providerThreadId },
       });
       this.emitLifecycleEvent(
@@ -1122,6 +1147,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     notification: JsonRpcNotification,
   ): void {
     const route = this.readRouteFields(notification.params);
+    this.maybeAdoptActiveTurnIdFromRoute(context, notification.method, route);
     const textDelta =
       notification.method === "item/agentMessage/delta"
         ? this.readString(notification.params, "delta")
@@ -1184,6 +1210,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
   private handleServerRequest(context: CodexSessionContext, request: JsonRpcRequest): void {
     const route = this.readRouteFields(request.params);
+    this.maybeAdoptActiveTurnIdFromRoute(context, request.method, route);
     const requestKind = this.requestKindForMethod(request.method);
     let requestId: ApprovalRequestId | undefined;
     if (requestKind) {
@@ -1341,12 +1368,70 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     assertSupportedCodexCliVersion(input);
   }
 
+  private spawnCodexAppServerProcess(input: {
+    readonly binaryPath: string;
+    readonly cwd: string;
+    readonly homePath?: string;
+  }): ChildProcessWithoutNullStreams {
+    return spawn(input.binaryPath, ["app-server"], {
+      cwd: input.cwd,
+      env: {
+        ...process.env,
+        ...(input.homePath ? { CODEX_HOME: input.homePath } : {}),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32",
+    });
+  }
+
   private updateSession(context: CodexSessionContext, updates: Partial<ProviderSession>): void {
     context.session = {
       ...context.session,
       ...updates,
       updatedAt: new Date().toISOString(),
     };
+  }
+
+  private shouldAdoptActiveTurnIdFromRouteMethod(method: string): boolean {
+    switch (method) {
+      case "item/agentMessage/delta":
+      case "item/reasoning/textDelta":
+      case "item/reasoning/summaryTextDelta":
+      case "item/commandExecution/outputDelta":
+      case "item/fileChange/outputDelta":
+      case "item/tool/requestUserInput":
+      case "item/commandExecution/requestApproval":
+      case "item/fileRead/requestApproval":
+      case "item/fileChange/requestApproval":
+      case "item/started":
+      case "item/completed":
+      case "turn/plan/updated":
+      case "turn/diff/updated":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private maybeAdoptActiveTurnIdFromRoute(
+    context: CodexSessionContext,
+    method: string,
+    route: { turnId?: TurnId },
+  ): void {
+    if (context.session.activeTurnId !== undefined) {
+      return;
+    }
+    if (route.turnId === undefined) {
+      return;
+    }
+    if (!this.shouldAdoptActiveTurnIdFromRouteMethod(method)) {
+      return;
+    }
+
+    this.updateSession(context, {
+      status: "running",
+      activeTurnId: route.turnId,
+    });
   }
 
   private requestKindForMethod(method: string): ProviderRequestKind | undefined {
@@ -1507,7 +1592,9 @@ function normalizeProviderThreadId(value: string | undefined): string | undefine
   return brandIfNonEmpty(value, (normalized) => normalized);
 }
 
-function readCodexProviderOptions(input: CodexAppServerStartSessionInput): {
+function readCodexProviderOptions(input: {
+  readonly providerOptions?: ProviderSessionStartInput["providerOptions"];
+}): {
   readonly binaryPath?: string;
   readonly homePath?: string;
 } {
@@ -1574,7 +1661,11 @@ function readResumeCursorThreadId(resumeCursor: unknown): string | undefined {
   return typeof rawThreadId === "string" ? normalizeProviderThreadId(rawThreadId) : undefined;
 }
 
-function readResumeThreadId(input: CodexAppServerStartSessionInput): string | undefined {
+function readResumeThreadId(input: {
+  readonly threadId?: ThreadId;
+  readonly runtimeMode?: RuntimeMode;
+  readonly resumeCursor?: unknown;
+}): string | undefined {
   return readResumeCursorThreadId(input.resumeCursor);
 }
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -83,49 +83,52 @@ describe("ProviderCommandReactor", () => {
     createdStateDirs.clear();
   });
 
-  async function createHarness(input?: { readonly stateDir?: string }) {
+  async function createHarness(input?: {
+    readonly stateDir?: string;
+    readonly buildSession?: (session: ProviderSession, rawInput: unknown) => ProviderSession;
+  }) {
     const now = new Date().toISOString();
     const stateDir = input?.stateDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "t3code-reactor-"));
     createdStateDirs.add(stateDir);
     const runtimeEventPubSub = Effect.runSync(PubSub.unbounded<ProviderRuntimeEvent>());
     let nextSessionIndex = 1;
     const runtimeSessions: Array<ProviderSession> = [];
-    const startSession = vi.fn((_: unknown, input: unknown) => {
+    const startSession = vi.fn((_: unknown, rawInput: unknown) => {
       const sessionIndex = nextSessionIndex++;
       const provider =
-        typeof input === "object" &&
-        input !== null &&
-        "provider" in input &&
-        input.provider === "codex"
-          ? input.provider
+        typeof rawInput === "object" &&
+        rawInput !== null &&
+        "provider" in rawInput &&
+        rawInput.provider === "codex"
+          ? rawInput.provider
           : "codex";
       const resumeCursor =
-        typeof input === "object" && input !== null && "resumeCursor" in input
-          ? input.resumeCursor
+        typeof rawInput === "object" && rawInput !== null && "resumeCursor" in rawInput
+          ? rawInput.resumeCursor
           : undefined;
       const model =
-        typeof input === "object" &&
-        input !== null &&
-        "model" in input &&
-        typeof input.model === "string"
-          ? input.model
+        typeof rawInput === "object" &&
+        rawInput !== null &&
+        "model" in rawInput &&
+        typeof rawInput.model === "string"
+          ? rawInput.model
           : undefined;
       const threadId =
-        typeof input === "object" &&
-        input !== null &&
-        "threadId" in input &&
-        typeof input.threadId === "string"
-          ? ThreadId.makeUnsafe(input.threadId)
+        typeof rawInput === "object" &&
+        rawInput !== null &&
+        "threadId" in rawInput &&
+        typeof rawInput.threadId === "string"
+          ? ThreadId.makeUnsafe(rawInput.threadId)
           : ThreadId.makeUnsafe(`thread-${sessionIndex}`);
       const session: ProviderSession = {
         provider,
         status: "ready" as const,
         runtimeMode:
-          typeof input === "object" &&
-          input !== null &&
-          "runtimeMode" in input &&
-          (input.runtimeMode === "approval-required" || input.runtimeMode === "full-access")
-            ? input.runtimeMode
+          typeof rawInput === "object" &&
+          rawInput !== null &&
+          "runtimeMode" in rawInput &&
+          (rawInput.runtimeMode === "approval-required" || rawInput.runtimeMode === "full-access")
+            ? rawInput.runtimeMode
             : "full-access",
         ...(model !== undefined ? { model } : {}),
         threadId,
@@ -133,8 +136,9 @@ describe("ProviderCommandReactor", () => {
         createdAt: now,
         updatedAt: now,
       };
-      runtimeSessions.push(session);
-      return Effect.succeed(session);
+      const resolvedSession = input?.buildSession?.(session, rawInput) ?? session;
+      runtimeSessions.push(resolvedSession);
+      return Effect.succeed(resolvedSession);
     });
     const sendTurn = vi.fn((_: unknown) =>
       Effect.succeed({
@@ -296,6 +300,42 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("binds the provider session activeTurnId when recovery returns a running session", async () => {
+    const harness = await createHarness({
+      buildSession: (session) => ({
+        ...session,
+        status: "running",
+        activeTurnId: asTurnId("turn-recovered"),
+      }),
+    });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-recovered-running"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-recovered-running"),
+          role: "user",
+          text: "resume and keep active turn",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+    expect(thread?.session?.status).toBe("running");
+    expect(thread?.session?.activeTurnId).toBe("turn-recovered");
   });
 
   it("forwards codex model options through session start and turn send", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -245,8 +245,8 @@ const make = Effect.gen(function* () {
           status: mapProviderSessionStatusToOrchestrationStatus(session.status),
           providerName: session.provider,
           runtimeMode: desiredRuntimeMode,
-          // Provider turn ids are not orchestration turn ids.
-          activeTurnId: null,
+          // This remains provider-scoped runtime state used for projection and interrupt routing.
+          activeTurnId: session.activeTurnId ?? null,
           lastError: session.lastError ?? null,
           updatedAt: session.updatedAt,
         },

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -254,6 +254,94 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it("keeps a recovered running session active while post-resume deltas stream, then settles ready on completion", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-recovered-running"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-recovered"),
+          updatedAt: now,
+          lastError: null,
+        },
+        createdAt: now,
+      }),
+    );
+
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" && thread.session?.activeTurnId === "turn-recovered",
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-recovered-delta-1"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-recovered"),
+      itemId: asItemId("item-recovered"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "recover",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-recovered-item-completed"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-recovered"),
+      itemId: asItemId("item-recovered"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    const midThread = await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" &&
+        thread.session?.activeTurnId === "turn-recovered" &&
+        thread.messages.some(
+          (message: ProviderRuntimeTestMessage) =>
+            message.id === "assistant:item-recovered" && message.text === "recover",
+        ),
+    );
+    expect(midThread.session?.status).toBe("running");
+    expect(midThread.session?.activeTurnId).toBe("turn-recovered");
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-recovered-turn-completed"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-recovered"),
+      payload: {
+        state: "completed",
+      },
+    });
+
+    const finalThread = await waitForThread(
+      harness.engine,
+      (thread) => thread.session?.status === "ready" && thread.session?.activeTurnId === null,
+    );
+    expect(finalThread.session?.status).toBe("ready");
+    expect(finalThread.session?.activeTurnId).toBeNull();
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -430,6 +430,51 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBeNull();
   });
 
+  it("clears a stale active turn when session.state.changed reports ready", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-stale-active-turn"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-recovered"),
+          updatedAt: now,
+          lastError: "old error",
+        },
+        createdAt: now,
+      }),
+    );
+
+    harness.emit({
+      type: "session.state.changed",
+      eventId: asEventId("evt-session-state-ready-clears-turn"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      payload: {
+        state: "ready",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.session?.status === "ready" &&
+        entry.session?.activeTurnId === null &&
+        entry.session?.lastError === null,
+    );
+    expect(thread.session?.status).toBe("ready");
+    expect(thread.session?.activeTurnId).toBeNull();
+    expect(thread.session?.lastError).toBeNull();
+  });
+
   it("does not clear active turn when session/thread started arrives mid-turn", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -836,6 +836,9 @@ const make = Effect.gen(function* () {
             ? (eventTurnId ?? null)
             : event.type === "turn.completed" || event.type === "session.exited"
               ? null
+              : event.type === "session.state.changed" &&
+                  (event.payload.state === "ready" || event.payload.state === "stopped")
+                ? null
               : activeTurnId;
         const status = (() => {
           switch (event.type) {

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -18,6 +18,7 @@ import { Effect, Fiber, Layer, Option, Stream } from "effect";
 
 import {
   CodexAppServerManager,
+  type CodexAppServerRecoverSessionInput,
   type CodexAppServerStartSessionInput,
   type CodexAppServerSendTurnInput,
 } from "../../codexAppServerManager.ts";
@@ -52,6 +53,24 @@ class FakeCodexManager extends CodexAppServerManager {
       threadId: asThreadId("thread-1"),
       turnId: asTurnId("turn-1"),
     }),
+  );
+
+  public recoverSessionImpl = vi.fn(
+    async (input: CodexAppServerRecoverSessionInput): Promise<ProviderSession> => {
+      const now = new Date().toISOString();
+      return {
+        provider: "codex",
+        status: input.recoveredTurn?.activeTurnId ? "running" : "ready",
+        runtimeMode: input.runtimeMode,
+        threadId: input.threadId,
+        cwd: input.cwd,
+        ...(input.recoveredTurn?.activeTurnId !== undefined
+          ? { activeTurnId: input.recoveredTurn.activeTurnId }
+          : {}),
+        createdAt: now,
+        updatedAt: now,
+      };
+    },
   );
 
   public interruptTurnImpl = vi.fn(
@@ -92,6 +111,10 @@ class FakeCodexManager extends CodexAppServerManager {
 
   override sendTurn(input: CodexAppServerSendTurnInput): Promise<ProviderTurnStartResult> {
     return this.sendTurnImpl(input);
+  }
+
+  override recoverSession(input: CodexAppServerRecoverSessionInput): Promise<ProviderSession> {
+    return this.recoverSessionImpl(input);
   }
 
   override interruptTurn(threadId: ThreadId, turnId?: TurnId): Promise<void> {
@@ -178,6 +201,33 @@ validationLayer("CodexAdapterLive validation", (it) => {
         threadId: asThreadId("thread-1"),
         model: "gpt-5.3-codex",
         serviceTier: "fast",
+        runtimeMode: "full-access",
+      });
+    }),
+  );
+
+  it.effect("forwards recovered turn state unchanged when recovering a session", () =>
+    Effect.gen(function* () {
+      validationManager.recoverSessionImpl.mockClear();
+      const adapter = yield* CodexAdapter;
+
+      yield* adapter.recoverSession({
+        provider: "codex",
+        threadId: asThreadId("thread-resume"),
+        resumeCursor: { threadId: "provider-thread-1" },
+        recoveredTurn: {
+          activeTurnId: asTurnId("turn-resume"),
+        },
+        runtimeMode: "full-access",
+      });
+
+      assert.deepStrictEqual(validationManager.recoverSessionImpl.mock.calls[0]?.[0], {
+        provider: "codex",
+        threadId: asThreadId("thread-resume"),
+        resumeCursor: { threadId: "provider-thread-1" },
+        recoveredTurn: {
+          activeTurnId: asTurnId("turn-resume"),
+        },
         runtimeMode: "full-access",
       });
     }),

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -33,6 +33,7 @@ import {
 import { CodexAdapter, type CodexAdapterShape } from "../Services/CodexAdapter.ts";
 import {
   CodexAppServerManager,
+  type CodexAppServerRecoverSessionInput,
   type CodexAppServerStartSessionInput,
 } from "../../codexAppServerManager.ts";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
@@ -1321,6 +1322,40 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
       }).pipe(Effect.map((session) => session));
     };
 
+    const recoverSession: CodexAdapterShape["recoverSession"] = (input) => {
+      if (input.provider !== PROVIDER) {
+        return Effect.fail(
+          new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "recoverSession",
+            issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+          }),
+        );
+      }
+
+      const managerInput: CodexAppServerRecoverSessionInput = {
+        threadId: input.threadId,
+        provider: "codex",
+        resumeCursor: input.resumeCursor,
+        ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+        ...(input.providerOptions !== undefined ? { providerOptions: input.providerOptions } : {}),
+        ...(input.recoveredTurn !== undefined ? { recoveredTurn: input.recoveredTurn } : {}),
+        runtimeMode: input.runtimeMode,
+        ...(input.model !== undefined ? { model: input.model } : {}),
+      };
+
+      return Effect.tryPromise({
+        try: () => manager.recoverSession(managerInput),
+        catch: (cause) =>
+          new ProviderAdapterProcessError({
+            provider: PROVIDER,
+            threadId: input.threadId,
+            detail: toMessage(cause, "Failed to recover Codex adapter session."),
+            cause,
+          }),
+      }).pipe(Effect.map((session) => session));
+    };
+
     const sendTurn: CodexAdapterShape["sendTurn"] = (input) =>
       Effect.gen(function* () {
         const codexAttachments = yield* Effect.forEach(
@@ -1504,6 +1539,7 @@ const makeCodexAdapter = (options?: CodexAdapterLiveOptions) =>
         sessionModelSwitch: "in-session",
       },
       startSession,
+      recoverSession,
       sendTurn,
       interruptTurn,
       readThread,

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -14,6 +14,7 @@ const fakeCodexAdapter: CodexAdapterShape = {
   provider: "codex",
   capabilities: { sessionModelSwitch: "in-session" },
   startSession: vi.fn(),
+  recoverSession: vi.fn(),
   sendTurn: vi.fn(),
   interruptTurn: vi.fn(),
   respondToRequest: vi.fn(),

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -7,6 +7,7 @@ import type {
   ProviderRuntimeEvent,
   ProviderSendTurnInput,
   ProviderSession,
+  ProviderStartOptions,
   ProviderTurnStartResult,
 } from "@t3tools/contracts";
 import {
@@ -82,6 +83,38 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
       sessions.set(session.threadId, session);
       return session;
     }),
+  );
+
+  const recoverSession = vi.fn(
+    (input: {
+      threadId: ThreadId;
+      provider: ProviderKind;
+      runtimeMode: "approval-required" | "full-access";
+      resumeCursor: unknown;
+      cwd?: string;
+      model?: string;
+      providerOptions?: ProviderStartOptions;
+      recoveredTurn?: { activeTurnId?: TurnId };
+    }) =>
+      Effect.sync(() => {
+        const now = new Date().toISOString();
+        const session: ProviderSession = {
+          provider,
+          status: input.recoveredTurn?.activeTurnId ? "running" : "ready",
+          runtimeMode: input.runtimeMode,
+          threadId: input.threadId,
+          resumeCursor: input.resumeCursor,
+          cwd: input.cwd ?? process.cwd(),
+          ...(input.model !== undefined ? { model: input.model } : {}),
+          ...(input.recoveredTurn?.activeTurnId !== undefined
+            ? { activeTurnId: input.recoveredTurn.activeTurnId }
+            : {}),
+          createdAt: now,
+          updatedAt: now,
+        };
+        sessions.set(session.threadId, session);
+        return session;
+      }),
   );
 
   const sendTurn = vi.fn(
@@ -178,6 +211,7 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
       sessionModelSwitch: "in-session",
     },
     startSession,
+    recoverSession,
     sendTurn,
     interruptTurn,
     respondToRequest,
@@ -199,6 +233,7 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
     adapter,
     emit,
     startSession,
+    recoverSession,
     sendTurn,
     interruptTurn,
     respondToRequest,
@@ -214,6 +249,24 @@ function makeFakeCodexAdapter(provider: ProviderKind = "codex") {
 
 const sleep = (ms: number) =>
   Effect.promise(() => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+
+const waitForRuntimeStatus = (
+  repository: typeof ProviderSessionRuntimeRepository.Service,
+  threadId: ThreadId,
+  status: "ready" | "running" | "stopped" | "error",
+) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const runtime = yield* repository.getByThreadId({ threadId });
+      if (Option.isSome(runtime) && runtime.value.status === status) {
+        return runtime.value;
+      }
+      yield* sleep(10);
+    }
+
+    const runtime = yield* repository.getByThreadId({ threadId });
+    return Option.getOrUndefined(runtime);
+  });
 
 function makeProviderServiceLayer() {
   const codex = makeFakeCodexAdapter();
@@ -383,7 +436,7 @@ it.effect(
         Layer.provide(AnalyticsService.layerTest),
       );
 
-      secondCodex.startSession.mockClear();
+      secondCodex.recoverSession.mockClear();
       secondCodex.rollbackThread.mockClear();
 
       yield* Effect.gen(function* () {
@@ -394,8 +447,8 @@ it.effect(
         });
       }).pipe(Effect.provide(secondProviderLayer));
 
-      assert.equal(secondCodex.startSession.mock.calls.length, 1);
-      const resumedStartInput = secondCodex.startSession.mock.calls[0]?.[0];
+      assert.equal(secondCodex.recoverSession.mock.calls.length, 1);
+      const resumedStartInput = secondCodex.recoverSession.mock.calls[0]?.[0];
       assert.equal(typeof resumedStartInput === "object" && resumedStartInput !== null, true);
       if (resumedStartInput && typeof resumedStartInput === "object") {
         const startPayload = resumedStartInput as {
@@ -504,7 +557,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
         runtimeMode: "full-access",
       });
       yield* routing.codex.stopSession(initial.threadId);
-      routing.codex.startSession.mockClear();
+      routing.codex.recoverSession.mockClear();
       routing.codex.rollbackThread.mockClear();
 
       yield* provider.rollbackConversation({
@@ -512,8 +565,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
         numTurns: 1,
       });
 
-      assert.equal(routing.codex.startSession.mock.calls.length, 1);
-      const resumedStartInput = routing.codex.startSession.mock.calls[0]?.[0];
+      assert.equal(routing.codex.recoverSession.mock.calls.length, 1);
+      const resumedStartInput = routing.codex.recoverSession.mock.calls[0]?.[0];
       assert.equal(typeof resumedStartInput === "object" && resumedStartInput !== null, true);
       if (resumedStartInput && typeof resumedStartInput === "object") {
         const startPayload = resumedStartInput as {
@@ -545,7 +598,7 @@ routing.layer("ProviderServiceLive routing", (it) => {
       });
 
       yield* routing.codex.stopAll();
-      routing.codex.startSession.mockClear();
+      routing.codex.recoverSession.mockClear();
       routing.codex.sendTurn.mockClear();
 
       yield* provider.sendTurn({
@@ -554,8 +607,8 @@ routing.layer("ProviderServiceLive routing", (it) => {
         attachments: [],
       });
 
-      assert.equal(routing.codex.startSession.mock.calls.length, 1);
-      const resumedStartInput = routing.codex.startSession.mock.calls[0]?.[0];
+      assert.equal(routing.codex.recoverSession.mock.calls.length, 1);
+      const resumedStartInput = routing.codex.recoverSession.mock.calls[0]?.[0];
       assert.equal(typeof resumedStartInput === "object" && resumedStartInput !== null, true);
       if (resumedStartInput && typeof resumedStartInput === "object") {
         const startPayload = resumedStartInput as {
@@ -570,6 +623,86 @@ routing.layer("ProviderServiceLive routing", (it) => {
         assert.equal(startPayload.threadId, initial.threadId);
       }
       assert.equal(routing.codex.sendTurn.mock.calls.length, 1);
+    }),
+  );
+
+  it.effect("passes recovered turn state with persisted activeTurnId during recovery", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+
+      const initial = yield* provider.startSession(asThreadId("thread-running-hint"), {
+        provider: "codex",
+        threadId: asThreadId("thread-running-hint"),
+        cwd: "/tmp/project-running-hint",
+        runtimeMode: "full-access",
+      });
+      yield* provider.sendTurn({
+        threadId: initial.threadId,
+        input: "resume me",
+        attachments: [],
+      });
+
+      yield* routing.codex.stopAll();
+      routing.codex.recoverSession.mockClear();
+
+      yield* provider.interruptTurn({
+        threadId: initial.threadId,
+      });
+
+      assert.equal(routing.codex.recoverSession.mock.calls.length, 1);
+      assert.deepEqual(routing.codex.recoverSession.mock.calls[0]?.[0], {
+        threadId: initial.threadId,
+        provider: "codex",
+        cwd: "/tmp/project-running-hint",
+        resumeCursor: initial.resumeCursor,
+        recoveredTurn: {
+          activeTurnId: asTurnId(`turn-${String(initial.threadId)}`),
+        },
+        runtimeMode: "full-access",
+      });
+    }),
+  );
+
+  it.effect("recovers ready state without recovered turn when persisted metadata is missing it", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const directory = yield* ProviderSessionDirectory;
+
+      const initial = yield* provider.startSession(asThreadId("thread-running-hint-missing"), {
+        provider: "codex",
+        threadId: asThreadId("thread-running-hint-missing"),
+        cwd: "/tmp/project-running-hint-missing",
+        runtimeMode: "full-access",
+      });
+
+      yield* directory.upsert({
+        threadId: initial.threadId,
+        provider: "codex",
+        status: "running",
+        runtimePayload: {
+          activeTurnId: null,
+        },
+      });
+
+      yield* routing.codex.stopAll();
+      routing.codex.recoverSession.mockClear();
+
+      yield* provider.interruptTurn({
+        threadId: initial.threadId,
+      });
+
+      assert.equal(routing.codex.recoverSession.mock.calls.length, 1);
+      assert.deepEqual(routing.codex.recoverSession.mock.calls[0]?.[0], {
+        threadId: initial.threadId,
+        provider: "codex",
+        cwd: "/tmp/project-running-hint-missing",
+        resumeCursor: initial.resumeCursor,
+        runtimeMode: "full-access",
+      });
+      const resumedStartInput = routing.codex.recoverSession.mock.calls[0]?.[0] as
+        | { recoveredTurn?: { activeTurnId?: unknown } }
+        | undefined;
+      assert.equal(resumedStartInput?.recoveredTurn?.activeTurnId, undefined);
     }),
   );
 
@@ -605,6 +738,23 @@ routing.layer("ProviderServiceLive routing", (it) => {
         threadId: asThreadId("thread-1"),
         runtimeMode: "full-access",
       });
+
+      const readyRuntime = yield* runtimeRepository.getByThreadId({
+        threadId: session.threadId,
+      });
+      assert.equal(Option.isSome(readyRuntime), true);
+      if (Option.isSome(readyRuntime)) {
+        assert.equal(readyRuntime.value.status, "ready");
+        const payload = readyRuntime.value.runtimePayload;
+        assert.equal(payload !== null && typeof payload === "object", true);
+        if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+          const runtimePayload = payload as {
+            activeTurnId: string | null;
+          };
+          assert.equal(runtimePayload.activeTurnId, null);
+        }
+      }
+
       yield* provider.sendTurn({
         threadId: session.threadId,
         input: "hello",
@@ -637,6 +787,107 @@ routing.layer("ProviderServiceLive routing", (it) => {
       }
     }),
   );
+
+  it.effect("persists turn completion runtime events back into provider_session_runtime", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+
+      const session = yield* provider.startSession(asThreadId("thread-runtime-complete"), {
+        provider: "codex",
+        threadId: asThreadId("thread-runtime-complete"),
+        runtimeMode: "full-access",
+      });
+      yield* provider.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+      yield* sleep(20);
+
+      routing.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("evt-runtime-complete"),
+        provider: "codex",
+        createdAt: new Date().toISOString(),
+        threadId: session.threadId,
+        turnId: asTurnId(`turn-${String(session.threadId)}`),
+        payload: {
+          state: "completed",
+        },
+      });
+      const completedRuntime = yield* waitForRuntimeStatus(
+        runtimeRepository,
+        session.threadId,
+        "ready",
+      );
+      assert.equal(completedRuntime !== undefined, true);
+      if (completedRuntime !== undefined) {
+        assert.equal(completedRuntime.status, "ready");
+        const payload = completedRuntime.runtimePayload;
+        assert.equal(payload !== null && typeof payload === "object", true);
+        if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+          const runtimePayload = payload as {
+            activeTurnId: string | null;
+            lastError: string | null;
+            lastRuntimeEvent: string | null;
+          };
+          assert.equal(runtimePayload.activeTurnId, null);
+          assert.equal(runtimePayload.lastError, null);
+          assert.equal(runtimePayload.lastRuntimeEvent, "turn.completed");
+        }
+      }
+    }),
+  );
+
+  it.effect("persists failed turn completion errors from runtime events", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+
+      const session = yield* provider.startSession(asThreadId("thread-runtime-failed"), {
+        provider: "codex",
+        threadId: asThreadId("thread-runtime-failed"),
+        runtimeMode: "full-access",
+      });
+      yield* provider.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+      yield* sleep(20);
+
+      routing.codex.emit({
+        type: "turn.completed",
+        eventId: asEventId("evt-runtime-failed"),
+        provider: "codex",
+        createdAt: new Date().toISOString(),
+        threadId: session.threadId,
+        turnId: asTurnId(`turn-${String(session.threadId)}`),
+        payload: {
+          state: "failed",
+          errorMessage: "turn failed",
+        },
+      });
+      const failedRuntime = yield* waitForRuntimeStatus(runtimeRepository, session.threadId, "error");
+      assert.equal(failedRuntime !== undefined, true);
+      if (failedRuntime !== undefined) {
+        assert.equal(failedRuntime.status, "error");
+        const payload = failedRuntime.runtimePayload;
+        assert.equal(payload !== null && typeof payload === "object", true);
+        if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+          const runtimePayload = payload as {
+            activeTurnId: string | null;
+            lastError: string | null;
+            lastRuntimeEvent: string | null;
+          };
+          assert.equal(runtimePayload.activeTurnId, null);
+          assert.equal(runtimePayload.lastError, "turn failed");
+          assert.equal(runtimePayload.lastRuntimeEvent, "turn.completed");
+        }
+      }
+    }),
+  );
 });
 
 const fanout = makeProviderServiceLayer();
@@ -663,7 +914,9 @@ fanout.layer("ProviderServiceLive fanout", (it) => {
         createdAt: new Date().toISOString(),
         threadId: session.threadId,
         turnId: asTurnId("turn-1"),
-        status: "completed",
+        payload: {
+          state: "completed",
+        },
       };
 
       fanout.codex.emit(completedEvent);
@@ -722,7 +975,9 @@ fanout.layer("ProviderServiceLive fanout", (it) => {
         createdAt: new Date().toISOString(),
         threadId: session.threadId,
         turnId: asTurnId("turn-1"),
-        status: "completed",
+        payload: {
+          state: "completed",
+        },
       });
 
       yield* Fiber.join(consumer);
@@ -787,7 +1042,9 @@ fanout.layer("ProviderServiceLive fanout", (it) => {
           createdAt: new Date().toISOString(),
           threadId: session.threadId,
           turnId: asTurnId("turn-1"),
-          status: "completed",
+          payload: {
+            state: "completed",
+          },
         },
       ];
 

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -788,6 +788,54 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
+  it.effect("clears persisted activeTurnId on session.state.changed ready events", () =>
+    Effect.gen(function* () {
+      const provider = yield* ProviderService;
+      const runtimeRepository = yield* ProviderSessionRuntimeRepository;
+
+      const session = yield* provider.startSession(asThreadId("thread-runtime-ready"), {
+        provider: "codex",
+        threadId: asThreadId("thread-runtime-ready"),
+        runtimeMode: "full-access",
+      });
+      yield* provider.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+      yield* sleep(20);
+
+      routing.codex.emit({
+        type: "session.state.changed",
+        eventId: asEventId("evt-runtime-ready"),
+        provider: "codex",
+        createdAt: new Date().toISOString(),
+        threadId: session.threadId,
+        payload: {
+          state: "ready",
+        },
+      });
+
+      const readyRuntime = yield* waitForRuntimeStatus(runtimeRepository, session.threadId, "ready");
+      assert.equal(readyRuntime !== undefined, true);
+      if (readyRuntime !== undefined) {
+        assert.equal(readyRuntime.status, "ready");
+        const payload = readyRuntime.runtimePayload;
+        assert.equal(payload !== null && typeof payload === "object", true);
+        if (payload !== null && typeof payload === "object" && !Array.isArray(payload)) {
+          const runtimePayload = payload as {
+            activeTurnId: string | null;
+            lastError: string | null;
+            lastRuntimeEvent: string | null;
+          };
+          assert.equal(runtimePayload.activeTurnId, null);
+          assert.equal(runtimePayload.lastError, null);
+          assert.equal(runtimePayload.lastRuntimeEvent, "session.state.changed");
+        }
+      }
+    }),
+  );
+
   it.effect("persists turn completion runtime events back into provider_session_runtime", () =>
     Effect.gen(function* () {
       const provider = yield* ProviderService;

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -11,6 +11,7 @@
  */
 import {
   NonNegativeInt,
+  type ProviderStartOptions,
   ThreadId,
   ProviderInterruptTurnInput,
   ProviderRespondToRequestInput,
@@ -30,6 +31,11 @@ import {
   ProviderSessionDirectory,
   type ProviderRuntimeBinding,
 } from "../Services/ProviderSessionDirectory.ts";
+import {
+  decodePersistedProviderRuntimePayload,
+  runtimeBindingPatchFromProviderEvent,
+  toPersistedRuntimePayloadFromSession,
+} from "../runtimePersistence.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 import { AnalyticsService } from "../../telemetry/Services/AnalyticsService.ts";
 
@@ -71,55 +77,22 @@ const decodeInputOrValidationError = <S extends Schema.Top>(input: {
     ),
   );
 
-function toRuntimeStatus(session: ProviderSession): "starting" | "running" | "stopped" | "error" {
+function toRuntimeStatus(
+  session: ProviderSession,
+): "starting" | "ready" | "running" | "stopped" | "error" {
   switch (session.status) {
     case "connecting":
       return "starting";
+    case "ready":
+      return "ready";
     case "error":
       return "error";
     case "closed":
       return "stopped";
-    case "ready":
     case "running":
     default:
       return "running";
   }
-}
-
-function toRuntimePayloadFromSession(
-  session: ProviderSession,
-  extra?: { readonly providerOptions?: unknown },
-): Record<string, unknown> {
-  return {
-    cwd: session.cwd ?? null,
-    model: session.model ?? null,
-    activeTurnId: session.activeTurnId ?? null,
-    lastError: session.lastError ?? null,
-    ...(extra?.providerOptions !== undefined ? { providerOptions: extra.providerOptions } : {}),
-  };
-}
-
-function readPersistedProviderOptions(
-  runtimePayload: ProviderRuntimeBinding["runtimePayload"],
-): Record<string, unknown> | undefined {
-  if (!runtimePayload || typeof runtimePayload !== "object" || Array.isArray(runtimePayload)) {
-    return undefined;
-  }
-  const raw = "providerOptions" in runtimePayload ? runtimePayload.providerOptions : undefined;
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
-  return raw as Record<string, unknown>;
-}
-
-function readPersistedCwd(
-  runtimePayload: ProviderRuntimeBinding["runtimePayload"],
-): string | undefined {
-  if (!runtimePayload || typeof runtimePayload !== "object" || Array.isArray(runtimePayload)) {
-    return undefined;
-  }
-  const rawCwd = "cwd" in runtimePayload ? runtimePayload.cwd : undefined;
-  if (typeof rawCwd !== "string") return undefined;
-  const trimmed = rawCwd.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 const makeProviderService = (options?: ProviderServiceLiveOptions) =>
@@ -150,7 +123,11 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     const upsertSessionBinding = (
       session: ProviderSession,
       threadId: ThreadId,
-      extra?: { readonly providerOptions?: unknown },
+      extra?: {
+        readonly providerOptions?: ProviderStartOptions;
+        readonly lastRuntimeEvent?: string;
+        readonly lastRuntimeEventAt?: string;
+      },
     ) =>
       directory.upsert({
         threadId,
@@ -158,7 +135,7 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
         runtimeMode: session.runtimeMode,
         status: toRuntimeStatus(session),
         ...(session.resumeCursor !== undefined ? { resumeCursor: session.resumeCursor } : {}),
-        runtimePayload: toRuntimePayloadFromSession(session, extra),
+        runtimePayload: toPersistedRuntimePayloadFromSession(session, extra),
       });
 
     const providers = yield* registry.listProviders();
@@ -167,7 +144,26 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
     );
 
     const processRuntimeEvent = (event: ProviderRuntimeEvent): Effect.Effect<void> =>
-      publishRuntimeEvent(event);
+      Effect.gen(function* () {
+        const existingBindingResult = yield* Effect.result(directory.getBinding(event.threadId));
+        const existingBinding =
+          existingBindingResult._tag === "Success"
+            ? Option.getOrUndefined(existingBindingResult.success)
+            : undefined;
+        const bindingPatch = runtimeBindingPatchFromProviderEvent(event, existingBinding);
+        if (bindingPatch) {
+          const persistResult = yield* Effect.result(directory.upsert(bindingPatch));
+          if (persistResult._tag === "Failure") {
+            yield* Effect.logWarning("failed to persist provider runtime state from event", {
+              threadId: event.threadId,
+              provider: event.provider,
+              eventType: event.type,
+              cause: persistResult.failure,
+            });
+          }
+        }
+        yield* publishRuntimeEvent(event);
+      });
 
     const worker = Effect.forever(
       Queue.take(runtimeEventQueue).pipe(Effect.flatMap(processRuntimeEvent)),
@@ -212,15 +208,35 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           );
         }
 
-        const persistedCwd = readPersistedCwd(input.binding.runtimePayload);
-        const persistedProviderOptions = readPersistedProviderOptions(input.binding.runtimePayload);
+        const persistedRuntime = decodePersistedProviderRuntimePayload(input.binding.runtimePayload);
+        const persistedCwd =
+          typeof persistedRuntime.cwd === "string" && persistedRuntime.cwd.trim().length > 0
+            ? persistedRuntime.cwd
+            : undefined;
+        const persistedProviderOptions =
+          persistedRuntime.providerOptions !== null &&
+          persistedRuntime.providerOptions !== undefined
+            ? persistedRuntime.providerOptions
+            : undefined;
+        const persistedModel =
+          typeof persistedRuntime.model === "string" && persistedRuntime.model.trim().length > 0
+            ? persistedRuntime.model
+            : undefined;
+        const recoveredTurn =
+          input.binding.status === "running" && persistedRuntime.activeTurnId !== undefined
+            ? persistedRuntime.activeTurnId === null
+              ? undefined
+              : { activeTurnId: persistedRuntime.activeTurnId }
+            : undefined;
 
-        const resumed = yield* adapter.startSession({
+        const resumed = yield* adapter.recoverSession({
           threadId: input.binding.threadId,
           provider: input.binding.provider,
+          resumeCursor: input.binding.resumeCursor,
           ...(persistedCwd ? { cwd: persistedCwd } : {}),
+          ...(persistedModel ? { model: persistedModel } : {}),
           ...(persistedProviderOptions ? { providerOptions: persistedProviderOptions } : {}),
-          ...(hasResumeCursor ? { resumeCursor: input.binding.resumeCursor } : {}),
+          ...(recoveredTurn !== undefined ? { recoveredTurn } : {}),
           runtimeMode: input.binding.runtimeMode ?? "full-access",
         });
         if (resumed.provider !== adapter.provider) {
@@ -291,11 +307,13 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
           );
         }
 
-        yield* upsertSessionBinding(session, threadId, {
-          ...(input.providerOptions !== undefined
+        yield* upsertSessionBinding(
+          session,
+          threadId,
+          input.providerOptions !== undefined
             ? { providerOptions: input.providerOptions }
-            : {}),
-        });
+            : undefined,
+        );
         yield* analytics.record("provider.session.started", {
           provider: session.provider,
           runtimeMode: input.runtimeMode,

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -11,11 +11,13 @@ import type {
   ApprovalRequestId,
   ProviderApprovalDecision,
   ProviderKind,
+  ProviderStartOptions,
   ProviderUserInputAnswers,
   ProviderRuntimeEvent,
   ProviderSendTurnInput,
   ProviderSession,
   ProviderSessionStartInput,
+  RuntimeMode,
   ThreadId,
   ProviderTurnStartResult,
   TurnId,
@@ -42,6 +44,21 @@ export interface ProviderThreadSnapshot {
   readonly turns: ReadonlyArray<ProviderThreadTurnSnapshot>;
 }
 
+export interface RecoveredTurnState {
+  readonly activeTurnId?: TurnId;
+}
+
+export interface ProviderSessionRecoveryInput {
+  readonly threadId: ThreadId;
+  readonly provider: ProviderKind;
+  readonly runtimeMode: RuntimeMode;
+  readonly resumeCursor: unknown;
+  readonly cwd?: string;
+  readonly model?: string;
+  readonly providerOptions?: ProviderStartOptions;
+  readonly recoveredTurn?: RecoveredTurnState;
+}
+
 export interface ProviderAdapterShape<TError> {
   /**
    * Provider kind implemented by this adapter.
@@ -54,6 +71,13 @@ export interface ProviderAdapterShape<TError> {
    */
   readonly startSession: (
     input: ProviderSessionStartInput,
+  ) => Effect.Effect<ProviderSession, TError>;
+
+  /**
+   * Recover a provider-backed session from persisted runtime state.
+   */
+  readonly recoverSession: (
+    input: ProviderSessionRecoveryInput,
   ) => Effect.Effect<ProviderSession, TError>;
 
   /**

--- a/apps/server/src/provider/runtimePersistence.ts
+++ b/apps/server/src/provider/runtimePersistence.ts
@@ -1,0 +1,255 @@
+import {
+  IsoDateTime,
+  ProviderStartOptions,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  TurnId,
+} from "@t3tools/contracts";
+import { Schema } from "effect";
+
+import type { ProviderRuntimeBinding } from "./Services/ProviderSessionDirectory.ts";
+
+const NullableString = Schema.NullOr(Schema.String);
+
+const PersistedProviderRuntimePayloadSchema = Schema.Struct({
+  cwd: Schema.optional(NullableString),
+  model: Schema.optional(NullableString),
+  providerOptions: Schema.optional(Schema.NullOr(ProviderStartOptions)),
+  activeTurnId: Schema.optional(Schema.NullOr(TurnId)),
+  lastError: Schema.optional(NullableString),
+  lastRuntimeEvent: Schema.optional(NullableString),
+  lastRuntimeEventAt: Schema.optional(Schema.NullOr(IsoDateTime)),
+});
+
+export type PersistedProviderRuntimePayload = typeof PersistedProviderRuntimePayloadSchema.Type;
+
+const decodePersistedPayloadSync = Schema.decodeUnknownSync(PersistedProviderRuntimePayloadSchema);
+
+function withRuntimeEventMetadata(
+  payload: PersistedProviderRuntimePayload,
+  event: ProviderRuntimeEvent,
+): PersistedProviderRuntimePayload {
+  return {
+    ...payload,
+    lastRuntimeEvent: event.type,
+    lastRuntimeEventAt: event.createdAt,
+  };
+}
+
+function runtimeTurnState(
+  event: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>,
+): "completed" | "failed" | "interrupted" | "cancelled" {
+  switch (event.payload.state) {
+    case "failed":
+    case "interrupted":
+    case "cancelled":
+    case "completed":
+      return event.payload.state;
+    default:
+      return "completed";
+  }
+}
+
+function shouldAdoptTurnFromEventType(type: ProviderRuntimeEvent["type"]): boolean {
+  switch (type) {
+    case "content.delta":
+    case "item.started":
+    case "item.updated":
+    case "item.completed":
+    case "request.opened":
+    case "request.resolved":
+    case "user-input.requested":
+    case "user-input.resolved":
+    case "turn.plan.updated":
+    case "turn.proposed.delta":
+    case "turn.proposed.completed":
+    case "turn.diff.updated":
+    case "task.started":
+    case "task.progress":
+    case "task.completed":
+    case "hook.started":
+    case "hook.progress":
+    case "hook.completed":
+    case "tool.progress":
+    case "tool.summary":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function decodePersistedProviderRuntimePayload(
+  runtimePayload: ProviderRuntimeBinding["runtimePayload"],
+): PersistedProviderRuntimePayload {
+  try {
+    return decodePersistedPayloadSync(runtimePayload);
+  } catch {
+    return {};
+  }
+}
+
+export function toPersistedRuntimePayloadFromSession(
+  session: ProviderSession,
+  extra?: {
+    readonly providerOptions?: ProviderStartOptions;
+    readonly lastRuntimeEvent?: string;
+    readonly lastRuntimeEventAt?: string;
+  },
+): PersistedProviderRuntimePayload {
+  return {
+    cwd: session.cwd ?? null,
+    model: session.model ?? null,
+    activeTurnId: session.activeTurnId ?? null,
+    lastError: session.lastError ?? null,
+    ...(extra?.providerOptions !== undefined ? { providerOptions: extra.providerOptions } : {}),
+    ...(extra?.lastRuntimeEvent !== undefined ? { lastRuntimeEvent: extra.lastRuntimeEvent } : {}),
+    ...(extra?.lastRuntimeEventAt !== undefined
+      ? { lastRuntimeEventAt: extra.lastRuntimeEventAt }
+      : {}),
+  };
+}
+
+export function runtimeBindingPatchFromProviderEvent(
+  event: ProviderRuntimeEvent,
+  existingBinding?: ProviderRuntimeBinding,
+): ProviderRuntimeBinding | undefined {
+  const existingPayload = decodePersistedProviderRuntimePayload(existingBinding?.runtimePayload);
+  const eventTurnId = event.turnId;
+
+  switch (event.type) {
+    case "session.started":
+    case "thread.started":
+      return {
+        threadId: event.threadId,
+        provider: event.provider,
+        status: "ready",
+        ...(event.type === "thread.started" && event.payload.providerThreadId
+          ? { resumeCursor: { threadId: event.payload.providerThreadId } }
+          : {}),
+        runtimePayload: withRuntimeEventMetadata(
+          {
+            activeTurnId: null,
+            lastError: null,
+          },
+          event,
+        ),
+      };
+
+    case "session.state.changed":
+      const sessionStateRuntimePayload =
+        event.payload.state === "error"
+          ? { lastError: event.payload.reason ?? existingPayload.lastError ?? null }
+          : event.payload.state === "ready"
+            ? { lastError: null }
+            : {};
+      return {
+        threadId: event.threadId,
+        provider: event.provider,
+        status:
+          event.payload.state === "starting"
+            ? "starting"
+            : event.payload.state === "ready"
+                ? "ready"
+              : event.payload.state === "running" || event.payload.state === "waiting"
+                ? "running"
+                : event.payload.state === "stopped"
+                  ? "stopped"
+                  : "error",
+        runtimePayload: withRuntimeEventMetadata(
+          sessionStateRuntimePayload,
+          event,
+        ),
+      };
+
+    case "turn.started":
+      return {
+        threadId: event.threadId,
+        provider: event.provider,
+        status: "running",
+        runtimePayload: withRuntimeEventMetadata(
+          {
+            activeTurnId: eventTurnId ?? existingPayload.activeTurnId ?? null,
+            lastError: null,
+          },
+          event,
+        ),
+      };
+
+    case "turn.completed":
+      return {
+        threadId: event.threadId,
+        provider: event.provider,
+        status: runtimeTurnState(event) === "failed" ? "error" : "ready",
+        runtimePayload: withRuntimeEventMetadata(
+          {
+            activeTurnId: null,
+            lastError:
+              runtimeTurnState(event) === "failed"
+                ? event.payload.errorMessage ?? existingPayload.lastError ?? null
+                : null,
+          },
+          event,
+        ),
+      };
+
+    case "turn.aborted":
+      return {
+        threadId: event.threadId,
+        provider: event.provider,
+        status: "ready",
+        runtimePayload: withRuntimeEventMetadata(
+          {
+            activeTurnId: null,
+          },
+          event,
+        ),
+      };
+
+    case "runtime.error":
+      return {
+        threadId: event.threadId,
+        provider: event.provider,
+        status: "error",
+        runtimePayload: withRuntimeEventMetadata(
+          {
+            ...(eventTurnId !== undefined ? { activeTurnId: eventTurnId } : {}),
+            lastError: event.payload.message ?? existingPayload.lastError ?? null,
+          },
+          event,
+        ),
+      };
+
+    case "session.exited":
+      return {
+        threadId: event.threadId,
+        provider: event.provider,
+        status: "stopped",
+        runtimePayload: withRuntimeEventMetadata(
+          {
+            activeTurnId: null,
+          },
+          event,
+        ),
+      };
+
+    default:
+      if (
+        eventTurnId !== undefined &&
+        existingPayload.activeTurnId == null &&
+        shouldAdoptTurnFromEventType(event.type)
+      ) {
+        return {
+          threadId: event.threadId,
+          provider: event.provider,
+          status: "running",
+          runtimePayload: withRuntimeEventMetadata(
+            {
+              activeTurnId: eventTurnId,
+            },
+            event,
+          ),
+        };
+      }
+      return undefined;
+  }
+}

--- a/apps/server/src/provider/runtimePersistence.ts
+++ b/apps/server/src/provider/runtimePersistence.ts
@@ -140,7 +140,9 @@ export function runtimeBindingPatchFromProviderEvent(
         event.payload.state === "error"
           ? { lastError: event.payload.reason ?? existingPayload.lastError ?? null }
           : event.payload.state === "ready"
-            ? { lastError: null }
+            ? { activeTurnId: null, lastError: null }
+            : event.payload.state === "stopped"
+              ? { activeTurnId: null }
             : {};
       return {
         threadId: event.threadId,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -893,6 +893,7 @@ export const ThreadTurnDiff = TurnCountRange.mapFields(
 
 export const ProviderSessionRuntimeStatus = Schema.Literals([
   "starting",
+  "ready",
   "running",
   "stopped",
   "error",


### PR DESCRIPTION
## Summary
This change fixes session state drift around Codex resume and abort flows.

When a session was resumed with an already-active turn, the server could still emit a `session/ready` lifecycle event even though the recovered session was actually running. Separately, when the runtime reported `turn/aborted` or later transitioned back to `ready` or `stopped`, stale `activeTurnId` state could survive in memory, orchestration projections, or persisted runtime records.

For users, that could show up as a thread that looked idle and running at the same time, or as a thread that appeared to have an active turn after the runtime had already gone ready. In the worst case, reconnect and recovery flows could leave the UI and server-side state disagreeing about whether the session was actually free to accept more work.

## Root Cause
The session lifecycle logic was not applying the same active-turn clearing rules across the full stack.

`CodexAppServerManager` already knew how to restore a recovered active turn, but it still emitted `session/ready` unconditionally after thread open completed. It also did not treat `turn/aborted` as a state transition that should clear the local active turn.

Downstream, the orchestration ingestion and runtime persistence layers updated status on `session.state.changed`, but they did not consistently null out `activeTurnId` when the runtime reported terminal non-running states like `ready` or `stopped`.

## Fix
The patch makes all three layers converge on the same rule: if the runtime is `ready` or `stopped`, there is no active turn.

`CodexAppServerManager` now suppresses `session/ready` when resume restores an active turn, and it explicitly handles `turn/aborted` by setting the session back to `ready`, clearing `activeTurnId`, and preserving any available error message.

The orchestration ingestion layer now clears stale active turns when `session.state.changed` reports `ready` or `stopped`, and runtime persistence now writes `activeTurnId: null` for those same cases while also clearing `lastError` on `ready`.

## Validation
I added regression coverage for:

- recovered sessions that restore an active turn
- recovered sessions that do not restore an active turn
- local session cleanup on `turn/aborted`
- orchestration projection cleanup on `session.state.changed: ready`
- persisted runtime cleanup on `session.state.changed: ready`

Checks run:

- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix resume state drift by implementing `recoverSession` across the Codex provider stack
> - Adds `recoverSession` to `CodexAppServerManager`, `CodexAdapter`, and the `ProviderAdapterShape` contract so session recovery uses a dedicated path instead of re-calling `startSession`.
> - When recovering with a `recoveredTurn.activeTurnId`, the session is restored to `running` state with that turn ID set; the `session/ready` event is suppressed. Without it, recovery behaves like a fresh start.
> - Adds a new [runtimePersistence.ts](https://github.com/pingdotgg/t3code/pull/863/files#diff-bc69b7ab017853bf99c349987a88b38789767026aeaab3e263b1cb140215e2dc) module with a `runtimeBindingPatchFromProviderEvent` reducer that derives precise `ProviderRuntimeBinding` patches (status, `activeTurnId`, `resumeCursor`, errors) from each incoming runtime event.
> - `ProviderService` now persists runtime state transitions on every provider event and passes `recoveredTurn` from persisted state during recovery when a non-null `activeTurnId` is stored.
> - Fixes `toRuntimeStatus` so sessions in `'ready'` state are persisted as `'ready'` instead of falling through to `'running'`.
> - Behavioral Change: `ProviderRuntimeIngestion` now clears `activeTurnId` on `session.state.changed` events with state `'ready'` or `'stopped'`, which previously left stale turn IDs in the read model.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bf3d7d3. 8 files reviewed, 5 issues evaluated, 2 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/codexAppServerManager.ts — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 1393](https://github.com/pingdotgg/t3code/blob/bf3d7d330a43833411c2125b49301f31b1eb158d/apps/server/src/codexAppServerManager.ts#L1393): On Windows, `spawn` is called with `shell: true`. If `input.binaryPath` contains spaces (e.g., `C:\Program Files\...`), the command will fail because `cmd.exe` interprets the space as a delimiter and `spawn` does not automatically quote the command argument when `shell: true` is active. This will cause the application server to fail to start for users with the application installed in a path with spaces. <b>[ Out of scope (triage) ]</b>
> </details>
>
> <details>
> <summary>apps/server/src/provider/Layers/ProviderService.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 352](https://github.com/pingdotgg/t3code/blob/bf3d7d330a43833411c2125b49301f31b1eb158d/apps/server/src/provider/Layers/ProviderService.ts#L352): In `sendTurn`, the call to `directory.upsert` overwrites the persisted session binding with a new `runtimePayload` object that only contains `activeTurnId` and event metadata. It fails to preserve the previously persisted `cwd`, `model`, and `providerOptions` established in `startSession`. Because `upsert` typically replaces the stored value, these configuration fields are lost. If the service restarts during or after a turn, `recoverSessionForThread` will be unable to restore the correct working directory or provider options, causing the session to resume with incorrect defaults (e.g., wrong `cwd`). <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->