### PR TITLE
(fix) set env-mode to loose for dev

### DIFF
--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -22,15 +22,23 @@ const MODE_ARGS = {
   dev: [
     "run",
     "dev",
+    "--env-mode=loose",
     "--ui=tui",
     "--filter=@t3tools/contracts",
     "--filter=@t3tools/web",
     "--filter=t3",
     "--parallel",
   ],
-  "dev:server": ["run", "dev", "--filter=t3"],
-  "dev:web": ["run", "dev", "--filter=@t3tools/web"],
-  "dev:desktop": ["run", "dev", "--filter=@t3tools/desktop", "--filter=@t3tools/web", "--parallel"],
+  "dev:server": ["run", "dev", "--env-mode=loose", "--filter=t3"],
+  "dev:web": ["run", "dev", "--env-mode=loose", "--filter=@t3tools/web"],
+  "dev:desktop": [
+    "run",
+    "dev",
+    "--env-mode=loose",
+    "--filter=@t3tools/desktop",
+    "--filter=@t3tools/web",
+    "--parallel",
+  ],
 } as const satisfies Record<string, ReadonlyArray<string>>;
 
 type DevMode = keyof typeof MODE_ARGS;


### PR DESCRIPTION
## What Changed
Added `--env-mode=loose` to all dev-mode turbo invocations in scripts/dev-runner.ts

## Why
Turbo v2 defaults to --env-mode=strict, which strips environment variables not listed in turbo.json's globalEnv before
  passing them to child tasks. This meant for instance that my `AZURE_API_KEY` wasn't listed, and never reached the server or codex app-server. 
  
  I alternatively considered explicitly adding the env vars in question to `globalPassThroughEnv` in `turbo.json`, but for maintainability I believe this is a better solution considering these are dev runners

## UI Changes
None

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `--env-mode=loose` for all dev runner modes
> Adds `--env-mode=loose` to the CLI arguments for `dev`, `dev:server`, `dev:web`, and `dev:desktop` in [dev-runner.ts](https://github.com/pingdotgg/t3code/pull/1115/files#diff-8ba446fc13205cee91be4164b3936316a911d90cfc2fb690c99c49ea439542bf). This relaxes environment variable resolution during local development.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd1fcf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->