### PR TITLE
Actions dialog: autofocus script-name field

### DIFF
--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -420,6 +420,7 @@ export default function ProjectScriptsControl({
                   </Popover>
                   <Input
                     id="script-name"
+                    autoFocus
                     placeholder="Test"
                     value={name}
                     onChange={(event) => setName(event.target.value)}


### PR DESCRIPTION
## What Changed

Autofocus the `script-name` field on the Actions dialog.

## Why

It's tedious to click the script name every time I'm adding/editing a script. This is better UX / accessibility.

## UI Changes

No UI changes. Interaction change:

https://github.com/user-attachments/assets/9393f0f6-803b-4bea-98e1-c419de390872

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Autofocus the script name field in the Actions dialog
> Adds `autoFocus` to the script name input in [ProjectScriptsControl.tsx](https://github.com/pingdotgg/t3code/pull/912/files#diff-e891caffa18ba1b7506cceb8fe52ad48887e3161ef59bee56d37cd57b61c511b) so the field receives focus when the form renders.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92e6508.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->