### PR TITLE
Fix mobile composer focus zoom

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -878,7 +878,7 @@ function ComposerPromptEditorInner({
         contentEditable={
           <ContentEditable
             className={cn(
-              "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-[14px] leading-relaxed text-foreground focus:outline-none",
+              "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-base leading-relaxed text-foreground focus:outline-none sm:text-[14px]",
               className,
             )}
             data-testid="composer-editor"
@@ -888,7 +888,7 @@ function ComposerPromptEditorInner({
           />
         }
         placeholder={
-          <div className="pointer-events-none absolute inset-0 text-[14px] leading-relaxed text-muted-foreground/35">
+          <div className="pointer-events-none absolute inset-0 text-base leading-relaxed text-muted-foreground/35 sm:text-[14px]">
             {placeholder}
           </div>
         }


### PR DESCRIPTION
## Summary
- use 16px composer text on mobile to avoid iPhone focus zoom
- keep the existing 14px composer sizing from  and up
- update the placeholder sizing to match the editor

## Testing
- ~/.bun/bin/bun fmt
- ~/.bun/bin/bun lint
- export PATH="/home/claude/.bun/bin:/home/claude/.local/bin:/home/claude/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games" && bun typecheck

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile composer focus zoom by using fluid text size in `ComposerPromptEditor`
> Sets the editor content and placeholder to `text-base` (16px) on mobile and `text-[14px]` at the `sm` breakpoint in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/1130/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4). Browsers trigger an automatic zoom on focus when font size is below 16px, so this prevents unwanted zoom on mobile devices.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2466048.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->