### PR TITLE
fix(web): guard terminal persistence when storage is unavailable

### DIFF
--- a/apps/web/src/terminalStateStore.test.ts
+++ b/apps/web/src/terminalStateStore.test.ts
@@ -4,12 +4,36 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { selectThreadTerminalState, useTerminalStateStore } from "./terminalStateStore";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-1");
+const storageBacking = new Map<string, string>();
+
+const storageMock: Storage = {
+  get length() {
+    return storageBacking.size;
+  },
+  clear() {
+    storageBacking.clear();
+  },
+  getItem(key) {
+    return storageBacking.get(key) ?? null;
+  },
+  key(index) {
+    return [...storageBacking.keys()][index] ?? null;
+  },
+  removeItem(key) {
+    storageBacking.delete(key);
+  },
+  setItem(key, value) {
+    storageBacking.set(key, value);
+  },
+};
 
 describe("terminalStateStore actions", () => {
   beforeEach(() => {
-    if (typeof localStorage !== "undefined") {
-      localStorage.clear();
-    }
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storageMock,
+    });
+    localStorage.clear();
     useTerminalStateStore.setState({ terminalStateByThreadId: {} });
   });
 

--- a/apps/web/src/terminalStateStore.ts
+++ b/apps/web/src/terminalStateStore.ts
@@ -27,6 +27,34 @@ interface ThreadTerminalState {
 
 const TERMINAL_STATE_STORAGE_KEY = "t3code:terminal-state:v1";
 
+const noopStorage: Storage = {
+  get length() {
+    return 0;
+  },
+  clear() {},
+  getItem() {
+    return null;
+  },
+  key() {
+    return null;
+  },
+  removeItem() {},
+  setItem() {},
+};
+
+function getTerminalStateStorage(): Storage {
+  const storage = globalThis.localStorage;
+  if (
+    storage &&
+    typeof storage.getItem === "function" &&
+    typeof storage.setItem === "function" &&
+    typeof storage.removeItem === "function"
+  ) {
+    return storage;
+  }
+  return noopStorage;
+}
+
 function normalizeTerminalIds(terminalIds: string[]): string[] {
   const ids = [...new Set(terminalIds.map((id) => id.trim()).filter((id) => id.length > 0))];
   return ids.length > 0 ? ids : [DEFAULT_THREAD_TERMINAL_ID];
@@ -542,7 +570,7 @@ export const useTerminalStateStore = create<TerminalStateStoreState>()(
     {
       name: TERMINAL_STATE_STORAGE_KEY,
       version: 1,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(getTerminalStateStorage),
       partialize: (state) => ({
         terminalStateByThreadId: state.terminalStateByThreadId,
       }),


### PR DESCRIPTION
## Summary
- guard the terminal Zustand persistence layer so it only uses `localStorage` when the runtime exposes the full storage API and otherwise falls back to a no-op storage backend
- stabilize `terminalStateStore` tests with an in-memory storage double so the suite exercises terminal behavior instead of runner-specific storage quirks
- document the root cause and verification details here so the fix stays focused without broad dependency churn

## Problem
On my local repro, the repo mostly validated cleanly after a reinstall, but `apps/web/src/terminalStateStore.test.ts` consistently failed under the current Bun/Vitest environment.

All 8 failures collapsed to the same persistence crash:

```text
TypeError: storage.setItem is not a function
```

The issue was not the terminal state logic itself. The problem was that the persisted Zustand store assumed `localStorage` was a complete Storage implementation whenever it existed. In this runtime, `localStorage` was present enough to be detected, but not complete enough for Zustand persistence to safely call `setItem`.

## Fix Details
- add `getTerminalStateStorage()` in `apps/web/src/terminalStateStore.ts` to validate the runtime storage shape before passing it into `createJSONStorage`
- return a no-op storage implementation when the runtime storage is missing or incomplete, which preserves app behavior while avoiding persistence crashes in unsupported environments
- replace the test's global storage assumptions with a deterministic in-memory storage mock in `apps/web/src/terminalStateStore.test.ts`

This keeps the fix intentionally narrow:
- no product behavior changes for normal browser environments
- no dependency upgrades or lockfile churn
- no unrelated web/store refactors

## Why this approach
I considered fixing this only in the test, but the crash originates inside the persisted store configuration itself. Making the store resilient is the more robust fix because it protects both tests and any non-browser or partially browser-like runtime edge cases.

I also avoided a broader dependency update pass here. The repo is already on a modern stack, and the failure was reproducible as a runtime compatibility issue rather than an outdated-package issue.

## Verification
I ran the focused suite first and then the full required repo checks:

```bash
bun x vitest run apps/web/src/terminalStateStore.test.ts
bun run fmt:check
bun lint
bun run typecheck
bun run test
```

All of the commands above pass with this change.

## Notes
- I did a full reinstall during debugging, but I reverted the generated `mockServiceWorker` diff so this PR only contains the targeted fix.
- The local machine that reproduced this had toolchain skew from the repo pins (`.mise.toml` requests Bun `1.3.9` and Node `24.13.1`), which made it even more valuable to keep the fix defensive.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard terminal state persistence when localStorage is unavailable
> The `useTerminalStateStore` in [terminalStateStore.ts](https://github.com/pingdotgg/t3code/pull/1021/files#diff-9e98e54d562825d3d06313f14e0c37ba761ec3457248dd98e1e388a6948fcd34) previously called `localStorage` directly in the persist middleware, causing errors when storage is absent or incomplete. A `getTerminalStateStorage` utility now validates that `localStorage` exposes the expected methods at runtime, falling back to a no-op `Storage` implementation if not. In valid environments, behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa7dbd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->