### PR TITLE
fix: checkpoint diffs never resolve due to shared PubSub subscriptions

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -2,6 +2,7 @@ import {
   CommandId,
   EventId,
   MessageId,
+  type ProjectId,
   ThreadId,
   TurnId,
   type OrchestrationEvent,
@@ -147,6 +148,175 @@ const make = Effect.gen(function* () {
 
   const isGitWorkspace = (cwd: string) => isGitRepository(cwd);
 
+  // Resolves the workspace CWD for checkpoint operations, preferring the
+  // active provider session CWD and falling back to the thread/project config.
+  // Returns undefined when no CWD can be determined or the workspace is not
+  // a git repository.
+  const resolveCheckpointCwd = Effect.fnUntraced(function* (input: {
+    readonly threadId: ThreadId;
+    readonly thread: { readonly projectId: ProjectId; readonly worktreePath: string | null };
+    readonly projects: ReadonlyArray<{ readonly id: ProjectId; readonly workspaceRoot: string }>;
+    readonly preferSessionRuntime: boolean;
+  }): Effect.fn.Return<string | undefined> {
+    const fromSession = yield* resolveSessionRuntimeForThread(input.threadId);
+    const fromThread = resolveThreadWorkspaceCwd({
+      thread: input.thread,
+      projects: input.projects,
+    });
+
+    const cwd = input.preferSessionRuntime
+      ? (Option.match(fromSession, {
+          onNone: () => undefined,
+          onSome: (runtime) => runtime.cwd,
+        }) ?? fromThread)
+      : (fromThread ??
+        Option.match(fromSession, {
+          onNone: () => undefined,
+          onSome: (runtime) => runtime.cwd,
+        }));
+
+    if (!cwd) {
+      return undefined;
+    }
+    if (!isGitWorkspace(cwd)) {
+      return undefined;
+    }
+    return cwd;
+  });
+
+  // Shared tail for both capture paths: creates the git checkpoint ref, diffs
+  // it against the previous turn, then dispatches the domain events to update
+  // the orchestration read model.
+  const captureAndDispatchCheckpoint = Effect.fnUntraced(function* (input: {
+    readonly threadId: ThreadId;
+    readonly turnId: TurnId;
+    readonly thread: {
+      readonly messages: ReadonlyArray<{
+        readonly id: MessageId;
+        readonly role: string;
+        readonly turnId: TurnId | null;
+      }>;
+    };
+    readonly cwd: string;
+    readonly turnCount: number;
+    readonly status: "ready" | "missing" | "error";
+    readonly assistantMessageId: MessageId | undefined;
+    readonly createdAt: string;
+  }) {
+    const fromTurnCount = Math.max(0, input.turnCount - 1);
+    const fromCheckpointRef = checkpointRefForThreadTurn(input.threadId, fromTurnCount);
+    const targetCheckpointRef = checkpointRefForThreadTurn(input.threadId, input.turnCount);
+
+    const fromCheckpointExists = yield* checkpointStore.hasCheckpointRef({
+      cwd: input.cwd,
+      checkpointRef: fromCheckpointRef,
+    });
+    if (!fromCheckpointExists) {
+      yield* Effect.logWarning("checkpoint capture missing pre-turn baseline", {
+        threadId: input.threadId,
+        turnId: input.turnId,
+        fromTurnCount,
+      });
+    }
+
+    yield* checkpointStore.captureCheckpoint({
+      cwd: input.cwd,
+      checkpointRef: targetCheckpointRef,
+    });
+
+    const files = yield* checkpointStore
+      .diffCheckpoints({
+        cwd: input.cwd,
+        fromCheckpointRef,
+        toCheckpointRef: targetCheckpointRef,
+        fallbackFromToHead: false,
+      })
+      .pipe(
+        Effect.map((diff) =>
+          parseTurnDiffFilesFromUnifiedDiff(diff).map((file) => ({
+            path: file.path,
+            kind: "modified" as const,
+            additions: file.additions,
+            deletions: file.deletions,
+          })),
+        ),
+        Effect.tapError((error) =>
+          appendCaptureFailureActivity({
+            threadId: input.threadId,
+            turnId: input.turnId,
+            detail: `Checkpoint captured, but turn diff summary is unavailable: ${error.message}`,
+            createdAt: input.createdAt,
+          }),
+        ),
+        Effect.catch((error) =>
+          Effect.logWarning("failed to derive checkpoint file summary", {
+            threadId: input.threadId,
+            turnId: input.turnId,
+            turnCount: input.turnCount,
+            detail: error.message,
+          }).pipe(Effect.as([])),
+        ),
+      );
+
+    const assistantMessageId =
+      input.assistantMessageId ??
+      input.thread.messages
+        .toReversed()
+        .find((entry) => entry.role === "assistant" && entry.turnId === input.turnId)?.id ??
+      MessageId.makeUnsafe(`assistant:${input.turnId}`);
+
+    yield* orchestrationEngine.dispatch({
+      type: "thread.turn.diff.complete",
+      commandId: serverCommandId("checkpoint-turn-diff-complete"),
+      threadId: input.threadId,
+      turnId: input.turnId,
+      completedAt: input.createdAt,
+      checkpointRef: targetCheckpointRef,
+      status: input.status,
+      files,
+      assistantMessageId,
+      checkpointTurnCount: input.turnCount,
+      createdAt: input.createdAt,
+    });
+
+    yield* orchestrationEngine.dispatch({
+      type: "thread.activity.append",
+      commandId: serverCommandId("checkpoint-captured-activity"),
+      threadId: input.threadId,
+      activity: {
+        id: EventId.makeUnsafe(crypto.randomUUID()),
+        tone: "info",
+        kind: "checkpoint.captured",
+        summary: "Checkpoint captured",
+        payload: {
+          turnCount: input.turnCount,
+          status: input.status,
+        },
+        turnId: input.turnId,
+        createdAt: input.createdAt,
+      },
+      createdAt: input.createdAt,
+    });
+
+    yield* receiptBus.publish({
+      type: "checkpoint.diff.finalized",
+      threadId: input.threadId,
+      turnId: input.turnId,
+      checkpointTurnCount: input.turnCount,
+      checkpointRef: targetCheckpointRef,
+      status: input.status,
+      createdAt: input.createdAt,
+    });
+    yield* receiptBus.publish({
+      type: "turn.processing.quiesced",
+      threadId: input.threadId,
+      turnId: input.turnId,
+      checkpointTurnCount: input.turnCount,
+      createdAt: input.createdAt,
+    });
+  });
+
+  // Captures a real git checkpoint when a turn completes via a runtime event.
   const captureCheckpointFromTurnCompletion = Effect.fnUntraced(function* (
     event: Extract<ProviderRuntimeEvent, { type: "turn.completed" }>,
   ) {
@@ -166,154 +336,111 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    if (thread.checkpoints.some((checkpoint) => checkpoint.turnId === turnId)) {
+    // Only skip if a real (non-placeholder) checkpoint already exists for this turn.
+    // ProviderRuntimeIngestion may insert placeholder entries with status "missing"
+    // before this reactor runs; those must not prevent real git capture.
+    if (
+      thread.checkpoints.some(
+        (checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing",
+      )
+    ) {
       return;
     }
 
-    const sessionRuntime = yield* resolveSessionRuntimeForThread(thread.id);
-    const checkpointCwd =
-      Option.match(sessionRuntime, {
-        onNone: () => undefined,
-        onSome: (runtime) => runtime.cwd,
-      }) ??
-      resolveThreadWorkspaceCwd({
-        thread,
-        projects: readModel.projects,
-      });
+    const checkpointCwd = yield* resolveCheckpointCwd({
+      threadId: thread.id,
+      thread,
+      projects: readModel.projects,
+      preferSessionRuntime: true,
+    });
     if (!checkpointCwd) {
-      yield* Effect.logWarning("checkpoint capture skipped: no active provider session cwd", {
-        threadId: thread.id,
-        turnId,
-      });
-      return;
-    }
-    if (!isGitWorkspace(checkpointCwd)) {
-      yield* Effect.logDebug("checkpoint capture skipped for non-git workspace", {
-        threadId: thread.id,
-        turnId,
-        cwd: checkpointCwd,
-      });
       return;
     }
 
+    // If a placeholder checkpoint exists for this turn, reuse its turn count
+    // instead of incrementing past it.
+    const existingPlaceholder = thread.checkpoints.find(
+      (checkpoint) => checkpoint.turnId === turnId && checkpoint.status === "missing",
+    );
     const currentTurnCount = thread.checkpoints.reduce(
       (maxTurnCount, checkpoint) => Math.max(maxTurnCount, checkpoint.checkpointTurnCount),
       0,
     );
-    const nextTurnCount = currentTurnCount + 1;
-    const fromTurnCount = Math.max(0, nextTurnCount - 1);
-    const fromCheckpointRef = checkpointRefForThreadTurn(thread.id, fromTurnCount);
-    const targetCheckpointRef = checkpointRefForThreadTurn(thread.id, nextTurnCount);
+    const nextTurnCount = existingPlaceholder
+      ? existingPlaceholder.checkpointTurnCount
+      : currentTurnCount + 1;
 
-    const fromCheckpointExists = yield* checkpointStore.hasCheckpointRef({
+    yield* captureAndDispatchCheckpoint({
+      threadId: thread.id,
+      turnId,
+      thread,
       cwd: checkpointCwd,
-      checkpointRef: fromCheckpointRef,
+      turnCount: nextTurnCount,
+      status: checkpointStatusFromRuntime(event.payload.state),
+      assistantMessageId: undefined,
+      createdAt: event.createdAt,
     });
-    if (!fromCheckpointExists) {
-      yield* Effect.logWarning("checkpoint completion missing pre-turn baseline", {
-        threadId: thread.id,
-        turnId,
-        fromTurnCount,
-      });
+  });
+
+  // Captures a real git checkpoint when a placeholder checkpoint (status "missing")
+  // is detected via a domain event. This replaces the placeholder with a real
+  // git-ref-based checkpoint.
+  //
+  // ProviderRuntimeIngestion creates placeholder checkpoints on turn.diff.updated
+  // events from the Codex runtime. This handler fires when the corresponding
+  // domain event arrives, allowing the reactor to capture the actual filesystem
+  // state into a git ref and dispatch a replacement checkpoint.
+  const captureCheckpointFromPlaceholder = Effect.fnUntraced(function* (
+    event: Extract<OrchestrationEvent, { type: "thread.turn-diff-completed" }>,
+  ) {
+    const { threadId, turnId, checkpointTurnCount, status } = event.payload;
+
+    // Only replace placeholders; skip events from our own real captures.
+    if (status !== "missing") {
+      return;
     }
 
-    yield* checkpointStore.captureCheckpoint({
-      cwd: checkpointCwd,
-      checkpointRef: targetCheckpointRef,
-    });
+    const readModel = yield* orchestrationEngine.getReadModel();
+    const thread = readModel.threads.find((entry) => entry.id === threadId);
+    if (!thread) {
+      yield* Effect.logWarning("checkpoint capture from placeholder skipped: thread not found", {
+        threadId,
+      });
+      return;
+    }
 
-    // Invalidate the workspace entry cache so the @-mention file picker
-    // reflects files created or deleted during this turn.
-    clearWorkspaceIndexCache(checkpointCwd);
-
-    const files = yield* checkpointStore
-      .diffCheckpoints({
-        cwd: checkpointCwd,
-        fromCheckpointRef,
-        toCheckpointRef: targetCheckpointRef,
-        fallbackFromToHead: false,
-      })
-      .pipe(
-        Effect.map((diff) =>
-          parseTurnDiffFilesFromUnifiedDiff(diff).map((file) => ({
-            path: file.path,
-            kind: "modified" as const,
-            additions: file.additions,
-            deletions: file.deletions,
-          })),
-        ),
-        Effect.tapError((error) =>
-          appendCaptureFailureActivity({
-            threadId: thread.id,
-            turnId,
-            detail: `Checkpoint captured, but turn diff summary is unavailable: ${error.message}`,
-            createdAt: event.createdAt,
-          }),
-        ),
-        Effect.catch((error) =>
-          Effect.logWarning("failed to derive checkpoint file summary", {
-            threadId: thread.id,
-            turnId,
-            turnCount: nextTurnCount,
-            detail: error.message,
-          }).pipe(Effect.as([])),
-        ),
+    // If a real checkpoint already exists for this turn, skip.
+    if (
+      thread.checkpoints.some(
+        (checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing",
+      )
+    ) {
+      yield* Effect.logDebug(
+        "checkpoint capture from placeholder skipped: real checkpoint already exists",
+        { threadId, turnId },
       );
+      return;
+    }
 
-    const assistantMessageId =
-      thread.messages
-        .toReversed()
-        .find((entry) => entry.role === "assistant" && entry.turnId === turnId)?.id ??
-      MessageId.makeUnsafe(`assistant:${turnId}`);
+    const checkpointCwd = yield* resolveCheckpointCwd({
+      threadId,
+      thread,
+      projects: readModel.projects,
+      preferSessionRuntime: true,
+    });
+    if (!checkpointCwd) {
+      return;
+    }
 
-    const now = event.createdAt;
-    yield* orchestrationEngine.dispatch({
-      type: "thread.turn.diff.complete",
-      commandId: serverCommandId("checkpoint-turn-diff-complete"),
-      threadId: thread.id,
+    yield* captureAndDispatchCheckpoint({
+      threadId,
       turnId,
-      completedAt: now,
-      checkpointRef: targetCheckpointRef,
-      status: checkpointStatusFromRuntime(event.payload.state),
-      files,
-      assistantMessageId,
-      checkpointTurnCount: nextTurnCount,
-      createdAt: now,
-    });
-    yield* receiptBus.publish({
-      type: "checkpoint.diff.finalized",
-      threadId: thread.id,
-      turnId,
-      checkpointTurnCount: nextTurnCount,
-      checkpointRef: targetCheckpointRef,
-      status: checkpointStatusFromRuntime(event.payload.state),
-      createdAt: now,
-    });
-    yield* receiptBus.publish({
-      type: "turn.processing.quiesced",
-      threadId: thread.id,
-      turnId,
-      checkpointTurnCount: nextTurnCount,
-      createdAt: now,
-    });
-
-    yield* orchestrationEngine.dispatch({
-      type: "thread.activity.append",
-      commandId: serverCommandId("checkpoint-captured-activity"),
-      threadId: thread.id,
-      activity: {
-        id: EventId.makeUnsafe(crypto.randomUUID()),
-        tone: "info",
-        kind: "checkpoint.captured",
-        summary: "Checkpoint captured",
-        payload: {
-          turnCount: nextTurnCount,
-          status: event.payload.state,
-        },
-        turnId,
-        createdAt: now,
-      },
-      createdAt: now,
+      thread,
+      cwd: checkpointCwd,
+      turnCount: checkpointTurnCount,
+      status: "ready",
+      assistantMessageId: undefined,
+      createdAt: event.payload.completedAt,
     });
   });
 
@@ -331,24 +458,13 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const checkpointCwdFromThreadOrProject = resolveThreadWorkspaceCwd({
+    const checkpointCwd = yield* resolveCheckpointCwd({
+      threadId: thread.id,
       thread,
       projects: readModel.projects,
+      preferSessionRuntime: false,
     });
-    const checkpointCwd =
-      checkpointCwdFromThreadOrProject ??
-      Option.match(yield* resolveSessionRuntimeForThread(thread.id), {
-        onNone: () => undefined,
-        onSome: (runtime) => runtime.cwd,
-      });
     if (!checkpointCwd) {
-      yield* Effect.logWarning("checkpoint pre-turn capture skipped: no workspace cwd", {
-        threadId: thread.id,
-        turnId,
-      });
-      return;
-    }
-    if (!isGitWorkspace(checkpointCwd)) {
       return;
     }
 
@@ -401,23 +517,13 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    const checkpointCwdFromThreadOrProject = resolveThreadWorkspaceCwd({
+    const checkpointCwd = yield* resolveCheckpointCwd({
+      threadId,
       thread,
       projects: readModel.projects,
+      preferSessionRuntime: false,
     });
-    const checkpointCwd =
-      checkpointCwdFromThreadOrProject ??
-      Option.match(yield* resolveSessionRuntimeForThread(threadId), {
-        onNone: () => undefined,
-        onSome: (runtime) => runtime.cwd,
-      });
     if (!checkpointCwd) {
-      yield* Effect.logWarning("checkpoint pre-turn capture skipped: no workspace cwd", {
-        threadId,
-      });
-      return;
-    }
-    if (!isGitWorkspace(checkpointCwd)) {
       return;
     }
 
@@ -592,6 +698,25 @@ const make = Effect.gen(function* () {
           }),
         ),
       );
+      return;
+    }
+
+    // When ProviderRuntimeIngestion creates a placeholder checkpoint (status "missing")
+    // from a turn.diff.updated runtime event, capture the real git checkpoint to
+    // replace it. The providerService.streamEvents PubSub does not reliably deliver
+    // turn.completed runtime events to this reactor (shared subscription), so
+    // reacting to the domain event is the reliable path.
+    if (event.type === "thread.turn-diff-completed") {
+      yield* captureCheckpointFromPlaceholder(event).pipe(
+        Effect.catch((error) =>
+          appendCaptureFailureActivity({
+            threadId: event.payload.threadId,
+            turnId: event.payload.turnId,
+            detail: error.message,
+            createdAt: new Date().toISOString(),
+          }).pipe(Effect.catch(() => Effect.void)),
+        ),
+      );
     }
   });
 
@@ -644,7 +769,8 @@ const make = Effect.gen(function* () {
         if (
           event.type !== "thread.turn-start-requested" &&
           event.type !== "thread.message-sent" &&
-          event.type !== "thread.checkpoint-revert-requested"
+          event.type !== "thread.checkpoint-revert-requested" &&
+          event.type !== "thread.turn-diff-completed"
         ) {
           return Effect.void;
         }

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -222,14 +222,16 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       return yield* Deferred.await(result);
     });
 
-  const streamDomainEvents: OrchestrationEngineShape["streamDomainEvents"] =
-    Stream.fromPubSub(eventPubSub);
-
   return {
     getReadModel,
     readEvents,
     dispatch,
-    streamDomainEvents,
+    // Each access creates a fresh PubSub subscription so that multiple
+    // consumers (wsServer, ProviderRuntimeIngestion, CheckpointReactor, etc.)
+    // each independently receive all domain events.
+    get streamDomainEvents(): OrchestrationEngineShape["streamDomainEvents"] {
+      return Stream.fromPubSub(eventPubSub);
+    },
   } satisfies OrchestrationEngineShape;
 });
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -537,7 +537,12 @@ const makeProviderService = (options?: ProviderServiceLiveOptions) =>
       listSessions,
       getCapabilities,
       rollbackConversation,
-      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+      // Each access creates a fresh PubSub subscription so that multiple
+      // consumers (ProviderRuntimeIngestion, CheckpointReactor, etc.) each
+      // independently receive all runtime events.
+      get streamEvents(): ProviderServiceShape["streamEvents"] {
+        return Stream.fromPubSub(runtimeEventPubSub);
+      },
     } satisfies ProviderServiceShape;
   });
 


### PR DESCRIPTION
Stream.fromPubSub() creates a subscription eagerly. Storing the result as a property meant all consumers shared one queue, so only the first reader (wsServer/ProviderRuntimeIngestion) got events. CheckpointReactor received zero events and never captured git checkpoints.

Fix: change streamDomainEvents and streamEvents to getters so each consumer gets its own subscription. Also add a domain event handler that replaces placeholder checkpoints with real git captures, and extract shared CWD resolution and capture logic to reduce duplication.

Closes #585
Closes #595


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix checkpoint diffs never resolving due to shared PubSub subscriptions
> - Converts `streamDomainEvents` in [`OrchestrationEngine`](https://github.com/pingdotgg/t3code/pull/864/files#diff-996de6bdce67b7926493255cf29e93653d211eca31023cf4c476b42f7dc59570) and `streamEvents` in [`ProviderService`](https://github.com/pingdotgg/t3code/pull/864/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775) from fixed stream exports to getters that call `Stream.fromPubSub()` on each access, giving each consumer an independent subscription.
> - Adds a `captureCheckpointFromPlaceholder` handler in [`CheckpointReactor`](https://github.com/pingdotgg/t3code/pull/864/files#diff-79dc41615f79575ae1404bd102df915797fb24ba34989557f80e229d305521fb) that replaces placeholder (status `"missing"`) checkpoints with a real git checkpoint when a `thread.turn-diff-completed` event is received.
> - Refactors `captureCheckpointFromTurnCompletion` so placeholder checkpoints no longer block a real capture for the same turn, and centralizes cwd resolution and capture dispatch into `resolveCheckpointCwd` and `captureAndDispatchCheckpoint` helpers.
> - Behavioral Change: workspace index cache is no longer cleared after checkpoint capture, and missing cwd/non-git workspaces now silently skip rather than emitting warning logs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 661a179.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->