### PR TITLE
feat: add quick theme toggle in sidebar header

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3,10 +3,12 @@ import {
   ChevronRightIcon,
   FolderIcon,
   GitPullRequestIcon,
+  MoonIcon,
   PlusIcon,
   RocketIcon,
   SettingsIcon,
   SquarePenIcon,
+  SunIcon,
   TerminalIcon,
   TriangleAlertIcon,
 } from "lucide-react";
@@ -64,6 +66,7 @@ import {
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Collapsible, CollapsibleContent } from "./ui/collapsible";
+import { Menu, MenuTrigger, MenuPopup, MenuRadioGroup, MenuRadioItem } from "./ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import {
   SidebarContent,
@@ -81,6 +84,7 @@ import {
   SidebarTrigger,
 } from "./ui/sidebar";
 import { useThreadSelectionStore } from "../threadSelectionStore";
+import { useTheme } from "../hooks/useTheme";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
 import { resolveThreadStatusPill, shouldClearThreadSelectionOnMouseDown } from "./Sidebar.logic";
@@ -276,6 +280,7 @@ export default function Sidebar() {
   const navigate = useNavigate();
   const isOnSettings = useLocation({ select: (loc) => loc.pathname === "/settings" });
   const { settings: appSettings } = useAppSettings();
+  const { theme, setTheme, resolvedTheme } = useTheme();
   const routeThreadId = useParams({
     strict: false,
     select: (params) => (params.threadId ? ThreadId.makeUnsafe(params.threadId) : null),
@@ -1259,12 +1264,38 @@ export default function Sidebar() {
     </div>
   );
 
+  const ThemeIcon = resolvedTheme === "dark" ? MoonIcon : SunIcon;
+
+  const themeDropdown = (
+    <Menu>
+      <MenuTrigger
+        render={
+          <button
+            type="button"
+            aria-label="Toggle theme"
+            className="ml-auto inline-flex size-7 items-center justify-center rounded-md text-muted-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
+          />
+        }
+      >
+        <ThemeIcon className="size-4" />
+      </MenuTrigger>
+      <MenuPopup align="end" side="bottom" className="min-w-[120px]">
+        <MenuRadioGroup value={theme} onValueChange={setTheme}>
+          <MenuRadioItem value="system">System</MenuRadioItem>
+          <MenuRadioItem value="light">Light</MenuRadioItem>
+          <MenuRadioItem value="dark">Dark</MenuRadioItem>
+        </MenuRadioGroup>
+      </MenuPopup>
+    </Menu>
+  );
+
   return (
     <>
       {isElectron ? (
         <>
           <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}
+            {themeDropdown}
             {showDesktopUpdateButton && (
               <Tooltip>
                 <TooltipTrigger
@@ -1288,7 +1319,10 @@ export default function Sidebar() {
         </>
       ) : (
         <SidebarHeader className="gap-3 px-3 py-2 sm:gap-2.5 sm:px-4 sm:py-3">
-          {wordmark}
+          <div className="flex items-center gap-2 w-full">
+            {wordmark}
+            {themeDropdown}
+          </div>
         </SidebarHeader>
       )}
 


### PR DESCRIPTION
## What Changed               
                                                                                                               
   Added a theme toggle icon button in the sidebar header, next to the T3 Code logo:                           
   - Sun/moon icon that reflects the current resolved theme                                                    
   - Dropdown menu with System, Light, and Dark options                                                        
   - Uses existing `useTheme` hook - syncs automatically with Settings page                                    
                                                                                                               
   ## Why                                                                                                      
Quick theme switching is a common UX pattern. Users shouldn't need to navigate to Settings just to toggle between light and dark mode. This provides convenient access while keeping the full theme configuration in Settings.                                                                      
                                                                                                               
   ## UI Changes                                                                                               

![](https://i.ibb.co/KjRJwqJD/ezgif-5c3f0f2fb097432d.gif)

   
                                                                                                               
   ## Checklist                                                                                                
                                                                                                               
   - [x] This PR is small and focused                                                                          
   - [x] I explained what changed and why                                                                      
   - [x] I included before/after screenshots for any UI changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add theme toggle (System/Light/Dark) to sidebar header
> Adds a sun/moon icon button to the sidebar header in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/924/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that opens a dropdown menu for selecting the app theme. The icon reflects the resolved theme (sun for light, moon for dark), and selecting an option calls `setTheme` from the `useTheme` hook. Both Electron and non-Electron header layouts are updated to include the toggle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 19f9a31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->