### PR TITLE
fix restore diff sidebar width after resize

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -18,7 +18,11 @@ import {
 import { Skeleton } from "~/components/ui/skeleton";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 import { useIsMobile } from "~/hooks/useMediaQuery";
-import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from "~/hooks/useLocalStorage";
 import { Schema } from "effect";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
@@ -542,13 +546,41 @@ function SidebarRail({
     if (!rail) return;
     const wrapper = rail.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
     if (!wrapper) return;
+    const defaultSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
 
-    const storedWidth = getLocalStorageItem(resolvedResizable.storageKey, Schema.Finite);
-    if (storedWidth === null) return;
-    const clampedWidth = clampSidebarWidth(storedWidth, resolvedResizable);
-    wrapper.style.setProperty("--sidebar-width", `${clampedWidth}px`);
-    resolvedResizable.onResize?.(clampedWidth);
-  }, [resolvedResizable]);
+    const applyStoredWidth = () => {
+      const storedWidth = getLocalStorageItem(resolvedResizable.storageKey!, Schema.Finite);
+      if (storedWidth === null) return;
+      const clampedWidth = clampSidebarWidth(storedWidth, resolvedResizable);
+      const sidebarContainer = rail
+        .closest<HTMLElement>("[data-slot='sidebar']")
+        ?.querySelector<HTMLElement>("[data-slot='sidebar-container']");
+      const accepted =
+        !sidebarContainer ||
+        !resolvedResizable.shouldAcceptWidth ||
+        resolvedResizable.shouldAcceptWidth({
+          currentWidth: sidebarContainer.getBoundingClientRect().width,
+          nextWidth: clampedWidth,
+          rail,
+          side: sidebarInstance?.side ?? "left",
+          sidebarRoot: rail.closest<HTMLElement>("[data-slot='sidebar']")!,
+          wrapper,
+        });
+      if (accepted) {
+        wrapper.style.setProperty("--sidebar-width", `${clampedWidth}px`);
+        resolvedResizable.onResize?.(clampedWidth);
+      } else {
+        wrapper.style.setProperty("--sidebar-width", defaultSidebarWidth);
+        removeLocalStorageItem(resolvedResizable.storageKey!);
+      }
+    };
+
+    applyStoredWidth();
+    window.addEventListener("resize", applyStoredWidth);
+    return () => {
+      window.removeEventListener("resize", applyStoredWidth);
+    };
+  }, [resolvedResizable, sidebarInstance?.side]);
 
   React.useEffect(() => {
     return () => {


### PR DESCRIPTION
## What Changed

- Revalidated the stored diff sidebar width when the app window resizes.
- Reset the diff sidebar back to its default width when a persisted width no longer fits the current layout.
- Restored the diff toggle interaction after monitor unplug and window resize scenarios.

## Why

The bug was caused by the diff sidebar restoring a previously saved custom width without re-checking whether that width still fit after the app window became smaller, like after unplugging a monitor.

Once that stale width no longer fit, the diff panel could end up in a broken layout state, so clicking the diff toggle button or pressing Cmd+D appeared to stop working even though the toggle logic still ran.

The fix makes the sidebar revalidate its stored width on restore and on window resize, and if that width is no longer valid, it falls back to the default sidebar width instead of keeping the broken one.

## UI Changes

- Diff toggle now recovers after unplugging an external monitor or resizing the desktop window smaller.
- No intentional visual redesign; this is a behavior fix for the existing diff sidebar interaction.

## Demos

### Before Fix

https://github.com/user-attachments/assets/156bbba6-8638-476b-8044-31a6c71735ae

### After Fix

https://github.com/user-attachments/assets/8b44887d-d1b5-43fe-bae7-83448bee96f1

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore diff sidebar width on window resize using `shouldAcceptWidth` validation
> - The `SidebarRail` component in [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1026/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd) now re-validates and re-applies the stored sidebar width on every window resize event, not just on mount.
> - An optional `shouldAcceptWidth` predicate receives the current and next widths plus relevant DOM refs; if it rejects the width, the sidebar resets to its CSS default and clears the stored value from localStorage.
> - Behavioral Change: the effect now also re-runs when `sidebarInstance?.side` changes, and `onResize` is only called when a stored width is accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6afe307.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->