### PR TITLE
fix: tighten node engine range for node:sqlite compat (#206)

### DIFF
--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -16,38 +16,11 @@ const defaultSqliteClientLoaders = {
   node: () => import("../NodeSqliteClient.ts"),
 } satisfies Record<string, () => Promise<Loader>>;
 
-/**
- * Verify that the current Node.js version includes the `node:sqlite` APIs
- * used by `NodeSqliteClient` — specifically `StatementSync.columns()` (added
- * in Node 22.16.0 / 23.11.0).
- *
- * @see https://github.com/nodejs/node/pull/57490
- */
-function checkNodeSqliteCompat(): void {
-  const parts = process.versions.node.split(".").map(Number);
-  const major = parts[0] ?? 0;
-  const minor = parts[1] ?? 0;
-  const supported =
-    (major === 22 && minor >= 16) ||
-    (major === 23 && minor >= 11) ||
-    major >= 24;
-
-  if (!supported) {
-    throw new Error(
-      `Node.js ${process.versions.node} is missing required node:sqlite APIs ` +
-        `(StatementSync.columns). Upgrade to Node.js >=22.16, >=23.11, or >=24.`,
-    );
-  }
-}
-
 const makeRuntimeSqliteLayer = (
   config: RuntimeSqliteLayerConfig,
 ): Layer.Layer<SqlClient.SqlClient> =>
   Effect.gen(function* () {
     const runtime = process.versions.bun !== undefined ? "bun" : "node";
-    if (runtime === "node") {
-      checkNodeSqliteCompat();
-    }
     const loader = defaultSqliteClientLoaders[runtime];
     const clientModule = yield* Effect.promise<Loader>(loader);
     return clientModule.layer(config);
@@ -68,10 +41,7 @@ export const makeSqlitePersistenceLive = (dbPath: string) =>
     const path = yield* Path.Path;
     yield* fs.makeDirectory(path.dirname(dbPath), { recursive: true });
 
-    return Layer.provideMerge(
-      setup,
-      makeRuntimeSqliteLayer({ filename: dbPath }),
-    );
+    return Layer.provideMerge(setup, makeRuntimeSqliteLayer({ filename: dbPath }));
   }).pipe(Layer.unwrap);
 
 export const SqlitePersistenceMemory = Layer.provideMerge(

--- a/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.ts
@@ -50,11 +50,35 @@ export interface SqliteMemoryClientConfig extends Omit<
   "filename" | "readonly"
 > {}
 
+/**
+ * Verify that the current Node.js version includes the `node:sqlite` APIs
+ * used by `NodeSqliteClient` — specifically `StatementSync.columns()` (added
+ * in Node 22.16.0 / 23.11.0).
+ *
+ * @see https://github.com/nodejs/node/pull/57490
+ */
+const checkNodeSqliteCompat = () => {
+  const parts = process.versions.node.split(".").map(Number);
+  const major = parts[0] ?? 0;
+  const minor = parts[1] ?? 0;
+  const supported = (major === 22 && minor >= 16) || (major === 23 && minor >= 11) || major >= 24;
+
+  if (!supported) {
+    return Effect.die(
+      `Node.js ${process.versions.node} is missing required node:sqlite APIs ` +
+        `(StatementSync.columns). Upgrade to Node.js >=22.16, >=23.11, or >=24.`,
+    );
+  }
+  return Effect.void;
+};
+
 const makeWithDatabase = (
   options: SqliteClientConfig,
   openDatabase: () => DatabaseSync,
 ): Effect.Effect<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> =>
   Effect.gen(function* () {
+    yield* checkNodeSqliteCompat();
+
     const compiler = Statement.makeCompilerSqlite(options.transformQueryNames);
     const transformRows = options.transformResultNames
       ? Statement.defaultTransforms(options.transformResultNames).array


### PR DESCRIPTION
## What Changed

Tightened `engines.node` from `^22.13 || ^23.4` to `^22.16 || ^23.11 || >=24.10` and added a runtime version check in `Sqlite.ts` before loading `node:sqlite`.

## Why

`StatementSync.columns()` (used in `NodeSqliteClient.ts`) was only added in Node [22.16](https://github.com/nodejs/node/pull/57490) / [23.11](https://github.com/nodejs/node/pull/57542). The previous engine range allowed 22.13+, so users on those versions crash with `TypeError: statement.columns is not a function`.

The runtime check is needed because `npx t3@alpha` skips engine checks. Gated on `runtime === "node"` so Bun is untouched.

Addresses #206

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] `bun lint` — clean
- [x] `bun typecheck` — server clean
- [x] `bun run test` — 446 passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce minimum Node.js versions for `node:sqlite` compatibility in `NodeSqliteClient`
> - Updates the `engines.node` constraint in [package.json](https://github.com/pingdotgg/t3code/pull/1096/files#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2) from `^22.13 || ^23.4 || >=24.10` to `^22.16 || ^23.11 || >=24.10` to match the versions where `node:sqlite` APIs are stable.
> - Adds a `checkNodeSqliteCompat` helper in [NodeSqliteClient.ts](https://github.com/pingdotgg/t3code/pull/1096/files#diff-cf61d9fd2d48cc7f6a5d0ebaaa66f8c39d982f536913a6fb92196591465087aa) that parses `process.versions.node` at runtime and calls `Effect.die` with a descriptive message if the version is unsupported.
> - `makeWithDatabase` now runs this check before opening the database, aborting initialization on incompatible Node versions.
> - Behavioral Change: servers running Node 22.13–22.15 or 23.4–23.10 will now fail fast with a clear error instead of attempting to use unavailable SQLite APIs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2a41a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->