### PR TITLE
fix(web,server): improve runtime error visibility in thread error banner

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -255,7 +255,7 @@ function runtimeEventToActivities(
           kind: "runtime.error",
           summary: "Runtime error",
           payload: {
-            message: truncateDetail(message),
+            message: truncateDetail(message, 512),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -14,7 +14,7 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
     <div className="pt-3 mx-auto max-w-3xl">
       <Alert variant="error">
         <CircleAlertIcon />
-        <AlertDescription className="line-clamp-3" title={error}>
+        <AlertDescription className="line-clamp-6" title={error}>
           {error}
         </AlertDescription>
         {onDismiss && (


### PR DESCRIPTION
## Summary

- Increase server-side runtime error truncation limit from 180 to 512 characters to preserve diagnostic detail
- Expand UI error banner from `line-clamp-3` to `line-clamp-6` so longer error messages remain readable without dominating the viewport

## Problem

Runtime errors (e.g. malformed local `SKILL.md` with invalid YAML frontmatter) are truncated twice: server-side to 180 chars, then UI-side to 3 lines via `line-clamp-3`. This makes errors like invalid YAML parsing failures nearly unreadable — the user has to take a screenshot fast before the banner disappears, and even then the text is cut off.

## Test plan

- [ ] Trigger a runtime error with a long message (e.g. malformed `.agent/skills/.../SKILL.md`)
- [ ] Verify the error banner shows enough text to diagnose the issue (up to 6 lines)
- [ ] Verify short errors still render cleanly without excess whitespace
- [ ] Server tests pass (`bun run test` in `apps/server`)

Closes #1084

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve runtime error visibility in thread error banner
> - Expands the error description in `ThreadErrorBanner` from 3 to 6 visible lines before clamping.
> - Passes an explicit `512` character limit to `truncateDetail` for `runtime.error` activity messages in [`ProviderRuntimeIngestion.ts`](https://github.com/pingdotgg/t3code/pull/1202/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7), replacing the previous default truncation length.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86b53ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->