### PR TITLE
Persist desktop settings to settings.json across releases

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -17,10 +17,17 @@ import {
 } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
+import { Schema } from "effect";
 import type {
+  DesktopSettings,
   DesktopTheme,
   DesktopUpdateActionResult,
   DesktopUpdateState,
+} from "@t3tools/contracts";
+import {
+  DesktopSettings as DesktopSettingsSchema,
+  DesktopSettingsInput as DesktopSettingsInputSchema,
+  DesktopSettingsSchemaVersion,
 } from "@t3tools/contracts";
 import { autoUpdater } from "electron-updater";
 
@@ -49,6 +56,8 @@ syncShellEnvironment();
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
+const GET_INITIAL_SETTINGS_CHANNEL = "desktop:get-initial-settings";
+const SET_SETTINGS_CHANNEL = "desktop:set-settings";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 const MENU_ACTION_CHANNEL = "desktop:menu-action";
@@ -70,6 +79,7 @@ const COMMIT_HASH_DISPLAY_LENGTH = 12;
 const LOG_DIR = Path.join(STATE_DIR, "logs");
 const LOG_FILE_MAX_BYTES = 10 * 1024 * 1024;
 const LOG_FILE_MAX_FILES = 10;
+const SETTINGS_FILE_NAME = "settings.json";
 const APP_RUN_ID = Crypto.randomBytes(6).toString("hex");
 const AUTO_UPDATE_STARTUP_DELAY_MS = 15_000;
 const AUTO_UPDATE_POLL_INTERVAL_MS = 4 * 60 * 60 * 1000;
