### PR TITLE
fix(web): replace hasOpenedDiff useState/useEffect latch with useRef

### DIFF
--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,6 +1,6 @@
 import { ThreadId } from "@t3tools/contracts";
 import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
-import { Suspense, lazy, type ReactNode, useCallback, useEffect, useState } from "react";
+import { Suspense, lazy, type ReactNode, useCallback, useEffect, useRef } from "react";
 
 import ChatView from "../components/ChatView";
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
@@ -176,7 +176,7 @@ function ChatThreadRouteView() {
   const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
   // TanStack Router keeps active route components mounted across param-only navigations
   // unless remountDeps are configured, so this stays warm across thread switches.
-  const [hasOpenedDiff, setHasOpenedDiff] = useState(diffOpen);
+  const hasOpenedDiffRef = useRef(diffOpen);
   const closeDiff = useCallback(() => {
     void navigate({
       to: "/$threadId",
@@ -195,11 +195,7 @@ function ChatThreadRouteView() {
     });
   }, [navigate, threadId]);
 
-  useEffect(() => {
-    if (diffOpen) {
-      setHasOpenedDiff(true);
-    }
-  }, [diffOpen]);
+  if (diffOpen) hasOpenedDiffRef.current = true;
 
   useEffect(() => {
     if (!threadsHydrated) {
@@ -216,7 +212,7 @@ function ChatThreadRouteView() {
     return null;
   }
 
-  const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
+  const shouldRenderDiffContent = diffOpen || hasOpenedDiffRef.current;
 
   if (!shouldUseDiffSheet) {
     return (


### PR DESCRIPTION
Replaces a `useState` + `useEffect` latch for `hasOpenedDiff` with a `useRef` written inline during render.

**What changed:** removed the effect that called `setHasOpenedDiff(true)` when `diffOpen` was true. The ref is initialized to `diffOpen` and set inline: `if (diffOpen) hasOpenedDiffRef.current = true`.

**Why:** calling `setState` inside a `useEffect` schedules an extra render after the initial one completes. The value is never needed to trigger a re-render — only to gate rendering of diff content — so a ref is the right tool.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `hasOpenedDiff` state latch with a ref in `ChatThreadRouteView`
> Replaces a `useState`/`useEffect` pattern with a `useRef` to track whether the diff panel has been opened. The ref is initialized to the current `diffOpen` value and set synchronously when `diffOpen` is true, removing an unnecessary render cycle caused by the prior effect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e07e402.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->