### PR TITLE
fix stale web build getting into server build/release

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -144,6 +144,7 @@ const buildCmd = Command.make(
       const clientTarget = path.join(serverDir, "dist/client");
 
       if (yield* fs.exists(webDist)) {
+        yield* fs.remove(clientTarget, { recursive: true, force: true });
         yield* fs.copy(webDist, clientTarget);
         yield* applyDevelopmentIconOverrides(repoRoot, serverDir);
         yield* Effect.log("[cli] Bundled web app into dist/client");

--- a/apps/server/turbo.jsonc
+++ b/apps/server/turbo.jsonc
@@ -2,6 +2,10 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "build": {
+      "dependsOn": ["@t3tools/web#build"],
+      "outputs": ["dist/**"],
+    },
     "start": {
       "dependsOn": ["build"],
       "cache": false,


### PR DESCRIPTION
## What Changed
`server` build now depends on `web` build. Also previous `web` build gets fully deleted before copying over the new build.

## Why

I noticed the latest v0.0.10 still had v0.0.9 in the settings -> about section
<img width="960" height="232" alt="image" src="https://github.com/user-attachments/assets/60b11b2f-d87d-4fbb-a79b-74165e1d360e" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale web build files persisting in server dist
> - The `buildCmd` handler in [cli.ts](https://github.com/pingdotgg/t3code/pull/944/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) now deletes `dist/client` before copying the web bundle, preventing stale files from prior builds.
> - [turbo.jsonc](https://github.com/pingdotgg/t3code/pull/944/files#diff-78f13bddfa7b22e578974afb008f37d61a8b6eae667550b1b3b7862375b592fb) adds a build pipeline entry declaring `@t3tools/web#build` as a dependency and `dist/**` as outputs, ensuring the web build runs before the server build in the monorepo task graph.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b5488df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->