### PR TITLE
fix: smooth "Working for" timer progression

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1899,7 +1899,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       ? (draftThread?.envMode ?? "local")
       : "local";
 
-  const shouldTickNow = isWorking || !latestTurnSettled;
+  const shouldTickNow = !!activeWorkStartedAt && (isWorking || !latestTurnSettled);
 
   useEffect(() => {
     if (!shouldTickNow) return;


### PR DESCRIPTION
## What Changed

Fixed the chat "Working for Xs" timer so it starts updating as soon as the working indicator is shown, instead of waiting for the thread to fully enter the `running` phase.

## Why

The timer could sit at `0s` for too long and then jump to `2s` because the UI rendered the working state before the 1-second ticker started. This keeps the elapsed time display aligned with the actual visible working state and makes the interaction feel consistent.

## UI Changes

No visible ui changes, just smoother "Working for..." experience

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix smooth timer progression for 'Working for' display in ChatView
> The `shouldTickNow` flag in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1034/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) replaces the `phase === 'running'` check as the gate for the time-ticking effect. An immediate `setNowTick(Date.now())` call is added before the interval starts, eliminating the 1-second delay before the timer first updates. The effect now also continues ticking when `activeWorkStartedAt` is set and the latest turn is not yet settled, covering cases where work has ended but the turn hasn't finalized.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1e9935.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->