### PR TITLE
feat(sidebar): show update time instead of creation time

### DIFF
--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -28,6 +28,7 @@ export function buildLocalDraftThread(
     messages: [],
     error,
     createdAt: draftThread.createdAt,
+    updatedAt: draftThread.createdAt,
     latestTurn: null,
     lastVisitedAt: draftThread.createdAt,
     branch: draftThread.branch,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  compareThreadsByLastActivity,
   hasUnseenCompletion,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   shouldClearThreadSelectionOnMouseDown,
 } from "./Sidebar.logic";
+import { ThreadId } from "@t3tools/contracts";
+
+function makeThreadId(id: string): ThreadId {
+  return ThreadId.makeUnsafe(id);
+}
 
 function makeLatestTurn(overrides?: {
   completedAt?: string | null;
@@ -173,6 +179,55 @@ describe("resolveThreadStatusPill", () => {
         hasPendingUserInput: false,
       }),
     ).toMatchObject({ label: "Completed", pulse: false });
+  });
+});
+
+describe("compareThreadsByLastActivity", () => {
+  it("sorts by updatedAt when present, newest first", () => {
+    const older = {
+      id: makeThreadId("thread-old"),
+      createdAt: "2026-03-01T10:00:00.000Z",
+      updatedAt: "2026-03-01T12:00:00.000Z",
+    };
+    const newer = {
+      id: makeThreadId("thread-new"),
+      createdAt: "2026-03-01T10:00:00.000Z",
+      updatedAt: "2026-03-01T14:00:00.000Z",
+    };
+    expect(compareThreadsByLastActivity(older, newer)).toBeGreaterThan(0);
+    expect(compareThreadsByLastActivity(newer, older)).toBeLessThan(0);
+  });
+
+  it("falls back to createdAt when updatedAt is absent", () => {
+    const older = { id: makeThreadId("thread-a"), createdAt: "2026-03-01T10:00:00.000Z" };
+    const newer = { id: makeThreadId("thread-b"), createdAt: "2026-03-01T12:00:00.000Z" };
+    expect(compareThreadsByLastActivity(older, newer)).toBeGreaterThan(0);
+    expect(compareThreadsByLastActivity(newer, older)).toBeLessThan(0);
+  });
+
+  it("uses id as tiebreaker when timestamps are equal", () => {
+    const a = {
+      id: makeThreadId("thread-aaa"),
+      createdAt: "2026-03-01T10:00:00.000Z",
+      updatedAt: "2026-03-01T10:00:00.000Z",
+    };
+    const b = {
+      id: makeThreadId("thread-zzz"),
+      createdAt: "2026-03-01T10:00:00.000Z",
+      updatedAt: "2026-03-01T10:00:00.000Z",
+    };
+    expect(compareThreadsByLastActivity(a, b)).toBeGreaterThan(0);
+    expect(compareThreadsByLastActivity(b, a)).toBeLessThan(0);
+  });
+
+  it("produces stable sort order for array", () => {
+    const threads = [
+      { id: makeThreadId("thread-1"), createdAt: "2026-03-01T10:00:00.000Z", updatedAt: "2026-03-01T14:00:00.000Z" },
+      { id: makeThreadId("thread-2"), createdAt: "2026-03-01T10:00:00.000Z", updatedAt: "2026-03-01T12:00:00.000Z" },
+      { id: makeThreadId("thread-3"), createdAt: "2026-03-01T10:00:00.000Z", updatedAt: "2026-03-01T16:00:00.000Z" },
+    ];
+    const sorted = [...threads].toSorted(compareThreadsByLastActivity);
+    expect(sorted.map((t) => t.id)).toEqual(["thread-3", "thread-1", "thread-2"]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -5,6 +5,27 @@ import { findLatestProposedPlan, isLatestTurnSettled } from "../session-logic";
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export type SidebarNewThreadEnvMode = "local" | "worktree";
 
+export type ThreadSortInput = Pick<Thread, "id"> & {
+  createdAt: string;
+  updatedAt?: string;
+};
+
+/**
+ * Comparator for sorting threads by last activity (updatedAt, then createdAt), newest first.
+ * Uses thread id as tiebreaker for deterministic order.
+ */
+export function compareThreadsByLastActivity(
+  a: ThreadSortInput,
+  b: ThreadSortInput,
+): number {
+  
+  const byDate =
+    new Date(b.updatedAt ?? b.createdAt).getTime() -
+    new Date(a.updatedAt ?? a.createdAt).getTime();
+  if (byDate !== 0) return byDate;
+  return b.id.localeCompare(a.id);
+}
+
 export interface ThreadStatusPill {
   label:
     | "Working"

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -84,6 +84,7 @@ import { useThreadSelectionStore } from "../threadSelectionStore";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
 import {
+  compareThreadsByLastActivity,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
@@ -385,11 +386,7 @@ export default function Sidebar() {
     (projectId: ProjectId) => {
       const latestThread = threads
         .filter((thread) => thread.projectId === projectId)
-        .toSorted((a, b) => {
-          const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-          if (byDate !== 0) return byDate;
-          return b.id.localeCompare(a.id);
-        })[0];
+        .toSorted(compareThreadsByLastActivity)[0];
       if (!latestThread) return;
 
       void navigate({
@@ -1295,12 +1292,7 @@ export default function Sidebar() {
                 {projects.map((project) => {
                   const projectThreads = threads
                     .filter((thread) => thread.projectId === project.id)
-                    .toSorted((a, b) => {
-                      const byDate =
-                        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-                      if (byDate !== 0) return byDate;
-                      return b.id.localeCompare(a.id);
-                    });
+                    .toSorted(compareThreadsByLastActivity);
                   const isThreadListExpanded = expandedThreadListsByProject.has(project.id);
                   const hasHiddenThreads = projectThreads.length > THREAD_PREVIEW_LIMIT;
                   const visibleThreads =
@@ -1551,7 +1543,9 @@ export default function Sidebar() {
                                               : "text-muted-foreground/40"
                                           }`}
                                         >
-                                          {formatRelativeTime(thread.createdAt)}
+                                          {formatRelativeTime(
+                                            thread.updatedAt ?? thread.createdAt,
+                                          )}
                                         </span>
                                       </div>
                                     </SidebarMenuSubButton>

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -26,6 +26,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     proposedPlans: [],
     error: null,
     createdAt: "2026-02-13T00:00:00.000Z",
+    updatedAt: "2026-02-13T00:00:00.000Z",
     latestTurn: null,
     branch: null,
     worktreePath: null,

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -309,6 +309,7 @@ export function syncServerReadModel(state: AppState, readModel: OrchestrationRea
         })),
         error: thread.session?.lastError ?? null,
         createdAt: thread.createdAt,
+        updatedAt: thread.updatedAt,
         latestTurn: thread.latestTurn,
         lastVisitedAt: existing?.lastVisitedAt ?? thread.updatedAt,
         branch: thread.branch,

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -96,6 +96,7 @@ export interface Thread {
   proposedPlans: ProposedPlan[];
   error: string | null;
   createdAt: string;
+  updatedAt: string;
   latestTurn: OrchestrationLatestTurn | null;
   lastVisitedAt?: string | undefined;
   branch: string | null;

--- a/apps/web/src/worktreeCleanup.test.ts
+++ b/apps/web/src/worktreeCleanup.test.ts
@@ -20,6 +20,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     proposedPlans: [],
     error: null,
     createdAt: "2026-02-13T00:00:00.000Z",
+    updatedAt: "2026-02-13T00:00:00.000Z",
     latestTurn: null,
     branch: null,
     worktreePath: null,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- **Thread type** (`types.ts`): Added `updatedAt` to the `Thread` interface.
- **Store** (`store.ts`): In `syncServerReadModel`, pass `thread.updatedAt` from the server read model into client state.
- **Sidebar** (`Sidebar.tsx`): Use `thread.updatedAt ?? thread.createdAt` for the timestamp label and for sorting threads.
- **Sidebar.logic** (`Sidebar.logic.ts`): Added `compareThreadsByLastActivity` and `ThreadSortInput` for sorting threads by last activity.
- **Tests**: Updated `store.test.ts`, `worktreeCleanup.test.ts`, and `ChatView.logic.ts` to include `updatedAt`. Added tests for `compareThreadsByLastActivity` in `Sidebar.logic.test.ts`.


## Why

The sidebar previously showed the thread creation time instead of the last activity time. Users expect threads to be ordered by when they were last used.
The server already maintains thread.updatedAt and updates it on messages, turns, and session changes. This change surfaces that field on the client and uses it for display and sorting.

## UI Changes

Before: Sidebar showed creation time (e.g. "4d ago"). Threads were ordered by creation time.
<img width="1849" height="955" alt="image" src="https://github.com/user-attachments/assets/fc8e6336-474f-410c-ba38-01a5518ebad7" />


After: Sidebar shows last activity time (e.g. "5m ago"). Threads are ordered by last activity (most recent first).
<img width="1849" height="955" alt="image" src="https://github.com/user-attachments/assets/c642c857-1f3f-42e7-bad2-78a7cd464e37" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show last update time instead of creation time in sidebar thread list
> - Adds `updatedAt` to the `Thread` interface and maps it from the server read model in [store.ts](https://github.com/pingdotgg/t3code/pull/1089/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82).
> - Introduces `compareThreadsByLastActivity` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/1089/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to sort threads by `updatedAt` (falling back to `createdAt`), with `id` as a tiebreaker.
> - Updates the sidebar thread list and `focusMostRecentThreadForProject` to use the new comparator and display `updatedAt` when available.
> - Behavioral Change: thread sort order and focused thread on project switch may change for threads that have been updated after creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcd6d06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->