### PR TITLE
feat: make check for updates menu item dynamic

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "effect": "catalog:",
-    "electron": "40.6.0",
+    "electron": "40.7.0",
     "electron-updater": "^6.6.2"
   },
   "devDependencies": {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -14,6 +14,7 @@ import {
   nativeTheme,
   protocol,
   shell,
+  MenuItem,
 } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
@@ -292,6 +293,8 @@ let updateDownloadInFlight = false;
 let updateInstallInFlight = false;
 let updaterConfigured = false;
 let updateState: DesktopUpdateState = initialUpdateState();
+const updateStateListeners = new Set<(state: DesktopUpdateState) => void>();
+updateStateListeners.add(() => emitUpdateState());
 
 function resolveUpdaterErrorContext(): DesktopUpdateErrorContext {
   if (updateInstallInFlight) return "install";
@@ -575,18 +578,69 @@ async function checkForUpdatesFromMenu(): Promise<void> {
   }
 }
 
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DEFAULT = "Check for Updates...";
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_CHECKING = "Checking for Updates...";
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_IDLE = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DEFAULT;
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DISABLED = "Updates unavailable";
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADING = "Downloading update...";
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADED = "Update downloaded";
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_AVAILABLE = "Update available";
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_UP_TO_DATE = "You're up to date!";
+const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_ERROR = "Update check failed";
+const checkForUpdatesMenuItem: MenuItem = new MenuItem({
+  label: CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DEFAULT,
+  click: async () => await handleCheckForUpdatesMenuClick(),
+});
+
+// TODO: Only the enabled status is actually dynamic here. Wait for upstream to allow for dynamic label updates.
+updateStateListeners.add((state) => {
+  switch (state.status) {
+    case "checking":
+      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_CHECKING;
+      checkForUpdatesMenuItem.enabled = false;
+      break;
+    case "available":
+      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_AVAILABLE;
+      checkForUpdatesMenuItem.enabled = false;
+      break;
+    case "downloading":
+      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADING;
+      checkForUpdatesMenuItem.enabled = false;
+      break;
+    case "downloaded":
+      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADED;
+      checkForUpdatesMenuItem.enabled = false;
+      break;
+    case "disabled":
+      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DISABLED;
+      checkForUpdatesMenuItem.enabled = false;
+      break;
+    case "error":
+      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_ERROR;
+      checkForUpdatesMenuItem.enabled = false;
+      break;
+    case "up-to-date":
+      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_UP_TO_DATE;
+      checkForUpdatesMenuItem.enabled = false;
+      break;
+    case "idle":
+      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_IDLE;
+      checkForUpdatesMenuItem.enabled = true;
+      break;
+  }
+});
+
+let applicationMenu: Menu | null = null;
+
 function configureApplicationMenu(): void {
-  const template: MenuItemConstructorOptions[] = [];
+  const template: (MenuItemConstructorOptions | MenuItem)[] = [];
 
   if (process.platform === "darwin") {
     template.push({
       label: app.name,
-      submenu: [
+      submenu: Menu.buildFromTemplate([
         { role: "about" },
-        {
-          label: "Check for Updates...",
-          click: () => handleCheckForUpdatesMenuClick(),
-        },
+        checkForUpdatesMenuItem,
         { type: "separator" },
         {
           label: "Settings...",
@@ -601,7 +655,7 @@ function configureApplicationMenu(): void {
         { role: "unhide" },
         { type: "separator" },
         { role: "quit" },
-      ],
+      ]),
     });
   }
 
@@ -641,16 +695,13 @@ function configureApplicationMenu(): void {
     { role: "windowMenu" },
     {
       role: "help",
-      submenu: [
-        {
-          label: "Check for Updates...",
-          click: () => handleCheckForUpdatesMenuClick(),
-        },
-      ],
+      // TODO: Is it safe to use the same menu item for both the root menu and the help menu?
+      submenu: Menu.buildFromTemplate([checkForUpdatesMenuItem]),
     },
   );
 
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  applicationMenu = Menu.buildFromTemplate(template);
+  Menu.setApplicationMenu(applicationMenu);
 }
 
 function resolveResourcePath(fileName: string): string | null {
@@ -743,7 +794,9 @@ function emitUpdateState(): void {
 
 function setUpdateState(patch: Partial<DesktopUpdateState>): void {
   updateState = { ...updateState, ...patch };
-  emitUpdateState();
+  for (const listener of updateStateListeners) {
+    listener(updateState);
+  }
 }
 
 function shouldEnableAutoUpdates(): boolean {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -24,6 +24,7 @@ import type {
   DesktopUpdateCheckResult,
   DesktopUpdateState,
 } from "@t3tools/contracts";
+import { DesktopUpdateStatusFriendlyLabelMap } from "@t3tools/contracts";
 import { autoUpdater } from "electron-updater";
 
 import type { ContextMenuItem } from "@t3tools/contracts";
@@ -578,18 +579,9 @@ async function checkForUpdatesFromMenu(): Promise<void> {
   }
 }
 
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DEFAULT = "Check for Updates...";
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_CHECKING = "Checking for Updates...";
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_IDLE = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DEFAULT;
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DISABLED = "Updates unavailable";
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADING = "Downloading update...";
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADED = "Update downloaded";
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_AVAILABLE = "Update available";
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_UP_TO_DATE = "You're up to date!";
-const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_ERROR = "Update check failed";
 function makeCheckForUpdatesMenuItem(): MenuItem {
   return new MenuItem({
-    label: CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DEFAULT,
+    label: DesktopUpdateStatusFriendlyLabelMap["idle"],
     click: async () => await handleCheckForUpdatesMenuClick(),
   });
 }
@@ -597,37 +589,18 @@ const checkForUpdatesMenuItemInAppMenu = makeCheckForUpdatesMenuItem();
 const checkForUpdatesMenuItemInHelpMenu = makeCheckForUpdatesMenuItem();
 
 function updateCheckForUpdatesMenuItem(menuItem: MenuItem, state: DesktopUpdateState): void {
+  menuItem.label = DesktopUpdateStatusFriendlyLabelMap[state.status];
   switch (state.status) {
     case "checking":
-      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_CHECKING;
-      menuItem.enabled = false;
-      break;
     case "available":
-      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_AVAILABLE;
-      menuItem.enabled = false;
-      break;
     case "downloading":
-      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADING;
-      menuItem.enabled = false;
-      break;
     case "downloaded":
-      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADED;
-      menuItem.enabled = false;
-      break;
     case "disabled":
-      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DISABLED;
-      menuItem.enabled = false;
-      break;
     case "error":
-      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_ERROR;
-      menuItem.enabled = false;
-      break;
     case "up-to-date":
-      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_UP_TO_DATE;
       menuItem.enabled = false;
       break;
     case "idle":
-      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_IDLE;
       menuItem.enabled = true;
       break;
   }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -533,29 +533,45 @@ function dispatchMenuAction(action: string): void {
 }
 
 function handleCheckForUpdatesMenuClick(): void {
-  const disabledReason = getAutoUpdateDisabledReason({
-    isDevelopment,
-    isPackaged: app.isPackaged,
-    platform: process.platform,
-    appImage: process.env.APPIMAGE,
-    disabledByEnv: process.env.T3CODE_DISABLE_AUTO_UPDATE === "1",
-  });
-  if (disabledReason) {
-    console.info("[desktop-updater] Manual update check requested, but updates are disabled.");
-    void dialog.showMessageBox({
-      type: "info",
-      title: "Updates unavailable",
-      message: "Automatic updates are not available right now.",
-      detail: disabledReason,
-      buttons: ["OK"],
-    });
-    return;
-  }
+  switch (updateState.status) {
+    case "idle":
+      {
+        const disabledReason = getAutoUpdateDisabledReason({
+          isDevelopment,
+          isPackaged: app.isPackaged,
+          platform: process.platform,
+          appImage: process.env.APPIMAGE,
+          disabledByEnv: process.env.T3CODE_DISABLE_AUTO_UPDATE === "1",
+        });
+        if (disabledReason) {
+          console.info(
+            "[desktop-updater] Manual update check requested, but updates are disabled.",
+          );
+          void dialog.showMessageBox({
+            type: "info",
+            title: "Updates unavailable",
+            message: "Automatic updates are not available right now.",
+            detail: disabledReason,
+            buttons: ["OK"],
+          });
+          return;
+        }
 
-  if (!BrowserWindow.getAllWindows().length) {
-    mainWindow = createWindow();
+        if (!BrowserWindow.getAllWindows().length) {
+          mainWindow = createWindow();
+        }
+        void checkForUpdatesFromMenu();
+      }
+      break;
+    case "available":
+      void downloadAvailableUpdate();
+      break;
+    case "downloaded":
+      void installDownloadedUpdate();
+      break;
+    default:
+      break;
   }
-  void checkForUpdatesFromMenu();
 }
 
 async function checkForUpdatesFromMenu(): Promise<void> {
@@ -582,7 +598,7 @@ async function checkForUpdatesFromMenu(): Promise<void> {
 function makeCheckForUpdatesMenuItem(): MenuItem {
   return new MenuItem({
     label: DesktopUpdateStatusFriendlyLabelMap["idle"],
-    click: async () => await handleCheckForUpdatesMenuClick(),
+    click: handleCheckForUpdatesMenuClick,
   });
 }
 const checkForUpdatesMenuItemInAppMenu = makeCheckForUpdatesMenuItem();
@@ -592,15 +608,15 @@ function updateCheckForUpdatesMenuItem(menuItem: MenuItem, state: DesktopUpdateS
   menuItem.label = DesktopUpdateStatusFriendlyLabelMap[state.status];
   switch (state.status) {
     case "checking":
-    case "available":
     case "downloading":
-    case "downloaded":
     case "disabled":
     case "error":
     case "up-to-date":
       menuItem.enabled = false;
       break;
     case "idle":
+    case "available":
+    case "downloaded":
       menuItem.enabled = true;
       break;
   }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -43,6 +43,7 @@ import {
   reduceDesktopUpdateStateOnDownloadStart,
   reduceDesktopUpdateStateOnInstallFailure,
   reduceDesktopUpdateStateOnNoUpdate,
+  reduceDesktopUpdateStateToIdle,
   reduceDesktopUpdateStateOnUpdateAvailable,
 } from "./updateMachine";
 import { isArm64HostRunningIntelBuild, resolveDesktopRuntimeInfo } from "./runtimeArch";
@@ -78,6 +79,7 @@ const LOG_FILE_MAX_FILES = 10;
 const APP_RUN_ID = Crypto.randomBytes(6).toString("hex");
 const AUTO_UPDATE_STARTUP_DELAY_MS = 15_000;
 const AUTO_UPDATE_POLL_INTERVAL_MS = 4 * 60 * 60 * 1000;
+const AUTO_UPDATE_TRANSIENT_IDLE_RESET_DELAY_MS = 5_000;
 const DESKTOP_UPDATE_CHANNEL = "latest";
 const DESKTOP_UPDATE_ALLOW_PRERELEASE = false;
 
@@ -294,6 +296,7 @@ let updateDownloadInFlight = false;
 let updateInstallInFlight = false;
 let updaterConfigured = false;
 let updateState: DesktopUpdateState = initialUpdateState();
+let updateIdleResetTimer: ReturnType<typeof setTimeout> | null = null;
 const updateStateListeners = new Set<(state: DesktopUpdateState) => void>();
 updateStateListeners.add(() => emitUpdateState());
 
@@ -578,20 +581,22 @@ async function checkForUpdatesFromMenu(): Promise<void> {
   await checkForUpdates("menu");
 
   if (updateState.status === "up-to-date") {
-    void dialog.showMessageBox({
+    await dialog.showMessageBox({
       type: "info",
       title: "You're up to date!",
       message: `T3 Code ${updateState.currentVersion} is currently the newest version available.`,
       buttons: ["OK"],
     });
+    resetUpdateStateToIdleIfNeeded();
   } else if (updateState.status === "error") {
-    void dialog.showMessageBox({
+    await dialog.showMessageBox({
       type: "warning",
       title: "Update check failed",
       message: "Could not check for updates.",
       detail: updateState.message ?? "An unknown error occurred. Please try again later.",
       buttons: ["OK"],
     });
+    resetUpdateStateToIdleIfNeeded();
   }
 }
 
@@ -788,8 +793,43 @@ function emitUpdateState(): void {
   }
 }
 
+function shouldResetUpdateStateToIdle(state: DesktopUpdateState): boolean {
+  return state.status === "up-to-date" || state.errorContext === "check";
+}
+
+function clearUpdateIdleResetTimer(): void {
+  if (updateIdleResetTimer) {
+    clearTimeout(updateIdleResetTimer);
+    updateIdleResetTimer = null;
+  }
+}
+
+function resetUpdateStateToIdleIfNeeded(): boolean {
+  clearUpdateIdleResetTimer();
+  if (!shouldResetUpdateStateToIdle(updateState)) {
+    return false;
+  }
+  setUpdateState(reduceDesktopUpdateStateToIdle(updateState));
+  return true;
+}
+
+function scheduleUpdateStateIdleReset(delayMs = AUTO_UPDATE_TRANSIENT_IDLE_RESET_DELAY_MS): void {
+  clearUpdateIdleResetTimer();
+  if (!shouldResetUpdateStateToIdle(updateState)) {
+    return;
+  }
+  updateIdleResetTimer = setTimeout(() => {
+    updateIdleResetTimer = null;
+    resetUpdateStateToIdleIfNeeded();
+  }, delayMs);
+  updateIdleResetTimer.unref();
+}
+
 function setUpdateState(patch: Partial<DesktopUpdateState>): void {
   updateState = { ...updateState, ...patch };
+  if (!shouldResetUpdateStateToIdle(updateState)) {
+    clearUpdateIdleResetTimer();
+  }
   for (const listener of updateStateListeners) {
     listener(updateState);
   }
@@ -827,6 +867,7 @@ async function checkForUpdates(reason: string): Promise<boolean> {
     setUpdateState(
       reduceDesktopUpdateStateOnCheckFailure(updateState, message, new Date().toISOString()),
     );
+    scheduleUpdateStateIdleReset();
     console.error(`[desktop-updater] Failed to check for updates: ${message}`);
     return true;
   } finally {
@@ -952,6 +993,7 @@ function configureAutoUpdater(): void {
   });
   autoUpdater.on("update-not-available", () => {
     setUpdateState(reduceDesktopUpdateStateOnNoUpdate(updateState, new Date().toISOString()));
+    scheduleUpdateStateIdleReset();
     lastLoggedDownloadMilestone = -1;
     console.info("[desktop-updater] No updates available.");
   });
@@ -1456,6 +1498,7 @@ app.on("before-quit", () => {
   isQuitting = true;
   updateInstallInFlight = false;
   writeDesktopLogHeader("before-quit received");
+  clearUpdateIdleResetTimer();
   clearUpdatePollTimer();
   stopBackend();
   restoreStdIoCapture?.();
@@ -1494,6 +1537,7 @@ if (process.platform !== "win32") {
     if (isQuitting) return;
     isQuitting = true;
     writeDesktopLogHeader("SIGINT received");
+    clearUpdateIdleResetTimer();
     clearUpdatePollTimer();
     stopBackend();
     restoreStdIoCapture?.();
@@ -1504,6 +1548,7 @@ if (process.platform !== "win32") {
     if (isQuitting) return;
     isQuitting = true;
     writeDesktopLogHeader("SIGTERM received");
+    clearUpdateIdleResetTimer();
     clearUpdatePollTimer();
     stopBackend();
     restoreStdIoCapture?.();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -592,7 +592,6 @@ const checkForUpdatesMenuItem: MenuItem = new MenuItem({
   click: async () => await handleCheckForUpdatesMenuClick(),
 });
 
-// TODO: Only the enabled status is actually dynamic here. Wait for upstream to allow for dynamic label updates.
 updateStateListeners.add((state) => {
   switch (state.status) {
     case "checking":

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -587,46 +587,55 @@ const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADED = "Update downloaded";
 const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_AVAILABLE = "Update available";
 const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_UP_TO_DATE = "You're up to date!";
 const CHECK_FOR_UPDATES_MENU_ITEM_LABEL_ERROR = "Update check failed";
-const checkForUpdatesMenuItem: MenuItem = new MenuItem({
-  label: CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DEFAULT,
-  click: async () => await handleCheckForUpdatesMenuClick(),
-});
+function makeCheckForUpdatesMenuItem(): MenuItem {
+  return new MenuItem({
+    label: CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DEFAULT,
+    click: async () => await handleCheckForUpdatesMenuClick(),
+  });
+}
+const checkForUpdatesMenuItemInAppMenu = makeCheckForUpdatesMenuItem();
+const checkForUpdatesMenuItemInHelpMenu = makeCheckForUpdatesMenuItem();
 
-updateStateListeners.add((state) => {
+function updateCheckForUpdatesMenuItem(menuItem: MenuItem, state: DesktopUpdateState): void {
   switch (state.status) {
     case "checking":
-      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_CHECKING;
-      checkForUpdatesMenuItem.enabled = false;
+      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_CHECKING;
+      menuItem.enabled = false;
       break;
     case "available":
-      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_AVAILABLE;
-      checkForUpdatesMenuItem.enabled = false;
+      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_AVAILABLE;
+      menuItem.enabled = false;
       break;
     case "downloading":
-      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADING;
-      checkForUpdatesMenuItem.enabled = false;
+      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADING;
+      menuItem.enabled = false;
       break;
     case "downloaded":
-      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADED;
-      checkForUpdatesMenuItem.enabled = false;
+      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DOWNLOADED;
+      menuItem.enabled = false;
       break;
     case "disabled":
-      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DISABLED;
-      checkForUpdatesMenuItem.enabled = false;
+      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_DISABLED;
+      menuItem.enabled = false;
       break;
     case "error":
-      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_ERROR;
-      checkForUpdatesMenuItem.enabled = false;
+      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_ERROR;
+      menuItem.enabled = false;
       break;
     case "up-to-date":
-      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_UP_TO_DATE;
-      checkForUpdatesMenuItem.enabled = false;
+      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_UP_TO_DATE;
+      menuItem.enabled = false;
       break;
     case "idle":
-      checkForUpdatesMenuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_IDLE;
-      checkForUpdatesMenuItem.enabled = true;
+      menuItem.label = CHECK_FOR_UPDATES_MENU_ITEM_LABEL_IDLE;
+      menuItem.enabled = true;
       break;
   }
+}
+
+updateStateListeners.add((state) => {
+  updateCheckForUpdatesMenuItem(checkForUpdatesMenuItemInAppMenu, state);
+  updateCheckForUpdatesMenuItem(checkForUpdatesMenuItemInHelpMenu, state);
 });
 
 let applicationMenu: Menu | null = null;
@@ -639,7 +648,7 @@ function configureApplicationMenu(): void {
       label: app.name,
       submenu: Menu.buildFromTemplate([
         { role: "about" },
-        checkForUpdatesMenuItem,
+        checkForUpdatesMenuItemInAppMenu,
         { type: "separator" },
         {
           label: "Settings...",
@@ -694,8 +703,7 @@ function configureApplicationMenu(): void {
     { role: "windowMenu" },
     {
       role: "help",
-      // TODO: Is it safe to use the same menu item for both the root menu and the help menu?
-      submenu: Menu.buildFromTemplate([checkForUpdatesMenuItem]),
+      submenu: Menu.buildFromTemplate([checkForUpdatesMenuItemInHelpMenu]),
     },
   );
 

--- a/apps/desktop/src/updateMachine.test.ts
+++ b/apps/desktop/src/updateMachine.test.ts
@@ -10,6 +10,7 @@ import {
   reduceDesktopUpdateStateOnDownloadStart,
   reduceDesktopUpdateStateOnInstallFailure,
   reduceDesktopUpdateStateOnNoUpdate,
+  reduceDesktopUpdateStateToIdle,
   reduceDesktopUpdateStateOnUpdateAvailable,
 } from "./updateMachine";
 
@@ -115,6 +116,24 @@ describe("updateMachine", () => {
     expect(state.downloadedVersion).toBeNull();
     expect(state.message).toBeNull();
     expect(state.errorContext).toBeNull();
+  });
+
+  it("returns transient check results back to idle", () => {
+    const upToDate = reduceDesktopUpdateStateToIdle({
+      ...createInitialDesktopUpdateState("1.0.0", runtimeInfo),
+      enabled: true,
+      status: "up-to-date",
+      checkedAt: "2026-03-04T00:00:00.000Z",
+      message: "stale",
+      errorContext: "check",
+      canRetry: true,
+    });
+
+    expect(upToDate.status).toBe("idle");
+    expect(upToDate.checkedAt).toBe("2026-03-04T00:00:00.000Z");
+    expect(upToDate.message).toBeNull();
+    expect(upToDate.errorContext).toBeNull();
+    expect(upToDate.canRetry).toBe(false);
   });
 
   it("tracks available, download start, and progress cleanly", () => {

--- a/apps/desktop/src/updateMachine.ts
+++ b/apps/desktop/src/updateMachine.ts
@@ -89,6 +89,19 @@ export function reduceDesktopUpdateStateOnNoUpdate(
   };
 }
 
+export function reduceDesktopUpdateStateToIdle(state: DesktopUpdateState): DesktopUpdateState {
+  return {
+    ...state,
+    status: "idle",
+    availableVersion: null,
+    downloadedVersion: null,
+    downloadPercent: null,
+    message: null,
+    errorContext: null,
+    canRetry: false,
+  };
+}
+
 export function reduceDesktopUpdateStateOnDownloadStart(
   state: DesktopUpdateState,
 ): DesktopUpdateState {

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -259,17 +259,17 @@ describe("canCheckForUpdate", () => {
     expect(canCheckForUpdate({ ...baseState, status: "idle" })).toBe(true);
   });
 
-  it("returns true when up-to-date", () => {
-    expect(canCheckForUpdate({ ...baseState, status: "up-to-date" })).toBe(true);
+  it("returns false when up-to-date is still being shown", () => {
+    expect(canCheckForUpdate({ ...baseState, status: "up-to-date" })).toBe(false);
   });
 
-  it("returns true when an update is available", () => {
+  it("returns false when an update is already available", () => {
     expect(
       canCheckForUpdate({ ...baseState, status: "available", availableVersion: "1.1.0" }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("returns true on error so the user can retry", () => {
+  it("returns false on check errors until the state returns to idle", () => {
     expect(
       canCheckForUpdate({
         ...baseState,
@@ -277,7 +277,7 @@ describe("canCheckForUpdate", () => {
         errorContext: "check",
         message: "network",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -101,10 +101,5 @@ export function shouldHighlightDesktopUpdateError(state: DesktopUpdateState | nu
 
 export function canCheckForUpdate(state: DesktopUpdateState | null): boolean {
   if (!state || !state.enabled) return false;
-  return (
-    state.status !== "checking" &&
-    state.status !== "downloading" &&
-    state.status !== "downloaded" &&
-    state.status !== "disabled"
-  );
+  return state.status === "idle";
 }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -17,6 +17,7 @@ import {
   type ServerProvider,
   type ServerProviderModel,
   ThreadId,
+  DesktopUpdateStatusFriendlyLabelMap,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { normalizeModelSlug } from "@t3tools/shared/model";
@@ -401,13 +402,8 @@ function AboutVersionSection() {
       : isDesktopUpdateButtonDisabled(updateState);
 
   const actionLabel: Record<string, string> = { download: "Download", install: "Install" };
-  const statusLabel: Record<string, string> = {
-    checking: "Checking…",
-    downloading: "Downloading…",
-    "up-to-date": "Up to Date",
-  };
-  const buttonLabel =
-    actionLabel[action] ?? statusLabel[updateState?.status ?? ""] ?? "Check for Updates";
+  const statusLabel = DesktopUpdateStatusFriendlyLabelMap;
+  const buttonLabel = actionLabel[action] ?? statusLabel[updateState?.status ?? "idle"];
   const description =
     action === "download" || action === "install"
       ? "Update available."

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
       "version": "0.0.14",
       "dependencies": {
         "effect": "catalog:",
-        "electron": "40.6.0",
+        "electron": "40.7.0",
         "electron-updater": "^6.6.2",
       },
       "devDependencies": {
@@ -1022,7 +1022,7 @@
 
     "effect": ["effect@4.0.0-beta.42", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.5.3", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.8", "multipasta": "^0.2.7", "toml": "^3.0.0", "uuid": "^13.0.0", "yaml": "^2.8.2" } }, "sha512-c1UrRP+tLzyHb4Fepl8XBDJlLQLkrcMXrRBba441GQRxMbeQ/aIOSFcBwSda1iMJ5l9F0lYc3Bhe33/whrmavQ=="],
 
-    "electron": ["electron@40.6.0", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-ett8W+yOFGDuM0vhJMamYSkrbV3LoaffzJd9GfjI96zRAxyrNqUSKqBpf/WGbQCweDxX2pkUCUfrv4wwKpsFZA=="],
+    "electron": ["electron@40.7.0", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-oQe76S/3V1rcb0+i45hAxnCH8udkRZSaHUNwglzNAEKbB94LSJ1qwbFo8+uRc2UsYZgCqSIMRcyX40GyOkD+Xw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.313", "", {}, "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA=="],
 

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -70,6 +70,17 @@ export type DesktopUpdateStatus =
   | "downloaded"
   | "error";
 
+export const DesktopUpdateStatusFriendlyLabelMap: Record<DesktopUpdateStatus, string> = {
+  disabled: "Updates Unavailable",
+  idle: "Check for Updates",
+  checking: "Checking…",
+  "up-to-date": "Up to Date",
+  available: "Update Available",
+  downloading: "Downloading…",
+  downloaded: "Update Downloaded",
+  error: "Update check failed",
+};
+
 export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
 


### PR DESCRIPTION
## What Changed

EDIT: I was dumb and didn't realize I wasn't actually testing on a newer version of Electron. This PR makes changes *and* updates electron to the minimal version needed for this feature to work.

~~This PR _**cannot**_ be merged in its current state as it depends on features not in upstream Electron yet, but I hope for that to change in the near future. Refs: https://github.com/electron/electron/pull/50266~~

~~Once Electron truly supports it,~~ this will allow us to change the label of the "Checking for Updates..." menu item on the fly.

## Why

This provides a much better user experience by giving visual indications of what is happening during the update process.

## UI Changes

(had some focus issues near the end, but I believe I covered most of the changes in the video)

https://github.com/user-attachments/assets/257863ff-a7e2-4d8d-9755-c1eee4a47cc8


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included ~before/~after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the 'Check for Updates' menu item dynamic based on update state
> - The 'Check for Updates' menu item in the App and Help menus now updates its label and enabled state in real time based on the current update status, using a shared `DesktopUpdateStatusFriendlyLabelMap` defined in [`packages/contracts/src/ipc.ts`](https://github.com/pingdotgg/t3code/pull/1124/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a).
> - Clicking the menu item is now context-aware: it checks when idle, downloads when an update is available, and installs when downloaded; it no-ops in all other states.
> - Transient states ('up-to-date', 'check error') automatically reset to 'idle' after dialogs are dismissed or after a 5-second delay, keeping the menu actionable.
> - `canCheckForUpdate` in the web frontend is tightened to return `true` only when status is `'idle'`, and the settings panel button label now uses the same canonical map.
> - Behavioral Change: the menu item is disabled during checking, downloading, and error states, whereas it was previously always enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dfa94af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the desktop auto-update state machine and menu wiring, plus bumps Electron, so regressions could affect update UX and state transitions. No auth/data-path changes, but behavior is timing- and state-dependent across desktop and web UI.
> 
> **Overview**
> Makes the desktop **“Check for Updates”** menu item dynamic: it is now a persistent `MenuItem` whose label and enabled state update live based on `DesktopUpdateState`, and clicking it routes to check/download/install depending on current status.
> 
> Adds a shared `DesktopUpdateStatusFriendlyLabelMap` in `@t3tools/contracts` and reuses it in both the desktop menu and the web Settings “Version” update button; the web UI also tightens `canCheckForUpdate` to only allow checks from the `idle` state.
> 
> Introduces a transient-state cleanup path by adding `reduceDesktopUpdateStateToIdle` and scheduling an automatic reset back to `idle` after “up-to-date” or check-error states, with cleanup of the reset timer on app shutdown/signals. Also bumps `electron` to `40.7.0` to support dynamic menu updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfa94af7521f420e7ccd88817a131f4315619ce8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->