### PR TITLE
feat(web): add docsUrl for providers to install from

### DIFF
--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -2,6 +2,8 @@ import { PROVIDER_DISPLAY_NAMES, type ServerProvider } from "@t3tools/contracts"
 import { memo } from "react";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { CircleAlertIcon } from "lucide-react";
+import { PROVIDER_OPTIONS } from "~/session-logic";
+import { ensureSentenceEnds } from "~/lib/utils";
 
 export const ProviderStatusBanner = memo(function ProviderStatusBanner({
   status,
@@ -19,13 +21,28 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
       : `${providerLabel} provider has limited availability.`;
   const title = `${providerLabel} provider status`;
 
+  const opts = PROVIDER_OPTIONS.find((opt) => opt.value === status.provider);
+
   return (
     <div className="pt-3 mx-auto max-w-3xl">
       <Alert variant={status.status === "error" ? "error" : "warning"}>
         <CircleAlertIcon />
         <AlertTitle>{title}</AlertTitle>
         <AlertDescription className="line-clamp-3" title={status.message ?? defaultMessage}>
-          {status.message ?? defaultMessage}
+          {ensureSentenceEnds(status.message ?? defaultMessage)}
+          {opts?.docsUrl ? (
+            <>
+              {" "}
+              <a
+                className="underline underline-offset-4 text-foreground hover:text-primary"
+                href={opts.docsUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Installation Guide
+              </a>
+            </>
+          ) : null}
         </AlertDescription>
       </Alert>
     </div>

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -34,3 +34,11 @@ export const newProjectId = (): ProjectId => ProjectId.makeUnsafe(randomUUID());
 export const newThreadId = (): ThreadId => ThreadId.makeUnsafe(randomUUID());
 
 export const newMessageId = (): MessageId => MessageId.makeUnsafe(randomUUID());
+
+export const ensureSentenceEnds = (value: string): string => {
+  const trimmed = value.trim();
+  if ([".", "!", "?"].includes(trimmed.at(-1) ?? "")) {
+    return trimmed;
+  }
+  return `${trimmed}.`;
+};

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -26,7 +26,7 @@ export const PROVIDER_OPTIONS: Array<{
   value: ProviderPickerKind;
   label: string;
   available: boolean;
-  docsUrl: string | null;
+  docsUrl: string;
 }> = [
   {
     value: "codex",

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -26,10 +26,26 @@ export const PROVIDER_OPTIONS: Array<{
   value: ProviderPickerKind;
   label: string;
   available: boolean;
+  docsUrl: string | null;
 }> = [
-  { value: "codex", label: "Codex", available: true },
-  { value: "claudeAgent", label: "Claude", available: true },
-  { value: "cursor", label: "Cursor", available: false },
+  {
+    value: "codex",
+    label: "Codex",
+    available: true,
+    docsUrl: "https://developers.openai.com/codex/cli/#cli-setup",
+  },
+  {
+    value: "claudeAgent",
+    label: "Claude",
+    available: true,
+    docsUrl: "https://code.claude.com/docs/en/quickstart#step-1-install-claude-code",
+  },
+  {
+    value: "cursor",
+    label: "Cursor",
+    available: false,
+    docsUrl: "https://cursor.com/docs/cli/installation#installation",
+  },
 ];
 
 export interface WorkLogEntry {


### PR DESCRIPTION
Closes  #627 

## What Changed

The health check banner now includes a link to docs, so users know where to download from.

## Why

Currently, the installation instructions are not included in error message. can cause confusion.

## UI Changes

Before:
<img width="1072" height="436" alt="image" src="https://github.com/user-attachments/assets/4e555d90-dfa8-47c7-bddf-c80758dfc2ff" />

After:
<img width="993" height="215" alt="image" src="https://github.com/user-attachments/assets/9a0787ea-3312-4de0-8614-c87711f083ee" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `docsUrl` field to provider options and show an 'Installation Guide' link in the provider status banner
> - Extends each entry in `PROVIDER_OPTIONS` ([session-logic.ts](https://github.com/pingdotgg/t3code/pull/1061/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6)) with a `docsUrl` field pointing to provider-specific installation documentation.
> - Updates [ProviderStatusBanner.tsx](https://github.com/pingdotgg/t3code/pull/1061/files#diff-d53076993b72ce28ed4241d2451251fe23b3d13a1fbc6effc6cc4a65c525e981) to render a contextual 'Installation Guide' link (opens in a new tab) when the active provider has a `docsUrl`.
> - Adds `ensureSentenceEnds` to [utils.ts](https://github.com/pingdotgg/t3code/pull/1061/files#diff-a77b1983abf81ad3ac9e3d762f4ea683e77399fc446a1f34a6c0d57cde0ab767) and applies it to banner status messages to guarantee terminal punctuation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a97baa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds static documentation URLs and minor message formatting; no auth, data writes, or backend behavior changes.
> 
> **Overview**
> The provider health/status banner now appends an **Installation Guide** link when the current provider has documentation configured, using a new `docsUrl` field on `PROVIDER_OPTIONS`.
> 
> It also normalizes banner copy by trimming and ensuring messages end with terminal punctuation via the new `ensureSentenceEnds` utility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a97baa0dc6b68ac44b3b7ea5b757309ec59492ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->