### PR TITLE
Use live thread activities for sidebar status pills

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -310,20 +310,6 @@ export default function Sidebar() {
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const shouldBrowseForProjectImmediately = isElectron;
   const shouldShowProjectPathEntry = addingProject && !shouldBrowseForProjectImmediately;
-  const pendingApprovalByThreadId = useMemo(() => {
-    const map = new Map<ThreadId, boolean>();
-    for (const thread of threads) {
-      map.set(thread.id, derivePendingApprovals(thread.activities).length > 0);
-    }
-    return map;
-  }, [threads]);
-  const pendingUserInputByThreadId = useMemo(() => {
-    const map = new Map<ThreadId, boolean>();
-    for (const thread of threads) {
-      map.set(thread.id, derivePendingUserInputs(thread.activities).length > 0);
-    }
-    return map;
-  }, [threads]);
   const projectCwdById = useMemo(
     () => new Map(projects.map((project) => [project.id, project.cwd] as const)),
     [projects],
@@ -1509,9 +1495,9 @@ export default function Sidebar() {
                                 const threadStatus = resolveThreadStatusPill({
                                   thread,
                                   hasPendingApprovals:
-                                    pendingApprovalByThreadId.get(thread.id) === true,
+                                    derivePendingApprovals(thread.activities).length > 0,
                                   hasPendingUserInput:
-                                    pendingUserInputByThreadId.get(thread.id) === true,
+                                    derivePendingUserInputs(thread.activities).length > 0,
                                 });
                                 const prStatus = prStatusIndicator(
                                   prByThreadId.get(thread.id) ?? null,


### PR DESCRIPTION
## What Changed

Updated sidebar thread status resolution to use each thread’s current activities directly when rendering rows, instead of reading from memoized per-thread pending-state maps.

In Sidebar.tsx:

- Removed memoized pendingApprovalByThreadId and pendingUserInputByThreadId maps.
- Replaced map lookups with direct per-thread derivation:
  - derivePendingApprovals(thread.activities).length > 0
  - derivePendingUserInputs(thread.activities).length > 0

## Why

Fixes #877: The sidebar status pill logic itself was correct, but it depended on cached maps that could become out of sync with the latest thread activity state. That caused cases where a thread could still show Working while it was actually awaiting user input.

Deriving pending state directly from the thread row’s live activities removes that stale-cache path and keeps the pill aligned with current thread state.
## UI Changes

Sidebar status badges now update correctly to reflect active pending-input/pending-approval states from live thread activity data (for example, showing Awaiting Input instead of incorrectly remaining on Working).

Before:
<img width="1074" height="770" alt="Screenshot 2026-03-11 at 9 51 13 AM" src="https://github.com/user-attachments/assets/2671b21e-d326-441b-964f-89c1a27dd818" />

After:
<img width="1061" height="626" alt="Screenshot 2026-03-11 at 10 15 25 AM" src="https://github.com/user-attachments/assets/5a8fef9a-099a-4bcc-92a3-208d3704dfab" />

https://github.com/user-attachments/assets/6348b1f6-8ea5-4489-99e2-2cf857bad9a4



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Compute sidebar thread status pills directly from live thread activities
> Removes two `useMemo`-derived maps (`pendingApprovalByThreadId`, `pendingUserInputByThreadId`) in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/919/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that precomputed boolean flags per thread. Status pills now derive their state inline at render time using `derivePendingApprovals` and `derivePendingUserInputs` on each thread's live activities, ensuring pills always reflect current activity state without stale memoized values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb1f343.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->