### PR TITLE
feat: replace worktree toggle with discoverable Select dropdown

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -13,6 +13,7 @@ import {
 } from "./BranchToolbar.logic";
 import { BranchToolbarBranchSelector } from "./BranchToolbarBranchSelector";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "./ui/select";
+import { Button } from "./ui/button";
 
 const envModeItems = [
   { value: "local", label: "Local" },
@@ -110,54 +111,50 @@ export default function BranchToolbar({
 
   return (
     <div className="mx-auto flex w-full max-w-3xl items-center justify-between px-5 pb-3 pt-1">
-      <div className="flex items-center gap-2">
-        {envLocked || activeWorktreePath ? (
-          <span className="inline-flex items-center gap-1.5 border border-transparent px-[calc(--spacing(2)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
-            {activeWorktreePath ? (
-              <>
-                <GitForkIcon className="size-3" />
-                Worktree
-              </>
+      {envLocked || activeWorktreePath ? (
+        <span className="inline-flex items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
+          {activeWorktreePath ? (
+            <>
+              <GitForkIcon className="size-3" />
+              Worktree
+            </>
+          ) : (
+            <>
+              <FolderIcon className="size-3" />
+              Local
+            </>
+          )}
+        </span>
+      ) : (
+        <Select
+          value={effectiveEnvMode}
+          onValueChange={(value) => onEnvModeChange(value as EnvMode)}
+          items={envModeItems}
+        >
+          <SelectTrigger variant="ghost" size="xs" className="font-medium">
+            {effectiveEnvMode === "worktree" ? (
+              <GitForkIcon className="size-3" />
             ) : (
-              <>
+              <FolderIcon className="size-3" />
+            )}
+            <SelectValue />
+          </SelectTrigger>
+          <SelectPopup>
+            <SelectItem value="local">
+              <span className="inline-flex items-center gap-1.5">
                 <FolderIcon className="size-3" />
                 Local
-              </>
-            )}
-          </span>
-        ) : (
-          <Select
-            value={effectiveEnvMode}
-            onValueChange={(value) => onEnvModeChange(value as EnvMode)}
-            items={envModeItems}
-          >
-            <SelectTrigger variant="ghost" size="sm">
-              <span className="inline-flex items-center gap-1.5">
-                {effectiveEnvMode === "worktree" ? (
-                  <GitForkIcon className="size-3" />
-                ) : (
-                  <FolderIcon className="size-3" />
-                )}
-                <SelectValue />
               </span>
-            </SelectTrigger>
-            <SelectPopup>
-              <SelectItem value="local">
-                <span className="inline-flex items-center gap-1.5">
-                  <FolderIcon className="size-3" />
-                  Local
-                </span>
-              </SelectItem>
-              <SelectItem value="worktree">
-                <span className="inline-flex items-center gap-1.5">
-                  <GitForkIcon className="size-3" />
-                  New worktree
-                </span>
-              </SelectItem>
-            </SelectPopup>
-          </Select>
-        )}
-      </div>
+            </SelectItem>
+            <SelectItem value="worktree">
+              <span className="inline-flex items-center gap-1.5">
+                <GitForkIcon className="size-3" />
+                New worktree
+              </span>
+            </SelectItem>
+          </SelectPopup>
+        </Select>
+      )}
 
       <BranchToolbarBranchSelector
         activeProjectCwd={activeProject.cwd}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -29,6 +29,7 @@ const selectTriggerVariants = cva(
         default: "min-h-9 px-[calc(--spacing(3)-1px)] sm:min-h-8",
         lg: "min-h-10 px-[calc(--spacing(3)-1px)] sm:min-h-9",
         sm: "min-h-8 gap-1.5 px-[calc(--spacing(2.5)-1px)] sm:min-h-7",
+        xs: "h-7 gap-1 rounded-md px-[calc(--spacing(2)-1px)] text-sm before:rounded-[calc(var(--radius-md)-1px)] sm:h-6 sm:text-xs [&_svg:not([class*='size-'])]:size-4 sm:[&_svg:not([class*='size-'])]:size-3.5",
       },
     },
   },


### PR DESCRIPTION
## What Changed

Replaced the hidden ghost button toggle for env mode (Local/Worktree) in the `BranchToolbar` with a proper `Select` dropdown using the existing `ui/select` component. Added `FolderIcon` and `GitForkIcon` icons to both the trigger and dropdown items. The locked/read-only state also now shows the matching icon.

## Why

The previous worktree toggle was a small, unstyled ghost button that looked like static text — users had no way to discover they could switch between Local and Worktree modes. A dropdown with a chevron indicator and icons makes the option immediately visible and self-explanatory.

## UI Changes

**Before:** A plain text button ("Local" / "New worktree") with no visual affordance — easy to miss entirely.
<img width="825" height="208" alt="image" src="https://github.com/user-attachments/assets/de42e2d0-a93d-4052-aac2-40decfed7d75" />

**After:** A Select dropdown with chevron indicator and mode-specific icons (folder for Local, git-fork for Worktree) that clearly communicates interactivity.
<img width="821" height="210" alt="image" src="https://github.com/user-attachments/assets/3e00c486-20e1-4650-9c11-68bd61b85175" />
<img width="802" height="124" alt="image" src="https://github.com/user-attachments/assets/0c72331f-6c68-4716-83e7-56901bd8a05c" />

**When in an existing thread**
<img width="807" height="453" alt="image" src="https://github.com/user-attachments/assets/b8e0d820-276b-4e4d-a5ac-3af9bc4d6ba7" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace worktree toggle with a Select dropdown in BranchToolbar
> - Replaces the ghost button/span toggle in [BranchToolbar.tsx](https://github.com/pingdotgg/t3code/pull/1001/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10) with a `Select` dropdown when the environment is unlocked and no worktree path is active, making mode selection more discoverable.
> - The dropdown is controlled by `effectiveEnvMode` and calls `onEnvModeChange` with the chosen `EnvMode`; locked or active-worktree states still render a static inline span, now with a contextual icon (`FolderIcon` / `GitForkIcon`).
> - Adds an `xs` size variant to [select.tsx](https://github.com/pingdotgg/t3code/pull/1001/files#diff-f8dc315356af4a3938a8bfea44f5cb369e197db435ab6b932a79253ad2844789) with compact height, padding, and font size to support the small trigger used in the toolbar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51556a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->