### PR TITLE
fix: create gh repo in Initialization that the rest of the application expects

### DIFF
--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -106,6 +106,32 @@ layer("GitHubCliLive", (it) => {
     }),
   );
 
+  it.effect("creates a repository from the current directory", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: "https://github.com/octocat/codething-mvp\n",
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+
+      yield* Effect.gen(function* () {
+        const gh = yield* GitHubCli;
+        return yield* gh.createRepository({
+          cwd: "/repo",
+          visibility: "private",
+        });
+      });
+
+      expect(mockedRunProcess).toHaveBeenCalledWith(
+        "gh",
+        ["repo", "create", "--source=.", "--private", "--remote", "origin"],
+        expect.objectContaining({ cwd: "/repo" }),
+      );
+    }),
+  );
+
   it.effect("surfaces a friendly error when the pull request is not found", () =>
     Effect.gen(function* () {
       mockedRunProcess.mockRejectedValueOnce(

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -241,6 +241,18 @@ const makeGitHubCli = Effect.sync(() => {
         ),
         Effect.map(normalizeRepositoryCloneUrls),
       ),
+    createRepository: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: [
+          "repo",
+          "create",
+          "--source=.",
+          `--${input.visibility}`,
+          "--remote",
+          input.remote ?? "origin",
+        ],
+      }).pipe(Effect.asVoid),
     createPullRequest: (input) =>
       execute({
         cwd: input.cwd,

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -408,6 +408,18 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
             input.bodyFile,
           ],
         }).pipe(Effect.asVoid),
+      createRepository: (input) =>
+        execute({
+          cwd: input.cwd,
+          args: [
+            "repo",
+            "create",
+            "--source=.",
+            `--${input.visibility}`,
+            "--remote",
+            input.remote ?? "origin",
+          ],
+        }).pipe(Effect.asVoid),
       getDefaultBranch: (input) =>
         execute({
           cwd: input.cwd,

--- a/apps/server/src/git/Services/GitHubCli.ts
+++ b/apps/server/src/git/Services/GitHubCli.ts
@@ -68,6 +68,15 @@ export interface GitHubCliShape {
   }) => Effect.Effect<GitHubRepositoryCloneUrls, GitHubCliError>;
 
   /**
+   * Create a GitHub repository from the current local repository.
+   */
+  readonly createRepository: (input: {
+    readonly cwd: string;
+    readonly visibility: "private" | "public" | "internal";
+    readonly remote?: string;
+  }) => Effect.Effect<void, GitHubCliError>;
+
+  /**
    * Create a pull request from branch context and body file.
    */
   readonly createPullRequest: (input: {

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -124,6 +124,7 @@ export function makeServerRuntimeServicesLayer() {
   return Layer.mergeAll(
     orchestrationReactorLayer,
     gitCoreLayer,
+    GitHubCliLive,
     gitManagerLayer,
     terminalLayer,
     KeybindingsLive,

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -48,6 +48,7 @@ import { ProviderService, type ProviderServiceShape } from "./provider/Services/
 import { ProviderHealth, type ProviderHealthShape } from "./provider/Services/ProviderHealth";
 import { Open, type OpenShape } from "./open";
 import { GitManager, type GitManagerShape } from "./git/Services/GitManager.ts";
+import { GitHubCli, type GitHubCliShape } from "./git/Services/GitHubCli.ts";
 import type { GitCoreShape } from "./git/Services/GitCore.ts";
 import { GitCore } from "./git/Services/GitCore.ts";
 import { GitCommandError, GitManagerError } from "./git/Errors.ts";
@@ -481,6 +482,7 @@ describe("WebSocket Server", () => {
       open?: OpenShape;
       gitManager?: GitManagerShape;
       gitCore?: Pick<GitCoreShape, "listBranches" | "initRepo" | "pullCurrentBranch">;
+      gitHubCli?: Pick<GitHubCliShape, "createRepository">;
       terminalManager?: TerminalManagerShape;
     } = {},
   ): Promise<Http.Server> {
@@ -516,6 +518,9 @@ describe("WebSocket Server", () => {
       options.gitManager ? Layer.succeed(GitManager, options.gitManager) : Layer.empty,
       options.gitCore
         ? Layer.succeed(GitCore, options.gitCore as unknown as GitCoreShape)
+        : Layer.empty,
+      options.gitHubCli
+        ? Layer.succeed(GitHubCli, options.gitHubCli as unknown as GitHubCliShape)
         : Layer.empty,
       options.terminalManager
         ? Layer.succeed(TerminalManager, options.terminalManager)
@@ -1630,6 +1635,7 @@ describe("WebSocket Server", () => {
       }),
     );
     const initRepo = vi.fn(() => Effect.void);
+    const createRepository = vi.fn(() => Effect.void);
     const pullCurrentBranch = vi.fn(() =>
       Effect.fail(
         new GitCommandError({
@@ -1648,6 +1654,9 @@ describe("WebSocket Server", () => {
         initRepo,
         pullCurrentBranch,
       },
+      gitHubCli: {
+        createRepository,
+      },
     });
     const addr = server.address();
     const port = typeof addr === "object" && addr !== null ? addr.port : 0;
@@ -1663,6 +1672,10 @@ describe("WebSocket Server", () => {
     const initResponse = await sendRequest(ws, WS_METHODS.gitInit, { cwd: "/repo/path" });
     expect(initResponse.error).toBeUndefined();
     expect(initRepo).toHaveBeenCalledWith({ cwd: "/repo/path" });
+    expect(createRepository).toHaveBeenCalledWith({
+      cwd: "/repo/path",
+      visibility: "private",
+    });
 
     const pullResponse = await sendRequest(ws, WS_METHODS.gitPull, { cwd: "/repo/path" });
     expect(pullResponse.result).toBeUndefined();

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -47,6 +47,7 @@ import { WebSocketServer, type WebSocket } from "ws";
 
 import { createLogger } from "./logger";
 import { GitManager } from "./git/Services/GitManager.ts";
+import { GitHubCli } from "./git/Services/GitHubCli.ts";
 import { TerminalManager } from "./terminal/Services/Manager.ts";
 import { Keybindings } from "./keybindings";
 import { searchWorkspaceEntries } from "./workspaceEntries";
@@ -213,6 +214,7 @@ export type ServerCoreRuntimeServices =
 export type ServerRuntimeServices =
   | ServerCoreRuntimeServices
   | GitManager
+  | GitHubCli
   | GitCore
   | TerminalManager
   | Keybindings
@@ -255,6 +257,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   const keybindingsManager = yield* Keybindings;
   const providerHealth = yield* ProviderHealth;
   const git = yield* GitCore;
+  const gitHubCli = yield* GitHubCli;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
 
@@ -833,7 +836,11 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
       case WS_METHODS.gitInit: {
         const body = stripRequestTag(request.body);
-        return yield* git.initRepo(body);
+        yield* git.initRepo(body);
+        return yield* gitHubCli.createRepository({
+          cwd: body.cwd,
+          visibility: "private",
+        });
       }
 
       case WS_METHODS.terminalOpen: {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed
`Initialize Git ` created only a local repo, so push/PR was broken until you manually created a GitHub repo and origin.

<!-- Describe the change clearly and keep scope tight. -->

## Why
This fix is right because it makes the button create the complete state the app already assumes (local repo plus GitHub remote)

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

N/A

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A)
- [x] I included a video for animation/interaction changes (N/A)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Create a private GitHub repo automatically during git init
> - The `WS_METHODS.gitInit` websocket handler in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/939/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) now calls `gitHubCli.createRepository` with `visibility: 'private'` after `git.initRepo`, tying the response to the repository creation result.
> - Adds `createRepository` to the `GitHubCli` service interface and layer, invoking `gh repo create --source=. --private --remote origin`.
> - `GitHubCliLive` is added to the top-level layer in [serverLayers.ts](https://github.com/pingdotgg/t3code/pull/939/files#diff-520184bba510d5aba90d0e9de6f471e393fff91ff4cb283eaf0b6d0096fa83fe) so it is available across the server runtime.
> - Behavioral Change: `gitInit` now fails if `gh repo create` fails, and a private GitHub remote repo is always created on every local repo init.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec79ce1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->