### PR TITLE
fix(web): show text input for adding projects on Linux desktop

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -39,7 +39,7 @@ import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
 import { useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
-import { isMacPlatform, newCommandId, newProjectId } from "../lib/utils";
+import { isLinuxPlatform, isMacPlatform, newCommandId, newProjectId } from "../lib/utils";
 import { useStore } from "../store";
 import { shortcutLabelForCommand } from "../keybindings";
 import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
@@ -305,7 +305,7 @@ export default function Sidebar() {
   const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
-  const isLinuxDesktop = isElectron && /linux/i.test(navigator.platform);
+  const isLinuxDesktop = isElectron && isLinuxPlatform(navigator.platform);
   const shouldBrowseForProjectImmediately = isElectron && !isLinuxDesktop;
   const shouldShowProjectPathEntry = addingProject && !shouldBrowseForProjectImmediately;
   const projectCwdById = useMemo(

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -16,6 +16,10 @@ export function isWindowsPlatform(platform: string): boolean {
   return /^win(dows)?/i.test(platform);
 }
 
+export function isLinuxPlatform(platform: string): boolean {
+  return /linux/i.test(platform);
+}
+
 export function randomUUID(): string {
   if (typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();


### PR DESCRIPTION
## Summary

On Linux/Wayland, the GTK file picker is broken for folder selection in Electron apps, completely blocking adding projects. This shows the web-style text input on Linux desktop instead of immediately opening the native file picker.

Closes #966
Closes #270

## Changes

- Skip the immediate file picker open on Linux desktop (`isElectron && /linux/i.test(navigator.platform)`)
- Linux users now see the path text input with an Add button (same UX as web mode)
- Mac/Windows behavior is unchanged

## Test plan

- [x] On Linux desktop: clicking "+" shows text input instead of opening file picker
- [ ] On Mac/Windows desktop: clicking "+" still opens native file picker immediately
- [x] On web: behavior unchanged
- [x] Typing a path and pressing Enter adds the project

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show text input for adding projects on Linux desktop in Sidebar
> On Linux Electron, the native file browser dialog cannot be used to add projects, so the text input path entry is shown instead. Adds `isLinuxPlatform` to [utils.ts](https://github.com/pingdotgg/t3code/pull/1075/files#diff-a77b1983abf81ad3ac9e3d762f4ea683e77399fc446a1f34a6c0d57cde0ab767) and uses it in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1075/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to set `shouldBrowseForProjectImmediately` to `false` on Linux Electron.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9757ff5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a28ad7a0-4dec-42f2-bec1-b4025441b641" />
