### PR TITLE
feat: Improve visibility of key bindings

### DIFF
--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -17,6 +17,7 @@ import {
   ResolvedKeybindingsConfig,
   type ServerConfigIssue,
 } from "@t3tools/contracts";
+import { DEFAULT_KEYBINDINGS } from "@t3tools/shared/keybindings";
 import { Mutable } from "effect/Types";
 import {
   Array,
@@ -64,17 +65,7 @@ type WhenToken =
   | { type: "lparen" }
   | { type: "rparen" };
 
-export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
-  { key: "mod+j", command: "terminal.toggle" },
-  { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
-  { key: "mod+n", command: "terminal.new", when: "terminalFocus" },
-  { key: "mod+w", command: "terminal.close", when: "terminalFocus" },
-  { key: "mod+d", command: "diff.toggle", when: "!terminalFocus" },
-  { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
-  { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
-  { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
-  { key: "mod+o", command: "editor.openFavorite" },
-];
+export { DEFAULT_KEYBINDINGS };
 
 function normalizeKeyToken(token: string): string {
   if (token === "space") return " ";

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFAULT_SHOW_HEADER_KEYBINDINGS_BUTTON,
   DEFAULT_TIMESTAMP_FORMAT,
   getAppModelOptions,
   normalizeCustomModelSlugs,
@@ -62,5 +63,11 @@ describe("resolveAppModelSelection", () => {
 describe("timestamp format defaults", () => {
   it("defaults timestamp format to locale", () => {
     expect(DEFAULT_TIMESTAMP_FORMAT).toBe("locale");
+  });
+});
+
+describe("header keybindings button defaults", () => {
+  it("shows the chat header keybindings button by default", () => {
+    expect(DEFAULT_SHOW_HEADER_KEYBINDINGS_BUTTON).toBe(true);
   });
 });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -10,6 +10,7 @@ export const MAX_CUSTOM_MODEL_LENGTH = 256;
 export const TIMESTAMP_FORMAT_OPTIONS = ["locale", "12-hour", "24-hour"] as const;
 export type TimestampFormat = (typeof TIMESTAMP_FORMAT_OPTIONS)[number];
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
+export const DEFAULT_SHOW_HEADER_KEYBINDINGS_BUTTON = true;
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
 };
@@ -27,6 +28,9 @@ const AppSettingsSchema = Schema.Struct({
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withConstructorDefault(() => Option.some(true))),
   enableAssistantStreaming: Schema.Boolean.pipe(
     Schema.withConstructorDefault(() => Option.some(false)),
+  ),
+  showHeaderKeybindingsButton: Schema.Boolean.pipe(
+    Schema.withConstructorDefault(() => Option.some(DEFAULT_SHOW_HEADER_KEYBINDINGS_BUTTON)),
   ),
   timestampFormat: Schema.Literals(["locale", "12-hour", "24-hour"]).pipe(
     Schema.withConstructorDefault(() => Option.some(DEFAULT_TIMESTAMP_FORMAT)),

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -16,17 +16,17 @@ import {
 } from "lucide-react";
 import React, { type FormEvent, type KeyboardEvent, useCallback, useMemo, useState } from "react";
 
-import {
-  keybindingValueForCommand,
-  decodeProjectScriptKeybindingRule,
-} from "~/lib/projectScriptKeybindings";
+import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
 import {
   commandForProjectScript,
   nextProjectScriptId,
   primaryProjectScript,
 } from "~/projectScripts";
-import { shortcutLabelForCommand } from "~/keybindings";
-import { isMacPlatform } from "~/lib/utils";
+import {
+  keybindingValueForCommand,
+  keybindingValueFromEvent,
+  shortcutLabelForCommand,
+} from "~/keybindings";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -96,57 +96,6 @@ interface ProjectScriptsControlProps {
   onDeleteScript: (scriptId: string) => Promise<void> | void;
 }
 
-function normalizeShortcutKeyToken(key: string): string | null {
-  const normalized = key.toLowerCase();
-  if (
-    normalized === "meta" ||
-    normalized === "control" ||
-    normalized === "ctrl" ||
-    normalized === "shift" ||
-    normalized === "alt" ||
-    normalized === "option"
-  ) {
-    return null;
-  }
-  if (normalized === " ") return "space";
-  if (normalized === "escape") return "esc";
-  if (normalized === "arrowup") return "arrowup";
-  if (normalized === "arrowdown") return "arrowdown";
-  if (normalized === "arrowleft") return "arrowleft";
-  if (normalized === "arrowright") return "arrowright";
-  if (normalized.length === 1) return normalized;
-  if (normalized.startsWith("f") && normalized.length <= 3) return normalized;
-  if (normalized === "enter" || normalized === "tab" || normalized === "backspace") {
-    return normalized;
-  }
-  if (normalized === "delete" || normalized === "home" || normalized === "end") {
-    return normalized;
-  }
-  if (normalized === "pageup" || normalized === "pagedown") return normalized;
-  return null;
-}
-
-function keybindingFromEvent(event: KeyboardEvent<HTMLInputElement>): string | null {
-  const keyToken = normalizeShortcutKeyToken(event.key);
-  if (!keyToken) return null;
-
-  const parts: string[] = [];
-  if (isMacPlatform(navigator.platform)) {
-    if (event.metaKey) parts.push("mod");
-    if (event.ctrlKey) parts.push("ctrl");
-  } else {
-    if (event.ctrlKey) parts.push("mod");
-    if (event.metaKey) parts.push("meta");
-  }
-  if (event.altKey) parts.push("alt");
-  if (event.shiftKey) parts.push("shift");
-  if (parts.length === 0) {
-    return null;
-  }
-  parts.push(keyToken);
-  return parts.join("+");
-}
-
 export default function ProjectScriptsControl({
   scripts,
   keybindings,
@@ -186,7 +135,7 @@ export default function ProjectScriptsControl({
       setKeybinding("");
       return;
     }
-    const next = keybindingFromEvent(event);
+    const next = keybindingValueFromEvent(event, navigator.platform);
     if (!next) return;
     setKeybinding(next);
   };

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -7,11 +7,13 @@ import {
 import { memo } from "react";
 import GitActionsControl from "../GitActionsControl";
 import { DiffIcon } from "lucide-react";
+import { useAppSettings } from "~/appSettings";
 import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
 import { Toggle } from "../ui/toggle";
 import { SidebarTrigger } from "../ui/sidebar";
+import { KeybindingsControl } from "./KeybindingsControl";
 import { OpenInPicker } from "./OpenInPicker";
 
 interface ChatHeaderProps {
@@ -53,6 +55,8 @@ export const ChatHeader = memo(function ChatHeader({
   onDeleteProjectScript,
   onToggleDiff,
 }: ChatHeaderProps) {
+  const { settings } = useAppSettings();
+
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
@@ -86,6 +90,9 @@ export const ChatHeader = memo(function ChatHeader({
             onDeleteScript={onDeleteProjectScript}
           />
         )}
+        {settings.showHeaderKeybindingsButton ? (
+          <KeybindingsControl keybindings={keybindings} triggerLabel="Keys" />
+        ) : null}
         {activeProjectName && (
           <OpenInPicker
             keybindings={keybindings}

--- a/apps/web/src/components/chat/KeybindingsControl.tsx
+++ b/apps/web/src/components/chat/KeybindingsControl.tsx
@@ -1,0 +1,328 @@
+import {
+  KeybindingRule as KeybindingRuleSchema,
+  type KeybindingCommand,
+  type ResolvedKeybindingsConfig,
+  type ServerConfig,
+} from "@t3tools/contracts";
+import { useQueryClient } from "@tanstack/react-query";
+import { Schema } from "effect";
+import { KeyboardIcon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { serverQueryKeys } from "~/lib/serverReactQuery";
+import { ensureNativeApi } from "~/nativeApi";
+import {
+  defaultShortcutValuesForCommand,
+  defaultWhenForCommand,
+  primaryDefaultShortcutValueForCommand,
+  STATIC_KEYBINDING_DEFINITIONS,
+  STATIC_KEYBINDING_SECTIONS,
+  keybindingValueForCommand,
+  keybindingValueFromEvent,
+  shortcutLabelsForCommand,
+} from "~/keybindings";
+import { cn } from "~/lib/utils";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "../ui/dialog";
+import { Input } from "../ui/input";
+import { Kbd } from "../ui/kbd";
+
+const INVALID_KEYBINDING_MESSAGE = "Enter a valid shortcut with at least one modifier key.";
+
+const SECTION_ACCENTS = {
+  workspace: "before:bg-sky-500/65",
+  chat: "before:bg-emerald-500/65",
+  terminal: "before:bg-amber-500/65",
+} as const;
+
+function buildDraftValues(
+  keybindings: ResolvedKeybindingsConfig,
+): Record<KeybindingCommand, string> {
+  return Object.fromEntries(
+    STATIC_KEYBINDING_DEFINITIONS.map((definition) => [
+      definition.command,
+      keybindingValueForCommand(keybindings, definition.command) ??
+        primaryDefaultShortcutValueForCommand(definition.command) ??
+        "",
+    ]),
+  ) as Record<KeybindingCommand, string>;
+}
+
+interface KeybindingsControlProps {
+  keybindings: ResolvedKeybindingsConfig;
+  triggerLabel?: string;
+  triggerClassName?: string;
+}
+
+export function KeybindingsControl({
+  keybindings,
+  triggerLabel = "Keys",
+  triggerClassName,
+}: KeybindingsControlProps) {
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [draftValues, setDraftValues] = useState<Record<KeybindingCommand, string>>(
+    buildDraftValues(keybindings),
+  );
+  const [savingCommand, setSavingCommand] = useState<KeybindingCommand | null>(null);
+  const [errorByCommand, setErrorByCommand] = useState<Partial<Record<KeybindingCommand, string>>>(
+    {},
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setDraftValues(buildDraftValues(keybindings));
+    setErrorByCommand({});
+  }, [keybindings, open]);
+
+  const sections = useMemo(
+    () =>
+      STATIC_KEYBINDING_SECTIONS.map((section) => ({
+        id: section.id,
+        title: section.title,
+        description: section.description,
+        definitions: STATIC_KEYBINDING_DEFINITIONS.filter(
+          (definition) => definition.section === section.id,
+        ),
+      })),
+    [],
+  );
+
+  const updateDraftValue = (command: KeybindingCommand, value: string) => {
+    setDraftValues((current) => ({
+      ...current,
+      [command]: value,
+    }));
+    setErrorByCommand((current) => ({
+      ...current,
+      [command]: undefined,
+    }));
+  };
+
+  const saveShortcut = async (command: KeybindingCommand) => {
+    const nextValue =
+      draftValues[command]?.trim() || primaryDefaultShortcutValueForCommand(command) || "";
+    const when = defaultWhenForCommand(command);
+    const decoded = Schema.decodeUnknownOption(KeybindingRuleSchema)({
+      key: nextValue,
+      command,
+      ...(when ? { when } : {}),
+    });
+
+    if (decoded._tag === "None") {
+      setErrorByCommand((current) => ({
+        ...current,
+        [command]: INVALID_KEYBINDING_MESSAGE,
+      }));
+      return;
+    }
+
+    setSavingCommand(command);
+    try {
+      const api = ensureNativeApi();
+      const result = await api.server.upsertKeybinding(decoded.value);
+      queryClient.setQueryData<ServerConfig>(serverQueryKeys.config(), (current) =>
+        current
+          ? {
+              ...current,
+              keybindings: result.keybindings,
+              issues: result.issues,
+            }
+          : current,
+      );
+      await queryClient.invalidateQueries({ queryKey: serverQueryKeys.all });
+    } catch (error) {
+      setErrorByCommand((current) => ({
+        ...current,
+        [command]: error instanceof Error ? error.message : "Unable to save shortcut.",
+      }));
+    } finally {
+      setSavingCommand(null);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        size="xs"
+        variant="outline"
+        className={cn("shrink-0", triggerClassName)}
+        aria-label="Open keybindings"
+        onClick={() => setOpen(true)}
+      >
+        <KeyboardIcon className="size-3.5" />
+        <span>{triggerLabel}</span>
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogPopup className="max-w-6xl">
+          <DialogHeader>
+            <DialogTitle>Keybindings</DialogTitle>
+            <DialogDescription>
+              Review active shortcuts, update them inline, or restore a command to its default
+              shortcut. Press a shortcut into any field and use Backspace to reset.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-6" scrollFade={false}>
+            {sections.map((section) => (
+              <section key={section.id} className="space-y-3">
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">{section.title}</h3>
+                  <p className="mt-1 text-xs text-muted-foreground">{section.description}</p>
+                </div>
+
+                <div className="overflow-x-auto rounded-2xl border border-border/70 bg-background/60">
+                  <div className="hidden min-w-[920px] grid-cols-[minmax(0,2.2fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.35fr)_auto] gap-4 border-b border-border/70 px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground md:grid">
+                    <div>Action</div>
+                    <div>Current</div>
+                    <div>Default</div>
+                    <div>Edit</div>
+                    <div>Apply</div>
+                  </div>
+
+                  <div className="min-w-[920px] divide-y divide-border/70 md:min-w-[920px]">
+                    {section.definitions.map((definition) => {
+                      const currentLabels = shortcutLabelsForCommand(
+                        keybindings,
+                        definition.command,
+                      );
+                      const defaultValues = defaultShortcutValuesForCommand(definition.command);
+                      const draftValue = draftValues[definition.command] ?? "";
+                      const normalizedDraftValue = draftValue.trim();
+                      const currentValue = keybindingValueForCommand(
+                        keybindings,
+                        definition.command,
+                      );
+                      const willReplaceMany = currentLabels.length > 1 || defaultValues.length > 1;
+                      const canSave =
+                        normalizedDraftValue.length > 0 && normalizedDraftValue !== currentValue;
+                      const isSaving = savingCommand === definition.command;
+                      const error = errorByCommand[definition.command];
+
+                      return (
+                        <div
+                          key={definition.command}
+                          className={cn(
+                            "relative grid grid-cols-[minmax(0,2.2fr)_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.35fr)_auto] gap-4 px-5 py-4 before:absolute before:bottom-3 before:left-0 before:top-3 before:w-px",
+                            SECTION_ACCENTS[section.id],
+                          )}
+                        >
+                          <div className="min-w-0 space-y-2">
+                            <div className="text-sm font-medium text-foreground">
+                              {definition.title}
+                            </div>
+                            <p className="text-sm text-muted-foreground">
+                              {definition.description}
+                            </p>
+                            <code className="inline-flex rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                              {definition.command}
+                            </code>
+                          </div>
+
+                          <div className="min-w-0 space-y-2">
+                            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground md:hidden">
+                              Current
+                            </div>
+                            <div className="flex min-h-10 flex-wrap gap-2">
+                              {currentLabels.length > 0 ? (
+                                currentLabels.map((label) => <Kbd key={label}>{label}</Kbd>)
+                              ) : (
+                                <span className="text-sm text-muted-foreground">None</span>
+                              )}
+                            </div>
+                            {willReplaceMany ? (
+                              <p className="text-xs text-muted-foreground">
+                                Saving here replaces all active shortcuts for this command with one
+                                binding.
+                              </p>
+                            ) : null}
+                          </div>
+
+                          <div className="min-w-0 space-y-2">
+                            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground md:hidden">
+                              Default
+                            </div>
+                            <div className="flex min-h-10 flex-wrap gap-2">
+                              {defaultValues.map((value) => (
+                                <Kbd key={value}>{value}</Kbd>
+                              ))}
+                            </div>
+                          </div>
+
+                          <div className="min-w-0 space-y-2">
+                            <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground md:hidden">
+                              Edit
+                            </div>
+                            <Input
+                              value={draftValue}
+                              readOnly
+                              className="font-mono text-sm"
+                              onKeyDown={(event) => {
+                                if (event.key === "Tab") return;
+                                event.preventDefault();
+                                if (event.key === "Backspace" || event.key === "Delete") {
+                                  updateDraftValue(
+                                    definition.command,
+                                    primaryDefaultShortcutValueForCommand(definition.command) ?? "",
+                                  );
+                                  return;
+                                }
+
+                                const nextValue = keybindingValueFromEvent(
+                                  event,
+                                  navigator.platform,
+                                );
+                                if (!nextValue) return;
+                                updateDraftValue(definition.command, nextValue);
+                              }}
+                            />
+                            <p className="text-xs text-muted-foreground">
+                              Press a shortcut. Use Backspace to restore default.
+                            </p>
+                            {error ? <p className="text-xs text-destructive">{error}</p> : null}
+                          </div>
+
+                          <div className="flex min-w-36 flex-col gap-2">
+                            <Button
+                              type="button"
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                updateDraftValue(
+                                  definition.command,
+                                  primaryDefaultShortcutValueForCommand(definition.command) ?? "",
+                                )
+                              }
+                            >
+                              Restore default
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              disabled={!canSave || isSaving}
+                              onClick={() => {
+                                void saveShortcut(definition.command);
+                              }}
+                            >
+                              {isSaving ? "Saving..." : "Save shortcut"}
+                            </Button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </section>
+            ))}
+          </DialogPanel>
+        </DialogPopup>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -1,4 +1,4 @@
-import { assert, describe, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 
 import {
   type KeybindingCommand,
@@ -11,6 +11,8 @@ import {
   isChatNewShortcut,
   isChatNewLocalShortcut,
   isDiffToggleShortcut,
+  keybindingValueForCommand,
+  keybindingValueFromEvent,
   isOpenFavoriteEditorShortcut,
   isTerminalClearShortcut,
   isTerminalCloseShortcut,
@@ -297,6 +299,30 @@ describe("chat/editor shortcuts", () => {
         context: { terminalFocus: true },
       }),
     );
+  });
+});
+
+describe("keybindingValueFromEvent", () => {
+  it("normalizes modifiers using mod on macOS", () => {
+    expect(
+      keybindingValueFromEvent(event({ key: "k", metaKey: true, shiftKey: true }), "MacIntel"),
+    ).toBe("mod+shift+k");
+  });
+
+  it("normalizes modifiers using mod on non-macOS", () => {
+    expect(
+      keybindingValueFromEvent(event({ key: "k", ctrlKey: true, altKey: true }), "Win32"),
+    ).toBe("mod+alt+k");
+  });
+
+  it("rejects shortcuts without a modifier", () => {
+    expect(keybindingValueFromEvent(event({ key: "k" }), "Linux")).toBeNull();
+  });
+});
+
+describe("keybindingValueForCommand", () => {
+  it("returns the latest serialized binding for a command", () => {
+    expect(keybindingValueForCommand(DEFAULT_BINDINGS, "chat.new")).toBe("mod+shift+o");
   });
 });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -4,6 +4,7 @@ import {
   type KeybindingWhenNode,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
+import { DEFAULT_KEYBINDINGS } from "@t3tools/shared/keybindings";
 import { isMacPlatform } from "./lib/utils";
 
 export interface ShortcutEventLike {
@@ -25,6 +26,82 @@ interface ShortcutMatchOptions {
   platform?: string;
   context?: Partial<ShortcutMatchContext>;
 }
+
+export interface StaticKeybindingDefinition {
+  command: KeybindingCommand;
+  title: string;
+  description: string;
+  section: "workspace" | "chat" | "terminal";
+}
+
+export const STATIC_KEYBINDING_SECTIONS = [
+  {
+    id: "workspace",
+    title: "Workspace",
+    description: "Project-level shortcuts for navigation and review.",
+  },
+  {
+    id: "chat",
+    title: "Chat",
+    description: "Shortcuts for starting new threads and switching context.",
+  },
+  {
+    id: "terminal",
+    title: "Terminal",
+    description: "Shortcuts that control the integrated terminal.",
+  },
+] as const;
+
+export const STATIC_KEYBINDING_DEFINITIONS: ReadonlyArray<StaticKeybindingDefinition> = [
+  {
+    command: "diff.toggle",
+    title: "Toggle diff panel",
+    description: "Open or hide the current thread diff without leaving chat.",
+    section: "workspace",
+  },
+  {
+    command: "editor.openFavorite",
+    title: "Open in editor",
+    description: "Open the active project or worktree in your preferred editor.",
+    section: "workspace",
+  },
+  {
+    command: "chat.new",
+    title: "New chat",
+    description: "Start a new thread while preserving the active branch or worktree context.",
+    section: "chat",
+  },
+  {
+    command: "chat.newLocal",
+    title: "New environment thread",
+    description: "Start a new thread in a fresh local or worktree environment.",
+    section: "chat",
+  },
+  {
+    command: "terminal.toggle",
+    title: "Toggle terminal",
+    description: "Open or hide the terminal drawer without changing threads.",
+    section: "terminal",
+  },
+  {
+    command: "terminal.split",
+    title: "Split terminal",
+    description: "Create another terminal pane when terminal focus is active.",
+    section: "terminal",
+  },
+  {
+    command: "terminal.new",
+    title: "New terminal",
+    description: "Create a fresh terminal when terminal focus is active.",
+    section: "terminal",
+  },
+  {
+    command: "terminal.close",
+    title: "Close terminal",
+    description: "Close the active terminal when terminal focus is active.",
+    section: "terminal",
+  },
+] as const;
 
 const TERMINAL_WORD_BACKWARD = "\u001bb";
 const TERMINAL_WORD_FORWARD = "\u001bf";
@@ -129,6 +206,23 @@ function formatShortcutKeyLabel(key: string): string {
   return key.slice(0, 1).toUpperCase() + key.slice(1);
 }
 
+function encodeShortcutKeyToken(key: string): string {
+  if (key === " ") return "space";
+  if (key === "escape") return "esc";
+  return key;
+}
+
+export function shortcutValueFromShortcut(shortcut: KeybindingShortcut): string {
+  const parts: string[] = [];
+  if (shortcut.modKey) parts.push("mod");
+  if (shortcut.ctrlKey) parts.push("ctrl");
+  if (shortcut.metaKey) parts.push("meta");
+  if (shortcut.altKey) parts.push("alt");
+  if (shortcut.shiftKey) parts.push("shift");
+  parts.push(encodeShortcutKeyToken(shortcut.key));
+  return parts.join("+");
+}
+
 export function formatShortcutLabel(
   shortcut: KeybindingShortcut,
   platform = navigator.platform,
@@ -164,6 +258,100 @@ export function shortcutLabelForCommand(
     return formatShortcutLabel(binding.shortcut, platform);
   }
   return null;
+}
+
+export function shortcutLabelsForCommand(
+  keybindings: ResolvedKeybindingsConfig,
+  command: KeybindingCommand,
+  platform = navigator.platform,
+): string[] {
+  return keybindings
+    .filter((binding) => binding.command === command)
+    .map((binding) => formatShortcutLabel(binding.shortcut, platform));
+}
+
+export function keybindingValueForCommand(
+  keybindings: ResolvedKeybindingsConfig,
+  command: KeybindingCommand,
+): string | null {
+  for (let index = keybindings.length - 1; index >= 0; index -= 1) {
+    const binding = keybindings[index];
+    if (!binding || binding.command !== command) continue;
+    return shortcutValueFromShortcut(binding.shortcut);
+  }
+  return null;
+}
+
+export function normalizeShortcutKeyToken(key: string): string | null {
+  const normalized = key.toLowerCase();
+  if (
+    normalized === "meta" ||
+    normalized === "control" ||
+    normalized === "ctrl" ||
+    normalized === "shift" ||
+    normalized === "alt" ||
+    normalized === "option"
+  ) {
+    return null;
+  }
+  if (normalized === " ") return "space";
+  if (normalized === "escape") return "esc";
+  if (normalized === "arrowup") return "arrowup";
+  if (normalized === "arrowdown") return "arrowdown";
+  if (normalized === "arrowleft") return "arrowleft";
+  if (normalized === "arrowright") return "arrowright";
+  if (normalized.length === 1) return normalized;
+  if (normalized.startsWith("f") && normalized.length <= 3) return normalized;
+  if (normalized === "enter" || normalized === "tab" || normalized === "backspace") {
+    return normalized;
+  }
+  if (normalized === "delete" || normalized === "home" || normalized === "end") {
+    return normalized;
+  }
+  if (normalized === "pageup" || normalized === "pagedown") return normalized;
+  return null;
+}
+
+export function keybindingValueFromEvent(
+  event: ShortcutEventLike,
+  platform = navigator.platform,
+): string | null {
+  const keyToken = normalizeShortcutKeyToken(event.key);
+  if (!keyToken) return null;
+
+  const parts: string[] = [];
+  if (isMacPlatform(platform)) {
+    if (event.metaKey) parts.push("mod");
+    if (event.ctrlKey) parts.push("ctrl");
+  } else {
+    if (event.ctrlKey) parts.push("mod");
+    if (event.metaKey) parts.push("meta");
+  }
+  if (event.altKey) parts.push("alt");
+  if (event.shiftKey) parts.push("shift");
+  if (parts.length === 0) {
+    return null;
+  }
+  parts.push(keyToken);
+  return parts.join("+");
+}
+
+export function defaultRulesForCommand(command: KeybindingCommand) {
+  return DEFAULT_KEYBINDINGS.filter((rule) => rule.command === command);
+}
+
+export function defaultWhenForCommand(command: KeybindingCommand): string | undefined {
+  const [firstRule] = defaultRulesForCommand(command);
+  return firstRule?.when;
+}
+
+export function defaultShortcutValuesForCommand(command: KeybindingCommand): string[] {
+  return defaultRulesForCommand(command).map((rule) => rule.key);
+}
+
+export function primaryDefaultShortcutValueForCommand(command: KeybindingCommand): string | null {
+  const values = defaultShortcutValuesForCommand(command);
+  return values.at(-1) ?? null;
 }
 
 export function isTerminalToggleShortcut(

--- a/apps/web/src/lib/projectScriptKeybindings.ts
+++ b/apps/web/src/lib/projectScriptKeybindings.ts
@@ -2,9 +2,9 @@ import {
   KeybindingRule as KeybindingRuleSchema,
   type KeybindingCommand,
   type KeybindingRule,
-  type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
 import { Schema } from "effect";
+import { keybindingValueForCommand } from "~/keybindings";
 
 export const PROJECT_SCRIPT_KEYBINDING_INVALID_MESSAGE = "Invalid keybinding.";
 
@@ -32,28 +32,4 @@ export function decodeProjectScriptKeybindingRule(input: {
   return decoded.value;
 }
 
-export function keybindingValueForCommand(
-  keybindings: ResolvedKeybindingsConfig,
-  command: KeybindingCommand,
-): string | null {
-  for (let index = keybindings.length - 1; index >= 0; index -= 1) {
-    const binding = keybindings[index];
-    if (!binding || binding.command !== command) continue;
-
-    const parts: string[] = [];
-    if (binding.shortcut.modKey) parts.push("mod");
-    if (binding.shortcut.ctrlKey) parts.push("ctrl");
-    if (binding.shortcut.metaKey) parts.push("meta");
-    if (binding.shortcut.altKey) parts.push("alt");
-    if (binding.shortcut.shiftKey) parts.push("shift");
-    const keyToken =
-      binding.shortcut.key === " "
-        ? "space"
-        : binding.shortcut.key === "escape"
-          ? "esc"
-          : binding.shortcut.key;
-    parts.push(keyToken);
-    return parts.join("+");
-  }
-  return null;
-}
+export { keybindingValueForCommand };

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -20,6 +20,7 @@ import {
 } from "../components/ui/select";
 import { Switch } from "../components/ui/switch";
 import { APP_VERSION } from "../branding";
+import { KeybindingsControl } from "../components/chat/KeybindingsControl";
 import { SidebarInset } from "~/components/ui/sidebar";
 
 const THEME_OPTIONS = [
@@ -111,6 +112,7 @@ function SettingsRouteView() {
   const codexHomePath = settings.codexHomePath;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
   const availableEditors = serverConfigQuery.data?.availableEditors;
+  const keybindings = serverConfigQuery.data?.keybindings ?? [];
 
   const openKeybindingsFile = useCallback(() => {
     if (!keybindingsConfigPath) return;
@@ -592,12 +594,58 @@ function SettingsRouteView() {
               <div className="mb-4">
                 <h2 className="text-sm font-medium text-foreground">Keybindings</h2>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  Open the persisted <code>keybindings.json</code> file to edit advanced bindings
-                  directly.
+                  Manage the built-in shortcuts from the app and use the JSON file for advanced
+                  overrides.
                 </p>
               </div>
 
               <div className="space-y-3">
+                <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">
+                      Show keybindings button in chat header
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Keep the <code>Keys</code> shortcut manager button visible in the top bar.
+                    </p>
+                  </div>
+                  <Switch
+                    checked={settings.showHeaderKeybindingsButton}
+                    onCheckedChange={(checked) =>
+                      updateSettings({
+                        showHeaderKeybindingsButton: Boolean(checked),
+                      })
+                    }
+                    aria-label="Show keybindings button in chat header"
+                  />
+                </div>
+
+                {settings.showHeaderKeybindingsButton !== defaults.showHeaderKeybindingsButton ? (
+                  <div className="flex justify-end">
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      onClick={() =>
+                        updateSettings({
+                          showHeaderKeybindingsButton: defaults.showHeaderKeybindingsButton,
+                        })
+                      }
+                    >
+                      Restore button visibility default
+                    </Button>
+                  </div>
+                ) : null}
+
+                <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">Keybinds manager</p>
+                    <p className="text-xs text-muted-foreground">
+                      Update built-in bindings without leaving settings.
+                    </p>
+                  </div>
+                  <KeybindingsControl keybindings={keybindings} triggerLabel="Manage keybindings" />
+                </div>
+
                 <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2">
                   <div className="min-w-0 flex-1">
                     <p className="text-xs font-medium text-foreground">Config file path</p>
@@ -616,7 +664,8 @@ function SettingsRouteView() {
                 </div>
 
                 <p className="text-xs text-muted-foreground">
-                  Opens in your preferred editor selection.
+                  The JSON file is still available for advanced bindings and manual edits. It opens
+                  in your preferred editor selection.
                 </p>
                 {openKeybindingsError ? (
                   <p className="text-xs text-destructive">{openKeybindingsError}</p>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,6 +31,10 @@
     "./schemaJson": {
       "types": "./src/schemaJson.ts",
       "import": "./src/schemaJson.ts"
+    },
+    "./keybindings": {
+      "types": "./src/keybindings.ts",
+      "import": "./src/keybindings.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -1,0 +1,13 @@
+import { type KeybindingRule } from "@t3tools/contracts";
+
+export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
+  { key: "mod+j", command: "terminal.toggle" },
+  { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
+  { key: "mod+n", command: "terminal.new", when: "terminalFocus" },
+  { key: "mod+w", command: "terminal.close", when: "terminalFocus" },
+  { key: "mod+d", command: "diff.toggle", when: "!terminalFocus" },
+  { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
+  { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
+  { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
+  { key: "mod+o", command: "editor.openFavorite" },
+] as const;


### PR DESCRIPTION
# Summary

Adds a "Keys" button to the top navigation bar that opens a keybindings dialog, making shortcuts more discoverable without digging through settings.

## What Changed

Added a "Keys" button to the top navigation bar that opens a keybindings dialog. The dialog displays all available key bindings grouped by category (Workspace, Chat, etc.) and allows users to:

- View current and default shortcuts
- Edit shortcuts inline
- Reset individual shortcuts to defaults via "Restore default"
- Save custom shortcut overrides

With also disable the button in the settings and open the keyboard shortcuts dialog from the settings in the existing keyboard shortcuts section.

## Why

Key bindings are currently only accessible through settings, making them easy to overlook. Many users rely on keyboard shortcuts for faster navigation, and having a dedicated, visible entry point in the top nav makes discoverability much better.

Resolves #1044

## UI Changes

**Before:**
No dedicated shortcut access in the top navigation.

**After:**
A "Keys" button is added to the top navigation bar. Clicking it opens a dialog listing all keybindings with inline editing and reset capabilities.

<img width="1920" height="1038" alt="image" src="https://github.com/user-attachments/assets/435a73b0-df59-4bc2-af21-a2e7c2dfb5f2" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add in-app keybindings manager dialog with chat header button
> - Adds a new `KeybindingsControl` component ([KeybindingsControl.tsx](https://github.com/pingdotgg/t3code/pull/1064/files#diff-027b899d98fbd83572ef7a052ff3c1dda0c7bc55cd1757a31c6f27a67ba46679)) that renders a dialog for viewing, editing, and restoring default keybindings, persisting changes via `server.upsertKeybinding`.
> - Adds a 'Keys' button to `ChatHeader` that opens the keybindings dialog, controlled by a new `showHeaderKeybindingsButton` app setting (defaults to `true`).
> - Adds a toggle for `showHeaderKeybindingsButton` and a 'Manage keybindings' button in the settings route ([_chat.settings.tsx](https://github.com/pingdotgg/t3code/pull/1064/files#diff-0707e8295d0df761e405e66f02211b55d56c6eaea1ac3cb99562525a9c589cc6)).
> - Moves `DEFAULT_KEYBINDINGS` to a new shared package export ([packages/shared/src/keybindings.ts](https://github.com/pingdotgg/t3code/pull/1064/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06)) so both server and web can import it.
> - Adds keybinding helper utilities to [apps/web/src/keybindings.ts](https://github.com/pingdotgg/t3code/pull/1064/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385) including `keybindingValueFromEvent`, `keybindingValueForCommand`, and `shortcutLabelsForCommand`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d08233a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->