### PR TITLE
fix: insert native file path when dropping or pasting non-image files

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type { DesktopBridge } from "@t3tools/contracts";
 
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
@@ -15,6 +15,7 @@ const wsUrl = process.env.T3CODE_DESKTOP_WS_URL ?? null;
 
 contextBridge.exposeInMainWorld("desktopBridge", {
   getWsUrl: () => wsUrl,
+  getPathForFile: (file: File) => webUtils.getPathForFile(file),
   pickFolder: () => ipcRenderer.invoke(PICK_FOLDER_CHANNEL),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -171,6 +171,7 @@ const EMPTY_AVAILABLE_EDITORS: EditorId[] = [];
 const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
 const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
+const COMPOSER_FILE_PATH_SEPARATOR = " ";
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
 
@@ -2097,17 +2098,32 @@ export default function ChatView({ threadId }: ChatViewProps) {
     removeComposerImageFromDraft(imageId);
   };
 
+  const addComposerAttachments = (files: File[]) => {
+    const imageFiles = files.filter((f) => f.type.startsWith("image/"));
+    const nonImageFiles = files.filter((f) => !f.type.startsWith("image/"));
+
+    if (imageFiles.length > 0) {
+      addComposerImages(imageFiles);
+    }
+
+    if (nonImageFiles.length > 0) {
+      const paths = nonImageFiles.map(
+        (file) => window.desktopBridge?.getPathForFile(file) ?? file.name,
+      );
+      const insertion = paths
+        .map((p) => (p.includes(" ") ? `"${p}"` : p))
+        .join(COMPOSER_FILE_PATH_SEPARATOR);
+      composerEditorRef.current?.insertTextAndFocus(insertion);
+    }
+  };
+
   const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
     const files = Array.from(event.clipboardData.files);
     if (files.length === 0) {
       return;
     }
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    if (imageFiles.length === 0) {
-      return;
-    }
     event.preventDefault();
-    addComposerImages(imageFiles);
+    addComposerAttachments(files);
   };
 
   const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
@@ -2151,8 +2167,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
     dragDepthRef.current = 0;
     setIsDragOverComposer(false);
     const files = Array.from(event.dataTransfer.files);
-    addComposerImages(files);
-    focusComposer();
+    const hasNonImageFiles = files.some((f) => !f.type.startsWith("image/"));
+    addComposerAttachments(files);
+    if (!hasNonImageFiles) focusComposer();
   };
 
   const onRevertToTurnCount = useCallback(

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -459,6 +459,7 @@ export interface ComposerPromptEditorHandle {
   focusAt: (cursor: number) => void;
   focusAtEnd: () => void;
   readSnapshot: () => { value: string; cursor: number; expandedCursor: number };
+  insertTextAndFocus: (text: string) => void;
 }
 
 interface ComposerPromptEditorProps {
@@ -813,6 +814,22 @@ function ComposerPromptEditorInner({
     return snapshot;
   }, [editor]);
 
+  const insertTextAndFocus = useCallback(
+    (text: string) => {
+      const rootElement = editor.getRootElement();
+      if (rootElement) {
+        rootElement.focus();
+      }
+      editor.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          selection.insertText(text);
+        }
+      });
+    },
+    [editor],
+  );
+
   useImperativeHandle(
     editorRef,
     () => ({
@@ -829,8 +846,9 @@ function ComposerPromptEditorInner({
         );
       },
       readSnapshot,
+      insertTextAndFocus,
     }),
-    [focusAt, readSnapshot],
+    [focusAt, readSnapshot, insertTextAndFocus],
   );
 
   const handleEditorChange = useCallback((editorState: EditorState) => {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -96,6 +96,7 @@ export interface DesktopUpdateActionResult {
 
 export interface DesktopBridge {
   getWsUrl: () => string | null;
+  getPathForFile: (file: File) => string;
   pickFolder: () => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;


### PR DESCRIPTION
## What Changed

When dropping or pasting non-image files (e.g. `.csv`, `.json`, `.txt`, `.riv`) onto the chat composer, their native filesystem path is now inserted at the cursor position instead of being silently ignored. Fixes #557.

- **ChatView**: New `addComposerAttachments` helper partitions files into images and non-images. Both `onComposerDrop` and `onComposerPaste` delegate to it. Non-image paths are auto-quoted when containing spaces.
- **ComposerPromptEditor**: Added `insertText(text)` using Lexical's `selection.insertText()` to insert at the real cursor position, correctly handling @mention nodes.
- **preload.ts**: Exposed `webUtils.getPathForFile(file)` via contextBridge (required since Electron's sandbox blocks `file.path`).
- **contracts/ipc.ts**: Added `getPathForFile` to `DesktopBridge` interface.

## Why

Dropping or pasting any non-image file silently failed with an "unsupported file type" error

## UI Changes

| | |
|-|-|
|*before*|<video src="https://github.com/user-attachments/assets/bd96d57b-f17b-44b8-99ba-1c5925a6212f" width=600>|
|*after*|<video src="https://github.com/user-attachments/assets/cf4f83f6-8da6-44f3-8949-d9a589cf0c4c" width=600>|








## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Insert native file paths when dropping or pasting non-image files into the composer
> - Adds `addComposerAttachments` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/885/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to split dropped/pasted files into images (handled as before) and non-images (inserted as paths).
> - Non-image file paths are resolved via `window.desktopBridge?.getPathForFile(file)` (Electron) or fall back to `file.name`; paths containing spaces are quoted and joined with a space separator.
> - Adds `insertTextAndFocus(text)` to `ComposerPromptEditorHandle` in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/885/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4), inserting text at the current Lexical selection with automatic focus.
> - Exposes `getPathForFile` on `desktopBridge` in [preload.ts](https://github.com/pingdotgg/t3code/pull/885/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac) via Electron's `webUtils.getPathForFile`.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e08a39d.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->