### PR TITLE
fix(desktop): show dialog after "Check for Updates" menu action

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -535,7 +535,28 @@ function handleCheckForUpdatesMenuClick(): void {
   if (!BrowserWindow.getAllWindows().length) {
     mainWindow = createWindow();
   }
-  void checkForUpdates("menu");
+  void checkForUpdatesFromMenu();
+}
+
+async function checkForUpdatesFromMenu(): Promise<void> {
+  await checkForUpdates("menu");
+
+  if (updateState.status === "up-to-date") {
+    void dialog.showMessageBox({
+      type: "info",
+      title: "You're up to date!",
+      message: `T3 Code ${updateState.currentVersion} is currently the newest version available.`,
+      buttons: ["OK"],
+    });
+  } else if (updateState.status === "error") {
+    void dialog.showMessageBox({
+      type: "warning",
+      title: "Update check failed",
+      message: "Could not check for updates.",
+      detail: updateState.message ?? "An unknown error occurred. Please try again later.",
+      buttons: ["OK"],
+    });
+  }
 }
 
 function configureApplicationMenu(): void {


### PR DESCRIPTION
Fixes #954 — also addresses the root cause behind #359, which was closed with a workaround (install from `.zip` instead of `.dmg`) that does not resolve the issue. The installation method is irrelevant — the problem is that `handleCheckForUpdatesMenuClick()` discards the check result, so there is no feedback path regardless of how the app was installed.

## What Changed

Extracted the menu-triggered update check into `checkForUpdatesFromMenu()`, which awaits the result and shows a native dialog:

- **"You're up to date!"** — when `electron-updater` reports no newer version
- **"Update check failed"** — with the error detail when the check errors

The existing fire-and-forget codepath for startup/poll checks is unchanged.

## Why

The sidebar rocket button only appears for actionable states (`available`, `downloading`, `downloaded`). The `checking` and `up-to-date` states are intentionally hidden in the sidebar, which means menu-triggered checks have no visible feedback path. Users have been reporting this as "Check for Updates does nothing" since v0.0.3 (#359). This brings the behavior in line with standard macOS conventions (VS Code, Chrome, etc.).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] N/A — no UI changes beyond the native OS dialog
- [x] N/A — no animation/interaction changes