### PR TITLE
fix:diff panel doesnt collapse

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -36,11 +36,7 @@ import { gitBranchesQueryOptions, gitCreateWorktreeMutationOptions } from "~/lib
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
 import { isElectron } from "../env";
-import {
-  closeDiffSearchParams,
-  parseDiffRouteSearch,
-  stripDiffSearchParams,
-} from "../diffRouteSearch";
+import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import {
   type ComposerTrigger,
   detectComposerTrigger,

--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -1,14 +1,6 @@
-import { stripSearchParams } from "@tanstack/react-router";
-import { TurnId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import {
-  closeDiffSearchParams,
-  type DiffRouteSearchNavigation,
-  parseDiffRouteSearch,
-  parseDiffRouteSearchNavigation,
-  retainDiffSearchParams,
-} from "./diffRouteSearch";
+import { parseDiffRouteSearch } from "./diffRouteSearch";
 
 describe("parseDiffRouteSearch", () => {
   it("parses valid diff search values", () => {
@@ -78,57 +70,5 @@ describe("parseDiffRouteSearch", () => {
     expect(parsed).toEqual({
       diff: "1",
     });
-  });
-
-  it("builds an explicit close navigation payload", () => {
-    expect(
-      closeDiffSearchParams({
-        diff: "1",
-        diffTurnId: TurnId.makeUnsafe("turn-1"),
-        diffFilePath: "src/app.ts",
-      }),
-    ).toEqual({
-      clearDiff: "1",
-    });
-  });
-
-  it("parses route control flags for navigation middleware", () => {
-    expect(
-      parseDiffRouteSearchNavigation({
-        clearDiff: "1",
-      }),
-    ).toEqual({
-      clearDiff: "1",
-    });
-  });
-
-  it("retains diff across navigations that do not touch diff state", () => {
-    expect(
-      retainDiffSearchParams({
-        search: {
-          diff: "1",
-        },
-        next: () => ({}),
-      }),
-    ).toEqual({
-      diff: "1",
-    });
-  });
-
-  it("does not reinsert diff when navigation explicitly clears it", () => {
-    const stripped = stripSearchParams<DiffRouteSearchNavigation>(["clearDiff"]);
-
-    const nextSearch = stripped({
-      search: {
-        diff: "1",
-      },
-      next: (search) =>
-        retainDiffSearchParams({
-          search,
-          next: () => closeDiffSearchParams(search),
-        }),
-    });
-
-    expect(nextSearch).toEqual({});
   });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -6,17 +6,7 @@ export interface DiffRouteSearch {
   diffFilePath?: string | undefined;
 }
 
-export interface DiffRouteSearchControls {
-  clearDiff?: "1";
-}
-
-export type DiffRouteSearchNavigation = DiffRouteSearch & DiffRouteSearchControls;
-
 function isDiffOpenValue(value: unknown): boolean {
-  return value === "1" || value === 1 || value === true;
-}
-
-function isClearDiffValue(value: unknown): boolean {
   return value === "1" || value === 1 || value === true;
 }
 
@@ -28,79 +18,22 @@ function normalizeSearchString(value: unknown): string | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
-export function stripDiffSearchParams<T extends object>(
+export function stripDiffSearchParams<T extends Record<string, unknown>>(
   params: T,
 ): Omit<T, "diff" | "diffTurnId" | "diffFilePath"> {
-  const {
-    diff: _diff,
-    diffTurnId: _diffTurnId,
-    diffFilePath: _diffFilePath,
-    ...rest
-  } = params as T & {
-    diff?: unknown;
-    diffTurnId?: unknown;
-    diffFilePath?: unknown;
-  };
+  const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, ...rest } = params;
   return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
 }
 
-export function closeDiffSearchParams<T extends object>(
-  params: T,
-): Omit<T, "diff" | "diffTurnId" | "diffFilePath"> & DiffRouteSearchControls {
-  return {
-    ...stripDiffSearchParams(params),
-    clearDiff: "1",
-  };
-}
-
-export function parseDiffRouteSearch(search: object): DiffRouteSearch {
-  const rawSearch = search as {
-    diff?: unknown;
-    diffTurnId?: unknown;
-    diffFilePath?: unknown;
-  };
-  const diff = isDiffOpenValue(rawSearch.diff) ? "1" : undefined;
-  const diffTurnIdRaw = diff ? normalizeSearchString(rawSearch.diffTurnId) : undefined;
+export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
+  const diff = isDiffOpenValue(search.diff) ? "1" : undefined;
+  const diffTurnIdRaw = diff ? normalizeSearchString(search.diffTurnId) : undefined;
   const diffTurnId = diffTurnIdRaw ? TurnId.makeUnsafe(diffTurnIdRaw) : undefined;
-  const diffFilePath =
-    diff && diffTurnId ? normalizeSearchString(rawSearch.diffFilePath) : undefined;
+  const diffFilePath = diff && diffTurnId ? normalizeSearchString(search.diffFilePath) : undefined;
 
   return {
     ...(diff ? { diff } : {}),
     ...(diffTurnId ? { diffTurnId } : {}),
     ...(diffFilePath ? { diffFilePath } : {}),
   };
-}
-
-export function parseDiffRouteSearchNavigation(search: object): DiffRouteSearchNavigation {
-  const rawSearch = search as {
-    clearDiff?: unknown;
-  };
-  const parsed = parseDiffRouteSearch(search);
-  const clearDiff = isClearDiffValue(rawSearch.clearDiff) ? "1" : undefined;
-
-  return {
-    ...parsed,
-    ...(clearDiff ? { clearDiff } : {}),
-  };
-}
-
-export function retainDiffSearchParams({
-  search,
-  next,
-}: {
-  search: DiffRouteSearchNavigation;
-  next: (newSearch: DiffRouteSearchNavigation) => DiffRouteSearchNavigation;
-}): DiffRouteSearchNavigation {
-  const result = next(search);
-
-  if (result.clearDiff === "1") {
-    return result;
-  }
-
-  if ("diff" in result) {
-    return result;
-  }
-
-  return search.diff ? { ...result, diff: search.diff } : result;
 }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

This PR fixes the diff panel so it can be closed again while keeping normal diff search-param retention behavior.

## Why

The chat route was re-retaining `diff=1` during close navigations, which caused the diff panel to immediately reopen instead of collapsing.

## UI Changes

N/A The expected behaviour was already working before, but it was broken a few days ago, so this is the PR to fix it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- N/A I included before/after screenshots for any UI changes
- N/A I included a video for animation/interaction changes\

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix collapsing diff panel by replacing diff param removal with a `clearDiff` signal
> - Previously, closing the diff panel removed the `diff` search param, but `retainSearchParams` would immediately re-add it on the next navigation, preventing the panel from actually closing.
> - Closing the diff now sets `clearDiff=1` in the URL instead of unsetting `diff`. A new `retainDiffUnlessCleared` middleware in [_chat.$threadId.tsx](https://github.com/pingdotgg/t3code/pull/992/files#diff-4ee19a4a6919608c555bdc4562ccba6ebb331bc0eec4d4d8c3be8543913c336e) carries the `diff` param forward across navigations unless `clearDiff` is present.
> - After the middleware processes the signal, `stripSearchParams(["clearDiff"])` removes `clearDiff` from the final URL so it doesn't persist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b71fc43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->