### PR TITLE
Fix resumed thread working indicators

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -8,6 +8,7 @@ import {
   type ProjectId,
   type ServerConfig,
   type ThreadId,
+  type TurnId,
   type WsWelcomePayload,
   WS_CHANNELS,
   WS_METHODS,
@@ -511,6 +512,16 @@ async function waitForComposerEditor(): Promise<HTMLElement> {
   return waitForElement(
     () => document.querySelector<HTMLElement>('[contenteditable="true"]'),
     "Unable to find composer editor.",
+  );
+}
+
+async function waitForThreadSidebarItem(threadTitle: string): Promise<HTMLElement> {
+  return waitForElement(
+    () =>
+      Array.from(document.querySelectorAll<HTMLElement>("[data-thread-item]")).find((item) =>
+        item.textContent?.includes(threadTitle),
+      ) ?? null,
+    `Unable to find sidebar item for thread "${threadTitle}".`,
   );
 }
 
@@ -1043,6 +1054,57 @@ describe("ChatView timeline estimator parity (full app)", () => {
         .element(page.getByText("Send a message to start the conversation."))
         .toBeInTheDocument();
       await expect.element(page.getByTestId("composer-editor")).toBeInTheDocument();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("keeps the chat and sidebar working indicators visible when a resumed thread stays active", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-resume-working" as MessageId,
+        targetText: "resume working regression",
+      }),
+    });
+
+    try {
+      await vi.waitFor(
+        () => {
+          expect(useStore.getState().threadsHydrated).toBe(true);
+          expect(useStore.getState().threads).toHaveLength(1);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      useStore.setState((state) => ({
+        ...state,
+        threads: state.threads.map((thread) =>
+          thread.id === THREAD_ID
+            ? {
+                ...thread,
+                session: thread.session
+                  ? {
+                      ...thread.session,
+                      status: "ready",
+                      orchestrationStatus: "running",
+                      activeTurnId: "turn-resumed" as TurnId,
+                    }
+                  : thread.session,
+              }
+            : thread,
+        ),
+      }));
+
+      await vi.waitFor(
+        () => {
+          expect(document.body.textContent).toContain("Working...");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      const threadItem = await waitForThreadSidebarItem("Browser test thread");
+      expect(threadItem.textContent).toContain("Working");
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -107,6 +107,57 @@ describe("resolveThreadStatusPill", () => {
     ).toMatchObject({ label: "Working", pulse: true });
   });
 
+  it("shows working when orchestration resumed but the legacy session status is ready", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            orchestrationStatus: "running",
+          },
+        },
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+      }),
+    ).toMatchObject({ label: "Working", pulse: true });
+  });
+
+  it("shows connecting when orchestration is still starting", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            orchestrationStatus: "starting",
+          },
+        },
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+      }),
+    ).toMatchObject({ label: "Connecting", pulse: true });
+  });
+
+  it("matches the canonical phase precedence when legacy and orchestration states disagree", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          session: {
+            ...baseThread.session,
+            status: "connecting",
+            orchestrationStatus: "running",
+          },
+        },
+        hasPendingApprovals: false,
+        hasPendingUserInput: false,
+      }),
+    ).toMatchObject({ label: "Connecting", pulse: true });
+  });
+
   it("shows plan ready when a settled plan turn has a proposed plan ready for follow-up", () => {
     expect(
       resolveThreadStatusPill({

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,5 +1,5 @@
 import type { Thread } from "../types";
-import { findLatestProposedPlan, isLatestTurnSettled } from "../session-logic";
+import { derivePhase, findLatestProposedPlan, isLatestTurnSettled } from "../session-logic";
 
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 
@@ -43,6 +43,7 @@ export function resolveThreadStatusPill(input: {
   hasPendingUserInput: boolean;
 }): ThreadStatusPill | null {
   const { hasPendingApprovals, hasPendingUserInput, thread } = input;
+  const phase = derivePhase(thread.session);
 
   if (hasPendingApprovals) {
     return {
@@ -62,7 +63,7 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
-  if (thread.session?.status === "running") {
+  if (phase === "running") {
     return {
       label: "Working",
       colorClass: "text-sky-600 dark:text-sky-300/80",
@@ -71,7 +72,7 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
-  if (thread.session?.status === "connecting") {
+  if (phase === "connecting") {
     return {
       label: "Connecting",
       colorClass: "text-sky-600 dark:text-sky-300/80",

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
+  derivePhase,
   PROVIDER_OPTIONS,
   derivePendingApprovals,
   derivePendingUserInputs,
@@ -636,6 +637,33 @@ describe("deriveActiveWorkStartedAt", () => {
         "2026-02-27T21:11:00.000Z",
       ),
     ).toBe("2026-02-27T21:11:00.000Z");
+  });
+});
+
+describe("derivePhase", () => {
+  it("treats a resumed session as running when orchestration is still active", () => {
+    expect(
+      derivePhase({
+        provider: "codex",
+        status: "ready",
+        createdAt: "2026-03-09T10:00:00.000Z",
+        updatedAt: "2026-03-09T10:00:01.000Z",
+        orchestrationStatus: "running",
+        activeTurnId: TurnId.makeUnsafe("turn-1"),
+      }),
+    ).toBe("running");
+  });
+
+  it("treats orchestration startup as connecting even before the legacy status catches up", () => {
+    expect(
+      derivePhase({
+        provider: "codex",
+        status: "ready",
+        createdAt: "2026-03-09T10:00:00.000Z",
+        updatedAt: "2026-03-09T10:00:01.000Z",
+        orchestrationStatus: "starting",
+      }),
+    ).toBe("connecting");
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -121,6 +121,17 @@ export function formatElapsed(startIso: string, endIso: string | undefined): str
 
 type LatestTurnTiming = Pick<OrchestrationLatestTurn, "turnId" | "startedAt" | "completedAt">;
 type SessionActivityState = Pick<ThreadSession, "orchestrationStatus" | "activeTurnId">;
+type SessionPhaseState = Pick<ThreadSession, "status" | "orchestrationStatus">;
+
+export function isSessionConnecting(session: SessionPhaseState | null): boolean {
+  if (!session) return false;
+  return session.status === "connecting" || session.orchestrationStatus === "starting";
+}
+
+export function isSessionRunning(session: SessionPhaseState | null): boolean {
+  if (!session) return false;
+  return session.status === "running" || session.orchestrationStatus === "running";
+}
 
 export function isLatestTurnSettled(
   latestTurn: LatestTurnTiming | null,
@@ -614,7 +625,7 @@ export function inferCheckpointTurnCountByTurnId(
 
 export function derivePhase(session: ThreadSession | null): SessionPhase {
   if (!session || session.status === "closed") return "disconnected";
-  if (session.status === "connecting") return "connecting";
-  if (session.status === "running") return "running";
+  if (isSessionConnecting(session)) return "connecting";
+  if (isSessionRunning(session)) return "running";
   return "ready";
 }


### PR DESCRIPTION
## What Changed

Resumed interrupted threads now continue to show active processing state in both the chat view and the sidebar even when the legacy `session.status` has already fallen back to `ready` but `orchestrationStatus` is still active. Fixes #881.

session-logic: `derivePhase()` now treats orchestration status as canonical for connecting and running states via shared `isSessionConnecting()` and `isSessionRunning()` helpers.
Sidebar.logic: thread status pills now use `derivePhase(thread.session)` instead of reading the legacy session status directly, so resumed threads still show `Working` or `Connecting` when orchestration is active.
session-logic.test / Sidebar.logic.test: added regression coverage for resumed-running, orchestration-starting, and mismatched legacy-vs-orchestration precedence cases.
ChatView.browser: added a rendered browser regression test that reproduces the stale resumed-thread state and verifies the chat working indicator and sidebar badge both stay visible.

## Why

Interrupted thread resume could leave the UI looking idle while the orchestration layer was still actively processing. In that state the user got no reliable feedback about whether the resumed thread was working, retrying, or stuck, which is exactly the issue reported in #881.

## UI Changes

before
resumed interrupted threads could look idle after reconnecting because neither the chat timeline nor the sidebar reliably showed an active processing indicator while orchestration was still running.

after
resumed interrupted threads keep showing the working indicator in the chat and the `Working` badge in the sidebar while orchestration remains active.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix working indicators for resumed threads by using `orchestrationStatus` in `derivePhase`
> - `derivePhase` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/886/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) now checks `orchestrationStatus` alongside legacy `session.status`, treating `'starting'` as `'connecting'` and `'running'` as `'running'` even when legacy status is `'ready'`.
> - `resolveThreadStatusPill` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/886/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) is updated to use `derivePhase`, so the sidebar pill label and pulse dot correctly show 'Working' or 'Connecting' for resumed threads.
> - New unit tests cover `derivePhase` and `resolveThreadStatusPill` for mixed legacy/orchestration states, and a new browser test asserts both the chat and sidebar indicators are visible when a resumed thread is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b44b33a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->