### PR TITLE
fix(ui): keep prior tool calls visible in thread timeline

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,0 +1,52 @@
+import { EventId, TurnId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import { deriveVisibleThreadWorkLogEntries } from "./ChatView.logic";
+
+function makeActivity(overrides: {
+  id?: string;
+  createdAt?: string;
+  kind?: string;
+  summary?: string;
+  tone?: OrchestrationThreadActivity["tone"];
+  payload?: Record<string, unknown>;
+  turnId?: string;
+  sequence?: number;
+}): OrchestrationThreadActivity {
+  return {
+    id: EventId.makeUnsafe(overrides.id ?? crypto.randomUUID()),
+    createdAt: overrides.createdAt ?? "2026-02-23T00:00:00.000Z",
+    kind: overrides.kind ?? "tool.started",
+    summary: overrides.summary ?? "Tool call",
+    tone: overrides.tone ?? "tool",
+    payload: overrides.payload ?? {},
+    turnId: overrides.turnId ? TurnId.makeUnsafe(overrides.turnId) : null,
+    ...(overrides.sequence !== undefined ? { sequence: overrides.sequence } : {}),
+  };
+}
+
+describe("deriveVisibleThreadWorkLogEntries", () => {
+  it("keeps completed tool calls from previous turns visible in the thread timeline", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tool-1",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        turnId: "turn-1",
+        kind: "tool.completed",
+        summary: "First tool call",
+      }),
+      makeActivity({
+        id: "tool-2",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        turnId: "turn-2",
+        kind: "tool.completed",
+        summary: "Second tool call",
+      }),
+    ];
+
+    expect(deriveVisibleThreadWorkLogEntries(activities).map((entry) => entry.id)).toEqual([
+      "tool-1",
+      "tool-2",
+    ]);
+  });
+});

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,9 +1,15 @@
-import { ProjectId, type ProviderKind, type ThreadId } from "@t3tools/contracts";
+import {
+  ProjectId,
+  type OrchestrationThreadActivity,
+  type ProviderKind,
+  type ThreadId,
+} from "@t3tools/contracts";
 import { type ChatMessage, type Thread } from "../types";
 import { randomUUID } from "~/lib/utils";
 import { getAppModelOptions } from "../appSettings";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import { Schema } from "effect";
+import { deriveWorkLogEntries, type WorkLogEntry } from "../session-logic";
 
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
 const WORKTREE_BRANCH_PREFIX = "t3code";
@@ -122,4 +128,10 @@ export function getCustomModelOptionsByProvider(settings: {
   return {
     codex: getAppModelOptions("codex", settings.customCodexModels),
   };
+}
+
+export function deriveVisibleThreadWorkLogEntries(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): WorkLogEntry[] {
+  return deriveWorkLogEntries(activities, undefined);
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -54,7 +54,6 @@ import {
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
   findLatestProposedPlan,
-  deriveWorkLogEntries,
   hasToolActivityForTurn,
   isLatestTurnSettled,
   formatElapsed,
@@ -149,6 +148,7 @@ import {
   buildTemporaryWorktreeBranchName,
   cloneComposerImageForRetry,
   collectUserMessageBlobPreviewUrls,
+  deriveVisibleThreadWorkLogEntries,
   getCustomModelOptionsByProvider,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
   LastInvokedScriptByProjectSchema,
@@ -578,8 +578,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
   const workLogEntries = useMemo(
-    () => deriveWorkLogEntries(threadActivities, activeLatestTurn?.turnId ?? undefined),
-    [activeLatestTurn?.turnId, threadActivities],
+    () => deriveVisibleThreadWorkLogEntries(threadActivities),
+    [threadActivities],
   );
   const latestTurnHasToolActivity = useMemo(
     () => hasToolActivityForTurn(threadActivities, activeLatestTurn?.turnId),


### PR DESCRIPTION
## What Changed

- Fixed the chat thread timeline so completed tool-call activity from earlier turns stays visible instead of disappearing when a newer turn becomes active.
- Moved the visible work-log derivation into `ChatView.logic` so the thread timeline uses thread-wide activity visibility rather than filtering to only the latest turn.
- Added a regression test covering completed tool calls from multiple turns to prevent this from breaking again.

## Why

Previously, the timeline only derived visible tool activity for the active turn, which caused completed tool calls from prior turns to disappear from the thread view. That made the history feel incomplete and made it harder to understand what work had already happened in the conversation.

This change fixes that by deriving the visible work log from the full thread activity list, which keeps the timeline accurate and predictable while preserving a small, focused fix.



## UI Changes

Before:

<img width="1093" height="1411" alt="image" src="https://github.com/user-attachments/assets/1d62c4ab-54e7-4183-b22d-bf70006615bf" />
<img width="1112" height="1418" alt="image" src="https://github.com/user-attachments/assets/9eb97306-a346-4d28-bd92-85cc59509dd0" />

After:
<img width="1112" height="1344" alt="image" src="https://github.com/user-attachments/assets/09fe16c1-a149-4eaa-a2df-8c947f3ef5e7" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep prior tool calls visible in thread timeline by removing turn scoping
> Previously, `workLogEntries` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1118/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) was derived with `deriveWorkLogEntries(threadActivities, activeLatestTurn?.turnId)`, which scoped entries to the active/latest turn and hid tool calls from earlier turns. A new `deriveVisibleThreadWorkLogEntries` wrapper in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/1118/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) calls `deriveWorkLogEntries` without a turn ID, so all completed tool call activities across all turns are retained in the timeline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6a514a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->