### PR TITLE
feat: persist diff panel state across thread navigation

### DIFF
--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,10 +1,14 @@
 import { ThreadId } from "@t3tools/contracts";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
 import { Suspense, lazy, type ReactNode, useCallback, useEffect } from "react";
 
 import ChatView from "../components/ChatView";
 import { useComposerDraftStore } from "../composerDraftStore";
-import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import {
+  type DiffRouteSearch,
+  parseDiffRouteSearch,
+  stripDiffSearchParams,
+} from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { useStore } from "../store";
 import { Sheet, SheetPopup } from "../components/ui/sheet";
@@ -224,5 +228,8 @@ function ChatThreadRouteView() {
 
 export const Route = createFileRoute("/_chat/$threadId")({
   validateSearch: (search) => parseDiffRouteSearch(search),
+  search: {
+    middlewares: [retainSearchParams<DiffRouteSearch>(["diff"])],
+  },
   component: ChatThreadRouteView,
 });


### PR DESCRIPTION
## Summary
- Uses TanStack Router's `retainSearchParams` middleware to carry the `diff` search param when navigating between threads
- Only `diff` is retained; `diffTurnId` and `diffFilePath` are thread specific and intentionally not carried over
- No changes needed to Sidebar, DiffPanel, or diffRouteSearch

Closes #874

## Test plan
- [x] `bun typecheck` passes
- [x] Open diff panel -> switch thread -> panel stays open (`?diff=1` carried over)
- [x] Close diff panel -> switch thread -> panel stays closed (no `diff` param)
- [x] Visit `/$threadId?diff=1` directly -> panel opens

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist diff panel search params across thread navigation
> Adds a `retainSearchParams` middleware to the `_chat.$threadId` route so the `diff` search param is preserved when navigating between threads. Previously, the `diff` param was lost on thread navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59ce2e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->