### PR TITLE
fix(sidebar): misleading thread timestamp

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -104,6 +104,25 @@ function formatRelativeTime(iso: string): string {
   return `${Math.floor(hours / 24)}d ago`;
 }
 
+function getThreadSidebarTimestamp(thread: Thread): string {
+  if (thread.messages.length === 0) {
+    return thread.createdAt;
+  }
+
+  let earliestTimestamp = thread.messages[0]?.createdAt ?? thread.createdAt;
+  let earliestTime = new Date(earliestTimestamp).getTime();
+
+  for (const message of thread.messages) {
+    const messageTime = new Date(message.createdAt).getTime();
+    if (messageTime < earliestTime) {
+      earliestTimestamp = message.createdAt;
+      earliestTime = messageTime;
+    }
+  }
+
+  return earliestTimestamp;
+}
+
 interface TerminalStatusIndicator {
   label: "Terminal process running";
   colorClass: string;
@@ -386,7 +405,9 @@ export default function Sidebar() {
       const latestThread = threads
         .filter((thread) => thread.projectId === projectId)
         .toSorted((a, b) => {
-          const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+          const byDate =
+            new Date(getThreadSidebarTimestamp(b)).getTime() -
+            new Date(getThreadSidebarTimestamp(a)).getTime();
           if (byDate !== 0) return byDate;
           return b.id.localeCompare(a.id);
         })[0];
@@ -1297,7 +1318,8 @@ export default function Sidebar() {
                     .filter((thread) => thread.projectId === project.id)
                     .toSorted((a, b) => {
                       const byDate =
-                        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+                        new Date(getThreadSidebarTimestamp(b)).getTime() -
+                        new Date(getThreadSidebarTimestamp(a)).getTime();
                       if (byDate !== 0) return byDate;
                       return b.id.localeCompare(a.id);
                     });
@@ -1551,7 +1573,7 @@ export default function Sidebar() {
                                               : "text-muted-foreground/40"
                                           }`}
                                         >
-                                          {formatRelativeTime(thread.createdAt)}
+                                          {formatRelativeTime(getThreadSidebarTimestamp(thread))}
                                         </span>
                                       </div>
                                     </SidebarMenuSubButton>


### PR DESCRIPTION
## What Changed
Updated sidebar thread recency to use the first message timestamp instead of the thread creation timestamp, with a fallback to `thread.createdAt` for empty threads. Applied the same derived timestamp to sidebar sorting and “most recent thread” selection so the displayed time and ordering stay consistent.

## Why
`thread.createdAt` reflects when the thread container was created, not when the conversation actually began. In this app that can happen before any real message is sent, especially with draft or pre-created threads, which makes the sidebar timestamp misleading. Using the first message `createdAt` better matches user expectations of thread recency, while falling back to thread creation keeps empty threads stable and predictable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar thread recency to use first message time instead of thread creation time
> Adds a `getThreadSidebarTimestamp` helper in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1030/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that returns the earliest message `createdAt` for a thread, falling back to `thread.createdAt` when no messages exist. Both thread sort order and the displayed relative timestamp now use this value instead of `thread.createdAt` directly.
>
> Behavioral Change: threads will reorder in the sidebar based on their first message time, which may differ from thread creation time and will change the visible ordering for existing threads.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0b0dae3. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->