### PR TITLE
fix: use system claude binary in packaged Electron app

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2237,9 +2237,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         const queryOptions: ClaudeQueryOptions = {
           ...(input.cwd ? { cwd: input.cwd } : {}),
           ...(input.model ? { model: input.model } : {}),
-          ...(providerOptions?.binaryPath
-            ? { pathToClaudeCodeExecutable: providerOptions.binaryPath }
-            : {}),
+          pathToClaudeCodeExecutable: providerOptions?.binaryPath ?? "claude",
           ...(effectiveEffort ? { effort: effectiveEffort } : {}),
           ...(permissionMode ? { permissionMode } : {}),
           ...(permissionMode === "bypassPermissions"


### PR DESCRIPTION
## What Changed

Default `pathToClaudeCodeExecutable` to `"claude"` (resolved via PATH) instead of leaving it unset, which lets the SDK fall back to its bundled `cli.js`.

## Why

The `claude-agent-sdk` bundles its own `cli.js` inside `node_modules`. In the packaged Electron app this file gets packed into the asar archive, where `child_process.spawn` cannot execute it — the Claude Code process exits with code 1 immediately after session start.

Using the system `claude` binary matches how the Codex adapter already defaults to `"codex"`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude binary path to default to system `claude` in packaged Electron app
> In [`ClaudeAdapter.ts`](https://github.com/pingdotgg/t3code/pull/1189/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), `pathToClaudeCodeExecutable` is now always set in `queryOptions`, defaulting to `"claude"` when no `binaryPath` is provided. Previously, the field was omitted entirely when `binaryPath` was absent, which caused the packaged Electron app to fail to locate the system Claude binary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12685fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->