### PR TITLE
fix(web): migrate legacy editor preference storage

### DIFF
--- a/apps/web/src/editorPreferences.test.ts
+++ b/apps/web/src/editorPreferences.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const LAST_EDITOR_KEY = "t3code:last-editor";
+
+function createStorage(initialEntries: Record<string, string> = {}): Storage {
+  const store = new Map(Object.entries(initialEntries));
+  return {
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    setItem: (key, value) => {
+      store.set(key, String(value));
+    },
+  };
+}
+
+function setWindowStorage(storage: Storage): void {
+  Object.defineProperty(globalThis, "window", {
+    value: { localStorage: storage },
+    configurable: true,
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "window");
+  vi.restoreAllMocks();
+});
+
+describe("resolveAndPersistPreferredEditor", () => {
+  it("migrates legacy raw preferred editor values from pre-JSON storage", async () => {
+    const storage = createStorage({ [LAST_EDITOR_KEY]: "vscode" });
+    setWindowStorage(storage);
+
+    const { resolveAndPersistPreferredEditor } = await import("./editorPreferences");
+
+    expect(resolveAndPersistPreferredEditor(["cursor", "vscode"])).toBe("vscode");
+    expect(storage.getItem(LAST_EDITOR_KEY)).toBe('"vscode"');
+  });
+
+  it("falls back to the first available editor when the stored value is malformed", async () => {
+    const storage = createStorage({ [LAST_EDITOR_KEY]: "{not-json}" });
+    setWindowStorage(storage);
+
+    const { resolveAndPersistPreferredEditor } = await import("./editorPreferences");
+
+    expect(resolveAndPersistPreferredEditor(["cursor", "vscode"])).toBe("cursor");
+    expect(storage.getItem(LAST_EDITOR_KEY)).toBe('"cursor"');
+  });
+});

--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -1,8 +1,42 @@
 import { EDITORS, EditorId, NativeApi } from "@t3tools/contracts";
-import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "./hooks/useLocalStorage";
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+  useLocalStorage,
+} from "./hooks/useLocalStorage";
 import { useMemo } from "react";
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
+
+function isKnownEditorId(value: string): value is EditorId {
+  return EDITORS.some((editor) => editor.id === value);
+}
+
+function readStoredPreferredEditor(): { editor: EditorId | null; needsMigration: boolean } {
+  try {
+    return {
+      editor: getLocalStorageItem(LAST_EDITOR_KEY, EditorId),
+      needsMigration: false,
+    };
+  } catch {
+    if (typeof window === "undefined") {
+      return { editor: null, needsMigration: false };
+    }
+
+    const raw = window.localStorage.getItem(LAST_EDITOR_KEY);
+    if (!raw) {
+      return { editor: null, needsMigration: false };
+    }
+
+    if (isKnownEditorId(raw)) {
+      return { editor: raw, needsMigration: true };
+    }
+
+    removeLocalStorageItem(LAST_EDITOR_KEY);
+    return { editor: null, needsMigration: false };
+  }
+}
 
 export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
   const [lastEditor, setLastEditor] = useLocalStorage(LAST_EDITOR_KEY, null, EditorId);
@@ -19,8 +53,13 @@ export function resolveAndPersistPreferredEditor(
   availableEditors: readonly EditorId[],
 ): EditorId | null {
   const availableEditorIds = new Set(availableEditors);
-  const stored = getLocalStorageItem(LAST_EDITOR_KEY, EditorId);
-  if (stored && availableEditorIds.has(stored)) return stored;
+  const stored = readStoredPreferredEditor();
+  if (stored.editor && availableEditorIds.has(stored.editor)) {
+    if (stored.needsMigration) {
+      setLocalStorageItem(LAST_EDITOR_KEY, stored.editor, EditorId);
+    }
+    return stored.editor;
+  }
   const editor = EDITORS.find((editor) => availableEditorIds.has(editor.id))?.id ?? null;
   if (editor) setLocalStorageItem(LAST_EDITOR_KEY, editor, EditorId);
   return editor ?? null;


### PR DESCRIPTION
## What Changed

Made preferred editor resolution tolerant of legacy `t3code:last-editor` values that were stored as raw strings before the JSON-backed localStorage helper was introduced.

If the stored value matches a known editor id like `vscode`, it is migrated to the current JSON format. If the stored value is malformed, the code now falls back to the first available editor and rewrites the key cleanly.

Added a focused regression test for both the legacy raw-string case and malformed storage fallback.

## Why

Older released builds wrote `t3code:last-editor` directly as plain strings. Current code decodes the same key as JSON, which can throw `Unexpected token v, "vscode" is not valid JSON` when opening files from the commit dialog or any other editor-opening path.

This keeps the fix local to editor preference migration instead of broadening storage behavior for unrelated keys.

### Decisions

- Kept the migration fallback in `editorPreferences.ts` instead of loosening the generic localStorage helper.
  That fixes the known compatibility issue without changing storage semantics for every other persisted key.

- Closes #1031

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate legacy editor preference storage to JSON-backed format
> - Adds `readStoredPreferredEditor` in [editorPreferences.ts](https://github.com/pingdotgg/t3code/pull/1091/files#diff-b95642bd2ec02008455dc34d764b6b380dc3cb63bf4eb8fc249e0a105220efdd) to handle legacy plain-string editor IDs stored before JSON serialization was used.
> - When a raw string matching a known editor ID is found, it is returned and rewritten as a JSON-encoded value; when the stored value is unrecognized, it is removed and the first available editor is persisted instead.
> - Adds tests covering both the migration path and the malformed-value fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0209a17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->