### PR TITLE
Use standard git diff output even when diff.external is configured

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -14,6 +14,7 @@ import { randomUUID } from "node:crypto";
 import { Effect, Layer, FileSystem, Path } from "effect";
 
 import { CheckpointInvariantError } from "../Errors.ts";
+import { machineReadableGitDiffArgs } from "../../git/diffArgs.ts";
 import { GitCommandError } from "../../git/Errors.ts";
 import { GitServiceLive } from "../../git/Layers/GitService.ts";
 import { GitService } from "../../git/Services/GitService.ts";
@@ -244,7 +245,13 @@ const makeCheckpointStore = Effect.gen(function* () {
       const result = yield* git.execute({
         operation,
         cwd: input.cwd,
-        args: ["diff", "--patch", "--minimal", "--no-color", fromCommitOid, toCommitOid],
+        args: machineReadableGitDiffArgs(
+          "--patch",
+          "--minimal",
+          "--no-color",
+          fromCommitOid,
+          toCommitOid,
+        ),
       });
 
       return result.stdout;

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { chmodSync, existsSync } from "node:fs";
 import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -220,6 +220,33 @@ function commitWithDate(
       GIT_AUTHOR_DATE: dateIsoString,
       GIT_COMMITTER_DATE: dateIsoString,
     });
+  });
+}
+
+function configureExternalDiff(
+  cwd: string,
+  scriptDir: string,
+): Effect.Effect<
+  void,
+  GitCommandError | PlatformError.PlatformError,
+  GitService | FileSystem.FileSystem
+> {
+  return Effect.gen(function* () {
+    const scriptPath = path.join(
+      scriptDir,
+      process.platform === "win32" ? "external-diff.cmd" : "external-diff.sh",
+    );
+    const scriptContents =
+      process.platform === "win32"
+        ? "@echo off\r\necho external-diff %*\r\n"
+        : '#!/bin/sh\necho external-diff "$@"\n';
+
+    yield* writeTextFile(scriptPath, scriptContents);
+    if (process.platform !== "win32") {
+      chmodSync(scriptPath, 0o755);
+    }
+
+    yield* git(cwd, ["config", "diff.external", scriptPath]);
   });
 }
 
@@ -1731,6 +1758,43 @@ it.layer(TestLayer)("git integration", (it) => {
         const statusAfter = yield* git(tmp, ["status", "--porcelain"]);
         expect(statusAfter).toContain("b.txt");
         expect(statusAfter).not.toContain("a.txt");
+      }),
+    );
+
+    it.effect("prepareCommitContext ignores configured external diff tools", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const externalDiffDir = yield* makeTmpDir("external-diff-test-");
+        yield* initRepoWithCommit(tmp);
+        const core = yield* GitCore;
+
+        yield* configureExternalDiff(tmp, externalDiffDir);
+        yield* writeTextFile(path.join(tmp, "README.md"), "new content\n");
+
+        const context = yield* core.prepareCommitContext(tmp);
+        expect(context).not.toBeNull();
+        expect(context!.stagedPatch).toContain("diff --git a/README.md b/README.md");
+        expect(context!.stagedPatch).not.toContain("external-diff");
+      }),
+    );
+
+    it.effect("readRangeContext ignores configured external diff tools", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const externalDiffDir = yield* makeTmpDir("external-diff-test-");
+        const { initialBranch } = yield* initRepoWithCommit(tmp);
+        const core = yield* GitCore;
+
+        yield* git(tmp, ["checkout", "-b", "feature/external-diff"]);
+        yield* writeTextFile(path.join(tmp, "README.md"), "new content\n");
+        yield* git(tmp, ["add", "README.md"]);
+        yield* git(tmp, ["commit", "-m", "update readme"]);
+        yield* configureExternalDiff(tmp, externalDiffDir);
+
+        const context = yield* core.readRangeContext(tmp, initialBranch);
+        expect(context.diffSummary).toContain("README.md");
+        expect(context.diffPatch).toContain("diff --git a/README.md b/README.md");
+        expect(context.diffPatch).not.toContain("external-diff");
       }),
     );
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1,5 +1,6 @@
 import { Cache, Data, Duration, Effect, Exit, FileSystem, Layer, Path } from "effect";
 
+import { machineReadableGitDiffArgs } from "../diffArgs.ts";
 import { GitCommandError } from "../Errors.ts";
 import { GitService } from "../Services/GitService.ts";
 import { GitCore, type GitCoreShape } from "../Services/GitCore.ts";
@@ -663,12 +664,16 @@ const makeGitCore = Effect.gen(function* () {
             "--porcelain=2",
             "--branch",
           ]),
