### PR TITLE
Fix scroll-to-bottom button hover fill

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3491,7 +3491,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 <button
                   type="button"
                   onClick={() => scrollMessagesToBottom("smooth")}
-                  className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                  className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:bg-[color-mix(in_srgb,var(--card)_94%,var(--foreground))] hover:text-foreground"
                 >
                   <ChevronDownIcon className="size-3.5" />
                   Scroll to bottom

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3491,7 +3491,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 <button
                   type="button"
                   onClick={() => scrollMessagesToBottom("smooth")}
-                  className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:bg-[color-mix(in_srgb,var(--card)_94%,var(--foreground))] hover:text-foreground"
+                  className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:bg-muted-background hover:text-accent-foreground"
                 >
                   <ChevronDownIcon className="size-3.5" />
                   Scroll to bottom


### PR DESCRIPTION
Summary

- fix the scroll-to-bottom pill hover state in chat
- replace the previous hover background token with muted-background so the button no longer looks transparent on hover
- keep the hover text on accent-foreground for contrast

Why
The previous hover styling made the floating pill read as transparent or visually unstable. This change gives it a more solid, predictable hover surface.

before

https://github.com/user-attachments/assets/95f73b55-1f3d-4b9c-80b0-3a3fed382ec2



after


https://github.com/user-attachments/assets/838bd9ef-1404-4c5f-96c7-9f1e4c065de4






Validation
```
bun fmt
bun lint
bun typecheck
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix hover background color on scroll-to-bottom button in chat view
> Changes the hover style on the 'Scroll to bottom' pill in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1182/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) from `hover:bg-accent` to `hover:bg-muted-background`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e9d8cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->