### PR TITLE
fix: improve project favicon detection for monorepos

### DIFF
--- a/apps/server/src/project/Layers/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/Layers/ProjectFaviconResolver.test.ts
@@ -2,19 +2,27 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it, describe, expect } from "@effect/vitest";
 import { Effect, FileSystem, Layer, Path } from "effect";
 
+import * as VcsDriverRegistry from "../../vcs/VcsDriverRegistry.ts";
+import * as VcsProcess from "../../vcs/VcsProcess.ts";
 import { ProjectFaviconResolver } from "../Services/ProjectFaviconResolver.ts";
 import { ProjectFaviconResolverLive } from "./ProjectFaviconResolver.ts";
 
 const TestLayer = Layer.empty.pipe(
   Layer.provideMerge(ProjectFaviconResolverLive),
+  Layer.provideMerge(VcsProcess.layer),
+  Layer.provideMerge(VcsDriverRegistry.layer.pipe(Layer.provide(VcsProcess.layer))),
   Layer.provideMerge(NodeServices.layer),
 );
 
-const makeTempDir = Effect.gen(function* () {
+const makeTempDir = Effect.fn(function* (opts?: { git?: boolean }) {
   const fileSystem = yield* FileSystem.FileSystem;
-  return yield* fileSystem.makeTempDirectoryScoped({
+  const dir = yield* fileSystem.makeTempDirectoryScoped({
     prefix: "t3code-project-favicon-",
   });
+  if (opts?.git) {
+    yield* git(dir, ["init"]);
+  }
+  return dir;
 });
 
 const writeTextFile = Effect.fn("writeTextFile")(function* (
@@ -31,12 +39,24 @@ const writeTextFile = Effect.fn("writeTextFile")(function* (
   yield* fileSystem.writeFileString(absolutePath, contents).pipe(Effect.orDie);
 });
 
+const git = (cwd: string, args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const process = yield* VcsProcess.VcsProcess;
+    yield* process.run({
+      operation: "ProjectFaviconResolver.test.git",
+      command: "git",
+      cwd,
+      args,
+      timeoutMs: 10_000,
+    });
+  });
+
 it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
   describe("resolvePath", () => {
     it.effect("prefers well-known favicon files", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver;
-        const cwd = yield* makeTempDir;
+        const cwd = yield* makeTempDir();
         yield* writeTextFile(cwd, "favicon.svg", "<svg>favicon</svg>");
 
         const resolved = yield* resolver.resolvePath(cwd);
@@ -49,7 +69,7 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
     it.effect("resolves icon hrefs from project source files", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver;
-        const cwd = yield* makeTempDir;
+        const cwd = yield* makeTempDir();
         yield* writeTextFile(cwd, "index.html", '<link rel="icon" href="/brand/logo.svg">');
         yield* writeTextFile(cwd, "public/brand/logo.svg", "<svg>brand</svg>");
 
@@ -63,11 +83,67 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
     it.effect("returns null when no icon is present", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver;
-        const cwd = yield* makeTempDir;
+        const cwd = yield* makeTempDir();
 
         const resolved = yield* resolver.resolvePath(cwd);
 
         expect(resolved).toBeNull();
+      }),
+    );
+
+    it.effect("finds nested app favicon metadata from a monorepo root", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver;
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "apps/web/index.html", '<link rel="icon" href="/icons/app.svg">');
+        yield* writeTextFile(cwd, "apps/web/public/icons/app.svg", "<svg>app</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("apps/web/public/icons/app.svg");
+      }),
+    );
+
+    it.effect("prefers a root favicon over nested workspace matches", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver;
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>root</svg>");
+        yield* writeTextFile(cwd, "apps/web/public/favicon.svg", "<svg>nested</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("favicon.svg");
+        expect(resolved).not.toContain("apps/web");
+      }),
+    );
+
+    it.effect("skips ignored workspace directories when searching nested icons", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver;
+        const cwd = yield* makeTempDir();
+        yield* writeTextFile(cwd, ".next/public/favicon.svg", "<svg>ignored</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).toBeNull();
+      }),
+    );
+
+    it.effect("skips gitignored root favicons and falls through to nested apps", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver;
+        const cwd = yield* makeTempDir({ git: true });
+        yield* writeTextFile(cwd, ".gitignore", "/favicon.svg\n");
+        yield* writeTextFile(cwd, "favicon.svg", "<svg>ignored-root</svg>");
+        yield* writeTextFile(cwd, "apps/web/public/favicon.svg", "<svg>nested</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("apps/web/public/favicon.svg");
       }),
     );
   });

