### PR TITLE
fix(server): prevent projects.writeFile symlink escapes

### DIFF
--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -1621,6 +1621,32 @@ describe("WebSocket Server", () => {
     expect(fs.existsSync(path.join(workspace, "..", "escape.md"))).toBe(false);
   });
 
+  it("rejects projects.writeFile paths that escape through a symlinked directory", async () => {
+    const workspace = makeTempDir("t3code-ws-write-file-symlink-workspace-");
+    const outsideDir = makeTempDir("t3code-ws-write-file-symlink-outside-");
+    const symlinkPath = path.join(workspace, "linked-outside");
+    fs.symlinkSync(outsideDir, symlinkPath, process.platform === "win32" ? "junction" : "dir");
+
+    server = await createTestServer({ cwd: "/test" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const [ws] = await connectAndAwaitWelcome(port);
+    connections.push(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.projectsWriteFile, {
+      cwd: workspace,
+      relativePath: "linked-outside/escape.md",
+      contents: "# owned\n",
+    });
+
+    expect(response.result).toBeUndefined();
+    expect(response.error?.message).toContain(
+      "Workspace file path must stay within the project root.",
+    );
+    expect(fs.existsSync(path.join(outsideDir, "escape.md"))).toBe(false);
+  });
+
   it("routes git core methods over websocket", async () => {
     const listBranches = vi.fn(() =>
       Effect.succeed({

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -7,6 +7,7 @@
  * @module Server
  */
 import http from "node:http";
+import { existsSync, realpathSync } from "node:fs";
 import type { Duplex } from "node:stream";
 
 import Mime from "@effect/platform-node/Mime";
@@ -157,41 +158,104 @@ function toPosixRelativePath(input: string): string {
   return input.replaceAll("\\", "/");
 }
 
+function isPathWithinRoot(params: {
+  rootPath: string;
+  candidatePath: string;
+  path: Path.Path;
+}): boolean {
+  const relativeToRoot = toPosixRelativePath(
+    params.path.relative(params.rootPath, params.candidatePath),
+  );
+  return !(
+    relativeToRoot.startsWith("../") ||
+    relativeToRoot === ".." ||
+    params.path.isAbsolute(relativeToRoot)
+  );
+}
+
+function resolveCanonicalPath(params: {
+  inputPath: string;
+  path: Path.Path;
+}): Effect.Effect<string, RouteRequestError> {
+  return Effect.try({
+    try: () => {
+      const unresolvedSegments: string[] = [];
+      let existingPath = params.inputPath;
+      while (!existsSync(existingPath)) {
+        const parentPath = params.path.dirname(existingPath);
+        if (parentPath === existingPath) {
+          throw new Error(`No existing ancestor found for path: ${params.inputPath}`);
+        }
+        unresolvedSegments.unshift(params.path.basename(existingPath));
+        existingPath = parentPath;
+      }
+
+      const canonicalExistingPath = realpathSync.native(existingPath);
+      return unresolvedSegments.reduce(
+        (currentPath, segment) => params.path.join(currentPath, segment),
+        canonicalExistingPath,
+      );
+    },
+    catch: () =>
+      new RouteRequestError({
+        message: "Workspace file path must stay within the project root.",
+      }),
+  });
+}
+
 function resolveWorkspaceWritePath(params: {
   workspaceRoot: string;
   relativePath: string;
   path: Path.Path;
 }): Effect.Effect<{ absolutePath: string; relativePath: string }, RouteRequestError> {
-  const normalizedInputPath = params.relativePath.trim();
-  if (params.path.isAbsolute(normalizedInputPath)) {
-    return Effect.fail(
-      new RouteRequestError({
+  return Effect.gen(function* () {
+    const normalizedInputPath = params.relativePath.trim();
+    if (params.path.isAbsolute(normalizedInputPath)) {
+      return yield* new RouteRequestError({
         message: "Workspace file path must be relative to the project root.",
-      }),
-    );
-  }
+      });
+    }
 
-  const absolutePath = params.path.resolve(params.workspaceRoot, normalizedInputPath);
-  const relativeToRoot = toPosixRelativePath(
-    params.path.relative(params.workspaceRoot, absolutePath),
-  );
-  if (
-    relativeToRoot.length === 0 ||
-    relativeToRoot === "." ||
-    relativeToRoot.startsWith("../") ||
-    relativeToRoot === ".." ||
-    params.path.isAbsolute(relativeToRoot)
-  ) {
-    return Effect.fail(
-      new RouteRequestError({
+    const absolutePath = params.path.resolve(params.workspaceRoot, normalizedInputPath);
+    const relativeToRoot = toPosixRelativePath(
+      params.path.relative(params.workspaceRoot, absolutePath),
+    );
+    if (
+      relativeToRoot.length === 0 ||
+      relativeToRoot === "." ||
+      relativeToRoot.startsWith("../") ||
+      relativeToRoot === ".." ||
+      params.path.isAbsolute(relativeToRoot)
+    ) {
+      return yield* new RouteRequestError({
         message: "Workspace file path must stay within the project root.",
-      }),
-    );
-  }
+      });
+    }
 
-  return Effect.succeed({
-    absolutePath,
-    relativePath: relativeToRoot,
+    const canonicalWorkspaceRoot = yield* resolveCanonicalPath({
+      inputPath: params.workspaceRoot,
+      path: params.path,
+    });
+    const canonicalTargetPath = yield* resolveCanonicalPath({
+      inputPath: absolutePath,
+      path: params.path,
+    });
+    if (
+      !isPathWithinRoot({
+        rootPath: canonicalWorkspaceRoot,
+        candidatePath: canonicalTargetPath,
+        path: params.path,
+      })
+    ) {
+      return yield* new RouteRequestError({
+        message: "Workspace file path must stay within the project root.",
+      });
+    }
+
+    return {
+      absolutePath: canonicalTargetPath,
+      relativePath: relativeToRoot,
+    };
   });
 }
 


### PR DESCRIPTION
Closes #1072

## What Changed

`projects.writeFile` now canonicalizes both the workspace root and the target path before writing, so a path that looks in-workspace lexically cannot escape the project root by traversing a symlinked directory.

This also adds a regression test that creates a symlink inside the workspace pointing to an outside directory and verifies the write is rejected without creating the outside file.

## Why

The previous check only validated the lexical relative path. That allowed a write like `linked-outside/escape.md` to pass validation when `linked-outside` was a symlink to a directory outside the workspace.

Related, but distinct: #316 reports a broader issue where WebSocket methods trust arbitrary client-supplied `cwd` values and can therefore operate in any directory the server can access. This PR addresses a different boundary failure: even when a caller is already operating against a chosen workspace, `projects.writeFile` can still escape that workspace by traversing an in-tree symlink. Fixing this PR improves workspace-root enforcement, but it does not fully resolve the broader `cwd`-validation problem described in #316.

## Minimal Repro Script

The script below is intentionally not committed in this PR. It is the smallest copy-pasteable repro I found that can be run from the repo root.

- Run it on `main` to prove the bug is present. It should print `VERDICT: UNFIXED/VULNERABLE` and show that an outside file was created.
- Run it on this branch to prove the fix is working. It should print `VERDICT: FIXED` and show that no outside file was created.

```bash
#!/usr/bin/env bash
set -euo pipefail

PORT=4321
LOG_FILE=$(mktemp)
WORKSPACE=$(mktemp -d)
OUTSIDE=$(mktemp -d)
RESPONSE_FILE=$(mktemp)

cleanup() {
  if [[ -n "${SERVER_PID:-}" ]]; then
    kill "$SERVER_PID" 2>/dev/null || true
    wait "$SERVER_PID" 2>/dev/null || true
  fi
  rm -f "$LOG_FILE"
  rm -f "$RESPONSE_FILE"
}
trap cleanup EXIT

env -u T3CODE_AUTH_TOKEN bun run --cwd apps/server dev -- --port "$PORT" --host 127.0.0.1 --no-browser >"$LOG_FILE" 2>&1 &
SERVER_PID=$!
sleep 3

ln -s "$OUTSIDE" "$WORKSPACE/linked-outside"
export WORKSPACE PORT RESPONSE_FILE

node --input-type=module <<'NODE'
const workspace = process.env.WORKSPACE;
const port = process.env.PORT;
const responseFile = process.env.RESPONSE_FILE;
const requestId = crypto.randomUUID();
const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
const fs = await import('node:fs/promises');

ws.addEventListener('message', (event) => {
  const message = JSON.parse(String(event.data));

  if (message.type === 'push' && message.channel === 'server.welcome') {
    ws.send(JSON.stringify({
      id: requestId,
      body: {
        _tag: 'projects.writeFile',
        cwd: workspace,
        relativePath: 'linked-outside/escape.txt',
        contents: 'escaped via symlink\n',
      },
    }));
    return;
  }

  if (message.id === requestId) {
    console.log('WebSocket response:');
    console.log(JSON.stringify(message, null, 2));
    fs.writeFile(responseFile, `${JSON.stringify(message, null, 2)}\n`, 'utf8').catch((error) => {
      console.error('Failed to persist response:', error);
    });
    ws.close();
  }
});
NODE

printf '\nOutside file path: %s\n' "$OUTSIDE/escape.txt"

if [[ -f "$OUTSIDE/escape.txt" ]]; then
  echo "VERDICT: UNFIXED/VULNERABLE"
  echo "The server wrote outside the workspace through the symlink."
  printf 'Outside file contents:\n'
  cat "$OUTSIDE/escape.txt" || true
else
  echo "VERDICT: FIXED"
  echo "The server did not create the outside file."
fi

if [[ -f "$RESPONSE_FILE" ]]; then
  printf '\nSaved response:\n'
  cat "$RESPONSE_FILE" || true
fi

exit 0
```

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent symlink escapes in `projects.writeFile` path validation
> - Adds `resolveCanonicalPath` in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/1071/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) to walk up to the nearest existing ancestor and resolve the real path via `realpathSync.native`, catching symlink indirections.
> - Updates `resolveWorkspaceWritePath` to compare canonical paths for both the workspace root and the target, rejecting writes that resolve outside the project root.
> - Adds a test in [wsServer.test.ts](https://github.com/pingdotgg/t3code/pull/1071/files#diff-30ed28ff3e0b23441a1395ccab21d3c0ddf523513084c6d69abef88fc03ca7b3) covering a symlinked directory that points outside the workspace.
> - Behavioral Change: `projects.writeFile` requests whose resolved path escapes the workspace root now fail with an error instead of writing the file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96ef886.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
