### PR TITLE
Fix worktree terminal startup race

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -39,10 +39,13 @@ interface WsRequestEnvelope {
   };
 }
 
+type RpcResolver = (request: WsRequestEnvelope["body"]) => unknown | undefined;
+
 interface TestFixture {
   snapshot: OrchestrationReadModel;
   serverConfig: ServerConfig;
   welcome: WsWelcomePayload;
+  rpcResolver: RpcResolver | undefined;
 }
 
 let fixture: TestFixture;
@@ -244,6 +247,7 @@ function buildFixture(snapshot: OrchestrationReadModel): TestFixture {
       bootstrapProjectId: PROJECT_ID,
       bootstrapThreadId: THREAD_ID,
     },
+    rpcResolver: undefined,
   };
 }
 
@@ -353,7 +357,13 @@ function createSnapshotWithLongProposedPlan(): OrchestrationReadModel {
   };
 }
 
-function resolveWsRpc(tag: string): unknown {
+function resolveWsRpc(request: WsRequestEnvelope["body"]): unknown {
+  const customResponse = fixture.rpcResolver?.(request);
+  if (customResponse !== undefined) {
+    return customResponse;
+  }
+
+  const tag = request._tag;
   if (tag === ORCHESTRATION_WS_METHODS.getSnapshot) {
     return fixture.snapshot;
   }
@@ -395,6 +405,11 @@ function resolveWsRpc(tag: string): unknown {
       truncated: false,
     };
   }
+  if (tag === WS_METHODS.terminalOpen || tag === WS_METHODS.terminalRestart) {
+    return {
+      history: "",
+    };
+  }
   return {};
 }
 
@@ -423,7 +438,7 @@ const worker = setupWorker(
       client.send(
         JSON.stringify({
           id: request.id,
-          result: resolveWsRpc(method),
+          result: resolveWsRpc(request.body),
         }),
       );
     });
