### PR TITLE
Add AgentWatch tool handling for Codex long-running jobs

### DIFF
--- a/apps/server/src/agentWatch.test.ts
+++ b/apps/server/src/agentWatch.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { AgentWatch } from "./agentWatch";
+
+describe("AgentWatch", () => {
+  it("starts a detached job and reports non-zero exits for inspection", async () => {
+    const watch = new AgentWatch(20);
+
+    try {
+      const started = watch.start({
+        command: "sleep 0.05; echo boom; exit 17",
+        staleAfterMs: 10_000,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 220));
+
+      const status = watch.status(started.jobId);
+      expect(status.status).toBe("exited");
+      expect(status.exitCode).toBe(17);
+      expect(status.shouldInspect).toBe(true);
+      expect(status.conditions.some((condition) => condition.code === "non_zero_exit")).toBe(true);
+    } finally {
+      watch.dispose();
+    }
+  });
+
+  it("returns only flagged jobs by default when polling", async () => {
+    const watch = new AgentWatch(20);
+
+    try {
+      watch.start({
+        command: "sleep 0.2; echo done",
+        staleAfterMs: 10_000,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 40));
+
+      const poll = watch.poll();
+      expect(poll.jobs).toHaveLength(0);
+    } finally {
+      watch.dispose();
+    }
+  });
+});

--- a/apps/server/src/agentWatch.ts
+++ b/apps/server/src/agentWatch.ts
@@ -69,7 +69,10 @@ function parseExitCodeFromLog(logPath: string): number | undefined {
     if (!match || match.length === 0) {
       return undefined;
     }
-    const latest = match[match.length - 1];
+    const latest = match.at(-1);
+    if (!latest) {
+      return undefined;
+    }
     const parsed = Number.parseInt(latest.slice(EXIT_MARKER_PREFIX.length), 10);
     return Number.isInteger(parsed) ? parsed : undefined;
   } catch {
@@ -220,7 +223,10 @@ export class AgentWatch {
 
       if (!isProcessAlive(job.pid)) {
         job.finishedAt = now;
-        job.exitCode = parseExitCodeFromLog(job.logPath);
+        const exitCode = parseExitCodeFromLog(job.logPath);
+        if (exitCode !== undefined) {
+          job.exitCode = exitCode;
+        }
       }
     }
   }
