### PR TITLE
Persist last selected model when opening new threads

### DIFF
--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -372,6 +372,8 @@ describe("composerDraftStore setModel", () => {
       draftsByThreadId: {},
       draftThreadsByThreadId: {},
       projectDraftThreadIdByProjectId: {},
+      lastSelectedModel: null,
+      lastSelectedProvider: null,
     });
   });
 
@@ -384,6 +386,23 @@ describe("composerDraftStore setModel", () => {
       "gpt-5.3-codex",
     );
   });
+
+  it("updates lastSelectedModel when a non-null model is set", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setModel(threadId, "gpt-5.3-codex");
+
+    expect(useComposerDraftStore.getState().lastSelectedModel).toBe("gpt-5.3-codex");
+  });
+
+  it("does not update lastSelectedModel when model is set to null", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setModel(threadId, "gpt-5.3-codex");
+    store.setModel(threadId, null);
+
+    expect(useComposerDraftStore.getState().lastSelectedModel).toBe("gpt-5.3-codex");
+  });
 });
 
 describe("composerDraftStore setProvider", () => {
@@ -394,6 +413,8 @@ describe("composerDraftStore setProvider", () => {
       draftsByThreadId: {},
       draftThreadsByThreadId: {},
       projectDraftThreadIdByProjectId: {},
+      lastSelectedModel: null,
+      lastSelectedProvider: null,
     });
   });
 
@@ -412,6 +433,14 @@ describe("composerDraftStore setProvider", () => {
     store.setProvider(threadId, null);
 
     expect(useComposerDraftStore.getState().draftsByThreadId[threadId]).toBeUndefined();
+  });
+
+  it("updates lastSelectedProvider when a non-null provider is set", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setProvider(threadId, "codex");
+
+    expect(useComposerDraftStore.getState().lastSelectedProvider).toBe("codex");
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -97,6 +97,8 @@ interface PersistedComposerDraftStoreState {
   draftsByThreadId: Record<ThreadId, PersistedComposerThreadDraftState>;
   draftThreadsByThreadId: Record<ThreadId, PersistedDraftThreadState>;
   projectDraftThreadIdByProjectId: Record<ProjectId, ThreadId>;
+  lastSelectedModel: string | null;
+  lastSelectedProvider: ProviderKind | null;
 }
 
 interface ComposerThreadDraftState {
@@ -130,6 +132,8 @@ interface ComposerDraftStoreState {
   draftsByThreadId: Record<ThreadId, ComposerThreadDraftState>;
   draftThreadsByThreadId: Record<ThreadId, DraftThreadState>;
   projectDraftThreadIdByProjectId: Record<ProjectId, ThreadId>;
+  lastSelectedModel: string | null;
+  lastSelectedProvider: ProviderKind | null;
   getDraftThreadByProjectId: (projectId: ProjectId) => ProjectDraftThread | null;
   getDraftThread: (threadId: ThreadId) => DraftThreadState | null;
   setProjectDraftThreadId: (
@@ -185,6 +189,8 @@ const EMPTY_PERSISTED_DRAFT_STORE_STATE: PersistedComposerDraftStoreState = {
   draftsByThreadId: {},
   draftThreadsByThreadId: {},
   projectDraftThreadIdByProjectId: {},
+  lastSelectedModel: null,
+  lastSelectedProvider: null,
 };
 
 const EMPTY_IMAGES: ComposerImageAttachment[] = [];
@@ -386,7 +392,13 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
     }
   }
   if (!rawDraftMap || typeof rawDraftMap !== "object") {
-    return { draftsByThreadId: {}, draftThreadsByThreadId, projectDraftThreadIdByProjectId };
+    return {
+      draftsByThreadId: {},
+      draftThreadsByThreadId,
+      projectDraftThreadIdByProjectId,
+      lastSelectedModel: null,
+      lastSelectedProvider: null,
+    };
   }
   const nextDraftsByThreadId: PersistedComposerDraftStoreState["draftsByThreadId"] = {};
   for (const [threadId, draftValue] of Object.entries(rawDraftMap as Record<string, unknown>)) {
@@ -450,10 +462,17 @@ function normalizePersistedComposerDraftState(value: unknown): PersistedComposer
       ...(codexFastMode ? { codexFastMode } : {}),
     };
   }
+  const lastSelectedModel =
+    typeof candidate.lastSelectedModel === "string"
+      ? (normalizeModelSlug(candidate.lastSelectedModel) ?? null)
+      : null;
+  const lastSelectedProvider = normalizeProviderKind(candidate.lastSelectedProvider);
   return {
     draftsByThreadId: nextDraftsByThreadId,
     draftThreadsByThreadId,
     projectDraftThreadIdByProjectId,
+    lastSelectedModel,
+    lastSelectedProvider,
   };
 }
 
@@ -563,6 +582,8 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
       draftsByThreadId: {},
       draftThreadsByThreadId: {},
       projectDraftThreadIdByProjectId: {},
