### PR TITLE
fix: fix menu copy

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -269,7 +269,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   // Tracks whether the user explicitly dismissed the sidebar for the active turn.
   const planSidebarDismissedForTurnRef = useRef<string | null>(null);
   // When set, the thread-change reset effect will open the sidebar instead of closing it.
-  // Used by "Implement in new thread" to carry the sidebar-open intent across navigation.
+  // Used by "Implement in a new thread" to carry the sidebar-open intent across navigation.
   const planSidebarOpenOnNextThreadRef = useRef(false);
   const [nowTick, setNowTick] = useState(() => Date.now());
   const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
@@ -3710,7 +3710,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                                     disabled={isSendBusy || isConnecting}
                                     onClick={() => void onImplementPlanInNewThread()}
                                   >
-                                    Implement in new thread
+                                    Implement in a new thread
                                   </MenuItem>
                                 </MenuPopup>
                               </Menu>


### PR DESCRIPTION
You can view my PRs and issues at https://pr-navigator.pages.dev/t3code-utkarsh

## What Changed

Changed the plan action menu item text from `Implement in new thread` to `Implement in a new thread`.

Also updated the nearby code comment so it matches the user-facing label.

## Why

The existing label reads awkwardly in the UI. This is a small copy fix that improves clarity and polish without changing behavior.

Closes #1062

## UI Changes

| Before | After |
| --- | --- |
| <img width="563" height="284" alt="image" src="https://github.com/user-attachments/assets/1e01aba3-2ecb-40f8-8cab-9907ef999f5b" /> | <img width="502" height="285" alt="image" src="https://github.com/user-attachments/assets/6ea96375-6b02-4ddc-9636-8ecf7c6b36a3" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix grammar in 'Implement in a new thread' menu item label
> Adds the missing article 'a' to the menu item label in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1063/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e). No logic or behavior is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54bba2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->