### PR TITLE
Show context window status in branch toolbar

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -416,6 +416,23 @@ function runtimeEventToActivities(
       ];
     }
 
+    case "thread.token-usage.updated": {
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "thread.token-usage.updated",
+          summary: "Context window updated",
+          payload: {
+            usage: event.payload.usage,
+          },
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
     case "item.updated": {
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];

--- a/apps/web/public/mockServiceWorker.js
+++ b/apps/web/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.9'
+const PACKAGE_VERSION = '2.12.10'
 const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -129,6 +129,7 @@ export default function BranchToolbar({
         branchCwd={branchCwd}
         effectiveEnvMode={effectiveEnvMode}
         envLocked={envLocked}
+        threadActivities={serverThread?.activities ?? []}
         onSetThreadBranch={setThreadBranch}
         {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}
         {...(onComposerFocusRequest ? { onComposerFocusRequest } : {})}

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -1,4 +1,4 @@
-import type { GitBranch } from "@t3tools/contracts";
+import type { GitBranch, OrchestrationThreadActivity } from "@t3tools/contracts";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronDownIcon } from "lucide-react";
@@ -20,6 +20,8 @@ import {
   gitStatusQueryOptions,
   invalidateGitQueries,
 } from "../lib/gitReactQuery";
+import { deriveLatestContextWindowStatus, type ContextWindowStatus } from "../lib/contextWindow";
+import { cn } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { parsePullRequestReference } from "../pullRequestReference";
 import {
@@ -48,6 +50,7 @@ interface BranchToolbarBranchSelectorProps {
   branchCwd: string | null;
   effectiveEnvMode: EnvMode;
   envLocked: boolean;
+  threadActivities: ReadonlyArray<OrchestrationThreadActivity>;
   onSetThreadBranch: (branch: string | null, worktreePath: string | null) => void;
   onCheckoutPullRequestRequest?: (reference: string) => void;
   onComposerFocusRequest?: () => void;
@@ -79,6 +82,7 @@ export function BranchToolbarBranchSelector({
   branchCwd,
   effectiveEnvMode,
   envLocked,
+  threadActivities,
   onSetThreadBranch,
   onCheckoutPullRequestRequest,
   onComposerFocusRequest,
@@ -146,6 +150,10 @@ export function BranchToolbarBranchSelector({
   );
   const [isBranchActionPending, startBranchActionTransition] = useTransition();
   const shouldVirtualizeBranchList = filteredBranchPickerItems.length > 40;
+  const contextWindowStatus = useMemo(
+    () => deriveLatestContextWindowStatus(threadActivities),
+    [threadActivities],
+  );
 
   const runBranchAction = (action: () => Promise<void>) => {
     startBranchActionTransition(async () => {
@@ -400,66 +408,137 @@ export function BranchToolbarBranchSelector({
   }
 
   return (
-    <Combobox
-      items={branchPickerItems}
-      filteredItems={filteredBranchPickerItems}
-      autoHighlight
-      virtualized={shouldVirtualizeBranchList}
-      onItemHighlighted={(_value, eventDetails) => {
-        if (!isBranchMenuOpen || eventDetails.index < 0) return;
-        branchListVirtualizer.scrollToIndex(eventDetails.index, { align: "auto" });
-      }}
-      onOpenChange={handleOpenChange}
-      open={isBranchMenuOpen}
-      value={resolvedActiveBranch}
-    >
-      <ComboboxTrigger
-        render={<Button variant="ghost" size="xs" />}
-        className="text-muted-foreground/70 hover:text-foreground/80"
-        disabled={(branchesQuery.isLoading && branches.length === 0) || isBranchActionPending}
+    <div className="flex items-center gap-1.5">
+      <Combobox
+        items={branchPickerItems}
+        filteredItems={filteredBranchPickerItems}
+        autoHighlight
+        virtualized={shouldVirtualizeBranchList}
+        onItemHighlighted={(_value, eventDetails) => {
+          if (!isBranchMenuOpen || eventDetails.index < 0) return;
+          branchListVirtualizer.scrollToIndex(eventDetails.index, { align: "auto" });
+        }}
+        onOpenChange={handleOpenChange}
+        open={isBranchMenuOpen}
+        value={resolvedActiveBranch}
       >
-        <span className="max-w-[240px] truncate">{triggerLabel}</span>
-        <ChevronDownIcon />
-      </ComboboxTrigger>
-      <ComboboxPopup align="end" side="top" className="w-80">
-        <div className="border-b p-1">
-          <ComboboxInput
-            className="[&_input]:font-sans rounded-md"
-            inputClassName="ring-0"
-            placeholder="Search branches..."
-            showTrigger={false}
-            size="sm"
-            value={branchQuery}
-            onChange={(event) => setBranchQuery(event.target.value)}
-          />
-        </div>
-        <ComboboxEmpty>No branches found.</ComboboxEmpty>
+        <ComboboxTrigger
+          render={<Button variant="ghost" size="xs" />}
+          className="text-muted-foreground/70 hover:text-foreground/80"
+          disabled={(branchesQuery.isLoading && branches.length === 0) || isBranchActionPending}
+        >
+          <span className="max-w-[240px] truncate">{triggerLabel}</span>
+          <ChevronDownIcon />
+        </ComboboxTrigger>
+        <ComboboxPopup align="end" side="top" className="w-80">
+          <div className="border-b p-1">
+            <ComboboxInput
+              className="[&_input]:font-sans rounded-md"
+              inputClassName="ring-0"
+              placeholder="Search branches..."
+              showTrigger={false}
+              size="sm"
+              value={branchQuery}
+              onChange={(event) => setBranchQuery(event.target.value)}
+            />
+          </div>
+          <ComboboxEmpty>No branches found.</ComboboxEmpty>
 
-        <ComboboxList ref={setBranchListRef} className="max-h-56">
-          {shouldVirtualizeBranchList ? (
-            <div
-              className="relative"
-              style={{
-                height: `${branchListVirtualizer.getTotalSize()}px`,
-              }}
-            >
-              {virtualBranchRows.map((virtualRow) => {
-                const itemValue = filteredBranchPickerItems[virtualRow.index];
-                if (!itemValue) return null;
-                return renderPickerItem(itemValue, virtualRow.index, {
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  width: "100%",
-                  transform: `translateY(${virtualRow.start}px)`,
-                });
-              })}
-            </div>
-          ) : (
-            filteredBranchPickerItems.map((itemValue, index) => renderPickerItem(itemValue, index))
-          )}
-        </ComboboxList>
-      </ComboboxPopup>
-    </Combobox>
+          <ComboboxList ref={setBranchListRef} className="max-h-56">
+            {shouldVirtualizeBranchList ? (
+              <div
+                className="relative"
+                style={{
+                  height: `${branchListVirtualizer.getTotalSize()}px`,
+                }}
+              >
+                {virtualBranchRows.map((virtualRow) => {
+                  const itemValue = filteredBranchPickerItems[virtualRow.index];
+                  if (!itemValue) return null;
+                  return renderPickerItem(itemValue, virtualRow.index, {
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    transform: `translateY(${virtualRow.start}px)`,
+                  });
+                })}
+              </div>
+            ) : (
+              filteredBranchPickerItems.map((itemValue, index) =>
+                renderPickerItem(itemValue, index),
+              )
+            )}
+          </ComboboxList>
+        </ComboboxPopup>
+      </Combobox>
+      {contextWindowStatus ? <ContextWindowRing status={contextWindowStatus} /> : null}
+    </div>
+  );
+}
+
+const tokenCountFormatter = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function ContextWindowRing({ status }: { status: ContextWindowStatus }) {
+  const size = 24;
+  const strokeWidth = 2;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - status.remainingRatio);
+  const remainingPercent = Math.round(status.remainingRatio * 100);
+  const label = `${remainingPercent}% context left`;
+  const detail = `${tokenCountFormatter.format(status.remainingTokens)} of ${tokenCountFormatter.format(status.totalTokens)} tokens left`;
+  const toneClassName =
+    status.remainingRatio <= 0.15
+      ? "text-destructive"
+      : status.remainingRatio <= 0.35
+        ? "text-warning"
+        : "text-success";
+
+  return (
+    <div
+      className="relative flex size-7 shrink-0 items-center justify-center"
+      aria-label={`${label}. ${detail}.`}
+      title={`${label} • ${detail}`}
+    >
+      <svg
+        className={cn("size-6 -rotate-90", toneClassName)}
+        viewBox={`0 0 ${size} ${size}`}
+        aria-hidden="true"
+      >
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeOpacity="0.16"
+          strokeWidth={strokeWidth}
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+          strokeWidth={strokeWidth}
+        />
+      </svg>
+      <span
+        className={cn(
+          "pointer-events-none absolute font-medium tabular-nums text-[7px] text-muted-foreground",
+          remainingPercent === 100 ? "tracking-[-0.04em]" : "",
+        )}
+      >
+        {remainingPercent}
+      </span>
+      <span className="sr-only">{`${label}. ${detail}.`}</span>
+    </div>
   );
 }

--- a/apps/web/src/lib/contextWindow.test.ts
+++ b/apps/web/src/lib/contextWindow.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { EventId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+
+import {
+  deriveContextWindowStatusFromUsage,
+  deriveLatestContextWindowStatus,
+} from "./contextWindow";
+
+describe("deriveContextWindowStatusFromUsage", () => {
+  it("derives remaining context from Codex thread token usage payloads", () => {
+    expect(
+      deriveContextWindowStatusFromUsage({
+        model_context_window: 128_000,
+        last_token_usage: {
+          input_tokens: 32_000,
+        },
+      }),
+    ).toEqual({
+      remainingRatio: 0.75,
+      remainingTokens: 96_000,
+      usedTokens: 32_000,
+      totalTokens: 128_000,
+    });
+  });
+
+  it("supports wrapped usage payloads with explicit remaining tokens", () => {
+    expect(
+      deriveContextWindowStatusFromUsage({
+        usage: {
+          modelContextWindow: 200_000,
+          remainingContextTokens: 50_000,
+        },
+      }),
+    ).toEqual({
+      remainingRatio: 0.25,
+      remainingTokens: 50_000,
+      usedTokens: 150_000,
+      totalTokens: 200_000,
+    });
+  });
+
+  it("ignores lifetime token totals that exceed the context window", () => {
+    expect(
+      deriveContextWindowStatusFromUsage({
+        model_context_window: 128_000,
+        total_token_usage: {
+          total_tokens: 900_000,
+        },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("deriveLatestContextWindowStatus", () => {
+  it("reads the most recent token-usage activity", () => {
+    const activities = [
+      {
+        id: EventId.makeUnsafe("activity-1"),
+        tone: "info",
+        kind: "thread.token-usage.updated",
+        summary: "Context window updated",
+        payload: {
+          usage: {
+            model_context_window: 100_000,
+            last_token_usage: {
+              input_tokens: 20_000,
+            },
+          },
+        },
+        turnId: null,
+        createdAt: "2026-03-11T00:00:00.000Z",
+      },
+      {
+        id: EventId.makeUnsafe("activity-2"),
+        tone: "info",
+        kind: "thread.token-usage.updated",
+        summary: "Context window updated",
+        payload: {
+          usage: {
+            model_context_window: 100_000,
+            remaining_context_tokens: 10_000,
+          },
+        },
+        turnId: null,
+        createdAt: "2026-03-11T00:00:01.000Z",
+      },
+    ] satisfies OrchestrationThreadActivity[];
+
+    expect(deriveLatestContextWindowStatus(activities)).toEqual({
+      remainingRatio: 0.1,
+      remainingTokens: 10_000,
+      usedTokens: 90_000,
+      totalTokens: 100_000,
+    });
+  });
+});

--- a/apps/web/src/lib/contextWindow.ts
+++ b/apps/web/src/lib/contextWindow.ts
@@ -1,0 +1,238 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+
+export interface ContextWindowStatus {
+  remainingRatio: number;
+  remainingTokens: number;
+  usedTokens: number;
+  totalTokens: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function asNonNegativeNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return value;
+}
+
+function readNumericField(
+  record: Record<string, unknown> | null,
+  keys: readonly string[],
+): number | null {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = asNonNegativeNumber(record[key]);
+    if (value !== null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function unwrapUsage(value: unknown): Record<string, unknown> | null {
+  const direct = asRecord(value);
+  if (!direct) {
+    return null;
+  }
+  const usage =
+    asRecord(direct.usage) ??
+    asRecord(direct.tokenUsage) ??
+    asRecord(direct.token_usage) ??
+    asRecord(direct.info);
+  return usage ?? direct;
+}
+
+function findContextWindowLimit(usage: Record<string, unknown> | null): number | null {
+  return (
+    readNumericField(usage, [
+      "model_context_window",
+      "modelContextWindow",
+      "context_window",
+      "contextWindow",
+      "max_input_tokens",
+      "maxInputTokens",
+    ]) ??
+    readNumericField(asRecord(usage?.limits), [
+      "model_context_window",
+      "modelContextWindow",
+      "context_window",
+      "contextWindow",
+      "max_input_tokens",
+      "maxInputTokens",
+    ])
+  );
+}
+
+function findRemainingTokens(
+  usage: Record<string, unknown> | null,
+  contextWindowLimit: number,
+): number | null {
+  const directRemaining =
+    readNumericField(usage, [
+      "remaining_context_tokens",
+      "remainingContextTokens",
+      "remaining_tokens",
+      "remainingTokens",
+      "context_left_tokens",
+      "contextLeftTokens",
+    ]) ??
+    readNumericField(asRecord(usage?.limits), [
+      "remaining_context_tokens",
+      "remainingContextTokens",
+      "remaining_tokens",
+      "remainingTokens",
+      "context_left_tokens",
+      "contextLeftTokens",
+    ]);
+  if (directRemaining !== null) {
+    return Math.min(directRemaining, contextWindowLimit);
+  }
+
+  const directRemainingRatio =
+    readNumericField(usage, [
+      "remaining_context_fraction",
+      "remainingContextFraction",
+      "remaining_context_ratio",
+      "remainingContextRatio",
+    ]) ??
+    readNumericField(asRecord(usage?.limits), [
+      "remaining_context_fraction",
+      "remainingContextFraction",
+      "remaining_context_ratio",
+      "remainingContextRatio",
+    ]);
+  if (directRemainingRatio !== null && directRemainingRatio <= 1) {
+    return Math.round(contextWindowLimit * directRemainingRatio);
+  }
+
+  const directRemainingPercent =
+    readNumericField(usage, [
+      "remaining_context_percent",
+      "remainingContextPercent",
+      "context_left_percent",
+      "contextLeftPercent",
+    ]) ??
+    readNumericField(asRecord(usage?.limits), [
+      "remaining_context_percent",
+      "remainingContextPercent",
+      "context_left_percent",
+      "contextLeftPercent",
+    ]);
+  if (directRemainingPercent !== null && directRemainingPercent <= 100) {
+    return Math.round(contextWindowLimit * (directRemainingPercent / 100));
+  }
+
+  return null;
+}
+
+function findUsedContextTokens(
+  usage: Record<string, unknown> | null,
+  contextWindowLimit: number,
+): number | null {
+  const candidates = [
+    readNumericField(asRecord(usage?.current_token_usage), [
+      "input_tokens",
+      "inputTokens",
+      "prompt_tokens",
+      "promptTokens",
+      "context_tokens",
+      "contextTokens",
+      "total_tokens",
+      "totalTokens",
+    ]),
+    readNumericField(asRecord(usage?.last_token_usage), [
+      "input_tokens",
+      "inputTokens",
+      "prompt_tokens",
+      "promptTokens",
+      "context_tokens",
+      "contextTokens",
+      "total_tokens",
+      "totalTokens",
+    ]),
+    readNumericField(usage, [
+      "input_tokens",
+      "inputTokens",
+      "prompt_tokens",
+      "promptTokens",
+      "context_tokens",
+      "contextTokens",
+      "total_tokens",
+      "totalTokens",
+    ]),
+    readNumericField(asRecord(usage?.total_token_usage), [
+      "input_tokens",
+      "inputTokens",
+      "prompt_tokens",
+      "promptTokens",
+      "context_tokens",
+      "contextTokens",
+      "total_tokens",
+      "totalTokens",
+    ]),
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate !== null && candidate <= contextWindowLimit) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function deriveContextWindowStatusFromUsage(
+  usageValue: unknown,
+): ContextWindowStatus | null {
+  const usage = unwrapUsage(usageValue);
+  const totalTokens = findContextWindowLimit(usage);
+  if (totalTokens === null || totalTokens <= 0) {
+    return null;
+  }
+
+  const remainingTokensFromPayload = findRemainingTokens(usage, totalTokens);
+  if (remainingTokensFromPayload !== null) {
+    const remainingTokens = Math.max(0, Math.min(totalTokens, remainingTokensFromPayload));
+    return {
+      remainingRatio: remainingTokens / totalTokens,
+      remainingTokens,
+      usedTokens: totalTokens - remainingTokens,
+      totalTokens,
+    };
+  }
+
+  const usedTokens = findUsedContextTokens(usage, totalTokens);
+  if (usedTokens === null) {
+    return null;
+  }
+
+  const remainingTokens = Math.max(0, totalTokens - usedTokens);
+  return {
+    remainingRatio: remainingTokens / totalTokens,
+    remainingTokens,
+    usedTokens,
+    totalTokens,
+  };
+}
+
+export function deriveLatestContextWindowStatus(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ContextWindowStatus | null {
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    const activity = activities[index];
+    if (!activity || activity.kind !== "thread.token-usage.updated") {
+      continue;
+    }
+    const status = deriveContextWindowStatusFromUsage(activity.payload);
+    if (status) {
+      return status;
+    }
+  }
+
+  return null;
+}

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -414,6 +414,7 @@ export function deriveWorkLogEntries(
   return ordered
     .filter((activity) => (latestTurnId ? activity.turnId === latestTurnId : true))
     .filter((activity) => activity.kind !== "tool.started")
+    .filter((activity) => activity.kind !== "thread.token-usage.updated")
     .filter((activity) => activity.kind !== "task.started" && activity.kind !== "task.completed")
     .filter((activity) => activity.summary !== "Checkpoint captured")
     .map((activity) => {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed
`Initialize Git ` created only a local repo, so push/PR was broken until you manually created a GitHub repo and origin.

<!-- Describe the change clearly and keep scope tight. -->

## Why
This fix is right because it makes the button create the complete state the app already assumes (local repo plus GitHub remote)

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

N/A

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show context window status as a ring indicator in the branch toolbar
> - Adds a `ContextWindowRing` component to [`BranchToolbarBranchSelector`](https://github.com/pingdotgg/t3code/pull/938/files#diff-95e72064c321265e2363abda12fd803f217db7d06a32a076ea7337d942367734) that displays remaining context tokens as a circular progress ring with a percentage label.
> - Introduces [`contextWindow.ts`](https://github.com/pingdotgg/t3code/pull/938/files#diff-7ca184c32d7cf96da57c102485f859064626dd9d63fabdf57a5e1d465b121c99) with utilities to normalize heterogeneously shaped token-usage payloads into a `ContextWindowStatus` (remainingRatio, remainingTokens, usedTokens, totalTokens).
> - Adds a new `thread.token-usage.updated` case in [`ProviderRuntimeIngestion.ts`](https://github.com/pingdotgg/t3code/pull/938/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) so token-usage events are surfaced as orchestration activities.
> - Filters `thread.token-usage.updated` activities out of work log entries in `deriveWorkLogEntries`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 291490d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->