### PR TITLE
fix: composer @file autocomplete cursor and spacing bugs

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -38,8 +38,11 @@ import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuer
 import { isElectron } from "../env";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import {
+  clampCollapsedComposerCursor,
   type ComposerTrigger,
+  collapseExpandedComposerCursor,
   detectComposerTrigger,
+  expandCollapsedComposerCursor,
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
 } from "../composer-logic";
@@ -265,7 +268,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const [attachmentPreviewHandoffByMessageId, setAttachmentPreviewHandoffByMessageId] = useState<
     Record<string, string[]>
   >({});
-  const [composerCursor, setComposerCursor] = useState(() => prompt.length);
+  const [composerCursor, setComposerCursor] = useState(() =>
+    collapseExpandedComposerCursor(prompt, prompt.length),
+  );
   const [composerTrigger, setComposerTrigger] = useState<ComposerTrigger | null>(() =>
     detectComposerTrigger(prompt, prompt.length),
   );
@@ -661,11 +666,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
 
     promptRef.current = nextCustomAnswer;
-    setComposerCursor(nextCustomAnswer.length);
+    const nextCursor = collapseExpandedComposerCursor(nextCustomAnswer, nextCustomAnswer.length);
+    setComposerCursor(nextCursor);
     setComposerTrigger(
       detectComposerTrigger(
         nextCustomAnswer,
-        expandCollapsedComposerCursor(nextCustomAnswer, nextCustomAnswer.length),
+        expandCollapsedComposerCursor(nextCustomAnswer, nextCursor),
       ),
     );
     setComposerHighlightedItemId(null);
@@ -1741,7 +1747,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
   useEffect(() => {
     promptRef.current = prompt;
-    setComposerCursor((existing) => Math.min(Math.max(0, existing), prompt.length));
+    setComposerCursor((existing) => clampCollapsedComposerCursor(prompt, existing));
   }, [prompt]);
 
   useEffect(() => {
@@ -1754,7 +1760,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     setSendPhase("idle");
     setSendStartedAt(null);
     setComposerHighlightedItemId(null);
-    setComposerCursor(promptRef.current.length);
+    setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
     setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
     dragDepthRef.current = 0;
     setIsDragOverComposer(false);
@@ -2432,7 +2438,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         });
         promptRef.current = trimmed;
         setPrompt(trimmed);
-        setComposerCursor(trimmed.length);
+        setComposerCursor(collapseExpandedComposerCursor(trimmed, trimmed.length));
         addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageForRetry));
         setComposerTrigger(detectComposerTrigger(trimmed, trimmed.length));
       }
@@ -2909,6 +2915,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         return false;
       }
       const next = replaceTextRange(promptRef.current, rangeStart, rangeEnd, replacement);
+      const nextCursor = collapseExpandedComposerCursor(next.text, next.cursor);
       promptRef.current = next.text;
       const activePendingQuestion = activePendingProgress?.activeQuestion;
       if (activePendingQuestion && activePendingUserInput) {
@@ -2925,10 +2932,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
       } else {
         setPrompt(next.text);
       }
-      setComposerCursor(next.cursor);
-      setComposerTrigger(detectComposerTrigger(next.text, next.cursor));
+      setComposerCursor(nextCursor);
+      setComposerTrigger(
+        detectComposerTrigger(next.text, expandCollapsedComposerCursor(next.text, nextCursor)),
+      );
       window.requestAnimationFrame(() => {
-        composerEditorRef.current?.focusAt(next.cursor);
+        composerEditorRef.current?.focusAt(nextCursor);
       });
       return true;
     },
@@ -2944,11 +2953,26 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (editorSnapshot) {
       return editorSnapshot;
     }
-    return { value: promptRef.current, cursor: composerCursor, expandedCursor: composerCursor };
+    return {
+      value: promptRef.current,
+      cursor: composerCursor,
+      expandedCursor: expandCollapsedComposerCursor(promptRef.current, composerCursor),
+    };
   }, [composerCursor]);
 
