### PR TITLE
fix(ws,sidebar): structured error payload and prevent horizontal overflow on project import

### DIFF
--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -20,7 +20,9 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
   ProjectId,
   ThreadId,
+  type WsError,
   WS_CHANNELS,
+  WS_ERROR_CODES,
   WS_METHODS,
   WebSocketRequest,
   type WsResponse as WsResponseMessage,
@@ -230,6 +232,40 @@ export class ServerLifecycleError extends Schema.TaggedErrorClass<ServerLifecycl
 class RouteRequestError extends Schema.TaggedErrorClass<RouteRequestError>()("RouteRequestError", {
   message: Schema.String,
 }) {}
+
+function buildWsErrorForClient(cause: Cause.Cause<unknown>): WsError {
+  const defect = Cause.squash(cause);
+  const rawMessage = defect instanceof Error ? defect.message : Cause.pretty(cause);
+  const firstLine = rawMessage.split("\n")[0]?.trim() ?? rawMessage;
+  const message = firstLine.replace(/^Error:\s*/i, "");
+
+  const dirNotExistPrefix = "Project directory does not exist: ";
+  const pathNotDirPrefix = "Project path is not a directory: ";
+  if (message.startsWith(dirNotExistPrefix)) {
+    return {
+      code: WS_ERROR_CODES.projectDirNotExist,
+      message: "Project directory does not exist",
+      path: message.slice(dirNotExistPrefix.length).trim() || undefined,
+    };
+  }
+  if (message.startsWith(pathNotDirPrefix)) {
+    return {
+      code: WS_ERROR_CODES.projectPathNotDirectory,
+      message: "Project path is not a directory",
+      path: message.slice(pathNotDirPrefix.length).trim() || undefined,
+    };
+  }
+  if (Schema.is(RouteRequestError)(defect)) {
+    return {
+      code: WS_ERROR_CODES.routeRequest,
+      message,
+    };
+  }
+  return {
+    code: WS_ERROR_CODES.unknown,
+    message,
+  };
+}
 
 export const createServer = Effect.fn(function* (): Effect.fn.Return<
   http.Server,
@@ -903,7 +939,10 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     if (messageText === null) {
       return yield* sendWsResponse({
         id: "unknown",
-        error: { message: "Invalid request format: Failed to read message" },
+        error: {
+          code: WS_ERROR_CODES.invalidRequest,
+          message: "Invalid request format: Failed to read message",
+        },
       });
     }
 
@@ -911,7 +950,10 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     if (Result.isFailure(request)) {
       return yield* sendWsResponse({
         id: "unknown",
-        error: { message: `Invalid request format: ${formatSchemaError(request.failure)}` },
+        error: {
+          code: WS_ERROR_CODES.invalidRequest,
+          message: `Invalid request format: ${formatSchemaError(request.failure)}`,
+        },
       });
     }
 
@@ -919,7 +961,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     if (Exit.isFailure(result)) {
       return yield* sendWsResponse({
         id: request.success.id,
-        error: { message: Cause.pretty(result.cause) },
+        error: buildWsErrorForClient(result.cause),
       });
     }
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1215,7 +1215,7 @@ export default function Sidebar() {
           </div>
 
           {shouldShowProjectPathEntry && (
-            <div className="mb-2 px-1">
+            <div className="mb-2 min-w-0 px-1 overflow-hidden">
               {isElectron && (
                 <button
                   type="button"
@@ -1227,7 +1227,7 @@ export default function Sidebar() {
                   {isPickingFolder ? "Picking folder..." : "Browse for folder"}
                 </button>
               )}
-              <div className="flex gap-1.5">
+              <div className="flex min-w-0 gap-1.5">
                 <input
                   ref={addProjectInputRef}
                   className={`min-w-0 flex-1 rounded-md border bg-secondary px-2 py-1 font-mono text-xs text-foreground placeholder:text-muted-foreground/40 focus:outline-none ${
@@ -1260,7 +1260,7 @@ export default function Sidebar() {
                 </button>
               </div>
               {addProjectError && (
-                <p className="mt-1 px-0.5 text-[11px] leading-tight text-red-400">
+                <p className="mt-1 min-w-0 break-words px-0.5 text-[11px] leading-tight text-red-400">
                   {addProjectError}
                 </p>
               )}

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -147,14 +147,26 @@ export const WebSocketRequest = Schema.Struct({
 });
 export type WebSocketRequest = typeof WebSocketRequest.Type;
 
+export const WS_ERROR_CODES = {
+  invalidRequest: "INVALID_REQUEST",
+  projectDirNotExist: "PROJECT_DIR_NOT_EXIST",
+  projectPathNotDirectory: "PROJECT_PATH_NOT_DIRECTORY",
+  routeRequest: "ROUTE_REQUEST_ERROR",
+  unknown: "UNKNOWN",
+} as const;
+export type WsErrorCode = (typeof WS_ERROR_CODES)[keyof typeof WS_ERROR_CODES];
+
+export const WsError = Schema.Struct({
+  code: Schema.String,
+  message: Schema.String,
+  path: Schema.optional(Schema.String),
+});
+export type WsError = typeof WsError.Type;
+
 export const WebSocketResponse = Schema.Struct({
   id: TrimmedNonEmptyString,
   result: Schema.optional(Schema.Unknown),
-  error: Schema.optional(
-    Schema.Struct({
-      message: Schema.String,
-    }),
-  ),
+  error: Schema.optional(WsError),
 });
 export type WebSocketResponse = typeof WebSocketResponse.Type;
 


### PR DESCRIPTION
## Summary

Fixes UX issues when adding a project with an invalid path: raw stack traces in error messages and horizontal scrollbar overflow in the sidebar.

## What changed

- **Contracts**: Added `WsError` schema and `WS_ERROR_CODES` for typed WebSocket error responses
- **Server**: `buildWsErrorForClient()` normalizes errors to `{ code, message, path? }` — users see "Project directory does not exist" instead of stack traces
- **Sidebar**: `min-w-0`, `overflow-hidden`, `break-words` on add-project form to prevent horizontal overflow when error text is long

## Why

- Users saw full stack traces when adding non-existent paths
- Long error text caused horizontal scroll in the sidebar
- Structured errors are easier to extend and handle on the client

## Before / After

**Before:** Raw stack trace in UI, horizontal scrollbar
**After:** Clean message "Project directory does not exist", text wraps without overflow

<img width="814" height="491" alt="Screenshot 2026-03-13 at 23 05 11" src="https://github.com/user-attachments/assets/5927b817-1a7c-4285-97ab-29441edbc2bd" />


<img width="771" height="313" alt="Screenshot 2026-03-13 at 22 51 25" src="https://github.com/user-attachments/assets/b24fdd86-208b-46e7-9b53-d2feeb20693d" />


<img width="1030" height="311" alt="Screenshot 2026-03-13 at 22 51 15" src="https://github.com/user-attachments/assets/51e399f9-65ea-43a8-a339-01be76fa5853" />


**Future improvement:** A cleaner approach would be to add `code` and `path` to `RouteRequestError` when it is created. The current message based detection is used because `Schema.is(RouteRequestError)` did not reliably match when extracting the defect from `Cause.squash`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured `WsError` payload with error codes and fix sidebar overflow on project import
> - Introduces `WS_ERROR_CODES` and a `WsError` schema in [`packages/contracts/src/ws.ts`](https://github.com/pingdotgg/t3code/pull/1045/files#diff-d7bcbddcc940489f8023f941eb2da10fc497046d131eecae771396692ed8a3dc) with `code`, `message`, and optional `path` fields, replacing the previous `{ message: string }` shape.
> - Adds a `buildWsErrorForClient` utility in [`apps/server/src/wsServer.ts`](https://github.com/pingdotgg/t3code/pull/1045/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) that maps internal Effect/Cause failures to structured errors, including specific codes for known project path errors.
> - Fixes horizontal overflow in [`apps/web/src/components/Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/1045/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) by adding `min-w-0`, `overflow-hidden`, and `break-words` to the project path entry container and error message.
> - Behavioral Change: WebSocket error responses now require a `code` field; clients expecting only `{ message }` will need to handle the new shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 05cd2f8.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->