### PR TITLE
fix(github): fix bug report issue template for screenshots

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -96,9 +96,18 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: Logs, stack traces, or screenshots
+      label: Logs or stack traces
       description: Paste the most relevant output only. Redact secrets.
       render: shell
+
+  - type: upload
+    id: attachments
+    attributes:
+      label: Screenshots, recordings, or supporting files
+      description: Upload screenshots, short recordings, repro archives, or log files. Redact secrets before uploading.
+    validations:
+      required: false
+      accept: ".png,.jpg,.jpeg,.gif,.webp,.svg,.mp4,.mov,.webm,.log,.txt,.json,.zip"
 
   - type: textarea
     id: workaround


### PR DESCRIPTION

You can view my PRs and issues at https://pr-navigator.pages.dev/t3code-utkarsh

## What Changed

Updated the GitHub bug issue template in `.github/ISSUE_TEMPLATE/bug_report.yml`.

- Renamed the existing `logs` field label from `Logs, stack traces, or screenshots` to `Logs or stack traces`
- Added a new optional `upload` field for screenshots, recordings, and supporting files
- Restricted accepted upload types to common image, video, log, text, JSON, and zip formats

## Why

The current bug form asks users to provide screenshots in a field rendered with `render: shell`. So, screenshots can't be added there.

Closes #1108 

## UI Changes

| Before | After |
| --- | --- |
| <img width="1152" height="346" alt="image" src="https://github.com/user-attachments/assets/4b3da5ff-20b4-470f-b12c-41ffcb1a815f" /> | <img width="1152" height="495" alt="image" src="https://github.com/user-attachments/assets/e4249308-5fa7-4d41-8e71-fbac6c0cb749" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dedicated file upload field to bug report form for screenshots and recordings
> Updates [bug_report.yml](https://github.com/pingdotgg/t3code/pull/1109/files#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653ef) to split the logs textarea and file attachments into separate fields. The logs textarea is relabeled to 'Logs or stack traces', and a new optional upload field accepts screenshots, recordings, and log files (`.png`, `.jpg`, `.gif`, `.mp4`, `.zip`, and more).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb5c169.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->