### PR TITLE
fix: fall back to PATH when codex binary missing

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -541,10 +541,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       };
 
       const codexOptions = readCodexProviderOptions(input);
-      const codexBinaryPath = codexOptions.binaryPath ?? "codex";
       const codexHomePath = codexOptions.homePath;
-      this.assertSupportedCodexCliVersion({
-        binaryPath: codexBinaryPath,
+      const codexBinaryPath = resolveCodexBinaryPath({
+        binaryPath: codexOptions.binaryPath ?? "codex",
         cwd: resolvedCwd,
         ...(codexHomePath ? { homePath: codexHomePath } : {}),
       });
@@ -1563,6 +1562,35 @@ function assertSupportedCodexCliVersion(input: {
   const parsedVersion = parseCodexCliVersion(`${stdout}\n${stderr}`);
   if (parsedVersion && !isCodexCliVersionSupported(parsedVersion)) {
     throw new Error(formatCodexCliUpgradeMessage(parsedVersion));
+  }
+}
+
+function resolveCodexBinaryPath(input: {
+  readonly binaryPath: string;
+  readonly cwd: string;
+  readonly homePath?: string;
+}): string {
+  try {
+    assertSupportedCodexCliVersion(input);
+    return input.binaryPath;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      input.binaryPath !== "codex" &&
+      message.includes("is not installed or not executable")
+    ) {
+      assertSupportedCodexCliVersion({
+        binaryPath: "codex",
+        cwd: input.cwd,
+        ...(input.homePath ? { homePath: input.homePath } : {}),
+      });
+      console.warn(
+        "codex cli binary path not executable; falling back to PATH lookup",
+        { binaryPath: input.binaryPath },
+      );
+      return "codex";
+    }
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- fall back to PATH lookup when a configured Codex binary path is missing
- keep existing behavior when the configured path works

## Motivation
Some installs (Homebrew/npm) surface stale or invalid binary paths. Today that hard-fails sessions even when `codex` is available on PATH. This change attempts the configured path first, then falls back to PATH for missing binaries.

## Testing
- not run (local change)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to PATH `codex` binary when configured binary path is not executable
> - Adds `resolveCodexBinaryPath` in [codexAppServerManager.ts](https://github.com/pingdotgg/t3code/pull/1025/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9) to validate the configured binary via `assertSupportedCodexCliVersion` before use.
> - If the configured path fails with "is not installed or not executable" and differs from the default `"codex"`, the function retries with `"codex"` from PATH and logs a console warning.
> - `startSession` now delegates binary resolution to this helper instead of asserting and selecting the path inline.
> - Behavioral Change: sessions that previously failed when a non-default binary path was misconfigured will now silently fall back to `codex` on PATH if available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 102c216.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->