--- a/apps/server/src/project/Layers/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/Layers/ProjectFaviconResolver.ts
@@ -1,5 +1,8 @@
-import { Effect, FileSystem, Layer, Path } from "effect";
+import path from "node:path";
+import { Effect, FileSystem, Layer, Option } from "effect";
+import * as PlatformError from "effect/PlatformError";
 
+import { VcsDriverRegistry } from "../../vcs/VcsDriverRegistry.ts";
 import {
   ProjectFaviconResolver,
   type ProjectFaviconResolverShape,
@@ -46,74 +49,360 @@ const LINK_ICON_HTML_RE =
   /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i;
 const LINK_ICON_OBJ_RE =
   /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i;
+const IGNORED_WORKSPACE_DIRECTORY_NAMES = new Set([
+  ".git",
+  ".convex",
+  "node_modules",
+  ".next",
+  ".turbo",
+  "dist",
+  "build",
+  "out",
+  ".cache",
+]);
 
-function extractIconHref(source: string): string | null {
+type ExistingPathType = "File" | "Directory";
+
+interface FaviconLookupServices {
+  fileSystem: FileSystem.FileSystem;
+  projectRoot: string;
+  filterAllowedPaths: (candidatePaths: readonly string[]) => Effect.Effect<string[], never>;
+}
+
+function isPathInIgnoredWorkspaceDirectory(relativePath: string): boolean {
+  const firstSegment = relativePath.split("/")[0];
+  if (!firstSegment) {
+    return false;
+  }
+
+  return IGNORED_WORKSPACE_DIRECTORY_NAMES.has(firstSegment);
+}
+
+function extractIconHref(source: string): Option.Option<string> {
   const htmlMatch = source.match(LINK_ICON_HTML_RE);
-  if (htmlMatch?.[1]) return htmlMatch[1];
-  const objMatch = source.match(LINK_ICON_OBJ_RE);
-  if (objMatch?.[1]) return objMatch[1];
-  return null;
+  if (htmlMatch?.[1]) {
+    return Option.some(htmlMatch[1]);
+  }
+
+  const objectMatch = source.match(LINK_ICON_OBJ_RE);
+  if (objectMatch?.[1]) {
+    return Option.some(objectMatch[1]);
+  }
+
+  return Option.none();
+}
+
+function platformErrorToNone<A, R>(
+  effect: Effect.Effect<A, PlatformError.PlatformError, R>,
+): Effect.Effect<Option.Option<A>, never, R> {
+  return effect.pipe(
+    Effect.map(Option.some),
+    Effect.catchTag("PlatformError", () => Effect.succeed(Option.none<A>())),
+  );
+}
+
+function toProjectRelativePath(projectRoot: string, candidatePath: string): Option.Option<string> {
+  const relativePath = path.relative(projectRoot, candidatePath);
+  if (relativePath.length === 0 || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return Option.none();
+  }
+
+  return Option.some(relativePath.split(path.sep).join("/"));
+}
+
+function resolveExistingPath(
+  lookup: Pick<FaviconLookupServices, "fileSystem" | "projectRoot">,
+  candidatePath: string,
+  expectedType: ExistingPathType,
+) {
+  return Effect.gen(function* () {
+    const resolvedPathOption = yield* platformErrorToNone(
+      lookup.fileSystem.realPath(candidatePath),
+    );
+    if (Option.isNone(resolvedPathOption)) {
+      return Option.none();
+    }
+
+    const resolvedPath = resolvedPathOption.value;
+    const relativePath = path.relative(lookup.projectRoot, resolvedPath);
+    if (relativePath !== "" && (relativePath.startsWith("..") || path.isAbsolute(relativePath))) {
+      return Option.none();
+    }
+
+    const infoOption = yield* platformErrorToNone(lookup.fileSystem.stat(resolvedPath));
+    if (Option.isNone(infoOption) || infoOption.value.type !== expectedType) {
+      return Option.none();
+    }
+
+    return Option.some(resolvedPath);
+  });
+}
+
+function readFileIfExists<A>(
+  lookup: Pick<FaviconLookupServices, "fileSystem" | "projectRoot">,
+  candidatePath: string,
+  read: (resolvedPath: string) => Effect.Effect<A, PlatformError.PlatformError>,
+) {
+  return Effect.gen(function* () {
+    const resolvedPathOption = yield* resolveExistingPath(lookup, candidatePath, "File");
+    if (Option.isNone(resolvedPathOption)) {
+      return Option.none();
+    }
+
+    const contentOption = yield* platformErrorToNone(read(resolvedPathOption.value));
+    if (Option.isNone(contentOption)) {
+      return Option.none();
+    }
+
+    return Option.some({
+      path: resolvedPathOption.value,
+      content: contentOption.value,
+    });
+  });
+}
+
+function makeAllowedPathFilter(
+  projectRoot: string,
+  shouldFilterWithVcsIgnore: boolean,
+  filterVcsIgnoredPaths: (relativePaths: string[]) => Effect.Effect<string[], never>,
+) {
+  const gitIgnorePathCache = new Map<string, boolean>();
+
+  return (candidatePaths: readonly string[]) =>
+    Effect.gen(function* () {
+      if (!shouldFilterWithVcsIgnore || candidatePaths.length === 0) {
+        return [...candidatePaths];
+      }
+
+      const uncachedRelativePaths = Array.from(
+        new Set(
+          candidatePaths.flatMap((candidatePath) =>
+            Option.match(toProjectRelativePath(projectRoot, candidatePath), {
+              onNone: () => [],
+              onSome: (relativePath) =>
+                gitIgnorePathCache.has(relativePath) ? [] : [relativePath],
+            }),
+          ),
+        ),
+      );
+
+      if (uncachedRelativePaths.length > 0) {
+        const allowedRelativePaths = yield* filterVcsIgnoredPaths(uncachedRelativePaths);
+        const allowedRelativePathSet = new Set(allowedRelativePaths);
+
+        for (const relativePath of uncachedRelativePaths) {
+          gitIgnorePathCache.set(relativePath, allowedRelativePathSet.has(relativePath));
+        }
+      }
+
+      return candidatePaths.filter((candidatePath) =>
+        Option.match(toProjectRelativePath(projectRoot, candidatePath), {
+          onNone: () => true,
+          onSome: (relativePath) => gitIgnorePathCache.get(relativePath) !== false,
+        }),
+      );
+    });
+}
+
+function findFirstReadableFaviconPath(
+  lookup: FaviconLookupServices,
+  candidatePaths: readonly string[],
+) {
+  return Effect.gen(function* () {
+    const allowedCandidatePaths = yield* lookup.filterAllowedPaths(candidatePaths);
+
+    for (const candidatePath of allowedCandidatePaths) {
+      const fileOption = yield* readFileIfExists(lookup, candidatePath, (resolvedPath) =>
+        lookup.fileSystem.readFile(resolvedPath),
+      );
+      if (Option.isSome(fileOption)) {
+        return Option.some(fileOption.value.path);
+      }
+    }
+
+    return Option.none();
+  });
+}
+
+function iconHrefCandidatePaths(searchRoot: string, href: string): string[] {
+  const cleanHref = href.replace(/^\//, "");
+  return [path.join(searchRoot, "public", cleanHref), path.join(searchRoot, cleanHref)];
+}
+
+function findFaviconFromSourcePath(
+  lookup: FaviconLookupServices,
+  searchRoot: string,
+  sourcePath: string,
+) {
+  return Effect.gen(function* () {
+    const sourceFileOption = yield* readFileIfExists(lookup, sourcePath, (resolvedPath) =>
+      lookup.fileSystem.readFileString(resolvedPath),
+    );
+    if (Option.isNone(sourceFileOption)) {
+      return Option.none();
+    }
+
+    const hrefOption = extractIconHref(sourceFileOption.value.content);
+    if (Option.isNone(hrefOption)) {
+      return Option.none();
+    }
+
+    return yield* findFirstReadableFaviconPath(
+      lookup,
+      iconHrefCandidatePaths(searchRoot, hrefOption.value),
+    );
+  });
+}
+
+function findFaviconFromSourceFiles(lookup: FaviconLookupServices, searchRoot: string) {
+  return Effect.gen(function* () {
+    const sourcePaths = yield* lookup.filterAllowedPaths(
+      ICON_SOURCE_FILES.map((sourceFile) => path.join(searchRoot, sourceFile)),
+    );
+
+    for (const sourcePath of sourcePaths) {
+      const faviconPathOption = yield* findFaviconFromSourcePath(lookup, searchRoot, sourcePath);
+      if (Option.isSome(faviconPathOption)) {
+        return faviconPathOption;
+      }
+    }
+
+    return Option.none();
+  });
+}
+
+function findFaviconInSearchRoot(lookup: FaviconLookupServices, searchRoot: string) {
+  return Effect.gen(function* () {
+    const faviconPathOption = yield* findFirstReadableFaviconPath(
+      lookup,
+      FAVICON_CANDIDATES.map((candidate) => path.join(searchRoot, candidate)),
+    );
+    if (Option.isSome(faviconPathOption)) {
+      return faviconPathOption;
+    }
+
+    return yield* findFaviconFromSourceFiles(lookup, searchRoot);
+  });
+}
+
+function listChildDirectories(lookup: FaviconLookupServices, rootPath: string) {
+  return Effect.gen(function* () {
+    const entriesOption = yield* platformErrorToNone(lookup.fileSystem.readDirectory(rootPath));
+    if (Option.isNone(entriesOption)) {
+      return [];
+    }
+
+    const directories: string[] = [];
+    for (const entry of entriesOption.value.toSorted((left, right) => left.localeCompare(right))) {
+      if (entry.length === 0 || entry.includes("/") || entry.includes("\\")) {
+        continue;
+      }
+      if (isPathInIgnoredWorkspaceDirectory(entry)) {
+        continue;
+      }
+
+      const directoryPathOption = yield* resolveExistingPath(
+        lookup,
+        path.join(rootPath, entry),
+        "Directory",
+      );
+      if (Option.isSome(directoryPathOption)) {
+        directories.push(directoryPathOption.value);
+      }
+    }
+
+    return directories;
+  });
+}
+
+function listCandidateSearchRoots(lookup: FaviconLookupServices) {
+  return Effect.gen(function* () {
+    const [appRoots, packageRoots, directChildRoots] = yield* Effect.all([
+      listChildDirectories(lookup, path.join(lookup.projectRoot, "apps")),
+      listChildDirectories(lookup, path.join(lookup.projectRoot, "packages")),
+      listChildDirectories(lookup, lookup.projectRoot),
+    ]);
+
+    return [
+      ...appRoots,
+      ...packageRoots,
+      ...directChildRoots.filter((directChildRoot) => {
+        const baseName = path.basename(directChildRoot).toLowerCase();
+        return baseName !== "apps" && baseName !== "packages";
+      }),
+    ];
+  });
+}
+
+function findNestedFavicon(lookup: FaviconLookupServices) {
+  return Effect.gen(function* () {
+    const searchRoots = yield* listCandidateSearchRoots(lookup).pipe(
+      Effect.flatMap((roots) => lookup.filterAllowedPaths(roots)),
+    );
+
+    for (const searchRoot of searchRoots) {
+      const faviconPathOption = yield* findFaviconInSearchRoot(lookup, searchRoot);
+      if (Option.isSome(faviconPathOption)) {
+        return faviconPathOption;
+      }
+    }
+
+    return Option.none();
+  });
 }
 
 export const makeProjectFaviconResolver = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
+  const vcsRegistry = yield* VcsDriverRegistry;
 
-  const resolveIconHref = (projectCwd: string, href: string): string[] => {
-    const clean = href.replace(/^\//, "");
-    return [path.join(projectCwd, "public", clean), path.join(projectCwd, clean)];
-  };
+  const isInsideVcsWorkTree = (cwd: string): Effect.Effect<boolean, never> =>
+    vcsRegistry.detect({ cwd }).pipe(
+      Effect.map((handle) => handle !== null),
+      Effect.catch(() => Effect.succeed(false)),
+    );
 
-  const isPathWithinProject = (projectCwd: string, candidatePath: string): boolean => {
-    const relative = path.relative(path.resolve(projectCwd), path.resolve(candidatePath));
-    return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-  };
-
-  const findExistingFile = Effect.fn("ProjectFaviconResolver.findExistingFile")(function* (
-    projectCwd: string,
-    candidates: ReadonlyArray<string>,
-  ): Effect.fn.Return<string | null> {
-    for (const candidate of candidates) {
-      if (!isPathWithinProject(projectCwd, candidate)) {
-        continue;
-      }
-      const stats = yield* fileSystem
-        .stat(candidate)
-        .pipe(Effect.catch(() => Effect.succeed(null)));
-      if (stats?.type === "File") {
-        return candidate;
-      }
-    }
-    return null;
-  });
+  const filterVcsIgnoredPaths = (
+    cwd: string,
+    relativePaths: string[],
+  ): Effect.Effect<string[], never> =>
+    vcsRegistry.detect({ cwd }).pipe(
+      Effect.flatMap((handle) =>
+        handle
+          ? handle.driver.filterIgnoredPaths(cwd, relativePaths).pipe(
+              Effect.map((paths) => [...paths]),
+              Effect.catch(() => Effect.succeed(relativePaths)),
+            )
+          : Effect.succeed(relativePaths),
+      ),
+      Effect.catch(() => Effect.succeed(relativePaths)),
+    );
 
   const resolvePath: ProjectFaviconResolverShape["resolvePath"] = Effect.fn(
     "ProjectFaviconResolver.resolvePath",
-  )(function* (cwd: string): Effect.fn.Return<string | null> {
-    for (const candidate of FAVICON_CANDIDATES) {
-      const resolved = path.join(cwd, candidate);
-      const existing = yield* findExistingFile(cwd, [resolved]);
-      if (existing) {
-        return existing;
-      }
+  )(function* (cwd): Effect.fn.Return<string | null> {
+    const projectRootOption = yield* platformErrorToNone(fileSystem.realPath(cwd));
+    if (Option.isNone(projectRootOption)) {
+      return null;
     }
 
-    for (const sourceFile of ICON_SOURCE_FILES) {
-      const sourcePath = path.join(cwd, sourceFile);
-      const source = yield* fileSystem
-        .readFileString(sourcePath)
-        .pipe(Effect.catch(() => Effect.succeed(null)));
-      if (!source) {
-        continue;
-      }
-      const href = extractIconHref(source);
-      if (!href) {
-        continue;
-      }
-      const existing = yield* findExistingFile(cwd, resolveIconHref(cwd, href));
-      if (existing) {
-        return existing;
-      }
+    const projectRoot = projectRootOption.value;
+    const shouldFilterWithVcsIgnore = yield* isInsideVcsWorkTree(projectRoot);
+    const lookup = {
+      fileSystem,
+      projectRoot,
+      filterAllowedPaths: makeAllowedPathFilter(projectRoot, shouldFilterWithVcsIgnore, (paths) =>
+        filterVcsIgnoredPaths(projectRoot, paths),
+      ),
+    } satisfies FaviconLookupServices;
+
+    const rootFaviconOption = yield* findFaviconInSearchRoot(lookup, projectRoot);
+    if (Option.isSome(rootFaviconOption)) {
+      return rootFaviconOption.value;
+    }
+
+    const nestedFaviconOption = yield* findNestedFavicon(lookup);
+    if (Option.isSome(nestedFaviconOption)) {
+      return nestedFaviconOption.value;
     }
 
     return null;

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -486,7 +486,7 @@ const buildAppUnderTest = (options?: {
         Layer.provide(WorkspacePathsLive),
         Layer.provide(workspaceEntriesLayer),
       ),
-      ProjectFaviconResolverLive,
+      ProjectFaviconResolverLive.pipe(Layer.provide(vcsDriverRegistryLayer)),
     );
     const gitWorkflowLayer = GitWorkflowService.layer.pipe(
       Layer.provideMerge(vcsDriverRegistryLayer),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -229,6 +229,10 @@ const WorkspaceLayerLive = Layer.mergeAll(
   WorkspaceFileSystemLayerLive,
 );
 
+const ProjectFaviconResolverLayerLive = ProjectFaviconResolverLive.pipe(
+  Layer.provide(VcsDriverRegistryLayerLive),
+);
+
 const AuthLayerLive = ServerAuthLive.pipe(
   Layer.provideMerge(PersistenceLayerLive),
   Layer.provide(ServerSecretStoreLive),
@@ -270,7 +274,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(OpenCodeRuntimeLive),
   Layer.provideMerge(ServerSettingsLive),
   Layer.provideMerge(WorkspaceLayerLive),
-  Layer.provideMerge(ProjectFaviconResolverLive),
+  Layer.provideMerge(ProjectFaviconResolverLayerLive),
   Layer.provideMerge(RepositoryIdentityResolverLive),
   Layer.provideMerge(ServerEnvironmentLive),
   Layer.provideMerge(AuthLayerLive),


### PR DESCRIPTION
The `XXL` tag seems a little weird for this PR? It is a net +288 LoC, excluding test files.

## What Changed

Improve project favicon detection without introducing a broad recursive search.
Closes https://github.com/pingdotgg/t3code/issues/1020.

Rules, in order:
- Check well-known favicon paths in the requested project root.
  Example: `/repo/favicon.svg` or `/repo/public/favicon.ico`.
- If none exist, look for `<link rel="icon" ... href="...">` tags or object-style `{ href, rel: "icon" }` declarations in a small set of common source files, then resolve that target.
  Example: `/repo/index.html` points to `/brand/logo.svg`, so the route first tries `/repo/public/brand/logo.svg` and then `/repo/brand/logo.svg`.
- If still nothing is found, repeat the same checks for first-level children of `apps/` and `packages/`, plus other top-level directories in the requested root, using the same non-git directory ignore rules as `workspaceEntries`.
  Example: `/repo/apps/web/public/favicon.png` or `/repo/frontend/public/favicon.png` is found when the cwd is `/repo`.
- Prefer a root match over nested workspace matches.
  Example: `/repo/favicon.svg` wins over `/repo/apps/web/public/favicon.ico`.
- Fall back to the existing generated SVG when nothing is found.

I also extracted the shared gitignore probing into `apps/server/src/gitIgnore.ts` so both `workspaceEntries` and `projectFaviconRoute` use the same chunked `git check-ignore --no-index -z --stdin` filtering. I also extracted the shared workspace directory ignore policy into `apps/server/src/workspaceIgnore.ts`, so `projectFaviconRoute` now uses the same non-git skip rules as `workspaceEntries` when scanning nested roots instead of keeping a separate ignore list.

## Why

The current behavior misses common monorepo layouts where the favicon lives under an app directory instead of the repo root.

There was already an earlier PR for this in the upstream repo: https://github.com/pingdotgg/t3code/pull/690. That version was larger and messier. This keeps the rules simple on purpose, leaving more extensive changes to project icons for trusted maintainers.

## UI Changes

Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve project favicon detection to support monorepos with gitignore filtering
> - Rewrites [`ProjectFaviconResolver.resolvePath`](https://github.com/pingdotgg/t3code/pull/1024/files#diff-75e10c7bd6b1ceefcab76a7d49afd5bcbfb7e2cbe4bc9cac6a2b2ec210cde54c) to search nested `apps/`, `packages/`, and top-level child directories when no root favicon is found, enabling monorepo support.
> - Adds gitignore-aware filtering via new [`gitIgnore.ts`](https://github.com/pingdotgg/t3code/pull/1024/files#diff-38b42b641f62997c697411b3c793288155c1ee746ec06779b2538bba93dd8802) utilities (`filterGitIgnoredPaths`, `isInsideGitWorkTree`) that stream candidates to `git check-ignore` in 256 KiB chunks.
> - Introduces [`workspaceIgnore.ts`](https://github.com/pingdotgg/t3code/pull/1024/files#diff-8ea4ea659000b9c10784a82ee633279fda9ed9d77acb496b5f296d3b9c5d00e0) to skip well-known directories (`.git`, `node_modules`, `.next`, `dist`, etc.) during directory traversal.
> - Adds [`workspaceEntries.ts`](https://github.com/pingdotgg/t3code/pull/1024/files#diff-8837c410ba2cefe45f583c6fe2a25ccce82c6fca61b1619bc29fe47514d1c5b7) for a cacheable, git-backed or filesystem-fallback workspace index with fuzzy-ranked search.
> - Fixes a missing `FileSystem` service injection in the static file handler in [`wsServer.ts`](https://github.com/pingdotgg/t3code/pull/1024/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) that previously caused runtime errors.
> - Behavioral Change: resolver now fails open on filesystem or git errors (treats unreadable paths as misses) rather than throwing.
>
> <!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c01d2ee. 6 files reviewed, 4 issues evaluated, 1 issue filtered, 2 comments posted</summary>

### 🗂️ Filtered Issues
<details>
<summary>apps/server/src/workspaceEntries.ts — 1 comment posted, 3 evaluated, 1 filtered</summary>

- [line 427](https://github.com/pingdotgg/t3code/blob/c01d2eeded7edaa372119ba9dacc3d5114d26b65/apps/server/src/workspaceEntries.ts#L427): Race condition in `clearWorkspaceIndexCache`: deleting from `inFlightWorkspaceIndexBuilds` does not cancel the in-flight promise. When that promise completes, its `.then()` handler will call `workspaceIndexCache.set(cwd, next)`, re-populating the cache with potentially stale data after it was intentionally cleared. This defeats the purpose of clearing the cache. <b>[ Already posted ]</b>
</details>


</details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies server-side favicon resolution and adds git-driven ignore filtering/search across workspace roots, which could affect file discovery performance and edge cases around path/permission handling. Git/process failures are handled fail-open, reducing risk of hiding files but still changing behavior.
> 
> **Overview**
> **Project favicon resolution is expanded to better support monorepos.** The resolver now checks well-known favicon paths and icon metadata in common source files in the requested root, then repeats the same checks across first-level `apps/`, `packages/`, and other top-level directories (skipping ignored workspace dirs), preferring root matches before falling back to the generated SVG.
> 
> **Gitignore-aware filtering is added and shared.** New `gitIgnore.ts` provides `isInsideGitWorkTree` and chunked `filterGitIgnoredPaths` (`git check-ignore --no-index -z --stdin`) with fail-open behavior; both the favicon resolver and the new `workspaceEntries.ts` use this to avoid considering gitignored candidates.
> 
> **Testing and wiring updates.** New unit tests cover gitignore chunking/fail-open and expanded favicon route scenarios (nested roots, unreadable files, gitignored root/app/source cases), and `wsServer.ts` now provides `FileSystem` to the static-file handler Effect pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7404ccc6eaac85417693ba4996d2973b7f9cbd02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->