### PR TITLE
Cache sidebar content for instant render on subsequent launches

### DIFF
--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -258,3 +258,70 @@ describe("store read model sync", () => {
     expect(next.projects.map((project) => project.id)).toEqual([project2, project1, project3]);
   });
 });
+
+describe("sidebar cache hydration", () => {
+  it("syncServerReadModel replaces cached threads and sets threadsHydrated", () => {
+    const cachedState: AppState = {
+      projects: [
+        {
+          id: ProjectId.makeUnsafe("stale-project"),
+          name: "Stale Project",
+          cwd: "/tmp/stale",
+          model: DEFAULT_MODEL_BY_PROVIDER.codex,
+          expanded: true,
+          scripts: [],
+        },
+      ],
+      threads: [
+        makeThread({
+          id: ThreadId.makeUnsafe("stale-thread"),
+          projectId: ProjectId.makeUnsafe("stale-project"),
+          title: "Stale Thread",
+        }),
+      ],
+      threadsHydrated: false,
+    };
+
+    const readModel = makeReadModel(
+      makeReadModelThread({ title: "Fresh Thread" }),
+    );
+    const next = syncServerReadModel(cachedState, readModel);
+
+    expect(next.threadsHydrated).toBe(true);
+    expect(next.threads).toHaveLength(1);
+    expect(next.threads[0]?.title).toBe("Fresh Thread");
+  });
+
+  it("cached threads with empty defaults are valid input to syncServerReadModel", () => {
+    const cachedState: AppState = {
+      projects: [
+        {
+          id: ProjectId.makeUnsafe("project-1"),
+          name: "Project",
+          cwd: "/tmp/project",
+          model: DEFAULT_MODEL_BY_PROVIDER.codex,
+          expanded: true,
+          scripts: [],
+        },
+      ],
+      threads: [
+        makeThread({
+          session: null,
+          messages: [],
+          activities: [],
+          proposedPlans: [],
+          turnDiffSummaries: [],
+          latestTurn: null,
+        }),
+      ],
+      threadsHydrated: false,
+    };
+
+    const readModel = makeReadModel(makeReadModelThread());
+    const next = syncServerReadModel(cachedState, readModel);
+
+    expect(next.threadsHydrated).toBe(true);
+    expect(next.threads[0]?.session).toBeNull();
+    expect(next.threads[0]?.messages).toEqual([]);
+  });
+});

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -13,7 +13,13 @@ import {
   resolveModelSlugForProvider,
 } from "@t3tools/shared/model";
 import { create } from "zustand";
-import { type ChatMessage, type Project, type Thread } from "./types";
+import {
+  type ChatMessage,
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type Project,
+  type Thread,
+} from "./types";
 import { Debouncer } from "@tanstack/react-pacer";
 
 // ── State ────────────────────────────────────────────────────────────
@@ -55,6 +61,22 @@ function readPersistedState(): AppState {
     const parsed = JSON.parse(raw) as {
       expandedProjectCwds?: string[];
       projectOrderCwds?: string[];
+      cachedProjects?: Array<{
+        id: string;
+        name: string;
+        cwd: string;
+        model: string;
+        expanded: boolean;
+        scripts: Project["scripts"];
+      }>;
+      cachedThreads?: Array<{
+        id: string;
+        projectId: string;
+        title: string;
+        createdAt: string;
+        branch: string | null;
+        worktreePath: string | null;
+      }>;
     };
     persistedExpandedProjectCwds.clear();
     persistedProjectOrderCwds.length = 0;
@@ -68,7 +90,37 @@ function readPersistedState(): AppState {
         persistedProjectOrderCwds.push(cwd);
       }
     }
-    return { ...initialState };
+
+    const projects: Project[] = (parsed.cachedProjects ?? []).map((p) => ({
+      id: p.id as Project["id"],
+      name: p.name,
+      cwd: p.cwd,
+      model: p.model,
+      expanded: p.expanded,
+      scripts: p.scripts ?? [],
+    }));
+
+    const threads: Thread[] = (parsed.cachedThreads ?? []).map((t) => ({
+      id: t.id as Thread["id"],
+      codexThreadId: null,
+      projectId: t.projectId as Thread["projectId"],
+      title: t.title,
+      model: DEFAULT_MODEL_BY_PROVIDER.codex,
+      runtimeMode: DEFAULT_RUNTIME_MODE,
+      interactionMode: DEFAULT_INTERACTION_MODE,
+      session: null,
+      messages: [],
+      proposedPlans: [],
+      error: null,
+      createdAt: t.createdAt,
+      latestTurn: null,
+      branch: t.branch,
+      worktreePath: t.worktreePath,
+      turnDiffSummaries: [],
+      activities: [],
+    }));
+
+    return { projects, threads, threadsHydrated: false };
   } catch {
     return initialState;
   }
@@ -86,6 +138,22 @@ function persistState(state: AppState): void {
           .filter((project) => project.expanded)
           .map((project) => project.cwd),
         projectOrderCwds: state.projects.map((project) => project.cwd),
+        cachedProjects: state.projects.map((project) => ({
+          id: project.id,
+          name: project.name,
+          cwd: project.cwd,
+          model: project.model,
+          expanded: project.expanded,
+          scripts: project.scripts,
+        })),
+        cachedThreads: state.threads.map((thread) => ({
+          id: thread.id,
+          projectId: thread.projectId,
+          title: thread.title,
+          createdAt: thread.createdAt,
+          branch: thread.branch,
+          worktreePath: thread.worktreePath,
+        })),
       }),
     );
     if (!legacyKeysCleanedUp) {


### PR DESCRIPTION
## What Changed

Caches the sidebar project & thread titles. 

## Why

The sidebar currently doesn't render anything until the WebSocket is connected, resulting in "No projects yet" being shown for a couple of seconds when the app is opened. This is a UX improvement.

## UI Changes

Before
<video src=https://github.com/user-attachments/assets/0ac669dd-a848-4ee5-988b-6ec79305dd60 />

After
<video src=https://github.com/user-attachments/assets/18b218cf-807c-45fe-a1b9-5afece3de6bd />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cache sidebar projects and threads in localStorage for instant render on subsequent launches
> - `readPersistedState` in [store.ts](https://github.com/pingdotgg/t3code/pull/946/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82) now parses `cachedProjects` and `cachedThreads` from localStorage and hydrates `state.projects` and `state.threads` on startup, with `threadsHydrated: false` until the server response arrives.
> - `persistState` now writes `cachedProjects` and `cachedThreads` to localStorage on each state update, expanding the storage schema.
> - Behavioral Change: on first load after this change, the sidebar renders from cache immediately rather than waiting for server data; stale cache is replaced once `syncServerReadModel` completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a15da82.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->