### PR TITLE
fix: clean up timeout in PlanSidebar to prevent memory leaks

### DIFF
--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback } from "react";
+import { memo, useState, useCallback, useRef, useEffect } from "react";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { ScrollArea } from "./ui/scroll-area";
@@ -66,6 +66,7 @@ const PlanSidebar = memo(function PlanSidebar({
   const [proposedPlanExpanded, setProposedPlanExpanded] = useState(false);
   const [isSavingToWorkspace, setIsSavingToWorkspace] = useState(false);
   const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const planMarkdown = activeProposedPlan?.planMarkdown ?? null;
   const displayedPlanMarkdown = planMarkdown ? stripDisplayedPlanMarkdown(planMarkdown) : null;
@@ -74,8 +75,15 @@ const PlanSidebar = memo(function PlanSidebar({
   const handleCopyPlan = useCallback(() => {
     if (!planMarkdown) return;
     void navigator.clipboard.writeText(planMarkdown);
+    if (copiedTimerRef.current != null) {
+      clearTimeout(copiedTimerRef.current);
+    }
+
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    copiedTimerRef.current = setTimeout(() => {
+      setCopied(false);
+      copiedTimerRef.current = null;
+    }, 2000);
   }, [planMarkdown]);
 
   const handleDownload = useCallback(() => {
@@ -120,6 +128,14 @@ const PlanSidebar = memo(function PlanSidebar({
       {/* Header */}
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-3">
         <div className="flex items-center gap-2">
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current \!= null) {
+        clearTimeout(copiedTimerRef.current);
+      }
+    };
+  }, []);
           <Badge
             variant="secondary"
             className="rounded-md bg-blue-500/10 px-1.5 py-0 text-[10px] font-semibold tracking-wide text-blue-400 uppercase"


### PR DESCRIPTION
## Summary

Fix timeout cleanup bug in PlanSidebar that could cause memory leaks and incorrect UI state.

## Changes

- `PlanSidebar.tsx`: Store timeout in ref and clear it on unmount or re-click

## Bug Details

The copy timeout was not being cleared when:
1. The component unmounted
2. The copy button was clicked multiple times

This could cause memory leaks and the "copied" state to persist incorrectly.

## Related Issues

Fixes #792 - Toasts keep hanging

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix timeout cleanup in `PlanSidebar` to prevent memory leaks on unmount
> - Stores the copy feedback timeout ID in a `copiedTimerRef` ref and clears any active timeout before starting a new one, so rapid successive copies no longer stack timers.
> - Adds a `useEffect` cleanup to clear any pending timeout when the component unmounts, preventing post-unmount state updates.
> - Risk: the `useEffect` cleanup block was placed inside the returned JSX rather than at the top level of the component function, which is syntactically invalid in TSX and may cause a runtime error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5388f04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->