### PR TITLE
Add open-worktree mode and reuse existing worktrees on send

### DIFF
--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   dedupeRemoteBranchesWithLocalMatches,
   deriveLocalBranchNameFromRemoteRef,
+  resolveEffectiveEnvMode,
+  resolvePendingWorktreeBranchSelection,
   resolveBranchSelectionTarget,
   resolveDraftEnvModeAfterBranchChange,
   resolveBranchToolbarValue,
@@ -27,6 +29,16 @@ describe("resolveDraftEnvModeAfterBranchChange", () => {
         effectiveEnvMode: "worktree",
       }),
     ).toBe("worktree");
+  });
+
+  it("keeps open-worktree mode when selecting a branch before worktree creation", () => {
+    expect(
+      resolveDraftEnvModeAfterBranchChange({
+        nextWorktreePath: null,
+        currentWorktreePath: null,
+        effectiveEnvMode: "open-worktree",
+      }),
+    ).toBe("open-worktree");
   });
 
   it("uses worktree mode when selecting a branch already attached to a worktree", () => {
@@ -63,6 +75,17 @@ describe("resolveBranchToolbarValue", () => {
     ).toBe("feature/base");
   });
 
+  it("keeps an explicitly selected open-worktree branch", () => {
+    expect(
+      resolveBranchToolbarValue({
+        envMode: "open-worktree",
+        activeWorktreePath: null,
+        activeThreadBranch: "feature/base",
+        currentGitBranch: "main",
+      }),
+    ).toBe("feature/base");
+  });
+
   it("shows the actual checked-out branch when not selecting a new worktree base", () => {
     expect(
       resolveBranchToolbarValue({
@@ -72,6 +95,18 @@ describe("resolveBranchToolbarValue", () => {
         currentGitBranch: "main",
       }),
     ).toBe("main");
+  });
+});
+
+describe("resolveEffectiveEnvMode", () => {
+  it("preserves open-worktree mode for draft threads before creation", () => {
+    expect(
+      resolveEffectiveEnvMode({
+        activeWorktreePath: null,
+        hasServerThread: false,
+        draftThreadEnvMode: "open-worktree",
+      }),
+    ).toBe("open-worktree");
   });
 });
 
@@ -264,6 +299,98 @@ describe("resolveBranchSelectionTarget", () => {
       checkoutCwd: "/repo/.t3/worktrees/feature-a",
       nextWorktreePath: "/repo/.t3/worktrees/feature-a",
       reuseExistingWorktree: false,
+    });
+  });
+});
+
+describe("resolvePendingWorktreeBranchSelection", () => {
+  it("stores the selected base branch for new worktree mode", () => {
+    expect(
+      resolvePendingWorktreeBranchSelection({
+        activeProjectCwd: "/repo",
+        envMode: "worktree",
+        branch: {
+          name: "feature/base",
+          isRemote: false,
+          worktreePath: null,
+        },
+      }),
+    ).toEqual({
+      branch: "feature/base",
+      envMode: "worktree",
+      worktreePath: null,
+    });
+  });
+
+  it("stores a local branch without a worktree for open-worktree mode", () => {
+    expect(
+      resolvePendingWorktreeBranchSelection({
+        activeProjectCwd: "/repo",
+        envMode: "open-worktree",
+        branch: {
+          name: "feature/open-me",
+          isRemote: false,
+          worktreePath: null,
+        },
+      }),
+    ).toEqual({
+      branch: "feature/open-me",
+      envMode: "open-worktree",
+      worktreePath: null,
+    });
+  });
+
+  it("normalizes remote-only branches for open-worktree mode", () => {
+    expect(
+      resolvePendingWorktreeBranchSelection({
+        activeProjectCwd: "/repo",
+        envMode: "open-worktree",
+        branch: {
+          name: "origin/feature/remote-only",
+          isRemote: true,
+          worktreePath: null,
+        },
+      }),
+    ).toEqual({
+      branch: "feature/remote-only",
+      envMode: "open-worktree",
+      worktreePath: null,
+    });
+  });
+
+  it("reuses an existing secondary worktree for open-worktree mode", () => {
+    expect(
+      resolvePendingWorktreeBranchSelection({
+        activeProjectCwd: "/repo",
+        envMode: "open-worktree",
+        branch: {
+          name: "feature/already-open",
+          isRemote: false,
+          worktreePath: "/repo/.t3/worktrees/feature-already-open",
+        },
+      }),
+    ).toEqual({
+      branch: "feature/already-open",
+      envMode: "worktree",
+      worktreePath: "/repo/.t3/worktrees/feature-already-open",
+    });
+  });
+
+  it("keeps open-worktree mode when selecting a branch from the main repo checkout", () => {
+    expect(
+      resolvePendingWorktreeBranchSelection({
+        activeProjectCwd: "/repo",
+        envMode: "open-worktree",
+        branch: {
+          name: "main",
+          isRemote: false,
+          worktreePath: "/repo",
+        },
+      }),
+    ).toEqual({
+      branch: "main",
+      envMode: "open-worktree",
+      worktreePath: null,
     });
   });
 });

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -1,6 +1,12 @@
 import type { GitBranch } from "@t3tools/contracts";
 
