### PR TITLE
fix(web): surface fatal bootstrap snapshot failure

### DIFF
--- a/apps/web/src/routes/-__root.browser.tsx
+++ b/apps/web/src/routes/-__root.browser.tsx
@@ -1,0 +1,360 @@
+import "../index.css";
+
+import {
+  ORCHESTRATION_WS_METHODS,
+  type MessageId,
+  type OrchestrationReadModel,
+  type ProjectId,
+  type ServerConfig,
+  type ThreadId,
+  type WsWelcomePayload,
+  WS_CHANNELS,
+  WS_METHODS,
+} from "@t3tools/contracts";
+import { RouterProvider, createMemoryHistory } from "@tanstack/react-router";
+import { HttpResponse, http, ws } from "msw";
+import { setupWorker } from "msw/browser";
+import type { ReactNode } from "react";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { useComposerDraftStore } from "../composerDraftStore";
+import { getRouter } from "../router";
+import { useStore } from "../store";
+
+vi.mock("../components/DiffWorkerPoolProvider", () => ({
+  DiffWorkerPoolProvider: ({ children }: { children?: ReactNode }) => children ?? null,
+}));
+
+const THREAD_ID = "thread-bootstrap-recovery-test" as ThreadId;
+const PROJECT_ID = "project-1" as ProjectId;
+const NOW_ISO = "2026-03-04T12:00:00.000Z";
+const SNAPSHOT_ERROR_MESSAGE = "Projection snapshot failed: malformed persisted state.";
+
+interface TestFixture {
+  snapshot: OrchestrationReadModel;
+  serverConfig: ServerConfig;
+  welcome: WsWelcomePayload;
+}
+
+let fixture: TestFixture;
+let pushSequence = 1;
+let snapshotResponses: Array<"error" | "success"> = [];
+
+const wsLink = ws.link(/ws(s)?:\/\/.*/);
+
+function createBaseServerConfig(): ServerConfig {
+  return {
+    cwd: "/repo/project",
+    keybindingsConfigPath: "/repo/project/.t3code-keybindings.json",
+    keybindings: [],
+    issues: [],
+    providers: [
+      {
+        provider: "codex",
+        status: "ready",
+        available: true,
+        authStatus: "authenticated",
+        checkedAt: NOW_ISO,
+      },
+    ],
+    availableEditors: [],
+  };
+}
+
+function createMinimalSnapshot(): OrchestrationReadModel {
+  return {
+    snapshotSequence: 1,
+    projects: [
+      {
+        id: PROJECT_ID,
+        title: "Project",
+        workspaceRoot: "/repo/project",
+        defaultModel: "gpt-5",
+        scripts: [],
+        createdAt: NOW_ISO,
+        updatedAt: NOW_ISO,
+        deletedAt: null,
+      },
+    ],
+    threads: [
+      {
+        id: THREAD_ID,
+        projectId: PROJECT_ID,
+        title: "Test thread",
+        model: "gpt-5",
+        interactionMode: "default",
+        runtimeMode: "full-access",
+        branch: "main",
+        worktreePath: null,
+        latestTurn: null,
+        createdAt: NOW_ISO,
+        updatedAt: NOW_ISO,
+        deletedAt: null,
+        messages: [
+          {
+            id: "msg-1" as MessageId,
+            role: "user",
+            text: "hello",
+            turnId: null,
+            streaming: false,
+            createdAt: NOW_ISO,
+            updatedAt: NOW_ISO,
+          },
+        ],
+        activities: [],
+        proposedPlans: [],
+        checkpoints: [],
+        session: {
+          threadId: THREAD_ID,
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "full-access",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: NOW_ISO,
+        },
+      },
+    ],
+    updatedAt: NOW_ISO,
+  };
+}
+
+function buildFixture(): TestFixture {
+  return {
+    snapshot: createMinimalSnapshot(),
+    serverConfig: createBaseServerConfig(),
+    welcome: {
+      cwd: "/repo/project",
+      projectName: "Project",
+      bootstrapProjectId: PROJECT_ID,
+      bootstrapThreadId: THREAD_ID,
+    },
+  };
+}
+
+function resolveWsRpc(tag: string): unknown {
+  if (tag === WS_METHODS.serverGetConfig) {
+    return fixture.serverConfig;
+  }
+  if (tag === WS_METHODS.gitListBranches) {
+    return {
+      isRepo: true,
+      hasOriginRemote: true,
+      branches: [{ name: "main", current: true, isDefault: true, worktreePath: null }],
+    };
+  }
+  if (tag === WS_METHODS.gitStatus) {
+    return {
+      branch: "main",
+      hasWorkingTreeChanges: false,
+      workingTree: { files: [], insertions: 0, deletions: 0 },
+      hasUpstream: true,
+      aheadCount: 0,
+      behindCount: 0,
+      pr: null,
+    };
+  }
+  if (tag === WS_METHODS.projectsSearchEntries) {
+    return { entries: [], truncated: false };
+  }
+  return {};
+}
+
+const worker = setupWorker(
+  wsLink.addEventListener("connection", ({ client }) => {
+    pushSequence = 1;
+    client.send(
+      JSON.stringify({
+        type: "push",
+        sequence: pushSequence++,
+        channel: WS_CHANNELS.serverWelcome,
+        data: fixture.welcome,
+      }),
+    );
+    client.addEventListener("message", (event) => {
+      const rawData = event.data;
+      if (typeof rawData !== "string") return;
+      let request: { id: string; body: { _tag: string; [key: string]: unknown } };
+      try {
+        request = JSON.parse(rawData);
+      } catch {
+        return;
+      }
+      const method = request.body?._tag;
+      if (typeof method !== "string") return;
+
+      if (method === ORCHESTRATION_WS_METHODS.getSnapshot) {
+        const responseMode = snapshotResponses.shift() ?? "success";
+        client.send(
+          JSON.stringify(
+            responseMode === "error"
+              ? {
+                  id: request.id,
+                  error: {
+                    message: SNAPSHOT_ERROR_MESSAGE,
+                  },
+                }
+              : {
+                  id: request.id,
+                  result: fixture.snapshot,
+                },
+          ),
+        );
+        return;
+      }
+
+      client.send(
+        JSON.stringify({
+          id: request.id,
+          result: resolveWsRpc(method),
+        }),
+      );
+    });
+  }),
+  http.get("*/attachments/:attachmentId", () => new HttpResponse(null, { status: 204 })),
+  http.get("*/api/project-favicon", () => new HttpResponse(null, { status: 204 })),
+);
+
+async function waitForElement<T extends Element>(
+  query: () => T | null,
+  errorMessage: string,
+): Promise<T> {
+  let element: T | null = null;
+  await vi.waitFor(
+    () => {
+      element = query();
+      expect(element, errorMessage).toBeTruthy();
+    },
+    { timeout: 8_000, interval: 16 },
+  );
+  return element!;
+}
+
+async function waitForComposerEditor(): Promise<HTMLElement> {
+  return waitForElement(
+    () => document.querySelector<HTMLElement>('[data-testid="composer-editor"]'),
+    "App should render composer editor",
+  );
+}
+
+async function waitForNoComposerEditor(): Promise<void> {
+  await vi.waitFor(
+    () => {
+      expect(document.querySelector('[data-testid="composer-editor"]')).toBeNull();
+    },
+    { timeout: 4_000, interval: 16 },
+  );
+}
+
+async function waitForRecoveryView(): Promise<HTMLElement> {
+  return waitForElement(
+    () => document.querySelector<HTMLElement>('[data-testid="initial-snapshot-recovery"]'),
+    "Expected initial snapshot recovery view",
+  );
+}
+
+async function waitForButton(label: string): Promise<HTMLButtonElement> {
+  return waitForElement(
+    () =>
+      Array.from(document.querySelectorAll("button")).find((button) =>
+        button.textContent?.includes(label),
+      ) ?? null,
+    `Expected button "${label}"`,
+  );
+}
+
+async function mountApp(): Promise<{ cleanup: () => Promise<void> }> {
+  const host = document.createElement("div");
+  host.style.position = "fixed";
+  host.style.inset = "0";
+  host.style.width = "100vw";
+  host.style.height = "100vh";
+  host.style.display = "grid";
+  host.style.overflow = "hidden";
+  document.body.append(host);
+
+  const router = getRouter(createMemoryHistory({ initialEntries: [`/${THREAD_ID}`] }));
+  const screen = await render(<RouterProvider router={router} />, { container: host });
+
+  return {
+    cleanup: async () => {
+      await screen.unmount();
+      host.remove();
+    },
+  };
+}
+
+describe("Initial snapshot recovery", () => {
+  beforeAll(async () => {
+    fixture = buildFixture();
+    await worker.start({
+      onUnhandledRequest: "bypass",
+      quiet: true,
+      serviceWorker: { url: "/mockServiceWorker.js" },
+    });
+  });
+
+  afterAll(async () => {
+    await worker.stop();
+  });
+
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = "";
+    pushSequence = 1;
+    snapshotResponses = [];
+    useComposerDraftStore.setState({
+      draftsByThreadId: {},
+      draftThreadsByThreadId: {},
+      projectDraftThreadIdByProjectId: {},
+    });
+    useStore.setState({
+      projects: [],
+      threads: [],
+      threadsHydrated: false,
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders a blocking recovery view when the initial snapshot fails", async () => {
+    snapshotResponses = ["error"];
+    const mounted = await mountApp();
+
+    try {
+      const recoveryView = await waitForRecoveryView();
+      expect(recoveryView.textContent).toContain("Couldn't load app state.");
+      expect(recoveryView.textContent).toContain("T3CODE_STATE_DIR");
+      expect(recoveryView.textContent).toContain("CODEX_HOME");
+      expect(recoveryView.textContent).toContain(SNAPSHOT_ERROR_MESSAGE);
+      await waitForButton("Retry snapshot");
+      await waitForNoComposerEditor();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("recovers after retrying a failed initial snapshot", async () => {
+    snapshotResponses = ["error", "success"];
+    const mounted = await mountApp();
+
+    try {
+      await waitForRecoveryView();
+      const retryButton = await waitForButton("Retry snapshot");
+      retryButton.click();
+
+      await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(document.querySelector('[data-testid="initial-snapshot-recovery"]')).toBeNull();
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+});

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import {
   useNavigate,
   useRouterState,
 } from "@tanstack/react-router";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, type MutableRefObject } from "react";
 import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import { Throttler } from "@tanstack/react-pacer";
 
@@ -36,6 +36,11 @@ export const Route = createRootRouteWithContext<{
 });
 
 function RootRouteView() {
+  const [hasLoadedInitialSnapshot, setHasLoadedInitialSnapshot] = useState(false);
+  const [initialSnapshotError, setInitialSnapshotError] = useState<unknown | null>(null);
+  const [isRetryingInitialSnapshot, setIsRetryingInitialSnapshot] = useState(false);
+  const retryInitialSnapshotRef = useRef<(() => Promise<boolean>) | null>(null);
+
   if (!readNativeApi()) {
     return (
       <div className="flex h-screen flex-col bg-background text-foreground">
@@ -51,11 +56,104 @@ function RootRouteView() {
   return (
     <ToastProvider>
       <AnchoredToastProvider>
-        <EventRouter />
-        <DesktopProjectBootstrap />
-        <Outlet />
+        <EventRouter
+          hasLoadedInitialSnapshot={hasLoadedInitialSnapshot}
+          setHasLoadedInitialSnapshot={setHasLoadedInitialSnapshot}
+          setInitialSnapshotError={setInitialSnapshotError}
+          retryInitialSnapshotRef={retryInitialSnapshotRef}
+        />
+        {initialSnapshotError ? (
+          <InitialSnapshotRecoveryView
+            error={initialSnapshotError}
+            isRetrying={isRetryingInitialSnapshot}
+            onRetry={() => {
+              const retryInitialSnapshot = retryInitialSnapshotRef.current;
+              if (!retryInitialSnapshot) {
+                return Promise.resolve();
+              }
+
+              setIsRetryingInitialSnapshot(true);
+              return retryInitialSnapshot()
+                .then(() => undefined)
+                .finally(() => {
+                  setIsRetryingInitialSnapshot(false);
+                });
+            }}
+          />
+        ) : (
+          <>
+            <DesktopProjectBootstrap />
+            <Outlet />
+          </>
+        )}
       </AnchoredToastProvider>
     </ToastProvider>
+  );
+}
+
+function InitialSnapshotRecoveryView(props: {
+  error: unknown;
+  isRetrying: boolean;
+  onRetry: () => Promise<void>;
+}) {
+  const message = errorMessage(props.error);
+  const details = errorDetails(props.error);
+
+  return (
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">
+      <div className="pointer-events-none absolute inset-0 opacity-80">
+        <div className="absolute inset-x-0 top-0 h-44 bg-[radial-gradient(44rem_16rem_at_top,color-mix(in_srgb,var(--color-red-500)_16%,transparent),transparent)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(145deg,color-mix(in_srgb,var(--background)_90%,var(--color-black))_0%,var(--background)_55%)]" />
+      </div>
+
+      <section
+        className="relative w-full max-w-xl rounded-2xl border border-border/80 bg-card/90 p-6 shadow-2xl shadow-black/20 backdrop-blur-md sm:p-8"
+        data-testid="initial-snapshot-recovery"
+      >
+        <p className="text-[11px] font-semibold tracking-[0.18em] text-muted-foreground uppercase">
+          {APP_DISPLAY_NAME}
+        </p>
+        <h1 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">
+          Couldn&apos;t load app state.
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          T3 Code could not load its initial state from persisted data. This can happen if
+          `T3CODE_STATE_DIR`, `CODEX_HOME`, or other saved app state has become invalid or
+          corrupted.
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{message}</p>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          Retry the snapshot load first. If the problem keeps happening, reload the app and retry
+          with a fresh `T3CODE_STATE_DIR`. If provider runtime state may be involved, also retry
+          with a fresh `CODEX_HOME`.
+        </p>
+
+        <div className="mt-5 flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            disabled={props.isRetrying}
+            onClick={() => {
+              void props.onRetry();
+            }}
+          >
+            {props.isRetrying ? "Retrying snapshot..." : "Retry snapshot"}
+          </Button>
+          <Button size="sm" variant="outline" onClick={() => window.location.reload()}>
+            Reload app
+          </Button>
+        </div>
+
+        <details className="group mt-5 overflow-hidden rounded-lg border border-border/70 bg-background/55">
+          <summary className="cursor-pointer list-none px-3 py-2 text-xs font-medium text-muted-foreground">
+            <span className="group-open:hidden">Show error details</span>
+            <span className="hidden group-open:inline">Hide error details</span>
+          </summary>
+          <pre className="max-h-56 overflow-auto border-t border-border/70 bg-background/80 px-3 py-2 text-xs text-foreground/85">
+            {details}
+          </pre>
+        </details>
+      </section>
+    </div>
   );
 }
 
@@ -130,7 +228,17 @@ function errorDetails(error: unknown): string {
   }
 }
 
-function EventRouter() {
+function EventRouter({
+  hasLoadedInitialSnapshot,
+  setHasLoadedInitialSnapshot,
+  setInitialSnapshotError,
+  retryInitialSnapshotRef,
+}: {
+  hasLoadedInitialSnapshot: boolean;
+  setHasLoadedInitialSnapshot: (loaded: boolean) => void;
+  setInitialSnapshotError: (error: unknown | null) => void;
+  retryInitialSnapshotRef: MutableRefObject<(() => Promise<boolean>) | null>;
+}) {
   const syncServerReadModel = useStore((store) => store.syncServerReadModel);
   const setProjectExpanded = useStore((store) => store.setProjectExpanded);
   const removeOrphanedTerminalStates = useTerminalStateStore(
@@ -141,8 +249,10 @@ function EventRouter() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const pathnameRef = useRef(pathname);
   const handledBootstrapThreadIdRef = useRef<string | null>(null);
+  const hasLoadedInitialSnapshotRef = useRef(hasLoadedInitialSnapshot);
 
   pathnameRef.current = pathname;
+  hasLoadedInitialSnapshotRef.current = hasLoadedInitialSnapshot;
 
   useEffect(() => {
     const api = readNativeApi();
@@ -156,6 +266,9 @@ function EventRouter() {
     const flushSnapshotSync = async (): Promise<void> => {
       const snapshot = await api.orchestration.getSnapshot();
       if (disposed) return;
+      hasLoadedInitialSnapshotRef.current = true;
+      setHasLoadedInitialSnapshot(true);
+      setInitialSnapshotError(null);
       latestSequence = Math.max(latestSequence, snapshot.snapshotSequence);
       syncServerReadModel(snapshot);
       clearPromotedDraftThreads(new Set(snapshot.threads.map((t) => t.id)));
@@ -173,19 +286,32 @@ function EventRouter() {
       }
     };
 
-    const syncSnapshot = async () => {
+    const syncSnapshot = async (): Promise<boolean> => {
       if (syncing) {
         pending = true;
-        return;
+        return hasLoadedInitialSnapshotRef.current;
       }
       syncing = true;
       pending = false;
       try {
         await flushSnapshotSync();
-      } catch {
+        return true;
+      } catch (error) {
+        if (!hasLoadedInitialSnapshotRef.current) {
+          setInitialSnapshotError(error);
+          return false;
+        }
+
         // Keep prior state and wait for next domain event to trigger a resync.
+        return true;
+      } finally {
+        syncing = false;
       }
-      syncing = false;
+    };
+
+    retryInitialSnapshotRef.current = syncSnapshot;
+    const clearRetryInitialSnapshot = () => {
+      retryInitialSnapshotRef.current = null;
     };
 
     const domainEventFlushThrottler = new Throttler(
@@ -231,8 +357,11 @@ function EventRouter() {
     });
     const unsubWelcome = onServerWelcome((payload) => {
       void (async () => {
-        await syncSnapshot();
+        const synced = await syncSnapshot();
         if (disposed) {
+          return;
+        }
+        if (!synced) {
           return;
         }
 
@@ -305,11 +434,16 @@ function EventRouter() {
       unsubTerminalEvent();
       unsubWelcome();
       unsubServerConfigUpdated();
+      clearRetryInitialSnapshot();
     };
   }, [
+    hasLoadedInitialSnapshot,
     navigate,
     queryClient,
     removeOrphanedTerminalStates,
+    retryInitialSnapshotRef,
+    setHasLoadedInitialSnapshot,
+    setInitialSnapshotError,
     setProjectExpanded,
     syncServerReadModel,
   ]);

--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -18,6 +18,7 @@ export default mergeConfig(
       include: [
         "src/components/ChatView.browser.tsx",
         "src/components/KeybindingsToast.browser.tsx",
+        "src/routes/-__root.browser.tsx",
       ],
       browser: {
         enabled: true,


### PR DESCRIPTION
Refs #961

## Summary

- surface fatal initial `orchestration.getSnapshot()` bootstrap failure instead of swallowing it
- render a blocking recovery view with `Retry snapshot`, `Reload app`, and expandable error details
- keep later snapshot resync failures unchanged

## Why

Today the first snapshot load can fail silently, which can leave the app unusable with no diagnosis or recovery path.

This PR keeps the fix tightly scoped to the initial web bootstrap path only.

## Non-goals

- no reset or clear-state UX
- no provider runtime hardening
- no Codex resume fallback widening
- no server contract changes

## UI Change

When the first snapshot load fails before any successful snapshot has loaded, the app now shows a blocking recovery view that mentions persisted state broadly (`T3CODE_STATE_DIR`, `CODEX_HOME`, or other saved app state), exposes the backend error details, and allows retrying without reload.

## Validation

- `bun run test:browser src/routes/-__root.browser.tsx`
- `bun fmt`
- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show blocking recovery view when initial orchestration snapshot fails to load
> - `EventRouter` in [`__root.tsx`](https://github.com/pingdotgg/t3code/pull/964/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) now tracks whether the first `getSnapshot` call succeeded; on failure it sets an error state and defers bootstrap navigation until a successful retry.
> - A new `InitialSnapshotRecoveryView` component renders a blocking UI with the error details and buttons to retry the snapshot or reload the app.
> - Adds browser tests in [`-__root.browser.tsx`](https://github.com/pingdotgg/t3code/pull/964/files#diff-e6205b04803147fc68e6eedc6bb41baeb23fa3a51794c9e10848b41e0f1443a3) using MSW WebSocket/HTTP mocks to verify the recovery view appears on failure and disappears after a successful retry.
> - Behavioral Change: before this change, a failed initial snapshot would leave the app in a broken/partial state; it now renders a dedicated recovery screen instead of the main UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b196590.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->