@@ -1043,6 +1058,128 @@ describe("ChatView timeline estimator parity (full app)", () => {
         .element(page.getByText("Send a message to start the conversation."))
         .toBeInTheDocument();
       await expect.element(page.getByTestId("composer-editor")).toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("keeps worktree setup terminal opens pinned to the new worktree during draft promotion", async () => {
+    const worktreePath = "/repo/.t3/worktrees/feature-bootstrap";
+    const setupCommand = "pnpm install";
+
+    useComposerDraftStore.setState({
+      draftsByThreadId: {
+        [THREAD_ID]: {
+          prompt: "bootstrap the worktree",
+          images: [],
+          nonPersistedImageIds: [],
+          persistedAttachments: [],
+          provider: null,
+          model: null,
+          runtimeMode: null,
+          interactionMode: null,
+          effort: null,
+          codexFastMode: false,
+        },
+      },
+      draftThreadsByThreadId: {
+        [THREAD_ID]: {
+          projectId: PROJECT_ID,
+          createdAt: NOW_ISO,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: "main",
+          worktreePath: null,
+          envMode: "worktree",
+        },
+      },
+      projectDraftThreadIdByProjectId: {
+        [PROJECT_ID]: THREAD_ID,
+      },
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.snapshot = {
+          ...nextFixture.snapshot,
+          projects: nextFixture.snapshot.projects.map((project) =>
+            project.id === PROJECT_ID
+              ? {
+                  ...project,
+                  scripts: [
+                    {
+                      id: "setup",
+                      name: "Setup",
+                      command: setupCommand,
+                      icon: "configure",
+                      runOnWorktreeCreate: true,
+                    },
+                  ],
+                }
+              : project,
+          ),
+        };
+        nextFixture.rpcResolver = (request) => {
+          if (request._tag === WS_METHODS.gitCreateWorktree) {
+            return {
+              worktree: {
+                branch: "feature-bootstrap",
+                path: worktreePath,
+              },
+            };
+          }
+          return undefined;
+        };
+      },
+    });
+
+    try {
+      const sendButton = page.getByRole("button", { name: "Send message" });
+      await expect.element(sendButton).toBeEnabled();
+      await sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          const terminalOpenRequests = wsRequests.filter(
+            (request) => request._tag === WS_METHODS.terminalOpen,
+          );
+          expect(terminalOpenRequests.length).toBeGreaterThanOrEqual(2);
+          expect(terminalOpenRequests[0]).toMatchObject({
+            _tag: WS_METHODS.terminalOpen,
+            threadId: THREAD_ID,
+            cwd: worktreePath,
+            env: {
+              T3CODE_PROJECT_ROOT: "/repo/project",
+              T3CODE_WORKTREE_PATH: worktreePath,
+            },
+          });
+          expect(terminalOpenRequests[1]).toMatchObject({
+            _tag: WS_METHODS.terminalOpen,
+            threadId: THREAD_ID,
+            cwd: worktreePath,
+            env: {
+              T3CODE_PROJECT_ROOT: "/repo/project",
+              T3CODE_WORKTREE_PATH: worktreePath,
+            },
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      await vi.waitFor(
+        () => {
+          const terminalWriteRequest = wsRequests.find(
+            (request) =>
+              request._tag === WS_METHODS.terminalWrite &&
+              request.threadId === THREAD_ID &&
+              request.data === `${setupCommand}\r`,
+          );
+          expect(terminalWriteRequest).toBeTruthy();
+        },
+        { timeout: 8_000, interval: 16 },
+      );
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2678,6 +2678,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
           // Keep local thread state in sync immediately so terminal drawer opens
           // with the worktree cwd/env instead of briefly using the project root.
           setStoreThreadBranch(threadIdForSend, result.worktree.branch, result.worktree.path);
+        } else if (isLocalDraftThread) {
+          // Draft threads render from the draft store until the server snapshot arrives.
+          // Sync the worktree context before opening the terminal so the drawer does not
+          // reopen the PTY against the old project root.
+          setDraftThreadContext(threadIdForSend, {
+            branch: result.worktree.branch,
+            worktreePath: result.worktree.path,
+            envMode: "worktree",
+          });
         }
       }
 


### PR DESCRIPTION
## What Changed

This fixes a race in the first-message worktree setup flow that could prevent actions configured to run automatically on worktree creation from running.

When a new worktree is created from a local draft thread, `ChatView` now updates the draft thread's branch/worktree context before running the setup script. This keeps the terminal drawer's mount-time `terminal.open` call aligned with the new worktree instead of briefly reopening the PTY against the project root.

I also added a browser regression test covering this path.

## Why

On the first message in worktree mode, the setup script terminal was opened with the new worktree path, but the terminal drawer could immediately remount and call `terminal.open` again using stale local draft-thread state.

Because `terminal.open` restarts the PTY when cwd or env changes, that second open could wipe out the injected setup command. The result was that the terminal opened, but the automatic worktree setup action did not run until it was triggered manually.

This change fixes that by keeping the local draft-thread state in sync as soon as the worktree is created.

## UI Changes

No visual UI changes.

This is a terminal startup timing/interaction fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix draft worktree terminal startup race by updating draft thread context on worktree creation
> - When a worktree is created from a local draft thread, `ChatView` now immediately calls `setDraftThreadContext` with the new branch, worktree path, and `envMode: 'worktree'`, so the terminal drawer targets the new worktree instead of the project root.
> - Adds a new browser integration test that verifies at least two `terminalOpen` requests are made with the correct worktree `cwd` and `env` after sending a message in a draft thread.
> - Extends the WebSocket mock in [`ChatView.browser.tsx`](https://github.com/pingdotgg/t3code/pull/879/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) to support a per-fixture `rpcResolver` hook and to return `{history: ""}` for `terminalOpen`/`terminalRestart` calls; the resolver now receives the full request body instead of just the method tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c388e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->