### PR TITLE
fix: enable fixPath() on Linux and call it before health check

### DIFF
--- a/apps/desktop/src/syncShellEnvironment.ts
+++ b/apps/desktop/src/syncShellEnvironment.ts
@@ -7,7 +7,7 @@ export function syncShellEnvironment(
     readEnvironment?: ShellEnvironmentReader;
   } = {},
 ): void {
-  if ((options.platform ?? process.platform) !== "darwin") return;
+  if ((options.platform ?? process.platform) === "win32") return;
 
   try {
     const shell = env.SHELL ?? "/bin/zsh";

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -18,6 +18,11 @@ import {
 } from "./config";
 import { fixPath, resolveStateDir } from "./os-jank";
 import { Open } from "./open";
+
+// Fix PATH eagerly before any Layer construction so that CLI probes
+// (e.g. ProviderHealthLive → `codex --version`) can find binaries
+// installed via version managers (nvm, bun, etc.).
+fixPath();
 import * as SqlitePersistence from "./persistence/Layers/Sqlite";
 import { makeServerProviderLayer, makeServerRuntimeServicesLayer } from "./serverLayers";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";

--- a/apps/server/src/os-jank.ts
+++ b/apps/server/src/os-jank.ts
@@ -3,7 +3,7 @@ import { Effect, Path } from "effect";
 import { readPathFromLoginShell } from "@t3tools/shared/shell";
 
 export function fixPath(): void {
-  if (process.platform !== "darwin") return;
+  if (process.platform === "win32") return;
 
   try {
     const shell = process.env.SHELL ?? "/bin/zsh";


### PR DESCRIPTION
## What Changed

- `apps/desktop/src/syncShellEnvironment.ts` and `apps/server/src/os-jank.ts`: changed platform guard from `!== "darwin"` to `=== "win32"`
- `apps/server/src/main.ts`: added top-level `fixPath()` call before any Layer construction

~5 lines changed across 3 files.

## Why

On Linux (AppImage), the Codex provider health check always fails with **"Codex CLI (`codex`) is not installed or not on PATH"** even when `codex` is installed and works from the terminal.

Two issues combine to cause this:

1. **`syncShellEnvironment()` / `fixPath()` skip Linux entirely** — both files guard with `process.platform !== "darwin"`, so `readPathFromLoginShell()` / `readEnvironmentFromLoginShell()` (which already work on Linux) are never called. On Linux AppImage the process inherits a minimal PATH that doesn't include user shell paths like `~/.nvm/versions/node/*/bin`.

2. **Server calls `fixPath()` too late** — it runs inside `Effect.gen` (line 243) but `ProviderHealthLive` is constructed as a Layer (line 200) which executes *before* the Effect body. The health check (`codex --version`) fires with the unfixed PATH. `apps/desktop/src/main.ts` already calls `syncShellEnvironment()` at module top-level — the server just needs to match this pattern.

See #1139 for full details and reproduction steps.

## Testing

- Verified on Ubuntu 22.04 with T3 Code AppImage v0.0.11, Node v24 via nvm, codex-cli 0.114.0
- Before fix: "Codex CLI (`codex`) is not installed or not on PATH"
- After fix: Codex provider status shows ready
- macOS behavior unchanged (same logic, just wider platform gate)
- Windows still skipped (`=== "win32"` guard)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Closes #1139