### PR TITLE
fix(web): allow closing the diff panel from the header toggle

### DIFF
--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseDiffRouteSearch } from "./diffRouteSearch";
+import { parseDiffRouteSearch, stripDiffSearchParams } from "./diffRouteSearch";
 
 describe("parseDiffRouteSearch", () => {
   it("parses valid diff search values", () => {
@@ -69,6 +69,21 @@ describe("parseDiffRouteSearch", () => {
 
     expect(parsed).toEqual({
       diff: "1",
+    });
+  });
+});
+
+describe("stripDiffSearchParams", () => {
+  it("removes diff-specific keys while preserving unrelated search params", () => {
+    const stripped = stripDiffSearchParams({
+      diff: "1",
+      diffFilePath: "src/app.ts",
+      diffTurnId: "turn-1",
+      tab: "files",
+    });
+
+    expect(stripped).toEqual({
+      tab: "files",
     });
   });
 });

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -181,7 +181,7 @@ function ChatThreadRouteView() {
     void navigate({
       to: "/$threadId",
       params: { threadId },
-      search: { diff: undefined },
+      search: (previous) => stripDiffSearchParams(previous),
     });
   }, [navigate, threadId]);
   const openDiff = useCallback(() => {


### PR DESCRIPTION
## What Changed

Fixes the diff panel toggle so the panel can be closed reliably after opening it from the chat header.

The close path now removes the diff-related search params from the current route state instead of navigating with a static `diff: undefined` payload. I also added a regression test for the shared diff search-param stripping helper.

## Why

The diff panel open state is URL-driven and this route retains the `diff` search param. The previous close flow could leave that retained state in place, which made the panel appear stuck open.

Clearing the diff state from the existing search object is the safest fix because it keeps the behavior aligned with the rest of the diff routing logic and avoids duplicate close logic.

## UI Changes

This is a behavior fix, not a visual redesign.

Before:
- Clicking the diff toggle opened the panel, but clicking it again could fail to close it.

https://github.com/user-attachments/assets/7ff6025f-5a02-42a6-86ff-1cca22b6f876

After:
- Clicking the same toggle cleanly closes the diff panel.

https://github.com/user-attachments/assets/232d2906-0613-4284-8909-f5da5859b001


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix closing the diff panel to clear all diff-related search params
> Previously, closing the diff panel only unset the `diff` param, leaving `diffTurnId` and `diffFilePath` in the URL. The `closeDiff` callback in [`_chat.$threadId.tsx`](https://github.com/pingdotgg/t3code/pull/1177/files#diff-4ee19a4a6919608c555bdc4562ccba6ebb331bc0eec4d4d8c3be8543913c336e) now calls `stripDiffSearchParams()` to remove all diff-related keys while preserving unrelated params like `tab`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6b70dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->