+  const extendReplacementRangeForTrailingSpace = (
+    text: string,
+    rangeEnd: number,
+    replacement: string,
+  ): number => {
+    if (!replacement.endsWith(" ")) {
+      return rangeEnd;
+    }
+    return text[rangeEnd] === " " ? rangeEnd + 1 : rangeEnd;
+  };
+
   const resolveActiveComposerTrigger = useCallback((): {
-    snapshot: { value: string; cursor: number };
+    snapshot: { value: string; cursor: number; expandedCursor: number };
     trigger: ComposerTrigger | null;
   } => {
     const snapshot = readComposerSnapshot();
@@ -2967,13 +2991,18 @@ export default function ChatView({ threadId }: ChatViewProps) {
       });
       const { snapshot, trigger } = resolveActiveComposerTrigger();
       if (!trigger) return;
-      const expectedToken = snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd);
       if (item.type === "path") {
+        const replacement = `@${item.path} `;
+        const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+          snapshot.value,
+          trigger.rangeEnd,
+          replacement,
+        );
         const applied = applyPromptReplacement(
           trigger.rangeStart,
-          trigger.rangeEnd,
-          `@${item.path} `,
-          { expectedText: expectedToken },
+          replacementRangeEnd,
+          replacement,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
         );
         if (applied) {
           setComposerHighlightedItemId(null);
@@ -2982,9 +3011,18 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
       if (item.type === "slash-command") {
         if (item.command === "model") {
-          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "/model ", {
-            expectedText: expectedToken,
-          });
+          const replacement = "/model ";
+          const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+            snapshot.value,
+            trigger.rangeEnd,
+            replacement,
+          );
+          const applied = applyPromptReplacement(
+            trigger.rangeStart,
+            replacementRangeEnd,
+            replacement,
+            { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+          );
           if (applied) {
             setComposerHighlightedItemId(null);
           }
@@ -2992,7 +3030,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         }
         void handleInteractionModeChange(item.command === "plan" ? "plan" : "default");
         const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
-          expectedText: expectedToken,
+          expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
         });
         if (applied) {
           setComposerHighlightedItemId(null);
@@ -3001,7 +3039,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
       onProviderModelSelect(item.provider, item.model);
       const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
-        expectedText: expectedToken,
+        expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
       });
       if (applied) {
         setComposerHighlightedItemId(null);

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -47,7 +47,12 @@ import {
   type Ref,
 } from "react";
 
-import { isCollapsedCursorAdjacentToMention } from "~/composer-logic";
+import {
+  clampCollapsedComposerCursor,
+  collapseExpandedComposerCursor,
+  expandCollapsedComposerCursor,
+  isCollapsedCursorAdjacentToMention,
+} from "~/composer-logic";
 import { splitPromptIntoComposerSegments } from "~/composer-editor-mentions";
 import { cn } from "~/lib/utils";
 import { basenameOfPath, getVscodeIconUrlForEntry } from "~/vscode-icons";
@@ -171,7 +176,7 @@ function renderMentionChipDom(container: HTMLElement, pathValue: string): void {
   container.append(icon, label);
 }
 
-function clampCursor(value: string, cursor: number): number {
+function clampExpandedCursor(value: string, cursor: number): number {
   if (!Number.isFinite(cursor)) return value.length;
   return Math.max(0, Math.min(value.length, Math.floor(cursor)));
 }
@@ -703,7 +708,12 @@ function ComposerPromptEditorInner({
 }: ComposerPromptEditorInnerProps) {
   const [editor] = useLexicalComposerContext();
   const onChangeRef = useRef(onChange);
-  const snapshotRef = useRef({ value, cursor: clampCursor(value, cursor) });
+  const initialCursor = clampCollapsedComposerCursor(value, cursor);
+  const snapshotRef = useRef({
+    value,
+    cursor: initialCursor,
+    expandedCursor: expandCollapsedComposerCursor(value, initialCursor),
+  });
   const isApplyingControlledUpdateRef = useRef(false);
 
   useEffect(() => {
@@ -715,13 +725,17 @@ function ComposerPromptEditorInner({
   }, [disabled, editor]);
 
   useLayoutEffect(() => {
-    const normalizedCursor = clampCursor(value, cursor);
+    const normalizedCursor = clampCollapsedComposerCursor(value, cursor);
     const previousSnapshot = snapshotRef.current;
     if (previousSnapshot.value === value && previousSnapshot.cursor === normalizedCursor) {
       return;
     }
 
-    snapshotRef.current = { value, cursor: normalizedCursor };
+    snapshotRef.current = {
+      value,
+      cursor: normalizedCursor,
+      expandedCursor: expandCollapsedComposerCursor(value, normalizedCursor),
+    };
 
     const rootElement = editor.getRootElement();
     const isFocused = Boolean(rootElement && document.activeElement === rootElement);
@@ -748,19 +762,22 @@ function ComposerPromptEditorInner({
     (nextCursor: number) => {
       const rootElement = editor.getRootElement();
       if (!rootElement) return;
-      const boundedCursor = clampCursor(snapshotRef.current.value, nextCursor);
+      const boundedCursor = clampCollapsedComposerCursor(snapshotRef.current.value, nextCursor);
       rootElement.focus();
       editor.update(() => {
         $setSelectionAtComposerOffset(boundedCursor);
       });
-      const nextExpandedCursor = editor
-        .getEditorState()
-        .read(() => $readExpandedSelectionOffsetFromEditorState(boundedCursor));
       snapshotRef.current = {
         value: snapshotRef.current.value,
         cursor: boundedCursor,
+        expandedCursor: expandCollapsedComposerCursor(snapshotRef.current.value, boundedCursor),
       };
-      onChangeRef.current(snapshotRef.current.value, boundedCursor, nextExpandedCursor, false);
+      onChangeRef.current(
+        snapshotRef.current.value,
+        boundedCursor,
+        snapshotRef.current.expandedCursor,
+        false,
+      );
     },
     [editor],
   );
@@ -770,20 +787,21 @@ function ComposerPromptEditorInner({
     cursor: number;
     expandedCursor: number;
   } => {
-    let snapshot: { value: string; cursor: number; expandedCursor: number } = {
-      ...snapshotRef.current,
-      expandedCursor: snapshotRef.current.cursor,
-    };
+    let snapshot = snapshotRef.current;
     editor.getEditorState().read(() => {
       const nextValue = $getRoot().getTextContent();
-      const fallbackCursor = clampCursor(nextValue, snapshotRef.current.cursor);
-      const nextCursor = clampCursor(
+      const fallbackCursor = clampCollapsedComposerCursor(nextValue, snapshotRef.current.cursor);
+      const nextCursor = clampCollapsedComposerCursor(
         nextValue,
         $readSelectionOffsetFromEditorState(fallbackCursor),
       );
-      const nextExpandedCursor = clampCursor(
+      const fallbackExpandedCursor = clampExpandedCursor(
         nextValue,
-        $readExpandedSelectionOffsetFromEditorState(fallbackCursor),
+        snapshotRef.current.expandedCursor,
+      );
+      const nextExpandedCursor = clampExpandedCursor(
+        nextValue,
+        $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
       );
       snapshot = {
         value: nextValue,
@@ -791,7 +809,7 @@ function ComposerPromptEditorInner({
         expandedCursor: nextExpandedCursor,
       };
     });
-    snapshotRef.current = { value: snapshot.value, cursor: snapshot.cursor };
+    snapshotRef.current = snapshot;
     return snapshot;
   }, [editor]);
 
@@ -803,7 +821,12 @@ function ComposerPromptEditorInner({
       },
       focusAt,
       focusAtEnd: () => {
-        focusAt(snapshotRef.current.value.length);
+        focusAt(
+          collapseExpandedComposerCursor(
+            snapshotRef.current.value,
+            snapshotRef.current.value.length,
+          ),
+        );
       },
       readSnapshot,
     }),
@@ -813,17 +836,25 @@ function ComposerPromptEditorInner({
   const handleEditorChange = useCallback((editorState: EditorState) => {
     editorState.read(() => {
       const nextValue = $getRoot().getTextContent();
-      const fallbackCursor = clampCursor(nextValue, snapshotRef.current.cursor);
-      const nextCursor = clampCursor(
+      const fallbackCursor = clampCollapsedComposerCursor(nextValue, snapshotRef.current.cursor);
+      const nextCursor = clampCollapsedComposerCursor(
         nextValue,
         $readSelectionOffsetFromEditorState(fallbackCursor),
       );
-      const nextExpandedCursor = clampCursor(
+      const fallbackExpandedCursor = clampExpandedCursor(
         nextValue,
-        $readExpandedSelectionOffsetFromEditorState(fallbackCursor),
+        snapshotRef.current.expandedCursor,
+      );
+      const nextExpandedCursor = clampExpandedCursor(
+        nextValue,
+        $readExpandedSelectionOffsetFromEditorState(fallbackExpandedCursor),
       );
       const previousSnapshot = snapshotRef.current;
-      if (previousSnapshot.value === nextValue && previousSnapshot.cursor === nextCursor) {
+      if (
+        previousSnapshot.value === nextValue &&
+        previousSnapshot.cursor === nextCursor &&
+        previousSnapshot.expandedCursor === nextExpandedCursor
+      ) {
         return;
       }
       if (isApplyingControlledUpdateRef.current) {
@@ -832,6 +863,7 @@ function ComposerPromptEditorInner({
       snapshotRef.current = {
         value: nextValue,
         cursor: nextCursor,
+        expandedCursor: nextExpandedCursor,
       };
       const cursorAdjacentToMention =
         isCollapsedCursorAdjacentToMention(nextValue, nextCursor, "left") ||

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  clampCollapsedComposerCursor,
+  collapseExpandedComposerCursor,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
   isCollapsedCursorAdjacentToMention,
@@ -84,6 +86,18 @@ describe("detectComposerTrigger", () => {
       rangeEnd: cursorAfterQuery,
     });
   });
+
+  it("detects trigger with true cursor even when regex-based mention detection would false-match", () => {
+    // MENTION_TOKEN_REGEX can false-match plain text like "@in" as a mention.
+    // The fix bypasses it by computing the expanded cursor from the Lexical node tree.
+    const text = "Please inspect @in this sentence";
+    const cursorAfterAt = "Please inspect @".length;
+
+    const trigger = detectComposerTrigger(text, cursorAfterAt);
+    expect(trigger).not.toBeNull();
+    expect(trigger?.kind).toBe("path");
+    expect(trigger?.query).toBe("");
+  });
 });
 
 describe("replaceTextRange", () => {
@@ -118,19 +132,63 @@ describe("expandCollapsedComposerCursor", () => {
 
     expect(detectComposerTrigger(text, expandedCursor)).toBeNull();
   });
+});
 
-  it("detectComposerTrigger works with true cursor even when expandCollapsedComposerCursor is wrong", () => {
-    // expandCollapsedComposerCursor uses MENTION_TOKEN_REGEX which can false-match
-    // plain text like "@in" as a mention. The fix bypasses it by computing the expanded
-    // cursor directly from the Lexical editor's node tree.
-    const text = "Please inspect @in this sentence";
-    const cursorAfterAt = "Please inspect @".length;
+describe("collapseExpandedComposerCursor", () => {
+  it("keeps cursor unchanged when no mention segment is present", () => {
+    expect(collapseExpandedComposerCursor("plain text", 5)).toBe(5);
+  });
 
-    // With the true cursor position, trigger detection works correctly
-    const trigger = detectComposerTrigger(text, cursorAfterAt);
-    expect(trigger).not.toBeNull();
-    expect(trigger?.kind).toBe("path");
-    expect(trigger?.query).toBe("");
+  it("maps expanded mention cursor back to collapsed cursor", () => {
+    const text = "what's in my @AGENTS.md fsfdas";
+    const collapsedCursorAfterMention = "what's in my ".length + 2;
+    const expandedCursorAfterMention = "what's in my @AGENTS.md ".length;
+
+    expect(collapseExpandedComposerCursor(text, expandedCursorAfterMention)).toBe(
+      collapsedCursorAfterMention,
+    );
+  });
+
+  it("keeps replacement cursors aligned when another mention already exists earlier", () => {
+    const text = "open @AGENTS.md then @src/index.ts ";
+    const expandedCursor = text.length;
+    const collapsedCursor = collapseExpandedComposerCursor(text, expandedCursor);
+
+    expect(collapsedCursor).toBe("open ".length + 1 + " then ".length + 2);
+    expect(expandCollapsedComposerCursor(text, collapsedCursor)).toBe(expandedCursor);
+  });
+});
+
+describe("clampCollapsedComposerCursor", () => {
+  it("clamps to collapsed prompt length when mentions are present", () => {
+    const text = "open @AGENTS.md then ";
+
+    expect(clampCollapsedComposerCursor(text, text.length)).toBe(
+      "open ".length + 1 + " then ".length,
+    );
+    expect(clampCollapsedComposerCursor(text, Number.POSITIVE_INFINITY)).toBe(
+      "open ".length + 1 + " then ".length,
+    );
+  });
+});
+
+describe("replaceTextRange trailing space consumption", () => {
+  it("double space after insertion when replacement ends with space", () => {
+    // Simulates: "and then |@AG| summarize" where | marks replacement range
+    // The replacement is "@AGENTS.md " (with trailing space)
+    // But if we don't extend rangeEnd, the existing space stays
+    const text = "and then @AG summarize";
+    const rangeStart = "and then ".length;
+    const rangeEnd = "and then @AG".length;
+
+    // Without consuming trailing space: double space
+    const withoutConsume = replaceTextRange(text, rangeStart, rangeEnd, "@AGENTS.md ");
+    expect(withoutConsume.text).toBe("and then @AGENTS.md  summarize");
+
+    // With consuming trailing space: single space
+    const extendedEnd = text[rangeEnd] === " " ? rangeEnd + 1 : rangeEnd;
+    const withConsume = replaceTextRange(text, rangeStart, extendedEnd, "@AGENTS.md ");
+    expect(withConsume.text).toBe("and then @AGENTS.md summarize");
   });
 });
 

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -67,7 +67,7 @@ function collapsedSegmentLength(
   return segment.type === "mention" ? 1 : segment.text.length;
 }
 
-function clampCollapsedComposerCursor(
+function clampCollapsedComposerCursorForSegments(
   segments: ReadonlyArray<{ type: "text"; text: string } | { type: "mention" }>,
   cursorInput: number,
 ): number {
@@ -81,6 +81,48 @@ function clampCollapsedComposerCursor(
   return Math.max(0, Math.min(collapsedLength, Math.floor(cursorInput)));
 }
 
+export function clampCollapsedComposerCursor(text: string, cursorInput: number): number {
+  return clampCollapsedComposerCursorForSegments(
+    splitPromptIntoComposerSegments(text),
+    cursorInput,
+  );
+}
+
+export function collapseExpandedComposerCursor(text: string, cursorInput: number): number {
+  const expandedCursor = clampCursor(text, cursorInput);
+  const segments = splitPromptIntoComposerSegments(text);
+  if (segments.length === 0) {
+    return expandedCursor;
+  }
+
+  let remaining = expandedCursor;
+  let collapsedCursor = 0;
+
+  for (const segment of segments) {
+    if (segment.type === "mention") {
+      const expandedLength = segment.path.length + 1;
+      if (remaining === 0) {
+        return collapsedCursor;
+      }
+      if (remaining <= expandedLength) {
+        return collapsedCursor + 1;
+      }
+      remaining -= expandedLength;
+      collapsedCursor += 1;
+      continue;
+    }
+
+    const segmentLength = segment.text.length;
+    if (remaining <= segmentLength) {
+      return collapsedCursor + remaining;
+    }
+    remaining -= segmentLength;
+    collapsedCursor += segmentLength;
+  }
+
+  return collapsedCursor;
+}
+
 export function isCollapsedCursorAdjacentToMention(
   text: string,
   cursorInput: number,
@@ -91,7 +133,7 @@ export function isCollapsedCursorAdjacentToMention(
     return false;
   }
 
-  const cursor = clampCollapsedComposerCursor(segments, cursorInput);
+  const cursor = clampCollapsedComposerCursorForSegments(segments, cursorInput);
   let collapsedOffset = 0;
 
   for (const segment of segments) {


### PR DESCRIPTION
Closes #291
Closes #922

## What Changed

Three fixes for the composer's `@file` autocomplete.

**Mid-text `@` trigger detection:**
`ComposerPromptEditor` now computes an expanded cursor from the Lexical node tree and passes it through `onChange` and `readSnapshot`. `ChatView` uses this expanded cursor in `detectComposerTrigger` instead of the regex-based `expandCollapsedComposerCursor`.

**Double space after completion:**
When the replacement (`@AGENTS.md `) already ends with a space and a space exists at the cursor, the insertion now consumes the existing space instead of leaving two.

**Caret lands at end of line after completion:**
`applyPromptReplacement` returned an expanded cursor from `replaceTextRange` but stored it as a collapsed cursor. All `setComposerCursor` call sites now use the correct coordinate system.

**Code changes:**
- Add `getExpandedAbsoluteOffsetForPoint` and `$readExpandedSelectionOffsetFromEditorState` to `ComposerPromptEditor.tsx`
- Pass `expandedCursor` through the `onChange` callback and `readSnapshot` interface
- Add `collapseExpandedComposerCursor` and export `clampCollapsedComposerCursor` in `composer-logic.ts`
- Add `extendReplacementRangeForTrailingSpace` to consume trailing spaces during completion
- Fix all `setComposerCursor` call sites to store collapsed offsets
- Add unit tests for collapsed/expanded cursor conversion and trailing space consumption

## Why

`expandCollapsedComposerCursor` uses `MENTION_TOKEN_REGEX` to locate mentions in raw text. When a user types `@` before an existing word (e.g., cursor between `inspect ` and `in this sentence`), the regex matches `@in` as a mention and shifts the cursor past it. `detectComposerTrigger` then receives the wrong offset and returns null, so the autocomplete popup never appears.

The Lexical editor already tracks which nodes are `ComposerMentionNode` instances. Reading the expanded cursor directly from the node tree eliminates the regex false-match problem.

The other two bugs come from mixing collapsed and expanded cursor offsets in `ChatView` and `ComposerPromptEditor`. Collapsed offsets count a mention pill as 1 character; expanded offsets count by full text length (`@AGENTS.md` = 11). Passing an expanded offset where collapsed is expected inflates the cursor position, and failing to consume an existing trailing space doubles the gap.

## UI Changes

### Before

https://github.com/user-attachments/assets/d7f8c7fe-29a2-461e-84d0-5ede11a96e5a

### After

https://github.com/user-attachments/assets/3d45e52d-c2fd-4b2a-87e7-c5da8eeecbde




> In the After video, also notice: after selecting a completion mid-text, the cursor lands immediately after the inserted mention (not at the end of the line), and there is exactly one space between the mention and the next word.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer `@file` autocomplete cursor placement and double-space bugs
> - Introduces a dual-cursor model in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/936/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4): a collapsed cursor for storage and a expanded cursor for trigger detection, so `@path` and `/command` triggers are detected correctly when the caret is mid-text or adjacent to mentions.
> - Adds `collapseExpandedComposerCursor` and `clampCollapsedComposerCursor` in [composer-logic.ts](https://github.com/pingdotgg/t3code/pull/936/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6) to map between expanded and collapsed cursor positions across mention segments.
> - Adds `extendReplacementRangeForTrailingSpace` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/936/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to consume an existing trailing space when inserting a token (e.g. `@path ` or `/model `) that ends with a space, preventing double spaces.
> - Behavioral Change: `onChange` on `ComposerPromptEditor` and several `ChatView` callbacks now carry an additional `expandedCursor` argument; internal cursor state is now stored in collapsed coordinates everywhere.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d401a74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->