### PR TITLE
fix: align ClaudeCodeAdapter tests with thread identity semantics

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeCodeAdapter.test.ts
@@ -546,14 +546,14 @@ describe("ClaudeCodeAdapterLive", () => {
         provider: "claudeCode",
         runtimeMode: "full-access",
       });
-      assert.equal(session.threadId, undefined);
+      assert.equal(session.threadId, THREAD_ID);
 
       const turn = yield* adapter.sendTurn({
         threadId: session.threadId,
         input: "hello",
         attachments: [],
       });
-      assert.equal(turn.threadId, undefined);
+      assert.equal(turn.threadId, THREAD_ID);
 
       harness.query.emit({
         type: "stream_event",
@@ -592,13 +592,13 @@ describe("ClaudeCodeAdapterLive", () => {
       const sessionStarted = runtimeEvents[0];
       assert.equal(sessionStarted?.type, "session.started");
       if (sessionStarted?.type === "session.started") {
-        assert.equal("threadId" in sessionStarted, false);
+        assert.equal(sessionStarted.threadId, THREAD_ID);
       }
 
       const threadStarted = runtimeEvents[4];
       assert.equal(threadStarted?.type, "thread.started");
       if (threadStarted?.type === "thread.started") {
-        assert.equal(threadStarted.threadId, "sdk-thread-real");
+        assert.equal(threadStarted.threadId, THREAD_ID);
       }
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
@@ -700,9 +700,9 @@ describe("ClaudeCodeAdapterLive", () => {
         runtimeMode: "full-access",
       });
 
-      assert.equal(session.threadId, "resume-thread-1");
+      assert.equal(session.threadId, RESUME_THREAD_ID);
       assert.deepEqual(session.resumeCursor, {
-        threadId: "resume-thread-1",
+        threadId: RESUME_THREAD_ID,
         resume: "550e8400-e29b-41d4-a716-446655440000",
         resumeSessionAt: "assistant-99",
         turnCount: 3,

--- a/apps/server/src/provider/Layers/ClaudeCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeCodeAdapter.ts
@@ -502,6 +502,7 @@ function makeClaudeCodeAdapter(options?: ClaudeCodeAdapterLiveOptions) {
                 provider: PROVIDER,
                 createdAt: observedAt,
                 method: sdkNativeMethod(message),
+                threadId: context.session.threadId,
                 ...(typeof message.session_id === "string"
                   ? { providerThreadId: message.session_id }
                   : {}),
@@ -510,7 +511,7 @@ function makeClaudeCodeAdapter(options?: ClaudeCodeAdapterLiveOptions) {
                 payload: message,
               },
             },
-            null,
+            context.session.threadId,
           );
       });
 


### PR DESCRIPTION
## Summary
- Fix 3 failing CI tests in `ClaudeCodeAdapter.test.ts`
- Update test expectations to match adapter's actual behavior: `session.threadId` always uses the orchestration-assigned thread ID (not undefined before SDK session_id)
- Add missing `threadId` to native event logger payloads for proper per-thread log routing

## Context
These are the 3 tests blocking CI on PR #179:
1. **"does not fabricate provider thread ids before first SDK session_id"** - Expected `undefined`, got `THREAD_ID`
2. **"passes parsed resume cursor values to Claude query options"** - Expected resume cursor threadId, got input threadId
3. **"writes provider-native observability records when enabled"** - Native events missing `threadId` field

## Test plan
- [x] `bun run test -- --run src/provider/Layers/ClaudeCodeAdapter.test.ts` (13/13 pass)
- [x] `bun run test -- --run src/provider/Layers/ProviderAdapterRegistry.test.ts` (2/2 pass)
- [x] `cd apps/web && bun run test -- --run src/session-logic.test.ts` (19/19 pass)
- [x] `bun lint` (0 errors)
- [x] `bun typecheck` (all 6 packages pass)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align `ClaudeCodeAdapter` tests and logging with thread identity semantics
> - Updates `ClaudeCodeAdapter` tests to assert that session and turn `threadId` values equal the provided `THREAD_ID` constant rather than `undefined`, and that emitted `session.started` and `thread.started` events carry the correct `threadId`.
> - Updates the resume-session test to use the `RESUME_THREAD_ID` constant instead of a hard-coded string for all related assertions.
> - Adds `threadId: context.session.threadId` to the native SDK event log payload in [`ClaudeCodeAdapter.ts`](https://github.com/pingdotgg/t3code/pull/943/files#diff-6971a178ab59334c6efbe6ec5c9e315d1ff93620c17e526a893dfc2991c46b5f) and passes it as the final argument to `nativeEventLogger.log`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7526133.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->