### PR TITLE
fix(web): fix header action labels collapsing too early by correcting flex distribution

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -344,7 +344,7 @@ describe("when: working tree has local changes", () => {
     assert.deepInclude(quick, {
       kind: "run_action",
       action: "commit_push_pr",
-      label: "Commit, push & PR",
+      label: "Commit, push & create PR",
     });
   });
 
@@ -455,7 +455,7 @@ describe("when: working tree has local changes and branch is behind upstream", (
     assert.deepInclude(quick, {
       kind: "run_action",
       action: "commit_push_pr",
-      label: "Commit, push & PR",
+      label: "Commit, push & create PR",
     });
   });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -219,7 +219,7 @@ export function resolveQuickAction(
       return { label: "Commit & push", disabled: false, kind: "run_action", action: "commit_push" };
     }
     return {
-      label: "Commit, push & PR",
+      label: "Commit, push & create PR",
       disabled: false,
       kind: "run_action",
       action: "commit_push_pr",

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -55,7 +55,7 @@ export const ChatHeader = memo(function ChatHeader({
 }: ChatHeaderProps) {
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2">
-      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
+      <div className="flex min-w-0 flex-initial shrink items-center gap-2 overflow-hidden sm:gap-3">
         <SidebarTrigger className="size-7 shrink-0 md:hidden" />
         <h2
           className="min-w-0 shrink truncate text-sm font-medium text-foreground"
@@ -74,7 +74,7 @@ export const ChatHeader = memo(function ChatHeader({
           </Badge>
         )}
       </div>
-      <div className="@container/header-actions flex min-w-0 flex-1 items-center justify-end gap-2 @sm/header-actions:gap-3">
+      <div className="@container/header-actions flex min-w-0 flex-1 items-center justify-end gap-2 overflow-hidden @sm/header-actions:gap-3">
         {activeProjectScripts && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}


### PR DESCRIPTION
## What Changed

- Changed the header title area from `flex-1` to `flex-initial shrink` so it only takes the space it needs instead of always claiming 50% (`ChatHeader.tsx` line 58)
- Added `overflow-hidden` to the actions div to prevent button overflow into the diff toggle (`ChatHeader.tsx` line 77)
- Reverted the label shortening from #771 — restored "Commit, push & create PR" since the full text now fits (`GitActionsControl.logic.ts`, `.test.ts`)

5 lines changed across 3 files, 0 lines added or removed.

## Why

The header was split 50/50 between title and actions via two `flex-1` divs. Both children had `flex: 1 1 0%`, splitting the available space exactly in half (398px each at 1100px viewport). The `@container/header-actions` container query on the actions div measured only that 398px — barely above the `@sm` (384px) threshold — so button labels collapsed to icons at ~1060px viewport width even though there was plenty of room.

This 50/50 split was introduced accidentally in commit `ce96ad0b` ("UI fixes"). Before that commit, the title had no `flex-1` and the actions div used `shrink-0` with the parent using `justify-between`. The restructuring gave both children `flex-1` as a side effect.

The maintainer identified this as the root cause in PR #773:

> "the real issue here is that the header is split in 50/50, so the thread title + project pill takes up 50% of the width even if not used, instead of letting the action buttons occupy that space"

**The fix:** Change the title div from `flex-1` to `flex-initial shrink`. Now the title takes only its content width (~132px for a typical short title) and the actions div claims all remaining space via `flex-1`. The `@container/header-actions` query stays on the actions div and now measures the actual available space (~660px at 1100px instead of 398px), keeping labels visible until the viewport genuinely gets tight.

`overflow-hidden` on the actions div prevents any remaining edge-case overflow from reaching the diff toggle button.

## UI Changes

**Before (1100px viewport):** Header action labels ("Build", "Open", "Commit & push") collapse to icon-only mode because the 50/50 split gives the actions div only 398px (barely above the 384px `@sm` threshold).

**After (1100px viewport):** All action labels are fully visible. The title takes only ~132px, leaving ~660px for actions — well above the 384px threshold.

<!-- screenshots to be added -->

## Checklist

- [x] This PR is small and focused (5-line change across 3 files)
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

---

Fixes #626. Fixes #806.
Related: #457, #399, #713, #426 (other header layout issues improved by better flex distribution).
Reverts label-shortening bandaid from #771 (no longer needed).
Obsoletes #773 (different approach to the same problem, as discussed by maintainer).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix header action labels collapsing too early by correcting flex distribution in `ChatHeader`
> - Changes the left header group from `flex-1` to `flex-initial shrink` so it no longer grows to fill all available space, preventing the right action area from being squeezed out.
> - Adds `overflow-hidden` to the right actions container to clip any remaining overflow.
> - Updates the `commit_push_pr` quick action label from "Commit, push & PR" to "Commit, push & create PR" in [`GitActionsControl.logic.ts`](https://github.com/pingdotgg/t3code/pull/1039/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) for clarity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae2bb04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->