### PR TITLE
fix(web): fix sidebar project drag clipping with variable-height items

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -24,7 +24,7 @@ import {
   type DragEndEvent,
 } from "@dnd-kit/core";
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import {
   DEFAULT_MODEL_BY_PROVIDER,
@@ -1320,7 +1320,7 @@ export default function Sidebar() {
           <DndContext
             sensors={projectDnDSensors}
             collisionDetection={projectCollisionDetection}
-            modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+            modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
             onDragStart={handleProjectDragStart}
             onDragEnd={handleProjectDragEnd}
             onDragCancel={handleProjectDragCancel}


### PR DESCRIPTION
## What Changed

Replaced `restrictToParentElement` with `restrictToFirstScrollableAncestor` in the sidebar project drag-and-drop modifiers.

## Why

When dragging a project with many expanded threads toward the bottom of the list, the dragged item gets visually clipped if it's taller than the project below it. This happens because `restrictToParentElement` constrains the entire dragged element within the parent element's bounds, which doesn't leave enough room for tall items to reach the last position.

This is a [known dnd-kit issue](https://github.com/clauderic/dnd-kit/issues/1231) with variable-height sortable items. `restrictToFirstScrollableAncestor` constrains to the sidebar's `ScrollArea` viewport instead, which gives enough room for tall items while still keeping the drag bounded.

> **Note:** The dragged item can now move slightly above the "PROJECTS" header and into the empty space below the list. This is a minor cosmetic tradeoff, happy to tighten it with a custom modifier if preferred.

## UI Changes

**Before:**

https://github.com/user-attachments/assets/040e4dc1-f352-45c0-aa21-662493c3a957

**After:**

https://github.com/user-attachments/assets/2830d09e-a185-425b-a7e2-9dcd6f12d95b


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar project drag clipping by switching to `restrictToFirstScrollableAncestor`
> The drag modifier in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1176/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) is changed from `restrictToParentElement` to `restrictToFirstScrollableAncestor`, fixing visual clipping when dragging variable-height items in the projects list. The vertical axis constraint is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f62ef92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->