### PR TITLE
fix: don't just show the creation time for threads in sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1551,7 +1551,11 @@ export default function Sidebar() {
                                               : "text-muted-foreground/40"
                                           }`}
                                         >
-                                          {formatRelativeTime(thread.createdAt)}
+                                          {formatRelativeTime(
+                                            thread.lastVisitedAt ??
+                                              thread.latestTurn?.completedAt ??
+                                              thread.createdAt,
+                                          )}
                                         </span>
                                       </div>
                                     </SidebarMenuSubButton>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1552,9 +1552,7 @@ export default function Sidebar() {
                                           }`}
                                         >
                                           {formatRelativeTime(
-                                            thread.lastVisitedAt ??
-                                              thread.latestTurn?.completedAt ??
-                                              thread.createdAt,
+                                            thread.messages.at(-1)?.createdAt ?? thread.createdAt,
                                           )}
                                         </span>
                                       </div>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -386,8 +386,9 @@ export default function Sidebar() {
       const latestThread = threads
         .filter((thread) => thread.projectId === projectId)
         .toSorted((a, b) => {
-          const byDate = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-          if (byDate !== 0) return byDate;
+          const aTime = a.messages.at(-1)?.createdAt ?? a.createdAt;
+          const bTime = b.messages.at(-1)?.createdAt ?? b.createdAt;
+          if (aTime !== bTime) return bTime.localeCompare(aTime);
           return b.id.localeCompare(a.id);
         })[0];
       if (!latestThread) return;
@@ -1296,9 +1297,9 @@ export default function Sidebar() {
                   const projectThreads = threads
                     .filter((thread) => thread.projectId === project.id)
                     .toSorted((a, b) => {
-                      const byDate =
-                        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-                      if (byDate !== 0) return byDate;
+                      const aTime = a.messages.at(-1)?.createdAt ?? a.createdAt;
+                      const bTime = b.messages.at(-1)?.createdAt ?? b.createdAt;
+                      if (aTime !== bTime) return bTime.localeCompare(aTime);
                       return b.id.localeCompare(a.id);
                     });
                   const isThreadListExpanded = expandedThreadListsByProject.has(project.id);


### PR DESCRIPTION
## What Changed

Should resolve #973. This updates the date indicator for threads as the thread itself updates. We can decided which dates we actually want to use as the canonical reference points.

EDIT: Changed strategies to use the last chat message's `createdAt`. Macroscope's summary below is out-of-date.

## Why

Users expect the date indicator to change as they interact with the thread.

## UI Changes

Before (`main`) and after (`sidebar-dates', my branch) on a thread I just got a response from:
<img width="241" height="32" alt="Screenshot 2026-03-16 at 03 50 21" src="https://github.com/user-attachments/assets/6da74334-a392-4652-bc00-4e28750886a4" />
<img width="241" height="32" alt="Screenshot 2026-03-16 at 03 50 05" src="https://github.com/user-attachments/assets/8ae3d30e-7684-4523-aa98-7774c71d6b20" />



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] ~I included a video for animation/interaction changes~


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sort sidebar threads and relative timestamps by last message time instead of creation time
> Threads in the sidebar were always sorted and labeled by their creation time. They are now sorted and labeled by the time of the last message, falling back to creation time when no messages exist.
>
> - Updates the per-project sort comparator in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1136/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to use the last message's `createdAt` when available.
> - Updates the `focusMostRecentThreadForProject` hook to use the same logic when selecting which thread to focus.
> - Behavioral Change: thread order in the sidebar and displayed relative timestamps will change for any thread that has received messages after creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85bb9a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->