### PR TITLE
fix: fix logo aligment regression on macOS

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1227,7 +1227,7 @@ export default function Sidebar() {
       <Tooltip>
         <TooltipTrigger
           render={
-            <div className="flex min-w-0 flex-1 items-center gap-1 mt-1.5 ml-1 cursor-pointer">
+            <div className="flex min-w-0 flex-1 items-center gap-1 ml-1 cursor-pointer">
               <T3Wordmark />
               <span className="truncate text-sm font-medium tracking-tight text-muted-foreground">
                 Code


### PR DESCRIPTION
## What Changed

This is a fix for a regression of #586. The alignment appears to have regressed at or around a6b22ec1c9b247536111dd2c2e8682f9b3f550c5. Honestly, it would be nice to tie these things together more directly, but it's a bit of a niche thing and would likely only work with something like `position: absolute`, which is its own set of issues.

## Why

The logo should be aligned the traffic lights on macOS (as evidenced by the original PR merging).

## UI Changes

### Before

<img width="234" height="39" alt="Screenshot 2026-03-12 at 03 13 15" src="https://github.com/user-attachments/assets/4ca22e10-563b-4b2d-b498-9437aa387af2" />

### After

<img width="234" height="39" alt="Screenshot 2026-03-12 at 03 14 20" src="https://github.com/user-attachments/assets/9bc36483-4563-4773-bc32-edf7c291543c" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] ~I included a video for animation/interaction changes~


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix logo alignment regression in sidebar on macOS
> Removes the `mt-1.5` top margin from the wordmark container div in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/960/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), restoring correct vertical positioning of the logo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb66767.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->