### PR TITLE
chore(release): align package versions before building artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Align package versions to release version
+        run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
+
       - name: Build desktop artifact
         shell: bash
         env:
@@ -243,6 +246,9 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Align package versions to release version
+        run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
 
       - name: Build CLI package
         run: bun run build --filter=@t3tools/web --filter=t3


### PR DESCRIPTION
Fixes #928

## What Changed

Run `scripts/update-release-package-versions.ts` before the desktop release build and CLI publish jobs.

This keeps the checked-out workspace package versions aligned with the release tag version before any web/server/desktop artifacts are compiled.

## Why

The release workflow was building from the tag commit before the version bump commit landed on `main`.

That let release artifacts compile bundled web/server code using the previous package version while the desktop artifact metadata was stamped with the new release version. Running the existing version-alignment script earlier keeps the built artifacts consistent with the release version.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align package versions to release version before building artifacts
> Adds a version alignment step in [release.yml](.github/workflows/release.yml) to both the `build` and `publish_cli` jobs, running `node scripts/update-release-package-versions.ts` immediately after dependency installation and before building artifacts. This ensures all package versions match the resolved release version at build time rather than relying on pre-committed values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9e8a18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->