### PR TITLE
fix: diff panel unclosable after retainSearchParams middleware

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1400,7 +1400,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       replace: true,
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return diffOpen ? rest : { ...rest, diff: "1" };
+        return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
       },
     });
   }, [diffOpen, navigate, threadId]);

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -1,9 +1,9 @@
 import { TurnId } from "@t3tools/contracts";
 
 export interface DiffRouteSearch {
-  diff?: "1";
-  diffTurnId?: TurnId;
-  diffFilePath?: string;
+  diff?: "1" | undefined;
+  diffTurnId?: TurnId | undefined;
+  diffFilePath?: string | undefined;
 }
 
 function isDiffOpenValue(value: unknown): boolean {

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -170,9 +170,7 @@ function ChatThreadRouteView() {
     void navigate({
       to: "/$threadId",
       params: { threadId },
-      search: (previous) => {
-        return stripDiffSearchParams(previous);
-      },
+      search: { diff: undefined },
     });
   }, [navigate, threadId]);
   const openDiff = useCallback(() => {


### PR DESCRIPTION
## Summary
- `retainSearchParams(["diff"])` re-injects `diff` from the current URL when close actions omit the key, making the panel unclosable
- Fix: set `diff: undefined` explicitly so the key is present (`in` check passes) and the middleware skips it
- Widen `DiffRouteSearch` types to accept `undefined` so no casts are needed

Closes #935
Closes #931

## Test plan
- [ ] `bun typecheck` passes
- [ ] Open diff panel -> close it -> panel closes (`diff` not re-injected)
- [ ] Open diff panel -> switch thread -> panel stays open
- [ ] Close diff panel -> switch thread -> panel stays closed