@@ -107,6 +117,42 @@ function logTimestamp(): string {
 
 function logScope(scope: string): string {
   return `${scope} run=${APP_RUN_ID}`;
+}
+
+function getSettingsPath(): string {
+  return Path.join(STATE_DIR, SETTINGS_FILE_NAME);
+}
+
+function decodeSettingsFile(raw: string): DesktopSettings {
+  return Schema.decodeSync(Schema.fromJsonString(DesktopSettingsSchema))(raw);
+}
+
+function readSettingsFileSync(): DesktopSettings | null {
+  try {
+    const raw = FS.readFileSync(getSettingsPath(), "utf8");
+    return decodeSettingsFile(raw);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== "ENOENT") {
+      console.warn("[desktop-settings] Failed to read settings.json", error);
+    }
+    return null;
+  }
+}
+
+async function writeSettingsFile(rawInput: unknown): Promise<DesktopSettings> {
+  const input = Schema.decodeUnknownSync(DesktopSettingsInputSchema)(rawInput);
+  const settings: DesktopSettings = {
+    version: app.getVersion(),
+    schemaVersion: DesktopSettingsSchemaVersion,
+    theme: input.theme,
+    appSettings: input.appSettings,
+  };
+  const settingsPath = getSettingsPath();
+  const tempPath = `${settingsPath}.tmp`;
+  await FS.promises.mkdir(Path.dirname(settingsPath), { recursive: true });
+  await FS.promises.writeFile(tempPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+  await FS.promises.rename(tempPath, settingsPath);
+  return settings;
 }
 
 function sanitizeLogValue(value: string): string {
@@ -1105,6 +1151,16 @@ function registerIpcHandlers(): void {
 
     nativeTheme.themeSource = theme;
   });
+
+  ipcMain.removeAllListeners(GET_INITIAL_SETTINGS_CHANNEL);
+  ipcMain.on(GET_INITIAL_SETTINGS_CHANNEL, (event) => {
+    event.returnValue = readSettingsFileSync();
+  });
+
+  ipcMain.removeHandler(SET_SETTINGS_CHANNEL);
+  ipcMain.handle(SET_SETTINGS_CHANNEL, async (_event, rawSettings: unknown) =>
+    writeSettingsFile(rawSettings),
+  );
 
   ipcMain.removeHandler(CONTEXT_MENU_CHANNEL);
   ipcMain.handle(

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -4,6 +4,8 @@ import type { DesktopBridge } from "@t3tools/contracts";
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
+const GET_INITIAL_SETTINGS_CHANNEL = "desktop:get-initial-settings";
+const SET_SETTINGS_CHANNEL = "desktop:set-settings";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 const MENU_ACTION_CHANNEL = "desktop:menu-action";
@@ -12,12 +14,17 @@ const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
 const UPDATE_INSTALL_CHANNEL = "desktop:update-install";
 const wsUrl = process.env.T3CODE_DESKTOP_WS_URL ?? null;
+const initialSettings = ipcRenderer.sendSync(GET_INITIAL_SETTINGS_CHANNEL) as
+  | DesktopBridge["initialSettings"]
+  | undefined;
 
 contextBridge.exposeInMainWorld("desktopBridge", {
   getWsUrl: () => wsUrl,
+  initialSettings: initialSettings ?? null,
   pickFolder: () => ipcRenderer.invoke(PICK_FOLDER_CHANNEL),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),
+  setSettings: (settings) => ipcRenderer.invoke(SET_SETTINGS_CHANNEL, settings),
   showContextMenu: (items, position) => ipcRenderer.invoke(CONTEXT_MENU_CHANNEL, items, position),
   openExternal: (url: string) => ipcRenderer.invoke(OPEN_EXTERNAL_CHANNEL, url),
   onMenuAction: (listener) => {

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1,40 +1,23 @@
-import { useCallback } from "react";
-import { Option, Schema } from "effect";
-import { type ProviderKind } from "@t3tools/contracts";
+import { useCallback, useEffect } from "react";
+import {
+  AppSettings as AppSettingsSchema,
+  DEFAULT_TIMESTAMP_FORMAT,
+  type ProviderKind,
+  type TimestampFormat,
+} from "@t3tools/contracts";
 import { getDefaultModel, getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
+import { getBootDesktopAppSettings, persistDesktopSettings } from "./desktopSettings";
 import { useLocalStorage } from "./hooks/useLocalStorage";
 
-const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
+export const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
 const MAX_CUSTOM_MODEL_COUNT = 32;
 export const MAX_CUSTOM_MODEL_LENGTH = 256;
-export const TIMESTAMP_FORMAT_OPTIONS = ["locale", "12-hour", "24-hour"] as const;
-export type TimestampFormat = (typeof TIMESTAMP_FORMAT_OPTIONS)[number];
-export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
+export { DEFAULT_TIMESTAMP_FORMAT };
+export type { TimestampFormat };
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
 };
 
-const AppSettingsSchema = Schema.Struct({
-  codexBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(
-    Schema.withConstructorDefault(() => Option.some("")),
-  ),
-  codexHomePath: Schema.String.check(Schema.isMaxLength(4096)).pipe(
-    Schema.withConstructorDefault(() => Option.some("")),
-  ),
-  defaultThreadEnvMode: Schema.Literals(["local", "worktree"]).pipe(
-    Schema.withConstructorDefault(() => Option.some("local")),
-  ),
-  confirmThreadDelete: Schema.Boolean.pipe(Schema.withConstructorDefault(() => Option.some(true))),
-  enableAssistantStreaming: Schema.Boolean.pipe(
-    Schema.withConstructorDefault(() => Option.some(false)),
-  ),
-  timestampFormat: Schema.Literals(["locale", "12-hour", "24-hour"]).pipe(
-    Schema.withConstructorDefault(() => Option.some(DEFAULT_TIMESTAMP_FORMAT)),
-  ),
-  customCodexModels: Schema.Array(Schema.String).pipe(
-    Schema.withConstructorDefault(() => Option.some([])),
-  ),
-});
 export type AppSettings = typeof AppSettingsSchema.Type;
 export interface AppModelOption {
   slug: string;
@@ -42,7 +25,7 @@ export interface AppModelOption {
   isCustom: boolean;
 }
 
-const DEFAULT_APP_SETTINGS = AppSettingsSchema.makeUnsafe({});
+export const DEFAULT_APP_SETTINGS = AppSettingsSchema.makeUnsafe({});
 
 export function normalizeCustomModelSlugs(
   models: Iterable<string | null | undefined>,
@@ -71,6 +54,14 @@ export function normalizeCustomModelSlugs(
   }
 
   return normalizedModels;
+}
+
+export function normalizeAppSettings(settings: AppSettings | null | undefined): AppSettings {
+  return {
+    ...DEFAULT_APP_SETTINGS,
+    ...settings,
+    customCodexModels: normalizeCustomModelSlugs(settings?.customCodexModels ?? [], "codex"),
+  };
 }
 
 export function getAppModelOptions(
@@ -145,7 +136,7 @@ export function resolveAppModelSelection(
 export function useAppSettings() {
   const [settings, setSettings] = useLocalStorage(
     APP_SETTINGS_STORAGE_KEY,
-    DEFAULT_APP_SETTINGS,
+    getBootDesktopAppSettings() ?? DEFAULT_APP_SETTINGS,
     AppSettingsSchema,
   );
 
@@ -163,8 +154,12 @@ export function useAppSettings() {
     setSettings(DEFAULT_APP_SETTINGS);
   }, [setSettings]);
 
+  useEffect(() => {
+    void persistDesktopSettings({ appSettings: normalizeAppSettings(settings) }).catch(() => {});
+  }, [settings]);
+
   return {
-    settings,
+    settings: normalizeAppSettings(settings),
     updateSettings,
     resetSettings,
     defaults: DEFAULT_APP_SETTINGS,

--- a/apps/web/src/desktopSettings.ts
+++ b/apps/web/src/desktopSettings.ts
@@ -1,0 +1,139 @@
+import type { DesktopSettings, DesktopSettingsInput, ThemePreference } from "@t3tools/contracts";
+import {
+  AppSettings as AppSettingsSchema,
+  DesktopSettingsSchemaVersion,
+  ThemePreference as ThemePreferenceSchema,
+} from "@t3tools/contracts";
+import { Schema } from "effect";
+import { APP_VERSION } from "./branding";
+import { isElectron } from "./env";
+import {
+  dispatchLocalStorageChange,
+  getLocalStorageItem,
+  setLocalStorageItem,
+} from "./hooks/useLocalStorage";
+import type { AppSettings } from "./appSettings";
+
+const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
+const THEME_STORAGE_KEY = "t3code:theme";
+const DEFAULT_APP_SETTINGS = AppSettingsSchema.makeUnsafe({});
+const DEFAULT_THEME: ThemePreference = "system";
+const INITIAL_DESKTOP_SETTINGS = isElectron
+  ? (window.desktopBridge?.initialSettings ?? null)
+  : null;
+
+let desktopSettingsHydrated = false;
+let lastPersistedSerialized: string | null = null;
+let latestTheme: ThemePreference = DEFAULT_THEME;
+let latestAppSettings: AppSettings = DEFAULT_APP_SETTINGS;
+
+function readThemeFromLocalStorage(): ThemePreference {
+  const raw = localStorage.getItem(THEME_STORAGE_KEY);
+  if (raw === "light" || raw === "dark" || raw === "system") {
+    return raw;
+  }
+  return "system";
+}
+
+function buildDesktopSettingsInput(): DesktopSettingsInput {
+  return {
+    theme: latestTheme,
+    appSettings: latestAppSettings,
+  };
+}
+
+function serializeSettingsInput(input: DesktopSettingsInput): string {
+  return JSON.stringify(input);
+}
+
+function hasLegacySettingsInLocalStorage(): boolean {
+  return (
+    localStorage.getItem(THEME_STORAGE_KEY) !== null ||
+    localStorage.getItem(APP_SETTINGS_STORAGE_KEY) !== null
+  );
+}
+
+function applyDesktopSettings(settings: DesktopSettings): void {
+  localStorage.setItem(THEME_STORAGE_KEY, settings.theme);
+  setLocalStorageItem(APP_SETTINGS_STORAGE_KEY, settings.appSettings, AppSettingsSchema);
+  dispatchLocalStorageChange(APP_SETTINGS_STORAGE_KEY);
+  window.dispatchEvent(new StorageEvent("storage", { key: THEME_STORAGE_KEY }));
+  latestTheme = settings.theme;
+  latestAppSettings = settings.appSettings;
+  lastPersistedSerialized = serializeSettingsInput({
+    theme: settings.theme,
+    appSettings: settings.appSettings,
+  });
+}
+
+if (INITIAL_DESKTOP_SETTINGS) {
+  applyDesktopSettings(INITIAL_DESKTOP_SETTINGS);
+  desktopSettingsHydrated = true;
+}
+
+export async function hydrateDesktopSettings(): Promise<void> {
+  if (!isElectron || !window.desktopBridge) {
+    return;
+  }
+
+  if (INITIAL_DESKTOP_SETTINGS) {
+    if (
+      INITIAL_DESKTOP_SETTINGS.version !== APP_VERSION ||
+      INITIAL_DESKTOP_SETTINGS.schemaVersion !== DesktopSettingsSchemaVersion
+    ) {
+      await persistDesktopSettings({ force: true }).catch(() => {});
+    }
+    return;
+  }
+
+  desktopSettingsHydrated = true;
+  latestTheme = Schema.decodeSync(ThemePreferenceSchema)(readThemeFromLocalStorage());
+  latestAppSettings =
+    getLocalStorageItem(APP_SETTINGS_STORAGE_KEY, AppSettingsSchema) ?? DEFAULT_APP_SETTINGS;
+  if (!hasLegacySettingsInLocalStorage()) {
+    lastPersistedSerialized = serializeSettingsInput({
+      theme: DEFAULT_THEME,
+      appSettings: DEFAULT_APP_SETTINGS,
+    });
+    return;
+  }
+
+  await persistDesktopSettings({ force: true }).catch(() => {});
+}
+
+export async function persistDesktopSettings(options?: {
+  force?: boolean;
+  theme?: ThemePreference;
+  appSettings?: AppSettings;
+}): Promise<void> {
+  if (!isElectron || !window.desktopBridge || !desktopSettingsHydrated) {
+    return;
+  }
+
+  if (options?.theme) {
+    latestTheme = Schema.decodeSync(ThemePreferenceSchema)(options.theme);
+  }
+  if (options?.appSettings) {
+    latestAppSettings = options.appSettings;
+  }
+
+  const next = buildDesktopSettingsInput();
+  const serialized = serializeSettingsInput(next);
+  if (!options?.force && serialized === lastPersistedSerialized) {
+    return;
+  }
+
+  const persisted = await window.desktopBridge.setSettings(next);
+  lastPersistedSerialized = serializeSettingsInput({
+    theme: persisted.theme,
+    appSettings: persisted.appSettings,
+  });
+}
+
+export function getBootDesktopTheme(): ThemePreference | null {
+  return desktopSettingsHydrated ? latestTheme : null;
+}
+
+export function getBootDesktopAppSettings(): AppSettings | null {
+  return desktopSettingsHydrated ? latestAppSettings : null;
+}

--- a/apps/web/src/hooks/useLocalStorage.ts
+++ b/apps/web/src/hooks/useLocalStorage.ts
@@ -39,13 +39,13 @@ export const removeLocalStorageItem = (key: string) => {
   isomorphicLocalStorage.removeItem(key);
 };
 
-const LOCAL_STORAGE_CHANGE_EVENT = "t3code:local_storage_change";
+export const LOCAL_STORAGE_CHANGE_EVENT = "t3code:local_storage_change";
 
 interface LocalStorageChangeDetail {
   key: string;
 }
 
-function dispatchLocalStorageChange(key: string) {
+export function dispatchLocalStorageChange(key: string) {
   if (typeof window === "undefined") return;
   window.dispatchEvent(
     new CustomEvent<LocalStorageChangeDetail>(LOCAL_STORAGE_CHANGE_EVENT, {

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { getBootDesktopTheme, persistDesktopSettings } from "../desktopSettings";
 
-type Theme = "light" | "dark" | "system";
+export type Theme = "light" | "dark" | "system";
 type ThemeSnapshot = {
   theme: Theme;
   systemDark: boolean;
 };
 
-const STORAGE_KEY = "t3code:theme";
+export const THEME_STORAGE_KEY = "t3code:theme";
 const MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
 let listeners: Array<() => void> = [];
@@ -21,7 +22,12 @@ function getSystemDark(): boolean {
 }
 
 function getStored(): Theme {
-  const raw = localStorage.getItem(STORAGE_KEY);
+  const bootTheme = getBootDesktopTheme();
+  if (bootTheme) {
+    return bootTheme;
+  }
+
+  const raw = localStorage.getItem(THEME_STORAGE_KEY);
   if (raw === "light" || raw === "dark" || raw === "system") return raw;
   return "system";
 }
@@ -85,7 +91,7 @@ function subscribe(listener: () => void): () => void {
 
   // Listen for storage changes from other tabs
   const handleStorage = (e: StorageEvent) => {
-    if (e.key === STORAGE_KEY) {
+    if (e.key === THEME_STORAGE_KEY) {
       applyTheme(getStored(), true);
       emitChange();
     }
@@ -107,8 +113,9 @@ export function useTheme() {
     theme === "system" ? (snapshot.systemDark ? "dark" : "light") : theme;
 
   const setTheme = useCallback((next: Theme) => {
-    localStorage.setItem(STORAGE_KEY, next);
+    localStorage.setItem(THEME_STORAGE_KEY, next);
     applyTheme(next, true);
+    void persistDesktopSettings({ theme: next }).catch(() => {});
     emitChange();
   }, []);
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,19 +6,28 @@ import { createHashHistory, createBrowserHistory } from "@tanstack/react-router"
 import "@xterm/xterm/css/xterm.css";
 import "./index.css";
 
+import { hydrateDesktopSettings } from "./desktopSettings";
 import { isElectron } from "./env";
-import { getRouter } from "./router";
 import { APP_DISPLAY_NAME } from "./branding";
 
 // Electron loads the app from a file-backed shell, so hash history avoids path resolution issues.
 const history = isElectron ? createHashHistory() : createBrowserHistory();
 
-const router = getRouter(history);
-
 document.title = APP_DISPLAY_NAME;
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <RouterProvider router={router} />
-  </React.StrictMode>,
-);
+async function bootstrap() {
+  if (isElectron) {
+    await hydrateDesktopSettings();
+  }
+
+  const { getRouter } = await import("./router");
+  const router = getRouter(history);
+
+  ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+    <React.StrictMode>
+      <RouterProvider router={router} />
+    </React.StrictMode>,
+  );
+}
+
+void bootstrap();

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -11,3 +11,4 @@ export * from "./git";
 export * from "./orchestration";
 export * from "./editor";
 export * from "./project";
+export * from "./settings";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -46,6 +46,7 @@ import type {
   OrchestrationReadModel,
 } from "./orchestration";
 import { EditorId } from "./editor";
+import type { DesktopSettings, DesktopSettingsInput } from "./settings";
 
 export interface ContextMenuItem<T extends string = string> {
   id: T;
@@ -96,9 +97,11 @@ export interface DesktopUpdateActionResult {
 
 export interface DesktopBridge {
   getWsUrl: () => string | null;
+  initialSettings: DesktopSettings | null;
   pickFolder: () => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;
+  setSettings: (settings: DesktopSettingsInput) => Promise<DesktopSettings>;
   showContextMenu: <T extends string>(
     items: readonly ContextMenuItem<T>[],
     position?: { x: number; y: number },

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -1,0 +1,47 @@
+import { Option, Schema } from "effect";
+
+export const ThemePreference = Schema.Literals(["light", "dark", "system"]);
+export type ThemePreference = typeof ThemePreference.Type;
+
+export const TIMESTAMP_FORMAT_OPTIONS = ["locale", "12-hour", "24-hour"] as const;
+export type TimestampFormat = (typeof TIMESTAMP_FORMAT_OPTIONS)[number];
+export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
+
+export const AppSettings = Schema.Struct({
+  codexBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(
+    Schema.withConstructorDefault(() => Option.some("")),
+  ),
+  codexHomePath: Schema.String.check(Schema.isMaxLength(4096)).pipe(
+    Schema.withConstructorDefault(() => Option.some("")),
+  ),
+  defaultThreadEnvMode: Schema.Literals(["local", "worktree"]).pipe(
+    Schema.withConstructorDefault(() => Option.some("local")),
+  ),
+  confirmThreadDelete: Schema.Boolean.pipe(Schema.withConstructorDefault(() => Option.some(true))),
+  enableAssistantStreaming: Schema.Boolean.pipe(
+    Schema.withConstructorDefault(() => Option.some(false)),
+  ),
+  timestampFormat: Schema.Literals(["locale", "12-hour", "24-hour"]).pipe(
+    Schema.withConstructorDefault(() => Option.some(DEFAULT_TIMESTAMP_FORMAT)),
+  ),
+  customCodexModels: Schema.Array(Schema.String).pipe(
+    Schema.withConstructorDefault(() => Option.some([])),
+  ),
+});
+export type AppSettings = typeof AppSettings.Type;
+
+export const DesktopSettingsSchemaVersion = 1 as const;
+
+export const DesktopSettings = Schema.Struct({
+  version: Schema.String,
+  schemaVersion: Schema.Number,
+  theme: ThemePreference,
+  appSettings: AppSettings,
+});
+export type DesktopSettings = typeof DesktopSettings.Type;
+
+export const DesktopSettingsInput = Schema.Struct({
+  theme: ThemePreference,
+  appSettings: AppSettings,
+});
+export type DesktopSettingsInput = typeof DesktopSettingsInput.Type;


### PR DESCRIPTION
## What Changed

- added shared desktop settings schemas and IPC types for a persisted desktop settings payload
- added Electron read/write support for `settings.json` in the desktop state directory
- exposed a synchronous `initialSettings` snapshot from preload so the renderer can read desktop settings before routes and hooks initialize
- added desktop settings bootstrap/migration logic in the web app:
  - read `settings.json` first on desktop
  - if it does not exist, fall back to legacy localStorage
  - if legacy values exist, write a new `settings.json`
- updated desktop theme and app settings persistence so UI changes write back to `settings.json`
- kept browser behavior unchanged

## Why

Packaged desktop builds were still effectively depending on Chromium localStorage in the Electron profile, which made preferences unreliable across release builds and caused startup-order issues where settings were only reflected after more of the app mounted.

This change gives desktop a stable, versioned `settings.json` source of truth and makes startup deterministic:
- desktop reads `settings.json` first
- legacy localStorage is only used as a one-time migration source when the file is missing
- subsequent desktop settings changes update the file directly

That fixes the desktop persistence bug without changing browser-only behavior.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist desktop settings to settings.json across app releases
> - Adds a new `settings.json` file to store desktop settings (theme and app settings) across releases, using atomic writes with a temp file and rename.
> - On startup in Electron, [main.tsx](https://github.com/pingdotgg/t3code/pull/1191/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) awaits `hydrateDesktopSettings` before rendering, loading persisted settings from disk and mirroring them to localStorage with storage change events.
> - A new [desktopSettings.ts](https://github.com/pingdotgg/t3code/pull/1191/files#diff-47d07585d32008e0cde19fcf0f39bf923b22424c0e9cd38a6101111b93f1e22f) module handles hydration, migration of legacy localStorage values to disk, and de-duplicated persistence via `window.desktopBridge.setSettings`.
> - Settings schemas and types (`DesktopSettings`, `DesktopSettingsInput`, `AppSettings`) are defined in a new [packages/contracts/src/settings.ts](https://github.com/pingdotgg/t3code/pull/1191/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) module using Effect Schema, and `DesktopBridge` is extended with `initialSettings` and `setSettings`.
> - Behavioral Change: In Electron, app settings and theme are now bootstrapped from disk rather than localStorage, and writes are validated and persisted to disk on every change.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4eae069. 10 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->