+      lastSelectedModel: null,
+      lastSelectedProvider: null,
       getDraftThreadByProjectId: (projectId) => {
         if (projectId.length === 0) {
           return null;
@@ -841,7 +862,13 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           } else {
             nextDraftsByThreadId[threadId] = nextDraft;
           }
-          return { draftsByThreadId: nextDraftsByThreadId };
+          const nextState: Partial<ComposerDraftStoreState> = {
+            draftsByThreadId: nextDraftsByThreadId,
+          };
+          if (normalizedProvider !== null) {
+            nextState.lastSelectedProvider = normalizedProvider;
+          }
+          return nextState;
         });
       },
       setModel: (threadId, model) => {
@@ -868,7 +895,13 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           } else {
             nextDraftsByThreadId[threadId] = nextDraft;
           }
-          return { draftsByThreadId: nextDraftsByThreadId };
+          const nextState: Partial<ComposerDraftStoreState> = {
+            draftsByThreadId: nextDraftsByThreadId,
+          };
+          if (normalizedModel !== null) {
+            nextState.lastSelectedModel = normalizedModel;
+          }
+          return nextState;
         });
       },
       setRuntimeMode: (threadId, runtimeMode) => {
@@ -1255,6 +1288,8 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           draftsByThreadId: persistedDraftsByThreadId,
           draftThreadsByThreadId: state.draftThreadsByThreadId,
           projectDraftThreadIdByProjectId: state.projectDraftThreadIdByProjectId,
+          lastSelectedModel: state.lastSelectedModel,
+          lastSelectedProvider: state.lastSelectedProvider,
         };
       },
       merge: (persistedState, currentState) => {
@@ -1270,6 +1305,8 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           draftsByThreadId,
           draftThreadsByThreadId: normalizedPersisted.draftThreadsByThreadId,
           projectDraftThreadIdByProjectId: normalizedPersisted.projectDraftThreadIdByProjectId,
+          lastSelectedModel: normalizedPersisted.lastSelectedModel,
+          lastSelectedProvider: normalizedPersisted.lastSelectedProvider,
         };
       },
     },

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -89,6 +89,9 @@ export function useHandleNewThread() {
       const threadId = newThreadId();
       const createdAt = new Date().toISOString();
       return (async () => {
+        const { lastSelectedModel, lastSelectedProvider, setModel, setProvider } =
+          useComposerDraftStore.getState();
+
         setProjectDraftThreadId(projectId, threadId, {
           createdAt,
           branch: options?.branch ?? null,
@@ -96,6 +99,13 @@ export function useHandleNewThread() {
           envMode: options?.envMode ?? "local",
           runtimeMode: DEFAULT_RUNTIME_MODE,
         });
+
+        if (lastSelectedModel) {
+          setModel(threadId, lastSelectedModel);
+        }
+        if (lastSelectedProvider) {
+          setProvider(threadId, lastSelectedProvider);
+        }
 
         await navigate({
           to: "/$threadId",


### PR DESCRIPTION
## What Changed

When a user selects a model in any thread and then opens a new thread, the new thread now pre-populates with that last selected model instead of resetting to the project/global default.

 - Added `lastSelectedModel` and `lastSelectedProvider` as persisted global fields in `composerDraftStore`
 - `setModel` and `setProvider` now write these globals whenever a non-null value is explicitly selected
 - `useHandleNewThread` reads these globals and pre-populates fresh thread drafts before navigating

Existing threads are unaffected as the new values are only written to freshly generated thread IDs that have no prior draft state. Started threads have their model locked via `lockedProvider`/`sessionProvider` in `ChatView` regardless.

## Why

Model selection was scoped to individual thread drafts (`draftsByThreadId[threadId].model`). When a new thread was created its draft started with `model: null`, causing `selectedModel` in `ChatView` to fall back to `activeProject.model ?? getDefaultModel()` silently discarding the user's recent choice. This fix introduces a lightweight "sticky last selection" that survives navigation and page reloads via localStorage, without requiring a new user-facing setting.

## UI Changes

No UI changes. The model picker component is unchanged, it just displays the pre-populated value on new threads.

## Demo

- This demo shows GPT-5.4 selected initially
- A second thread is opened showing `GPT-5.4` again (behavior unchanged)
- The second thread chat model is changed to `GPT-5.2` and a prompt is sent (behavior unchanged)
- A new third thread is opened and shows `GPT-5.2` selected automatically (`new behavior`)
- The original thread is opened showing that `GPT-5.4` is unchanged (behavior unchanged)

![t3code_persistant_model_selection](https://github.com/user-attachments/assets/c7f02462-b427-46d7-b24c-12f08fac2243)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist last selected model and provider when opening a new thread
> - Adds `lastSelectedModel` and `lastSelectedProvider` fields to the composer draft store, persisted alongside thread drafts.
> - When `setModel` or `setProvider` is called with a non-null value, the store records it as the last selection; null values leave the persisted selection unchanged.
> - In [`useHandleNewThread`](https://github.com/pingdotgg/t3code/pull/1056/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef), newly created threads are initialized with the last non-null model and provider from the store.
> - On rehydration, persisted values are normalized via `normalizeModelSlug` and `normalizeProviderKind` before being merged into live state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2813e5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->