### PR TITLE
fix: unpack native node modules from asar archive

### DIFF
--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -455,6 +455,7 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     directories: {
       buildResources: "apps/desktop/resources",
     },
+    asarUnpack: ["**/*.node"],
   };
   const publishConfig = resolveGitHubPublishConfig();
   if (publishConfig) {


### PR DESCRIPTION
## What Changed

Taken from #1098. Even if that PR isn't merged, this line is still important. This extracts out any native Node modules our of our ASAR archive. See below for more information.

## Why

By default, all of our code and files are packed into a `.asar` archive. Electron wraps several filesystem actions and such so that this is mostly transparent to runtime code. However, [support for native Node modules is limited.](https://www.electronjs.org/docs/latest/tutorial/asar-archives#limitations-of-the-node-api) Electron actually suggests that end developers unpack `.node` modules explicitly, this does so. While we currently don't explicitly use any native modules, but we may in the future (and some *do* appear to be in our dependency graph). If any code in our dependency tree every tries to reach out to a native Node module, it may fail and cause our app to crash. We don't want that. 

## UI Changes

N/A

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] ~I included before/after screenshots for any UI changes~
- [x] ~I included a video for animation/interaction changes~


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unpack native Node modules from asar archive in desktop build
> Adds `asarUnpack: ["**/*.node"]` to the build config in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/1099/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d). Native `.node` modules cannot be loaded from inside an asar archive at runtime, so they must be extracted alongside it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3887c96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->