### PR TITLE
fix(web): preserve composer input when planning question appears

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -665,15 +665,27 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const questionChanged =
       lastSyncedPendingInputRef.current?.requestId !== nextRequestId ||
       lastSyncedPendingInputRef.current?.questionId !== nextQuestionId;
-    const textChangedExternally = promptRef.current !== nextCustomAnswer;
 
     lastSyncedPendingInputRef.current = {
       requestId: nextRequestId,
       questionId: nextQuestionId,
     };
 
-    if (!questionChanged && !textChangedExternally) {
+    // Don't sync when there's user-typed content in the composer.
+    // This keeps the pending question input independent from the main composer draft.
+    // Previously, this would overwrite user-typed text when a planning question appeared.
+    const hasUserTypedInComposer = promptRef.current.length > 0;
+    if (hasUserTypedInComposer) {
       return;
+    }
+
+    // For new questions (questionChanged), always sync to show the question's placeholder.
+    if (!questionChanged) {
+      // For same question: only sync if text actually changed externally.
+      const textChangedExternally = promptRef.current !== nextCustomAnswer;
+      if (!textChangedExternally) {
+        return;
+      }
     }
 
     promptRef.current = nextCustomAnswer;


### PR DESCRIPTION
## What Changed

Preserved user-typed text in the composer when a planning question appears while the user is typing. Previously, the input would be cleared because the sync effect would overwrite it with the empty pending answer.

## Why

The sync effect that copies pending user input to the composer was unconditionally overwriting user content. When a planning question pops up, the effect would set the composer value to the empty pending answer, clearing whatever the user had typed. This made for a poor user experience.

The fix adds a check to skip syncing when the user has already typed content in the composer, keeping the pending question input independent from the main composer draft.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Fixes #808

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve composer input when a planning question appears in ChatView
> Previously, pending question input would overwrite any text the user had already typed in the composer. Now, [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1080/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) checks `promptRef.current.length > 0` before syncing and skips the sync if the user has typed content. For the same (unchanged) question, syncing only happens when the external text has actually changed; new questions still sync to display their placeholder text.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b948b8d. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->