### PR TITLE
fix(web): preserve scroll when collapsing large changed-files trees

### DIFF
--- a/apps/web/src/components/chat/ChangedFilesTree.tsx
+++ b/apps/web/src/components/chat/ChangedFilesTree.tsx
@@ -50,6 +50,7 @@ export const ChangedFilesTree = memo(function ChangedFilesTree(props: {
         <div key={`dir:${node.path}`}>
           <button
             type="button"
+            data-scroll-anchor-ignore
             className="group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80"
             style={{ paddingLeft: `${leftPadding}px` }}
             onClick={() => toggleDirectory(node.path, depth === 0)}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -245,9 +245,14 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     rowVirtualizer.measure();
   }, [rowVirtualizer, timelineWidthPx]);
   useEffect(() => {
-    rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (_item, _delta, instance) => {
+    rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => {
       const viewportHeight = instance.scrollRect?.height ?? 0;
       const scrollOffset = instance.scrollOffset ?? 0;
+      const itemIntersectsViewport =
+        item.end > scrollOffset && item.start < scrollOffset + viewportHeight;
+      if (itemIntersectsViewport) {
+        return false;
+      }
       const remainingDistance = instance.getTotalSize() - (scrollOffset + viewportHeight);
       return remainingDistance > AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
     };
@@ -458,6 +463,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                             type="button"
                             size="xs"
                             variant="outline"
+                            data-scroll-anchor-ignore
                             onClick={() => onToggleAllDirectories(turnSummary.turnId)}
                           >
                             {allDirectoriesExpanded ? "Collapse all" : "Expand all"}


### PR DESCRIPTION
## Summary
Fix chat scroll jumps when collapsing very large changed-files trees.

## Problem
When a changed-files section contains hundreds of entries, collapsing the tree can shrink the rendered message enough that the timeline repositions the viewport unexpectedly. In practice this makes the collapse controls feel broken because the user gets pulled away from the message they were interacting with.

## What changed
- stop virtualizer scroll compensation when the resized row is currently visible
- mark changed-files collapse and directory toggle controls with `data-scroll-anchor-ignore` so click-anchor restoration does not interfere with those interactions

## Why
The bug happens during an intentional height change inside the message the user is actively viewing. In that case, preserving the current viewport is more stable than trying to compensate for the size change. The virtualizer can still adjust scroll for off-screen rows, but visible changed-files interactions now keep the user anchored in place.

## UI Changes

Before:
https://github.com/user-attachments/assets/60f06a27-9776-4c6d-b553-611fbbf5b2a0
* Notice tree collapses correctly but the user is then immediately taken to the top of thread
* 'Collapse all' button immediately takes the user to the top of thread

After:
https://github.com/user-attachments/assets/eacd53a5-66f9-41e7-b70c-7b4de1b0292d
* Tree collapses work fine, keeping position
* 'Collapse all' button also keeps position

## Good to have
Might also be nice to have the default as collapsed if the number of changed files is greater then a certain number? 

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve scroll position when collapsing changed-files trees in the chat timeline
> - Adds `data-scroll-anchor-ignore` to directory toggle buttons in [`ChangedFilesTree.tsx`](https://github.com/pingdotgg/t3code/pull/1113/files#diff-6864e7755be29c811b2329bf788d411fda278c8f9a22f4ec373e82a9acc03f0c) and the collapse/expand button in [`MessagesTimeline.tsx`](https://github.com/pingdotgg/t3code/pull/1113/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) so clicks on these buttons don't trigger scroll anchor adjustments.
> - Updates `shouldAdjustScrollPositionOnItemSizeChange` in `MessagesTimeline` to skip scroll adjustments when the resized item is within the viewport, preventing jarring scroll jumps when collapsing large file trees.
> - Behavioral Change: scroll position adjustments now only fire when the resized item is outside the viewport and the remaining distance to the bottom exceeds `AUTO_SCROLL_BOTTOM_THRESHOLD_PX`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b0d5e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->