### PR TITLE
feat: Adds Search for projects and threads

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -41,7 +41,7 @@ import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import { useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
-import { isMacPlatform, newCommandId, newProjectId, newThreadId } from "../lib/utils";
+import { cn, isMacPlatform, newCommandId, newProjectId, newThreadId } from "../lib/utils";
 import { useStore } from "../store";
 import { isChatNewLocalShortcut, isChatNewShortcut, shortcutLabelForCommand } from "../keybindings";
 import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
@@ -1366,14 +1366,14 @@ export default function Sidebar() {
               Search projects and threads
             </label>
             <div className="flex items-center w-full relative">
-              <Input
+              <input
                 id="sidebar-search-input"
                 type="text"
                 value={searchValue}
                 onChange={(e) => setSearchValue(e.target.value)}
                 placeholder="Search projects/threads"
                 aria-label="Search projects and threads"
-                className={searchValue && "pr-6"}
+                className="border-0 border-b border-primary focus:ring-0 focus:border-accent focus:outline-none"
                 autoComplete="off"
               />
               {searchValue && (


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->
I have added a search input that you can use to search both projects and threads.
## Why
If you have a lot of threads, you might want to search which project/thread you want to use
<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

Before: 
<img width="1212" height="756" alt="image" src="https://github.com/user-attachments/assets/3d59488e-2a59-4c34-bc83-c51eff6915e3" />
After:
<img width="1208" height="756" alt="image" src="https://github.com/user-attachments/assets/deb67eaa-7fb4-408d-8322-d4a564676cc7" />

https://github.com/user-attachments/assets/6af589ec-980f-46c5-b10b-d4f83859d921
## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add search to sidebar to filter projects and threads by name
> - Adds a search input at the top of the projects list in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/903/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that filters visible projects and threads by project name or thread title.
> - When a search is active, the thread preview limit (`THREAD_PREVIEW_LIMIT`) is bypassed so all matching threads are shown, and projects with no matches display 'No threads found'.
> - The empty state message changes to 'No projects or threads found' during an active search.
> - Behavioral Change: drag-and-drop sorting operates over the filtered project set when a search is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d6fd97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->