### PR TITLE
fix(web): prefer desktop runtime version in desktop UI

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -29,7 +29,6 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   DEFAULT_RUNTIME_MODE,
   DEFAULT_MODEL_BY_PROVIDER,
-  type DesktopUpdateState,
   ProjectId,
   ThreadId,
   type GitStatusResult,
@@ -39,7 +38,8 @@ import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/rea
 import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import { useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
-import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
+import { APP_STAGE_LABEL } from "../branding";
+import { resolveDisplayedAppVersion, useDesktopUpdateState } from "../hooks/useDesktopUpdateState";
 import { isMacPlatform, newCommandId, newProjectId, newThreadId } from "../lib/utils";
 import { useStore } from "../store";
 import { isChatNewLocalShortcut, isChatNewShortcut, shortcutLabelForCommand } from "../keybindings";
@@ -301,7 +301,7 @@ export default function Sidebar() {
   const renamingInputRef = useRef<HTMLInputElement | null>(null);
   const dragInProgressRef = useRef(false);
   const suppressProjectClickAfterDragRef = useRef(false);
-  const [desktopUpdateState, setDesktopUpdateState] = useState<DesktopUpdateState | null>(null);
+  const desktopUpdateState = useDesktopUpdateState();
   const selectedThreadIds = useThreadSelectionStore((s) => s.selectedThreadIds);
   const toggleThreadSelection = useThreadSelectionStore((s) => s.toggleThread);
   const rangeSelectTo = useThreadSelectionStore((s) => s.rangeSelectTo);
@@ -1078,40 +1078,11 @@ export default function Sidebar() {
     threads,
   ]);
 
-  useEffect(() => {
-    if (!isElectron) return;
-    const bridge = window.desktopBridge;
-    if (
-      !bridge ||
-      typeof bridge.getUpdateState !== "function" ||
-      typeof bridge.onUpdateState !== "function"
-    ) {
-      return;
-    }
-
-    let disposed = false;
-    let receivedSubscriptionUpdate = false;
-    const unsubscribe = bridge.onUpdateState((nextState) => {
-      if (disposed) return;
-      receivedSubscriptionUpdate = true;
-      setDesktopUpdateState(nextState);
-    });
-
-    void bridge
-      .getUpdateState()
-      .then((nextState) => {
-        if (disposed || receivedSubscriptionUpdate) return;
-        setDesktopUpdateState(nextState);
-      })
-      .catch(() => undefined);
-
-    return () => {
-      disposed = true;
-      unsubscribe();
-    };
-  }, []);
-
   const showDesktopUpdateButton = isElectron && shouldShowDesktopUpdateButton(desktopUpdateState);
+  const displayedAppVersion = resolveDisplayedAppVersion({
+    desktopUpdateState,
+    isDesktopRuntime: isElectron,
+  });
 
   const desktopUpdateTooltip = desktopUpdateState
     ? getDesktopUpdateButtonTooltip(desktopUpdateState)
@@ -1239,7 +1210,7 @@ export default function Sidebar() {
           }
         />
         <TooltipPopup side="bottom" sideOffset={2}>
-          Version {APP_VERSION}
+          Version {displayedAppVersion}
         </TooltipPopup>
       </Tooltip>
     </div>

--- a/apps/web/src/hooks/useDesktopUpdateState.test.ts
+++ b/apps/web/src/hooks/useDesktopUpdateState.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { DesktopUpdateState } from "@t3tools/contracts";
+
+import { resolveDisplayedAppVersion } from "./useDesktopUpdateState";
+
+const baseDesktopUpdateState: DesktopUpdateState = {
+  enabled: true,
+  status: "up-to-date",
+  currentVersion: "0.0.11",
+  hostArch: "arm64",
+  appArch: "arm64",
+  runningUnderArm64Translation: false,
+  availableVersion: null,
+  downloadedVersion: null,
+  downloadPercent: null,
+  checkedAt: null,
+  message: null,
+  errorContext: null,
+  canRetry: false,
+};
+
+describe("resolveDisplayedAppVersion", () => {
+  it("keeps the fallback version outside desktop runtime", () => {
+    expect(
+      resolveDisplayedAppVersion({
+        desktopUpdateState: baseDesktopUpdateState,
+        fallbackVersion: "0.0.10",
+        isDesktopRuntime: false,
+      }),
+    ).toBe("0.0.10");
+  });
+
+  it("prefers the desktop runtime version when available", () => {
+    expect(
+      resolveDisplayedAppVersion({
+        desktopUpdateState: baseDesktopUpdateState,
+        fallbackVersion: "0.0.10",
+        isDesktopRuntime: true,
+      }),
+    ).toBe("0.0.11");
+  });
+
+  it("falls back when the runtime state is missing", () => {
+    expect(
+      resolveDisplayedAppVersion({
+        desktopUpdateState: null,
+        fallbackVersion: "0.0.10",
+        isDesktopRuntime: true,
+      }),
+    ).toBe("0.0.10");
+  });
+});

--- a/apps/web/src/hooks/useDesktopUpdateState.ts
+++ b/apps/web/src/hooks/useDesktopUpdateState.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+import type { DesktopUpdateState } from "@t3tools/contracts";
+
+import { APP_VERSION } from "../branding";
+import { isElectron } from "../env";
+
+interface ResolveDisplayedAppVersionInput {
+  readonly desktopUpdateState: DesktopUpdateState | null;
+  readonly fallbackVersion?: string;
+  readonly isDesktopRuntime: boolean;
+}
+
+export function resolveDisplayedAppVersion({
+  desktopUpdateState,
+  fallbackVersion = APP_VERSION,
+  isDesktopRuntime,
+}: ResolveDisplayedAppVersionInput): string {
+  if (!isDesktopRuntime) {
+    return fallbackVersion;
+  }
+
+  const runtimeVersion = desktopUpdateState?.currentVersion.trim();
+  return runtimeVersion && runtimeVersion.length > 0 ? runtimeVersion : fallbackVersion;
+}
+
+export function useDesktopUpdateState(): DesktopUpdateState | null {
+  const [desktopUpdateState, setDesktopUpdateState] = useState<DesktopUpdateState | null>(null);
+
+  useEffect(() => {
+    if (!isElectron) return;
+    const bridge = window.desktopBridge;
+    if (
+      !bridge ||
+      typeof bridge.getUpdateState !== "function" ||
+      typeof bridge.onUpdateState !== "function"
+    ) {
+      return;
+    }
+
+    let disposed = false;
+    let receivedSubscriptionUpdate = false;
+    const unsubscribe = bridge.onUpdateState((nextState) => {
+      if (disposed) return;
+      receivedSubscriptionUpdate = true;
+      setDesktopUpdateState(nextState);
+    });
+
+    void bridge
+      .getUpdateState()
+      .then((nextState) => {
+        if (disposed || receivedSubscriptionUpdate) return;
+        setDesktopUpdateState(nextState);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, []);
+
+  return desktopUpdateState;
+}

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -6,6 +6,7 @@ import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 
 import { MAX_CUSTOM_MODEL_LENGTH, useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
+import { resolveDisplayedAppVersion, useDesktopUpdateState } from "../hooks/useDesktopUpdateState";
 import { useTheme } from "../hooks/useTheme";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { ensureNativeApi } from "../nativeApi";
@@ -13,7 +14,6 @@ import { preferredTerminalEditor } from "../terminal-links";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Switch } from "../components/ui/switch";
-import { APP_VERSION } from "../branding";
 import { SidebarInset } from "~/components/ui/sidebar";
 
 const THEME_OPTIONS = [
@@ -84,6 +84,7 @@ function SettingsRouteView() {
   const { theme, setTheme, resolvedTheme } = useTheme();
   const { settings, defaults, updateSettings } = useAppSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const desktopUpdateState = useDesktopUpdateState();
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);
   const [openKeybindingsError, setOpenKeybindingsError] = useState<string | null>(null);
   const [customModelInputByProvider, setCustomModelInputByProvider] = useState<
@@ -98,6 +99,10 @@ function SettingsRouteView() {
   const codexBinaryPath = settings.codexBinaryPath;
   const codexHomePath = settings.codexHomePath;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
+  const displayedAppVersion = resolveDisplayedAppVersion({
+    desktopUpdateState,
+    isDesktopRuntime: isElectron,
+  });
 
   const openKeybindingsFile = useCallback(() => {
     if (!keybindingsConfigPath) return;
@@ -573,7 +578,9 @@ function SettingsRouteView() {
                     Current version of the application.
                   </p>
                 </div>
-                <code className="text-xs font-medium text-muted-foreground">{APP_VERSION}</code>
+                <code className="text-xs font-medium text-muted-foreground">
+                  {displayedAppVersion}
+                </code>
               </div>
             </section>
           </div>


### PR DESCRIPTION
Closes #947

Follow-up to #720.

## What Changed

- Prefer `desktopUpdateState.currentVersion` over `APP_VERSION` when running under Electron
- Reuse a shared `useDesktopUpdateState` hook in both the sidebar and Settings
- Keep `APP_VERSION` as the fallback for normal browser usage

## Why

The desktop UI was showing the web bundle version instead of the installed desktop runtime version.

This keeps the fix scoped to display logic only. No updater behavior or install flow changed.

## UI Changes

Affected UI:
- sidebar version tooltip
- Settings > About

Before:
- See #947 for the stale version example reported by users.

After:
- The same UI now shows the desktop runtime's current version when running in Electron.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --cwd apps/web test src/hooks/useDesktopUpdateState.test.ts`

## Context

- #720 added the version display
- #928 reported the stale version symptom on v0.0.10

## Validation

- [ ] This PR is small and focused
- [ ] I explained what changed and why


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show desktop runtime app version in sidebar and settings version display
> - Extracts desktop update state management into a `useDesktopUpdateState` hook in [`useDesktopUpdateState.ts`](https://github.com/pingdotgg/t3code/pull/957/files#diff-1d3126c4acb7f16ca4715bbc91be727ae7880175b14be57520e5e723e31de422), replacing inline `useEffect` logic in the sidebar.
> - Adds `resolveDisplayedAppVersion` to return the runtime-reported version when running in Electron, or the build-time `APP_VERSION` as a fallback.
> - Updates both the sidebar version tooltip ([`Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/957/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1)) and the settings page version field ([`_chat.settings.tsx`](https://github.com/pingdotgg/t3code/pull/957/files#diff-0707e8295d0df761e405e66f02211b55d56c6eaea1ac3cb99562525a9c589cc6)) to use this resolved version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eea2d83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->