@@ -232,7 +238,11 @@ export class AgentWatch {
 
     const conditions: AgentWatchCondition[] = [];
 
-    if (status === "running" && outputFreshnessMs !== undefined && outputFreshnessMs > job.staleAfterMs) {
+    if (
+      status === "running" &&
+      outputFreshnessMs !== undefined &&
+      outputFreshnessMs > job.staleAfterMs
+    ) {
       conditions.push({
         code: "stale_output",
         message: `No terminal output for ${outputFreshnessMs}ms (threshold ${job.staleAfterMs}ms).`,
@@ -292,7 +302,9 @@ export class AgentWatch {
     if (toolName === "agentwatch.poll") {
       return this.poll({
         ...(typeof args?.jobId === "string" ? { jobId: args.jobId } : {}),
-        ...(typeof args?.includeHealthy === "boolean" ? { includeHealthy: args.includeHealthy } : {}),
+        ...(typeof args?.includeHealthy === "boolean"
+          ? { includeHealthy: args.includeHealthy }
+          : {}),
       });
     }
 

--- a/apps/server/src/agentWatch.ts
+++ b/apps/server/src/agentWatch.ts
@@ -1,0 +1,308 @@
+import { closeSync, mkdtempSync, openSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+
+export type AgentWatchConditionCode =
+  | "stale_output"
+  | "non_zero_exit"
+  | "abnormal_exit"
+  | "missing_job";
+
+export interface AgentWatchCondition {
+  code: AgentWatchConditionCode;
+  message: string;
+}
+
+export interface AgentWatchJobSnapshot {
+  jobId: string;
+  label: string;
+  command: string;
+  cwd: string;
+  pid: number;
+  status: "running" | "exited";
+  exitCode?: number;
+  startedAt: string;
+  finishedAt?: string;
+  lastOutputAt?: string;
+  outputFreshnessMs?: number;
+  shouldInspect: boolean;
+  conditions: AgentWatchCondition[];
+}
+
+interface AgentWatchJob {
+  jobId: string;
+  label: string;
+  command: string;
+  cwd: string;
+  pid: number;
+  logPath: string;
+  staleAfterMs: number;
+  startedAt: number;
+  finishedAt?: number;
+  exitCode?: number;
+  lastOutputAt?: number;
+}
+
+const DEFAULT_STALE_AFTER_MS = 90_000;
+const DEFAULT_WATCHDOG_INTERVAL_MS = 5_000;
+const EXIT_MARKER_PREFIX = "__AGENTWATCH_EXIT_CODE:";
+
+function nowIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function parseExitCodeFromLog(logPath: string): number | undefined {
+  try {
+    const content = readFileSync(logPath, "utf8");
+    const match = content.match(/__AGENTWATCH_EXIT_CODE:(\d+)/g);
+    if (!match || match.length === 0) {
+      return undefined;
+    }
+    const latest = match[match.length - 1];
+    const parsed = Number.parseInt(latest.slice(EXIT_MARKER_PREFIX.length), 10);
+    return Number.isInteger(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function tailLog(logPath: string, lines: number): string {
+  try {
+    const content = readFileSync(logPath, "utf8");
+    const parsedLines = content.split(/\r?\n/g);
+    return parsedLines.slice(-Math.max(1, lines)).join("\n").trim();
+  } catch {
+    return "";
+  }
+}
+
+export interface AgentWatchStartInput {
+  command: string;
+  cwd?: string;
+  label?: string;
+  staleAfterMs?: number;
+}
+
+export interface AgentWatchPollInput {
+  jobId?: string;
+  includeHealthy?: boolean;
+}
+
+export class AgentWatch {
+  private readonly jobs = new Map<string, AgentWatchJob>();
+  private readonly runtimeDir: string;
+  private readonly interval: ReturnType<typeof setInterval>;
+
+  constructor(watchdogIntervalMs = DEFAULT_WATCHDOG_INTERVAL_MS) {
+    this.runtimeDir = mkdtempSync(path.join(tmpdir(), "agentwatch-"));
+    this.interval = setInterval(() => {
+      this.tick();
+    }, watchdogIntervalMs);
+    this.interval.unref();
+  }
+
+  dispose(): void {
+    clearInterval(this.interval);
+  }
+
+  start(input: AgentWatchStartInput): AgentWatchJobSnapshot {
+    const command = input.command.trim();
+    if (command.length === 0) {
+      throw new Error("AgentWatch start requires a non-empty command.");
+    }
+
+    const jobId = randomUUID();
+    const cwd = input.cwd ?? process.cwd();
+    const logPath = path.join(this.runtimeDir, `${jobId}.log`);
+    const logFd = openSync(logPath, "a");
+
+    const wrappedCommand = `${command}; __agentwatch_exit=$?; echo "${EXIT_MARKER_PREFIX}$__agentwatch_exit"`;
+
+    const child = spawn("bash", ["-lc", wrappedCommand], {
+      cwd,
+      detached: true,
+      stdio: ["ignore", logFd, logFd],
+      env: process.env,
+    });
+    child.unref();
+    closeSync(logFd);
+
+    const job: AgentWatchJob = {
+      jobId,
+      label: input.label?.trim() || `job-${jobId.slice(0, 8)}`,
+      command,
+      cwd,
+      pid: child.pid ?? -1,
+      logPath,
+      staleAfterMs: input.staleAfterMs ?? DEFAULT_STALE_AFTER_MS,
+      startedAt: Date.now(),
+    };
+
+    this.jobs.set(jobId, job);
+    this.tick();
+    return this.toSnapshot(job, Date.now());
+  }
+
+  status(jobId: string): AgentWatchJobSnapshot {
+    this.tick();
+    const job = this.jobs.get(jobId);
+    if (!job) {
+      return {
+        jobId,
+        label: "unknown",
+        command: "",
+        cwd: "",
+        pid: -1,
+        status: "exited",
+        startedAt: nowIso(Date.now()),
+        shouldInspect: true,
+        conditions: [{ code: "missing_job", message: `No AgentWatch job found for id ${jobId}.` }],
+      };
+    }
+
+    return this.toSnapshot(job, Date.now());
+  }
+
+  poll(input: AgentWatchPollInput = {}): { jobs: AgentWatchJobSnapshot[] } {
+    this.tick();
+    const now = Date.now();
+
+    if (input.jobId) {
+      const snapshot = this.status(input.jobId);
+      if (!input.includeHealthy && !snapshot.shouldInspect) {
+        return { jobs: [] };
+      }
+      return { jobs: [snapshot] };
+    }
+
+    const snapshots = Array.from(this.jobs.values()).map((job) => this.toSnapshot(job, now));
+    return {
+      jobs: input.includeHealthy ? snapshots : snapshots.filter((job) => job.shouldInspect),
+    };
+  }
+
+  tail(jobId: string, lines = 50): { jobId: string; output: string } {
+    const job = this.jobs.get(jobId);
+    if (!job) {
+      return { jobId, output: "" };
+    }
+
+    return {
+      jobId,
+      output: tailLog(job.logPath, lines),
+    };
+  }
+
+  private tick(): void {
+    const now = Date.now();
+    for (const job of this.jobs.values()) {
+      try {
+        const stats = statSync(job.logPath);
+        job.lastOutputAt = stats.mtimeMs;
+      } catch {
+        // log may not exist yet
+      }
+
+      if (job.finishedAt !== undefined) {
+        continue;
+      }
+
+      if (!isProcessAlive(job.pid)) {
+        job.finishedAt = now;
+        job.exitCode = parseExitCodeFromLog(job.logPath);
+      }
+    }
+  }
+
+  private toSnapshot(job: AgentWatchJob, now: number): AgentWatchJobSnapshot {
+    const status = job.finishedAt === undefined ? "running" : "exited";
+    const outputFreshnessMs =
+      job.lastOutputAt !== undefined ? Math.max(0, Math.round(now - job.lastOutputAt)) : undefined;
+
+    const conditions: AgentWatchCondition[] = [];
+
+    if (status === "running" && outputFreshnessMs !== undefined && outputFreshnessMs > job.staleAfterMs) {
+      conditions.push({
+        code: "stale_output",
+        message: `No terminal output for ${outputFreshnessMs}ms (threshold ${job.staleAfterMs}ms).`,
+      });
+    }
+
+    if (status === "exited") {
+      if (job.exitCode === undefined) {
+        conditions.push({
+          code: "abnormal_exit",
+          message: "Process exited without a recorded exit code.",
+        });
+      } else if (job.exitCode !== 0) {
+        conditions.push({
+          code: "non_zero_exit",
+          message: `Process exited with code ${job.exitCode}.`,
+        });
+      }
+    }
+
+    return {
+      jobId: job.jobId,
+      label: job.label,
+      command: job.command,
+      cwd: job.cwd,
+      pid: job.pid,
+      status,
+      ...(job.exitCode !== undefined ? { exitCode: job.exitCode } : {}),
+      startedAt: nowIso(job.startedAt),
+      ...(job.finishedAt !== undefined ? { finishedAt: nowIso(job.finishedAt) } : {}),
+      ...(job.lastOutputAt !== undefined ? { lastOutputAt: nowIso(job.lastOutputAt) } : {}),
+      ...(outputFreshnessMs !== undefined ? { outputFreshnessMs } : {}),
+      shouldInspect: conditions.length > 0,
+      conditions,
+    };
+  }
+
+  handleToolCall(toolName: string, args: Record<string, unknown> | undefined): unknown {
+    if (toolName === "agentwatch.start") {
+      return {
+        job: this.start({
+          command: typeof args?.command === "string" ? args.command : "",
+          ...(typeof args?.cwd === "string" ? { cwd: args.cwd } : {}),
+          ...(typeof args?.label === "string" ? { label: args.label } : {}),
+          ...(typeof args?.staleAfterMs === "number" ? { staleAfterMs: args.staleAfterMs } : {}),
+        }),
+      };
+    }
+
+    if (toolName === "agentwatch.status") {
+      if (typeof args?.jobId !== "string") {
+        throw new Error("agentwatch.status requires jobId.");
+      }
+      return { job: this.status(args.jobId) };
+    }
+
+    if (toolName === "agentwatch.poll") {
+      return this.poll({
+        ...(typeof args?.jobId === "string" ? { jobId: args.jobId } : {}),
+        ...(typeof args?.includeHealthy === "boolean" ? { includeHealthy: args.includeHealthy } : {}),
+      });
+    }
+
+    if (toolName === "agentwatch.tail") {
+      if (typeof args?.jobId !== "string") {
+        throw new Error("agentwatch.tail requires jobId.");
+      }
+      return this.tail(args.jobId, typeof args?.lines === "number" ? args.lines : 50);
+    }
+
+    throw new Error(`Unsupported tool: ${toolName}`);
+  }
+}

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -748,8 +748,6 @@ describe("respondToUserInput", () => {
   });
 });
 
-
-
 describe("handleServerRequest tool calls", () => {
   it("routes item/tool/call to AgentWatch and writes a JSON-RPC result", () => {
     const manager = new CodexAppServerManager();
@@ -767,6 +765,7 @@ describe("handleServerRequest tool calls", () => {
       pendingApprovals: new Map(),
       pendingUserInputs: new Map(),
     };
+    type TestContext = typeof context;
 
     const writeMessage = vi
       .spyOn(manager as unknown as { writeMessage: (...args: unknown[]) => void }, "writeMessage")
@@ -782,7 +781,7 @@ describe("handleServerRequest tool calls", () => {
 
     (
       manager as unknown as {
-        handleServerRequest: (context: typeof context, request: Record<string, unknown>) => void;
+        handleServerRequest: (context: TestContext, request: Record<string, unknown>) => void;
       }
     ).handleServerRequest(context, {
       jsonrpc: "2.0",

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -748,6 +748,59 @@ describe("respondToUserInput", () => {
   });
 });
 
+
+
+describe("handleServerRequest tool calls", () => {
+  it("routes item/tool/call to AgentWatch and writes a JSON-RPC result", () => {
+    const manager = new CodexAppServerManager();
+    const context = {
+      session: {
+        sessionId: "sess_1",
+        provider: "codex",
+        status: "ready",
+        threadId: asThreadId("thread_1"),
+        resumeCursor: { threadId: "thread_1" },
+        runtimeMode: "full-access",
+        createdAt: "2026-02-10T00:00:00.000Z",
+        updatedAt: "2026-02-10T00:00:00.000Z",
+      },
+      pendingApprovals: new Map(),
+      pendingUserInputs: new Map(),
+    };
+
+    const writeMessage = vi
+      .spyOn(manager as unknown as { writeMessage: (...args: unknown[]) => void }, "writeMessage")
+      .mockImplementation(() => {});
+
+    const handleToolCall = vi
+      .spyOn(
+        (manager as unknown as { agentWatch: { handleToolCall: (...args: unknown[]) => unknown } })
+          .agentWatch,
+        "handleToolCall",
+      )
+      .mockReturnValue({ jobs: [] });
+
+    (
+      manager as unknown as {
+        handleServerRequest: (context: typeof context, request: Record<string, unknown>) => void;
+      }
+    ).handleServerRequest(context, {
+      jsonrpc: "2.0",
+      id: 3,
+      method: "item/tool/call",
+      params: {
+        toolName: "agentwatch.poll",
+        arguments: { includeHealthy: false },
+      },
+    });
+
+    expect(handleToolCall).toHaveBeenCalledWith("agentwatch.poll", { includeHealthy: false });
+    expect(writeMessage).toHaveBeenCalledWith(context, {
+      id: 3,
+      result: { jobs: [] },
+    });
+  });
+});
 describe.skipIf(!process.env.CODEX_BINARY_PATH)("startSession live Codex resume", () => {
   it("keeps prior thread history when resuming with a changed runtime mode", async () => {
     const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "codex-live-resume-"));

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -515,6 +515,7 @@ export interface CodexAppServerManagerEvents {
 
 export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEvents> {
   private readonly sessions = new Map<ThreadId, CodexSessionContext>();
+  private readonly agentWatch = new AgentWatch();
 
   private runPromise: (effect: Effect.Effect<unknown, never>) => Promise<unknown>;
   constructor(services?: ServiceMap.ServiceMap<never>) {
@@ -1219,7 +1220,8 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     if (request.method === "item/tool/call") {
-      const toolName = this.readString(request.params, "toolName") ?? this.readString(request.params, "name");
+      const toolName =
+        this.readString(request.params, "toolName") ?? this.readString(request.params, "name");
       const rawArgs =
         this.readObject(request.params, "arguments") ??
         this.readObject(request.params, "input") ??

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -27,6 +27,7 @@ import {
   isCodexCliVersionSupported,
   parseCodexCliVersion,
 } from "./provider/codexCliVersion";
+import { AgentWatch } from "./agentWatch";
 
 type PendingRequestKey = string;
 
@@ -1015,6 +1016,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     for (const threadId of this.sessions.keys()) {
       this.stopSession(threadId);
     }
+    this.agentWatch.dispose();
   }
 
   private requireSession(threadId: ThreadId): CodexSessionContext {
@@ -1214,6 +1216,43 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         ...(route.turnId ? { turnId: route.turnId } : {}),
         ...(route.itemId ? { itemId: route.itemId } : {}),
       });
+    }
+
+    if (request.method === "item/tool/call") {
+      const toolName = this.readString(request.params, "toolName") ?? this.readString(request.params, "name");
+      const rawArgs =
+        this.readObject(request.params, "arguments") ??
+        this.readObject(request.params, "input") ??
+        this.readObject(request.params, "args") ??
+        this.parseJsonObject(this.readString(request.params, "arguments"));
+
+      if (!toolName) {
+        this.writeMessage(context, {
+          id: request.id,
+          error: {
+            code: -32602,
+            message: "item/tool/call is missing a tool name",
+          },
+        });
+        return;
+      }
+
+      try {
+        const result = this.agentWatch.handleToolCall(toolName, rawArgs);
+        this.writeMessage(context, {
+          id: request.id,
+          result,
+        });
+      } catch (error) {
+        this.writeMessage(context, {
+          id: request.id,
+          error: {
+            code: -32000,
+            message: error instanceof Error ? error.message : "item/tool/call failed",
+          },
+        });
+      }
+      return;
     }
 
     this.emitEvent({
@@ -1449,6 +1488,19 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     }
 
     return route;
+  }
+
+  private parseJsonObject(value: string | undefined): Record<string, unknown> | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    try {
+      const parsed = JSON.parse(value);
+      return this.readObject(parsed);
+    } catch {
+      return undefined;
+    }
   }
 
   private readObject(value: unknown, key?: string): Record<string, unknown> | undefined {


### PR DESCRIPTION
## Summary
- add a small server-side `AgentWatch` runtime for monitored long-running shell jobs
- route Codex `item/tool/call` requests for `agentwatch.start|status|poll|tail` through `CodexAppServerManager`
- add focused regression tests for the AgentWatch runtime and tool-call routing

## Why
This is a small reliability-oriented slice that lets Codex hand off long-running commands to a monitored background job instead of keeping everything tied to a single turn.

## Scope
This PR intentionally avoids the later UI and orchestration follow-up work. It only adds the core runtime and Codex server plumbing.

## Validation
- `bun fmt`
- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add AgentWatch tool handling for Codex long-running jobs
> - Introduces [`AgentWatch`](https://github.com/pingdotgg/t3code/pull/1088/files#diff-f0e9da333da34891c4cab48dfdc878a7ec73786aef3998d4d077619fa8e8236e), a job supervisor that starts detached shell commands via `bash -lc`, tracks liveness and output staleness, and captures exit codes by appending a sentinel marker to the job's log file.
> - Exposes `agentwatch.start`, `agentwatch.status`, `agentwatch.poll`, and `agentwatch.tail` tools via a `handleToolCall` interface.
> - Integrates `AgentWatch` into [`CodexAppServerManager`](https://github.com/pingdotgg/t3code/pull/1088/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9), routing `item/tool/call` JSON-RPC requests to `agentWatch.handleToolCall` and disposing the instance on `stopAll()`.
> - Behavioral Change: `handleServerRequest` now handles a new `item/tool/call` method, returning `-32602` for missing tool name and `-32000` for tool invocation failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 664fb01. 4 files reviewed, 4 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->