### PR TITLE
fix(web): fully clear diff route state when closing panel

### DIFF
--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -37,3 +37,7 @@ export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRoute
     ...(diffFilePath ? { diffFilePath } : {}),
   };
 }
+
+export const threadDiffRouteSearchOptions = {
+  validateSearch: parseDiffRouteSearch,
+} as const;

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,14 +1,10 @@
 import { ThreadId } from "@t3tools/contracts";
-import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Suspense, lazy, type ReactNode, useCallback, useEffect } from "react";
 
 import ChatView from "../components/ChatView";
 import { useComposerDraftStore } from "../composerDraftStore";
-import {
-  type DiffRouteSearch,
-  parseDiffRouteSearch,
-  stripDiffSearchParams,
-} from "../diffRouteSearch";
+import { stripDiffSearchParams, threadDiffRouteSearchOptions } from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { useStore } from "../store";
 import { Sheet, SheetPopup } from "../components/ui/sheet";
@@ -227,9 +223,6 @@ function ChatThreadRouteView() {
 }
 
 export const Route = createFileRoute("/_chat/$threadId")({
-  validateSearch: (search) => parseDiffRouteSearch(search),
-  search: {
-    middlewares: [retainSearchParams<DiffRouteSearch>(["diff"])],
-  },
+  ...threadDiffRouteSearchOptions,
   component: ChatThreadRouteView,
 });

--- a/apps/web/src/threadRouteSearch.test.ts
+++ b/apps/web/src/threadRouteSearch.test.ts
@@ -1,0 +1,38 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { describe, expect, it } from "vitest";
+
+import { stripDiffSearchParams, threadDiffRouteSearchOptions } from "./diffRouteSearch";
+
+describe("thread route diff search state", () => {
+  it("allows removing diff params from the active thread route", async () => {
+    const threadId = "thread-route-search-test";
+    const rootRoute = createRootRoute();
+    const threadRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "$threadId",
+      ...threadDiffRouteSearchOptions,
+      component: () => null,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([threadRoute]),
+      history: createMemoryHistory({
+        initialEntries: [`/${threadId}?diff=1&diffTurnId=turn-1&diffFilePath=src/app.ts`],
+      }),
+    });
+
+    await router.load();
+    await router.navigate({
+      to: "/$threadId",
+      params: { threadId },
+      search: (previous) => stripDiffSearchParams(previous),
+    });
+
+    expect(router.state.location.search).toEqual({});
+    expect(router.state.location.href).toBe(`/${threadId}`);
+  });
+});


### PR DESCRIPTION
## Summary

This also targets the diff-panel close bug addressed in #937. I noticed that PR after preparing this one, so if that approach is preferred this PR can be closed.

This affects both browser and desktop builds because the diff panel state is driven by the same web route/search logic.

This version differs in two ways:

- it clears the full diff route state on close, not just `diff`
- it adds a focused regression test for removing diff search state from the active thread route

Closes #931
Closes #935

## Repro

1. Open a thread.
2. Open the diff panel.
3. Try to close it with the close button.
4. On narrow layouts, try dismissing it by clicking the overlay.

## Actual on `main`

The route keeps `diff=1`, so the diff panel does not really close.

## Root Cause

The thread route retains the `diff` search param at the route level, so explicit close navigation that strips diff params is immediately overridden by retained search state.

## What This Changes

- removes route-level diff search retention from the thread route
- keeps shared diff search validation through the thread route search options
- adds a regression test proving `stripDiffSearchParams(previous)` removes diff route state from the active thread route

## Why This Differs From #937

#937 fixes the stuck-open symptom by unsetting `diff`, but leaves `diffTurnId` and `diffFilePath` behind.

This PR clears all diff route params on close, which keeps the URL and route state fully in sync after dismissing the panel.

## Testing

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test -- src/threadRouteSearch.test.ts`
- manually verified on `main` that:
  - close button does not close the diff panel
  - overlay dismiss does not close the diff panel on narrow layouts
- manually verified on this branch that both close paths work
