### PR TITLE
feat: macOS universal binary instead of separate x64/arm64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,16 +85,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: macOS arm64
+          - label: macOS universal
             runner: macos-14
             platform: mac
             target: dmg
-            arch: arm64
-          - label: macOS x64
-            runner: macos-15-intel
-            platform: mac
-            target: dmg
-            arch: x64
+            arch: universal
           - label: Linux x64
             runner: ubuntu-24.04
             platform: linux
@@ -210,12 +205,6 @@ jobs:
             done
           done
 
-          if [[ "${{ matrix.platform }}" == "mac" && "${{ matrix.arch }}" != "arm64" ]]; then
-            if [[ -f release-publish/latest-mac.yml ]]; then
-              mv release-publish/latest-mac.yml "release-publish/latest-mac-${{ matrix.arch }}.yml"
-            fi
-          fi
-
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -277,13 +266,6 @@ jobs:
           pattern: desktop-*
           merge-multiple: true
           path: release-assets
-
-      - name: Merge macOS updater manifests
-        run: |
-          node scripts/merge-mac-update-manifests.ts \
-            release-assets/latest-mac.yml \
-            release-assets/latest-mac-x64.yml
-          rm -f release-assets/latest-mac-x64.yml
 
       - name: Publish release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Replaces the two separate macOS build matrix entries (`macOS arm64` on `macos-14` + `macOS x64` on `macos-15-intel`) with a single **universal binary** build (`arch: universal` on `macos-14`)
- Removes the `latest-mac.yml` rename workaround in the asset collection step
- Removes the "Merge macOS updater manifests" step and its dependency on `scripts/merge-mac-update-manifests.ts`

## How it works

No build script changes are needed — the existing `scripts/build-desktop-artifact.ts` already supports `universal` as a valid arch value:

- `BuildArch` is defined as `Schema.Literals(["arm64", "x64", "universal"])` (line 21)
- The macOS platform config explicitly allows `["arm64", "x64", "universal"]` (lines 50-64)
- The arch is passed to electron-builder as `--universal` (line 694), which electron-builder natively understands — it builds both x86_64 and arm64 slices, then uses `@electron/universal` (which wraps `lipo`) to merge them into a single fat binary automatically

This PR only changes the workflow YAML to pass `universal` instead of running two separate arch-specific jobs.

## Benefits

### Simpler release pipeline
The workflow drops from 4 matrix jobs to 3. The macOS-specific manifest merging logic (`merge-mac-update-manifests.ts`, the `latest-mac-x64.yml` rename) is eliminated entirely — fewer moving parts, fewer places for the release to break.

### Better user experience
Users download a single `.dmg` that works on both Intel and Apple Silicon Macs. No more choosing the wrong architecture, no confusion between two macOS downloads on the releases page.

### Simpler auto-update
With one universal build, electron-builder produces a single `latest-mac.yml` manifest that covers both architectures. No need to merge two separate manifests at release time.

### Reduced CI cost
One macOS runner instead of two per release. Apple Silicon runners (`macos-14`) can natively build universal binaries via `lipo`, so no cross-compilation is needed.

## Trade-offs

- The universal `.dmg` will be roughly **2x the size** of a single-arch DMG since it bundles both x86_64 and arm64 slices. This is standard practice (e.g. VS Code, Chrome, Discord all ship universal binaries).
- The single build job may take slightly longer than either individual arch build, but total wall-clock time decreases since the two jobs no longer run (and the merge step is gone).

## Test plan

- [ ] Trigger a workflow_dispatch release on the fork and verify the universal `.dmg` is produced
- [ ] Verify the `.dmg` runs natively on both Apple Silicon and Intel Macs
- [ ] Confirm `latest-mac.yml` is published without needing the merge script
- [ ] Confirm auto-update works on both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)