### PR TITLE
Add workspace open targets and Ghostty support

### DIFF
--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -50,6 +50,7 @@ const testLayer = Layer.mergeAll(
   Layer.succeed(Open, {
     openBrowser: (_target: string) => Effect.void,
     openInEditor: () => Effect.void,
+    openWorkspace: () => Effect.void,
   } satisfies OpenShape),
   AnalyticsService.layerTest,
   FetchHttpClient.layer,

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -8,7 +8,9 @@ import {
   isCommandAvailable,
   launchDetached,
   resolveAvailableEditors,
+  resolveAvailableOpenTargets,
   resolveEditorLaunch,
+  resolveWorkspaceLaunch,
 } from "./open";
 import { Effect } from "effect";
 import { assertSuccess } from "@effect/vitest/utils";
@@ -117,6 +119,78 @@ describe("resolveEditorLaunch", () => {
   );
 });
 
+describe("resolveWorkspaceLaunch", () => {
+  it.effect("returns editor-backed workspace launches for existing workspace targets", () =>
+    Effect.gen(function* () {
+      const cursorLaunch = yield* resolveWorkspaceLaunch(
+        { cwd: "/tmp/workspace", target: "cursor" },
+        "darwin",
+      );
+      assert.deepEqual(cursorLaunch, {
+        command: "cursor",
+        args: ["/tmp/workspace"],
+      });
+
+      const fileManagerLaunch = yield* resolveWorkspaceLaunch(
+        { cwd: "/tmp/workspace", target: "file-manager" },
+        "linux",
+      );
+      assert.deepEqual(fileManagerLaunch, {
+        command: "xdg-open",
+        args: ["/tmp/workspace"],
+      });
+    }),
+  );
+
+  it.effect("uses AppleScript for Ghostty on macOS", () =>
+    Effect.gen(function* () {
+      const launch = yield* resolveWorkspaceLaunch(
+        { cwd: "/tmp/workspace", target: "ghostty" },
+        "darwin",
+      );
+
+      assert.deepEqual(launch, {
+        command: "osascript",
+        args: [
+          "-e",
+          [
+            'tell application "Ghostty"',
+            "    activate",
+            "    set cfg to new surface configuration",
+            '    set initial working directory of cfg to "/tmp/workspace"',
+            "    new window with configuration cfg",
+            "end tell",
+          ].join("\n"),
+        ],
+      });
+    }),
+  );
+
+  it.effect("uses Ghostty CLI for Linux", () =>
+    Effect.gen(function* () {
+      const launch = yield* resolveWorkspaceLaunch(
+        { cwd: "/tmp/workspace", target: "ghostty" },
+        "linux",
+      );
+
+      assert.deepEqual(launch, {
+        command: "ghostty",
+        args: ["+new-window", "--working-directory", "/tmp/workspace"],
+      });
+    }),
+  );
+
+  it.effect("rejects Ghostty on unsupported platforms", () =>
+    Effect.gen(function* () {
+      const result = yield* resolveWorkspaceLaunch(
+        { cwd: "C:\\workspace", target: "ghostty" },
+        "win32",
+      ).pipe(Effect.result);
+      assert.equal(result._tag, "Failure");
+    }),
+  );
+});
+
 describe("launchDetached", () => {
   it.effect("resolves when command can be spawned", () =>
     Effect.gen(function* () {
@@ -215,6 +289,83 @@ describe("resolveAvailableEditors", () => {
         PATHEXT: ".COM;.EXE;.BAT;.CMD",
       });
       assert.deepEqual(editors, ["cursor", "file-manager"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("resolveAvailableOpenTargets", () => {
+  it("returns Ghostty on macOS when the app is installed", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-open-targets-darwin-"));
+    try {
+      fs.writeFileSync(path.join(dir, "cursor"), "#!/bin/sh\n", { mode: 0o755 });
+      fs.writeFileSync(path.join(dir, "open"), "#!/bin/sh\n", { mode: 0o755 });
+
+      const targets = resolveAvailableOpenTargets(
+        "darwin",
+        {
+          PATH: dir,
+        },
+        {
+          isMacApplicationAvailable: (appName) => appName === "Ghostty",
+        },
+      );
+      assert.deepEqual(targets, ["cursor", "ghostty", "file-manager"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits Ghostty on macOS when the app is not installed", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-open-targets-darwin-missing-"));
+    try {
+      fs.writeFileSync(path.join(dir, "cursor"), "#!/bin/sh\n", { mode: 0o755 });
+      fs.writeFileSync(path.join(dir, "open"), "#!/bin/sh\n", { mode: 0o755 });
+      fs.writeFileSync(path.join(dir, "ghostty"), "#!/bin/sh\n", { mode: 0o755 });
+
+      const targets = resolveAvailableOpenTargets(
+        "darwin",
+        {
+          PATH: dir,
+        },
+        {
+          isMacApplicationAvailable: () => false,
+        },
+      );
+      assert.deepEqual(targets, ["cursor", "file-manager"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns Ghostty on Linux only when the CLI is available", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-open-targets-"));
+    try {
+      fs.writeFileSync(path.join(dir, "cursor"), "#!/bin/sh\n", { mode: 0o755 });
+      fs.writeFileSync(path.join(dir, "ghostty"), "#!/bin/sh\n", { mode: 0o755 });
+      fs.writeFileSync(path.join(dir, "xdg-open"), "#!/bin/sh\n", { mode: 0o755 });
+
+      const targets = resolveAvailableOpenTargets("linux", {
+        PATH: dir,
+      });
+      assert.deepEqual(targets, ["cursor", "ghostty", "file-manager"]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("omits Ghostty on unsupported platforms", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-open-targets-win-"));
+    try {
+      fs.writeFileSync(path.join(dir, "cursor.CMD"), "@echo off\r\n", "utf8");
+      fs.writeFileSync(path.join(dir, "explorer.EXE"), "MZ", "utf8");
+
+      const targets = resolveAvailableOpenTargets("win32", {
+        PATH: dir,
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+      });
+      assert.deepEqual(targets, ["cursor", "file-manager"]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -6,11 +6,16 @@
  *
  * @module Open
  */
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { accessSync, constants, statSync } from "node:fs";
 import { extname, join } from "node:path";
 
-import { EDITORS, type EditorId } from "@t3tools/contracts";
+import {
+  EDITORS,
+  type EditorId,
+  WORKSPACE_OPEN_TARGETS,
+  type WorkspaceOpenTargetId,
+} from "@t3tools/contracts";
 import { ServiceMap, Schema, Effect, Layer } from "effect";
 
 // ==============================
@@ -27,6 +32,11 @@ export interface OpenInEditorInput {
   readonly editor: EditorId;
 }
 
+export interface OpenWorkspaceInput {
+  readonly cwd: string;
+  readonly target: WorkspaceOpenTargetId;
+}
+
 interface EditorLaunch {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
@@ -35,6 +45,10 @@ interface EditorLaunch {
 interface CommandAvailabilityOptions {
   readonly platform?: NodeJS.Platform;
   readonly env?: NodeJS.ProcessEnv;
+}
+
+interface OpenTargetAvailabilityOptions extends CommandAvailabilityOptions {
+  readonly isMacApplicationAvailable?: (appName: string) => boolean;
 }
 
 const LINE_COLUMN_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
@@ -53,6 +67,16 @@ function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
       return "explorer";
     default:
       return "xdg-open";
+  }
+}
+
+function ghosttyCommandForPlatform(platform: NodeJS.Platform): string | null {
+  switch (platform) {
+    case "darwin":
+    case "linux":
+      return "ghostty";
+    default:
+      return null;
   }
 }
 
@@ -177,6 +201,90 @@ export function resolveAvailableEditors(
   return available;
 }
 
+function isWorkspaceEditorTarget(target: WorkspaceOpenTargetId): target is EditorId {
+  return target !== "ghostty";
+}
+
+function resolveWorkspaceTargetCommand(
+  target: WorkspaceOpenTargetId,
+  platform: NodeJS.Platform,
+): string | null {
+  if (target === "ghostty") {
+    return ghosttyCommandForPlatform(platform);
+  }
+
+  const editorDef = EDITORS.find((editor) => editor.id === target);
+  if (!editorDef) return null;
+  return editorDef.command ?? fileManagerCommandForPlatform(platform);
+}
+
+function isMacApplicationAvailable(appName: string): boolean {
+  const result = spawnSync("open", ["-Ra", appName], {
+    stdio: "ignore",
+  });
+  return result.status === 0;
+}
+
+function isWorkspaceTargetAvailable(
+  target: WorkspaceOpenTargetId,
+  options: OpenTargetAvailabilityOptions,
+): boolean {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+
+  if (target === "ghostty") {
+    switch (platform) {
+      case "darwin":
+        return (options.isMacApplicationAvailable ?? isMacApplicationAvailable)("Ghostty");
+      case "linux":
+        return isCommandAvailable("ghostty", { platform, env });
+      default:
+        return false;
+    }
+  }
+
+  const command = resolveWorkspaceTargetCommand(target, platform);
+  if (!command) return false;
+  return isCommandAvailable(command, { platform, env });
+}
+
+export function resolveAvailableOpenTargets(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  options: Omit<OpenTargetAvailabilityOptions, "platform" | "env"> = {},
+): ReadonlyArray<WorkspaceOpenTargetId> {
+  const available: WorkspaceOpenTargetId[] = [];
+
+  for (const target of WORKSPACE_OPEN_TARGETS) {
+    if (
+      isWorkspaceTargetAvailable(target.id, {
+        platform,
+        env,
+        ...options,
+      })
+    ) {
+      available.push(target.id);
+    }
+  }
+
+  return available;
+}
+
+function escapeAppleScriptString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function ghosttyAppleScript(cwd: string): string {
+  return [
+    'tell application "Ghostty"',
+    "    activate",
+    "    set cfg to new surface configuration",
+    `    set initial working directory of cfg to ${escapeAppleScriptString(cwd)}`,
+    "    new window with configuration cfg",
+    "end tell",
+  ].join("\n");
+}
+
 /**
  * OpenShape - Service API for browser and editor launch actions.
  */
@@ -192,6 +300,11 @@ export interface OpenShape {
    * Launches the editor as a detached process so server startup is not blocked.
    */
   readonly openInEditor: (input: OpenInEditorInput) => Effect.Effect<void, OpenError>;
+
+  /**
+   * Open a workspace in a selected workspace launcher target.
+   */
+  readonly openWorkspace: (input: OpenWorkspaceInput) => Effect.Effect<void, OpenError>;
 }
 
 /**
@@ -223,6 +336,32 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
   }
 
   return { command: fileManagerCommandForPlatform(platform), args: [input.cwd] };
+});
+
+export const resolveWorkspaceLaunch = Effect.fnUntraced(function* (
+  input: OpenWorkspaceInput,
+  platform: NodeJS.Platform = process.platform,
+): Effect.fn.Return<EditorLaunch, OpenError> {
+  if (isWorkspaceEditorTarget(input.target)) {
+    return yield* resolveEditorLaunch({ cwd: input.cwd, editor: input.target }, platform);
+  }
+
+  switch (platform) {
+    case "darwin":
+      return {
+        command: "osascript",
+        args: ["-e", ghosttyAppleScript(input.cwd)],
+      };
+    case "linux":
+      return {
+        command: "ghostty",
+        args: ["+new-window", "--working-directory", input.cwd],
+      };
+    default:
+      return yield* new OpenError({
+        message: `Unsupported workspace target ${input.target} on platform ${platform}`,
+      });
+  }
 });
 
 export const launchDetached = (launch: EditorLaunch) =>
@@ -270,6 +409,7 @@ const make = Effect.gen(function* () {
         catch: (cause) => new OpenError({ message: "Browser auto-open failed", cause }),
       }),
     openInEditor: (input) => Effect.flatMap(resolveEditorLaunch(input), launchDetached),
+    openWorkspace: (input) => Effect.flatMap(resolveWorkspaceLaunch(input), launchDetached),
   } satisfies OpenShape;
 });
 

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -14,6 +14,7 @@ import { makeServerProviderLayer, makeServerRuntimeServicesLayer } from "./serve
 import {
   DEFAULT_TERMINAL_ID,
   EDITORS,
+  WORKSPACE_OPEN_TARGETS,
   EventId,
   ORCHESTRATION_WS_CHANNELS,
   ORCHESTRATION_WS_METHODS,
@@ -62,6 +63,7 @@ const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 const defaultOpenService: OpenShape = {
   openBrowser: () => Effect.void,
   openInEditor: () => Effect.void,
+  openWorkspace: () => Effect.void,
 };
 
 const defaultProviderStatuses: ReadonlyArray<ServerProviderStatus> = [
@@ -442,12 +444,23 @@ function compileKeybindings(bindings: KeybindingsConfig): ResolvedKeybindingsCon
 
 const DEFAULT_RESOLVED_KEYBINDINGS = compileKeybindings([...DEFAULT_KEYBINDINGS]);
 const VALID_EDITOR_IDS = new Set(EDITORS.map((editor) => editor.id));
+const VALID_OPEN_TARGET_IDS = new Set(WORKSPACE_OPEN_TARGETS.map((target) => target.id));
 
 function expectAvailableEditors(value: unknown): void {
   expect(Array.isArray(value)).toBe(true);
   for (const editorId of value as unknown[]) {
     expect(typeof editorId).toBe("string");
     expect(VALID_EDITOR_IDS.has(editorId as (typeof EDITORS)[number]["id"])).toBe(true);
+  }
+}
+
+function expectAvailableOpenTargets(value: unknown): void {
+  expect(Array.isArray(value)).toBe(true);
+  for (const targetId of value as unknown[]) {
+    expect(typeof targetId).toBe("string");
+    expect(
+      VALID_OPEN_TARGET_IDS.has(targetId as (typeof WORKSPACE_OPEN_TARGETS)[number]["id"]),
+    ).toBe(true);
   }
 }
 
@@ -831,8 +844,12 @@ describe("WebSocket Server", () => {
       issues: [],
       providers: defaultProviderStatuses,
       availableEditors: expect.any(Array),
+      availableOpenTargets: expect.any(Array),
     });
     expectAvailableEditors((response.result as { availableEditors: unknown }).availableEditors);
+    expectAvailableOpenTargets(
+      (response.result as { availableOpenTargets: unknown }).availableOpenTargets,
+    );
   });
 
   it("bootstraps default keybindings file when missing", async () => {
@@ -856,8 +873,12 @@ describe("WebSocket Server", () => {
       issues: [],
       providers: defaultProviderStatuses,
       availableEditors: expect.any(Array),
+      availableOpenTargets: expect.any(Array),
     });
     expectAvailableEditors((response.result as { availableEditors: unknown }).availableEditors);
+    expectAvailableOpenTargets(
+      (response.result as { availableOpenTargets: unknown }).availableOpenTargets,
+    );
 
     const persistedConfig = JSON.parse(
       fs.readFileSync(keybindingsPath, "utf8"),
@@ -891,8 +912,12 @@ describe("WebSocket Server", () => {
       ],
       providers: defaultProviderStatuses,
       availableEditors: expect.any(Array),
+      availableOpenTargets: expect.any(Array),
     });
     expectAvailableEditors((response.result as { availableEditors: unknown }).availableEditors);
+    expectAvailableOpenTargets(
+      (response.result as { availableOpenTargets: unknown }).availableOpenTargets,
+    );
     expect(fs.readFileSync(keybindingsPath, "utf8")).toBe("{ not-json");
   });
 
@@ -925,6 +950,7 @@ describe("WebSocket Server", () => {
       issues: Array<{ kind: string; index?: number; message: string }>;
       providers: ReadonlyArray<ServerProviderStatus>;
       availableEditors: unknown;
+      availableOpenTargets: unknown;
     };
     expect(result.cwd).toBe("/my/workspace");
     expect(result.keybindingsConfigPath).toBe(keybindingsPath);
@@ -945,6 +971,7 @@ describe("WebSocket Server", () => {
     expect(result.keybindings.some((entry) => entry.command === "terminal.new")).toBe(true);
     expect(result.providers).toEqual(defaultProviderStatuses);
     expectAvailableEditors(result.availableEditors);
+    expectAvailableOpenTargets(result.availableOpenTargets);
   });
 
   it("pushes server.configUpdated issues when keybindings file changes", async () => {
@@ -990,6 +1017,7 @@ describe("WebSocket Server", () => {
         openCalls.push({ cwd: input.cwd, editor: input.editor });
         return Effect.void;
       },
+      openWorkspace: () => Effect.void,
     };
 
     server = await createTestServer({ cwd: "/my/workspace", open: openService });
@@ -1005,6 +1033,32 @@ describe("WebSocket Server", () => {
     });
     expect(response.error).toBeUndefined();
     expect(openCalls).toEqual([{ cwd: "/my/workspace", editor: "cursor" }]);
+  });
+
+  it("routes shell.openWorkspace through the injected open service", async () => {
+    const openCalls: Array<{ cwd: string; target: string }> = [];
+    const openService: OpenShape = {
+      openBrowser: () => Effect.void,
+      openInEditor: () => Effect.void,
+      openWorkspace: (input) => {
+        openCalls.push({ cwd: input.cwd, target: input.target });
+        return Effect.void;
+      },
+    };
+
+    server = await createTestServer({ cwd: "/my/workspace", open: openService });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const [ws] = await connectAndAwaitWelcome(port);
+    connections.push(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.shellOpenWorkspace, {
+      cwd: "/my/workspace",
+      target: "ghostty",
+    });
+    expect(response.error).toBeUndefined();
+    expect(openCalls).toEqual([{ cwd: "/my/workspace", target: "ghostty" }]);
   });
 
   it("reads keybindings from the configured state directory", async () => {
@@ -1038,8 +1092,12 @@ describe("WebSocket Server", () => {
       issues: [],
       providers: defaultProviderStatuses,
       availableEditors: expect.any(Array),
+      availableOpenTargets: expect.any(Array),
     });
     expectAvailableEditors((response.result as { availableEditors: unknown }).availableEditors);
+    expectAvailableOpenTargets(
+      (response.result as { availableOpenTargets: unknown }).availableOpenTargets,
+    );
   });
 
   it("upserts keybinding rules and updates cached server config", async () => {
@@ -1085,9 +1143,13 @@ describe("WebSocket Server", () => {
       issues: [],
       providers: defaultProviderStatuses,
       availableEditors: expect.any(Array),
+      availableOpenTargets: expect.any(Array),
     });
     expectAvailableEditors(
       (configResponse.result as { availableEditors: unknown }).availableEditors,
+    );
+    expectAvailableOpenTargets(
+      (configResponse.result as { availableOpenTargets: unknown }).availableOpenTargets,
     );
   });
 
@@ -1467,6 +1529,7 @@ describe("WebSocket Server", () => {
       openBrowser: () => Effect.void,
       openInEditor: () =>
         Effect.sync(() => BigInt(1)).pipe(Effect.map((result) => result as unknown as void)),
+      openWorkspace: () => Effect.void,
     };
 
     try {

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -57,7 +57,7 @@ import { ProviderService } from "./provider/Services/ProviderService";
 import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import { CheckpointDiffQuery } from "./checkpointing/Services/CheckpointDiffQuery";
 import { clamp } from "effect/Number";
-import { Open, resolveAvailableEditors } from "./open";
+import { Open, resolveAvailableEditors, resolveAvailableOpenTargets } from "./open";
 import { ServerConfig } from "./config";
 import { GitCore } from "./git/Services/GitCore.ts";
 import { tryHandleProjectFaviconRequest } from "./projectFaviconRoute";
@@ -249,6 +249,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     autoBootstrapProjectFromCwd,
   } = serverConfig;
   const availableEditors = resolveAvailableEditors();
+  const availableOpenTargets = resolveAvailableOpenTargets();
 
   const gitManager = yield* GitManager;
   const terminalManager = yield* TerminalManager;
@@ -602,7 +603,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   const projectionReadModelQuery = yield* ProjectionSnapshotQuery;
   const checkpointDiffQuery = yield* CheckpointDiffQuery;
   const orchestrationReactor = yield* OrchestrationReactor;
-  const { openInEditor } = yield* Open;
+  const { openInEditor, openWorkspace } = yield* Open;
 
   const subscriptionsScope = yield* Scope.make("sequential");
   yield* Effect.addFinalizer(() => Scope.close(subscriptionsScope, Exit.void));
@@ -781,6 +782,11 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         return yield* openInEditor(body);
       }
 
+      case WS_METHODS.shellOpenWorkspace: {
+        const body = stripRequestTag(request.body);
+        return yield* openWorkspace(body);
+      }
+
       case WS_METHODS.gitStatus: {
         const body = stripRequestTag(request.body);
         return yield* gitManager.status(body);
@@ -875,6 +881,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
           issues: keybindingsConfig.issues,
           providers: providerStatuses,
           availableEditors,
+          availableOpenTargets,
         };
 
       case WS_METHODS.serverUpsertKeybinding: {

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -109,6 +109,7 @@ function createBaseServerConfig(): ServerConfig {
       },
     ],
     availableEditors: [],
+    availableOpenTargets: [],
   };
 }
 
@@ -897,6 +898,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
         nextFixture.serverConfig = {
           ...nextFixture.serverConfig,
           availableEditors: ["vscode"],
+          availableOpenTargets: ["vscode"],
         };
       },
     });
@@ -924,6 +926,80 @@ describe("ChatView timeline estimator parity (full app)", () => {
         },
         { timeout: 8_000, interval: 16 },
       );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("opens Ghostty from the workspace Open menu without changing the file editor preference", async () => {
+    useComposerDraftStore.setState({
+      draftThreadsByThreadId: {
+        [THREAD_ID]: {
+          projectId: PROJECT_ID,
+          createdAt: NOW_ISO,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          envMode: "local",
+        },
+      },
+      projectDraftThreadIdByProjectId: {
+        [PROJECT_ID]: THREAD_ID,
+      },
+    });
+    window.localStorage.setItem("t3code:last-editor", "vscode");
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["vscode"],
+          availableOpenTargets: ["ghostty", "vscode"],
+        };
+      },
+    });
+
+    try {
+      const menuTrigger = await waitForElement(() => {
+        const openActions = Array.from(
+          document.querySelectorAll("[aria-label='Subscription actions']"),
+        ).find((group) =>
+          Array.from(group.querySelectorAll("button")).some(
+            (button) => button.textContent?.trim() === "Open",
+          ),
+        );
+        if (!openActions) return null;
+        return (openActions.querySelectorAll("button")[1] ?? null) as HTMLButtonElement | null;
+      }, "Unable to find Open menu trigger.");
+      menuTrigger.click();
+
+      const ghosttyOption = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("[role='menuitem']")).find((item) =>
+            item.textContent?.includes("Ghostty"),
+          ) as HTMLElement | null,
+        "Unable to find Ghostty option.",
+      );
+      ghosttyOption.click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenWorkspace,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenWorkspace,
+            cwd: "/repo/project",
+            target: "ghostty",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      expect(window.localStorage.getItem("t3code:last-editor")).toBe("vscode");
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2,6 +2,7 @@ import {
   type ApprovalRequestId,
   DEFAULT_MODEL_BY_PROVIDER,
   type EditorId,
+  type WorkspaceOpenTargetId,
   type KeybindingCommand,
   type CodexReasoningEffort,
   type MessageId,
@@ -164,6 +165,7 @@ const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
 const EMPTY_AVAILABLE_EDITORS: EditorId[] = [];
+const EMPTY_AVAILABLE_OPEN_TARGETS: WorkspaceOpenTargetId[] = [];
 const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
 const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
@@ -958,6 +960,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
   const availableEditors = serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
+  const availableOpenTargets =
+    serverConfigQuery.data?.availableOpenTargets ?? EMPTY_AVAILABLE_OPEN_TARGETS;
   const providerStatuses = serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES;
   const activeProvider = activeThread?.session?.provider ?? "codex";
   const activeProviderStatus = useMemo(
@@ -3171,6 +3175,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           }
           keybindings={keybindings}
           availableEditors={availableEditors}
+          availableOpenTargets={availableOpenTargets}
           diffToggleShortcutLabel={diffPanelShortcutLabel}
           gitCwd={gitCwd}
           diffOpen={diffOpen}

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -20,12 +20,6 @@ export const CursorIcon: Icon = (props) => (
   </svg>
 );
 
-export const GhosttyIcon: Icon = (props) => (
-  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
-    <path d="M12 2a8 8 0 0 0-8 8v11l4-2.5 4 2.5 4-2.5 4 2.5V10a8 8 0 0 0-8-8Zm-2.75 8.5a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Zm5.5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Zm-5.33 5.95a.75.75 0 0 1 .99-1.13c.45.4.98.6 1.59.6s1.14-.2 1.59-.6a.75.75 0 1 1 .99 1.13 3.85 3.85 0 0 1-2.58.97 3.85 3.85 0 0 1-2.58-.97Z" />
-  </svg>
-);
-
 export const VisualStudioCode: Icon = (props) => {
   const id = useId();
   const maskId = `${id}-vscode-a`;

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -20,6 +20,12 @@ export const CursorIcon: Icon = (props) => (
   </svg>
 );
 
+export const GhosttyIcon: Icon = (props) => (
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 2a8 8 0 0 0-8 8v11l4-2.5 4 2.5 4-2.5 4 2.5V10a8 8 0 0 0-8-8Zm-2.75 8.5a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Zm5.5 0a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Zm-5.33 5.95a.75.75 0 0 1 .99-1.13c.45.4.98.6 1.59.6s1.14-.2 1.59-.6a.75.75 0 1 1 .99 1.13 3.85 3.85 0 0 1-2.58.97 3.85 3.85 0 0 1-2.58-.97Z" />
+  </svg>
+);
+
 export const VisualStudioCode: Icon = (props) => {
   const id = useId();
   const maskId = `${id}-vscode-a`;

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -14,12 +14,17 @@ import {
 import { RouterProvider, createMemoryHistory } from "@tanstack/react-router";
 import { ws, http, HttpResponse } from "msw";
 import { setupWorker } from "msw/browser";
+import type { ReactNode } from "react";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
 import { useComposerDraftStore } from "../composerDraftStore";
 import { getRouter } from "../router";
 import { useStore } from "../store";
+
+vi.mock("./DiffWorkerPoolProvider", () => ({
+  DiffWorkerPoolProvider: ({ children }: { children?: ReactNode }) => children ?? null,
+}));
 
 const THREAD_ID = "thread-kb-toast-test" as ThreadId;
 const PROJECT_ID = "project-1" as ProjectId;
@@ -53,6 +58,7 @@ function createBaseServerConfig(): ServerConfig {
       },
     ],
     availableEditors: [],
+    availableOpenTargets: [],
   };
 }
 

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -3,6 +3,7 @@ import {
   type ProjectScript,
   type ResolvedKeybindingsConfig,
   type ThreadId,
+  type WorkspaceOpenTargetId,
 } from "@t3tools/contracts";
 import { memo } from "react";
 import GitActionsControl from "../GitActionsControl";
@@ -24,6 +25,7 @@ interface ChatHeaderProps {
   preferredScriptId: string | null;
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
+  availableOpenTargets: ReadonlyArray<WorkspaceOpenTargetId>;
   diffToggleShortcutLabel: string | null;
   gitCwd: string | null;
   diffOpen: boolean;
@@ -44,6 +46,7 @@ export const ChatHeader = memo(function ChatHeader({
   preferredScriptId,
   keybindings,
   availableEditors,
+  availableOpenTargets,
   diffToggleShortcutLabel,
   gitCwd,
   diffOpen,
@@ -90,6 +93,7 @@ export const ChatHeader = memo(function ChatHeader({
           <OpenInPicker
             keybindings={keybindings}
             availableEditors={availableEditors}
+            availableOpenTargets={availableOpenTargets}
             openInCwd={openInCwd}
           />
         )}

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -1,11 +1,16 @@
-import { EDITORS, type EditorId, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import {
+  EDITORS,
+  type EditorId,
+  type ResolvedKeybindingsConfig,
+  type WorkspaceOpenTargetId,
+} from "@t3tools/contracts";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
 import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { Group, GroupSeparator } from "../ui/group";
 import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "../ui/menu";
-import { CursorIcon, Icon, VisualStudioCode, Zed } from "../Icons";
+import { CursorIcon, GhosttyIcon, Icon, VisualStudioCode, Zed } from "../Icons";
 import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 
@@ -14,18 +19,20 @@ const LAST_EDITOR_KEY = "t3code:last-editor";
 export const OpenInPicker = memo(function OpenInPicker({
   keybindings,
   availableEditors,
+  availableOpenTargets,
   openInCwd,
 }: {
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
+  availableOpenTargets: ReadonlyArray<WorkspaceOpenTargetId>;
   openInCwd: string | null;
 }) {
   const [lastEditor, setLastEditor] = useState<EditorId>(() => {
     const stored = localStorage.getItem(LAST_EDITOR_KEY);
-    return EDITORS.some((e) => e.id === stored) ? (stored as EditorId) : EDITORS[0].id;
+    return EDITORS.some((editor) => editor.id === stored) ? (stored as EditorId) : EDITORS[0].id;
   });
 
-  const allOptions = useMemo<Array<{ label: string; Icon: Icon; value: EditorId }>>(
+  const allOptions = useMemo<Array<{ label: string; Icon: Icon; value: WorkspaceOpenTargetId }>>(
     () => [
       {
         label: "Cursor",
@@ -43,6 +50,11 @@ export const OpenInPicker = memo(function OpenInPicker({
         value: "zed",
       },
       {
+        label: "Ghostty",
+        Icon: GhosttyIcon,
+        value: "ghostty",
+      },
+      {
         label: isMacPlatform(navigator.platform)
           ? "Finder"
           : isWindowsPlatform(navigator.platform)
@@ -54,15 +66,23 @@ export const OpenInPicker = memo(function OpenInPicker({
     ],
     [],
   );
-  const options = useMemo(
-    () => allOptions.filter((option) => availableEditors.includes(option.value)),
+  const openTargetOptions = useMemo(
+    () => allOptions.filter((option) => availableOpenTargets.includes(option.value)),
+    [allOptions, availableOpenTargets],
+  );
+  const editorOptions = useMemo(
+    () =>
+      allOptions.filter(
+        (option) =>
+          option.value !== "ghostty" && availableEditors.includes(option.value as EditorId),
+      ),
     [allOptions, availableEditors],
   );
 
-  const effectiveEditor = options.some((option) => option.value === lastEditor)
+  const effectiveEditor = editorOptions.some((option) => option.value === lastEditor)
     ? lastEditor
-    : (options[0]?.value ?? null);
-  const primaryOption = options.find(({ value }) => value === effectiveEditor) ?? null;
+    : ((editorOptions[0]?.value ?? null) as EditorId | null);
+  const primaryOption = editorOptions.find(({ value }) => value === effectiveEditor) ?? null;
 
   const openInEditor = useCallback(
     (editorId: EditorId | null) => {
@@ -74,7 +94,21 @@ export const OpenInPicker = memo(function OpenInPicker({
       localStorage.setItem(LAST_EDITOR_KEY, editor);
       setLastEditor(editor);
     },
-    [effectiveEditor, openInCwd, setLastEditor],
+    [effectiveEditor, openInCwd],
+  );
+
+  const openTarget = useCallback(
+    (target: WorkspaceOpenTargetId) => {
+      const api = readNativeApi();
+      if (!api || !openInCwd) return;
+      if (target === "ghostty") {
+        void api.shell.openWorkspace(openInCwd, target);
+        return;
+      }
+
+      openInEditor(target);
+    },
+    [openInCwd, openInEditor],
   );
 
   const openFavoriteEditorShortcutLabel = useMemo(
@@ -83,18 +117,16 @@ export const OpenInPicker = memo(function OpenInPicker({
   );
 
   useEffect(() => {
-    const handler = (e: globalThis.KeyboardEvent) => {
-      const api = readNativeApi();
-      if (!isOpenFavoriteEditorShortcut(e, keybindings)) return;
-      if (!api || !openInCwd) return;
-      if (!effectiveEditor) return;
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (!isOpenFavoriteEditorShortcut(event, keybindings)) return;
+      if (!openInCwd || !effectiveEditor) return;
 
-      e.preventDefault();
-      void api.shell.openInEditor(openInCwd, effectiveEditor);
+      event.preventDefault();
+      openInEditor(effectiveEditor);
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [effectiveEditor, keybindings, openInCwd]);
+  }, [effectiveEditor, keybindings, openInCwd, openInEditor]);
 
   return (
     <Group aria-label="Subscription actions">
@@ -111,13 +143,22 @@ export const OpenInPicker = memo(function OpenInPicker({
       </Button>
       <GroupSeparator className="hidden @sm/header-actions:block" />
       <Menu>
-        <MenuTrigger render={<Button aria-label="Copy options" size="icon-xs" variant="outline" />}>
+        <MenuTrigger
+          render={
+            <Button
+              aria-label="Open options"
+              data-open-options-trigger="true"
+              size="icon-xs"
+              variant="outline"
+            />
+          }
+        >
           <ChevronDownIcon aria-hidden="true" className="size-4" />
         </MenuTrigger>
         <MenuPopup align="end">
-          {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
-          {options.map(({ label, Icon, value }) => (
-            <MenuItem key={value} onClick={() => openInEditor(value)}>
+          {openTargetOptions.length === 0 && <MenuItem disabled>No open targets found</MenuItem>}
+          {openTargetOptions.map(({ label, Icon, value }) => (
+            <MenuItem key={value} onClick={() => openTarget(value)}>
               <Icon aria-hidden="true" className="text-muted-foreground" />
               {label}
               {value === effectiveEditor && openFavoriteEditorShortcutLabel && (

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -6,11 +6,11 @@ import {
 } from "@t3tools/contracts";
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
-import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
+import { ChevronDownIcon, FolderClosedIcon, TerminalIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { Group, GroupSeparator } from "../ui/group";
 import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "../ui/menu";
-import { CursorIcon, GhosttyIcon, Icon, VisualStudioCode, Zed } from "../Icons";
+import { CursorIcon, Icon, VisualStudioCode, Zed } from "../Icons";
 import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 
@@ -51,7 +51,7 @@ export const OpenInPicker = memo(function OpenInPicker({
       },
       {
         label: "Ghostty",
-        Icon: GhosttyIcon,
+        Icon: TerminalIcon,
         value: "ghostty",
       },
       {

--- a/apps/web/src/terminalStateStore.test.ts
+++ b/apps/web/src/terminalStateStore.test.ts
@@ -1,13 +1,38 @@
 import { ThreadId } from "@t3tools/contracts";
-import { beforeEach, describe, expect, it } from "vitest";
-
-import { selectThreadTerminalState, useTerminalStateStore } from "./terminalStateStore";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-1");
+let selectThreadTerminalState: typeof import("./terminalStateStore").selectThreadTerminalState;
+let useTerminalStateStore: typeof import("./terminalStateStore").useTerminalStateStore;
+
+function installMockLocalStorage(): void {
+  const storage = new Map<string, string>();
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      key: (index: number) => Array.from(storage.keys())[index] ?? null,
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      get length() {
+        return storage.size;
+      },
+    } satisfies Storage,
+  });
+}
 
 describe("terminalStateStore actions", () => {
-  beforeEach(() => {
-    if (typeof localStorage !== "undefined") {
+  beforeEach(async () => {
+    installMockLocalStorage();
+    vi.resetModules();
+    ({ selectThreadTerminalState, useTerminalStateStore } = await import("./terminalStateStore"));
+
+    if (typeof localStorage.clear === "function") {
       localStorage.clear();
     }
     useTerminalStateStore.setState({ terminalStateByThreadId: {} });

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
 const requestMock = vi.fn<(...args: Array<unknown>) => Promise<unknown>>();
 const showContextMenuFallbackMock =
   vi.fn<
@@ -115,6 +116,11 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  if (originalWindowDescriptor) {
+    Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "window");
+  }
 });
 
 describe("wsNativeApi", () => {
@@ -317,6 +323,32 @@ describe("wsNativeApi", () => {
       cwd: "/tmp/project",
       relativePath: "plan.md",
       contents: "# Plan\n",
+    });
+  });
+
+  it("forwards shell.openInEditor requests to the websocket shell method", async () => {
+    requestMock.mockResolvedValue(undefined);
+    const { createWsNativeApi } = await import("./wsNativeApi");
+
+    const api = createWsNativeApi();
+    await api.shell.openInEditor("/tmp/project", "vscode");
+
+    expect(requestMock).toHaveBeenCalledWith(WS_METHODS.shellOpenInEditor, {
+      cwd: "/tmp/project",
+      editor: "vscode",
+    });
+  });
+
+  it("forwards shell.openWorkspace requests to the websocket shell method", async () => {
+    requestMock.mockResolvedValue(undefined);
+    const { createWsNativeApi } = await import("./wsNativeApi");
+
+    const api = createWsNativeApi();
+    await api.shell.openWorkspace("/tmp/project", "ghostty");
+
+    expect(requestMock).toHaveBeenCalledWith(WS_METHODS.shellOpenWorkspace, {
+      cwd: "/tmp/project",
+      target: "ghostty",
     });
   });
 

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -118,6 +118,8 @@ export function createWsNativeApi(): NativeApi {
     shell: {
       openInEditor: (cwd, editor) =>
         transport.request(WS_METHODS.shellOpenInEditor, { cwd, editor }),
+      openWorkspace: (cwd, target) =>
+        transport.request(WS_METHODS.shellOpenWorkspace, { cwd, target }),
       openExternal: async (url) => {
         if (window.desktopBridge) {
           const opened = await window.desktopBridge.openExternal(url);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,4 +10,5 @@ export * from "./server";
 export * from "./git";
 export * from "./orchestration";
 export * from "./editor";
+export * from "./openTarget";
 export * from "./project";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -36,6 +36,7 @@ import type {
   TerminalWriteInput,
 } from "./terminal";
 import type { ServerUpsertKeybindingInput, ServerUpsertKeybindingResult } from "./server";
+import type { WorkspaceOpenTargetId } from "./openTarget";
 import type {
   ClientOrchestrationCommand,
   OrchestrationGetFullThreadDiffInput,
@@ -131,6 +132,7 @@ export interface NativeApi {
   };
   shell: {
     openInEditor: (cwd: string, editor: EditorId) => Promise<void>;
+    openWorkspace: (cwd: string, target: WorkspaceOpenTargetId) => Promise<void>;
     openExternal: (url: string) => Promise<void>;
   };
   git: {

--- a/packages/contracts/src/openTarget.test.ts
+++ b/packages/contracts/src/openTarget.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { Schema } from "effect";
+
+import { OpenWorkspaceTargetInput, WorkspaceOpenTargetId } from "./openTarget";
+
+const decodeWorkspaceOpenTargetId = Schema.decodeUnknownSync(WorkspaceOpenTargetId);
+const decodeOpenWorkspaceTargetInput = Schema.decodeUnknownSync(OpenWorkspaceTargetInput);
+
+describe("WorkspaceOpenTargetId", () => {
+  it("accepts Ghostty", () => {
+    expect(decodeWorkspaceOpenTargetId("ghostty")).toBe("ghostty");
+  });
+
+  it("rejects unknown targets", () => {
+    expect(() => decodeWorkspaceOpenTargetId("unknown-target")).toThrow();
+  });
+});
+
+describe("OpenWorkspaceTargetInput", () => {
+  it("accepts cwd and target", () => {
+    const parsed = decodeOpenWorkspaceTargetInput({
+      cwd: " /tmp/workspace ",
+      target: "ghostty",
+    });
+
+    expect(parsed.cwd).toBe("/tmp/workspace");
+    expect(parsed.target).toBe("ghostty");
+  });
+});

--- a/packages/contracts/src/openTarget.ts
+++ b/packages/contracts/src/openTarget.ts
@@ -1,0 +1,21 @@
+import { Schema } from "effect";
+import { TrimmedNonEmptyString } from "./baseSchemas";
+
+export const WORKSPACE_OPEN_TARGETS = [
+  { id: "cursor", label: "Cursor" },
+  { id: "vscode", label: "VS Code" },
+  { id: "zed", label: "Zed" },
+  { id: "ghostty", label: "Ghostty" },
+  { id: "file-manager", label: "File Manager" },
+] as const;
+
+export const WorkspaceOpenTargetId = Schema.Literals(
+  WORKSPACE_OPEN_TARGETS.map((target) => target.id),
+);
+export type WorkspaceOpenTargetId = typeof WorkspaceOpenTargetId.Type;
+
+export const OpenWorkspaceTargetInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  target: WorkspaceOpenTargetId,
+});
+export type OpenWorkspaceTargetInput = typeof OpenWorkspaceTargetInput.Type;

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -2,6 +2,7 @@ import { Schema } from "effect";
 import { IsoDateTime, TrimmedNonEmptyString } from "./baseSchemas";
 import { KeybindingRule, ResolvedKeybindingsConfig } from "./keybindings";
 import { EditorId } from "./editor";
+import { WorkspaceOpenTargetId } from "./openTarget";
 import { ProviderKind } from "./orchestration";
 
 const KeybindingsMalformedConfigIssue = Schema.Struct({
@@ -52,6 +53,7 @@ export const ServerConfig = Schema.Struct({
   issues: ServerConfigIssues,
   providers: ServerProviderStatuses,
   availableEditors: Schema.Array(EditorId),
+  availableOpenTargets: Schema.Array(WorkspaceOpenTargetId),
 });
 export type ServerConfig = typeof ServerConfig.Type;
 

--- a/packages/contracts/src/ws.test.ts
+++ b/packages/contracts/src/ws.test.ts
@@ -73,6 +73,20 @@ it.effect("accepts git.preparePullRequestThread requests", () =>
   }),
 );
 
+it.effect("accepts shell.openWorkspace requests", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeWebSocketRequest({
+      id: "req-open-workspace-1",
+      body: {
+        _tag: WS_METHODS.shellOpenWorkspace,
+        cwd: "/repo",
+        target: "ghostty",
+      },
+    });
+    assert.strictEqual(parsed.body._tag, WS_METHODS.shellOpenWorkspace);
+  }),
+);
+
 it.effect("accepts typed websocket push envelopes with sequence", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeWsResponse({

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -37,6 +37,7 @@ import { KeybindingRule } from "./keybindings";
 import { ProjectSearchEntriesInput, ProjectWriteFileInput } from "./project";
 import { OpenInEditorInput } from "./editor";
 import { ServerConfigUpdatedPayload } from "./server";
+import { OpenWorkspaceTargetInput } from "./openTarget";
 
 // ── WebSocket RPC Method Names ───────────────────────────────────────
 
@@ -50,6 +51,7 @@ export const WS_METHODS = {
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
+  shellOpenWorkspace: "shell.openWorkspace",
 
   // Git methods
   gitPull: "git.pull",
@@ -114,6 +116,7 @@ const WebSocketRequestBody = Schema.Union([
 
   // Shell methods
   tagRequestBody(WS_METHODS.shellOpenInEditor, OpenInEditorInput),
+  tagRequestBody(WS_METHODS.shellOpenWorkspace, OpenWorkspaceTargetInput),
 
   // Git methods
   tagRequestBody(WS_METHODS.gitPull, GitPullInput),


### PR DESCRIPTION
## Summary

Adds support for opening a workspace with broader open targets instead of editors only.

This PR:
- adds a new `shell.openWorkspace` websocket/native API method
- introduces shared `WorkspaceOpenTargetId` contracts
- exposes `availableOpenTargets` from the server config
- adds Ghostty as a supported workspace target
- keeps the existing favorite editor and primary Open button behavior unchanged
- updates the chat header open menu to show available workspace targets

## Behavior

- If Ghostty is installed and supported on the current platform, it appears in the Open menu.
- If Ghostty is not installed, it is omitted from the available targets and nothing changes for the user.
- The primary Open button still uses the preferred editor and does not switch to Ghostty.

## Validation

Passed:
- `bun fmt`
- `bun lint`
- `bun typecheck`

Targeted tests passed:
- `bun run test src/open.test.ts src/wsServer.test.ts` in `apps/server`
- `bun run test src/openTarget.test.ts src/ws.test.ts` in `packages/contracts`
- `bun run test src/wsNativeApi.test.ts src/terminalStateStore.test.ts` in `apps/web`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Ghostty terminal as a workspace open target in the Open menu
> - Adds a `WORKSPACE_OPEN_TARGETS` contract and `WorkspaceOpenTargetId` type in [`packages/contracts/src/openTarget.ts`](https://github.com/pingdotgg/t3code/pull/952/files#diff-a881a802e454f766d9c772ddcd3d7b51c5f50889103b3278f3a12a822ce03264), plus a new `shell.openWorkspace` WebSocket method.
> - Server computes `availableOpenTargets` (including Ghostty when detected) and returns it in `getConfig`; a new `openWorkspace` RPC routes to the `Open` service.
> - Ghostty launch uses AppleScript (`osascript`) on macOS and the `ghostty` CLI on Linux; unsupported platforms return an error.
> - [`OpenInPicker`](https://github.com/pingdotgg/t3code/pull/952/files#diff-e2a98d212ae98eb3ec0902f11d6e8f0daeb2b1729c80a65a8792371f7605e802) renders Ghostty alongside editors, invokes `shell.openWorkspace` for it, and skips updating the saved last-editor preference when Ghostty is selected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f01e46d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->