-          runGitStdout("GitCore.statusDetails.unstagedNumstat", cwd, ["diff", "--numstat"]),
-          runGitStdout("GitCore.statusDetails.stagedNumstat", cwd, [
-            "diff",
-            "--cached",
-            "--numstat",
-          ]),
+          runGitStdout(
+            "GitCore.statusDetails.unstagedNumstat",
+            cwd,
+            machineReadableGitDiffArgs("--numstat"),
+          ),
+          runGitStdout(
+            "GitCore.statusDetails.stagedNumstat",
+            cwd,
+            machineReadableGitDiffArgs("--cached", "--numstat"),
+          ),
         ],
         { concurrency: "unbounded" },
       );
@@ -782,21 +787,20 @@ const makeGitCore = Effect.gen(function* () {
         yield* runGit("GitCore.prepareCommitContext.addAll", cwd, ["add", "-A"]);
       }
 
-      const stagedSummary = yield* runGitStdout("GitCore.prepareCommitContext.stagedSummary", cwd, [
-        "diff",
-        "--cached",
-        "--name-status",
-      ]).pipe(Effect.map((stdout) => stdout.trim()));
+      const stagedSummary = yield* runGitStdout(
+        "GitCore.prepareCommitContext.stagedSummary",
+        cwd,
+        machineReadableGitDiffArgs("--cached", "--name-status"),
+      ).pipe(Effect.map((stdout) => stdout.trim()));
       if (stagedSummary.length === 0) {
         return null;
       }
 
-      const stagedPatch = yield* runGitStdout("GitCore.prepareCommitContext.stagedPatch", cwd, [
-        "diff",
-        "--cached",
-        "--patch",
-        "--minimal",
-      ]);
+      const stagedPatch = yield* runGitStdout(
+        "GitCore.prepareCommitContext.stagedPatch",
+        cwd,
+        machineReadableGitDiffArgs("--cached", "--patch", "--minimal"),
+      );
 
       return {
         stagedSummary,
@@ -970,13 +974,16 @@ const makeGitCore = Effect.gen(function* () {
       const [commitSummary, diffSummary, diffPatch] = yield* Effect.all(
         [
           runGitStdout("GitCore.readRangeContext.log", cwd, ["log", "--oneline", range]),
-          runGitStdout("GitCore.readRangeContext.diffStat", cwd, ["diff", "--stat", range]),
-          runGitStdout("GitCore.readRangeContext.diffPatch", cwd, [
-            "diff",
-            "--patch",
-            "--minimal",
-            range,
-          ]),
+          runGitStdout(
+            "GitCore.readRangeContext.diffStat",
+            cwd,
+            machineReadableGitDiffArgs("--stat", range),
+          ),
+          runGitStdout(
+            "GitCore.readRangeContext.diffPatch",
+            cwd,
+            machineReadableGitDiffArgs("--patch", "--minimal", range),
+          ),
         ],
         { concurrency: "unbounded" },
       );

--- a/apps/server/src/git/diffArgs.ts
+++ b/apps/server/src/git/diffArgs.ts
@@ -1,0 +1,3 @@
+export function machineReadableGitDiffArgs(...args: ReadonlyArray<string>): ReadonlyArray<string> {
+  return ["diff", "--no-ext-diff", ...args];
+}


### PR DESCRIPTION
### Why?

T3 Code uses `git diff` output to build patch and stat views in the app. When a user has `diff.external` configured, those commands can return tool-specific output instead of standard unified diffs, which breaks parsing and rendering.

### How?

Added a small shared helper for machine-readable `git diff` invocations and used it for the server-side diff, stat, and numstat calls that feed status details, commit context, range context, and checkpoint diffs.

Added regression tests that configure `diff.external` and verify the app still receives standard diff output.

### Decisions

- Applied `--no-ext-diff` only to diff commands where T3 Code expects machine-readable output.

- Closes #927

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--no-ext-diff` to all git diff invocations to ignore configured external diff tools
> - Introduces `machineReadableGitDiffArgs` helper in [`diffArgs.ts`](https://github.com/pingdotgg/t3code/pull/1092/files#diff-faa6764e69ae9cd5354d57733125dce3f5f8ca0733a652949e962dacc28aa1dd) that prepends `"diff"` and `"--no-ext-diff"` to any provided git diff arguments.
> - Updates `GitCore` (`statusDetails`, `prepareCommitContext`, `readRangeContext`) and `CheckpointStore` (`diffCheckpoints`) to use this helper, ensuring `diff.external` config is ignored.
> - Adds integration tests in [`GitCore.test.ts`](https://github.com/pingdotgg/t3code/pull/1092/files#diff-49e9b5a653566cf07288b6f6d553d942f05d7f26eba74c4e0f94a9e2a144f986) that configure an external diff script and assert it is not invoked by `prepareCommitContext` or `readRangeContext`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 115cf97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->