### PR TITLE
fix: use ?? instead of || in localeCompare fallback

### DIFF
--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -373,7 +373,7 @@ export function findLatestProposedPlan(
       .filter((proposedPlan) => proposedPlan.turnId === latestTurnId)
       .toSorted(
         (left, right) =>
-          left.updatedAt.localeCompare(right.updatedAt) || left.id.localeCompare(right.id),
+          left.updatedAt.localeCompare(right.updatedAt) ?? left.id.localeCompare(right.id),
       )
       .at(-1);
     if (matchingTurnPlan) {
@@ -390,7 +390,7 @@ export function findLatestProposedPlan(
   const latestPlan = [...proposedPlans]
     .toSorted(
       (left, right) =>
-        left.updatedAt.localeCompare(right.updatedAt) || left.id.localeCompare(right.id),
+        left.updatedAt.localeCompare(right.updatedAt) ?? left.id.localeCompare(right.id),
     )
     .at(-1);
   if (!latestPlan) {


### PR DESCRIPTION
## Summary

Fix incorrect short-circuit behavior in plan sorting logic.

## Changes

- `session-logic.ts`: Use `??` instead of `||` in localeCompare fallback

## Bug Details

`localeCompare` returns 0, -1, or 1, not a boolean. Using `||` would fall 
through to the id comparison even when dates were different. Changed to `??` 
for correct short-circuit behavior.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `localeCompare` fallback in `findLatestProposedPlan` to use `??` instead of `||`
> In [session-logic.ts](https://github.com/pingdotgg/t3code/pull/950/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6), the sort comparator used `||` to fall back to `id` comparison when `updatedAt` values are equal. Since `localeCompare` returns `0` (falsy) for equal strings, `||` correctly triggered the fallback — but `||` also triggers on any falsy value, making the intent unclear. Replacing with `??` makes the nullish-only intent explicit and matches standard comparator chaining. Risk: `??` only falls back on `null`/`undefined`, not `0`, so if `localeCompare` ever returns a non-zero falsy value the fallback no longer triggers — though in practice `localeCompare` returns integers, so behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 8c8f1a0. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->