### PR TITLE
feat(desktop): add "Copy Image" to right-click context menu

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1695,6 +1695,14 @@ function createWindow(): BrowserWindow {
       );
     }
 
+    if (params.mediaType === "image") {
+      menuTemplate.push({
+        label: "Copy Image",
+        click: () => window.webContents.copyImageAt(params.x, params.y),
+      });
+      menuTemplate.push({ type: "separator" });
+    }
+
     menuTemplate.push(
       { role: "cut", enabled: params.editFlags.canCut },
       { role: "copy", enabled: params.editFlags.canCopy },


### PR DESCRIPTION
## What Changed

Added a "Copy Image" option to the Electron right-click context menu when clicking on an image.

## Why

The Electron context menu only showed Cut/Copy/Paste/Select All. There was no way to copy an image from the app, whether from the expanded image preview or the smaller image thumbnails.

## UI Changes

**Before:**
On expanded image preview:
<img width="962" height="334" alt="2026-03-13_21-54" src="https://github.com/user-attachments/assets/9011ac9d-06d9-4bdc-b44c-645d4e8e2530" />

On image thumbnail:
<img width="837" height="290" alt="2026-03-13_21-56" src="https://github.com/user-attachments/assets/4e03fc2a-1efb-48bc-aa0d-f9b731d45560" />


**After:**
On expanded image preview:
<img width="921" height="325" alt="2026-03-13_21-55" src="https://github.com/user-attachments/assets/72200131-5f6b-42cc-9cc9-e6dd642baa2d" />

On image thumbnail:
<img width="860" height="289" alt="image" src="https://github.com/user-attachments/assets/3a8ad08c-e731-44a2-8ef1-59333dadc062" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add "Copy Image" to the desktop right-click context menu
> In [main.ts](https://github.com/pingdotgg/t3code/pull/1052/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb), the `context-menu` event handler in `createWindow` now injects a "Copy Image" menu item when right-clicking on an image. Selecting it calls `webContents.copyImageAt(x, y)` to copy the image to the clipboard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ae725c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change in the desktop context menu that calls Electron’s built-in `webContents.copyImageAt`; no auth or data processing changes.
> 
> **Overview**
> Adds a **"Copy Image"** item to the desktop Electron `webContents` right-click context menu when the clicked element is an image (`params.mediaType === "image"`). Selecting it copies the image under the cursor via `webContents.copyImageAt(x, y)`, inserted before the standard cut/copy/paste entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e8b583b1d638c6aec2bf54d23c0984a5872590e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->