-export type EnvMode = "local" | "worktree";
+export type EnvMode = "local" | "worktree" | "open-worktree";
+
+export function isPendingWorktreeMode(
+  envMode: EnvMode,
+): envMode is Extract<EnvMode, "worktree" | "open-worktree"> {
+  return envMode === "worktree" || envMode === "open-worktree";
+}
 
 export function resolveEffectiveEnvMode(input: {
   activeWorktreePath: string | null;
@@ -8,9 +14,13 @@ export function resolveEffectiveEnvMode(input: {
   draftThreadEnvMode: EnvMode | undefined;
 }): EnvMode {
   const { activeWorktreePath, hasServerThread, draftThreadEnvMode } = input;
-  return activeWorktreePath || (!hasServerThread && draftThreadEnvMode === "worktree")
-    ? "worktree"
-    : "local";
+  if (activeWorktreePath) {
+    return "worktree";
+  }
+  if (!hasServerThread && draftThreadEnvMode) {
+    return draftThreadEnvMode;
+  }
+  return "local";
 }
 
 export function resolveDraftEnvModeAfterBranchChange(input: {
@@ -22,8 +32,8 @@ export function resolveDraftEnvModeAfterBranchChange(input: {
   if (nextWorktreePath) {
     return "worktree";
   }
-  if (effectiveEnvMode === "worktree" && !currentWorktreePath) {
-    return "worktree";
+  if (isPendingWorktreeMode(effectiveEnvMode) && !currentWorktreePath) {
+    return effectiveEnvMode;
   }
   return "local";
 }
@@ -35,7 +45,7 @@ export function resolveBranchToolbarValue(input: {
   currentGitBranch: string | null;
 }): string | null {
   const { envMode, activeWorktreePath, activeThreadBranch, currentGitBranch } = input;
-  if (envMode === "worktree" && !activeWorktreePath) {
+  if (isPendingWorktreeMode(envMode) && !activeWorktreePath) {
     return activeThreadBranch ?? currentGitBranch;
   }
   return currentGitBranch ?? activeThreadBranch;
@@ -119,5 +129,40 @@ export function resolveBranchSelectionTarget(input: {
     checkoutCwd: nextWorktreePath ?? activeProjectCwd,
     nextWorktreePath,
     reuseExistingWorktree: false,
+  };
+}
+
+export function resolvePendingWorktreeBranchSelection(input: {
+  activeProjectCwd: string;
+  envMode: Extract<EnvMode, "worktree" | "open-worktree">;
+  branch: Pick<GitBranch, "name" | "isRemote" | "worktreePath">;
+}): {
+  branch: string;
+  envMode: EnvMode;
+  worktreePath: string | null;
+} {
+  const { activeProjectCwd, envMode, branch } = input;
+
+  if (envMode === "worktree") {
+    return {
+      branch: branch.name,
+      envMode,
+      worktreePath: null,
+    };
+  }
+
+  if (branch.worktreePath) {
+    const isProjectRoot = branch.worktreePath === activeProjectCwd;
+    return {
+      branch: branch.name,
+      envMode: isProjectRoot ? envMode : "worktree",
+      worktreePath: isProjectRoot ? null : branch.worktreePath,
+    };
+  }
+
+  return {
+    branch: branch.isRemote ? deriveLocalBranchNameFromRemoteRef(branch.name) : branch.name,
+    envMode,
+    worktreePath: null,
   };
 }

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -16,6 +16,7 @@ import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "./u
 
 const envModeItems = [
   { value: "local", label: "Local" },
+  { value: "open-worktree", label: "Open worktree" },
   { value: "worktree", label: "New worktree" },
 ] as const;
 
@@ -55,7 +56,7 @@ export default function BranchToolbar({
   });
 
   const setThreadBranch = useCallback(
-    (branch: string | null, worktreePath: string | null) => {
+    (branch: string | null, worktreePath: string | null, envMode?: EnvMode) => {
       if (!activeThreadId) return;
       const api = readNativeApi();
       // If the effective cwd is about to change, stop the running session so the
@@ -86,7 +87,7 @@ export default function BranchToolbar({
       const nextDraftEnvMode = resolveDraftEnvModeAfterBranchChange({
         nextWorktreePath: worktreePath,
         currentWorktreePath: activeWorktreePath,
-        effectiveEnvMode,
+        effectiveEnvMode: envMode ?? effectiveEnvMode,
       });
       setDraftThreadContext(threadId, {
         branch,
@@ -131,10 +132,10 @@ export default function BranchToolbar({
           items={envModeItems}
         >
           <SelectTrigger variant="ghost" size="xs" className="font-medium">
-            {effectiveEnvMode === "worktree" ? (
-              <GitForkIcon className="size-3" />
-            ) : (
+            {effectiveEnvMode === "local" ? (
               <FolderIcon className="size-3" />
+            ) : (
+              <GitForkIcon className="size-3" />
             )}
             <SelectValue />
           </SelectTrigger>
@@ -143,6 +144,12 @@ export default function BranchToolbar({
               <span className="inline-flex items-center gap-1.5">
                 <FolderIcon className="size-3" />
                 Local
+              </span>
+            </SelectItem>
+            <SelectItem value="open-worktree">
+              <span className="inline-flex items-center gap-1.5">
+                <GitForkIcon className="size-3" />
+                Open worktree
               </span>
             </SelectItem>
             <SelectItem value="worktree">

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -26,6 +26,8 @@ import {
   dedupeRemoteBranchesWithLocalMatches,
   deriveLocalBranchNameFromRemoteRef,
   EnvMode,
+  isPendingWorktreeMode,
+  resolvePendingWorktreeBranchSelection,
   resolveBranchSelectionTarget,
   resolveBranchToolbarValue,
 } from "./BranchToolbar.logic";
@@ -48,7 +50,11 @@ interface BranchToolbarBranchSelectorProps {
   branchCwd: string | null;
   effectiveEnvMode: EnvMode;
   envLocked: boolean;
-  onSetThreadBranch: (branch: string | null, worktreePath: string | null) => void;
+  onSetThreadBranch: (
+    branch: string | null,
+    worktreePath: string | null,
+    envMode?: EnvMode,
+  ) => void;
   onCheckoutPullRequestRequest?: (reference: string) => void;
   onComposerFocusRequest?: () => void;
 }
@@ -66,7 +72,7 @@ function getBranchTriggerLabel(input: {
   if (!resolvedActiveBranch) {
     return "Select branch";
   }
-  if (effectiveEnvMode === "worktree" && !activeWorktreePath) {
+  if (isPendingWorktreeMode(effectiveEnvMode) && !activeWorktreePath) {
     return `From ${resolvedActiveBranch}`;
   }
   return resolvedActiveBranch;
@@ -112,7 +118,7 @@ export function BranchToolbarBranchSelector({
   const normalizedDeferredBranchQuery = deferredTrimmedBranchQuery.toLowerCase();
   const prReference = parsePullRequestReference(trimmedBranchQuery);
   const isSelectingWorktreeBase =
-    effectiveEnvMode === "worktree" && !envLocked && !activeWorktreePath;
+    isPendingWorktreeMode(effectiveEnvMode) && !envLocked && !activeWorktreePath;
   const checkoutPullRequestItemValue =
     prReference && onCheckoutPullRequestRequest ? `__checkout_pull_request__:${prReference}` : null;
   const canCreateBranch = !isSelectingWorktreeBase && trimmedBranchQuery.length > 0;
@@ -158,9 +164,14 @@ export function BranchToolbarBranchSelector({
     const api = readNativeApi();
     if (!api || !branchCwd || isBranchActionPending) return;
 
-    // In new-worktree mode, selecting a branch sets the base branch.
+    // In pending worktree modes, selecting a branch configures the future target.
     if (isSelectingWorktreeBase) {
-      onSetThreadBranch(branch.name, null);
+      const nextSelection = resolvePendingWorktreeBranchSelection({
+        activeProjectCwd,
+        envMode: effectiveEnvMode,
+        branch,
+      });
+      onSetThreadBranch(nextSelection.branch, nextSelection.worktreePath, nextSelection.envMode);
       setIsBranchMenuOpen(false);
       onComposerFocusRequest?.();
       return;

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  resolveInitialWorktreeCreation,
+  resolveOpenWorktreeReuseCandidate,
+  resolvePendingWorktreeBranchForSend,
+} from "./ChatView.logic";
+
+describe("resolvePendingWorktreeBranchForSend", () => {
+  it("uses the explicit branch when one is already stored", () => {
+    expect(
+      resolvePendingWorktreeBranchForSend({
+        envMode: "open-worktree",
+        isFirstMessage: true,
+        branch: "feature/demo",
+        currentGitBranch: "master",
+        worktreePath: null,
+      }),
+    ).toBe("feature/demo");
+  });
+
+  it("defaults pending worktree modes to the current git branch on first send", () => {
+    expect(
+      resolvePendingWorktreeBranchForSend({
+        envMode: "open-worktree",
+        isFirstMessage: true,
+        branch: null,
+        currentGitBranch: "master",
+        worktreePath: null,
+      }),
+    ).toBe("master");
+
+    expect(
+      resolvePendingWorktreeBranchForSend({
+        envMode: "worktree",
+        isFirstMessage: true,
+        branch: null,
+        currentGitBranch: "main",
+        worktreePath: null,
+      }),
+    ).toBe("main");
+  });
+
+  it("does not infer a branch outside pending first-send worktree setup", () => {
+    expect(
+      resolvePendingWorktreeBranchForSend({
+        envMode: "local",
+        isFirstMessage: true,
+        branch: null,
+        currentGitBranch: "main",
+        worktreePath: null,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolvePendingWorktreeBranchForSend({
+        envMode: "open-worktree",
+        isFirstMessage: false,
+        branch: null,
+        currentGitBranch: "main",
+        worktreePath: null,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveInitialWorktreeCreation", () => {
+  it("returns none for local mode", () => {
+    const buildNewBranchName = vi.fn(() => "t3code/unused");
+
+    expect(
+      resolveInitialWorktreeCreation({
+        envMode: "local",
+        isFirstMessage: true,
+        branch: "main",
+        worktreePath: null,
+        buildNewBranchName,
+      }),
+    ).toEqual({ type: "none" });
+    expect(buildNewBranchName).not.toHaveBeenCalled();
+  });
+
+  it("creates a temp branch request for new worktree mode", () => {
+    const buildNewBranchName = vi.fn(() => "t3code/temp-branch");
+
+    expect(
+      resolveInitialWorktreeCreation({
+        envMode: "worktree",
+        isFirstMessage: true,
+        branch: "main",
+        worktreePath: null,
+        buildNewBranchName,
+      }),
+    ).toEqual({
+      type: "new-worktree",
+      branch: "main",
+      newBranch: "t3code/temp-branch",
+    });
+    expect(buildNewBranchName).toHaveBeenCalledOnce();
+  });
+
+  it("omits temp branch creation for open-worktree mode", () => {
+    const buildNewBranchName = vi.fn(() => "t3code/temp-branch");
+
+    expect(
+      resolveInitialWorktreeCreation({
+        envMode: "open-worktree",
+        isFirstMessage: true,
+        branch: "feature/existing",
+        worktreePath: null,
+        buildNewBranchName,
+      }),
+    ).toEqual({
+      type: "open-worktree",
+      branch: "feature/existing",
+    });
+    expect(buildNewBranchName).not.toHaveBeenCalled();
+  });
+
+  it("returns none when the thread already has a worktree", () => {
+    const buildNewBranchName = vi.fn(() => "t3code/temp-branch");
+
+    expect(
+      resolveInitialWorktreeCreation({
+        envMode: "open-worktree",
+        isFirstMessage: true,
+        branch: "feature/existing",
+        worktreePath: "/repo/.t3/worktrees/feature-existing",
+        buildNewBranchName,
+      }),
+    ).toEqual({ type: "none" });
+    expect(buildNewBranchName).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveOpenWorktreeReuseCandidate", () => {
+  it("reuses the main repo checkout as local mode", () => {
+    expect(
+      resolveOpenWorktreeReuseCandidate({
+        activeProjectCwd: "/repo",
+        branchName: "master",
+        branches: [
+          {
+            name: "master",
+            current: true,
+            isDefault: true,
+            worktreePath: "/repo",
+          },
+        ],
+      }),
+    ).toEqual({
+      branch: "master",
+      worktreePath: null,
+    });
+  });
+
+  it("reuses an existing secondary worktree", () => {
+    expect(
+      resolveOpenWorktreeReuseCandidate({
+        activeProjectCwd: "/repo",
+        branchName: "feature/demo",
+        branches: [
+          {
+            name: "feature/demo",
+            current: false,
+            isDefault: false,
+            worktreePath: "/repo/.t3/worktrees/feature-demo",
+          },
+        ],
+      }),
+    ).toEqual({
+      branch: "feature/demo",
+      worktreePath: "/repo/.t3/worktrees/feature-demo",
+    });
+  });
+
+  it("returns null when the branch is not already checked out", () => {
+    expect(
+      resolveOpenWorktreeReuseCandidate({
+        activeProjectCwd: "/repo",
+        branchName: "feature/demo",
+        branches: [
+          {
+            name: "feature/demo",
+            current: false,
+            isDefault: false,
+            worktreePath: null,
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,8 +1,12 @@
-import { ProjectId, type ProviderKind, type ThreadId } from "@t3tools/contracts";
+import { ProjectId, type GitBranch, type ProviderKind, type ThreadId } from "@t3tools/contracts";
 import { type ChatMessage, type Thread } from "../types";
 import { randomUUID } from "~/lib/utils";
 import { getAppModelOptions } from "../appSettings";
-import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
+import {
+  type ComposerImageAttachment,
+  type DraftThreadEnvMode,
+  type DraftThreadState,
+} from "../composerDraftStore";
 import { Schema } from "effect";
 
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
@@ -77,6 +81,35 @@ export interface PullRequestDialogState {
   key: number;
 }
 
+export type InitialWorktreeCreation =
+  | { type: "none" }
+  | { type: "open-worktree"; branch: string }
+  | { type: "new-worktree"; branch: string; newBranch: string };
+
+export function resolvePendingWorktreeBranchForSend(input: {
+  envMode: DraftThreadEnvMode;
+  isFirstMessage: boolean;
+  branch: string | null;
+  currentGitBranch: string | null;
+  worktreePath: string | null;
+}): string | null {
+  const { envMode, isFirstMessage, branch, currentGitBranch, worktreePath } = input;
+
+  if (branch) {
+    return branch;
+  }
+
+  if (!isFirstMessage || worktreePath) {
+    return null;
+  }
+
+  if (envMode === "worktree" || envMode === "open-worktree") {
+    return currentGitBranch;
+  }
+
+  return null;
+}
+
 export function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -98,6 +131,56 @@ export function buildTemporaryWorktreeBranchName(): string {
   // Keep the 8-hex suffix shape for backend temporary-branch detection.
   const token = randomUUID().slice(0, 8).toLowerCase();
   return `${WORKTREE_BRANCH_PREFIX}/${token}`;
+}
+
+export function resolveInitialWorktreeCreation(input: {
+  envMode: DraftThreadEnvMode;
+  isFirstMessage: boolean;
+  branch: string | null;
+  worktreePath: string | null;
+  buildNewBranchName: () => string;
+}): InitialWorktreeCreation {
+  const { envMode, isFirstMessage, branch, worktreePath, buildNewBranchName } = input;
+
+  if (!isFirstMessage || worktreePath || !branch) {
+    return { type: "none" };
+  }
+
+  if (envMode === "worktree") {
+    return {
+      type: "new-worktree",
+      branch,
+      newBranch: buildNewBranchName(),
+    };
+  }
+
+  if (envMode === "open-worktree") {
+    return {
+      type: "open-worktree",
+      branch,
+    };
+  }
+
+  return { type: "none" };
+}
+
+export function resolveOpenWorktreeReuseCandidate(input: {
+  activeProjectCwd: string;
+  branches: ReadonlyArray<GitBranch>;
+  branchName: string;
+}): { branch: string; worktreePath: string | null } | null {
+  const matchingBranch = input.branches.find(
+    (branch) => !branch.isRemote && branch.name === input.branchName && branch.worktreePath,
+  );
+  if (!matchingBranch?.worktreePath) {
+    return null;
+  }
+
+  return {
+    branch: matchingBranch.name,
+    worktreePath:
+      matchingBranch.worktreePath === input.activeProjectCwd ? null : matchingBranch.worktreePath,
+  };
 }
 
 export function cloneComposerImageForRetry(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -154,6 +154,9 @@ import {
   LastInvokedScriptByProjectSchema,
   PullRequestDialogState,
   readFileAsDataUrl,
+  resolveInitialWorktreeCreation,
+  resolveOpenWorktreeReuseCandidate,
+  resolvePendingWorktreeBranchForSend,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
   SendPhase,
@@ -913,6 +916,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const effectivePathQuery = pathTriggerQuery.length > 0 ? debouncedPathQuery : "";
   const branchesQuery = useQuery(gitBranchesQueryOptions(gitCwd));
+  const currentGitBranch =
+    branchesQuery.data?.branches.find((branch) => branch.current && !branch.isRemote)?.name ?? null;
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const workspaceEntriesQuery = useQuery(
     projectSearchEntriesQueryOptions({
@@ -2236,25 +2241,65 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (!activeProject) return;
     const threadIdForSend = activeThread.id;
     const isFirstMessage = !isServerThread || activeThread.messages.length === 0;
-    const baseBranchForWorktree =
-      isFirstMessage && envMode === "worktree" && !activeThread.worktreePath
-        ? activeThread.branch
-        : null;
+    const resolvedPendingWorktreeBranch = resolvePendingWorktreeBranchForSend({
+      envMode,
+      isFirstMessage,
+      branch: activeThread.branch,
+      currentGitBranch,
+      worktreePath: activeThread.worktreePath,
+    });
+    let initialWorktreeCreation = resolveInitialWorktreeCreation({
+      envMode,
+      isFirstMessage,
+      branch: resolvedPendingWorktreeBranch,
+      worktreePath: activeThread.worktreePath,
+      buildNewBranchName: buildTemporaryWorktreeBranchName,
+    });
 
-    // In worktree mode, require an explicit base branch so we don't silently
-    // fall back to local execution when branch selection is missing.
-    const shouldCreateWorktree =
-      isFirstMessage && envMode === "worktree" && !activeThread.worktreePath;
-    if (shouldCreateWorktree && !activeThread.branch) {
+    // Pending worktree modes can reuse the currently checked-out branch shown in
+    // the toolbar, but still require a resolvable branch before first send.
+    const shouldSelectNewWorktreeBranch =
+      isFirstMessage &&
+      envMode === "worktree" &&
+      !activeThread.worktreePath &&
+      !resolvedPendingWorktreeBranch;
+    if (shouldSelectNewWorktreeBranch) {
       setStoreThreadError(
         threadIdForSend,
         "Select a base branch before sending in New worktree mode.",
       );
       return;
     }
+    const shouldSelectOpenWorktreeBranch =
+      isFirstMessage &&
+      envMode === "open-worktree" &&
+      !activeThread.worktreePath &&
+      !resolvedPendingWorktreeBranch;
+    if (shouldSelectOpenWorktreeBranch) {
+      setStoreThreadError(threadIdForSend, "Select a branch before sending in Open worktree mode.");
+      return;
+    }
+
+    let resolvedExistingOpenWorktreeTarget: { branch: string; worktreePath: string | null } | null =
+      null;
+    if (initialWorktreeCreation.type === "open-worktree") {
+      const branchesResult = await api.git
+        .listBranches({ cwd: activeProject.cwd })
+        .catch(() => null);
+      resolvedExistingOpenWorktreeTarget = branchesResult
+        ? resolveOpenWorktreeReuseCandidate({
+            activeProjectCwd: activeProject.cwd,
+            branches: branchesResult.branches,
+            branchName: initialWorktreeCreation.branch,
+          })
+        : null;
+      if (resolvedExistingOpenWorktreeTarget) {
+        initialWorktreeCreation = { type: "none" };
+      }
+    }
 
     sendInFlightRef.current = true;
-    beginSendPhase(baseBranchForWorktree ? "preparing-worktree" : "sending-turn");
+    beginSendPhase(initialWorktreeCreation.type === "none" ? "sending-turn" : "preparing-worktree");
 
     const composerImagesSnapshot = [...composerImages];
     const messageIdForSend = newMessageId();
@@ -2300,31 +2345,71 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
     let createdServerThreadForLocalDraft = false;
     let turnStartSucceeded = false;
-    let nextThreadBranch = activeThread.branch;
-    let nextThreadWorktreePath = activeThread.worktreePath;
+    let nextThreadBranch =
+      resolvedExistingOpenWorktreeTarget?.branch ??
+      resolvedPendingWorktreeBranch ??
+      activeThread.branch;
+    let nextThreadWorktreePath =
+      resolvedExistingOpenWorktreeTarget?.worktreePath ?? activeThread.worktreePath;
     await (async () => {
-      // On first message: lock in branch + create worktree if needed.
-      if (baseBranchForWorktree) {
-        beginSendPhase("preparing-worktree");
-        const newBranch = buildTemporaryWorktreeBranchName();
-        const result = await createWorktreeMutation.mutateAsync({
-          cwd: activeProject.cwd,
-          branch: baseBranchForWorktree,
-          newBranch,
+      if (resolvedExistingOpenWorktreeTarget && isServerThread) {
+        await api.orchestration.dispatchCommand({
+          type: "thread.meta.update",
+          commandId: newCommandId(),
+          threadId: threadIdForSend,
+          branch: nextThreadBranch,
+          worktreePath: nextThreadWorktreePath,
         });
-        nextThreadBranch = result.worktree.branch;
-        nextThreadWorktreePath = result.worktree.path;
+        setStoreThreadBranch(threadIdForSend, nextThreadBranch, nextThreadWorktreePath);
+      }
+
+      // On first message: lock in branch + create worktree if needed.
+      if (initialWorktreeCreation.type !== "none") {
+        beginSendPhase("preparing-worktree");
+        try {
+          const result = await createWorktreeMutation.mutateAsync({
+            cwd: activeProject.cwd,
+            branch: initialWorktreeCreation.branch,
+            ...(initialWorktreeCreation.type === "new-worktree"
+              ? { newBranch: initialWorktreeCreation.newBranch }
+              : {}),
+          });
+          nextThreadBranch = result.worktree.branch;
+          nextThreadWorktreePath = result.worktree.path;
+        } catch (error) {
+          if (initialWorktreeCreation.type !== "open-worktree") {
+            throw error;
+          }
+
+          const branchesResult = await api.git
+            .listBranches({ cwd: activeProject.cwd })
+            .catch(() => null);
+          const reuseCandidate = branchesResult
+            ? resolveOpenWorktreeReuseCandidate({
+                activeProjectCwd: activeProject.cwd,
+                branches: branchesResult.branches,
+                branchName: initialWorktreeCreation.branch,
+              })
+            : null;
+          if (!reuseCandidate) {
+            throw error;
+          }
+
+          nextThreadBranch = reuseCandidate.branch;
+          nextThreadWorktreePath = reuseCandidate.worktreePath;
+        }
+
         if (isServerThread) {
           await api.orchestration.dispatchCommand({
             type: "thread.meta.update",
             commandId: newCommandId(),
             threadId: threadIdForSend,
-            branch: result.worktree.branch,
-            worktreePath: result.worktree.path,
+            branch: nextThreadBranch,
+            worktreePath: nextThreadWorktreePath,
           });
           // Keep local thread state in sync immediately so terminal drawer opens
           // with the worktree cwd/env instead of briefly using the project root.
-          setStoreThreadBranch(threadIdForSend, result.worktree.branch, result.worktree.path);
+          setStoreThreadBranch(threadIdForSend, nextThreadBranch, nextThreadWorktreePath);
         }
       }
 
@@ -2365,7 +2450,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
 
       let setupScript: ProjectScript | null = null;
-      if (baseBranchForWorktree) {
+      if (initialWorktreeCreation.type !== "none") {
         setupScript = setupProjectScript(activeProject.scripts);
       }
       if (setupScript) {

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1,7 +1,9 @@
 import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createJSONStorage } from "zustand/middleware";
 
 import {
+  COMPOSER_DRAFT_STORAGE_KEY,
   type ComposerImageAttachment,
   createDebouncedStorage,
   useComposerDraftStore,
@@ -324,7 +326,7 @@ describe("composerDraftStore project draft thread mapping", () => {
     } as unknown as {
       branch?: string | null;
       worktreePath?: string | null;
-      envMode?: "local" | "worktree";
+      envMode?: "local" | "worktree" | "open-worktree";
     };
     store.setProjectDraftThreadId(projectId, threadId, runtimeUndefinedOptions);
 
@@ -333,6 +335,105 @@ describe("composerDraftStore project draft thread mapping", () => {
       branch: "feature/base",
       worktreePath: null,
       envMode: "worktree",
+    });
+  });
+
+  it("preserves open-worktree mode without a worktree path", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectId, threadId, {
+      branch: "feature/open",
+      worktreePath: null,
+      envMode: "open-worktree",
+    });
+
+    expect(useComposerDraftStore.getState().getDraftThread(threadId)).toMatchObject({
+      projectId,
+      branch: "feature/open",
+      worktreePath: null,
+      envMode: "open-worktree",
+    });
+  });
+
+  it("collapses open-worktree mode to worktree when a worktree path exists", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectId, threadId, {
+      branch: "feature/open",
+      worktreePath: "/tmp/feature-open",
+      envMode: "open-worktree",
+    });
+
+    expect(useComposerDraftStore.getState().getDraftThread(threadId)).toMatchObject({
+      projectId,
+      branch: "feature/open",
+      worktreePath: "/tmp/feature-open",
+      envMode: "worktree",
+    });
+  });
+});
+
+describe("composerDraftStore persisted env mode normalization", () => {
+  const projectId = ProjectId.makeUnsafe("persisted-project");
+  const threadId = ThreadId.makeUnsafe("persisted-thread");
+  let storageMap: Map<string, string>;
+  let originalStorage: ReturnType<typeof useComposerDraftStore.persist.getOptions>["storage"];
+
+  beforeEach(() => {
+    storageMap = new Map<string, string>();
+    originalStorage = useComposerDraftStore.persist.getOptions().storage;
+    useComposerDraftStore.persist.setOptions({
+      storage: createJSONStorage(() => ({
+        getItem: (name) => storageMap.get(name) ?? null,
+        setItem: (name, value) => {
+          storageMap.set(name, value);
+        },
+        removeItem: (name) => {
+          storageMap.delete(name);
+        },
+      })),
+    });
+    useComposerDraftStore.setState({
+      draftsByThreadId: {},
+      draftThreadsByThreadId: {},
+      projectDraftThreadIdByProjectId: {},
+    });
+  });
+
+  afterEach(() => {
+    useComposerDraftStore.persist.setOptions({ storage: originalStorage });
+  });
+
+  it("rehydrates persisted open-worktree mode without collapsing it", async () => {
+    storageMap.set(
+      COMPOSER_DRAFT_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          draftsByThreadId: {},
+          draftThreadsByThreadId: {
+            [threadId]: {
+              projectId,
+              createdAt: "2026-01-01T00:00:00.000Z",
+              runtimeMode: "full-access",
+              interactionMode: "default",
+              branch: "feature/open",
+              worktreePath: null,
+              envMode: "open-worktree",
+            },
+          },
+          projectDraftThreadIdByProjectId: {
+            [projectId]: threadId,
+          },
+        },
+        version: 1,
+      }),
+    );
+
+    await useComposerDraftStore.persist.rehydrate();
+
+    expect(useComposerDraftStore.getState().getDraftThread(threadId)).toMatchObject({
+      projectId,
+      branch: "feature/open",
+      worktreePath: null,
+      envMode: "open-worktree",
     });
   });
 });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -15,7 +15,7 @@ import { create } from "zustand";
 import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
-export type DraftThreadEnvMode = "local" | "worktree";
+export type DraftThreadEnvMode = "local" | "worktree" | "open-worktree";
 
 const COMPOSER_PERSIST_DEBOUNCE_MS = 300;
 
@@ -294,10 +294,13 @@ function normalizeDraftThreadEnvMode(
   value: unknown,
   fallbackWorktreePath: string | null,
 ): DraftThreadEnvMode {
-  if (value === "local" || value === "worktree") {
+  if (fallbackWorktreePath) {
+    return "worktree";
+  }
+  if (value === "local" || value === "worktree" || value === "open-worktree") {
     return value;
   }
-  return fallbackWorktreePath ? "worktree" : "local";
+  return "local";
 }
 
 function normalizePersistedComposerDraftState(value: unknown): PersistedComposerDraftStoreState {
@@ -611,9 +614,10 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
                 ? (existingThread?.branch ?? null)
                 : (options.branch ?? null),
             worktreePath: nextWorktreePath,
-            envMode:
-              options?.envMode ??
-              (nextWorktreePath ? "worktree" : (existingThread?.envMode ?? "local")),
+            envMode: normalizeDraftThreadEnvMode(
+              options?.envMode ?? existingThread?.envMode,
+              nextWorktreePath,
+            ),
           };
           const hasSameProjectMapping = previousThreadIdForProject === threadId;
           const hasSameDraftThread =
@@ -682,8 +686,10 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
             interactionMode: options.interactionMode ?? existing.interactionMode,
             branch: options.branch === undefined ? existing.branch : (options.branch ?? null),
             worktreePath: nextWorktreePath,
-            envMode:
-              options.envMode ?? (nextWorktreePath ? "worktree" : (existing.envMode ?? "local")),
+            envMode: normalizeDraftThreadEnvMode(
+              options.envMode ?? existing.envMode,
+              nextWorktreePath,
+            ),
           };
           const isUnchanged =
             nextDraftThread.projectId === existing.projectId &&

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -166,12 +166,17 @@ export function gitCreateWorktreeMutationOptions(input: { queryClient: QueryClie
     }: {
       cwd: string;
       branch: string;
-      newBranch: string;
+      newBranch?: string;
       path?: string | null;
     }) => {
       const api = ensureNativeApi();
       if (!cwd) throw new Error("Git worktree creation is unavailable.");
-      return api.git.createWorktree({ cwd, branch, newBranch, path: path ?? null });
+      return api.git.createWorktree({
+        cwd,
+        branch,
+        ...(newBranch ? { newBranch } : {}),
+        path: path ?? null,
+      });
     },
     mutationKey: ["git", "mutation", "create-worktree"] as const,
     onSettled: async () => {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- added `open-worktree` env mode across branch toolbar, draft store, and send flow
- reuse existing checked-out worktrees when possible; only create when needed
- allow create-worktree calls without `newBranch` and cover behavior with new tests

## Why

These changes address #1047 by adding the ability to open an existing remote branch in a new worktree without creating a new branch with the t3code extension. The existing New Worktree and Local options continue to function as before. If Open Worktree is used on a branch that already has a local worktree, the thread will automatically attach to that existing worktree instead of creating a new one. If the project's default branch is selected, the local workspace will be used instead of creating a new worktree.

## UI Changes

<img width="811" height="205" alt="Screenshot 2026-03-14 at 7 10 52 PM" src="https://github.com/user-attachments/assets/08055ea0-7aa6-4d69-addf-708038ceca23" />
<img width="811" height="253" alt="Screenshot 2026-03-14 at 7 11 50 PM" src="https://github.com/user-attachments/assets/53c78543-e0bc-4c1f-b156-cf34a9e5d61a" />
<img width="788" height="105" alt="Screenshot 2026-03-14 at 7 13 51 PM" src="https://github.com/user-attachments/assets/d95a1b5e-865d-4caf-bfe7-091449647b05" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
