### PR TITLE
Add copy workspace path button to thread action menu

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -702,7 +702,8 @@ export default function Sidebar() {
       if (!api) return;
       const thread = threads.find((t) => t.id === threadId);
       if (!thread) return;
-      const threadWorkspacePath = thread.worktreePath ?? projectCwdById.get(thread.projectId) ?? null;
+      const threadWorkspacePath =
+        thread.worktreePath ?? projectCwdById.get(thread.projectId) ?? null;
       const clicked = await api.contextMenu.show(
         [
           { id: "rename", label: "Rename thread" },


### PR DESCRIPTION
## What Changed

Adds a `Copy Path` action to the thread right-click menu in the left sidebar.

The copied path prefers the thread worktree path and falls back to the project cwd when the thread is not using a separate worktree.

## Why

This makes it easier to grab the workspace path for a thread directly from the sidebar without opening the thread and manually finding the path elsewhere.

## UI Changes

Adds a new `Copy Path` entry to the existing thread context menu in the sidebar.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Verification

- `bun lint`
- `bun typecheck`

## Screenshots
Before:
<img width="124" height="118" alt="Screenshot 2026-03-16 at 12 46 11 pm" src="https://github.com/user-attachments/assets/432d72dd-e60a-4ef9-8d8c-bfbd83f57e8e" />

After:
<img width="126" height="136" alt="Screenshot 2026-03-16 at 12 46 02 pm" src="https://github.com/user-attachments/assets/3f49c611-512f-4f78-b523-7922acdb2c4c" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Copy Path' option to thread context menu in sidebar
> Adds a new "Copy Path" item to the right-click context menu for threads in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1128/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1). The item copies the thread's `worktreePath`, falling back to the project's current working directory, and shows a success or error toast based on availability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26123af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Copy Path" functionality to thread context menus, enabling users to conveniently copy workspace paths directly to their clipboard.
  * Displays appropriate notifications: success messages when paths are copied and error messages when operations fail or path data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->