### PR TITLE
Opened by mistake, closing

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+tone_instructions: "Only comment on issues introduced by the PR. Prefer high-signal, actionable feedback that matches existing project conventions."
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: false
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  suggested_reviewers: false
+  poem: false
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: false
+
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/dist/**"
+    - "!**/.turbo/**"
+    - "!bun.lock"
+
+  path_instructions:
+    - path: "apps/server/**"
+      instructions: |
+        Prioritize correctness, reliability, and predictable behavior under reconnects,
+        session restarts, partial streams, and provider failures.
+    - path: "apps/web/**"
+      instructions: |
+        Prioritize UI correctness, responsive layout behavior, and avoiding unnecessary
+        rerenders or fragile client state transitions.
+    - path: "packages/contracts/**"
+      instructions: |
+        This package should stay schema-only. Flag protocol and schema changes that could
+        break compatibility across server and web.
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   quality:
     name: Format, Lint, Typecheck, Test, Browser Test, Build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   preflight:
@@ -27,7 +26,7 @@ jobs:
       ref: ${{ github.sha }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - id: release_meta
         name: Resolve release version
@@ -61,7 +60,7 @@ jobs:
           bun-version-file: package.json
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: package.json
 
@@ -107,7 +106,7 @@ jobs:
             arch: x64
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.preflight.outputs.ref }}
           fetch-depth: 0
@@ -118,7 +117,7 @@ jobs:
           bun-version-file: package.json
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: package.json
 
@@ -143,6 +142,7 @@ jobs:
           AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
           AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
           AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
+          T3CODE_DESKTOP_UPDATE_REPOSITORY: ${{ vars.T3CODE_DESKTOP_UPDATE_REPOSITORY || github.repository }}
         run: |
           args=(
             --platform "${{ matrix.platform }}"
@@ -217,62 +217,29 @@ jobs:
           fi
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: desktop-${{ matrix.platform }}-${{ matrix.arch }}
           path: release-publish/*
           if-no-files-found: error
 
-  publish_cli:
-    name: Publish CLI to npm
+  release:
+    name: Publish GitHub Release
     needs: [preflight, build]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.preflight.outputs.ref }}
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version-file: package.json
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
-          registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Align package versions to release version
-        run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
-
-      - name: Build CLI package
-        run: bun run build --filter=@t3tools/web --filter=t3
-
-      - name: Publish CLI package
-        run: node apps/server/scripts/cli.ts publish --tag latest --app-version "${{ needs.preflight.outputs.version }}" --verbose
-
-  release:
-    name: Publish GitHub Release
-    needs: [preflight, build, publish_cli]
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.preflight.outputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: package.json
 
       - name: Download all desktop artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           pattern: desktop-*
           merge-multiple: true
@@ -317,7 +284,7 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
@@ -340,7 +307,7 @@ jobs:
           bun-version-file: package.json
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version-file: package.json
 

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,59 @@
+name: Sync Upstream
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 * * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-upstream-main
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: Merge upstream/main into main
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: package.json
+
+      - name: Configure upstream remote
+        run: |
+          git remote remove upstream 2>/dev/null || true
+          git remote add upstream https://github.com/pingdotgg/t3code.git
+
+      - name: Fetch upstream main
+        run: git fetch upstream main
+
+      - name: Merge upstream main
+        run: git merge --no-edit upstream/main
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Push main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: git push origin HEAD:main

--- a/README.md
+++ b/README.md
@@ -1,19 +1,50 @@
-# T3 Code
+# T3 Code + Copilot
 
-T3 Code is a minimal web GUI for coding agents. Currently Codex-first, with Claude Code support coming soon.
+This repo is a T3 Code fork that stays up to date with upstream and adds GitHub Copilot support.
+
+T3 Code is a minimal web GUI for coding agents. This fork supports both Codex and GitHub Copilot.
+
+## Preview
+
+<img width="1792" height="1001" alt="2026-03-09_02-36-10" src="https://github.com/user-attachments/assets/2d2bb48f-1485-44e0-804e-468f4111d376" />
+<img width="1912" height="1178" alt="image" src="https://github.com/user-attachments/assets/38cd4bb2-b27e-47e6-9565-d26c4c97fdd3" />
+
+## This fork
+
+- tracks upstream `pingdotgg/t3code`
+- adds GitHub Copilot provider support
+- keeps Codex support working too
 
 ## How to use
 
 > [!WARNING]
-> You need to have [Codex CLI](https://github.com/openai/codex) installed and authorized for T3 Code to work.
+> You need to have either [Codex CLI](https://github.com/openai/codex) or GitHub Copilot available and authorized for T3 Code to work.
+> When you run T3 Code from source, `bun install` is enough for Copilot support because `apps/server` already depends on `@github/copilot` and `@github/copilot-sdk`.
+> If you want to use GitHub Copilot CLI directly in a terminal, follow GitHub's [Copilot CLI installation guide](https://docs.github.com/copilot/how-tos/set-up/install-copilot-cli). If Copilot comes from an organization or enterprise, the Copilot CLI policy must be enabled there.
+
+## Copilot setup
+
+For the app itself, there is no separate global Copilot install step when running from source:
 
 ```bash
-npx t3
+bun install
 ```
 
-You can also just install the desktop app. It's cooler.
+If you are using Copilot CLI directly in your terminal, install it with GitHub's docs and sign in from a trusted folder. On first launch, Copilot will prompt you to use `/login` if you are not already authenticated.
 
-Install the [desktop app from the Releases page](https://github.com/pingdotgg/t3code/releases)
+The easiest way to use this fork is the desktop app.
+
+- Download it from the [releases page](https://github.com/zortos293/t3code-copilot/releases)
+- Launch the app and choose either `Codex` or `GitHub Copilot`
+
+You can also run it from source:
+
+```bash
+bun install
+bun run dev
+```
+
+Open the app, connect your provider, and start chatting.
 
 ## Some notes
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3tools/desktop",
-  "version": "0.0.10",
+  "version": "0.1.25",
   "private": true,
   "main": "dist-electron/main.js",
   "scripts": {

--- a/apps/desktop/src/backendRestartPolicy.test.ts
+++ b/apps/desktop/src/backendRestartPolicy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BACKEND_MAX_CONSECUTIVE_FAILURES,
+  BACKEND_STABLE_RUN_MS,
+  decideBackendRestart,
+  INITIAL_BACKEND_RESTART_STATE,
+  noteBackendLaunch,
+} from "./backendRestartPolicy";
+
+describe("backendRestartPolicy", () => {
+  it("backs off for consecutive fast crashes", () => {
+    const firstLaunch = noteBackendLaunch(INITIAL_BACKEND_RESTART_STATE, 1_000);
+    const firstFailure = decideBackendRestart(firstLaunch, 1_100);
+    expect(firstFailure.type).toBe("restart");
+    expect(firstFailure.delayMs).toBe(500);
+
+    const secondLaunch = noteBackendLaunch(firstFailure.nextState, 2_000);
+    const secondFailure = decideBackendRestart(secondLaunch, 2_100);
+    expect(secondFailure.type).toBe("restart");
+    expect(secondFailure.delayMs).toBe(1_000);
+  });
+
+  it("treats a stable run as a fresh failure streak", () => {
+    const priorFailures = {
+      consecutiveFailures: 4,
+      lastLaunchAtMs: 10_000,
+    };
+
+    const decision = decideBackendRestart(priorFailures, 10_000 + BACKEND_STABLE_RUN_MS);
+
+    expect(decision.type).toBe("restart");
+    expect(decision.delayMs).toBe(500);
+    expect(decision.nextState.consecutiveFailures).toBe(1);
+  });
+
+  it("stops restarting after too many rapid failures", () => {
+    let state = INITIAL_BACKEND_RESTART_STATE;
+
+    for (let index = 0; index < BACKEND_MAX_CONSECUTIVE_FAILURES - 1; index += 1) {
+      state = noteBackendLaunch(state, 1_000 + index * 100);
+      const decision = decideBackendRestart(state, 1_050 + index * 100);
+      expect(decision.type).toBe("restart");
+      state = decision.nextState;
+    }
+
+    state = noteBackendLaunch(state, 5_000);
+    const fatalDecision = decideBackendRestart(state, 5_050);
+
+    expect(fatalDecision.type).toBe("fatal");
+    expect(fatalDecision.nextState.consecutiveFailures).toBe(BACKEND_MAX_CONSECUTIVE_FAILURES);
+  });
+});

--- a/apps/desktop/src/backendRestartPolicy.ts
+++ b/apps/desktop/src/backendRestartPolicy.ts
@@ -1,0 +1,54 @@
+export interface BackendRestartState {
+  readonly consecutiveFailures: number;
+  readonly lastLaunchAtMs: number | null;
+}
+
+export interface BackendRestartDecision {
+  readonly type: "restart" | "fatal";
+  readonly delayMs: number;
+  readonly nextState: BackendRestartState;
+  readonly uptimeMs: number;
+}
+
+export const BACKEND_STABLE_RUN_MS = 5_000;
+export const BACKEND_MAX_CONSECUTIVE_FAILURES = 5;
+const BACKEND_RESTART_BASE_DELAY_MS = 500;
+const BACKEND_RESTART_MAX_DELAY_MS = 10_000;
+
+export const INITIAL_BACKEND_RESTART_STATE: BackendRestartState = {
+  consecutiveFailures: 0,
+  lastLaunchAtMs: null,
+};
+
+export function noteBackendLaunch(
+  state: BackendRestartState,
+  launchedAtMs: number,
+): BackendRestartState {
+  return {
+    ...state,
+    lastLaunchAtMs: launchedAtMs,
+  };
+}
+
+export function decideBackendRestart(
+  state: BackendRestartState,
+  nowMs: number,
+): BackendRestartDecision {
+  const uptimeMs = state.lastLaunchAtMs === null ? 0 : Math.max(0, nowMs - state.lastLaunchAtMs);
+  const stableRun = uptimeMs >= BACKEND_STABLE_RUN_MS;
+  const consecutiveFailures = stableRun ? 1 : state.consecutiveFailures + 1;
+  const delayMs = Math.min(
+    BACKEND_RESTART_BASE_DELAY_MS * 2 ** Math.max(consecutiveFailures - 1, 0),
+    BACKEND_RESTART_MAX_DELAY_MS,
+  );
+
+  return {
+    type: consecutiveFailures >= BACKEND_MAX_CONSECUTIVE_FAILURES ? "fatal" : "restart",
+    delayMs,
+    nextState: {
+      consecutiveFailures,
+      lastLaunchAtMs: null,
+    },
+    uptimeMs,
+  };
+}

--- a/apps/desktop/src/macCodeSigning.test.ts
+++ b/apps/desktop/src/macCodeSigning.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { hasDeveloperIdApplicationAuthority } from "./macCodeSigning";
+
+describe("hasDeveloperIdApplicationAuthority", () => {
+  it("matches a Developer ID Application authority line", () => {
+    expect(
+      hasDeveloperIdApplicationAuthority(`Executable=/Applications/T3 Code.app/Contents/MacOS/T3 Code
+Identifier=com.t3tools.t3code
+Authority=Developer ID Application: T3 Tools, Inc. (ABCDE12345)
+Authority=Developer ID Certification Authority
+Authority=Apple Root CA`),
+    ).toBe(true);
+  });
+
+  it("ignores ad hoc signatures and unsigned output", () => {
+    expect(
+      hasDeveloperIdApplicationAuthority(`Executable=/Applications/T3 Code.app/Contents/MacOS/T3 Code
+Signature=adhoc`),
+    ).toBe(false);
+    expect(hasDeveloperIdApplicationAuthority("code object is not signed at all")).toBe(false);
+  });
+});

--- a/apps/desktop/src/macCodeSigning.ts
+++ b/apps/desktop/src/macCodeSigning.ts
@@ -1,0 +1,5 @@
+export function hasDeveloperIdApplicationAuthority(value: string): boolean {
+  return value
+    .split(/\r?\n/)
+    .some((line) => line.trim().startsWith("Authority=Developer ID Application:"));
+}

--- a/apps/desktop/src/macUpdateInstaller.test.ts
+++ b/apps/desktop/src/macUpdateInstaller.test.ts
@@ -1,0 +1,62 @@
+import * as FS from "node:fs";
+import * as OS from "node:os";
+import * as Path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildMacManualUpdateInstallScript,
+  findFirstAppBundlePath,
+  resolveDownloadedMacUpdateZipPath,
+} from "./macUpdateInstaller";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    FS.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveDownloadedMacUpdateZipPath", () => {
+  it("returns the downloaded zip path", () => {
+    expect(resolveDownloadedMacUpdateZipPath(["/tmp/update.zip", "/tmp/update.blockmap"])).toBe(
+      "/tmp/update.zip",
+    );
+  });
+
+  it("returns null when no zip exists", () => {
+    expect(resolveDownloadedMacUpdateZipPath(["/tmp/update.blockmap"])).toBeNull();
+  });
+});
+
+describe("findFirstAppBundlePath", () => {
+  it("finds an extracted app bundle recursively", () => {
+    const rootDir = FS.mkdtempSync(Path.join(OS.tmpdir(), "t3-mac-update-"));
+    tempDirs.push(rootDir);
+
+    const appPath = Path.join(rootDir, "nested", "T3 Code.app");
+    FS.mkdirSync(appPath, { recursive: true });
+
+    expect(findFirstAppBundlePath(rootDir)).toBe(appPath);
+  });
+});
+
+describe("buildMacManualUpdateInstallScript", () => {
+  it("builds a detached installer script with admin fallback", () => {
+    const script = buildMacManualUpdateInstallScript({
+      appPid: 123,
+      sourceAppPath: "/tmp/T3 Code's Update.app",
+      targetAppPath: "/Applications/T3 Code.app",
+      stagingDir: "/tmp/t3-stage",
+    });
+
+    expect(script).toContain("APP_PID=123");
+    expect(script).toContain("wait_for_app_exit");
+    expect(script).toContain("/usr/bin/ditto");
+    expect(script).toContain("/usr/bin/osascript");
+    expect(script).toContain(`SOURCE_APP='/tmp/T3 Code'\\''s Update.app'`);
+    expect(script).toContain(`TARGET_APP='/Applications/T3 Code.app'`);
+    expect(script).toContain('/usr/bin/open -n "$TARGET_APP"');
+  });
+});

--- a/apps/desktop/src/macUpdateInstaller.ts
+++ b/apps/desktop/src/macUpdateInstaller.ts
@@ -1,0 +1,89 @@
+import * as FS from "node:fs";
+import * as Path from "node:path";
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+export function resolveDownloadedMacUpdateZipPath(
+  downloadedFiles: ReadonlyArray<string>,
+): string | null {
+  for (const file of downloadedFiles) {
+    if (file.toLowerCase().endsWith(".zip")) {
+      return file;
+    }
+  }
+  return null;
+}
+
+export function findFirstAppBundlePath(rootDir: string): string | null {
+  const queue = [rootDir];
+
+  while (queue.length > 0) {
+    const currentDir = queue.shift();
+    if (!currentDir) {
+      continue;
+    }
+
+    for (const entry of FS.readdirSync(currentDir, { withFileTypes: true })) {
+      const entryPath = Path.join(currentDir, entry.name);
+      if (entry.isDirectory() && entry.name.endsWith(".app")) {
+        return entryPath;
+      }
+      if (entry.isDirectory()) {
+        queue.push(entryPath);
+      }
+    }
+  }
+
+  return null;
+}
+
+export function buildMacManualUpdateInstallScript(args: {
+  appPid: number;
+  sourceAppPath: string;
+  targetAppPath: string;
+  stagingDir: string;
+}): string {
+  const sourceAppPath = shellQuote(args.sourceAppPath);
+  const targetAppPath = shellQuote(args.targetAppPath);
+  const stagingDir = shellQuote(args.stagingDir);
+
+  return `#!/bin/sh
+set -eu
+APP_PID=${args.appPid}
+SOURCE_APP=${sourceAppPath}
+TARGET_APP=${targetAppPath}
+STAGING_DIR=${stagingDir}
+
+cleanup() {
+  /bin/rm -rf "$STAGING_DIR"
+}
+
+trap cleanup EXIT
+
+wait_for_app_exit() {
+  while /bin/kill -0 "$APP_PID" 2>/dev/null; do
+    /bin/sleep 0.2
+  done
+}
+
+install_update() {
+  /bin/rm -rf "$TARGET_APP"
+  /usr/bin/ditto "$SOURCE_APP" "$TARGET_APP"
+}
+
+wait_for_app_exit
+
+if ! install_update >/dev/null 2>&1; then
+  export SOURCE_APP TARGET_APP
+  /usr/bin/osascript <<'APPLESCRIPT'
+set sourceApp to system attribute "SOURCE_APP"
+set targetApp to system attribute "TARGET_APP"
+do shell script "/bin/rm -rf " & quoted form of targetApp & " && /usr/bin/ditto " & quoted form of sourceApp & " " & quoted form of targetApp with administrator privileges
+APPLESCRIPT
+fi
+
+/usr/bin/open -n "$TARGET_APP"
+`;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -28,6 +28,12 @@ import type { ContextMenuItem } from "@t3tools/contracts";
 import { NetService } from "@t3tools/shared/Net";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
+import { hasDeveloperIdApplicationAuthority } from "./macCodeSigning";
+import {
+  buildMacManualUpdateInstallScript,
+  findFirstAppBundlePath,
+  resolveDownloadedMacUpdateZipPath,
+} from "./macUpdateInstaller";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
 import {
@@ -43,6 +49,11 @@ import {
   reduceDesktopUpdateStateOnUpdateAvailable,
 } from "./updateMachine";
 import { isArm64HostRunningIntelBuild, resolveDesktopRuntimeInfo } from "./runtimeArch";
+import {
+  decideBackendRestart,
+  INITIAL_BACKEND_RESTART_STATE,
+  noteBackendLaunch,
+} from "./backendRestartPolicy";
 
 syncShellEnvironment();
 
@@ -83,7 +94,6 @@ let backendProcess: ChildProcess.ChildProcess | null = null;
 let backendPort = 0;
 let backendAuthToken = "";
 let backendWsUrl = "";
-let restartAttempt = 0;
 let restartTimer: ReturnType<typeof setTimeout> | null = null;
 let isQuitting = false;
 let desktopProtocolRegistered = false;
@@ -91,8 +101,11 @@ let aboutCommitHashCache: string | null | undefined;
 let desktopLogSink: RotatingFileSink | null = null;
 let backendLogSink: RotatingFileSink | null = null;
 let restoreStdIoCapture: (() => void) | null = null;
+let backendRestartState = INITIAL_BACKEND_RESTART_STATE;
 
 let destructiveMenuIconCache: Electron.NativeImage | null | undefined;
+let macDeveloperIdSigned: boolean | null = null;
+let downloadedUpdateFiles: string[] = [];
 const desktopRuntimeInfo = resolveDesktopRuntimeInfo({
   platform: process.platform,
   processArch: process.arch,
@@ -113,6 +126,48 @@ function sanitizeLogValue(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
+function resolveMacAppBundlePath(): string | null {
+  if (process.platform !== "darwin" || !app.isPackaged) {
+    return null;
+  }
+
+  return Path.resolve(process.execPath, "..", "..", "..");
+}
+
+function isMacDeveloperIdSignedBuild(): boolean {
+  if (process.platform !== "darwin" || !app.isPackaged) {
+    return false;
+  }
+  if (macDeveloperIdSigned !== null) {
+    return macDeveloperIdSigned;
+  }
+
+  const appBundlePath = resolveMacAppBundlePath();
+  if (!appBundlePath) {
+    macDeveloperIdSigned = false;
+    return macDeveloperIdSigned;
+  }
+
+  const result = ChildProcess.spawnSync("codesign", ["--display", "--verbose=4", appBundlePath], {
+    encoding: "utf8",
+  });
+  const details = `${result.stdout ?? ""}\n${result.stderr ?? ""}`.trim();
+  macDeveloperIdSigned = result.status === 0 && hasDeveloperIdApplicationAuthority(details);
+
+  if (!macDeveloperIdSigned) {
+    const diagnostic =
+      result.error?.message ||
+      (result.status === 0
+        ? "missing Developer ID Application authority in code signature"
+        : details || `codesign exited with status ${result.status ?? "unknown"}`);
+    console.info(
+      `[desktop-updater] macOS code-signing check indicates manual install fallback will be used: ${sanitizeLogValue(diagnostic)}`,
+    );
+  }
+
+  return macDeveloperIdSigned;
+}
+
 function writeDesktopLogHeader(message: string): void {
   if (!desktopLogSink) return;
   desktopLogSink.write(`[${logTimestamp()}] [${logScope("desktop")}] ${message}\n`);
@@ -131,6 +186,14 @@ function formatErrorMessage(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+function setDownloadedUpdateFiles(files: ReadonlyArray<string>): void {
+  downloadedUpdateFiles = [...files];
+}
+
+function clearDownloadedUpdateFiles(): void {
+  downloadedUpdateFiles = [];
 }
 
 function getSafeExternalUrl(rawUrl: unknown): string | null {
@@ -513,13 +576,7 @@ function dispatchMenuAction(action: string): void {
 }
 
 function handleCheckForUpdatesMenuClick(): void {
-  const disabledReason = getAutoUpdateDisabledReason({
-    isDevelopment,
-    isPackaged: app.isPackaged,
-    platform: process.platform,
-    appImage: process.env.APPIMAGE,
-    disabledByEnv: process.env.T3CODE_DISABLE_AUTO_UPDATE === "1",
-  });
+  const disabledReason = resolveAutoUpdateDisabledReason();
   if (disabledReason) {
     console.info("[desktop-updater] Manual update check requested, but updates are disabled.");
     void dialog.showMessageBox({
@@ -730,16 +787,14 @@ function setUpdateState(patch: Partial<DesktopUpdateState>): void {
   emitUpdateState();
 }
 
-function shouldEnableAutoUpdates(): boolean {
-  return (
-    getAutoUpdateDisabledReason({
-      isDevelopment,
-      isPackaged: app.isPackaged,
-      platform: process.platform,
-      appImage: process.env.APPIMAGE,
-      disabledByEnv: process.env.T3CODE_DISABLE_AUTO_UPDATE === "1",
-    }) === null
-  );
+function resolveAutoUpdateDisabledReason(): string | null {
+  return getAutoUpdateDisabledReason({
+    isDevelopment,
+    isPackaged: app.isPackaged,
+    platform: process.platform,
+    appImage: process.env.APPIMAGE,
+    disabledByEnv: process.env.T3CODE_DISABLE_AUTO_UPDATE === "1",
+  });
 }
 
 async function checkForUpdates(reason: string): Promise<void> {
@@ -777,16 +832,66 @@ async function downloadAvailableUpdate(): Promise<{ accepted: boolean; completed
   console.info("[desktop-updater] Downloading update...");
 
   try {
-    await autoUpdater.downloadUpdate();
+    const downloadedFiles = await autoUpdater.downloadUpdate();
+    setDownloadedUpdateFiles(downloadedFiles);
     return { accepted: true, completed: true };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
+    clearDownloadedUpdateFiles();
     setUpdateState(reduceDesktopUpdateStateOnDownloadFailure(updateState, message));
     console.error(`[desktop-updater] Failed to download update: ${message}`);
     return { accepted: true, completed: false };
   } finally {
     updateDownloadInFlight = false;
   }
+}
+
+function installDownloadedUnsignedMacUpdate(): void {
+  const currentAppPath = resolveMacAppBundlePath();
+  if (!currentAppPath) {
+    throw new Error("Could not resolve the current app bundle path.");
+  }
+
+  const downloadedZipPath = resolveDownloadedMacUpdateZipPath(downloadedUpdateFiles);
+  if (!downloadedZipPath) {
+    throw new Error("Could not locate the downloaded macOS update archive.");
+  }
+
+  const stagingDir = FS.mkdtempSync(Path.join(OS.tmpdir(), "t3-mac-update-"));
+  const extractedDir = Path.join(stagingDir, "extracted");
+  FS.mkdirSync(extractedDir, { recursive: true });
+
+  const unzipResult = ChildProcess.spawnSync(
+    "ditto",
+    ["-x", "-k", downloadedZipPath, extractedDir],
+    {
+      encoding: "utf8",
+    },
+  );
+  if (unzipResult.status !== 0) {
+    const details = `${unzipResult.stdout ?? ""}\n${unzipResult.stderr ?? ""}`.trim();
+    throw new Error(details || `ditto exited with status ${unzipResult.status ?? "unknown"}`);
+  }
+
+  const extractedAppPath = findFirstAppBundlePath(extractedDir);
+  if (!extractedAppPath) {
+    throw new Error("Could not find the extracted app bundle inside the downloaded update.");
+  }
+
+  const installerScriptPath = Path.join(stagingDir, "install-update.sh");
+  const installerScript = buildMacManualUpdateInstallScript({
+    appPid: process.pid,
+    sourceAppPath: extractedAppPath,
+    targetAppPath: currentAppPath,
+    stagingDir,
+  });
+  FS.writeFileSync(installerScriptPath, installerScript, { mode: 0o700 });
+
+  const installerProcess = ChildProcess.spawn("/bin/sh", [installerScriptPath], {
+    detached: true,
+    stdio: "ignore",
+  });
+  installerProcess.unref();
 }
 
 async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed: boolean }> {
@@ -798,7 +903,12 @@ async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed
   clearUpdatePollTimer();
   try {
     await stopBackendAndWaitForExit();
-    autoUpdater.quitAndInstall();
+    if (process.platform === "darwin" && !isMacDeveloperIdSignedBuild()) {
+      installDownloadedUnsignedMacUpdate();
+      app.quit();
+    } else {
+      autoUpdater.quitAndInstall();
+    }
     return { accepted: true, completed: true };
   } catch (error: unknown) {
     const message = formatErrorMessage(error);
@@ -810,13 +920,15 @@ async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed
 }
 
 function configureAutoUpdater(): void {
-  const enabled = shouldEnableAutoUpdates();
+  const disabledReason = resolveAutoUpdateDisabledReason();
+  const enabled = disabledReason === null;
   setUpdateState({
     ...createInitialDesktopUpdateState(app.getVersion(), desktopRuntimeInfo),
     enabled,
     status: enabled ? "idle" : "disabled",
   });
   if (!enabled) {
+    console.info(`[desktop-updater] Automatic updates disabled: ${disabledReason}`);
     return;
   }
   updaterConfigured = true;
@@ -857,6 +969,7 @@ function configureAutoUpdater(): void {
     console.info("[desktop-updater] Looking for updates...");
   });
   autoUpdater.on("update-available", (info) => {
+    clearDownloadedUpdateFiles();
     setUpdateState(
       reduceDesktopUpdateStateOnUpdateAvailable(
         updateState,
@@ -868,6 +981,7 @@ function configureAutoUpdater(): void {
     console.info(`[desktop-updater] Update available: ${info.version}`);
   });
   autoUpdater.on("update-not-available", () => {
+    clearDownloadedUpdateFiles();
     setUpdateState(reduceDesktopUpdateStateOnNoUpdate(updateState, new Date().toISOString()));
     lastLoggedDownloadMilestone = -1;
     console.info("[desktop-updater] No updates available.");
@@ -932,8 +1046,19 @@ function backendEnv(): NodeJS.ProcessEnv {
 function scheduleBackendRestart(reason: string): void {
   if (isQuitting || restartTimer) return;
 
-  const delayMs = Math.min(500 * 2 ** restartAttempt, 10_000);
-  restartAttempt += 1;
+  const decision = decideBackendRestart(backendRestartState, Date.now());
+  backendRestartState = decision.nextState;
+  if (decision.type === "fatal") {
+    handleFatalStartupError(
+      "backend",
+      new Error(
+        `The background server crashed ${decision.nextState.consecutiveFailures} times in a row within ${decision.uptimeMs}ms. Check ${Path.join(LOG_DIR, "server-child.log")} for details.`,
+      ),
+    );
+    return;
+  }
+
+  const delayMs = decision.delayMs;
   console.error(`[desktop] backend exited unexpectedly (${reason}); restarting in ${delayMs}ms`);
 
   restartTimer = setTimeout(() => {
@@ -952,6 +1077,7 @@ function startBackend(): void {
   }
 
   const captureBackendLogs = app.isPackaged && backendLogSink !== null;
+  backendRestartState = noteBackendLaunch(backendRestartState, Date.now());
   const child = ChildProcess.spawn(process.execPath, [backendEntry], {
     cwd: resolveBackendCwd(),
     // In Electron main, process.execPath points to the Electron binary.
@@ -974,10 +1100,6 @@ function startBackend(): void {
     `pid=${child.pid ?? "unknown"} port=${backendPort} cwd=${resolveBackendCwd()}`,
   );
   captureBackendOutput(child);
-
-  child.once("spawn", () => {
-    restartAttempt = 0;
-  });
 
   child.on("error", (error) => {
     if (backendProcess === child) {
@@ -1006,6 +1128,8 @@ function stopBackend(): void {
     restartTimer = null;
   }
 
+  backendRestartState = INITIAL_BACKEND_RESTART_STATE;
+
   const child = backendProcess;
   backendProcess = null;
   if (!child) return;
@@ -1025,6 +1149,8 @@ async function stopBackendAndWaitForExit(timeoutMs = 5_000): Promise<void> {
     clearTimeout(restartTimer);
     restartTimer = null;
   }
+
+  backendRestartState = INITIAL_BACKEND_RESTART_STATE;
 
   const child = backendProcess;
   backendProcess = null;

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -10,6 +10,7 @@
     "typecheck": "astro check"
   },
   "dependencies": {
+    "@t3tools/shared": "workspace:*",
     "astro": "^6.0.4"
   },
   "devDependencies": {

--- a/apps/marketing/src/lib/releases.ts
+++ b/apps/marketing/src/lib/releases.ts
@@ -1,9 +1,23 @@
-const REPO = "pingdotgg/t3code";
+import {
+  DEFAULT_GITHUB_REPOSITORY,
+  formatGitHubRepository,
+  parseGitHubRepository,
+} from "@t3tools/shared/githubRepository";
+
+const REPOSITORY =
+  parseGitHubRepository(import.meta.env.PUBLIC_T3CODE_RELEASE_REPOSITORY) ??
+  parseGitHubRepository(DEFAULT_GITHUB_REPOSITORY);
+
+if (!REPOSITORY) {
+  throw new Error("Default GitHub release repository is invalid.");
+}
+
+const REPO = formatGitHubRepository(REPOSITORY);
 
 export const RELEASES_URL = `https://github.com/${REPO}/releases`;
 
 const API_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
-const CACHE_KEY = "t3code-latest-release";
+const CACHE_KEY = `t3code-latest-release:${REPO}`;
 
 export interface ReleaseAsset {
   name: string;

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,9 +1,9 @@
 {
   "name": "t3",
-  "version": "0.0.10",
+  "version": "0.1.25",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pingdotgg/t3code",
+    "url": "https://github.com/zortos293/t3code-copilot",
     "directory": "apps/server"
   },
   "bin": {
@@ -17,17 +17,20 @@
     "dev": "bun run src/index.ts",
     "build": "node scripts/cli.ts build",
     "start": "node dist/index.mjs",
-    "prepare": "effect-language-service patch",
+    "prepare": "node ../../scripts/run-effect-language-service-patch.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
     "@effect/platform-node": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
+    "@github/copilot": "1.0.7",
+    "@github/copilot-sdk": "0.1.32",
     "@pierre/diffs": "^1.1.0-beta.16",
     "effect": "catalog:",
     "node-pty": "^1.1.0",
     "open": "^10.1.0",
+    "smol-toml": "^1.6.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/apps/server/src/attachmentPaths.test.ts
+++ b/apps/server/src/attachmentPaths.test.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeAttachmentRelativePathFrom,
+  resolveAttachmentRelativePathFrom,
+} from "./attachmentPaths.ts";
+
+describe("attachmentPaths", () => {
+  it("normalizes Windows-style separators for persisted attachment paths", () => {
+    expect(normalizeAttachmentRelativePathFrom("thread-a\\message-a\\image.png", path.win32)).toBe(
+      "thread-a/message-a/image.png",
+    );
+  });
+
+  it("rejects Windows traversal attempts", () => {
+    expect(
+      resolveAttachmentRelativePathFrom(
+        {
+          stateDir: "C:\\state",
+          relativePath: "..\\outside.png",
+        },
+        path.win32,
+      ),
+    ).toBeNull();
+  });
+
+  it("resolves valid Windows attachment paths inside the attachments root", () => {
+    expect(
+      resolveAttachmentRelativePathFrom(
+        {
+          stateDir: "C:\\state",
+          relativePath: "thread-a\\message-a\\image.png",
+        },
+        path.win32,
+      ),
+    ).toBe(path.win32.resolve("C:\\state\\attachments\\thread-a\\message-a\\image.png"));
+  });
+});

--- a/apps/server/src/attachmentPaths.ts
+++ b/apps/server/src/attachmentPaths.ts
@@ -2,27 +2,57 @@ import path from "node:path";
 
 export const ATTACHMENTS_ROUTE_PREFIX = "/attachments";
 
-export function normalizeAttachmentRelativePath(rawRelativePath: string): string | null {
-  const normalized = path.normalize(rawRelativePath).replace(/^[/\\]+/, "");
+interface AttachmentPathApi {
+  normalize(path: string): string;
+  join(...paths: string[]): string;
+  resolve(...paths: string[]): string;
+  relative(from: string, to: string): string;
+  isAbsolute(path: string): boolean;
+}
+
+export function normalizeAttachmentRelativePathFrom(
+  rawRelativePath: string,
+  pathApi: AttachmentPathApi,
+): string | null {
+  const normalized = pathApi.normalize(rawRelativePath).replace(/^[/\\]+/, "");
   if (normalized.length === 0 || normalized.startsWith("..") || normalized.includes("\0")) {
     return null;
   }
   return normalized.replace(/\\/g, "/");
 }
 
-export function resolveAttachmentRelativePath(input: {
-  readonly stateDir: string;
-  readonly relativePath: string;
-}): string | null {
-  const normalizedRelativePath = normalizeAttachmentRelativePath(input.relativePath);
+export function normalizeAttachmentRelativePath(rawRelativePath: string): string | null {
+  return normalizeAttachmentRelativePathFrom(rawRelativePath, path);
+}
+
+export function resolveAttachmentRelativePathFrom(
+  input: {
+    readonly stateDir: string;
+    readonly relativePath: string;
+  },
+  pathApi: AttachmentPathApi,
+): string | null {
+  const normalizedRelativePath = normalizeAttachmentRelativePathFrom(input.relativePath, pathApi);
   if (!normalizedRelativePath) {
     return null;
   }
 
-  const attachmentsRoot = path.resolve(path.join(input.stateDir, "attachments"));
-  const filePath = path.resolve(path.join(attachmentsRoot, normalizedRelativePath));
-  if (!filePath.startsWith(`${attachmentsRoot}${path.sep}`)) {
+  const attachmentsRoot = pathApi.resolve(pathApi.join(input.stateDir, "attachments"));
+  const filePath = pathApi.resolve(pathApi.join(attachmentsRoot, normalizedRelativePath));
+  const relativeToRoot = pathApi.relative(attachmentsRoot, filePath);
+  if (
+    relativeToRoot.length === 0 ||
+    relativeToRoot.startsWith("..") ||
+    pathApi.isAbsolute(relativeToRoot)
+  ) {
     return null;
   }
   return filePath;
+}
+
+export function resolveAttachmentRelativePath(input: {
+  readonly stateDir: string;
+  readonly relativePath: string;
+}): string | null {
+  return resolveAttachmentRelativePathFrom(input, path);
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,6 +5,8 @@ import * as Layer from "effect/Layer";
 
 import { CliConfig, t3Cli } from "./main";
 import { OpenLive } from "./open";
+import { SkillsManagerLive } from "./skills/SkillsManager";
+import { McpManagerLive } from "./mcp/McpManager";
 import { Command } from "effect/unstable/cli";
 import { version } from "../package.json" with { type: "json" };
 import { ServerLive } from "./wsServer";
@@ -15,6 +17,8 @@ const RuntimeLayer = Layer.empty.pipe(
   Layer.provideMerge(CliConfig.layer),
   Layer.provideMerge(ServerLive),
   Layer.provideMerge(OpenLive),
+  Layer.provideMerge(SkillsManagerLive),
+  Layer.provideMerge(McpManagerLive),
   Layer.provideMerge(NetService.layer),
   Layer.provideMerge(NodeServices.layer),
   Layer.provideMerge(FetchHttpClient.layer),

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -13,6 +13,8 @@ import { NetService } from "@t3tools/shared/Net";
 import { CliConfig, recordStartupHeartbeat, t3Cli, type CliConfigShape } from "./main";
 import { ServerConfig, type ServerConfigShape } from "./config";
 import { Open, type OpenShape } from "./open";
+import { SkillsManager, type SkillsManagerShape } from "./skills/SkillsManager";
+import { McpManager, type McpManagerShape } from "./mcp/McpManager";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
 import { Server, type ServerShape } from "./wsServer";
@@ -51,6 +53,22 @@ const testLayer = Layer.mergeAll(
     openBrowser: (_target: string) => Effect.void,
     openInEditor: () => Effect.void,
   } satisfies OpenShape),
+  Layer.succeed(SkillsManager, {
+    list: Effect.succeed({ skills: [] }),
+    toggle: () => Effect.succeed({ skillName: "", enabled: false }),
+    search: () => Effect.succeed({ skills: [] }),
+    install: () => Effect.succeed({ success: true, message: "" }),
+    uninstall: () => Effect.succeed({ success: true, message: "" }),
+    readContent: () => Effect.succeed({ skillName: "", content: "" }),
+  } satisfies SkillsManagerShape),
+  Layer.succeed(McpManager, {
+    list: Effect.succeed({ servers: [] }),
+    add: () => Effect.succeed({ success: true, message: "" }),
+    remove: () => Effect.succeed({ success: true, message: "" }),
+    toggle: () => Effect.succeed({ name: "", enabled: false }),
+    update: () => Effect.succeed({ success: true, message: "" }),
+    browse: Effect.succeed({ servers: [] }),
+  } satisfies McpManagerShape),
   AnalyticsService.layerTest,
   FetchHttpClient.layer,
   NodeServices.layer,
@@ -84,36 +102,39 @@ beforeEach(() => {
 });
 
 it.layer(testLayer)("server CLI command", (it) => {
-  it.effect("parses all CLI flags and wires scoped start/stop", () =>
-    Effect.gen(function* () {
-      yield* runCli([
-        "--mode",
-        "desktop",
-        "--port",
-        "4010",
-        "--host",
-        "0.0.0.0",
-        "--state-dir",
-        "/tmp/t3-cli-state",
-        "--dev-url",
-        "http://127.0.0.1:5173",
-        "--no-browser",
-        "--auth-token",
-        "auth-secret",
-      ]);
+  it.effect(
+    "parses all CLI flags and wires scoped start/stop",
+    () =>
+      Effect.gen(function* () {
+        yield* runCli([
+          "--mode",
+          "desktop",
+          "--port",
+          "4010",
+          "--host",
+          "0.0.0.0",
+          "--state-dir",
+          "/tmp/t3-cli-state",
+          "--dev-url",
+          "http://127.0.0.1:5173",
+          "--no-browser",
+          "--auth-token",
+          "auth-secret",
+        ]);
 
-      assert.equal(start.mock.calls.length, 1);
-      assert.equal(resolvedConfig?.mode, "desktop");
-      assert.equal(resolvedConfig?.port, 4010);
-      assert.equal(resolvedConfig?.host, "0.0.0.0");
-      assert.equal(resolvedConfig?.stateDir, "/tmp/t3-cli-state");
-      assert.equal(resolvedConfig?.devUrl?.toString(), "http://127.0.0.1:5173/");
-      assert.equal(resolvedConfig?.noBrowser, true);
-      assert.equal(resolvedConfig?.authToken, "auth-secret");
-      assert.equal(resolvedConfig?.autoBootstrapProjectFromCwd, false);
-      assert.equal(resolvedConfig?.logWebSocketEvents, true);
-      assert.equal(stop.mock.calls.length, 1);
-    }),
+        assert.equal(start.mock.calls.length, 1);
+        assert.equal(resolvedConfig?.mode, "desktop");
+        assert.equal(resolvedConfig?.port, 4010);
+        assert.equal(resolvedConfig?.host, "0.0.0.0");
+        assert.equal(resolvedConfig?.stateDir, "/tmp/t3-cli-state");
+        assert.equal(resolvedConfig?.devUrl?.toString(), "http://127.0.0.1:5173/");
+        assert.equal(resolvedConfig?.noBrowser, true);
+        assert.equal(resolvedConfig?.authToken, "auth-secret");
+        assert.equal(resolvedConfig?.autoBootstrapProjectFromCwd, false);
+        assert.equal(resolvedConfig?.logWebSocketEvents, true);
+        assert.equal(stop.mock.calls.length, 1);
+      }),
+    15_000,
   );
 
   it.effect("supports --token as an alias for --auth-token", () =>

--- a/apps/server/src/mcp/McpManager.ts
+++ b/apps/server/src/mcp/McpManager.ts
@@ -1,0 +1,651 @@
+/**
+ * McpManager - Service for listing, adding, removing, toggling, and browsing
+ * MCP (Model Context Protocol) servers.
+ *
+ * Reads/writes from native CLI config files:
+ *  - Codex:  ~/.codex/config.toml   ([mcp_servers.*] sections)
+ *  - Copilot: ~/.copilot/mcp-config.json  (mcpServers object)
+ *
+ * Disabled servers are tracked in ~/.t3/mcp-disabled.json so they can be
+ * re-enabled without data loss.
+ */
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
+
+import type {
+  McpServerConfig,
+  McpListResult,
+  McpAddInput,
+  McpAddResult,
+  McpRemoveInput,
+  McpRemoveResult,
+  McpToggleInput,
+  McpToggleResult,
+  McpUpdateInput,
+  McpUpdateResult,
+  McpBrowseResult,
+  McpCatalogEntry,
+} from "@t3tools/contracts";
+import { Effect, Layer, Schema, ServiceMap } from "effect";
+
+// ── Error ────────────────────────────────────────────────────────────
+
+export class McpError extends Schema.TaggedErrorClass<McpError>()("McpError", {
+  message: Schema.String,
+  cause: Schema.optional(Schema.Defect),
+}) {}
+
+// ── Service Interface ────────────────────────────────────────────────
+
+export interface McpManagerShape {
+  readonly list: Effect.Effect<McpListResult, McpError>;
+  readonly add: (input: McpAddInput) => Effect.Effect<McpAddResult, McpError>;
+  readonly remove: (input: McpRemoveInput) => Effect.Effect<McpRemoveResult, McpError>;
+  readonly toggle: (input: McpToggleInput) => Effect.Effect<McpToggleResult, McpError>;
+  readonly update: (input: McpUpdateInput) => Effect.Effect<McpUpdateResult, McpError>;
+  readonly browse: Effect.Effect<McpBrowseResult, McpError>;
+}
+
+export class McpManager extends ServiceMap.Service<McpManager, McpManagerShape>()(
+  "t3/mcp/McpManager",
+) {}
+
+// ── Paths ────────────────────────────────────────────────────────────
+
+const home = os.homedir();
+const CODEX_CONFIG_PATH = path.join(home, ".codex", "config.toml");
+const COPILOT_MCP_PATH = path.join(home, ".copilot", "mcp-config.json");
+const DISABLED_CACHE_PATH = path.join(home, ".t3", "mcp-disabled.json");
+const VALID_SERVER_NAME = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+function assertValidServerName(name: string): void {
+  if (!VALID_SERVER_NAME.test(name)) {
+    throw new Error(`Invalid MCP server name: ${name}`);
+  }
+}
+
+/** Validate that an add/update input has a valid transport configuration. */
+function assertValidTransport(input: {
+  command?: string | undefined;
+  url?: string | undefined;
+  bearerToken?: string | undefined;
+  provider: "codex" | "copilot";
+}): void {
+  if (!input.command && !input.url) {
+    throw new Error("Either command (stdio) or url (http) must be provided");
+  }
+  if (input.command && input.url) {
+    throw new Error("Cannot specify both command and url — pick stdio or http transport");
+  }
+  if (input.bearerToken && input.provider !== "codex") {
+    throw new Error("bearerToken is only supported for Codex provider");
+  }
+}
+
+// ── Per-file mutex to serialize config read-modify-write ─────────────
+
+class Mutex {
+  private queue: (() => void)[] = [];
+  private locked = false;
+
+  async acquire(): Promise<() => void> {
+    if (!this.locked) {
+      this.locked = true;
+      return () => this.release();
+    }
+    return new Promise<() => void>((resolve) => {
+      this.queue.push(() => resolve(() => this.release()));
+    });
+  }
+
+  private release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    } else {
+      this.locked = false;
+    }
+  }
+}
+
+const codexMutex = new Mutex();
+const copilotMutex = new Mutex();
+const disabledMutex = new Mutex();
+
+/** Run fn while holding the mutexes for the given provider + disabled cache. */
+async function withConfigLock<T>(provider: "codex" | "copilot", fn: () => Promise<T>): Promise<T> {
+  const configRelease = await (provider === "codex" ? codexMutex : copilotMutex).acquire();
+  const disabledRelease = await disabledMutex.acquire();
+  try {
+    return await fn();
+  } finally {
+    disabledRelease();
+    configRelease();
+  }
+}
+
+// ── Disabled cache (preserves configs of disabled servers) ───────────
+
+interface DisabledEntry {
+  provider: "codex" | "copilot";
+  config: Record<string, unknown>;
+}
+
+type DisabledCache = Record<string, DisabledEntry>;
+
+async function readDisabledCache(): Promise<DisabledCache> {
+  try {
+    const raw = await fsp.readFile(DISABLED_CACHE_PATH, "utf-8");
+    return JSON.parse(raw) as DisabledCache;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+async function writeDisabledCache(cache: DisabledCache): Promise<void> {
+  await fsp.mkdir(path.dirname(DISABLED_CACHE_PATH), { recursive: true });
+  await fsp.writeFile(DISABLED_CACHE_PATH, JSON.stringify(cache, null, 2) + "\n", "utf-8");
+}
+
+// ── Codex config (TOML) ─────────────────────────────────────────────
+
+interface CodexTomlConfig {
+  [key: string]: unknown;
+  mcp_servers?: Record<string, Record<string, unknown>>;
+}
+
+async function readCodexConfig(): Promise<CodexTomlConfig> {
+  try {
+    const raw = await fsp.readFile(CODEX_CONFIG_PATH, "utf-8");
+    return parseToml(raw) as CodexTomlConfig;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+async function writeCodexConfig(config: CodexTomlConfig): Promise<void> {
+  await fsp.mkdir(path.dirname(CODEX_CONFIG_PATH), { recursive: true });
+  await fsp.writeFile(CODEX_CONFIG_PATH, stringifyToml(config) + "\n", "utf-8");
+}
+
+function codexEntryToMcpServer(
+  name: string,
+  entry: Record<string, unknown>,
+  enabled: boolean,
+): McpServerConfig {
+  const headers =
+    entry.headers != null && typeof entry.headers === "object" && !Array.isArray(entry.headers)
+      ? (entry.headers as Record<string, string>)
+      : undefined;
+  return {
+    name,
+    provider: "codex",
+    enabled,
+    ...(typeof entry.type === "string" ? { type: entry.type } : {}),
+    ...(typeof entry.command === "string" ? { command: entry.command } : {}),
+    ...(Array.isArray(entry.args) ? { args: entry.args as string[] } : {}),
+    ...(typeof entry.url === "string" ? { url: entry.url } : {}),
+    ...(headers ? { headers } : {}),
+    ...(typeof entry.bearer_token_env_var === "string"
+      ? { bearerToken: entry.bearer_token_env_var }
+      : {}),
+    ...(Array.isArray(entry.tools) ? { tools: entry.tools as string[] } : {}),
+  };
+}
+
+// ── Copilot config (JSON) ────────────────────────────────────────────
+
+interface CopilotMcpConfig {
+  mcpServers?: Record<string, Record<string, unknown>>;
+}
+
+async function readCopilotConfig(): Promise<CopilotMcpConfig> {
+  try {
+    const raw = await fsp.readFile(COPILOT_MCP_PATH, "utf-8");
+    return JSON.parse(raw) as CopilotMcpConfig;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+async function writeCopilotConfig(config: CopilotMcpConfig): Promise<void> {
+  await fsp.mkdir(path.dirname(COPILOT_MCP_PATH), { recursive: true });
+  await fsp.writeFile(COPILOT_MCP_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
+}
+
+function copilotEntryToMcpServer(
+  name: string,
+  entry: Record<string, unknown>,
+  enabled: boolean,
+): McpServerConfig {
+  const headers =
+    entry.headers != null && typeof entry.headers === "object" && !Array.isArray(entry.headers)
+      ? (entry.headers as Record<string, string>)
+      : undefined;
+  return {
+    name,
+    provider: "copilot",
+    enabled,
+    ...(typeof entry.type === "string" ? { type: entry.type } : {}),
+    ...(typeof entry.command === "string" ? { command: entry.command } : {}),
+    ...(Array.isArray(entry.args) ? { args: entry.args as string[] } : {}),
+    ...(typeof entry.url === "string" ? { url: entry.url } : {}),
+    ...(headers ? { headers } : {}),
+    ...(Array.isArray(entry.tools) ? { tools: entry.tools as string[] } : {}),
+  };
+}
+
+// ── Curated MCP Catalog ──────────────────────────────────────────────
+
+const MCP_CATALOG: McpCatalogEntry[] = [
+  {
+    name: "context7",
+    description: "Up-to-date documentation and code examples for any library",
+    mcpUrl: "https://mcp.context7.com/mcp",
+    infoUrl: "https://context7.com",
+  },
+  {
+    name: "playwright",
+    description: "Browser automation, testing, and scraping with Playwright",
+    command: "npx",
+    args: ["@playwright/mcp@latest"],
+    infoUrl: "https://github.com/microsoft/playwright-mcp",
+  },
+  {
+    name: "filesystem",
+    description: "Read, write, and manage files and directories",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-filesystem"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+    installPrompts: [
+      {
+        id: "path",
+        label: "Allowed Directory",
+        placeholder: "/Users/you/Documents",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "github",
+    description: "Interact with GitHub repos, issues, and pull requests",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-github"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/github",
+    installPrompts: [
+      {
+        id: "token",
+        label: "GitHub Personal Access Token",
+        placeholder: "ghp_xxxxxxxxxxxx",
+        required: false,
+      },
+    ],
+  },
+  {
+    name: "postgres",
+    description: "Query and manage PostgreSQL databases",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-postgres"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres",
+    installPrompts: [
+      {
+        id: "connectionString",
+        label: "Connection String",
+        placeholder: "postgresql://user:pass@localhost:5432/mydb",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "sqlite",
+    description: "Query and manage SQLite databases",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-sqlite"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite",
+    installPrompts: [
+      {
+        id: "dbPath",
+        label: "Database Path",
+        placeholder: "/path/to/database.sqlite",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "brave-search",
+    description: "Search the web using Brave Search API",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-brave-search"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search",
+    installPrompts: [
+      {
+        id: "apiKey",
+        label: "Brave API Key",
+        placeholder: "BSA_xxxxxxxxxxxxxxxx",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "memory",
+    description: "Persistent memory using a local knowledge graph",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-memory"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+  },
+  {
+    name: "fetch",
+    description: "Fetch and convert web content to markdown",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-fetch"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
+  },
+  {
+    name: "puppeteer",
+    description: "Automate browser interactions and take screenshots",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-puppeteer"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer",
+  },
+  {
+    name: "slack",
+    description: "Interact with Slack workspaces and channels",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-slack"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/slack",
+    installPrompts: [
+      {
+        id: "botToken",
+        label: "Slack Bot Token",
+        placeholder: "xoxb-xxxxxxxxxxxx",
+        required: true,
+      },
+      {
+        id: "teamId",
+        label: "Slack Team ID",
+        placeholder: "T0123456789",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "sequential-thinking",
+    description: "Dynamic problem-solving through structured thought sequences",
+    command: "npx",
+    args: ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+    infoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
+  },
+];
+
+// ── Implementation ───────────────────────────────────────────────────
+
+function listServers(): Effect.Effect<McpListResult, McpError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const [codexConfig, copilotConfig, disabled] = await Promise.all([
+        readCodexConfig(),
+        readCopilotConfig(),
+        readDisabledCache(),
+      ]);
+
+      const servers: McpServerConfig[] = [];
+
+      // Codex servers (from config.toml)
+      if (codexConfig.mcp_servers) {
+        for (const [name, entry] of Object.entries(codexConfig.mcp_servers)) {
+          servers.push(codexEntryToMcpServer(name, entry, true));
+        }
+      }
+
+      // Copilot servers (from mcp-config.json)
+      if (copilotConfig.mcpServers) {
+        for (const [name, entry] of Object.entries(copilotConfig.mcpServers)) {
+          servers.push(copilotEntryToMcpServer(name, entry, true));
+        }
+      }
+
+      // Disabled servers (from cache — keys are "provider:name")
+      for (const [cacheKey, entry] of Object.entries(disabled)) {
+        const name = cacheKey.slice(entry.provider.length + 1);
+        const alreadyListed = servers.some((s) => s.name === name && s.provider === entry.provider);
+        if (!alreadyListed) {
+          if (entry.provider === "codex") {
+            servers.push(codexEntryToMcpServer(name, entry.config, false));
+          } else {
+            servers.push(copilotEntryToMcpServer(name, entry.config, false));
+          }
+        }
+      }
+
+      servers.sort((a, b) => a.name.localeCompare(b.name));
+      return { servers } satisfies McpListResult;
+    },
+    catch: (cause) => new McpError({ message: "Failed to list MCP servers", cause }),
+  });
+}
+
+function addServer(input: McpAddInput): Effect.Effect<McpAddResult, McpError> {
+  return Effect.tryPromise({
+    try: () =>
+      withConfigLock(input.provider, async () => {
+        assertValidServerName(input.name);
+        assertValidTransport(input);
+        if (input.provider === "codex") {
+          const config = await readCodexConfig();
+          if (!config.mcp_servers) config.mcp_servers = {};
+
+          if (config.mcp_servers[input.name]) {
+            return { success: false, message: `"${input.name}" already exists in Codex config` };
+          }
+
+          const entry: Record<string, unknown> = {};
+          if (input.command) entry.command = input.command;
+          if (input.args?.length) entry.args = [...input.args];
+          if (input.url) entry.url = input.url;
+          if (input.headers && Object.keys(input.headers).length > 0) {
+            entry.headers = { ...input.headers };
+          }
+          if (input.bearerToken) entry.bearer_token_env_var = input.bearerToken;
+          config.mcp_servers[input.name] = entry;
+          await writeCodexConfig(config);
+        } else {
+          const config = await readCopilotConfig();
+          if (!config.mcpServers) config.mcpServers = {};
+
+          if (config.mcpServers[input.name]) {
+            return { success: false, message: `"${input.name}" already exists in Copilot config` };
+          }
+
+          const entry: Record<string, unknown> = {};
+          if (input.command) {
+            entry.type = "stdio";
+            entry.command = input.command;
+          }
+          if (input.args?.length) entry.args = [...input.args];
+          if (input.url) {
+            if (!input.command) entry.type = "http";
+            entry.url = input.url;
+          }
+          if (input.headers && Object.keys(input.headers).length > 0) {
+            entry.headers = { ...input.headers };
+          }
+          config.mcpServers[input.name] = entry;
+          await writeCopilotConfig(config);
+        }
+
+        return { success: true, message: `Added "${input.name}" to ${input.provider}` };
+      }),
+    catch: (cause) => new McpError({ message: `Failed to add MCP server: ${input.name}`, cause }),
+  });
+}
+
+function removeServer(input: McpRemoveInput): Effect.Effect<McpRemoveResult, McpError> {
+  return Effect.tryPromise({
+    try: () =>
+      withConfigLock(input.provider, async () => {
+        if (input.provider === "codex") {
+          const config = await readCodexConfig();
+          if (!config.mcp_servers?.[input.name]) {
+            return { success: false, message: `"${input.name}" not found in Codex config` };
+          }
+          delete config.mcp_servers[input.name];
+          await writeCodexConfig(config);
+        } else {
+          const config = await readCopilotConfig();
+          if (!config.mcpServers?.[input.name]) {
+            return { success: false, message: `"${input.name}" not found in Copilot config` };
+          }
+          delete config.mcpServers[input.name];
+          await writeCopilotConfig(config);
+        }
+
+        // Also remove from disabled cache if present
+        const disabled = await readDisabledCache();
+        const key = `${input.provider}:${input.name}`;
+        if (disabled[key]) {
+          delete disabled[key];
+          await writeDisabledCache(disabled);
+        }
+
+        return { success: true, message: `Removed "${input.name}" from ${input.provider}` };
+      }),
+    catch: (cause) =>
+      new McpError({ message: `Failed to remove MCP server: ${input.name}`, cause }),
+  });
+}
+
+function toggleServer(input: McpToggleInput): Effect.Effect<McpToggleResult, McpError> {
+  return Effect.tryPromise({
+    try: () =>
+      withConfigLock(input.provider, async () => {
+        const cacheKey = `${input.provider}:${input.name}`;
+
+        if (!input.enabled) {
+          // Disable: move from native config to disabled cache
+          let config: Record<string, unknown> | undefined;
+
+          if (input.provider === "codex") {
+            const codexConfig = await readCodexConfig();
+            config = codexConfig.mcp_servers?.[input.name];
+            if (!config) {
+              throw new Error(`"${input.name}" not found in Codex config`);
+            }
+            delete codexConfig.mcp_servers![input.name];
+            await writeCodexConfig(codexConfig);
+          } else {
+            const copilotConfig = await readCopilotConfig();
+            config = copilotConfig.mcpServers?.[input.name];
+            if (!config) {
+              throw new Error(`"${input.name}" not found in Copilot config`);
+            }
+            delete copilotConfig.mcpServers![input.name];
+            await writeCopilotConfig(copilotConfig);
+          }
+
+          const disabled = await readDisabledCache();
+          disabled[cacheKey] = { provider: input.provider, config };
+          await writeDisabledCache(disabled);
+        } else {
+          // Enable: move from disabled cache back to native config
+          const disabled = await readDisabledCache();
+          const entry = disabled[cacheKey];
+
+          if (!entry) {
+            throw new Error(`"${input.name}" not found in disabled cache`);
+          }
+
+          if (input.provider === "codex") {
+            const codexConfig = await readCodexConfig();
+            if (!codexConfig.mcp_servers) codexConfig.mcp_servers = {};
+            codexConfig.mcp_servers[input.name] = entry.config;
+            await writeCodexConfig(codexConfig);
+          } else {
+            const copilotConfig = await readCopilotConfig();
+            if (!copilotConfig.mcpServers) copilotConfig.mcpServers = {};
+            copilotConfig.mcpServers[input.name] = entry.config;
+            await writeCopilotConfig(copilotConfig);
+          }
+          delete disabled[cacheKey];
+          await writeDisabledCache(disabled);
+        }
+
+        return { name: input.name, enabled: input.enabled } satisfies McpToggleResult;
+      }),
+    catch: (cause) =>
+      new McpError({ message: `Failed to toggle MCP server: ${input.name}`, cause }),
+  });
+}
+
+function browseCatalog(): Effect.Effect<McpBrowseResult, McpError> {
+  return Effect.succeed({ servers: MCP_CATALOG } satisfies McpBrowseResult);
+}
+
+function updateServer(input: McpUpdateInput): Effect.Effect<McpUpdateResult, McpError> {
+  return Effect.tryPromise({
+    try: () =>
+      withConfigLock(input.provider, async () => {
+        if (input.provider === "codex") {
+          const config = await readCodexConfig();
+          const entry = config.mcp_servers?.[input.name];
+          if (!entry) {
+            return { success: false, message: `"${input.name}" not found in Codex config` };
+          }
+          if (input.command !== undefined) entry.command = input.command;
+          if (input.args !== undefined) entry.args = [...input.args];
+          if (input.url !== undefined) entry.url = input.url;
+          if (input.headers !== undefined) entry.headers = { ...input.headers };
+          if (input.bearerToken !== undefined) entry.bearer_token_env_var = input.bearerToken;
+          // Validate resulting transport state
+          assertValidTransport({
+            command: typeof entry.command === "string" ? entry.command : undefined,
+            url: typeof entry.url === "string" ? entry.url : undefined,
+            bearerToken:
+              typeof entry.bearer_token_env_var === "string"
+                ? entry.bearer_token_env_var
+                : undefined,
+            provider: input.provider,
+          });
+          await writeCodexConfig(config);
+        } else {
+          const config = await readCopilotConfig();
+          const entry = config.mcpServers?.[input.name];
+          if (!entry) {
+            return { success: false, message: `"${input.name}" not found in Copilot config` };
+          }
+          if (input.command !== undefined) entry.command = input.command;
+          if (input.args !== undefined) entry.args = [...input.args];
+          if (input.url !== undefined) entry.url = input.url;
+          if (input.headers !== undefined) entry.headers = { ...input.headers };
+          // Sync type field with current transport
+          entry.type = entry.command ? "stdio" : "http";
+          // Validate resulting transport state
+          assertValidTransport({
+            command: typeof entry.command === "string" ? entry.command : undefined,
+            url: typeof entry.url === "string" ? entry.url : undefined,
+            provider: input.provider,
+          });
+          await writeCopilotConfig(config);
+        }
+
+        return { success: true, message: `Updated "${input.name}" in ${input.provider}` };
+      }),
+    catch: (cause) =>
+      new McpError({ message: `Failed to update MCP server: ${input.name}`, cause }),
+  });
+}
+
+// ── Live Layer ───────────────────────────────────────────────────────
+
+export const McpManagerLive = Layer.succeed(McpManager, {
+  list: listServers(),
+  add: addServer,
+  remove: removeServer,
+  toggle: toggleServer,
+  update: updateServer,
+  browse: browseCatalog(),
+});

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -5,7 +5,7 @@ import {
   EventId,
   type OrchestrationEvent,
   type ProviderModelOptions,
-  type ProviderKind,
+  ProviderKind,
   type ProviderStartOptions,
   type OrchestrationSession,
   ThreadId,
@@ -206,8 +206,10 @@ const make = Effect.gen(function* () {
     }
 
     const desiredRuntimeMode = thread.runtimeMode;
-    const currentProvider: ProviderKind | undefined =
-      thread.session?.providerName === "codex" ? thread.session.providerName : undefined;
+    const currentProvider =
+      thread.session?.providerName && Schema.is(ProviderKind)(thread.session.providerName)
+        ? thread.session.providerName
+        : undefined;
     const preferredProvider: ProviderKind | undefined = options?.provider ?? currentProvider;
     const desiredModel = options?.model ?? thread.model;
     const effectiveCwd = resolveThreadWorkspaceCwd({

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -49,7 +49,7 @@ const asTurnId = (value: string): TurnId => TurnId.makeUnsafe(value);
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
   readonly eventId: EventId;
-  readonly provider: "codex";
+  readonly provider: "codex" | "copilot";
   readonly createdAt: string;
   readonly threadId: ThreadId;
   readonly turnId?: string | undefined;
@@ -1373,6 +1373,98 @@ describe("ProviderRuntimeIngestion", () => {
     expect(finalMessage?.streaming).toBe(false);
   });
 
+  it("completes streaming assistant messages even when read model lookup lags completion", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-streaming-lag"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("message-streaming-lag"),
+          role: "user",
+          text: "stream with lag",
+          attachments: [],
+        },
+        assistantDeliveryMode: "streaming",
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await Effect.runPromise(Effect.sleep("30 millis"));
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-streaming-lag"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-streaming-lag"),
+    });
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" &&
+        thread.session?.activeTurnId === "turn-streaming-lag",
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-streaming-lag"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-streaming-lag"),
+      itemId: asItemId("item-streaming-lag"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "hello lagged",
+      },
+    });
+
+    const liveThread = await waitForThread(harness.engine, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-lag" &&
+          message.streaming &&
+          message.text === "hello lagged",
+      ),
+    );
+    const liveMessage = liveThread.messages.find(
+      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-streaming-lag",
+    );
+    expect(liveMessage?.streaming).toBe(true);
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-streaming-lag"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-streaming-lag"),
+      itemId: asItemId("item-streaming-lag"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    const finalThread = await waitForThread(harness.engine, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === "assistant:item-streaming-lag" && !message.streaming,
+      ),
+    );
+    const finalMessage = finalThread.messages.find(
+      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-streaming-lag",
+    );
+    expect(finalMessage?.text).toBe("hello lagged");
+    expect(finalMessage?.streaming).toBe(false);
+  });
+
   it("spills oversized buffered deltas and still finalizes full assistant text", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
@@ -1707,6 +1799,66 @@ describe("ProviderRuntimeIngestion", () => {
         (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.started",
       ),
     ).toBe(true);
+  });
+
+  it("preserves completed tool metadata for orchestration activity rendering", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-tool-completed-rendering"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-tool-rendering"),
+      itemId: asItemId("item-tool-rendering"),
+      payload: {
+        itemType: "command_execution",
+        status: "completed",
+        title: "bash",
+        detail: "npm run dev <exited with exit code 0>",
+        data: {
+          item: {
+            command: ["npm", "run", "dev"],
+            result: {
+              content: "npm run dev <exited with exit code 0>",
+              exitCode: 0,
+            },
+          },
+        },
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-tool-completed-rendering",
+      ),
+    );
+
+    const activity = thread.activities.find(
+      (entry: ProviderRuntimeTestActivity) => entry.id === "evt-tool-completed-rendering",
+    );
+    const payload =
+      activity?.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : undefined;
+
+    expect(activity?.kind).toBe("tool.completed");
+    expect(activity?.summary).toBe("bash");
+    expect(payload?.itemType).toBe("command_execution");
+    expect(payload?.title).toBe("bash");
+    expect(payload?.status).toBe("completed");
+    expect(payload?.detail).toBe("npm run dev <exited with exit code 0>");
+    expect(payload?.data).toEqual({
+      item: {
+        command: ["npm", "run", "dev"],
+        result: {
+          content: "npm run dev <exited with exit code 0>",
+          exitCode: 0,
+        },
+      },
+    });
   });
 
   it("consumes P1 runtime events into thread metadata, diff checkpoints, and activities", async () => {
@@ -2056,5 +2208,136 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(thread.session?.status).toBe("error");
     expect(thread.session?.lastError).toBe("runtime still processed");
+  });
+
+  it("maps turn.aborted event into interrupted session status and clears activeTurnId", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    // Start a turn so the session goes to running with an activeTurnId.
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-abort"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-abort-1"),
+    });
+
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" && thread.session?.activeTurnId === "turn-abort-1",
+    );
+
+    // Emit turn.aborted (as the CopilotAdapter does after session.abort()).
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId: asTurnId("turn-abort-1"),
+      payload: {
+        reason: "user requested abort",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) => entry.session?.status === "interrupted" && entry.session?.activeTurnId === null,
+    );
+    expect(thread.session?.status).toBe("interrupted");
+    expect(thread.session?.activeTurnId).toBeNull();
+    expect(thread.session?.lastError).toBeNull();
+  });
+
+  it("accepts a new turn after turn.aborted transitions session back to running", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    // Start and abort a turn.
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-pre-abort"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-pre-abort"),
+    });
+
+    await waitForThread(harness.engine, (thread) => thread.session?.status === "running");
+
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted-2"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId: asTurnId("turn-pre-abort"),
+      payload: {
+        reason: "user abort",
+      },
+    });
+
+    await waitForThread(harness.engine, (entry) => entry.session?.status === "interrupted");
+
+    // Send a new turn — the session should accept it and go back to running.
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-after-abort"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId: asTurnId("turn-after-abort"),
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.session?.status === "running" && entry.session?.activeTurnId === "turn-after-abort",
+    );
+    expect(thread.session?.status).toBe("running");
+    expect(thread.session?.activeTurnId).toBe("turn-after-abort");
+  });
+
+  it("ignores a late turn.aborted for a different turn than the active one", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    // Start turn-2 so it becomes the active turn.
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-active"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-2"),
+    });
+
+    await waitForThread(
+      harness.engine,
+      (thread) => thread.session?.status === "running" && thread.session?.activeTurnId === "turn-2",
+    );
+
+    // A late abort arrives for a stale turn (turn-1) — should be ignored.
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted-stale"),
+      provider: "copilot",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      turnId: asTurnId("turn-1"),
+      payload: { reason: "late abort" },
+    });
+
+    // Allow event processing to settle, then verify state is unchanged.
+    await harness.drain();
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) => entry.session?.status === "running" && entry.session?.activeTurnId === "turn-2",
+    );
+    expect(thread.session?.status).toBe("running");
+    expect(thread.session?.activeTurnId).toBe("turn-2");
   });
 });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -2,6 +2,7 @@ import {
   ApprovalRequestId,
   type AssistantDeliveryMode,
   CommandId,
+  type ItemLifecyclePayload,
   MessageId,
   type OrchestrationEvent,
   type OrchestrationProposedPlanId,
@@ -80,6 +81,16 @@ function normalizeProposedPlanMarkdown(planMarkdown: string | undefined): string
     return undefined;
   }
   return trimmed;
+}
+
+function toolLifecycleActivityPayload(payload: ItemLifecyclePayload) {
+  return {
+    itemType: payload.itemType,
+    ...(payload.title ? { title: payload.title } : {}),
+    ...(payload.status ? { status: payload.status } : {}),
+    ...(payload.detail ? { detail: truncateDetail(payload.detail) } : {}),
+    ...(payload.data !== undefined ? { data: payload.data } : {}),
+  };
 }
 
 function proposedPlanIdForTurn(threadId: ThreadId, turnId: TurnId): string {
@@ -419,12 +430,7 @@ function runtimeEventToActivities(
           tone: "tool",
           kind: "tool.updated",
           summary: event.payload.title ?? "Tool updated",
-          payload: {
-            itemType: event.payload.itemType,
-            ...(event.payload.status ? { status: event.payload.status } : {}),
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
-            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
-          },
+          payload: toolLifecycleActivityPayload(event.payload),
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
         },
@@ -442,10 +448,7 @@ function runtimeEventToActivities(
           tone: "tool",
           kind: "tool.completed",
           summary: event.payload.title ?? "Tool",
-          payload: {
-            itemType: event.payload.itemType,
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
-          },
+          payload: toolLifecycleActivityPayload(event.payload),
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
         },
@@ -463,10 +466,7 @@ function runtimeEventToActivities(
           tone: "tool",
           kind: "tool.started",
           summary: `${event.payload.title ?? "Tool"} started`,
-          payload: {
-            itemType: event.payload.itemType,
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
-          },
+          payload: toolLifecycleActivityPayload(event.payload),
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
         },
@@ -499,6 +499,12 @@ const make = Effect.gen(function* () {
     capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
     timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
     lookup: () => Effect.succeed(""),
+  });
+
+  const assistantMessageSawDeltaByMessageId = yield* Cache.make<MessageId, boolean>({
+    capacity: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.succeed(false),
   });
 
   const bufferedProposedPlanById = yield* Cache.make<string, { text: string; createdAt: string }>({
@@ -600,6 +606,18 @@ const make = Effect.gen(function* () {
   const clearBufferedAssistantText = (messageId: MessageId) =>
     Cache.invalidate(bufferedAssistantTextByMessageId, messageId);
 
+  const markAssistantMessageSawDelta = (messageId: MessageId) =>
+    Cache.set(assistantMessageSawDeltaByMessageId, messageId, true);
+
+  const takeAssistantMessageSawDelta = (messageId: MessageId) =>
+    Cache.getOption(assistantMessageSawDeltaByMessageId, messageId).pipe(
+      Effect.flatMap((existing) =>
+        Cache.invalidate(assistantMessageSawDeltaByMessageId, messageId).pipe(
+          Effect.as(Option.getOrElse(existing, () => false)),
+        ),
+      ),
+    );
+
   const appendBufferedProposedPlan = (planId: string, delta: string, createdAt: string) =>
     Cache.getOption(bufferedProposedPlanById, planId).pipe(
       Effect.flatMap((existingEntry) => {
@@ -625,7 +643,10 @@ const make = Effect.gen(function* () {
     Cache.invalidate(bufferedProposedPlanById, planId);
 
   const clearAssistantMessageState = (messageId: MessageId) =>
-    clearBufferedAssistantText(messageId);
+    Effect.all([
+      clearBufferedAssistantText(messageId),
+      Cache.invalidate(assistantMessageSawDeltaByMessageId, messageId),
+    ]).pipe(Effect.asVoid);
 
   const finalizeAssistantMessage = (input: {
     event: ProviderRuntimeEvent;
@@ -636,15 +657,31 @@ const make = Effect.gen(function* () {
     commandTag: string;
     finalDeltaCommandTag: string;
     fallbackText?: string;
+    existingMessage?: {
+      readonly id: MessageId;
+      readonly text: string;
+      readonly streaming: boolean;
+    };
   }) =>
     Effect.gen(function* () {
+      if (input.existingMessage && !input.existingMessage.streaming) {
+        yield* clearAssistantMessageState(input.messageId);
+        return;
+      }
+
       const bufferedText = yield* takeBufferedAssistantText(input.messageId);
+      const sawDelta = yield* takeAssistantMessageSawDelta(input.messageId);
       const text =
         bufferedText.length > 0
           ? bufferedText
-          : (input.fallbackText?.trim().length ?? 0) > 0
+          : !sawDelta && (input.fallbackText?.trim().length ?? 0) > 0
             ? input.fallbackText!
             : "";
+
+      if (text.length === 0 && !sawDelta && !input.existingMessage) {
+        yield* clearAssistantMessageState(input.messageId);
+        return;
+      }
 
       if (text.length > 0) {
         yield* orchestrationEngine.dispatch({
@@ -864,6 +901,9 @@ const make = Effect.gen(function* () {
       const now = event.createdAt;
       const eventTurnId = toTurnId(event.turnId);
       const activeTurnId = thread.session?.activeTurnId ?? null;
+      const existingAssistantMessageById = new Map(
+        thread.messages.map((message) => [message.id, message] as const),
+      );
 
       const conflictsWithActiveTurn =
         activeTurnId !== null && eventTurnId !== undefined && !sameId(activeTurnId, eventTurnId);
@@ -882,6 +922,7 @@ const make = Effect.gen(function* () {
           case "turn.started":
             return !conflictsWithActiveTurn;
           case "turn.completed":
+          case "turn.aborted":
             if (conflictsWithActiveTurn || missingTurnForActiveTurn) {
               return false;
             }
@@ -906,12 +947,15 @@ const make = Effect.gen(function* () {
         event.type === "session.exited" ||
         event.type === "thread.started" ||
         event.type === "turn.started" ||
-        event.type === "turn.completed"
+        event.type === "turn.completed" ||
+        event.type === "turn.aborted"
       ) {
         const nextActiveTurnId =
           event.type === "turn.started"
             ? (eventTurnId ?? null)
-            : event.type === "turn.completed" || event.type === "session.exited"
+            : event.type === "turn.completed" ||
+                event.type === "turn.aborted" ||
+                event.type === "session.exited"
               ? null
               : activeTurnId;
         const status = (() => {
@@ -924,6 +968,8 @@ const make = Effect.gen(function* () {
               return "stopped";
             case "turn.completed":
               return runtimeTurnState(event) === "failed" ? "error" : "ready";
+            case "turn.aborted":
+              return "interrupted";
             case "session.started":
             case "thread.started":
               // Provider thread/session start notifications can arrive during an
@@ -936,7 +982,7 @@ const make = Effect.gen(function* () {
             ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")
             : event.type === "turn.completed" && runtimeTurnState(event) === "failed"
               ? (runtimeTurnErrorMessage(event) ?? thread.session?.lastError ?? "Turn failed")
-              : status === "ready"
+              : status === "ready" || status === "interrupted"
                 ? null
                 : (thread.session?.lastError ?? null);
 
@@ -994,6 +1040,7 @@ const make = Effect.gen(function* () {
         if (turnId) {
           yield* rememberAssistantMessageId(thread.id, turnId, assistantMessageId);
         }
+        yield* markAssistantMessageSawDelta(assistantMessageId);
 
         const assistantDeliveryMode = yield* Ref.get(assistantDeliveryModeRef);
         if (assistantDeliveryMode === "buffered") {
@@ -1065,6 +1112,9 @@ const make = Effect.gen(function* () {
           createdAt: now,
           commandTag: "assistant-complete",
           finalDeltaCommandTag: "assistant-delta-finalize",
+          ...(existingAssistantMessageById.has(assistantMessageId)
+            ? { existingMessage: existingAssistantMessageById.get(assistantMessageId)! }
+            : {}),
           ...(assistantCompletion.fallbackText !== undefined && shouldApplyFallbackCompletionText
             ? { fallbackText: assistantCompletion.fallbackText }
             : {}),
@@ -1087,7 +1137,10 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (event.type === "turn.completed") {
+      if (
+        (event.type === "turn.completed" || event.type === "turn.aborted") &&
+        shouldApplyThreadLifecycle
+      ) {
         const turnId = toTurnId(event.turnId);
         if (turnId) {
           const assistantMessageIds = yield* getAssistantMessageIdsForTurn(thread.id, turnId);
@@ -1102,6 +1155,9 @@ const make = Effect.gen(function* () {
                 createdAt: now,
                 commandTag: "assistant-complete-finalize",
                 finalDeltaCommandTag: "assistant-delta-finalize-fallback",
+                ...(existingAssistantMessageById.has(assistantMessageId)
+                  ? { existingMessage: existingAssistantMessageById.get(assistantMessageId)! }
+                  : {}),
               }),
             { concurrency: 1 },
           ).pipe(Effect.asVoid);

--- a/apps/server/src/provider/Layers/CopilotAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.test.ts
@@ -1,0 +1,313 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { ThreadId } from "@t3tools/contracts";
+import { type SessionEvent } from "@github/copilot-sdk";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { afterAll, it, vi } from "@effect/vitest";
+
+import { Effect, Fiber, Layer, Stream } from "effect";
+
+import { ServerConfig } from "../../config.ts";
+import { CopilotAdapter } from "../Services/CopilotAdapter.ts";
+import { makeCopilotAdapterLive } from "./CopilotAdapter.ts";
+
+const asThreadId = (value: string): ThreadId => ThreadId.makeUnsafe(value);
+
+class FakeCopilotSession {
+  public readonly sessionId: string;
+
+  public readonly modeSetImpl = vi.fn(
+    async ({ mode }: { mode: "interactive" | "plan" | "autopilot" }) => ({
+      mode,
+    }),
+  );
+
+  public readonly planReadImpl = vi.fn(
+    async (): Promise<{
+      exists: boolean;
+      content: string | null;
+      path: string | null;
+    }> => ({
+      exists: false,
+      content: null,
+      path: null,
+    }),
+  );
+
+  public readonly sendImpl = vi.fn(
+    async (_options: { prompt: string; attachments?: unknown; mode?: string }) => "message-1",
+  );
+
+  public readonly abortImpl = vi.fn(async () => undefined);
+  public readonly destroyImpl = vi.fn(async () => undefined);
+  public readonly getMessagesImpl = vi.fn(async () => [] as SessionEvent[]);
+
+  private readonly handlers = new Set<(event: SessionEvent) => void>();
+
+  public readonly rpc = {
+    mode: {
+      set: this.modeSetImpl,
+    },
+    plan: {
+      read: this.planReadImpl,
+    },
+  };
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  on(handler: (event: SessionEvent) => void) {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  send(options: { prompt: string; attachments?: unknown; mode?: string }) {
+    return this.sendImpl(options);
+  }
+
+  abort() {
+    return this.abortImpl();
+  }
+
+  destroy() {
+    return this.destroyImpl();
+  }
+
+  getMessages() {
+    return this.getMessagesImpl();
+  }
+
+  emit(event: SessionEvent) {
+    for (const handler of this.handlers) {
+      handler(event);
+    }
+  }
+}
+
+class FakeCopilotClient {
+  public readonly startImpl = vi.fn(async () => undefined);
+  public readonly listModelsImpl = vi.fn(async () => []);
+  public readonly createSessionImpl = vi.fn(async (_config: unknown) => this.session);
+  public readonly resumeSessionImpl = vi.fn(
+    async (_sessionId: string, _config: unknown) => this.session,
+  );
+  public readonly stopImpl = vi.fn(async () => [] as Error[]);
+
+  constructor(private readonly session: FakeCopilotSession) {}
+
+  start() {
+    return this.startImpl();
+  }
+
+  listModels() {
+    return this.listModelsImpl();
+  }
+
+  createSession(config: unknown) {
+    return this.createSessionImpl(config);
+  }
+
+  resumeSession(sessionId: string, config: unknown) {
+    return this.resumeSessionImpl(sessionId, config);
+  }
+
+  stop() {
+    return this.stopImpl();
+  }
+}
+
+const modeSession = new FakeCopilotSession("copilot-session-mode");
+const modeClient = new FakeCopilotClient(modeSession);
+const modeLayer = it.layer(
+  makeCopilotAdapterLive({
+    clientFactory: () => modeClient,
+  }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+modeLayer("CopilotAdapterLive interaction mode", (it) => {
+  it.effect("switches the Copilot session mode when interactionMode changes", () =>
+    Effect.gen(function* () {
+      modeSession.modeSetImpl.mockClear();
+      modeSession.sendImpl.mockClear();
+
+      const adapter = yield* CopilotAdapter;
+      const session = yield* adapter.startSession({
+        provider: "copilot",
+        threadId: asThreadId("thread-mode"),
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "Plan the work",
+        interactionMode: "plan",
+        attachments: [],
+      });
+      yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "Now execute it",
+        interactionMode: "default",
+        attachments: [],
+      });
+
+      assert.deepStrictEqual(modeSession.modeSetImpl.mock.calls, [
+        [{ mode: "plan" }],
+        [{ mode: "interactive" }],
+      ]);
+      assert.equal(modeSession.sendImpl.mock.calls[0]?.[0]?.mode, "immediate");
+      assert.equal(modeSession.sendImpl.mock.calls[1]?.[0]?.mode, "immediate");
+    }),
+  );
+});
+
+const planSession = new FakeCopilotSession("copilot-session-plan");
+const planClient = new FakeCopilotClient(planSession);
+const planLayer = it.layer(
+  makeCopilotAdapterLive({
+    clientFactory: () => planClient,
+  }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+planLayer("CopilotAdapterLive proposed plan events", (it) => {
+  it.effect("emits a proposed-plan completion event from Copilot plan updates", () =>
+    Effect.gen(function* () {
+      planSession.modeSetImpl.mockClear();
+      planSession.planReadImpl.mockReset();
+      planSession.planReadImpl.mockResolvedValue({
+        exists: true,
+        content: "# Ship it\n\n- first\n- second",
+        path: "/tmp/copilot-session-plan/plan.md",
+      });
+
+      const adapter = yield* CopilotAdapter;
+      const session = yield* adapter.startSession({
+        provider: "copilot",
+        threadId: asThreadId("thread-plan"),
+        runtimeMode: "full-access",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 4).pipe(Stream.runDrain);
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "Draft a plan",
+        interactionMode: "plan",
+        attachments: [],
+      });
+
+      const eventsFiber = yield* Stream.take(adapter.streamEvents, 2).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      planSession.emit({
+        id: "evt-plan-changed",
+        timestamp: new Date().toISOString(),
+        parentId: null,
+        type: "session.plan_changed",
+        data: {
+          operation: "update",
+        },
+      } satisfies SessionEvent);
+
+      const events = Array.from(yield* Fiber.join(eventsFiber));
+      assert.equal(events[0]?.type, "turn.plan.updated");
+      if (events[0]?.type === "turn.plan.updated") {
+        assert.equal(events[0].turnId, turn.turnId);
+        assert.equal(events[0].payload.explanation, "Plan updated");
+      }
+
+      assert.equal(events[1]?.type, "turn.proposed.completed");
+      if (events[1]?.type === "turn.proposed.completed") {
+        assert.equal(events[1].turnId, turn.turnId);
+        assert.equal(events[1].payload.planMarkdown, "# Ship it\n\n- first\n- second");
+      }
+    }),
+  );
+});
+
+const mcpSession = new FakeCopilotSession("copilot-session-mcp");
+const mcpClient = new FakeCopilotClient(mcpSession);
+const mcpLayer = it.layer(
+  makeCopilotAdapterLive({
+    clientFactory: () => mcpClient,
+  }).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+);
+
+mcpLayer("CopilotAdapterLive MCP config loading", (it) => {
+  it.effect("passes local MCP servers from mcp-config.json to the SDK", () =>
+    Effect.gen(function* () {
+      const configDir = mkdtempSync(path.join(os.tmpdir(), "t3-copilot-mcp-"));
+      try {
+        writeFileSync(
+          path.join(configDir, "mcp-config.json"),
+          JSON.stringify({
+            mcpServers: {
+              "local-badge-repro": {
+                command: "node",
+                args: ["/tmp/t3code-local-mcp-reproduction/dist/index.js"],
+              },
+            },
+          }),
+          "utf8",
+        );
+        mcpClient.createSessionImpl.mockClear();
+
+        const adapter = yield* CopilotAdapter;
+        yield* adapter.startSession({
+          provider: "copilot",
+          threadId: asThreadId("thread-mcp"),
+          runtimeMode: "full-access",
+          providerOptions: {
+            copilot: {
+              configDir,
+            },
+          },
+        });
+
+        const config = mcpClient.createSessionImpl.mock.calls[0]?.[0] as
+          | {
+              configDir?: string;
+              mcpServers?: Record<string, unknown>;
+            }
+          | undefined;
+
+        assert.equal(config?.configDir, configDir);
+        assert.deepStrictEqual(config?.mcpServers, {
+          "local-badge-repro": {
+            type: "local",
+            command: "node",
+            args: ["/tmp/t3code-local-mcp-reproduction/dist/index.js"],
+            tools: ["*"],
+          },
+        });
+      } finally {
+        rmSync(configDir, { recursive: true, force: true });
+      }
+    }),
+  );
+});
+
+afterAll(() => {
+  void modeSession.destroy();
+  void modeClient.stop();
+  void planSession.destroy();
+  void planClient.stop();
+  void mcpSession.destroy();
+  void mcpClient.stop();
+});

--- a/apps/server/src/provider/Layers/CopilotAdapter.ts
+++ b/apps/server/src/provider/Layers/CopilotAdapter.ts
@@ -1,0 +1,1672 @@
+import { randomUUID } from "node:crypto";
+
+import {
+  type CodexReasoningEffort,
+  EventId,
+  type ProviderApprovalDecision,
+  ProviderItemId,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderTurnStartResult,
+  type ProviderUserInputAnswers,
+  RuntimeItemId,
+  RuntimeRequestId,
+  RuntimeTaskId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import {
+  CopilotClient,
+  type CopilotClientOptions,
+  type ModelInfo,
+  type PermissionRequest,
+  type PermissionRequestResult,
+  type SessionEvent,
+} from "@github/copilot-sdk";
+import { Effect, Layer, Queue, Stream } from "effect";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { type EventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import {
+  assistantUsageFields,
+  beginCopilotTurn,
+  clearTurnTracking,
+  completionTurnRefs,
+  isCopilotTurnTerminalEvent,
+  markTurnAwaitingCompletion,
+  recordTurnUsage,
+  type CopilotTurnTrackingState,
+} from "./copilotTurnTracking.ts";
+import { loadCopilotMcpServers } from "./copilotMcpServers.ts";
+import { normalizeCopilotCliPathOverride, resolveBundledCopilotCliPath } from "./copilotCliPath.ts";
+import { CopilotAdapter, type CopilotAdapterShape } from "../Services/CopilotAdapter.ts";
+import type {
+  ProviderThreadSnapshot,
+  ProviderThreadTurnSnapshot,
+} from "../Services/ProviderAdapter.ts";
+
+const PROVIDER = "copilot" as const;
+const USER_INPUT_QUESTION_ID = "answer";
+const USER_INPUT_QUESTION_HEADER = "Question";
+
+export interface CopilotAdapterLiveOptions {
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly clientFactory?: (options: CopilotClientOptions) => CopilotClientHandle;
+}
+
+interface PendingApprovalRequest {
+  readonly requestType:
+    | "command_execution_approval"
+    | "file_change_approval"
+    | "file_read_approval"
+    | "dynamic_tool_call"
+    | "unknown";
+  readonly turnId: TurnId | undefined;
+  readonly resolve: (result: PermissionRequestResult) => void;
+}
+
+interface CopilotUserInputRequest {
+  readonly question: string;
+  readonly choices?: ReadonlyArray<string>;
+  readonly allowFreeform?: boolean;
+}
+
+interface CopilotUserInputResponse {
+  readonly answer: string;
+  readonly wasFreeform: boolean;
+}
+
+interface PendingUserInputRequest {
+  readonly request: CopilotUserInputRequest;
+  readonly turnId: TurnId | undefined;
+  readonly resolve: (result: CopilotUserInputResponse) => void;
+}
+
+interface ActiveCopilotSession extends CopilotTurnTrackingState {
+  readonly client: CopilotClientHandle;
+  session: CopilotSessionHandle;
+  readonly threadId: ThreadId;
+  readonly createdAt: string;
+  readonly runtimeMode: ProviderSession["runtimeMode"];
+  cwd: string | undefined;
+  configDir: string | undefined;
+  model: string | undefined;
+  reasoningEffort: CodexReasoningEffort | undefined;
+  interactionMode: "default" | "plan" | undefined;
+  updatedAt: string;
+  lastError: string | undefined;
+  toolTitlesByCallId: Map<string, string>;
+  pendingApprovalResolvers: Map<string, PendingApprovalRequest>;
+  pendingUserInputResolvers: Map<string, PendingUserInputRequest>;
+  unsubscribe: () => void;
+}
+
+interface CopilotSessionHandle {
+  readonly sessionId: string;
+  readonly rpc: {
+    readonly mode: {
+      set(input: { mode: "interactive" | "plan" | "autopilot" }): Promise<{
+        mode: "interactive" | "plan" | "autopilot";
+      }>;
+    };
+    readonly plan: {
+      read(): Promise<{
+        exists: boolean;
+        content: string | null;
+        path: string | null;
+      }>;
+    };
+  };
+  destroy(): Promise<void>;
+  on(handler: (event: SessionEvent) => void): () => void;
+  send(options: { prompt: string; attachments?: unknown; mode?: string }): Promise<string>;
+  abort(): Promise<void>;
+  getMessages(): Promise<SessionEvent[]>;
+}
+
+interface CopilotClientHandle {
+  start(): Promise<void>;
+  listModels(): Promise<ModelInfo[]>;
+  createSession(
+    config: Parameters<CopilotClient["createSession"]>[0],
+  ): Promise<CopilotSessionHandle>;
+  resumeSession(
+    sessionId: string,
+    config: Parameters<CopilotClient["resumeSession"]>[1],
+  ): Promise<CopilotSessionHandle>;
+  stop(): Promise<Error[]>;
+}
+
+function toMessage(cause: unknown, fallback: string): string {
+  if (cause instanceof Error && cause.message.length > 0) {
+    return cause.message;
+  }
+  return fallback;
+}
+
+function makeEventId(prefix: string) {
+  return EventId.makeUnsafe(`${prefix}-${randomUUID()}`);
+}
+
+function toTurnId(value: string | undefined): TurnId | undefined {
+  if (!value || value.trim().length === 0) return undefined;
+  return TurnId.makeUnsafe(value);
+}
+
+function toRuntimeItemId(value: string | undefined) {
+  if (!value || value.trim().length === 0) return undefined;
+  return RuntimeItemId.makeUnsafe(value);
+}
+
+function toProviderItemId(value: string | undefined) {
+  if (!value || value.trim().length === 0) return undefined;
+  return ProviderItemId.makeUnsafe(value);
+}
+
+function toRuntimeRequestId(value: string | undefined) {
+  if (!value || value.trim().length === 0) return undefined;
+  return RuntimeRequestId.makeUnsafe(value);
+}
+
+function toRuntimeTaskId(value: string | undefined) {
+  if (!value || value.trim().length === 0) return undefined;
+  return RuntimeTaskId.makeUnsafe(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return value as Record<string, unknown>;
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function mapSupportedModelsById(models: ReadonlyArray<ModelInfo>) {
+  return new Map(models.map((model) => [model.id, model]));
+}
+
+function getCopilotReasoningEffort(modelOptions: unknown) {
+  const record = asRecord(modelOptions);
+  const copilot = asRecord(record?.copilot);
+  const reasoningEffort = normalizeString(copilot?.reasoningEffort);
+  return reasoningEffort === "low" ||
+    reasoningEffort === "medium" ||
+    reasoningEffort === "high" ||
+    reasoningEffort === "xhigh"
+    ? reasoningEffort
+    : undefined;
+}
+
+function extractResumeSessionId(resumeCursor: unknown): string | undefined {
+  if (typeof resumeCursor === "string" && resumeCursor.trim().length > 0) {
+    return resumeCursor.trim();
+  }
+  const record = asRecord(resumeCursor);
+  const sessionId = normalizeString(record?.sessionId);
+  return sessionId;
+}
+
+function toCopilotSessionMode(interactionMode: "default" | "plan"): "interactive" | "plan" {
+  return interactionMode === "plan" ? "plan" : "interactive";
+}
+
+function toInteractionMode(mode: string): "default" | "plan" {
+  return mode === "plan" ? "plan" : "default";
+}
+
+function approvalDecisionToPermissionResult(
+  decision: ProviderApprovalDecision,
+): PermissionRequestResult {
+  switch (decision) {
+    case "accept":
+    case "acceptForSession":
+      return { kind: "approved" };
+    case "decline":
+    case "cancel":
+    default:
+      return { kind: "denied-interactively-by-user" };
+  }
+}
+
+function requestTypeFromPermissionRequest(request: PermissionRequest) {
+  switch (request.kind) {
+    case "shell":
+      return "command_execution_approval" as const;
+    case "write":
+      return "file_change_approval" as const;
+    case "read":
+      return "file_read_approval" as const;
+    case "mcp":
+    case "custom-tool":
+      return "dynamic_tool_call" as const;
+    default:
+      return "unknown" as const;
+  }
+}
+
+function requestDetailFromPermissionRequest(request: PermissionRequest): string | undefined {
+  switch (request.kind) {
+    case "shell":
+      return trimToUndefined(String(request.fullCommandText ?? ""));
+    case "write":
+      return trimToUndefined(String(request.fileName ?? request.intention ?? ""));
+    case "read":
+      return trimToUndefined(String(request.path ?? request.intention ?? ""));
+    case "mcp":
+      return trimToUndefined(String(request.toolTitle ?? request.toolName ?? ""));
+    case "url":
+      return trimToUndefined(String(request.url ?? request.intention ?? ""));
+    case "custom-tool":
+      return trimToUndefined(String(request.toolName ?? request.toolDescription ?? ""));
+    default:
+      return undefined;
+  }
+}
+
+function itemTypeFromToolEvent(event: Extract<SessionEvent, { type: "tool.execution_start" }>) {
+  return event.data.mcpToolName ? "mcp_tool_call" : "dynamic_tool_call";
+}
+
+function toolDetailFromEvent(data: {
+  readonly toolName?: string;
+  readonly mcpToolName?: string;
+  readonly mcpServerName?: string;
+}) {
+  return trimToUndefined(
+    [data.mcpServerName, data.mcpToolName ?? data.toolName].filter(Boolean).join(" / "),
+  );
+}
+
+function withRefs(input: {
+  readonly threadId: ThreadId;
+  readonly eventId: EventId;
+  readonly createdAt: string;
+  readonly turnId: TurnId | undefined;
+  readonly providerTurnId?: TurnId | undefined;
+  readonly itemId: string | undefined;
+  readonly requestId: string | undefined;
+  readonly rawMethod: string | undefined;
+  readonly rawPayload: unknown;
+}): Omit<ProviderRuntimeEvent, "type" | "payload"> {
+  const providerTurnId = input.providerTurnId ?? input.turnId;
+  const providerItemId = toProviderItemId(input.itemId);
+  const providerRequestId = trimToUndefined(input.requestId);
+  return {
+    eventId: input.eventId,
+    provider: PROVIDER,
+    threadId: input.threadId,
+    createdAt: input.createdAt,
+    ...(input.turnId ? { turnId: input.turnId } : {}),
+    ...(input.itemId ? { itemId: toRuntimeItemId(input.itemId) } : {}),
+    ...(input.requestId ? { requestId: toRuntimeRequestId(input.requestId) } : {}),
+    ...(providerTurnId || providerItemId || providerRequestId
+      ? {
+          providerRefs: {
+            ...(providerTurnId ? { providerTurnId } : {}),
+            ...(providerItemId ? { providerItemId } : {}),
+            ...(providerRequestId ? { providerRequestId } : {}),
+          },
+        }
+      : {}),
+    raw: {
+      source: input.rawMethod ? "copilot.sdk.session-event" : "copilot.sdk.synthetic",
+      ...(input.rawMethod ? { method: input.rawMethod } : {}),
+      payload: input.rawPayload,
+    },
+  };
+}
+
+function mapHistoryToTurns(
+  threadId: ThreadId,
+  events: ReadonlyArray<SessionEvent>,
+): ProviderThreadSnapshot {
+  const turns: Array<ProviderThreadTurnSnapshot> = [];
+  let current: { id: TurnId; items: Array<unknown> } | undefined;
+
+  for (const event of events) {
+    if (event.type === "assistant.turn_start") {
+      current = {
+        id: TurnId.makeUnsafe(event.data.turnId),
+        items: [event],
+      };
+      turns.push(current);
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    current.items.push(event);
+    if (isCopilotTurnTerminalEvent(event)) {
+      current = undefined;
+    }
+  }
+
+  return {
+    threadId,
+    turns: turns.map((turn) => ({
+      id: turn.id,
+      items: turn.items,
+    })),
+  };
+}
+
+function makeSyntheticEvent(
+  threadId: ThreadId,
+  type: ProviderRuntimeEvent["type"],
+  payload: ProviderRuntimeEvent["payload"],
+  extra?: {
+    readonly turnId?: TurnId | undefined;
+    readonly itemId?: string | undefined;
+    readonly requestId?: string | undefined;
+  },
+): ProviderRuntimeEvent {
+  return {
+    ...withRefs({
+      threadId,
+      eventId: makeEventId("copilot-synthetic"),
+      createdAt: new Date().toISOString(),
+      turnId: extra?.turnId,
+      itemId: extra?.itemId,
+      requestId: extra?.requestId,
+      rawMethod: undefined,
+      rawPayload: payload,
+    }),
+    type,
+    payload,
+  } as ProviderRuntimeEvent;
+}
+
+function resolveUserInputAnswer(
+  pending: PendingUserInputRequest,
+  answers: ProviderUserInputAnswers,
+): CopilotUserInputResponse {
+  const direct = answers[USER_INPUT_QUESTION_ID];
+  const candidate =
+    typeof direct === "string"
+      ? direct
+      : Object.values(answers).find((value): value is string => typeof value === "string");
+  const answer = trimToUndefined(candidate) ?? "";
+  return {
+    answer,
+    wasFreeform: !pending.request.choices?.includes(answer),
+  };
+}
+
+function createSessionRecord(input: {
+  readonly threadId: ThreadId;
+  readonly client: CopilotClientHandle;
+  readonly session: CopilotSessionHandle;
+  readonly runtimeMode: ProviderSession["runtimeMode"];
+  readonly pendingApprovalResolvers: Map<string, PendingApprovalRequest>;
+  readonly pendingUserInputResolvers: Map<string, PendingUserInputRequest>;
+  readonly cwd: string | undefined;
+  readonly configDir: string | undefined;
+  readonly model: string | undefined;
+  readonly reasoningEffort: CodexReasoningEffort | undefined;
+}): ActiveCopilotSession {
+  return {
+    client: input.client,
+    session: input.session,
+    threadId: input.threadId,
+    createdAt: new Date().toISOString(),
+    runtimeMode: input.runtimeMode,
+    cwd: input.cwd,
+    configDir: input.configDir,
+    model: input.model,
+    reasoningEffort: input.reasoningEffort,
+    interactionMode: undefined,
+    updatedAt: new Date().toISOString(),
+    lastError: undefined,
+    currentTurnId: undefined,
+    currentProviderTurnId: undefined,
+    pendingCompletionTurnId: undefined,
+    pendingCompletionProviderTurnId: undefined,
+    pendingTurnIds: [],
+    pendingTurnUsage: undefined,
+    toolTitlesByCallId: new Map(),
+    pendingApprovalResolvers: input.pendingApprovalResolvers,
+    pendingUserInputResolvers: input.pendingUserInputResolvers,
+    unsubscribe: () => undefined,
+  };
+}
+
+const makeCopilotAdapter = (options?: CopilotAdapterLiveOptions) =>
+  Effect.gen(function* () {
+    const serverConfig = yield* ServerConfig;
+    const nativeEventLogger = options?.nativeEventLogger;
+    const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();
+    const sessions = new Map<ThreadId, ActiveCopilotSession>();
+
+    const emitRuntimeEvents = (events: ReadonlyArray<ProviderRuntimeEvent>) =>
+      Effect.runPromise(Queue.offerAll(runtimeEventQueue, events).pipe(Effect.asVoid)).catch(
+        () => undefined,
+      );
+
+    const writeNativeEvent = (threadId: ThreadId, event: SessionEvent) => {
+      if (!nativeEventLogger) return Promise.resolve();
+      return Effect.runPromise(nativeEventLogger.write(event, threadId)).catch(() => undefined);
+    };
+
+    const currentSyntheticTurnId = (record: ActiveCopilotSession) =>
+      completionTurnRefs(record).turnId ?? record.currentTurnId;
+
+    const syncInteractionMode = (
+      record: ActiveCopilotSession,
+      interactionMode: "default" | "plan",
+    ) => {
+      if (record.interactionMode === interactionMode) {
+        return Effect.void;
+      }
+      return Effect.tryPromise({
+        try: async () => {
+          await record.session.rpc.mode.set({
+            mode: toCopilotSessionMode(interactionMode),
+          });
+          record.interactionMode = interactionMode;
+        },
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.mode.set",
+            detail: toMessage(cause, "Failed to switch GitHub Copilot interaction mode."),
+            cause,
+          }),
+      });
+    };
+
+    const emitLatestProposedPlan = (record: ActiveCopilotSession) =>
+      Effect.tryPromise({
+        try: () => record.session.rpc.plan.read(),
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.plan.read",
+            detail: toMessage(cause, "Failed to read the GitHub Copilot plan."),
+            cause,
+          }),
+      }).pipe(
+        Effect.flatMap((plan) => {
+          const planMarkdown = trimToUndefined(plan.content ?? undefined);
+          if (!plan.exists || !planMarkdown) {
+            return Effect.void;
+          }
+          return Queue.offer(
+            runtimeEventQueue,
+            makeSyntheticEvent(
+              record.threadId,
+              "turn.proposed.completed",
+              {
+                planMarkdown,
+              },
+              { turnId: currentSyntheticTurnId(record) },
+            ),
+          ).pipe(Effect.asVoid);
+        }),
+      );
+
+    const mapSessionEvent = (
+      record: ActiveCopilotSession,
+      event: SessionEvent,
+    ): ReadonlyArray<ProviderRuntimeEvent> => {
+      const currentTurnId = record.currentTurnId;
+      const currentProviderTurnId = record.currentProviderTurnId;
+      const resolveOrchestrationTurnId = (
+        providerTurnId: TurnId | undefined,
+      ): TurnId | undefined => {
+        if (providerTurnId && currentProviderTurnId && providerTurnId === currentProviderTurnId) {
+          return currentTurnId ?? providerTurnId;
+        }
+        return currentTurnId ?? providerTurnId;
+      };
+      const base = (input?: {
+        readonly turnId?: TurnId | undefined;
+        readonly providerTurnId?: TurnId | undefined;
+        readonly itemId?: string | undefined;
+        readonly requestId?: string | undefined;
+      }) =>
+        withRefs({
+          threadId: record.threadId,
+          eventId: EventId.makeUnsafe(event.id),
+          createdAt: event.timestamp,
+          turnId: resolveOrchestrationTurnId(input?.providerTurnId ?? input?.turnId),
+          providerTurnId: input?.providerTurnId ?? input?.turnId,
+          itemId: input?.itemId,
+          requestId: input?.requestId,
+          rawMethod: event.type,
+          rawPayload: event,
+        });
+
+      switch (event.type) {
+        case "session.start":
+        case "session.resume":
+          return [
+            {
+              ...base(),
+              type: "session.started",
+              payload: {
+                message:
+                  event.type === "session.resume"
+                    ? "Resumed GitHub Copilot session"
+                    : "Started GitHub Copilot session",
+                resume: event.data,
+              },
+            },
+            {
+              ...base(),
+              type: "thread.started",
+              payload: {
+                providerThreadId:
+                  event.type === "session.start" ? event.data.sessionId : record.session.sessionId,
+              },
+            },
+          ];
+        case "session.info":
+          return [
+            {
+              ...base(),
+              type: "runtime.warning",
+              payload: {
+                message: event.data.message,
+                detail: event.data,
+              },
+            },
+          ];
+        case "session.warning":
+          return [
+            {
+              ...base(),
+              type: "runtime.warning",
+              payload: {
+                message: event.data.message,
+                detail: event.data,
+              },
+            },
+          ];
+        case "session.error":
+          return [
+            {
+              ...base(),
+              type: "runtime.error",
+              payload: {
+                message: event.data.message,
+                class: "provider_error",
+                detail: event.data,
+              },
+            },
+            {
+              ...base(),
+              type: "session.state.changed",
+              payload: {
+                state: "error",
+                reason: "session.error",
+                detail: event.data,
+              },
+            },
+          ];
+        case "session.idle": {
+          const idleCompletionRefs = completionTurnRefs(record);
+          const idleCompletionEvents: ProviderRuntimeEvent[] =
+            idleCompletionRefs.turnId || idleCompletionRefs.providerTurnId
+              ? [
+                  {
+                    ...base(idleCompletionRefs),
+                    type: "turn.completed",
+                    payload: {
+                      state: "completed",
+                      ...assistantUsageFields(record.pendingTurnUsage),
+                    },
+                  } satisfies ProviderRuntimeEvent,
+                ]
+              : [];
+          return [
+            ...idleCompletionEvents,
+            {
+              ...base(),
+              type: "session.state.changed",
+              payload: {
+                state: "ready",
+                reason: "session.idle",
+              },
+            },
+            {
+              ...base(),
+              type: "thread.state.changed",
+              payload: {
+                state: "idle",
+                detail: event.data,
+              },
+            },
+          ];
+        }
+        case "session.title_changed":
+          return [
+            {
+              ...base(),
+              type: "thread.metadata.updated",
+              payload: {
+                name: event.data.title,
+                metadata: event.data,
+              },
+            },
+          ];
+        case "session.model_change":
+          return [
+            {
+              ...base(),
+              type: "model.rerouted",
+              payload: {
+                fromModel: event.data.previousModel ?? "unknown",
+                toModel: event.data.newModel,
+                reason: "session.model_change",
+              },
+            },
+          ];
+        case "session.plan_changed":
+          return [
+            {
+              ...base(),
+              type: "turn.plan.updated",
+              payload: {
+                explanation: `Plan ${event.data.operation}d`,
+                plan: [],
+              },
+            },
+          ];
+        case "session.workspace_file_changed":
+          return [
+            {
+              ...base(),
+              type: "files.persisted",
+              payload: {
+                files: [
+                  {
+                    filename: event.data.path,
+                    fileId: event.data.path,
+                  },
+                ],
+              },
+            },
+          ];
+        case "session.context_changed":
+          return [
+            {
+              ...base(),
+              type: "thread.metadata.updated",
+              payload: {
+                metadata: event.data,
+              },
+            },
+          ];
+        case "session.usage_info":
+          return [
+            {
+              ...base(),
+              type: "thread.token-usage.updated",
+              payload: {
+                usage: event.data,
+              },
+            },
+          ];
+        case "session.task_complete":
+          return [
+            {
+              ...base(),
+              type: "task.completed",
+              payload: {
+                taskId:
+                  toRuntimeTaskId(record.threadId) ?? RuntimeTaskId.makeUnsafe(record.threadId),
+                status: "completed",
+                ...(trimToUndefined(event.data.summary) ? { summary: event.data.summary } : {}),
+              },
+            },
+          ];
+        case "assistant.turn_start":
+          return [
+            {
+              ...base({ providerTurnId: toTurnId(event.data.turnId) }),
+              type: "turn.started",
+              payload: record.model ? { model: record.model } : {},
+            },
+            {
+              ...base({ providerTurnId: toTurnId(event.data.turnId) }),
+              type: "session.state.changed",
+              payload: {
+                state: "running",
+                reason: "assistant.turn_start",
+              },
+            },
+          ];
+        case "assistant.reasoning":
+          return [
+            {
+              ...base({ itemId: event.data.reasoningId }),
+              type: "item.completed",
+              payload: {
+                itemType: "reasoning",
+                status: "completed",
+                title: "Reasoning",
+                detail: trimToUndefined(event.data.content),
+                data: event.data,
+              },
+            },
+          ];
+        case "assistant.reasoning_delta":
+          return [
+            {
+              ...base({ itemId: event.data.reasoningId }),
+              type: "content.delta",
+              payload: {
+                streamKind: "reasoning_text",
+                delta: event.data.deltaContent,
+              },
+            },
+          ];
+        case "assistant.message":
+          return [
+            {
+              ...base({ itemId: event.data.messageId }),
+              type: "item.completed",
+              payload: {
+                itemType: "assistant_message",
+                status: "completed",
+                title: "Assistant message",
+                detail: trimToUndefined(event.data.content),
+                data: event.data,
+              },
+            },
+          ];
+        case "assistant.message_delta":
+          return [
+            {
+              ...base({ itemId: event.data.messageId }),
+              type: "content.delta",
+              payload: {
+                streamKind: "assistant_text",
+                delta: event.data.deltaContent,
+              },
+            },
+          ];
+        case "assistant.turn_end":
+          return [];
+        case "assistant.usage": {
+          const completionRefs = completionTurnRefs(record);
+          const completionBase =
+            completionRefs.turnId || completionRefs.providerTurnId ? base(completionRefs) : base();
+          return [
+            {
+              ...completionBase,
+              type: "thread.token-usage.updated",
+              payload: {
+                usage: event.data,
+              },
+            },
+          ];
+        }
+        case "abort": {
+          const abortedTurnRefs = completionTurnRefs(record);
+          const abortedBase =
+            abortedTurnRefs.turnId || abortedTurnRefs.providerTurnId
+              ? base(abortedTurnRefs)
+              : base();
+          return [
+            {
+              ...abortedBase,
+              type: "turn.aborted",
+              payload: {
+                reason: event.data.reason,
+              },
+            },
+          ];
+        }
+        case "tool.execution_start":
+          return [
+            {
+              ...base({ itemId: event.data.toolCallId }),
+              type: "item.started",
+              payload: {
+                itemType: itemTypeFromToolEvent(event),
+                status: "inProgress",
+                title: event.data.toolName ?? "Tool call",
+                ...(toolDetailFromEvent(event.data)
+                  ? { detail: toolDetailFromEvent(event.data) }
+                  : {}),
+                data: event.data,
+              },
+            },
+          ];
+        case "tool.execution_progress":
+          return [
+            {
+              ...base({ itemId: event.data.toolCallId }),
+              type: "tool.progress",
+              payload: {
+                toolUseId: event.data.toolCallId,
+                summary: event.data.progressMessage,
+              },
+            },
+          ];
+        case "tool.execution_partial_result":
+          return [
+            {
+              ...base({ itemId: event.data.toolCallId }),
+              type: "tool.progress",
+              payload: {
+                toolUseId: event.data.toolCallId,
+                summary: event.data.partialOutput,
+              },
+            },
+          ];
+        case "tool.execution_complete":
+          return [
+            {
+              ...base({ itemId: event.data.toolCallId }),
+              type: "item.completed",
+              payload: {
+                itemType: event.data.result?.contents?.some(
+                  (content) => content.type === "terminal",
+                )
+                  ? "command_execution"
+                  : "dynamic_tool_call",
+                status: event.data.success ? "completed" : "failed",
+                title: record.toolTitlesByCallId.get(event.data.toolCallId) ?? "Tool call",
+                ...(trimToUndefined(event.data.result?.content)
+                  ? { detail: event.data.result?.content }
+                  : {}),
+                data: event.data,
+              },
+            },
+            ...(trimToUndefined(event.data.result?.content)
+              ? [
+                  {
+                    ...base({ itemId: event.data.toolCallId }),
+                    type: "tool.summary" as const,
+                    payload: {
+                      summary: event.data.result?.content ?? "",
+                      precedingToolUseIds: [event.data.toolCallId],
+                    },
+                  },
+                ]
+              : []),
+          ];
+        case "skill.invoked":
+          return [
+            {
+              ...base(),
+              type: "task.progress",
+              payload: {
+                taskId:
+                  toRuntimeTaskId(event.data.name) ?? RuntimeTaskId.makeUnsafe(event.data.name),
+                description: `Invoked skill ${event.data.name}`,
+              },
+            },
+          ];
+        case "subagent.started":
+          return [
+            {
+              ...base(),
+              type: "task.started",
+              payload: {
+                taskId:
+                  toRuntimeTaskId(event.data.toolCallId) ??
+                  RuntimeTaskId.makeUnsafe(event.data.toolCallId),
+                description: trimToUndefined(event.data.agentDescription),
+                taskType: "subagent",
+              },
+            },
+          ];
+        case "subagent.completed":
+          return [
+            {
+              ...base(),
+              type: "task.completed",
+              payload: {
+                taskId:
+                  toRuntimeTaskId(event.data.toolCallId) ??
+                  RuntimeTaskId.makeUnsafe(event.data.toolCallId),
+                status: "completed",
+                ...(trimToUndefined(event.data.agentDisplayName)
+                  ? { summary: event.data.agentDisplayName }
+                  : {}),
+              },
+            },
+          ];
+        case "subagent.failed":
+          return [
+            {
+              ...base(),
+              type: "task.completed",
+              payload: {
+                taskId:
+                  toRuntimeTaskId(event.data.toolCallId) ??
+                  RuntimeTaskId.makeUnsafe(event.data.toolCallId),
+                status: "failed",
+                ...(trimToUndefined(event.data.error) ? { summary: event.data.error } : {}),
+              },
+            },
+          ];
+        default:
+          return [];
+      }
+    };
+
+    const createInteractionHandlers = (
+      threadId: ThreadId,
+      getCurrentTurnId: () => TurnId | undefined,
+      getRuntimeMode: () => ProviderSession["runtimeMode"],
+      pendingApprovalResolvers: Map<string, PendingApprovalRequest>,
+      pendingUserInputResolvers: Map<string, PendingUserInputRequest>,
+    ) => {
+      const onPermissionRequest = (request: PermissionRequest) =>
+        getRuntimeMode() === "full-access"
+          ? Promise.resolve<PermissionRequestResult>({ kind: "approved" })
+          : new Promise<PermissionRequestResult>((resolve) => {
+              const requestId = `copilot-approval-${randomUUID()}`;
+              const turnId = getCurrentTurnId();
+              pendingApprovalResolvers.set(requestId, {
+                requestType: requestTypeFromPermissionRequest(request),
+                turnId,
+                resolve,
+              });
+              void emitRuntimeEvents([
+                makeSyntheticEvent(
+                  threadId,
+                  "request.opened",
+                  {
+                    requestType: requestTypeFromPermissionRequest(request),
+                    ...(requestDetailFromPermissionRequest(request)
+                      ? { detail: requestDetailFromPermissionRequest(request) }
+                      : {}),
+                    args: request,
+                  },
+                  { requestId, turnId },
+                ),
+              ]);
+            });
+
+      const onUserInputRequest = (request: CopilotUserInputRequest) =>
+        new Promise<CopilotUserInputResponse>((resolve) => {
+          const requestId = `copilot-user-input-${randomUUID()}`;
+          const turnId = getCurrentTurnId();
+          pendingUserInputResolvers.set(requestId, {
+            request,
+            turnId,
+            resolve,
+          });
+          void emitRuntimeEvents([
+            makeSyntheticEvent(
+              threadId,
+              "user-input.requested",
+              {
+                questions: [
+                  {
+                    id: USER_INPUT_QUESTION_ID,
+                    header: USER_INPUT_QUESTION_HEADER,
+                    question: request.question,
+                    options: (request.choices ?? []).map((choice: string) => ({
+                      label: choice,
+                      description: choice,
+                    })),
+                  },
+                ],
+              },
+              { requestId, turnId },
+            ),
+          ]);
+        });
+
+      return {
+        onPermissionRequest,
+        onUserInputRequest,
+      };
+    };
+
+    const validateSessionConfiguration = (input: {
+      readonly client: CopilotClientHandle;
+      readonly threadId: ThreadId;
+      readonly model: string | undefined;
+      readonly reasoningEffort: CodexReasoningEffort | undefined;
+    }) =>
+      Effect.gen(function* () {
+        if (!input.model && !input.reasoningEffort) {
+          return;
+        }
+
+        yield* Effect.tryPromise({
+          try: () => input.client.start(),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: toMessage(cause, "Failed to start GitHub Copilot client."),
+              cause,
+            }),
+        });
+
+        const supportedModels = mapSupportedModelsById(
+          yield* Effect.tryPromise({
+            try: () => input.client.listModels(),
+            catch: (cause) =>
+              new ProviderAdapterProcessError({
+                provider: PROVIDER,
+                threadId: input.threadId,
+                detail: toMessage(cause, "Failed to load GitHub Copilot model metadata."),
+                cause,
+              }),
+          }),
+        );
+        const selectedModel = input.model ? supportedModels.get(input.model) : undefined;
+
+        if (input.model && !selectedModel) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "session.model",
+            issue: `GitHub Copilot model '${input.model}' is not available in the current Copilot runtime.`,
+          });
+        }
+
+        if (!input.reasoningEffort) {
+          return;
+        }
+
+        if (!selectedModel) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "session.reasoningEffort",
+            issue:
+              "GitHub Copilot reasoning effort requires an explicit supported model selection.",
+          });
+        }
+
+        const supportedReasoningEfforts = selectedModel.supportedReasoningEfforts ?? [];
+        if (supportedReasoningEfforts.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "session.reasoningEffort",
+            issue: `GitHub Copilot model '${selectedModel.id}' does not support reasoning effort configuration.`,
+          });
+        }
+
+        if (!supportedReasoningEfforts.includes(input.reasoningEffort)) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "session.reasoningEffort",
+            issue: `GitHub Copilot model '${selectedModel.id}' does not support reasoning effort '${input.reasoningEffort}'.`,
+          });
+        }
+      });
+
+    const reconfigureSession = (
+      record: ActiveCopilotSession,
+      input: {
+        readonly model: string | undefined;
+        readonly reasoningEffort: CodexReasoningEffort | undefined;
+      },
+    ) =>
+      Effect.tryPromise({
+        try: async () => {
+          const sessionId = record.session.sessionId;
+          const previousSession = record.session;
+          const previousUnsubscribe = record.unsubscribe;
+          previousUnsubscribe();
+          await previousSession.destroy();
+
+          const handlers = createInteractionHandlers(
+            record.threadId,
+            () => record.currentTurnId,
+            () => record.runtimeMode,
+            record.pendingApprovalResolvers,
+            record.pendingUserInputResolvers,
+          );
+          const nextSession = await record.client.resumeSession(sessionId, {
+            ...handlers,
+            ...(input.model ? { model: input.model } : {}),
+            ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
+            ...(record.cwd ? { workingDirectory: record.cwd } : {}),
+            ...(record.configDir ? { configDir: record.configDir } : {}),
+            streaming: true,
+          });
+
+          record.session = nextSession;
+          record.model = input.model;
+          record.reasoningEffort = input.reasoningEffort;
+          record.interactionMode = undefined;
+          record.updatedAt = new Date().toISOString();
+          record.unsubscribe = nextSession.on((event) => {
+            handleSessionEvent(record, event);
+          });
+        },
+        catch: (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.reconfigure",
+            detail: toMessage(cause, "Failed to reconfigure GitHub Copilot session."),
+            cause,
+          }),
+      });
+
+    const handleSessionEvent = (record: ActiveCopilotSession, event: SessionEvent) => {
+      record.updatedAt = event.timestamp;
+      if (event.type === "assistant.turn_start") {
+        beginCopilotTurn(record, TurnId.makeUnsafe(event.data.turnId));
+      }
+      if (event.type === "assistant.usage") {
+        recordTurnUsage(record, event.data);
+      }
+      if (event.type === "session.error") {
+        record.lastError = event.data.message;
+      }
+      if (event.type === "session.model_change") {
+        record.model = event.data.newModel;
+      }
+      if (event.type === "session.mode_changed") {
+        record.interactionMode = toInteractionMode(event.data.newMode);
+      }
+      if (event.type === "tool.execution_start" && trimToUndefined(event.data.toolName)) {
+        record.toolTitlesByCallId.set(event.data.toolCallId, trimToUndefined(event.data.toolName)!);
+      }
+
+      void writeNativeEvent(record.threadId, event);
+      const runtimeEvents = mapSessionEvent(record, event);
+      if (runtimeEvents.length > 0) {
+        void emitRuntimeEvents(runtimeEvents);
+      }
+      if (event.type === "session.plan_changed" && event.data.operation !== "delete") {
+        void Effect.runPromise(emitLatestProposedPlan(record)).catch((cause) => {
+          void emitRuntimeEvents([
+            makeSyntheticEvent(
+              record.threadId,
+              "runtime.warning",
+              {
+                message: "Failed to read GitHub Copilot plan.",
+                detail: toMessage(cause, "Failed to read GitHub Copilot plan."),
+              },
+              { turnId: currentSyntheticTurnId(record) },
+            ),
+          ]);
+        });
+      }
+      if (event.type === "tool.execution_complete") {
+        record.toolTitlesByCallId.delete(event.data.toolCallId);
+      }
+      if (event.type === "assistant.turn_end") {
+        markTurnAwaitingCompletion(record);
+      }
+      if (event.type === "abort" || event.type === "session.idle") {
+        clearTurnTracking(record);
+      }
+    };
+
+    const getSessionRecord = (threadId: ThreadId) => {
+      const record = sessions.get(threadId);
+      if (!record) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(record);
+    };
+
+    const stopRecord = async (record: ActiveCopilotSession) => {
+      record.unsubscribe();
+      try {
+        await record.session.destroy();
+      } catch {
+        // best effort
+      }
+      try {
+        await record.client.stop();
+      } catch {
+        // best effort
+      }
+      for (const pending of record.pendingApprovalResolvers.values()) {
+        pending.resolve({ kind: "denied-interactively-by-user" });
+      }
+      for (const pending of record.pendingUserInputResolvers.values()) {
+        pending.resolve({ answer: "", wasFreeform: true });
+      }
+      sessions.delete(record.threadId);
+    };
+
+    const startSession: CopilotAdapterShape["startSession"] = (input) =>
+      Effect.gen(function* () {
+        if (input.provider !== undefined && input.provider !== PROVIDER) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "startSession",
+            issue: `Expected provider '${PROVIDER}', received '${input.provider}'.`,
+          });
+        }
+
+        const existing = sessions.get(input.threadId);
+        if (existing) {
+          return {
+            provider: PROVIDER,
+            status: "ready",
+            runtimeMode: existing.runtimeMode,
+            ...(existing.cwd ? { cwd: existing.cwd } : {}),
+            ...(existing.model ? { model: existing.model } : {}),
+            threadId: input.threadId,
+            resumeCursor: existing.session.sessionId,
+            createdAt: existing.createdAt,
+            updatedAt: existing.updatedAt,
+            ...(existing.lastError ? { lastError: existing.lastError } : {}),
+          } satisfies ProviderSession;
+        }
+
+        const cliPath =
+          normalizeCopilotCliPathOverride(input.providerOptions?.copilot?.cliPath) ??
+          resolveBundledCopilotCliPath();
+        const configDir = trimToUndefined(input.providerOptions?.copilot?.configDir);
+        const mcpServers = yield* Effect.tryPromise({
+          try: () => loadCopilotMcpServers(configDir),
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: toMessage(cause, "Failed to load GitHub Copilot MCP configuration."),
+              cause,
+            }),
+        });
+        const resumeSessionId = extractResumeSessionId(input.resumeCursor);
+        const clientOptions: CopilotClientOptions = {
+          ...(cliPath ? { cliPath } : {}),
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+          logLevel: "error",
+        };
+        const client = options?.clientFactory?.(clientOptions) ?? new CopilotClient(clientOptions);
+        const pendingApprovalResolvers = new Map<string, PendingApprovalRequest>();
+        const pendingUserInputResolvers = new Map<string, PendingUserInputRequest>();
+        const reasoningEffort = getCopilotReasoningEffort(input.modelOptions);
+        let sessionRecord: ActiveCopilotSession | undefined;
+        const handlers = createInteractionHandlers(
+          input.threadId,
+          () => sessionRecord?.currentTurnId,
+          () => sessionRecord?.runtimeMode ?? input.runtimeMode,
+          pendingApprovalResolvers,
+          pendingUserInputResolvers,
+        );
+
+        yield* validateSessionConfiguration({
+          client,
+          threadId: input.threadId,
+          model: input.model,
+          reasoningEffort,
+        });
+
+        const session = yield* Effect.tryPromise({
+          try: async () => {
+            if (resumeSessionId) {
+              return client.resumeSession(resumeSessionId, {
+                ...handlers,
+                ...(input.model ? { model: input.model } : {}),
+                ...(reasoningEffort ? { reasoningEffort } : {}),
+                ...(input.cwd ? { workingDirectory: input.cwd } : {}),
+                ...(configDir ? { configDir } : {}),
+                ...(mcpServers ? { mcpServers } : {}),
+                streaming: true,
+              });
+            }
+            return client.createSession({
+              ...handlers,
+              ...(input.model ? { model: input.model } : {}),
+              ...(reasoningEffort ? { reasoningEffort } : {}),
+              ...(input.cwd ? { workingDirectory: input.cwd } : {}),
+              ...(configDir ? { configDir } : {}),
+              ...(mcpServers ? { mcpServers } : {}),
+              streaming: true,
+            });
+          },
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: toMessage(cause, "Failed to start GitHub Copilot session."),
+              cause,
+            }),
+        });
+
+        const record = createSessionRecord({
+          threadId: input.threadId,
+          client,
+          session,
+          runtimeMode: input.runtimeMode,
+          pendingApprovalResolvers,
+          pendingUserInputResolvers,
+          cwd: input.cwd,
+          configDir,
+          model: input.model,
+          reasoningEffort,
+        });
+        const unsubscribe = session.on((event) => {
+          handleSessionEvent(record, event);
+        });
+        record.unsubscribe = unsubscribe;
+        sessionRecord = record;
+        sessions.set(input.threadId, record);
+
+        yield* Queue.offerAll(runtimeEventQueue, [
+          makeSyntheticEvent(input.threadId, "session.started", {
+            message: resumeSessionId
+              ? "Resumed GitHub Copilot session"
+              : "Started GitHub Copilot session",
+            resume: { sessionId: session.sessionId },
+          }),
+          makeSyntheticEvent(input.threadId, "session.configured", {
+            config: {
+              ...(input.cwd ? { cwd: input.cwd } : {}),
+              ...(input.model ? { model: input.model } : {}),
+              ...(reasoningEffort ? { reasoningEffort } : {}),
+              ...(configDir ? { configDir } : {}),
+              streaming: true,
+            },
+          }),
+          makeSyntheticEvent(input.threadId, "thread.started", {
+            providerThreadId: session.sessionId,
+          }),
+          makeSyntheticEvent(input.threadId, "session.state.changed", {
+            state: "ready",
+            reason: "session.started",
+          }),
+        ]);
+
+        return {
+          provider: PROVIDER,
+          status: "ready",
+          runtimeMode: input.runtimeMode,
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+          ...(input.model ? { model: input.model } : {}),
+          threadId: input.threadId,
+          resumeCursor: session.sessionId,
+          createdAt: record.createdAt,
+          updatedAt: record.updatedAt,
+        } satisfies ProviderSession;
+      });
+
+    const sendTurn: CopilotAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(input.threadId);
+        const explicitReasoningEffort = getCopilotReasoningEffort(input.modelOptions);
+        const nextModel = input.model ?? record.model;
+        const nextReasoningEffort =
+          explicitReasoningEffort !== undefined
+            ? explicitReasoningEffort
+            : input.model && input.model !== record.model
+              ? undefined
+              : record.reasoningEffort;
+        const attachments = (input.attachments ?? []).map((attachment) => {
+          const attachmentPath = resolveAttachmentPath({
+            stateDir: serverConfig.stateDir,
+            attachment,
+          });
+          if (!attachmentPath) {
+            throw new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session.send",
+              detail: `Invalid attachment id '${attachment.id}'.`,
+            });
+          }
+          return {
+            type: "file" as const,
+            path: attachmentPath,
+            displayName: attachment.name,
+          };
+        });
+
+        yield* validateSessionConfiguration({
+          client: record.client,
+          threadId: input.threadId,
+          model: nextModel,
+          reasoningEffort: nextReasoningEffort,
+        });
+
+        if (nextModel !== record.model || nextReasoningEffort !== record.reasoningEffort) {
+          yield* reconfigureSession(record, {
+            model: nextModel,
+            reasoningEffort: nextReasoningEffort,
+          });
+        }
+
+        const interactionMode = input.interactionMode ?? record.interactionMode ?? "default";
+        yield* syncInteractionMode(record, interactionMode);
+
+        const turnId = TurnId.makeUnsafe(`copilot-turn-${randomUUID()}`);
+        record.pendingTurnIds.push(turnId);
+        record.currentTurnId = turnId;
+        record.currentProviderTurnId = undefined;
+
+        yield* Effect.tryPromise({
+          try: () =>
+            record.session.send({
+              prompt: input.input ?? "",
+              ...(attachments.length > 0 ? { attachments } : {}),
+              mode: "immediate",
+            }),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session.send",
+              detail: toMessage(cause, "Failed to send GitHub Copilot turn."),
+              cause,
+            }),
+        }).pipe(
+          Effect.tapError(() =>
+            Effect.sync(() => {
+              record.pendingTurnIds = record.pendingTurnIds.filter(
+                (candidate) => candidate !== turnId,
+              );
+              if (record.currentTurnId === turnId) {
+                record.currentTurnId = undefined;
+              }
+            }),
+          ),
+        );
+
+        record.updatedAt = new Date().toISOString();
+
+        return {
+          threadId: input.threadId,
+          turnId,
+          resumeCursor: record.session.sessionId,
+        } satisfies ProviderTurnStartResult;
+      });
+
+    const interruptTurn: CopilotAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        yield* Effect.tryPromise({
+          try: () => record.session.abort(),
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session.abort",
+              detail: toMessage(cause, "Failed to interrupt GitHub Copilot turn."),
+              cause,
+            }),
+        });
+      });
+
+    const respondToRequest: CopilotAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        const pending = record.pendingApprovalResolvers.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.permission.respond",
+            detail: `Unknown pending GitHub Copilot approval request '${requestId}'.`,
+          });
+        }
+        record.pendingApprovalResolvers.delete(requestId);
+        pending.resolve(approvalDecisionToPermissionResult(decision));
+        yield* Queue.offer(
+          runtimeEventQueue,
+          makeSyntheticEvent(
+            threadId,
+            "request.resolved",
+            {
+              requestType: pending.requestType,
+              decision,
+              resolution: approvalDecisionToPermissionResult(decision),
+            },
+            { requestId, turnId: pending.turnId },
+          ),
+        );
+      });
+
+    const respondToUserInput: CopilotAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        const pending = record.pendingUserInputResolvers.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session.userInput.respond",
+            detail: `Unknown pending GitHub Copilot user-input request '${requestId}'.`,
+          });
+        }
+        record.pendingUserInputResolvers.delete(requestId);
+        pending.resolve(resolveUserInputAnswer(pending, answers));
+        yield* Queue.offer(
+          runtimeEventQueue,
+          makeSyntheticEvent(
+            threadId,
+            "user-input.resolved",
+            {
+              answers,
+            },
+            { requestId, turnId: pending.turnId },
+          ),
+        );
+      });
+
+    const stopSession: CopilotAdapterShape["stopSession"] = (threadId) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        yield* Effect.tryPromise({
+          try: async () => {
+            await stopRecord(record);
+          },
+          catch: (cause) =>
+            new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId,
+              detail: toMessage(cause, "Failed to stop GitHub Copilot session."),
+              cause,
+            }),
+        });
+      });
+
+    const listSessions: CopilotAdapterShape["listSessions"] = () =>
+      Effect.sync(() =>
+        Array.from(sessions.values()).map(
+          (record) =>
+            ({
+              provider: PROVIDER,
+              status: record.currentTurnId ? "running" : "ready",
+              runtimeMode: record.runtimeMode,
+              threadId: record.threadId,
+              resumeCursor: record.session.sessionId,
+              createdAt: record.createdAt,
+              updatedAt: record.updatedAt,
+              ...(record.cwd ? { cwd: record.cwd } : {}),
+              ...(record.model ? { model: record.model } : {}),
+              ...(record.currentTurnId ? { activeTurnId: record.currentTurnId } : {}),
+              ...(record.lastError ? { lastError: record.lastError } : {}),
+            }) satisfies ProviderSession,
+        ),
+      );
+
+    const hasSession: CopilotAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => sessions.has(threadId));
+
+    const readThread: CopilotAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const record = yield* getSessionRecord(threadId);
+        return yield* Effect.tryPromise({
+          try: async () => {
+            const messages = await record.session.getMessages();
+            return mapHistoryToTurns(threadId, messages);
+          },
+          catch: (cause) =>
+            new ProviderAdapterRequestError({
+              provider: PROVIDER,
+              method: "session.getMessages",
+              detail: toMessage(cause, "Failed to read GitHub Copilot thread history."),
+              cause,
+            }),
+        });
+      });
+
+    const rollbackThread: CopilotAdapterShape["rollbackThread"] = (_threadId) =>
+      Effect.fail(
+        new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "thread.rollback",
+          detail:
+            "GitHub Copilot SDK does not expose a supported conversation rollback API for existing sessions.",
+        }),
+      );
+
+    const stopAll: CopilotAdapterShape["stopAll"] = () =>
+      Effect.tryPromise({
+        try: async () => {
+          await Promise.all(Array.from(sessions.values()).map((record) => stopRecord(record)));
+        },
+        catch: (cause) =>
+          new ProviderAdapterProcessError({
+            provider: PROVIDER,
+            threadId: ThreadId.makeUnsafe("_all"),
+            detail: toMessage(cause, "Failed to stop GitHub Copilot sessions."),
+            cause,
+          }),
+      });
+
+    return {
+      provider: PROVIDER,
+      capabilities: {
+        sessionModelSwitch: "in-session",
+      },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      readThread,
+      rollbackThread,
+      stopAll,
+      streamEvents: Stream.fromQueue(runtimeEventQueue),
+    } satisfies CopilotAdapterShape;
+  });
+
+export const CopilotAdapterLive = Layer.effect(CopilotAdapter, makeCopilotAdapter());
+
+export function makeCopilotAdapterLive(options?: CopilotAdapterLiveOptions) {
+  return Layer.effect(CopilotAdapter, makeCopilotAdapter(options));
+}

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -5,6 +5,7 @@ import { assertFailure } from "@effect/vitest/utils";
 import { Effect, Layer, Stream } from "effect";
 
 import { CodexAdapter, CodexAdapterShape } from "../Services/CodexAdapter.ts";
+import { CopilotAdapter, type CopilotAdapterShape } from "../Services/CopilotAdapter.ts";
 import { ProviderAdapterRegistry } from "../Services/ProviderAdapterRegistry.ts";
 import { ProviderAdapterRegistryLive } from "./ProviderAdapterRegistry.ts";
 import { ProviderUnsupportedError } from "../Errors.ts";
@@ -27,9 +28,32 @@ const fakeCodexAdapter: CodexAdapterShape = {
   streamEvents: Stream.empty,
 };
 
+const fakeCopilotAdapter: CopilotAdapterShape = {
+  provider: "copilot",
+  capabilities: { sessionModelSwitch: "in-session" },
+  startSession: vi.fn(),
+  sendTurn: vi.fn(),
+  interruptTurn: vi.fn(),
+  respondToRequest: vi.fn(),
+  respondToUserInput: vi.fn(),
+  stopSession: vi.fn(),
+  listSessions: vi.fn(),
+  hasSession: vi.fn(),
+  readThread: vi.fn(),
+  rollbackThread: vi.fn(),
+  stopAll: vi.fn(),
+  streamEvents: Stream.empty,
+};
+
 const layer = it.layer(
   Layer.mergeAll(
-    Layer.provide(ProviderAdapterRegistryLive, Layer.succeed(CodexAdapter, fakeCodexAdapter)),
+    Layer.provide(
+      ProviderAdapterRegistryLive,
+      Layer.mergeAll(
+        Layer.succeed(CodexAdapter, fakeCodexAdapter),
+        Layer.succeed(CopilotAdapter, fakeCopilotAdapter),
+      ),
+    ),
     NodeServices.layer,
   ),
 );
@@ -42,7 +66,7 @@ layer("ProviderAdapterRegistryLive", (it) => {
       assert.equal(codex, fakeCodexAdapter);
 
       const providers = yield* registry.listProviders();
-      assert.deepEqual(providers, ["codex"]);
+      assert.deepEqual(providers, ["codex", "copilot"]);
     }),
   );
 

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -16,6 +16,7 @@ import {
   type ProviderAdapterRegistryShape,
 } from "../Services/ProviderAdapterRegistry.ts";
 import { CodexAdapter } from "../Services/CodexAdapter.ts";
+import { CopilotAdapter } from "../Services/CopilotAdapter.ts";
 
 export interface ProviderAdapterRegistryLiveOptions {
   readonly adapters?: ReadonlyArray<ProviderAdapterShape<ProviderAdapterError>>;
@@ -23,7 +24,10 @@ export interface ProviderAdapterRegistryLiveOptions {
 
 const makeProviderAdapterRegistry = (options?: ProviderAdapterRegistryLiveOptions) =>
   Effect.gen(function* () {
-    const adapters = options?.adapters !== undefined ? options.adapters : [yield* CodexAdapter];
+    const adapters =
+      options?.adapters !== undefined
+        ? options.adapters
+        : [yield* CodexAdapter, yield* CopilotAdapter];
     const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));
 
     const getByProvider: ProviderAdapterRegistryShape["getByProvider"] = (provider) => {

--- a/apps/server/src/provider/Layers/ProviderHealth.test.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.test.ts
@@ -6,6 +6,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   checkCodexProviderStatus,
+  getCopilotHealthCheckTimeoutMs,
   hasCustomModelProvider,
   parseAuthStatusFromOutput,
   readCodexConfigModelProvider,
@@ -463,5 +464,13 @@ it.layer(NodeServices.layer)("ProviderHealth", (it) => {
         assert.strictEqual(yield* hasCustomModelProvider, true);
       }),
     );
+  });
+
+  describe("getCopilotHealthCheckTimeoutMs", () => {
+    it("uses a longer startup timeout on Windows", () => {
+      assert.strictEqual(getCopilotHealthCheckTimeoutMs("darwin"), 4_000);
+      assert.strictEqual(getCopilotHealthCheckTimeoutMs("linux"), 4_000);
+      assert.strictEqual(getCopilotHealthCheckTimeoutMs("win32"), 10_000);
+    });
   });
 });

--- a/apps/server/src/provider/Layers/ProviderHealth.ts
+++ b/apps/server/src/provider/Layers/ProviderHealth.ts
@@ -11,10 +11,13 @@
 import * as OS from "node:os";
 import type {
   ServerProviderAuthStatus,
+  ServerProviderModel,
+  ServerProviderQuotaSnapshot,
   ServerProviderStatus,
   ServerProviderStatusState,
 } from "@t3tools/contracts";
-import { Array, Effect, Fiber, FileSystem, Layer, Option, Path, Result, Stream } from "effect";
+import { CopilotClient, type ModelInfo } from "@github/copilot-sdk";
+import { Effect, Fiber, FileSystem, Layer, Option, Path, Result, Stream } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import {
@@ -23,9 +26,15 @@ import {
   parseCodexCliVersion,
 } from "../codexCliVersion";
 import { ProviderHealth, type ProviderHealthShape } from "../Services/ProviderHealth";
+import { resolveBundledCopilotCliPath } from "./copilotCliPath.ts";
 
 const DEFAULT_TIMEOUT_MS = 4_000;
 const CODEX_PROVIDER = "codex" as const;
+const COPILOT_PROVIDER = "copilot" as const;
+
+export function getCopilotHealthCheckTimeoutMs(platform: string = process.platform): number {
+  return platform === "win32" ? 10_000 : DEFAULT_TIMEOUT_MS;
+}
 
 // ── Pure helpers ────────────────────────────────────────────────────
 
@@ -33,6 +42,76 @@ export interface CommandResult {
   readonly stdout: string;
   readonly stderr: string;
   readonly code: number;
+}
+
+interface CopilotHealthProbeError {
+  readonly _tag: "CopilotHealthProbeError";
+  readonly cause: unknown;
+}
+
+const COPILOT_QUOTA_PRIORITY = ["premium_interactions", "chat", "completions"] as const;
+
+export function mapCopilotModel(model: ModelInfo): ServerProviderModel {
+  return {
+    id: model.id,
+    name: model.name,
+    supportsReasoningEffort: (model.supportedReasoningEfforts?.length ?? 0) > 0,
+    ...(model.supportedReasoningEfforts && model.supportedReasoningEfforts.length > 0
+      ? { supportedReasoningEfforts: [...model.supportedReasoningEfforts] }
+      : {}),
+    ...(model.defaultReasoningEffort
+      ? { defaultReasoningEffort: model.defaultReasoningEffort }
+      : {}),
+    ...(typeof model.billing?.multiplier === "number"
+      ? { billingMultiplier: model.billing.multiplier }
+      : {}),
+  } satisfies ServerProviderModel;
+}
+
+interface CopilotQuotaSnapshotInfo {
+  readonly entitlementRequests: number;
+  readonly usedRequests: number;
+  readonly remainingPercentage: number;
+  readonly overage: number;
+  readonly overageAllowedWithExhaustedQuota: boolean;
+  readonly resetDate?: string;
+}
+
+function compareCopilotQuotaKeys(left: string, right: string): number {
+  const leftPriority = COPILOT_QUOTA_PRIORITY.indexOf(
+    left as (typeof COPILOT_QUOTA_PRIORITY)[number],
+  );
+  const rightPriority = COPILOT_QUOTA_PRIORITY.indexOf(
+    right as (typeof COPILOT_QUOTA_PRIORITY)[number],
+  );
+  const normalizedLeftPriority = leftPriority === -1 ? Number.POSITIVE_INFINITY : leftPriority;
+  const normalizedRightPriority = rightPriority === -1 ? Number.POSITIVE_INFINITY : rightPriority;
+  return normalizedLeftPriority - normalizedRightPriority || left.localeCompare(right);
+}
+
+export function mapCopilotQuotaSnapshots(
+  quotaSnapshots: Record<string, CopilotQuotaSnapshotInfo> | undefined,
+): ReadonlyArray<ServerProviderQuotaSnapshot> {
+  if (!quotaSnapshots) return [];
+
+  return Object.entries(quotaSnapshots)
+    .toSorted(([leftKey], [rightKey]) => compareCopilotQuotaKeys(leftKey, rightKey))
+    .map(([key, snapshot]) => {
+      const entitlementRequests = Math.max(0, Math.trunc(snapshot.entitlementRequests));
+      const usedRequests = Math.max(0, Math.trunc(snapshot.usedRequests));
+      const mapped: ServerProviderQuotaSnapshot = {
+        key,
+        entitlementRequests,
+        usedRequests,
+        remainingRequests: Math.max(0, entitlementRequests - usedRequests),
+        remainingPercentage: snapshot.remainingPercentage,
+        overage: Math.max(0, Math.trunc(snapshot.overage)),
+        overageAllowedWithExhaustedQuota: snapshot.overageAllowedWithExhaustedQuota,
+      };
+      return snapshot.resetDate
+        ? Object.assign({}, mapped, { resetDate: snapshot.resetDate })
+        : mapped;
+    });
 }
 
 function nonEmptyTrimmed(value: string | undefined): string | undefined {
@@ -390,18 +469,108 @@ export const checkCodexProviderStatus: Effect.Effect<
   } satisfies ServerProviderStatus;
 });
 
+export const checkCopilotProviderStatus: Effect.Effect<ServerProviderStatus> = Effect.gen(
+  function* () {
+    const checkedAt = new Date().toISOString();
+    const probe = yield* Effect.tryPromise({
+      try: async () => {
+        const cliPath = resolveBundledCopilotCliPath();
+        const client = new CopilotClient({
+          ...(cliPath ? { cliPath } : {}),
+          logLevel: "error",
+        });
+        try {
+          await client.start();
+          const [status, authStatus] = await Promise.all([
+            client.getStatus(),
+            client.getAuthStatus().catch(() => undefined),
+          ]);
+          const [models, quota] =
+            authStatus?.isAuthenticated === true
+              ? await Promise.all([
+                  client.listModels().catch(() => undefined),
+                  client.rpc.account.getQuota().catch(() => undefined),
+                ])
+              : [undefined, undefined];
+          return { status, authStatus, models, quota };
+        } finally {
+          await client.stop().catch(() => []);
+        }
+      },
+      catch: (cause) =>
+        ({
+          _tag: "CopilotHealthProbeError",
+          cause,
+        }) satisfies CopilotHealthProbeError,
+    }).pipe(Effect.timeoutOption(getCopilotHealthCheckTimeoutMs()), Effect.result);
+
+    if (Result.isFailure(probe)) {
+      const error = probe.failure.cause;
+      return {
+        provider: COPILOT_PROVIDER,
+        status: "error" as const,
+        available: false,
+        authStatus: "unknown" as const,
+        checkedAt,
+        message:
+          error instanceof Error
+            ? `Failed to start GitHub Copilot CLI health check: ${error.message}.`
+            : "Failed to start GitHub Copilot CLI health check.",
+      };
+    }
+
+    if (Option.isNone(probe.success)) {
+      return {
+        provider: COPILOT_PROVIDER,
+        status: "error" as const,
+        available: false,
+        authStatus: "unknown" as const,
+        checkedAt,
+        message: "GitHub Copilot CLI health check timed out while starting the SDK client.",
+      };
+    }
+
+    const authStatus: ServerProviderAuthStatus =
+      probe.success.value.authStatus?.isAuthenticated === true
+        ? "authenticated"
+        : probe.success.value.authStatus?.isAuthenticated === false
+          ? "unauthenticated"
+          : "unknown";
+    const status: ServerProviderStatusState =
+      authStatus === "unauthenticated" ? "error" : authStatus === "unknown" ? "warning" : "ready";
+    const quotaSnapshots = mapCopilotQuotaSnapshots(probe.success.value.quota?.quotaSnapshots);
+
+    return {
+      provider: COPILOT_PROVIDER,
+      status,
+      available: true,
+      authStatus,
+      checkedAt,
+      ...(probe.success.value.models && probe.success.value.models.length > 0
+        ? { models: probe.success.value.models.map(mapCopilotModel) }
+        : {}),
+      ...(quotaSnapshots.length > 0 ? { quotaSnapshots } : {}),
+      ...(probe.success.value.authStatus?.statusMessage
+        ? { message: probe.success.value.authStatus.statusMessage }
+        : probe.success.value.status?.version
+          ? { message: `GitHub Copilot CLI ${probe.success.value.status.version}` }
+          : {}),
+    } satisfies ServerProviderStatus;
+  },
+);
+
 // ── Layer ───────────────────────────────────────────────────────────
 
 export const ProviderHealthLive = Layer.effect(
   ProviderHealth,
   Effect.gen(function* () {
-    const codexStatusFiber = yield* checkCodexProviderStatus.pipe(
-      Effect.map(Array.of),
-      Effect.forkScoped,
-    );
+    const providerStatusesFiber = yield* Effect.all(
+      [checkCodexProviderStatus, checkCopilotProviderStatus],
+      { concurrency: "unbounded" },
+    ).pipe(Effect.forkScoped);
 
     return {
-      getStatuses: Fiber.join(codexStatusFiber),
+      getStatuses: Fiber.join(providerStatusesFiber),
     } satisfies ProviderHealthShape;
   }),
 );

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -22,7 +22,7 @@ function decodeProviderKind(
   providerName: string,
   operation: string,
 ): Effect.Effect<ProviderKind, ProviderSessionDirectoryPersistenceError> {
-  if (providerName === "codex") {
+  if (providerName === "codex" || providerName === "copilot") {
     return Effect.succeed(providerName);
   }
   return Effect.fail(

--- a/apps/server/src/provider/Layers/copilotCliPath.test.ts
+++ b/apps/server/src/provider/Layers/copilotCliPath.test.ts
@@ -1,0 +1,102 @@
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveBundledCopilotCliPathFrom } from "./copilotCliPath.ts";
+
+const CURRENT_DIR = "/repo/apps/server/src/provider/Layers";
+const SDK_ENTRYPOINT = "/repo/apps/server/node_modules/@github/copilot-sdk/dist/index.js";
+
+describe("copilotCliPath", () => {
+  it("prefers the native binary on Windows", () => {
+    const npmLoaderPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot",
+      "npm-loader.js",
+    );
+    const binaryPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot-win32-x64",
+      "copilot.exe",
+    );
+    const existingPaths = new Set([npmLoaderPath, binaryPath]);
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        currentDir: CURRENT_DIR,
+        sdkEntrypoint: SDK_ENTRYPOINT,
+        platform: "win32",
+        arch: "x64",
+        exists: (candidate) => existingPaths.has(candidate),
+      }),
+    ).toBe(binaryPath);
+  });
+
+  it("keeps the native binary preference on non-Windows platforms", () => {
+    const npmLoaderPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot",
+      "npm-loader.js",
+    );
+    const binaryPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot-linux-x64",
+      "copilot",
+    );
+    const existingPaths = new Set([npmLoaderPath, binaryPath]);
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        currentDir: CURRENT_DIR,
+        sdkEntrypoint: SDK_ENTRYPOINT,
+        platform: "linux",
+        arch: "x64",
+        exists: (candidate) => existingPaths.has(candidate),
+      }),
+    ).toBe(binaryPath);
+  });
+
+  it("falls back to npm-loader.js when no native binary is present on Windows", () => {
+    const npmLoaderPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot",
+      "npm-loader.js",
+    );
+    const existingPaths = new Set([npmLoaderPath]);
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        currentDir: CURRENT_DIR,
+        sdkEntrypoint: SDK_ENTRYPOINT,
+        platform: "win32",
+        arch: "x64",
+        exists: (candidate) => existingPaths.has(candidate),
+      }),
+    ).toBe(npmLoaderPath);
+  });
+
+  it("falls back to npm-loader.js when no native binary is present on non-Windows platforms", () => {
+    const npmLoaderPath = join(
+      "/repo/apps/server/node_modules",
+      "@github",
+      "copilot",
+      "npm-loader.js",
+    );
+    const existingPaths = new Set([npmLoaderPath]);
+
+    expect(
+      resolveBundledCopilotCliPathFrom({
+        currentDir: CURRENT_DIR,
+        sdkEntrypoint: SDK_ENTRYPOINT,
+        platform: "darwin",
+        arch: "arm64",
+        exists: (candidate) => existingPaths.has(candidate),
+      }),
+    ).toBe(npmLoaderPath);
+  });
+});

--- a/apps/server/src/provider/Layers/copilotCliPath.ts
+++ b/apps/server/src/provider/Layers/copilotCliPath.ts
@@ -1,0 +1,168 @@
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const CURRENT_DIR = dirname(fileURLToPath(import.meta.url));
+const GITHUB_SCOPE_DIR = "@github";
+const COPILOT_PATHLESS_COMMAND_PATTERN = /^copilot(?:\.(?:exe|cmd|bat))?$/i;
+const COPILOT_NPM_LOADER = "npm-loader.js";
+
+function dedupePaths(paths: ReadonlyArray<string | undefined>): string[] {
+  const resolved: string[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of paths) {
+    if (!candidate || seen.has(candidate)) continue;
+    seen.add(candidate);
+    resolved.push(candidate);
+  }
+
+  return resolved;
+}
+
+function resolveSdkEntrypoint(): string | undefined {
+  try {
+    return require.resolve("@github/copilot-sdk");
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveProcessResourcesPath(): string | undefined {
+  const processWithResourcesPath = process as NodeJS.Process & {
+    readonly resourcesPath?: string;
+  };
+  return processWithResourcesPath.resourcesPath;
+}
+
+export function normalizeCopilotCliPathOverride(
+  value: string | null | undefined,
+): string | undefined {
+  if (value == null) return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  if (
+    !trimmed.includes("/") &&
+    !trimmed.includes("\\") &&
+    COPILOT_PATHLESS_COMMAND_PATTERN.test(trimmed)
+  ) {
+    return undefined;
+  }
+
+  return trimmed;
+}
+
+function resolveGithubScopeDirFromSdkEntrypoint(
+  sdkEntrypoint: string | undefined,
+): string | undefined {
+  if (!sdkEntrypoint) return undefined;
+  return join(dirname(dirname(sdkEntrypoint)), "..");
+}
+
+function resolveNodeModulesRoots(input: {
+  currentDir: string;
+  resourcesPath?: string;
+  sdkEntrypoint?: string;
+}): string[] {
+  const githubScopeDir = resolveGithubScopeDirFromSdkEntrypoint(input.sdkEntrypoint);
+  return dedupePaths([
+    input.resourcesPath ? join(input.resourcesPath, "app.asar.unpacked/node_modules") : undefined,
+    input.resourcesPath ? join(input.resourcesPath, "node_modules") : undefined,
+    join(input.currentDir, "../../../node_modules"),
+    join(input.currentDir, "../../../../../node_modules"),
+    githubScopeDir ? join(githubScopeDir, "..") : undefined,
+  ]);
+}
+
+function getCopilotPlatformBinaryName(platform: string): string {
+  return platform === "win32" ? "copilot.exe" : "copilot";
+}
+
+export function getBundledCopilotPlatformPackages(
+  platform: string = process.platform,
+  arch: string = process.arch,
+): ReadonlyArray<string> {
+  if (platform === "darwin" && arch === "arm64") {
+    return ["copilot-darwin-arm64"];
+  }
+  if (platform === "darwin" && arch === "x64") {
+    return ["copilot-darwin-x64"];
+  }
+  if (platform === "linux" && arch === "arm64") {
+    return ["copilot-linux-arm64"];
+  }
+  if (platform === "linux" && arch === "x64") {
+    return ["copilot-linux-x64"];
+  }
+  if (platform === "win32" && arch === "arm64") {
+    return ["copilot-win32-arm64"];
+  }
+  if (platform === "win32" && arch === "x64") {
+    return ["copilot-win32-x64"];
+  }
+
+  return [];
+}
+
+export function resolveBundledCopilotCliPathFrom(input: {
+  currentDir: string;
+  resourcesPath?: string;
+  sdkEntrypoint?: string;
+  platform?: string;
+  arch?: string;
+  exists?: (path: string) => boolean;
+}): string | undefined {
+  const platform = input.platform ?? process.platform;
+  const arch = input.arch ?? process.arch;
+  const exists = input.exists ?? existsSync;
+  const sdkEntrypoint = input.sdkEntrypoint;
+  const nodeModulesRoots = resolveNodeModulesRoots({
+    currentDir: input.currentDir,
+    ...(input.resourcesPath ? { resourcesPath: input.resourcesPath } : {}),
+    ...(sdkEntrypoint ? { sdkEntrypoint } : {}),
+  });
+  const binaryName = getCopilotPlatformBinaryName(platform);
+  const platformPackages = getBundledCopilotPlatformPackages(platform, arch);
+
+  const binaryCandidates = nodeModulesRoots.flatMap((root) =>
+    platformPackages.map((packageName) => join(root, GITHUB_SCOPE_DIR, packageName, binaryName)),
+  );
+  const npmLoaderCandidates = nodeModulesRoots.map((root) =>
+    join(root, GITHUB_SCOPE_DIR, "copilot", COPILOT_NPM_LOADER),
+  );
+  for (const candidate of dedupePaths([...binaryCandidates, ...npmLoaderCandidates])) {
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+
+  const githubScopeDir = resolveGithubScopeDirFromSdkEntrypoint(sdkEntrypoint);
+  if (!githubScopeDir) {
+    return undefined;
+  }
+
+  const sdkSiblingBinaryCandidates = platformPackages.map((packageName) =>
+    join(githubScopeDir, packageName, binaryName),
+  );
+  const sdkSiblingLoaderPath = join(githubScopeDir, "copilot", COPILOT_NPM_LOADER);
+  for (const candidate of dedupePaths([...sdkSiblingBinaryCandidates, sdkSiblingLoaderPath])) {
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export function resolveBundledCopilotCliPath(): string | undefined {
+  const sdkEntrypoint = resolveSdkEntrypoint();
+  const resourcesPath = resolveProcessResourcesPath();
+  return resolveBundledCopilotCliPathFrom({
+    currentDir: CURRENT_DIR,
+    ...(resourcesPath ? { resourcesPath } : {}),
+    ...(sdkEntrypoint ? { sdkEntrypoint } : {}),
+  });
+}

--- a/apps/server/src/provider/Layers/copilotMcpServers.ts
+++ b/apps/server/src/provider/Layers/copilotMcpServers.ts
@@ -1,0 +1,124 @@
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { MCPServerConfig } from "@github/copilot-sdk";
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.flatMap((item) => {
+    const normalized = asNonEmptyString(item);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function asStringRecord(value: unknown): Record<string, string> | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+
+  const entries = Object.entries(record).flatMap(([key, item]) => {
+    const normalized = asNonEmptyString(item);
+    return normalized ? [[key, normalized] as const] : [];
+  });
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function asTimeout(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function normalizeTools(value: unknown): string[] {
+  const tools = asStringArray(value);
+  return tools ?? ["*"];
+}
+
+function toMcpServerConfig(entry: unknown): MCPServerConfig | undefined {
+  const record = asRecord(entry);
+  if (!record) {
+    return undefined;
+  }
+
+  const type = asNonEmptyString(record.type);
+  const command = asNonEmptyString(record.command);
+  const args = asStringArray(record.args) ?? [];
+  const url = asNonEmptyString(record.url);
+  const tools = normalizeTools(record.tools);
+  const timeout = asTimeout(record.timeout);
+  const env = asStringRecord(record.env);
+  const cwd = asNonEmptyString(record.cwd);
+  const headers = asStringRecord(record.headers);
+
+  if (command && (type === undefined || type === "local" || type === "stdio")) {
+    return {
+      type: "local",
+      command,
+      args,
+      tools,
+      ...(env ? { env } : {}),
+      ...(cwd ? { cwd } : {}),
+      ...(timeout !== undefined ? { timeout } : {}),
+    };
+  }
+
+  if (url && (type === undefined || type === "http" || type === "sse")) {
+    return {
+      type: type === "sse" ? "sse" : "http",
+      url,
+      tools,
+      ...(headers ? { headers } : {}),
+      ...(timeout !== undefined ? { timeout } : {}),
+    };
+  }
+
+  return undefined;
+}
+
+export async function loadCopilotMcpServers(
+  configDir: string | undefined,
+): Promise<Record<string, MCPServerConfig> | undefined> {
+  const baseDir = asNonEmptyString(configDir) ?? path.join(os.homedir(), ".copilot");
+  const configPath = path.join(baseDir, "mcp-config.json");
+
+  let raw: string;
+  try {
+    raw = await fsp.readFile(configPath, "utf-8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+
+  const parsed = asRecord(JSON.parse(raw));
+  const servers = asRecord(parsed?.mcpServers);
+  if (!servers) {
+    return undefined;
+  }
+
+  const normalizedEntries = Object.entries(servers).flatMap(([name, value]) => {
+    const normalized = toMcpServerConfig(value);
+    return normalized ? [[name, normalized] as const] : [];
+  });
+
+  return normalizedEntries.length > 0 ? Object.fromEntries(normalizedEntries) : undefined;
+}

--- a/apps/server/src/provider/Layers/copilotTurnTracking.test.ts
+++ b/apps/server/src/provider/Layers/copilotTurnTracking.test.ts
@@ -1,0 +1,59 @@
+import { TurnId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  assistantUsageFields,
+  beginCopilotTurn,
+  clearTurnTracking,
+  isCopilotTurnTerminalEvent,
+  markTurnAwaitingCompletion,
+  recordTurnUsage,
+  type CopilotTurnTrackingState,
+} from "./copilotTurnTracking.ts";
+
+function makeState(): CopilotTurnTrackingState {
+  return {
+    currentTurnId: undefined,
+    currentProviderTurnId: undefined,
+    pendingCompletionTurnId: undefined,
+    pendingCompletionProviderTurnId: undefined,
+    pendingTurnIds: [],
+    pendingTurnUsage: undefined,
+  };
+}
+
+describe("copilotTurnTracking", () => {
+  it("keeps turn tracking alive until session.idle", () => {
+    expect(isCopilotTurnTerminalEvent({ type: "assistant.usage" } as never)).toBe(false);
+    expect(isCopilotTurnTerminalEvent({ type: "session.idle" } as never)).toBe(true);
+    expect(isCopilotTurnTerminalEvent({ type: "abort" } as never)).toBe(true);
+  });
+
+  it("preserves usage details for the eventual turn completion event", () => {
+    const state = makeState();
+    state.pendingTurnIds.push(TurnId.makeUnsafe("turn-1"));
+
+    beginCopilotTurn(state, TurnId.makeUnsafe("provider-turn-1"));
+    recordTurnUsage(state, {
+      model: "gpt-4.1",
+      cost: 0.42,
+      totalTokens: 123,
+    } as never);
+    markTurnAwaitingCompletion(state);
+
+    expect(assistantUsageFields(state.pendingTurnUsage)).toEqual({
+      usage: {
+        model: "gpt-4.1",
+        cost: 0.42,
+        totalTokens: 123,
+      },
+      modelUsage: { model: "gpt-4.1" },
+      totalCostUsd: 0.42,
+    });
+
+    clearTurnTracking(state);
+    expect(state.pendingTurnUsage).toBeUndefined();
+    expect(state.currentTurnId).toBeUndefined();
+    expect(state.pendingCompletionTurnId).toBeUndefined();
+  });
+});

--- a/apps/server/src/provider/Layers/copilotTurnTracking.ts
+++ b/apps/server/src/provider/Layers/copilotTurnTracking.ts
@@ -1,0 +1,69 @@
+import { TurnId } from "@t3tools/contracts";
+import type { SessionEvent } from "@github/copilot-sdk";
+
+export type CopilotAssistantUsage = Extract<SessionEvent, { type: "assistant.usage" }>["data"];
+
+export interface CopilotTurnTrackingState {
+  currentTurnId: TurnId | undefined;
+  currentProviderTurnId: TurnId | undefined;
+  pendingCompletionTurnId: TurnId | undefined;
+  pendingCompletionProviderTurnId: TurnId | undefined;
+  pendingTurnIds: Array<TurnId>;
+  pendingTurnUsage: CopilotAssistantUsage | undefined;
+}
+
+export function completionTurnRefs(state: CopilotTurnTrackingState) {
+  return {
+    turnId: state.pendingCompletionTurnId ?? state.currentTurnId,
+    providerTurnId: state.pendingCompletionProviderTurnId ?? state.currentProviderTurnId,
+  };
+}
+
+export function beginCopilotTurn(state: CopilotTurnTrackingState, providerTurnId: TurnId): void {
+  state.pendingCompletionTurnId = undefined;
+  state.pendingCompletionProviderTurnId = undefined;
+  state.pendingTurnUsage = undefined;
+  state.currentProviderTurnId = providerTurnId;
+  state.currentTurnId = state.pendingTurnIds.shift() ?? state.currentTurnId ?? providerTurnId;
+}
+
+export function markTurnAwaitingCompletion(state: CopilotTurnTrackingState): void {
+  state.pendingCompletionTurnId = state.currentTurnId ?? state.pendingCompletionTurnId;
+  state.pendingCompletionProviderTurnId =
+    state.currentProviderTurnId ?? state.pendingCompletionProviderTurnId;
+}
+
+export function recordTurnUsage(
+  state: CopilotTurnTrackingState,
+  usage: CopilotAssistantUsage,
+): void {
+  state.pendingTurnUsage = usage;
+}
+
+export function clearTurnTracking(state: CopilotTurnTrackingState): void {
+  state.currentTurnId = undefined;
+  state.currentProviderTurnId = undefined;
+  state.pendingCompletionTurnId = undefined;
+  state.pendingCompletionProviderTurnId = undefined;
+  state.pendingTurnUsage = undefined;
+}
+
+export function assistantUsageFields(usage: CopilotAssistantUsage | undefined): {
+  usage?: CopilotAssistantUsage;
+  modelUsage?: { model: string };
+  totalCostUsd?: number;
+} {
+  if (!usage) {
+    return {};
+  }
+
+  return {
+    usage,
+    ...(usage.cost !== undefined ? { totalCostUsd: usage.cost } : {}),
+    ...(usage.model ? { modelUsage: { model: usage.model } } : {}),
+  };
+}
+
+export function isCopilotTurnTerminalEvent(event: SessionEvent): boolean {
+  return event.type === "abort" || event.type === "session.idle";
+}

--- a/apps/server/src/provider/Services/CopilotAdapter.ts
+++ b/apps/server/src/provider/Services/CopilotAdapter.ts
@@ -1,0 +1,12 @@
+import { ServiceMap } from "effect";
+
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+export interface CopilotAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {
+  readonly provider: "copilot";
+}
+
+export class CopilotAdapter extends ServiceMap.Service<CopilotAdapter, CopilotAdapterShape>()(
+  "t3/provider/Services/CopilotAdapter",
+) {}

--- a/apps/server/src/serverLayers.ts
+++ b/apps/server/src/serverLayers.ts
@@ -20,6 +20,7 @@ import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRun
 import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus";
 import { ProviderUnsupportedError } from "./provider/Errors";
 import { makeCodexAdapterLive } from "./provider/Layers/CodexAdapter";
+import { makeCopilotAdapterLive } from "./provider/Layers/CopilotAdapter";
 import { ProviderAdapterRegistryLive } from "./provider/Layers/ProviderAdapterRegistry";
 import { makeProviderServiceLive } from "./provider/Layers/ProviderService";
 import { ProviderSessionDirectoryLive } from "./provider/Layers/ProviderSessionDirectory";
@@ -58,8 +59,12 @@ export function makeServerProviderLayer(): Layer.Layer<
     const codexAdapterLayer = makeCodexAdapterLive(
       nativeEventLogger ? { nativeEventLogger } : undefined,
     );
+    const copilotAdapterLayer = makeCopilotAdapterLive(
+      nativeEventLogger ? { nativeEventLogger } : undefined,
+    );
     const adapterRegistryLayer = ProviderAdapterRegistryLive.pipe(
       Layer.provide(codexAdapterLayer),
+      Layer.provide(copilotAdapterLayer),
       Layer.provideMerge(providerSessionDirectoryLayer),
     );
     return makeProviderServiceLive(

--- a/apps/server/src/skills/SkillsManager.ts
+++ b/apps/server/src/skills/SkillsManager.ts
@@ -1,0 +1,406 @@
+/**
+ * SkillsManager - Service for listing, toggling, searching, installing, and
+ * uninstalling agent skills.
+ *
+ * Skills are enabled when their directory lives under `~/.agents/skills/<name>/`
+ * and disabled when moved to `~/.t3/disabledSkills/<name>/`.
+ *
+ */
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+  SkillMetadata,
+  SkillsListResult,
+  SkillsToggleInput,
+  SkillsToggleResult,
+  SkillsSearchInput,
+  SkillsSearchResult,
+  SkillSearchResultEntry,
+  SkillsInstallInput,
+  SkillsInstallResult,
+  SkillsUninstallInput,
+  SkillsUninstallResult,
+  SkillsReadContentInput,
+  SkillsReadContentResult,
+} from "@t3tools/contracts";
+import { Effect, Layer, Schema, ServiceMap } from "effect";
+import { runProcess } from "../processRunner";
+
+// ── Error ────────────────────────────────────────────────────────────
+
+export class SkillsError extends Schema.TaggedErrorClass<SkillsError>()("SkillsError", {
+  message: Schema.String,
+  cause: Schema.optional(Schema.Defect),
+}) {}
+
+// ── Service Interface ────────────────────────────────────────────────
+
+export interface SkillsManagerShape {
+  readonly list: Effect.Effect<SkillsListResult, SkillsError>;
+  readonly toggle: (input: SkillsToggleInput) => Effect.Effect<SkillsToggleResult, SkillsError>;
+  readonly search: (input: SkillsSearchInput) => Effect.Effect<SkillsSearchResult, SkillsError>;
+  readonly install: (input: SkillsInstallInput) => Effect.Effect<SkillsInstallResult, SkillsError>;
+  readonly uninstall: (
+    input: SkillsUninstallInput,
+  ) => Effect.Effect<SkillsUninstallResult, SkillsError>;
+  readonly readContent: (
+    input: SkillsReadContentInput,
+  ) => Effect.Effect<SkillsReadContentResult, SkillsError>;
+}
+
+export class SkillsManager extends ServiceMap.Service<SkillsManager, SkillsManagerShape>()(
+  "t3/skills/SkillsManager",
+) {}
+
+const home = os.homedir();
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const ENABLED_SKILLS_DIR = path.join(home, ".agents", "skills");
+const DISABLED_SKILLS_DIR = path.join(home, ".t3", "disabledSkills");
+
+const VALID_SKILL_SLUG = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+const SKILLS_SEARCH_TIMEOUT_MS = 5_000;
+
+function assertValidSkillSlug(name: string): void {
+  if (!VALID_SKILL_SLUG.test(name)) {
+    throw new Error(`Invalid skill name: ${name}`);
+  }
+}
+
+function stripQuotes(s: string): string {
+  return (s.startsWith("'") && s.endsWith("'")) || (s.startsWith('"') && s.endsWith('"'))
+    ? s.slice(1, -1)
+    : s;
+}
+
+/** Extract `name` and `description` from SKILL.md YAML frontmatter. */
+function parseSkillFrontmatter(content: string): { name: string; description: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return { name: "", description: "" };
+
+  const frontmatter = match[1]!;
+  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+  const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
+
+  const rawName = nameMatch?.[1]?.trim() ?? "";
+  const rawDesc = descMatch?.[1]?.trim() ?? "";
+
+  return {
+    name: stripQuotes(rawName),
+    description: stripQuotes(rawDesc),
+  };
+}
+
+/**
+ * Resolve the SKILL.md path for a skill directory, trying SKILL.md then skill.md.
+ * Returns the absolute path or undefined if neither exists.
+ */
+function resolveSkillMdPath(skillDir: string): string | undefined {
+  for (const filename of ["SKILL.md", "skill.md"]) {
+    const p = path.join(skillDir, filename);
+    try {
+      fs.accessSync(p);
+      return p;
+    } catch {
+      // try next
+    }
+  }
+  return undefined;
+}
+
+type SkillDirectoryState = {
+  readonly enabled: boolean;
+  readonly skillDir: string;
+};
+
+async function pathExists(candidatePath: string): Promise<boolean> {
+  try {
+    await fsp.access(candidatePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveSkillDirectoryState(
+  skillName: string,
+): Promise<SkillDirectoryState | undefined> {
+  const enabledSkillDir = path.join(ENABLED_SKILLS_DIR, skillName);
+  if (await pathExists(enabledSkillDir)) {
+    return { enabled: true, skillDir: enabledSkillDir };
+  }
+
+  const disabledSkillDir = path.join(DISABLED_SKILLS_DIR, skillName);
+  if (await pathExists(disabledSkillDir)) {
+    return { enabled: false, skillDir: disabledSkillDir };
+  }
+
+  return undefined;
+}
+
+async function moveSkillDirectory(sourceDir: string, destinationDir: string): Promise<void> {
+  await fsp.mkdir(path.dirname(destinationDir), { recursive: true });
+  await fsp.rename(sourceDir, destinationDir);
+}
+
+async function listSkillDirectoryStates(): Promise<SkillDirectoryState[]> {
+  const states: SkillDirectoryState[] = [];
+  const seenNames = new Set<string>();
+
+  for (const [rootDir, enabled] of [
+    [ENABLED_SKILLS_DIR, true],
+    [DISABLED_SKILLS_DIR, false],
+  ] as const) {
+    let dirEntries: fs.Dirent[];
+    try {
+      dirEntries = await fsp.readdir(rootDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of dirEntries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      if (seenNames.has(entry.name)) continue;
+      seenNames.add(entry.name);
+      states.push({
+        enabled,
+        skillDir: path.join(rootDir, entry.name),
+      });
+    }
+  }
+
+  return states;
+}
+
+/** Run a CLI command and return stdout. */
+function runCommand(
+  command: string,
+  args: string[],
+  timeoutMs: number,
+): Effect.Effect<string, SkillsError> {
+  return Effect.tryPromise({
+    try: () => runProcess(command, args, { timeoutMs }).then((r) => r.stdout),
+    catch: (cause) =>
+      new SkillsError({ message: `Command failed: ${command} ${args.join(" ")}`, cause }),
+  });
+}
+
+/** Read all installed skills from the enabled and disabled skill roots. */
+function listSkills(): Effect.Effect<SkillsListResult, SkillsError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const skills: SkillMetadata[] = [];
+      const directoryStates = await listSkillDirectoryStates();
+
+      for (const directoryState of directoryStates) {
+        const skillName = path.basename(directoryState.skillDir);
+        const skillDir = directoryState.skillDir;
+        const skillMdPath = resolveSkillMdPath(skillDir);
+
+        let content = "";
+        if (skillMdPath) {
+          try {
+            content = await fsp.readFile(skillMdPath, "utf-8");
+          } catch {
+            // Couldn't read SKILL.md
+          }
+        }
+
+        const { description } = parseSkillFrontmatter(content);
+        const enabled = directoryState.enabled;
+        const agents = enabled ? ["Codex"] : [];
+
+        skills.push({
+          name: skillName,
+          description,
+          enabled,
+          agents,
+        });
+      }
+
+      skills.sort((a, b) => a.name.localeCompare(b.name));
+      return { skills } satisfies SkillsListResult;
+    },
+    catch: (cause) => new SkillsError({ message: `Failed to list skills`, cause }),
+  });
+}
+
+/** Toggle a skill by moving its directory between the enabled and disabled roots. */
+function toggleSkill(input: SkillsToggleInput): Effect.Effect<SkillsToggleResult, SkillsError> {
+  return Effect.tryPromise({
+    try: async () => {
+      assertValidSkillSlug(input.skillName);
+      const skillState = await resolveSkillDirectoryState(input.skillName);
+      if (!skillState) {
+        throw new Error(`Skill not found: ${input.skillName}`);
+      }
+      if (skillState.enabled === input.enabled) {
+        return { skillName: input.skillName, enabled: input.enabled } satisfies SkillsToggleResult;
+      }
+
+      const destinationRootDir = input.enabled ? ENABLED_SKILLS_DIR : DISABLED_SKILLS_DIR;
+      const destinationDir = path.join(destinationRootDir, input.skillName);
+      if (await pathExists(destinationDir)) {
+        throw new Error(`Destination already exists for skill: ${input.skillName}`);
+      }
+      await moveSkillDirectory(skillState.skillDir, destinationDir);
+
+      return { skillName: input.skillName, enabled: input.enabled } satisfies SkillsToggleResult;
+    },
+    catch: (cause) =>
+      new SkillsError({ message: `Failed to toggle skill: ${input.skillName}`, cause }),
+  });
+}
+
+/** Search skills.sh registry via HTTP API. */
+function searchSkills(input: SkillsSearchInput): Effect.Effect<SkillsSearchResult, SkillsError> {
+  return Effect.tryPromise({
+    try: async () => {
+      const url = `https://skills.sh/api/search?q=${encodeURIComponent(input.query)}&limit=10`;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), SKILLS_SEARCH_TIMEOUT_MS);
+      let res: Response;
+      try {
+        res = await fetch(url, { signal: controller.signal });
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          throw new Error(`skills.sh API timed out after ${SKILLS_SEARCH_TIMEOUT_MS}ms`, {
+            cause: error,
+          });
+        }
+        throw error;
+      } finally {
+        clearTimeout(timeoutId);
+      }
+      if (!res.ok) throw new Error(`skills.sh API returned ${res.status}`);
+      const data = (await res.json()) as {
+        skills: Array<{ id: string; name: string; installs: number; source: string }>;
+      };
+      const skills: SkillSearchResultEntry[] = data.skills.map((s) => ({
+        name: s.name,
+        source: s.source,
+        installs: s.installs,
+        url: `https://skills.sh/${s.id}`,
+      }));
+      return { skills } satisfies SkillsSearchResult;
+    },
+    catch: (cause) => new SkillsError({ message: `Failed to search skills.sh`, cause }),
+  });
+}
+
+/** Install a skill from skills.sh into the enabled skills directory. */
+function installSkill(input: SkillsInstallInput): Effect.Effect<SkillsInstallResult, SkillsError> {
+  try {
+    assertValidSkillSlug(input.skillName);
+  } catch (error) {
+    return Effect.succeed({
+      success: false,
+      message: error instanceof Error ? error.message : `Invalid skill name: ${input.skillName}`,
+    } satisfies SkillsInstallResult);
+  }
+  return runCommand(
+    "npx",
+    ["skills", "add", input.source, "-s", input.skillName, "-g", "-y"],
+    120_000,
+  ).pipe(
+    Effect.map(
+      () =>
+        ({
+          success: true,
+          message: `Successfully installed ${input.skillName}`,
+        }) satisfies SkillsInstallResult,
+    ),
+    Effect.catch((error: SkillsError) =>
+      Effect.succeed({
+        success: false,
+        message: error.message,
+      } satisfies SkillsInstallResult),
+    ),
+  );
+}
+
+/** Uninstall a skill by removing it from both enabled and disabled storage. */
+function uninstallSkill(
+  input: SkillsUninstallInput,
+): Effect.Effect<SkillsUninstallResult, SkillsError> {
+  return Effect.tryPromise({
+    try: async () => {
+      assertValidSkillSlug(input.skillName);
+      const candidates = [
+        path.join(ENABLED_SKILLS_DIR, input.skillName),
+        path.join(DISABLED_SKILLS_DIR, input.skillName),
+      ];
+      let removedAny = false;
+
+      for (const candidate of candidates) {
+        if (!(await pathExists(candidate))) continue;
+        await fsp.rm(candidate, { recursive: true, force: false });
+        removedAny = true;
+      }
+
+      if (!removedAny) {
+        return {
+          success: false,
+          message: `Skill not found: ${input.skillName}`,
+        } satisfies SkillsUninstallResult;
+      }
+
+      return {
+        success: true,
+        message: `Successfully uninstalled ${input.skillName}`,
+      } satisfies SkillsUninstallResult;
+    },
+    catch: (cause) =>
+      new SkillsError({ message: `Failed to uninstall skill: ${input.skillName}`, cause }),
+  }).pipe(
+    Effect.catch((error: SkillsError) =>
+      Effect.succeed({
+        success: false,
+        message: error.message,
+      } satisfies SkillsUninstallResult),
+    ),
+  );
+}
+
+/** Read the full SKILL.md content (stripping YAML frontmatter) for a given skill. */
+function readContent(
+  input: SkillsReadContentInput,
+): Effect.Effect<SkillsReadContentResult, SkillsError> {
+  return Effect.tryPromise({
+    try: async () => {
+      assertValidSkillSlug(input.skillName);
+      const skillState = await resolveSkillDirectoryState(input.skillName);
+      if (!skillState) {
+        throw new Error(`Skill not found: ${input.skillName}`);
+      }
+      const skillMdPath = resolveSkillMdPath(skillState.skillDir);
+      if (!skillMdPath) {
+        throw new Error(`No SKILL.md found for ${input.skillName}`);
+      }
+
+      const raw = await fsp.readFile(skillMdPath, "utf-8");
+
+      // Strip YAML frontmatter (everything between opening and closing ---)
+      const content = raw.replace(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n)?/, "").trim();
+
+      return { skillName: input.skillName, content } satisfies SkillsReadContentResult;
+    },
+    catch: (cause) =>
+      new SkillsError({ message: `Failed to read skill content: ${input.skillName}`, cause }),
+  });
+}
+
+// ── Live Layer ───────────────────────────────────────────────────────
+
+export const SkillsManagerLive = Layer.succeed(SkillsManager, {
+  list: listSkills(),
+  toggle: toggleSkill,
+  search: searchSkills,
+  install: installSkill,
+  uninstall: uninstallSkill,
+  readContent,
+});

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -7,6 +7,8 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Exit, Layer, PlatformError, PubSub, Scope, Stream } from "effect";
 import { describe, expect, it, afterEach, vi } from "vitest";
 import { createServer } from "./wsServer";
+import { SkillsManagerLive } from "./skills/SkillsManager";
+import { McpManagerLive } from "./mcp/McpManager";
 import WebSocket from "ws";
 import { ServerConfig, type ServerConfigShape } from "./config";
 import { makeServerProviderLayer, makeServerRuntimeServicesLayer } from "./serverLayers";
@@ -532,6 +534,8 @@ describe("WebSocket Server", () => {
     const dependenciesLayer = Layer.empty.pipe(
       Layer.provideMerge(runtimeLayer),
       Layer.provideMerge(providerHealthLayer),
+      Layer.provideMerge(SkillsManagerLive),
+      Layer.provideMerge(McpManagerLive),
       Layer.provideMerge(openLayer),
       Layer.provideMerge(serverConfigLayer),
       Layer.provideMerge(AnalyticsService.layerTest),
@@ -631,6 +635,25 @@ describe("WebSocket Server", () => {
     expect(response.headers.get("content-type")).toContain("image/png");
     const bytes = Buffer.from(await response.arrayBuffer());
     expect(bytes).toEqual(Buffer.from("hello-encoded-attachment"));
+  });
+
+  it("serves persisted attachments by attachment id lookup", async () => {
+    const stateDir = makeTempDir("t3code-state-attachments-id-");
+    const attachmentId = "thread-a-00000000-0000-4000-8000-000000000001";
+    const attachmentPath = path.join(stateDir, "attachments", `${attachmentId}.png`);
+    fs.mkdirSync(path.dirname(attachmentPath), { recursive: true });
+    fs.writeFileSync(attachmentPath, Buffer.from("hello-id-attachment"));
+
+    server = await createTestServer({ cwd: "/test/project", stateDir });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+    expect(port).toBeGreaterThan(0);
+
+    const response = await fetch(`http://127.0.0.1:${port}/attachments/${attachmentId}`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("image/png");
+    const bytes = Buffer.from(await response.arrayBuffer());
+    expect(bytes).toEqual(Buffer.from("hello-id-attachment"));
   });
 
   it("serves static index for root path", async () => {

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -58,6 +58,8 @@ import { ProviderHealth } from "./provider/Services/ProviderHealth";
 import { CheckpointDiffQuery } from "./checkpointing/Services/CheckpointDiffQuery";
 import { clamp } from "effect/Number";
 import { Open, resolveAvailableEditors } from "./open";
+import { SkillsManager } from "./skills/SkillsManager";
+import { McpManager } from "./mcp/McpManager";
 import { ServerConfig } from "./config";
 import { GitCore } from "./git/Services/GitCore.ts";
 import { tryHandleProjectFaviconRequest } from "./projectFaviconRoute";
@@ -217,7 +219,9 @@ export type ServerRuntimeServices =
   | TerminalManager
   | Keybindings
   | Open
-  | AnalyticsService;
+  | AnalyticsService
+  | SkillsManager
+  | McpManager;
 
 export class ServerLifecycleError extends Schema.TaggedErrorClass<ServerLifecycleError>()(
   "ServerLifecycleError",
@@ -253,6 +257,8 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   const gitManager = yield* GitManager;
   const terminalManager = yield* TerminalManager;
   const keybindingsManager = yield* Keybindings;
+  const skillsManager = yield* SkillsManager;
+  const mcpManager = yield* McpManager;
   const providerHealth = yield* ProviderHealth;
   const git = yield* GitCore;
   const fileSystem = yield* FileSystem.FileSystem;
@@ -865,6 +871,60 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         const body = stripRequestTag(request.body);
         return yield* terminalManager.close(body);
       }
+
+      case WS_METHODS.skillsList:
+        return yield* skillsManager.list;
+
+      case WS_METHODS.skillsToggle: {
+        const body = stripRequestTag(request.body);
+        return yield* skillsManager.toggle(body);
+      }
+
+      case WS_METHODS.skillsSearch: {
+        const body = stripRequestTag(request.body);
+        return yield* skillsManager.search(body);
+      }
+
+      case WS_METHODS.skillsInstall: {
+        const body = stripRequestTag(request.body);
+        return yield* skillsManager.install(body);
+      }
+
+      case WS_METHODS.skillsUninstall: {
+        const body = stripRequestTag(request.body);
+        return yield* skillsManager.uninstall(body);
+      }
+
+      case WS_METHODS.skillsReadContent: {
+        const body = stripRequestTag(request.body);
+        return yield* skillsManager.readContent(body);
+      }
+
+      case WS_METHODS.mcpList:
+        return yield* mcpManager.list;
+
+      case WS_METHODS.mcpAdd: {
+        const body = stripRequestTag(request.body);
+        return yield* mcpManager.add(body);
+      }
+
+      case WS_METHODS.mcpRemove: {
+        const body = stripRequestTag(request.body);
+        return yield* mcpManager.remove(body);
+      }
+
+      case WS_METHODS.mcpToggle: {
+        const body = stripRequestTag(request.body);
+        return yield* mcpManager.toggle(body);
+      }
+
+      case WS_METHODS.mcpUpdate: {
+        const body = stripRequestTag(request.body);
+        return yield* mcpManager.update(body);
+      }
+
+      case WS_METHODS.mcpBrowse:
+        return yield* mcpManager.browse;
 
       case WS_METHODS.serverGetConfig:
         const keybindingsConfig = yield* keybindingsManager.loadConfigState;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@t3tools/web",
-  "version": "0.0.10",
+  "version": "0.1.25",
   "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "prepare": "effect-language-service patch",
+    "prepare": "node ../../scripts/run-effect-language-service-patch.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1,8 +1,7 @@
-import { useCallback } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 import { Option, Schema } from "effect";
 import { TrimmedNonEmptyString, type ProviderKind } from "@t3tools/contracts";
 import { getDefaultModel, getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
-import { useLocalStorage } from "./hooks/useLocalStorage";
 
 const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
 const MAX_CUSTOM_MODEL_COUNT = 32;
@@ -12,6 +11,7 @@ export type TimestampFormat = (typeof TIMESTAMP_FORMAT_OPTIONS)[number];
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
 const BUILT_IN_MODEL_SLUGS_BY_PROVIDER: Record<ProviderKind, ReadonlySet<string>> = {
   codex: new Set(getModelOptions("codex").map((option) => option.slug)),
+  copilot: new Set(getModelOptions("copilot").map((option) => option.slug)),
 };
 
 const AppSettingsSchema = Schema.Struct({
@@ -19,6 +19,12 @@ const AppSettingsSchema = Schema.Struct({
     Schema.withConstructorDefault(() => Option.some("")),
   ),
   codexHomePath: Schema.String.check(Schema.isMaxLength(4096)).pipe(
+    Schema.withConstructorDefault(() => Option.some("")),
+  ),
+  copilotCliPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(
+    Schema.withConstructorDefault(() => Option.some("")),
+  ),
+  copilotConfigDir: Schema.String.check(Schema.isMaxLength(4096)).pipe(
     Schema.withConstructorDefault(() => Option.some("")),
   ),
   defaultThreadEnvMode: Schema.Literals(["local", "worktree"]).pipe(
@@ -34,6 +40,9 @@ const AppSettingsSchema = Schema.Struct({
   customCodexModels: Schema.Array(Schema.String).pipe(
     Schema.withConstructorDefault(() => Option.some([])),
   ),
+  customCopilotModels: Schema.Array(Schema.String).pipe(
+    Schema.withConstructorDefault(() => Option.some([])),
+  ),
   textGenerationModel: Schema.optional(TrimmedNonEmptyString),
 });
 export type AppSettings = typeof AppSettingsSchema.Type;
@@ -43,15 +52,27 @@ export interface AppModelOption {
   isCustom: boolean;
 }
 
+export interface BuiltInAppModelOption {
+  slug: string;
+  name: string;
+}
 const DEFAULT_APP_SETTINGS = AppSettingsSchema.makeUnsafe({});
+
+let listeners: Array<() => void> = [];
+let cachedRawSettings: string | null | undefined;
+let cachedSnapshot: AppSettings = DEFAULT_APP_SETTINGS;
 
 export function normalizeCustomModelSlugs(
   models: Iterable<string | null | undefined>,
   provider: ProviderKind = "codex",
+  builtInOptions?: readonly BuiltInAppModelOption[],
 ): string[] {
   const normalizedModels: string[] = [];
   const seen = new Set<string>();
-  const builtInModelSlugs = BUILT_IN_MODEL_SLUGS_BY_PROVIDER[provider];
+  const builtInModelSlugs =
+    builtInOptions !== undefined
+      ? new Set(builtInOptions.map((option) => option.slug))
+      : BUILT_IN_MODEL_SLUGS_BY_PROVIDER[provider];
 
   for (const candidate of models) {
     const normalized = normalizeModelSlug(candidate, provider);
@@ -74,19 +95,29 @@ export function normalizeCustomModelSlugs(
   return normalizedModels;
 }
 
+function normalizeAppSettings(settings: AppSettings): AppSettings {
+  return {
+    ...settings,
+    customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
+    customCopilotModels: normalizeCustomModelSlugs(settings.customCopilotModels, "copilot"),
+  };
+}
+
 export function getAppModelOptions(
   provider: ProviderKind,
   customModels: readonly string[],
   selectedModel?: string | null,
+  builtInOptions?: readonly BuiltInAppModelOption[],
 ): AppModelOption[] {
-  const options: AppModelOption[] = getModelOptions(provider).map(({ slug, name }) => ({
+  const resolvedBuiltInOptions = builtInOptions ?? getModelOptions(provider);
+  const options: AppModelOption[] = resolvedBuiltInOptions.map(({ slug, name }) => ({
     slug,
     name,
     isCustom: false,
   }));
   const seen = new Set(options.map((option) => option.slug));
 
-  for (const slug of normalizeCustomModelSlugs(customModels, provider)) {
+  for (const slug of normalizeCustomModelSlugs(customModels, provider, resolvedBuiltInOptions)) {
     if (seen.has(slug)) {
       continue;
     }
@@ -115,8 +146,9 @@ export function resolveAppModelSelection(
   provider: ProviderKind,
   customModels: readonly string[],
   selectedModel: string | null | undefined,
+  builtInOptions?: readonly BuiltInAppModelOption[],
 ): string {
-  const options = getAppModelOptions(provider, customModels, selectedModel);
+  const options = getAppModelOptions(provider, customModels, selectedModel, builtInOptions);
   const trimmedSelectedModel = selectedModel?.trim();
   if (trimmedSelectedModel) {
     const direct = options.find((option) => option.slug === trimmedSelectedModel);
@@ -134,35 +166,123 @@ export function resolveAppModelSelection(
 
   const normalizedSelectedModel = normalizeModelSlug(selectedModel, provider);
   if (!normalizedSelectedModel) {
-    return getDefaultModel(provider);
+    return builtInOptions?.[0]?.slug ?? getDefaultModel(provider);
   }
 
   return (
     options.find((option) => option.slug === normalizedSelectedModel)?.slug ??
+    builtInOptions?.[0]?.slug ??
     getDefaultModel(provider)
   );
 }
 
+export function getSlashModelOptions(
+  provider: ProviderKind,
+  customModels: readonly string[],
+  query: string,
+  selectedModel?: string | null,
+  builtInOptions?: readonly BuiltInAppModelOption[],
+): AppModelOption[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const options = getAppModelOptions(provider, customModels, selectedModel, builtInOptions);
+  if (!normalizedQuery) {
+    return options;
+  }
+
+  return options.filter((option) => {
+    const searchSlug = option.slug.toLowerCase();
+    const searchName = option.name.toLowerCase();
+    return searchSlug.includes(normalizedQuery) || searchName.includes(normalizedQuery);
+  });
+}
+
+function emitChange(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function parsePersistedSettings(value: string | null): AppSettings {
+  if (!value) {
+    return DEFAULT_APP_SETTINGS;
+  }
+
+  try {
+    return normalizeAppSettings(Schema.decodeSync(Schema.fromJsonString(AppSettingsSchema))(value));
+  } catch {
+    return DEFAULT_APP_SETTINGS;
+  }
+}
+
+export function getAppSettingsSnapshot(): AppSettings {
+  if (typeof window === "undefined") {
+    return DEFAULT_APP_SETTINGS;
+  }
+
+  const raw = window.localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+  if (raw === cachedRawSettings) {
+    return cachedSnapshot;
+  }
+
+  cachedRawSettings = raw;
+  cachedSnapshot = parsePersistedSettings(raw);
+  return cachedSnapshot;
+}
+
+function persistSettings(next: AppSettings): void {
+  if (typeof window === "undefined") return;
+
+  const raw = JSON.stringify(next);
+  try {
+    if (raw !== cachedRawSettings) {
+      window.localStorage.setItem(APP_SETTINGS_STORAGE_KEY, raw);
+    }
+  } catch {
+    // Best-effort persistence only.
+  }
+
+  cachedRawSettings = raw;
+  cachedSnapshot = next;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.push(listener);
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === APP_SETTINGS_STORAGE_KEY) {
+      emitChange();
+    }
+  };
+
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners = listeners.filter((entry) => entry !== listener);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
 export function useAppSettings() {
-  const [settings, setSettings] = useLocalStorage(
-    APP_SETTINGS_STORAGE_KEY,
-    DEFAULT_APP_SETTINGS,
-    AppSettingsSchema,
+  const settings = useSyncExternalStore(
+    subscribe,
+    getAppSettingsSnapshot,
+    () => DEFAULT_APP_SETTINGS,
   );
 
-  const updateSettings = useCallback(
-    (patch: Partial<AppSettings>) => {
-      setSettings((prev) => ({
-        ...prev,
+  const updateSettings = useCallback((patch: Partial<AppSettings>) => {
+    const next = normalizeAppSettings(
+      Schema.decodeSync(AppSettingsSchema)({
+        ...getAppSettingsSnapshot(),
         ...patch,
-      }));
-    },
-    [setSettings],
-  );
+      }),
+    );
+    persistSettings(next);
+    emitChange();
+  }, []);
 
   const resetSettings = useCallback(() => {
-    setSettings(DEFAULT_APP_SETTINGS);
-  }, [setSettings]);
+    persistSettings(DEFAULT_APP_SETTINGS);
+    emitChange();
+  }, []);
 
   return {
     settings,

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,7 +1,104 @@
-import { ThreadId } from "@t3tools/contracts";
+import { EventId, ThreadId, TurnId, type OrchestrationThreadActivity } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { buildExpiredTerminalContextToastCopy, deriveComposerSendState } from "./ChatView.logic";
+import {
+  buildExpiredTerminalContextToastCopy,
+  deriveComposerSendState,
+  deriveVisibleThreadWorkLogEntries,
+  orderCopilotBuiltInModelOptions,
+  resolveProviderHealthBannerProvider,
+} from "./ChatView.logic";
+
+function makeActivity(overrides: {
+  id?: string;
+  createdAt?: string;
+  kind?: string;
+  summary?: string;
+  tone?: OrchestrationThreadActivity["tone"];
+  payload?: Record<string, unknown>;
+  turnId?: string;
+  sequence?: number;
+}): OrchestrationThreadActivity {
+  return {
+    id: EventId.makeUnsafe(overrides.id ?? crypto.randomUUID()),
+    createdAt: overrides.createdAt ?? "2026-02-23T00:00:00.000Z",
+    kind: overrides.kind ?? "tool.started",
+    summary: overrides.summary ?? "Tool call",
+    tone: overrides.tone ?? "tool",
+    payload: overrides.payload ?? {},
+    turnId: overrides.turnId ? TurnId.makeUnsafe(overrides.turnId) : null,
+    ...(overrides.sequence !== undefined ? { sequence: overrides.sequence } : {}),
+  };
+}
+
+describe("resolveProviderHealthBannerProvider", () => {
+  it("uses the active session provider when a session exists", () => {
+    expect(
+      resolveProviderHealthBannerProvider({
+        sessionProvider: "codex",
+        selectedProvider: "copilot",
+      }),
+    ).toBe("codex");
+  });
+
+  it("uses selected draft provider before session starts", () => {
+    expect(
+      resolveProviderHealthBannerProvider({
+        sessionProvider: null,
+        selectedProvider: "copilot",
+      }),
+    ).toBe("copilot");
+  });
+});
+
+describe("orderCopilotBuiltInModelOptions", () => {
+  it("reorders runtime copilot models to match the preferred built-in picker order", () => {
+    expect(
+      orderCopilotBuiltInModelOptions([
+        { slug: "gpt-5.4", name: "GPT-5.4" },
+        { slug: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+        { slug: "gpt-5.4-mini", name: "GPT-5.4 mini" },
+        { slug: "gpt-5.2", name: "GPT-5.2" },
+      ]).map((option) => option.slug),
+    ).toEqual(["gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"]);
+  });
+
+  it("keeps unknown runtime-only models after the preferred built-in models", () => {
+    expect(
+      orderCopilotBuiltInModelOptions([
+        { slug: "gpt-5.4", name: "GPT-5.4" },
+        { slug: "future-runtime-model", name: "Future Runtime Model" },
+        { slug: "gpt-5.4-mini", name: "GPT-5.4 mini" },
+      ]).map((option) => option.slug),
+    ).toEqual(["gpt-5.4", "gpt-5.4-mini", "future-runtime-model"]);
+  });
+});
+
+describe("deriveVisibleThreadWorkLogEntries", () => {
+  it("keeps completed tool calls from previous turns visible in the thread timeline", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "tool-1",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        turnId: "turn-1",
+        kind: "tool.completed",
+        summary: "First tool call",
+      }),
+      makeActivity({
+        id: "tool-2",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        turnId: "turn-2",
+        kind: "tool.completed",
+        summary: "Second tool call",
+      }),
+    ];
+
+    expect(deriveVisibleThreadWorkLogEntries(activities).map((entry) => entry.id)).toEqual([
+      "tool-1",
+      "tool-2",
+    ]);
+  });
+});
 
 describe("deriveComposerSendState", () => {
   it("treats expired terminal pills as non-sendable content", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,14 +1,22 @@
-import { ProjectId, type ProviderKind, type ThreadId } from "@t3tools/contracts";
-import { type ChatMessage, type Thread } from "../types";
-import { randomUUID } from "~/lib/utils";
-import { getAppModelOptions } from "../appSettings";
-import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
+import {
+  ProjectId,
+  type OrchestrationThreadActivity,
+  type ProviderKind,
+  type ThreadId,
+} from "@t3tools/contracts";
+import { getModelOptions } from "@t3tools/shared/model";
 import { Schema } from "effect";
+
+import { getAppModelOptions, type BuiltInAppModelOption } from "../appSettings";
+import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import {
   filterTerminalContextsWithText,
   stripInlineTerminalContextPlaceholders,
   type TerminalContextDraft,
 } from "../lib/terminalContext";
+import { deriveWorkLogEntries, type WorkLogEntry } from "../session-logic";
+import { type ChatMessage, type Thread } from "../types";
+import { randomUUID } from "~/lib/utils";
 
 export const LAST_INVOKED_SCRIPT_BY_PROJECT_KEY = "t3code:last-invoked-script-by-project";
 const WORKTREE_BRANCH_PREFIX = "t3code";
@@ -100,7 +108,6 @@ export function readFileAsDataUrl(file: File): Promise<string> {
 }
 
 export function buildTemporaryWorktreeBranchName(): string {
-  // Keep the 8-hex suffix shape for backend temporary-branch detection.
   const token = randomUUID().slice(0, 8).toLowerCase();
   return `${WORKTREE_BRANCH_PREFIX}/${token}`;
 }
@@ -123,10 +130,59 @@ export function cloneComposerImageForRetry(
 
 export function getCustomModelOptionsByProvider(settings: {
   customCodexModels: readonly string[];
+  customCopilotModels?: readonly string[];
+  builtInCopilotOptions?: ReadonlyArray<BuiltInAppModelOption>;
 }): Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>> {
   return {
     codex: getAppModelOptions("codex", settings.customCodexModels),
+    copilot: getAppModelOptions(
+      "copilot",
+      settings.customCopilotModels ?? [],
+      undefined,
+      settings.builtInCopilotOptions,
+    ),
   };
+}
+
+export function orderCopilotBuiltInModelOptions(
+  runtimeOptions: ReadonlyArray<BuiltInAppModelOption>,
+  preferredOptions: ReadonlyArray<BuiltInAppModelOption> = getModelOptions("copilot"),
+): ReadonlyArray<BuiltInAppModelOption> {
+  const preferredIndexBySlug = new Map(
+    preferredOptions.map((option, index) => [option.slug, index] as const),
+  );
+
+  return runtimeOptions
+    .map((option, runtimeIndex) => ({ option, runtimeIndex }))
+    .toSorted((left, right) => {
+      const leftPreferredIndex = preferredIndexBySlug.get(left.option.slug);
+      const rightPreferredIndex = preferredIndexBySlug.get(right.option.slug);
+
+      if (leftPreferredIndex !== undefined && rightPreferredIndex !== undefined) {
+        return leftPreferredIndex - rightPreferredIndex;
+      }
+      if (leftPreferredIndex !== undefined) {
+        return -1;
+      }
+      if (rightPreferredIndex !== undefined) {
+        return 1;
+      }
+      return left.runtimeIndex - right.runtimeIndex;
+    })
+    .map(({ option }) => option);
+}
+
+export function resolveProviderHealthBannerProvider(input: {
+  sessionProvider: ProviderKind | null;
+  selectedProvider: ProviderKind;
+}): ProviderKind {
+  return input.sessionProvider ?? input.selectedProvider;
+}
+
+export function deriveVisibleThreadWorkLogEntries(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): WorkLogEntry[] {
+  return deriveWorkLogEntries(activities, undefined);
 }
 
 export function deriveComposerSendState(options: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,6 +1,7 @@
 import {
   type ApprovalRequestId,
   DEFAULT_MODEL_BY_PROVIDER,
+  EDITORS,
   type EditorId,
   type KeybindingCommand,
   type CodexReasoningEffort,
@@ -13,6 +14,8 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
   type ResolvedKeybindingsConfig,
   type ProviderApprovalDecision,
+  type ServerProviderModel,
+  type ServerProviderQuotaSnapshot,
   type ServerProviderStatus,
   type ProviderKind,
   type ThreadId,
@@ -24,23 +27,42 @@ import {
 import {
   getDefaultModel,
   getDefaultReasoningEffort,
+  getModelOptions,
   getReasoningEffortOptions,
   normalizeModelSlug,
   resolveModelSlugForProvider,
 } from "@t3tools/shared/model";
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useId,
+} from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import {
+  measureElement as measureVirtualElement,
+  type VirtualItem,
+  useVirtualizer,
+} from "@tanstack/react-virtual";
 import { gitBranchesQueryOptions, gitCreateWorktreeMutationOptions } from "~/lib/gitReactQuery";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
+import { skillsListQueryOptions } from "~/lib/skillsReactQuery";
+
 import { isElectron } from "../env";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import {
   clampCollapsedComposerCursor,
-  type ComposerTrigger,
   collapseExpandedComposerCursor,
+  type ComposerSlashCommand,
+  type ComposerTrigger,
+  type ComposerTriggerKind,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
   parseStandaloneComposerSlashCommand,
@@ -54,13 +76,17 @@ import {
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
   findLatestProposedPlan,
-  deriveWorkLogEntries,
+  type PendingApproval,
+  type PendingUserInput,
+  type ProviderPickerKind,
+  PROVIDER_OPTIONS,
   hasActionableProposedPlan,
   hasToolActivityForTurn,
   isLatestTurnSettled,
   formatElapsed,
+  type WorkLogEntry,
 } from "../session-logic";
-import { isScrollContainerNearBottom } from "../chat-scroll";
+import { AUTO_SCROLL_BOTTOM_THRESHOLD_PX, isScrollContainerNearBottom } from "../chat-scroll";
 import {
   buildPendingUserInputAnswers,
   derivePendingUserInputProgress,
@@ -69,10 +95,15 @@ import {
 } from "../pendingUserInput";
 import { useStore } from "../store";
 import {
+  buildCollapsedProposedPlanPreviewMarkdown,
   buildPlanImplementationThreadTitle,
   buildPlanImplementationPrompt,
+  buildProposedPlanMarkdownFilename,
+  downloadPlanAsTextFile,
+  normalizePlanMarkdownForExport,
   proposedPlanTitle,
   resolvePlanFollowUpSubmission,
+  stripDisplayedPlanMarkdown,
 } from "../proposedPlan";
 import { truncateTitle } from "../truncateTitle";
 import {
@@ -81,34 +112,105 @@ import {
   DEFAULT_THREAD_TERMINAL_ID,
   MAX_TERMINALS_PER_GROUP,
   type ChatMessage,
+  type TurnDiffFileChange,
   type TurnDiffSummary,
 } from "../types";
-import { basenameOfPath } from "../vscode-icons";
+import { basenameOfPath, getVscodeIconUrlForEntry } from "../vscode-icons";
 import { useTheme } from "../hooks/useTheme";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
+import {
+  buildTurnDiffTree,
+  summarizeTurnDiffStats,
+  type TurnDiffTreeNode,
+} from "../lib/turnDiffTree";
 import BranchToolbar from "./BranchToolbar";
-import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
+import GitActionsControl from "./GitActionsControl";
+import {
+  isOpenFavoriteEditorShortcut,
+  resolveShortcutCommand,
+  shortcutLabelForCommand,
+} from "../keybindings";
+import ChatMarkdown from "./ChatMarkdown";
 import PlanSidebar from "./PlanSidebar";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
+import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import {
   BotIcon,
+  BoxIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   CircleAlertIcon,
+  DatabaseIcon,
+  EyeIcon,
+  FileIcon,
+  FolderIcon,
+  DiffIcon,
+  EllipsisIcon,
+  FolderClosedIcon,
+  GlobeIcon,
+  HammerIcon,
   ListTodoIcon,
   LockIcon,
   LockOpenIcon,
+  type LucideIcon,
+  SearchIcon,
+  SquarePenIcon,
+  TerminalIcon,
+  TargetIcon,
+  Undo2Icon,
+  WrenchIcon,
   XIcon,
+  CopyIcon,
+  CheckIcon,
+  ZapIcon,
 } from "lucide-react";
 import { Button } from "./ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./ui/collapsible";
+import { Input } from "./ui/input";
 import { Separator } from "./ui/separator";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
-import { cn, randomUUID } from "~/lib/utils";
+import { Group, GroupSeparator } from "./ui/group";
+import {
+  Menu,
+  MenuGroup,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator as MenuDivider,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuShortcut,
+  MenuTrigger,
+} from "./ui/menu";
+import {
+  ClaudeAI,
+  CursorIcon,
+  Gemini,
+  GitHubIcon,
+  Icon,
+  OpenAI,
+  OpenCodeIcon,
+  VisualStudioCode,
+  Zed,
+} from "./Icons";
+import { cn, isMacPlatform, isWindowsPlatform, randomUUID } from "~/lib/utils";
+import { Badge } from "./ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { Command, CommandItem, CommandList } from "./ui/command";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
 import { toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
-import { type NewProjectScriptInput } from "./ProjectScriptsControl";
+import ProjectScriptsControl, { type NewProjectScriptInput } from "./ProjectScriptsControl";
 import {
   commandForProjectScript,
   nextProjectScriptId,
@@ -116,11 +218,16 @@ import {
   projectScriptIdFromCommand,
   setupProjectScript,
 } from "~/projectScripts";
+import { Toggle } from "./ui/toggle";
 import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
-import { resolveAppModelSelection, useAppSettings } from "../appSettings";
-import { isTerminalFocused } from "../lib/terminalFocus";
+import {
+  resolveAppModelSelection,
+  type BuiltInAppModelOption,
+  type TimestampFormat,
+  useAppSettings,
+} from "../appSettings";
 import {
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
@@ -138,21 +245,15 @@ import {
 } from "../lib/terminalContext";
 import { shouldUseCompactComposerFooter } from "./composerFooterLayout";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+import { clamp } from "effect/Number";
 import { ComposerPromptEditor, type ComposerPromptEditorHandle } from "./ComposerPromptEditor";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
-import { MessagesTimeline } from "./chat/MessagesTimeline";
-import { ChatHeader } from "./chat/ChatHeader";
-import { buildExpandedImagePreview, ExpandedImagePreview } from "./chat/ExpandedImagePreview";
-import { AVAILABLE_PROVIDER_OPTIONS, ProviderModelPicker } from "./chat/ProviderModelPicker";
-import { ComposerCommandItem, ComposerCommandMenu } from "./chat/ComposerCommandMenu";
-import { ComposerPendingApprovalActions } from "./chat/ComposerPendingApprovalActions";
-import { CodexTraitsPicker } from "./chat/CodexTraitsPicker";
-import { CompactComposerControlsMenu } from "./chat/CompactComposerControlsMenu";
-import { ComposerPendingApprovalPanel } from "./chat/ComposerPendingApprovalPanel";
-import { ComposerPendingUserInputPanel } from "./chat/ComposerPendingUserInputPanel";
-import { ComposerPlanFollowUpBanner } from "./chat/ComposerPlanFollowUpBanner";
-import { ProviderHealthBanner } from "./chat/ProviderHealthBanner";
-import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
+import { estimateTimelineMessageHeight } from "./timelineHeight";
+import { formatTimestamp } from "../timestampFormat";
+import {
+  computeMessageDurationStart,
+  normalizeCompactToolLabel,
+} from "./chat/MessagesTimeline.logic";
 import {
   buildExpiredTerminalContextToastCopy,
   buildLocalDraftThread,
@@ -160,17 +261,53 @@ import {
   cloneComposerImageForRetry,
   collectUserMessageBlobPreviewUrls,
   deriveComposerSendState,
+  deriveVisibleThreadWorkLogEntries,
   getCustomModelOptionsByProvider,
   LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
-  LastInvokedScriptByProjectSchema,
+  orderCopilotBuiltInModelOptions,
   PullRequestDialogState,
   readFileAsDataUrl,
+  resolveProviderHealthBannerProvider,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
   SendPhase,
 } from "./ChatView.logic";
-import { useLocalStorage } from "~/hooks/useLocalStorage";
 
+function formatMessageMeta(
+  createdAt: string,
+  duration: string | null,
+  timestampFormat: TimestampFormat,
+): string {
+  if (!duration) return formatTimestamp(createdAt, timestampFormat);
+  return `${formatTimestamp(createdAt, timestampFormat)} • ${duration}`;
+}
+
+function formatWorkingTimer(startIso: string, endIso: string): string | null {
+  const startedAtMs = Date.parse(startIso);
+  const endedAtMs = Date.parse(endIso);
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(endedAtMs)) {
+    return null;
+  }
+
+  const elapsedSeconds = Math.max(0, Math.floor((endedAtMs - startedAtMs) / 1000));
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds}s`;
+  }
+
+  const hours = Math.floor(elapsedSeconds / 3600);
+  const minutes = Math.floor((elapsedSeconds % 3600) / 60);
+  const seconds = elapsedSeconds % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+const LAST_EDITOR_KEY = "t3code:last-editor";
+const MAX_VISIBLE_WORK_LOG_ENTRIES = 6;
+const ALWAYS_UNVIRTUALIZED_TAIL_ROWS = 8;
 const ATTACHMENT_PREVIEW_HANDOFF_TTL_MS = 5000;
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
 const IMAGE_ONLY_BOOTSTRAP_PROMPT =
@@ -179,11 +316,667 @@ const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
 const EMPTY_AVAILABLE_EDITORS: EditorId[] = [];
+const EMPTY_PROVIDER_MODELS: ServerProviderModel[] = [];
 const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
 const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
+
+function readLastInvokedScriptByProjectFromStorage(): Record<string, string> {
+  const stored = localStorage.getItem(LAST_INVOKED_SCRIPT_BY_PROJECT_KEY);
+  if (!stored) return {};
+
+  try {
+    const parsed: unknown = JSON.parse(stored);
+    if (!parsed || typeof parsed !== "object") return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[0] === "string" && typeof entry[1] === "string",
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function workToneClass(tone: "thinking" | "tool" | "info" | "error"): string {
+  if (tone === "error") return "text-rose-300/50 dark:text-rose-300/50";
+  if (tone === "tool") return "text-muted-foreground/70";
+  if (tone === "thinking") return "text-muted-foreground/50";
+  return "text-muted-foreground/40";
+}
+
+function workToneIcon(tone: "thinking" | "tool" | "info" | "error") {
+  if (tone === "error") {
+    return {
+      icon: CircleAlertIcon,
+      className: "text-foreground/92",
+    };
+  }
+  if (tone === "thinking") {
+    return {
+      icon: BotIcon,
+      className: "text-foreground/92",
+    };
+  }
+  if (tone === "info") {
+    return {
+      icon: CheckIcon,
+      className: "text-foreground/92",
+    };
+  }
+  return {
+    icon: ZapIcon,
+    className: "text-foreground/92",
+  };
+}
+
+function workEntryPreview(workEntry: {
+  detail?: string;
+  command?: string;
+  changedFiles?: ReadonlyArray<string>;
+}): string | null {
+  if (workEntry.command) return workEntry.command;
+  if (workEntry.detail) return workEntry.detail;
+  if ((workEntry.changedFiles?.length ?? 0) > 0) {
+    const [firstPath] = workEntry.changedFiles ?? [];
+    if (!firstPath) return null;
+    return workEntry.changedFiles!.length === 1
+      ? firstPath
+      : `${firstPath} +${workEntry.changedFiles!.length - 1} more`;
+  }
+  return null;
+}
+
+function workEntryIcon(workEntry: WorkLogEntry): LucideIcon {
+  if (workEntry.requestKind === "command") return TerminalIcon;
+  if (workEntry.requestKind === "file-read") return EyeIcon;
+  if (workEntry.requestKind === "file-change") return SquarePenIcon;
+
+  if (workEntry.itemType === "command_execution" || workEntry.command) {
+    return TerminalIcon;
+  }
+  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
+    return SquarePenIcon;
+  }
+  if (workEntry.itemType === "web_search") return GlobeIcon;
+  if (workEntry.itemType === "image_view") return EyeIcon;
+
+  switch (workEntry.itemType) {
+    case "mcp_tool_call":
+      return WrenchIcon;
+    case "dynamic_tool_call":
+    case "collab_agent_tool_call":
+      return HammerIcon;
+  }
+
+  const haystack = [
+    workEntry.label,
+    workEntry.toolTitle,
+    workEntry.detail,
+    workEntry.output,
+    workEntry.command,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join(" ")
+    .toLowerCase();
+
+  if (haystack.includes("report_intent") || haystack.includes("intent logged")) {
+    return TargetIcon;
+  }
+  if (
+    haystack.includes("bash") ||
+    haystack.includes("read_bash") ||
+    haystack.includes("write_bash") ||
+    haystack.includes("stop_bash") ||
+    haystack.includes("list_bash")
+  ) {
+    return TerminalIcon;
+  }
+  if (haystack.includes("sql")) return DatabaseIcon;
+  if (haystack.includes("view")) return EyeIcon;
+  if (haystack.includes("apply_patch")) return SquarePenIcon;
+  if (haystack.includes("rg") || haystack.includes("glob") || haystack.includes("search")) {
+    return SearchIcon;
+  }
+  if (haystack.includes("skill")) return ZapIcon;
+  if (haystack.includes("ask_user") || haystack.includes("approval")) return BotIcon;
+  if (haystack.includes("store_memory")) return FolderIcon;
+  if (haystack.includes("edit") || haystack.includes("patch")) return WrenchIcon;
+  if (haystack.includes("file")) return FileIcon;
+
+  if (haystack.includes("task")) return HammerIcon;
+
+  if (workEntry.activityKind === "turn.plan.updated") return ListTodoIcon;
+  if (workEntry.activityKind === "task.progress") return HammerIcon;
+  if (workEntry.activityKind === "approval.requested") return BotIcon;
+  if (workEntry.activityKind === "approval.resolved") return CheckIcon;
+
+  return workToneIcon(workEntry.tone).icon;
+}
+
+function capitalizePhrase(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return value;
+  }
+  return `${trimmed.charAt(0).toUpperCase()}${trimmed.slice(1)}`;
+}
+
+function toolWorkEntryHeading(workEntry: WorkLogEntry): string {
+  if (!workEntry.toolTitle) {
+    return capitalizePhrase(normalizeCompactToolLabel(workEntry.label));
+  }
+  return capitalizePhrase(normalizeCompactToolLabel(workEntry.toolTitle));
+}
+
+function primaryWorkEntryPath(workEntry: WorkLogEntry): string | null {
+  const [firstPath] = workEntry.changedFiles ?? [];
+  return firstPath ?? null;
+}
+
+function toolWorkEntryStatusBadge(workEntry: WorkLogEntry): {
+  label: string;
+  variant: "error" | "info" | "warning";
+} | null {
+  if (typeof workEntry.exitCode === "number") {
+    if (workEntry.exitCode === 0) {
+      return null;
+    }
+    return {
+      label: `Exit ${workEntry.exitCode}`,
+      variant: "error",
+    };
+  }
+
+  switch (workEntry.toolStatus) {
+    case "failed":
+      return { label: "Failed", variant: "error" };
+    case "declined":
+      return { label: "Declined", variant: "warning" };
+    case "inProgress":
+      return { label: "Running", variant: "info" };
+    default:
+      return null;
+  }
+}
+
+function summarizeToolOutput(value: string, limit = 96): string {
+  const singleLine = value.replace(/\s+/g, " ").trim();
+  if (singleLine.length <= limit) {
+    return singleLine;
+  }
+  return `${singleLine.slice(0, Math.max(0, limit - 3))}...`;
+}
+
+function collapsedToolWorkEntryPreview(
+  workEntry: WorkLogEntry,
+  primaryPath: string | null,
+): string | null {
+  if (workEntry.itemType === "command_execution" || workEntry.requestKind === "command") {
+    if (workEntry.output) {
+      return summarizeToolOutput(workEntry.output);
+    }
+    if (workEntry.command) {
+      return workEntry.command;
+    }
+  }
+  if (primaryPath) {
+    return primaryPath;
+  }
+  if (workEntry.command) {
+    return workEntry.command;
+  }
+  if (workEntry.output) {
+    return summarizeToolOutput(workEntry.output);
+  }
+  if (workEntry.detail) {
+    return summarizeToolOutput(workEntry.detail);
+  }
+  return null;
+}
+
+function isRichToolWorkEntry(workEntry: WorkLogEntry): boolean {
+  return workEntry.activityKind === "tool.completed" || workEntry.activityKind === "tool.updated";
+}
+
+const ToolWorkEntryRow = memo(function ToolWorkEntryRow(props: {
+  workEntry: WorkLogEntry;
+  workEntryIndex: number;
+  timestampFormat: TimestampFormat;
+}) {
+  const { workEntry, workEntryIndex, timestampFormat } = props;
+  const [open, setOpen] = useState(false);
+  const iconConfig = workToneIcon(workEntry.tone);
+  const EntryIcon = workEntryIcon(workEntry);
+  const heading = toolWorkEntryHeading(workEntry);
+  const statusBadge = toolWorkEntryStatusBadge(workEntry);
+  const primaryPath = !workEntry.command ? primaryWorkEntryPath(workEntry) : null;
+  const additionalPaths =
+    workEntry.changedFiles?.slice(primaryPath ? 1 : 0, primaryPath ? 4 : 4) ?? [];
+  const hiddenPathCount =
+    (workEntry.changedFiles?.length ?? 0) - additionalPaths.length - (primaryPath ? 1 : 0);
+  const preview = collapsedToolWorkEntryPreview(workEntry, primaryPath);
+  const displayText = preview ? `${heading} - ${preview}` : heading;
+  const hasExpandedDetails = Boolean(
+    workEntry.command ||
+    primaryPath ||
+    additionalPaths.length > 0 ||
+    workEntry.output ||
+    typeof workEntry.exitCode === "number",
+  );
+
+  const summaryRow = (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-lg px-1 py-1 transition-colors duration-150",
+        hasExpandedDetails ? "hover:bg-accent/25" : "",
+      )}
+    >
+      {hasExpandedDetails && (
+        <ChevronRightIcon
+          className={cn(
+            "size-3 shrink-0 text-muted-foreground/45 transition-transform duration-150",
+            open && "rotate-90",
+          )}
+        />
+      )}
+      <span
+        className={cn(
+          "flex size-5 shrink-0 items-center justify-center",
+          iconConfig.className,
+          !hasExpandedDetails && "ml-5",
+        )}
+      >
+        <EntryIcon className="size-3" />
+      </span>
+      <div className="min-w-0 flex-1 overflow-hidden">
+        <p
+          className={cn(
+            "truncate text-[11px] leading-5",
+            workToneClass(workEntry.tone),
+            preview ? "text-muted-foreground/70" : "",
+          )}
+          title={displayText}
+        >
+          <span className={cn("text-foreground/80", workToneClass(workEntry.tone))}>{heading}</span>
+          {preview && <span className="text-muted-foreground/55"> - {preview}</span>}
+        </p>
+      </div>
+      {statusBadge && (
+        <Badge
+          variant={statusBadge.variant}
+          className="shrink-0 px-1 py-0 font-mono text-[8px] uppercase tracking-[0.14em]"
+        >
+          {statusBadge.label}
+        </Badge>
+      )}
+      <span className="shrink-0 text-[9px] text-muted-foreground/35">
+        {formatTimestamp(workEntry.createdAt, timestampFormat)}
+      </span>
+    </div>
+  );
+
+  const expandedDetails = (
+    <div className="mt-1 space-y-1.5 pl-10">
+      {workEntry.command && (
+        <div
+          className="flex min-w-0 items-center gap-1.5 rounded-md border border-border/55 bg-background/55 px-2 py-1"
+          title={workEntry.command}
+        >
+          <TerminalIcon className="size-3 shrink-0 text-muted-foreground/65" />
+          <span className="truncate font-mono text-[10px] text-foreground/78">
+            {workEntry.command}
+          </span>
+        </div>
+      )}
+
+      {!workEntry.command && primaryPath && (
+        <div className="flex min-w-0 items-center gap-1.5">
+          <Badge variant="outline" className="max-w-32 shrink-0 truncate px-1.5 py-0 text-[10px]">
+            {basenameOfPath(primaryPath)}
+          </Badge>
+          <span
+            className="min-w-0 truncate font-mono text-[10px] text-muted-foreground/70"
+            title={primaryPath}
+          >
+            {primaryPath}
+          </span>
+        </div>
+      )}
+
+      {additionalPaths.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {additionalPaths.map((filePath) => (
+            <span
+              key={`${workEntry.id}:${filePath}`}
+              className="rounded-md border border-border/55 bg-background/55 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/75"
+              title={filePath}
+            >
+              {filePath}
+            </span>
+          ))}
+          {hiddenPathCount > 0 && (
+            <span className="px-1 text-[10px] text-muted-foreground/55">+{hiddenPathCount}</span>
+          )}
+        </div>
+      )}
+
+      {workEntry.output && (
+        <div className="rounded-md border border-border/55 bg-background/75 px-2.5 py-2">
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono text-[10px] leading-4 text-foreground/78">
+            {workEntry.output}
+          </pre>
+        </div>
+      )}
+
+      {typeof workEntry.exitCode === "number" && (
+        <div className="text-[9px] font-mono uppercase tracking-[0.12em] text-muted-foreground/55">
+          {workEntry.exitCode === 0 ? "Exited successfully" : `Exit ${workEntry.exitCode}`}
+        </div>
+      )}
+    </div>
+  );
+
+  if (!hasExpandedDetails) {
+    return (
+      <div
+        className="animate-in fade-in slide-in-from-bottom-1 rounded-lg duration-200"
+        style={{
+          animationDelay: `${Math.min(workEntryIndex, 4) * 40}ms`,
+        }}
+      >
+        {summaryRow}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="animate-in fade-in slide-in-from-bottom-1 rounded-lg duration-200"
+      style={{
+        animationDelay: `${Math.min(workEntryIndex, 4) * 40}ms`,
+      }}
+    >
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger className="block w-full text-left">{summaryRow}</CollapsibleTrigger>
+        <CollapsibleContent>{expandedDetails}</CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+});
+
+const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
+  workEntry: WorkLogEntry;
+  workEntryIndex: number;
+  timestampFormat: TimestampFormat;
+}) {
+  const { workEntry, workEntryIndex, timestampFormat } = props;
+  const iconConfig = workToneIcon(workEntry.tone);
+  const EntryIcon = workEntryIcon(workEntry);
+  const heading = toolWorkEntryHeading(workEntry);
+  const preview = workEntryPreview(workEntry);
+  const displayText = preview ? `${heading} - ${preview}` : heading;
+  const hasChangedFiles = (workEntry.changedFiles?.length ?? 0) > 0;
+  const previewIsChangedFiles = hasChangedFiles && !workEntry.command && !workEntry.detail;
+
+  return (
+    <div
+      className="animate-in fade-in slide-in-from-bottom-1 rounded-lg px-1 py-1 duration-200"
+      style={{
+        animationDelay: `${Math.min(workEntryIndex, 4) * 40}ms`,
+      }}
+    >
+      <div className="flex items-center gap-2 transition-[opacity,translate] duration-200">
+        <span
+          className={cn("flex size-5 shrink-0 items-center justify-center", iconConfig.className)}
+        >
+          <EntryIcon className="size-3" />
+        </span>
+        <div className="min-w-0 flex-1 overflow-hidden animate-in fade-in duration-300">
+          <p
+            className={cn(
+              "truncate text-[11px] leading-5",
+              workToneClass(workEntry.tone),
+              preview ? "text-muted-foreground/70" : "",
+            )}
+            title={displayText}
+          >
+            <span className={cn("text-foreground/80", workToneClass(workEntry.tone))}>
+              {heading}
+            </span>
+            {preview && <span className="text-muted-foreground/55"> - {preview}</span>}
+          </p>
+        </div>
+        <span className="shrink-0 text-[9px] text-muted-foreground/35">
+          {formatTimestamp(workEntry.createdAt, timestampFormat)}
+        </span>
+      </div>
+      {hasChangedFiles && !previewIsChangedFiles && (
+        <div className="animate-in fade-in slide-in-from-bottom-1 mt-1 flex flex-wrap gap-1 pl-6 duration-200">
+          {workEntry.changedFiles?.slice(0, 4).map((filePath) => (
+            <span
+              key={`${workEntry.id}:${filePath}`}
+              className="rounded-md border border-border/55 bg-background/55 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/75"
+              title={filePath}
+            >
+              {filePath}
+            </span>
+          ))}
+          {(workEntry.changedFiles?.length ?? 0) > 4 && (
+            <span className="px-1 text-[10px] text-muted-foreground/55">
+              +{(workEntry.changedFiles?.length ?? 0) - 4}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+interface ExpandedImageItem {
+  src: string;
+  name: string;
+}
+
+interface ExpandedImagePreview {
+  images: ExpandedImageItem[];
+  index: number;
+}
+
+function buildExpandedImagePreview(
+  images: ReadonlyArray<{ id: string; name: string; previewUrl?: string }>,
+  selectedImageId: string,
+): ExpandedImagePreview | null {
+  const previewableImages = images.flatMap((image) =>
+    image.previewUrl ? [{ id: image.id, src: image.previewUrl, name: image.name }] : [],
+  );
+  if (previewableImages.length === 0) {
+    return null;
+  }
+  const selectedIndex = previewableImages.findIndex((image) => image.id === selectedImageId);
+  if (selectedIndex < 0) {
+    return null;
+  }
+  return {
+    images: previewableImages.map((image) => ({ src: image.src, name: image.name })),
+    index: selectedIndex,
+  };
+}
+
+type ComposerCommandItem =
+  | {
+      id: string;
+      type: "path";
+      path: string;
+      pathKind: ProjectEntry["kind"];
+      label: string;
+      description: string;
+    }
+  | {
+      id: string;
+      type: "slash-command";
+      command: ComposerSlashCommand;
+      label: string;
+      description: string;
+    }
+  | {
+      id: string;
+      type: "model";
+      provider: ProviderKind;
+      model: ModelSlug;
+      label: string;
+      description: string;
+      showFastBadge: boolean;
+    }
+  | {
+      id: string;
+      type: "skill";
+      skillName: string;
+      label: string;
+      description: string;
+    };
+
+const VscodeEntryIcon = memo(function VscodeEntryIcon(props: {
+  pathValue: string;
+  kind: "file" | "directory";
+  theme: "light" | "dark";
+  className?: string;
+}) {
+  const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
+  const iconUrl = useMemo(
+    () => getVscodeIconUrlForEntry(props.pathValue, props.kind, props.theme),
+    [props.kind, props.pathValue, props.theme],
+  );
+  const failed = failedIconUrl === iconUrl;
+
+  if (failed) {
+    return props.kind === "directory" ? (
+      <FolderIcon className={cn("size-4 text-muted-foreground/80", props.className)} />
+    ) : (
+      <FileIcon className={cn("size-4 text-muted-foreground/80", props.className)} />
+    );
+  }
+
+  return (
+    <img
+      src={iconUrl}
+      alt=""
+      aria-hidden="true"
+      className={cn("size-4 shrink-0", props.className)}
+      loading="lazy"
+      onError={() => setFailedIconUrl(iconUrl)}
+    />
+  );
+});
+
+const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
+  item: ComposerCommandItem;
+  resolvedTheme: "light" | "dark";
+  isActive: boolean;
+  onSelect: (item: ComposerCommandItem) => void;
+}) {
+  const itemRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (props.isActive) {
+      itemRef.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [props.isActive]);
+
+  return (
+    <CommandItem
+      ref={itemRef}
+      value={props.item.id}
+      className={cn(
+        "cursor-pointer select-none gap-2",
+        props.isActive && "bg-accent text-accent-foreground",
+      )}
+      onMouseDown={(event) => {
+        event.preventDefault();
+      }}
+      onClick={() => {
+        props.onSelect(props.item);
+      }}
+    >
+      {props.item.type === "path" ? (
+        <VscodeEntryIcon
+          pathValue={props.item.path}
+          kind={props.item.pathKind}
+          theme={props.resolvedTheme}
+        />
+      ) : null}
+      {props.item.type === "slash-command" ? (
+        <BotIcon className="size-4 text-muted-foreground/80" />
+      ) : null}
+      {props.item.type === "skill" ? <BoxIcon className="size-4 shrink-0 text-violet-500" /> : null}
+      {props.item.type === "model" ? (
+        <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+          model
+        </Badge>
+      ) : null}
+      <span className="flex shrink-0 items-center gap-1.5">
+        {props.item.type === "model" && props.item.showFastBadge ? (
+          <ZapIcon className="size-3.5 shrink-0 text-amber-500" />
+        ) : null}
+        <span className="whitespace-nowrap font-medium">{props.item.label}</span>
+      </span>
+      <span className="min-w-0 truncate text-muted-foreground/70 text-xs">
+        {props.item.description}
+      </span>
+    </CommandItem>
+  );
+});
+
+const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
+  items: ComposerCommandItem[];
+  resolvedTheme: "light" | "dark";
+  isLoading: boolean;
+  triggerKind: ComposerTriggerKind | null;
+  activeItemId: string | null;
+  onHighlightedItemChange: (itemId: string | null) => void;
+  onSelect: (item: ComposerCommandItem) => void;
+}) {
+  return (
+    <Command
+      mode="none"
+      autoHighlight={false}
+      onItemHighlighted={(highlightedValue) => {
+        props.onHighlightedItemChange(
+          typeof highlightedValue === "string" ? highlightedValue : null,
+        );
+      }}
+    >
+      <div className="relative overflow-hidden rounded-xl border border-border/80 bg-popover/96 shadow-lg/8 backdrop-blur-xs">
+        <CommandList className="max-h-64">
+          {props.items.map((item) => (
+            <ComposerCommandMenuItem
+              key={item.id}
+              item={item}
+              resolvedTheme={props.resolvedTheme}
+              isActive={props.activeItemId === item.id}
+              onSelect={props.onSelect}
+            />
+          ))}
+        </CommandList>
+        {props.items.length === 0 && (
+          <p className="px-3 py-2 text-muted-foreground/70 text-xs">
+            {props.isLoading
+              ? props.triggerKind === "slash-skill"
+                ? "Loading skills..."
+                : "Searching workspace files..."
+              : props.triggerKind === "path"
+                ? "No matching files or folders."
+                : props.triggerKind === "slash-skill"
+                  ? "No matching skills."
+                  : "No matching command."}
+          </p>
+        )}
+      </div>
+    </Command>
+  );
+});
 
 const extendReplacementRangeForTrailingSpace = (
   text: string,
@@ -279,6 +1072,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     (store) => store.syncPersistedAttachments,
   );
   const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
+  const clearDraftThread = useComposerDraftStore((store) => store.clearDraftThread);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
   const getDraftThreadByProjectId = useComposerDraftStore(
     (store) => store.getDraftThreadByProjectId,
@@ -337,11 +1131,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const [composerTrigger, setComposerTrigger] = useState<ComposerTrigger | null>(() =>
     detectComposerTrigger(prompt, prompt.length),
   );
-  const [lastInvokedScriptByProjectId, setLastInvokedScriptByProjectId] = useLocalStorage(
-    LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
-    {},
-    LastInvokedScriptByProjectSchema,
-  );
+  const [lastInvokedScriptByProjectId, setLastInvokedScriptByProjectId] = useState<
+    Record<string, string>
+  >(() => readLastInvokedScriptByProjectFromStorage());
   const messagesScrollRef = useRef<HTMLDivElement>(null);
   const [messagesScrollElement, setMessagesScrollElement] = useState<HTMLDivElement | null>(null);
   const shouldAutoScrollRef = useRef(true);
@@ -452,6 +1244,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [draftThread, fallbackDraftProject?.model, localDraftError, threadId],
   );
   const activeThread = serverThread ?? localDraftThread;
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const runtimeMode =
     composerDraft.runtimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode =
@@ -575,11 +1368,49 @@ export default function ChatView({ threadId }: ChatViewProps) {
     ? (sessionProvider ?? selectedProviderByThreadId ?? null)
     : null;
   const selectedProvider: ProviderKind = lockedProvider ?? selectedProviderByThreadId ?? "codex";
-  const baseThreadModel = resolveModelSlugForProvider(
-    selectedProvider,
-    activeThread?.model ?? activeProject?.model ?? getDefaultModel(selectedProvider),
+  const providerStatuses = serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES;
+  const copilotProviderStatus =
+    providerStatuses.find((status) => status.provider === "copilot") ?? null;
+  const copilotProviderModels = copilotProviderStatus?.models ?? EMPTY_PROVIDER_MODELS;
+  const copilotQuotaSummary = useMemo(
+    () => deriveCopilotQuotaSummary(copilotProviderStatus?.quotaSnapshots),
+    [copilotProviderStatus?.quotaSnapshots],
   );
-  const customModelsForSelectedProvider = settings.customCodexModels;
+  const builtInModelOptionsByProvider = useMemo<
+    Record<ProviderKind, ReadonlyArray<BuiltInAppModelOption>>
+  >(
+    () => ({
+      codex: getModelOptions("codex"),
+      copilot:
+        copilotProviderModels.length > 0
+          ? orderCopilotBuiltInModelOptions(
+              copilotProviderModels.map((model) => ({ slug: model.id, name: model.name })),
+            )
+          : getModelOptions("copilot"),
+    }),
+    [copilotProviderModels],
+  );
+  const defaultModelByProvider = useMemo<Record<ProviderKind, string>>(
+    () => ({
+      codex: getDefaultModel("codex"),
+      copilot: builtInModelOptionsByProvider.copilot[0]?.slug ?? getDefaultModel("copilot"),
+    }),
+    [builtInModelOptionsByProvider],
+  );
+  const baseThreadModel =
+    selectedProvider === "copilot"
+      ? resolveAppModelSelection(
+          "copilot",
+          settings.customCopilotModels,
+          activeThread?.model ?? activeProject?.model ?? defaultModelByProvider.copilot,
+          builtInModelOptionsByProvider.copilot,
+        )
+      : resolveModelSlugForProvider(
+          selectedProvider,
+          activeThread?.model ?? activeProject?.model ?? defaultModelByProvider[selectedProvider],
+        );
+  const customModelsForSelectedProvider =
+    selectedProvider === "copilot" ? settings.customCopilotModels : settings.customCodexModels;
   const selectedModel = useMemo(() => {
     const draftModel = composerDraft.model;
     if (!draftModel) {
@@ -589,22 +1420,46 @@ export default function ChatView({ threadId }: ChatViewProps) {
       selectedProvider,
       customModelsForSelectedProvider,
       draftModel,
+      builtInModelOptionsByProvider[selectedProvider],
     ) as ModelSlug;
-  }, [baseThreadModel, composerDraft.model, customModelsForSelectedProvider, selectedProvider]);
-  const reasoningOptions = getReasoningEffortOptions(selectedProvider);
+  }, [
+    baseThreadModel,
+    builtInModelOptionsByProvider,
+    composerDraft.model,
+    customModelsForSelectedProvider,
+    selectedProvider,
+  ]);
+  const selectedCopilotModelMetadata =
+    selectedProvider === "copilot"
+      ? (copilotProviderModels.find((model) => model.id === selectedModel) ?? null)
+      : null;
+  const reasoningOptions =
+    selectedProvider === "codex"
+      ? getReasoningEffortOptions("codex")
+      : (selectedCopilotModelMetadata?.supportedReasoningEfforts ?? []);
   const supportsReasoningEffort = reasoningOptions.length > 0;
-  const selectedEffort = composerDraft.effort ?? getDefaultReasoningEffort(selectedProvider);
+  const defaultReasoningEffort =
+    selectedProvider === "codex"
+      ? getDefaultReasoningEffort("codex")
+      : (selectedCopilotModelMetadata?.defaultReasoningEffort ?? null);
+  const selectedEffort =
+    composerDraft.effort && reasoningOptions.includes(composerDraft.effort)
+      ? composerDraft.effort
+      : defaultReasoningEffort;
   const selectedCodexFastModeEnabled =
     selectedProvider === "codex" ? composerDraft.codexFastMode : false;
   const selectedModelOptionsForDispatch = useMemo(() => {
-    if (selectedProvider !== "codex") {
-      return undefined;
+    if (selectedProvider === "codex") {
+      const codexOptions = {
+        ...(supportsReasoningEffort && selectedEffort ? { reasoningEffort: selectedEffort } : {}),
+        ...(selectedCodexFastModeEnabled ? { fastMode: true } : {}),
+      };
+      return Object.keys(codexOptions).length > 0 ? { codex: codexOptions } : undefined;
     }
-    const codexOptions = {
-      ...(supportsReasoningEffort && selectedEffort ? { reasoningEffort: selectedEffort } : {}),
-      ...(selectedCodexFastModeEnabled ? { fastMode: true } : {}),
-    };
-    return Object.keys(codexOptions).length > 0 ? { codex: codexOptions } : undefined;
+    if (selectedProvider === "copilot" && supportsReasoningEffort && selectedEffort) {
+      return { copilot: { reasoningEffort: selectedEffort } };
+    }
+    return undefined;
   }, [selectedCodexFastModeEnabled, selectedEffort, selectedProvider, supportsReasoningEffort]);
   const providerOptionsForDispatch = useMemo(() => {
     if (!settings.codexBinaryPath && !settings.codexHomePath) {
@@ -619,8 +1474,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
   }, [settings.codexBinaryPath, settings.codexHomePath]);
   const selectedModelForPicker = selectedModel;
   const modelOptionsByProvider = useMemo(
-    () => getCustomModelOptionsByProvider(settings),
-    [settings],
+    () =>
+      getCustomModelOptionsByProvider({
+        customCodexModels: settings.customCodexModels,
+        customCopilotModels: settings.customCopilotModels,
+        builtInCopilotOptions: builtInModelOptionsByProvider.copilot,
+      }),
+    [builtInModelOptionsByProvider.copilot, settings],
   );
   const selectedModelForPickerWithCustomFallback = useMemo(() => {
     const currentOptions = modelOptionsByProvider[selectedProvider];
@@ -657,8 +1517,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
   const workLogEntries = useMemo(
-    () => deriveWorkLogEntries(threadActivities, activeLatestTurn?.turnId ?? undefined),
-    [activeLatestTurn?.turnId, threadActivities],
+    () => deriveVisibleThreadWorkLogEntries(threadActivities),
+    [threadActivities],
   );
   const latestTurnHasToolActivity = useMemo(
     () => hasToolActivityForTurn(threadActivities, activeLatestTurn?.turnId),
@@ -767,9 +1627,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
     );
     setComposerHighlightedItemId(null);
   }, [
+    activePendingProgress?.activeQuestion?.id,
     activePendingProgress?.customAnswer,
     activePendingUserInput?.requestId,
-    activePendingProgress?.activeQuestion?.id,
   ]);
   useEffect(() => {
     attachmentPreviewHandoffByMessageIdRef.current = attachmentPreviewHandoffByMessageId;
@@ -992,7 +1852,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const effectivePathQuery = pathTriggerQuery.length > 0 ? debouncedPathQuery : "";
   const branchesQuery = useQuery(gitBranchesQueryOptions(gitCwd));
-  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const isSkillTrigger = composerTriggerKind === "slash-skill";
+  const skillsQuery = useQuery({
+    ...skillsListQueryOptions(),
+    enabled: isSkillTrigger && isElectron,
+  });
   const workspaceEntriesQuery = useQuery(
     projectSearchEntriesQueryOptions({
       cwd: gitCwd,
@@ -1016,36 +1880,74 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
 
     if (composerTrigger.kind === "slash-command") {
-      const slashCommandItems = [
-        {
-          id: "slash:model",
-          type: "slash-command",
-          command: "model",
-          label: "/model",
-          description: "Switch response model for this thread",
-        },
-        {
-          id: "slash:plan",
-          type: "slash-command",
-          command: "plan",
-          label: "/plan",
-          description: "Switch this thread into plan mode",
-        },
-        {
-          id: "slash:default",
-          type: "slash-command",
-          command: "default",
-          label: "/default",
-          description: "Switch this thread back to normal chat mode",
-        },
-      ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
+      const baseSlashCommandItems: Array<Extract<ComposerCommandItem, { type: "slash-command" }>> =
+        [
+          {
+            id: "slash:model",
+            type: "slash-command",
+            command: "model",
+            label: "/model",
+            description: "Switch response model for this thread",
+          },
+          {
+            id: "slash:plan",
+            type: "slash-command",
+            command: "plan",
+            label: "/plan",
+            description: "Switch this thread into plan mode",
+          },
+          {
+            id: "slash:default",
+            type: "slash-command",
+            command: "default",
+            label: "/default",
+            description: "Switch this thread back to normal chat mode",
+          },
+        ];
+
+      const slashCommandItems: Array<Extract<ComposerCommandItem, { type: "slash-command" }>> =
+        isElectron
+          ? [
+              ...baseSlashCommandItems,
+              {
+                id: "slash:skills",
+                type: "slash-command",
+                command: "skills",
+                label: "/skills",
+                description: "Use a skill in this message",
+              },
+            ]
+          : baseSlashCommandItems;
+
       const query = composerTrigger.query.trim().toLowerCase();
       if (!query) {
-        return [...slashCommandItems];
+        return slashCommandItems;
       }
       return slashCommandItems.filter(
         (item) => item.command.includes(query) || item.label.slice(1).includes(query),
       );
+    }
+
+    if (composerTrigger.kind === "slash-skill") {
+      const enabledSkills = skillsQuery.data?.skills.filter((s) => s.enabled) ?? [];
+      const query = composerTrigger.query.trim().toLowerCase();
+      return enabledSkills
+        .filter(
+          (s) =>
+            !query ||
+            s.name.toLowerCase().includes(query) ||
+            s.description.toLowerCase().includes(query),
+        )
+        .map((s) => ({
+          id: `skill:${s.name}`,
+          type: "skill" as const,
+          skillName: s.name,
+          label: s.name
+            .split("-")
+            .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+            .join(" "),
+          description: s.description,
+        }));
     }
 
     return searchableModelOptions
@@ -1063,8 +1965,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
         model: slug,
         label: name,
         description: `${providerLabel} · ${slug}`,
+        showFastBadge: false,
       }));
-  }, [composerTrigger, searchableModelOptions, workspaceEntries]);
+  }, [composerTrigger, searchableModelOptions, skillsQuery.data, workspaceEntries]);
   const composerMenuOpen = Boolean(composerTrigger);
   const activeComposerMenuItem = useMemo(
     () =>
@@ -1082,8 +1985,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
   const availableEditors = serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
-  const providerStatuses = serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES;
-  const activeProvider = activeThread?.session?.provider ?? "codex";
+  const activeProvider = resolveProviderHealthBannerProvider({
+    sessionProvider: activeThread?.session?.provider ?? null,
+    selectedProvider,
+  });
   const activeProviderStatus = useMemo(
     () => providerStatuses.find((status) => status.provider === activeProvider) ?? null,
     [activeProvider, providerStatuses],
@@ -1134,16 +2039,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     (activeThread.messages.length > 0 ||
       (activeThread.session !== null && activeThread.session.status !== "closed")),
   );
-  const activeTerminalGroup =
-    terminalState.terminalGroups.find(
-      (group) => group.id === terminalState.activeTerminalGroupId,
-    ) ??
-    terminalState.terminalGroups.find((group) =>
-      group.terminalIds.includes(terminalState.activeTerminalId),
-    ) ??
-    null;
-  const hasReachedSplitLimit =
-    (activeTerminalGroup?.terminalIds.length ?? 0) >= MAX_TERMINALS_PER_GROUP;
+  const hasReachedTerminalLimit = terminalState.terminalIds.length >= MAX_TERMINALS_PER_GROUP;
   const setThreadError = useCallback(
     (targetThreadId: ThreadId | null, error: string | null) => {
       if (!targetThreadId) return;
@@ -1233,17 +2129,17 @@ export default function ChatView({ threadId }: ChatViewProps) {
     setTerminalOpen(!terminalState.terminalOpen);
   }, [activeThreadId, setTerminalOpen, terminalState.terminalOpen]);
   const splitTerminal = useCallback(() => {
-    if (!activeThreadId || hasReachedSplitLimit) return;
+    if (!activeThreadId || hasReachedTerminalLimit) return;
     const terminalId = `terminal-${randomUUID()}`;
     storeSplitTerminal(activeThreadId, terminalId);
     setTerminalFocusRequestId((value) => value + 1);
-  }, [activeThreadId, hasReachedSplitLimit, storeSplitTerminal]);
+  }, [activeThreadId, storeSplitTerminal, hasReachedTerminalLimit]);
   const createNewTerminal = useCallback(() => {
-    if (!activeThreadId) return;
+    if (!activeThreadId || hasReachedTerminalLimit) return;
     const terminalId = `terminal-${randomUUID()}`;
     storeNewTerminal(activeThreadId, terminalId);
     setTerminalFocusRequestId((value) => value + 1);
-  }, [activeThreadId, storeNewTerminal]);
+  }, [activeThreadId, storeNewTerminal, hasReachedTerminalLimit]);
   const activateTerminal = useCallback(
     (terminalId: string) => {
       if (!activeThreadId) return;
@@ -1268,11 +2164,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
               .clear({ threadId: activeThreadId, terminalId })
               .catch(() => undefined);
           }
-          await api.terminal.close({
-            threadId: activeThreadId,
-            terminalId,
-            deleteHistory: true,
-          });
+          await api.terminal.close({ threadId: activeThreadId, terminalId, deleteHistory: true });
         })().catch(() => fallbackExitWrite());
       } else {
         void fallbackExitWrite();
@@ -1310,7 +2202,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
         DEFAULT_THREAD_TERMINAL_ID;
       const isBaseTerminalBusy = terminalState.runningTerminalIds.includes(baseTerminalId);
       const wantsNewTerminal = Boolean(options?.preferNewTerminal) || isBaseTerminalBusy;
-      const shouldCreateNewTerminal = wantsNewTerminal;
+      const shouldCreateNewTerminal =
+        wantsNewTerminal && terminalState.terminalIds.length < MAX_TERMINALS_PER_GROUP;
       const targetTerminalId = shouldCreateNewTerminal
         ? `terminal-${randomUUID()}`
         : baseTerminalId;
@@ -1370,7 +2263,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setThreadError,
       storeNewTerminal,
       storeSetActiveTerminal,
-      setLastInvokedScriptByProjectId,
       terminalState.activeTerminalId,
       terminalState.runningTerminalIds,
       terminalState.terminalIds,
@@ -1612,6 +2504,21 @@ export default function ChatView({ threadId }: ChatViewProps) {
     },
     [serverThread],
   );
+
+  useEffect(() => {
+    try {
+      if (Object.keys(lastInvokedScriptByProjectId).length === 0) {
+        localStorage.removeItem(LAST_INVOKED_SCRIPT_BY_PROJECT_KEY);
+        return;
+      }
+      localStorage.setItem(
+        LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
+        JSON.stringify(lastInvokedScriptByProjectId),
+      );
+    } catch {
+      // Ignore storage write failures (private mode, quota exceeded, etc.)
+    }
+  }, [lastInvokedScriptByProjectId]);
 
   // Auto-scroll on new messages
   const messageCount = timelineMessages.length;
@@ -2090,6 +2997,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
   }, [activeThreadId, focusComposer, terminalState.terminalOpen]);
 
   useEffect(() => {
+    const isTerminalFocused = (): boolean => {
+      const activeElement = document.activeElement;
+      if (!(activeElement instanceof HTMLElement)) return false;
+      if (activeElement.classList.contains("xterm-helper-textarea")) return true;
+      return activeElement.closest(".thread-terminal-drawer .xterm") !== null;
+    };
+
     const handler = (event: globalThis.KeyboardEvent) => {
       if (!activeThreadId || event.defaultPrevented) return;
       const shortcutContext = {
@@ -2097,9 +3011,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         terminalOpen: Boolean(terminalState.terminalOpen),
       };
 
-      const command = resolveShortcutCommand(event, keybindings, {
-        context: shortcutContext,
-      });
+      const command = resolveShortcutCommand(event, keybindings, { context: shortcutContext });
       if (!command) return;
 
       if (command === "terminal.toggle") {
@@ -2602,6 +3514,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
         createdAt: messageCreatedAt,
       });
       turnStartSucceeded = true;
+      if (createdServerThreadForLocalDraft) {
+        const snapshot = await api.orchestration.getSnapshot();
+        syncServerReadModel(snapshot);
+      }
+      if (isFirstMessage) {
+        clearDraftThread(threadIdForSend);
+      }
     })().catch(async (err: unknown) => {
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
         await api.orchestration
@@ -3061,16 +3980,23 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setComposerDraftProvider(activeThread.id, provider);
       setComposerDraftModel(
         activeThread.id,
-        resolveAppModelSelection(provider, settings.customCodexModels, model),
+        resolveAppModelSelection(
+          provider,
+          provider === "copilot" ? settings.customCopilotModels : settings.customCodexModels,
+          model,
+          builtInModelOptionsByProvider[provider],
+        ),
       );
       scheduleComposerFocus();
     },
     [
       activeThread,
+      builtInModelOptionsByProvider,
       lockedProvider,
       scheduleComposerFocus,
       setComposerDraftModel,
       setComposerDraftProvider,
+      settings.customCopilotModels,
       settings.customCodexModels,
     ],
   );
@@ -3200,6 +4126,18 @@ export default function ChatView({ threadId }: ChatViewProps) {
         }
         return;
       }
+      if (item.type === "skill") {
+        const applied = applyPromptReplacement(
+          trigger.rangeStart,
+          trigger.rangeEnd,
+          `$${item.skillName} `,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd) },
+        );
+        if (applied) {
+          setComposerHighlightedItemId(null);
+        }
+        return;
+      }
       if (item.type === "slash-command") {
         if (item.command === "model") {
           const replacement = "/model ";
@@ -3214,6 +4152,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
             replacement,
             { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
           );
+          if (applied) {
+            setComposerHighlightedItemId(null);
+          }
+          return;
+        }
+        if (item.command === "skills") {
+          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "/skills ", {
+            expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+          });
           if (applied) {
             setComposerHighlightedItemId(null);
           }
@@ -3265,10 +4212,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [composerHighlightedItemId, composerMenuItems],
   );
   const isComposerMenuLoading =
-    composerTriggerKind === "path" &&
-    ((pathTriggerQuery.length > 0 && composerPathQueryDebouncer.state.isPending) ||
-      workspaceEntriesQuery.isLoading ||
-      workspaceEntriesQuery.isFetching);
+    (composerTriggerKind === "path" &&
+      ((pathTriggerQuery.length > 0 && composerPathQueryDebouncer.state.isPending) ||
+        workspaceEntriesQuery.isLoading ||
+        workspaceEntriesQuery.isFetching)) ||
+    (composerTriggerKind === "slash-skill" && skillsQuery.isLoading);
 
   const onPromptChange = useCallback(
     (
@@ -3519,14 +4467,27 @@ export default function ChatView({ threadId }: ChatViewProps) {
               data-chat-composer-form="true"
             >
               <div
-                className={`group rounded-[20px] border bg-card transition-colors duration-200 focus-within:border-ring/45 ${
-                  isDragOverComposer ? "border-primary/70 bg-accent/30" : "border-border"
+                className={`group relative overflow-visible rounded-[20px] border bg-card transition-colors duration-200 ${
+                  isDragOverComposer
+                    ? interactionMode === "plan"
+                      ? "border-ring-plan/70 bg-accent/30"
+                      : "border-primary/70 bg-accent/30"
+                    : interactionMode === "plan"
+                      ? "border-border focus-within:border-ring-plan/45"
+                      : "border-border focus-within:border-ring/45"
                 }`}
                 onDragEnter={onComposerDragEnter}
                 onDragOver={onComposerDragOver}
                 onDragLeave={onComposerDragLeave}
                 onDrop={onComposerDrop}
               >
+                {interactionMode === "plan" && (
+                  <span
+                    className={`absolute -top-3 left-5 rounded-full border bg-card transition-colors duration-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-widest ${isDragOverComposer ? "border-ring-plan/70 text-ring-plan" : "border-border group-focus-within:border-ring-plan/45 text-ring-plan/50 group-focus-within:text-ring-plan"}`}
+                  >
+                    Plan
+                  </span>
+                )}
                 {activePendingApproval ? (
                   <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
                     <ComposerPendingApprovalPanel
@@ -3715,25 +4676,35 @@ export default function ChatView({ threadId }: ChatViewProps) {
                         model={selectedModelForPickerWithCustomFallback}
                         lockedProvider={lockedProvider}
                         modelOptionsByProvider={modelOptionsByProvider}
+                        copilotModels={copilotProviderModels}
+                        copilotQuotaSummary={copilotQuotaSummary}
                         onProviderModelChange={onProviderModelSelect}
                       />
 
                       {isComposerFooterCompact ? (
-                        <CompactComposerControlsMenu
-                          activePlan={Boolean(activePlan || activeProposedPlan || planSidebarOpen)}
-                          interactionMode={interactionMode}
-                          planSidebarOpen={planSidebarOpen}
-                          runtimeMode={runtimeMode}
-                          selectedEffort={selectedEffort}
-                          selectedProvider={selectedProvider}
-                          selectedCodexFastModeEnabled={selectedCodexFastModeEnabled}
-                          reasoningOptions={reasoningOptions}
-                          onEffortSelect={onEffortSelect}
-                          onCodexFastModeChange={onCodexFastModeChange}
-                          onToggleInteractionMode={toggleInteractionMode}
-                          onTogglePlanSidebar={togglePlanSidebar}
-                          onToggleRuntimeMode={toggleRuntimeMode}
-                        />
+                        <>
+                          <InteractionModeToggleButton
+                            interactionMode={interactionMode}
+                            onClick={toggleInteractionMode}
+                          />
+                          <CompactComposerControlsMenu
+                            activePlan={Boolean(
+                              activePlan || activeProposedPlan || planSidebarOpen,
+                            )}
+                            interactionMode={interactionMode}
+                            planSidebarOpen={planSidebarOpen}
+                            runtimeMode={runtimeMode}
+                            selectedEffort={selectedEffort}
+                            selectedProvider={selectedProvider}
+                            selectedCodexFastModeEnabled={selectedCodexFastModeEnabled}
+                            reasoningOptions={reasoningOptions}
+                            onEffortSelect={onEffortSelect}
+                            onCodexFastModeChange={onCodexFastModeChange}
+                            onToggleInteractionMode={toggleInteractionMode}
+                            onTogglePlanSidebar={togglePlanSidebar}
+                            onToggleRuntimeMode={toggleRuntimeMode}
+                          />
+                        </>
                       ) : (
                         <>
                           {selectedProvider === "codex" && selectedEffort != null ? (
@@ -3742,8 +4713,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
                                 orientation="vertical"
                                 className="mx-0.5 hidden h-4 sm:block"
                               />
-                              <CodexTraitsPicker
+                              <ModelTraitsPicker
                                 effort={selectedEffort}
+                                defaultEffort={defaultReasoningEffort}
                                 fastModeEnabled={selectedCodexFastModeEnabled}
                                 options={reasoningOptions}
                                 onEffortChange={onEffortSelect}
@@ -3757,27 +4729,23 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             className="mx-0.5 hidden h-4 sm:block"
                           />
 
-                          <Button
-                            variant="ghost"
-                            className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
-                            size="sm"
-                            type="button"
-                            onClick={toggleInteractionMode}
-                            title={
-                              interactionMode === "plan"
-                                ? "Plan mode — click to return to normal chat mode"
-                                : "Default mode — click to enter plan mode"
-                            }
-                          >
-                            <BotIcon />
-                            <span className="sr-only sm:not-sr-only">
-                              {interactionMode === "plan" ? "Plan" : "Chat"}
-                            </span>
-                          </Button>
+                          {selectedProvider !== "codex" && selectedEffort != null ? (
+                            <ModelTraitsPicker
+                              effort={selectedEffort}
+                              defaultEffort={defaultReasoningEffort}
+                              options={reasoningOptions}
+                              onEffortChange={onEffortSelect}
+                            />
+                          ) : null}
 
                           <Separator
                             orientation="vertical"
                             className="mx-0.5 hidden h-4 sm:block"
+                          />
+
+                          <InteractionModeToggleButton
+                            interactionMode={interactionMode}
+                            onClick={toggleInteractionMode}
                           />
 
                           <Button
@@ -3937,7 +4905,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
                         ) : (
                           <button
                             type="submit"
-                            className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/90 text-primary-foreground transition-all duration-150 hover:bg-primary hover:scale-105 disabled:opacity-30 disabled:hover:scale-100 sm:h-8 sm:w-8"
+                            className={`flex h-9 w-9 items-center justify-center rounded-full transition-all duration-150 disabled:opacity-30 disabled:hover:scale-100 sm:h-8 sm:w-8 ${
+                              interactionMode === "plan"
+                                ? "bg-ring-plan/90 text-white hover:bg-ring-plan hover:scale-105"
+                                : "bg-primary/90 text-primary-foreground hover:bg-primary hover:scale-105"
+                            }`}
                             disabled={
                               isSendBusy || isConnecting || !composerSendState.hasSendableContent
                             }
@@ -4145,3 +5117,2055 @@ export default function ChatView({ threadId }: ChatViewProps) {
     </div>
   );
 }
+
+interface ChatHeaderProps {
+  activeThreadId: ThreadId;
+  activeThreadTitle: string;
+  activeProjectName: string | undefined;
+  isGitRepo: boolean;
+  openInCwd: string | null;
+  activeProjectScripts: ProjectScript[] | undefined;
+  preferredScriptId: string | null;
+  keybindings: ResolvedKeybindingsConfig;
+  availableEditors: ReadonlyArray<EditorId>;
+  diffToggleShortcutLabel: string | null;
+  gitCwd: string | null;
+  diffOpen: boolean;
+  onRunProjectScript: (script: ProjectScript) => void;
+  onAddProjectScript: (input: NewProjectScriptInput) => Promise<void>;
+  onUpdateProjectScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void>;
+  onDeleteProjectScript: (scriptId: string) => Promise<void>;
+  onToggleDiff: () => void;
+}
+
+const ChatHeader = memo(function ChatHeader({
+  activeThreadId,
+  activeThreadTitle,
+  activeProjectName,
+  isGitRepo,
+  openInCwd,
+  activeProjectScripts,
+  preferredScriptId,
+  keybindings,
+  availableEditors,
+  diffToggleShortcutLabel,
+  gitCwd,
+  diffOpen,
+  onRunProjectScript,
+  onAddProjectScript,
+  onUpdateProjectScript,
+  onDeleteProjectScript,
+  onToggleDiff,
+}: ChatHeaderProps) {
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
+        <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+        <h2
+          className="min-w-0 shrink truncate text-sm font-medium text-foreground"
+          title={activeThreadTitle}
+        >
+          {activeThreadTitle}
+        </h2>
+        {activeProjectName && (
+          <Badge variant="outline" className="min-w-0 shrink truncate">
+            {activeProjectName}
+          </Badge>
+        )}
+        {activeProjectName && !isGitRepo && (
+          <Badge variant="outline" className="shrink-0 text-[10px] text-amber-700">
+            No Git
+          </Badge>
+        )}
+      </div>
+      <div className="@container/header-actions flex min-w-0 flex-1 items-center justify-end gap-2 @sm/header-actions:gap-3">
+        {activeProjectScripts && (
+          <ProjectScriptsControl
+            scripts={activeProjectScripts}
+            keybindings={keybindings}
+            preferredScriptId={preferredScriptId}
+            onRunScript={onRunProjectScript}
+            onAddScript={onAddProjectScript}
+            onUpdateScript={onUpdateProjectScript}
+            onDeleteScript={onDeleteProjectScript}
+          />
+        )}
+        {activeProjectName && (
+          <OpenInPicker
+            keybindings={keybindings}
+            availableEditors={availableEditors}
+            openInCwd={openInCwd}
+          />
+        )}
+        {activeProjectName && <GitActionsControl gitCwd={gitCwd} activeThreadId={activeThreadId} />}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Toggle
+                className="shrink-0"
+                pressed={diffOpen}
+                onPressedChange={onToggleDiff}
+                aria-label="Toggle diff panel"
+                variant="outline"
+                size="xs"
+                disabled={!isGitRepo}
+              >
+                <DiffIcon className="size-3" />
+              </Toggle>
+            }
+          />
+          <TooltipPopup side="bottom">
+            {!isGitRepo
+              ? "Diff panel is unavailable because this project is not a git repository."
+              : diffToggleShortcutLabel
+                ? `Toggle diff panel (${diffToggleShortcutLabel})`
+                : "Toggle diff panel"}
+          </TooltipPopup>
+        </Tooltip>
+      </div>
+    </div>
+  );
+});
+
+const ThreadErrorBanner = memo(function ThreadErrorBanner({
+  error,
+  onDismiss,
+}: {
+  error: string | null;
+  onDismiss?: () => void;
+}) {
+  if (!error) return null;
+  return (
+    <div className="pt-3 mx-auto max-w-3xl">
+      <Alert variant="error">
+        <CircleAlertIcon />
+        <AlertDescription className="line-clamp-3" title={error}>
+          {error}
+        </AlertDescription>
+        {onDismiss && (
+          <AlertAction>
+            <button
+              type="button"
+              aria-label="Dismiss error"
+              className="inline-flex size-6 items-center justify-center rounded-md text-destructive/60 transition-colors hover:text-destructive"
+              onClick={onDismiss}
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          </AlertAction>
+        )}
+      </Alert>
+    </div>
+  );
+});
+
+const ProviderHealthBanner = memo(function ProviderHealthBanner({
+  status,
+}: {
+  status: ServerProviderStatus | null;
+}) {
+  if (!status || status.status === "ready") {
+    return null;
+  }
+
+  const defaultMessage =
+    status.status === "error"
+      ? `${status.provider} provider is unavailable.`
+      : `${status.provider} provider has limited availability.`;
+
+  return (
+    <div className="pt-3 mx-auto max-w-3xl">
+      <Alert variant={status.status === "error" ? "error" : "warning"}>
+        <CircleAlertIcon />
+        <AlertTitle>
+          {status.provider === "codex" ? "Codex provider status" : `${status.provider} status`}
+        </AlertTitle>
+        <AlertDescription className="line-clamp-3" title={status.message ?? defaultMessage}>
+          {status.message ?? defaultMessage}
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+});
+
+interface ComposerPendingApprovalPanelProps {
+  approval: PendingApproval;
+  pendingCount: number;
+}
+
+const ComposerPendingApprovalPanel = memo(function ComposerPendingApprovalPanel({
+  approval,
+  pendingCount,
+}: ComposerPendingApprovalPanelProps) {
+  const approvalSummary =
+    approval.requestKind === "command"
+      ? "Command approval requested"
+      : approval.requestKind === "file-read"
+        ? "File-read approval requested"
+        : "File-change approval requested";
+
+  return (
+    <div className="px-4 py-3.5 sm:px-5 sm:py-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="uppercase text-sm tracking-[0.2em]">PENDING APPROVAL</span>
+        <span className="text-sm font-medium">{approvalSummary}</span>
+        {pendingCount > 1 ? (
+          <span className="text-xs text-muted-foreground">1/{pendingCount}</span>
+        ) : null}
+      </div>
+    </div>
+  );
+});
+
+interface ComposerPendingApprovalActionsProps {
+  requestId: ApprovalRequestId;
+  isResponding: boolean;
+  onRespondToApproval: (
+    requestId: ApprovalRequestId,
+    decision: ProviderApprovalDecision,
+  ) => Promise<void>;
+}
+
+const ComposerPendingApprovalActions = memo(function ComposerPendingApprovalActions({
+  requestId,
+  isResponding,
+  onRespondToApproval,
+}: ComposerPendingApprovalActionsProps) {
+  return (
+    <>
+      <Button
+        size="sm"
+        variant="ghost"
+        disabled={isResponding}
+        onClick={() => void onRespondToApproval(requestId, "cancel")}
+      >
+        Cancel turn
+      </Button>
+      <Button
+        size="sm"
+        variant="destructive-outline"
+        disabled={isResponding}
+        onClick={() => void onRespondToApproval(requestId, "decline")}
+      >
+        Decline
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={isResponding}
+        onClick={() => void onRespondToApproval(requestId, "acceptForSession")}
+      >
+        Always allow this session
+      </Button>
+      <Button
+        size="sm"
+        variant="default"
+        disabled={isResponding}
+        onClick={() => void onRespondToApproval(requestId, "accept")}
+      >
+        Approve once
+      </Button>
+    </>
+  );
+});
+
+interface PendingUserInputPanelProps {
+  pendingUserInputs: PendingUserInput[];
+  respondingRequestIds: ApprovalRequestId[];
+  answers: Record<string, PendingUserInputDraftAnswer>;
+  questionIndex: number;
+  onSelectOption: (questionId: string, optionLabel: string) => void;
+  onAdvance: () => void;
+}
+
+const ComposerPendingUserInputPanel = memo(function ComposerPendingUserInputPanel({
+  pendingUserInputs,
+  respondingRequestIds,
+  answers,
+  questionIndex,
+  onSelectOption,
+  onAdvance,
+}: PendingUserInputPanelProps) {
+  if (pendingUserInputs.length === 0) return null;
+  const activePrompt = pendingUserInputs[0];
+  if (!activePrompt) return null;
+
+  return (
+    <ComposerPendingUserInputCard
+      key={activePrompt.requestId}
+      prompt={activePrompt}
+      isResponding={respondingRequestIds.includes(activePrompt.requestId)}
+      answers={answers}
+      questionIndex={questionIndex}
+      onSelectOption={onSelectOption}
+      onAdvance={onAdvance}
+    />
+  );
+});
+
+const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard({
+  prompt,
+  isResponding,
+  answers,
+  questionIndex,
+  onSelectOption,
+  onAdvance,
+}: {
+  prompt: PendingUserInput;
+  isResponding: boolean;
+  answers: Record<string, PendingUserInputDraftAnswer>;
+  questionIndex: number;
+  onSelectOption: (questionId: string, optionLabel: string) => void;
+  onAdvance: () => void;
+}) {
+  const progress = derivePendingUserInputProgress(prompt.questions, answers, questionIndex);
+  const activeQuestion = progress.activeQuestion;
+  const autoAdvanceTimerRef = useRef<number | null>(null);
+
+  // Clear auto-advance timer on unmount
+  useEffect(() => {
+    return () => {
+      if (autoAdvanceTimerRef.current !== null) {
+        window.clearTimeout(autoAdvanceTimerRef.current);
+      }
+    };
+  }, []);
+
+  const selectOptionAndAutoAdvance = useCallback(
+    (questionId: string, optionLabel: string) => {
+      onSelectOption(questionId, optionLabel);
+      if (autoAdvanceTimerRef.current !== null) {
+        window.clearTimeout(autoAdvanceTimerRef.current);
+      }
+      autoAdvanceTimerRef.current = window.setTimeout(() => {
+        autoAdvanceTimerRef.current = null;
+        onAdvance();
+      }, 200);
+    },
+    [onSelectOption, onAdvance],
+  );
+
+  // Keyboard shortcut: number keys 1-9 select corresponding option and auto-advance.
+  // Works even when the Lexical composer (contenteditable) has focus — the composer
+  // doubles as a custom-answer field during user input, and when it's empty the digit
+  // keys should pick options instead of typing into the editor.
+  useEffect(() => {
+    if (!activeQuestion || isResponding) return;
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+        return;
+      }
+      // If the user has started typing a custom answer in the contenteditable
+      // composer, let digit keys pass through so they can type numbers.
+      if (target instanceof HTMLElement && target.isContentEditable) {
+        const hasCustomText = progress.customAnswer.length > 0;
+        if (hasCustomText) return;
+      }
+      const digit = Number.parseInt(event.key, 10);
+      if (Number.isNaN(digit) || digit < 1 || digit > 9) return;
+      const optionIndex = digit - 1;
+      if (optionIndex >= activeQuestion.options.length) return;
+      const option = activeQuestion.options[optionIndex];
+      if (!option) return;
+      event.preventDefault();
+      selectOptionAndAutoAdvance(activeQuestion.id, option.label);
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [activeQuestion, isResponding, selectOptionAndAutoAdvance, progress.customAnswer.length]);
+
+  if (!activeQuestion) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 py-3 sm:px-5">
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2">
+          {prompt.questions.length > 1 ? (
+            <span className="flex h-5 items-center rounded-md bg-muted/60 px-1.5 text-[10px] font-medium tabular-nums text-muted-foreground/60">
+              {questionIndex + 1}/{prompt.questions.length}
+            </span>
+          ) : null}
+          <span className="text-[11px] font-semibold tracking-widest text-muted-foreground/50 uppercase">
+            {activeQuestion.header}
+          </span>
+        </div>
+      </div>
+      <p className="mt-1.5 text-sm text-foreground/90">{activeQuestion.question}</p>
+      <div className="mt-3 space-y-1">
+        {activeQuestion.options.map((option, index) => {
+          const isSelected = progress.selectedOptionLabel === option.label;
+          const shortcutKey = index < 9 ? index + 1 : null;
+          return (
+            <button
+              key={`${activeQuestion.id}:${option.label}`}
+              type="button"
+              disabled={isResponding}
+              onClick={() => selectOptionAndAutoAdvance(activeQuestion.id, option.label)}
+              className={cn(
+                "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-all duration-150",
+                isSelected
+                  ? "border-blue-500/40 bg-blue-500/8 text-foreground"
+                  : "border-transparent bg-muted/20 text-foreground/80 hover:bg-muted/40 hover:border-border/40",
+                isResponding && "opacity-50 cursor-not-allowed",
+              )}
+            >
+              {shortcutKey !== null ? (
+                <kbd
+                  className={cn(
+                    "flex size-5 shrink-0 items-center justify-center rounded text-[11px] font-medium tabular-nums transition-colors duration-150",
+                    isSelected
+                      ? "bg-blue-500/20 text-blue-400"
+                      : "bg-muted/40 text-muted-foreground/50 group-hover:bg-muted/60 group-hover:text-muted-foreground/70",
+                  )}
+                >
+                  {shortcutKey}
+                </kbd>
+              ) : null}
+              <div className="min-w-0 flex-1">
+                <span className="text-sm font-medium">{option.label}</span>
+                {option.description && option.description !== option.label ? (
+                  <span className="ml-2 text-xs text-muted-foreground/50">
+                    {option.description}
+                  </span>
+                ) : null}
+              </div>
+              {isSelected ? <CheckIcon className="size-3.5 shrink-0 text-blue-400" /> : null}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+});
+
+const ComposerPlanFollowUpBanner = memo(function ComposerPlanFollowUpBanner({
+  planTitle,
+}: {
+  planTitle: string | null;
+}) {
+  return (
+    <div className="px-4 py-3.5 sm:px-5 sm:py-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="uppercase text-sm tracking-[0.2em]">Plan ready</span>
+        {planTitle ? (
+          <span className="min-w-0 flex-1 truncate text-sm font-medium">{planTitle}</span>
+        ) : null}
+      </div>
+      {/* <div className="mt-2 text-xs text-muted-foreground">
+        Review the plan
+      </div> */}
+    </div>
+  );
+});
+
+const MessageCopyButton = memo(function MessageCopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [text]);
+
+  return (
+    <Button type="button" size="xs" variant="outline" onClick={handleCopy} title="Copy message">
+      {copied ? <CheckIcon className="size-3 text-success" /> : <CopyIcon className="size-3" />}
+    </Button>
+  );
+});
+
+function hasNonZeroStat(stat: { additions: number; deletions: number }): boolean {
+  return stat.additions > 0 || stat.deletions > 0;
+}
+
+const DiffStatLabel = memo(function DiffStatLabel(props: {
+  additions: number;
+  deletions: number;
+  showParentheses?: boolean;
+}) {
+  const { additions, deletions, showParentheses = false } = props;
+  return (
+    <>
+      {showParentheses && <span className="text-muted-foreground/70">(</span>}
+      <span className="text-success">+{additions}</span>
+      <span className="mx-0.5 text-muted-foreground/70">/</span>
+      <span className="text-destructive">-{deletions}</span>
+      {showParentheses && <span className="text-muted-foreground/70">)</span>}
+    </>
+  );
+});
+
+function collectDirectoryPaths(nodes: ReadonlyArray<TurnDiffTreeNode>): string[] {
+  const paths: string[] = [];
+  for (const node of nodes) {
+    if (node.kind !== "directory") continue;
+    paths.push(node.path);
+    paths.push(...collectDirectoryPaths(node.children));
+  }
+  return paths;
+}
+
+function buildDirectoryExpansionState(
+  directoryPaths: ReadonlyArray<string>,
+  expanded: boolean,
+): Record<string, boolean> {
+  const expandedState: Record<string, boolean> = {};
+  for (const directoryPath of directoryPaths) {
+    expandedState[directoryPath] = expanded;
+  }
+  return expandedState;
+}
+
+const ChangedFilesTree = memo(function ChangedFilesTree(props: {
+  turnId: TurnId;
+  files: ReadonlyArray<TurnDiffFileChange>;
+  allDirectoriesExpanded: boolean;
+  resolvedTheme: "light" | "dark";
+  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+}) {
+  const { files, allDirectoriesExpanded, onOpenTurnDiff, resolvedTheme, turnId } = props;
+  const treeNodes = useMemo(() => buildTurnDiffTree(files), [files]);
+  const directoryPathsKey = useMemo(
+    () => collectDirectoryPaths(treeNodes).join("\u0000"),
+    [treeNodes],
+  );
+  const allDirectoryExpansionState = useMemo(
+    () =>
+      buildDirectoryExpansionState(
+        directoryPathsKey ? directoryPathsKey.split("\u0000") : [],
+        allDirectoriesExpanded,
+      ),
+    [allDirectoriesExpanded, directoryPathsKey],
+  );
+  const [expandedDirectories, setExpandedDirectories] = useState<Record<string, boolean>>(() =>
+    buildDirectoryExpansionState(directoryPathsKey ? directoryPathsKey.split("\u0000") : [], true),
+  );
+  useEffect(() => {
+    setExpandedDirectories(allDirectoryExpansionState);
+  }, [allDirectoryExpansionState]);
+
+  const toggleDirectory = useCallback((pathValue: string, fallbackExpanded: boolean) => {
+    setExpandedDirectories((current) => ({
+      ...current,
+      [pathValue]: !(current[pathValue] ?? fallbackExpanded),
+    }));
+  }, []);
+
+  const renderTreeNode = (node: TurnDiffTreeNode, depth: number) => {
+    const leftPadding = 8 + depth * 14;
+    if (node.kind === "directory") {
+      const isExpanded = expandedDirectories[node.path] ?? depth === 0;
+      return (
+        <div key={`dir:${node.path}`}>
+          <button
+            type="button"
+            className="group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80"
+            style={{ paddingLeft: `${leftPadding}px` }}
+            onClick={() => toggleDirectory(node.path, depth === 0)}
+          >
+            <ChevronRightIcon
+              aria-hidden="true"
+              className={cn(
+                "size-3.5 shrink-0 text-muted-foreground/70 transition-transform group-hover:text-foreground/80",
+                isExpanded && "rotate-90",
+              )}
+            />
+            {isExpanded ? (
+              <FolderIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
+            ) : (
+              <FolderClosedIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
+            )}
+            <span className="truncate font-mono text-[11px] text-muted-foreground/90 group-hover:text-foreground/90">
+              {node.name}
+            </span>
+            {hasNonZeroStat(node.stat) && (
+              <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums">
+                <DiffStatLabel additions={node.stat.additions} deletions={node.stat.deletions} />
+              </span>
+            )}
+          </button>
+          {isExpanded && (
+            <div className="space-y-0.5">
+              {node.children.map((childNode) => renderTreeNode(childNode, depth + 1))}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <button
+        key={`file:${node.path}`}
+        type="button"
+        className="group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80"
+        style={{ paddingLeft: `${leftPadding}px` }}
+        onClick={() => onOpenTurnDiff(turnId, node.path)}
+      >
+        <span aria-hidden="true" className="size-3.5 shrink-0" />
+        <VscodeEntryIcon
+          pathValue={node.path}
+          kind="file"
+          theme={resolvedTheme}
+          className="size-3.5 text-muted-foreground/70"
+        />
+        <span className="truncate font-mono text-[11px] text-muted-foreground/80 group-hover:text-foreground/90">
+          {node.name}
+        </span>
+        {node.stat && (
+          <span className="ml-auto shrink-0 font-mono text-[10px] tabular-nums">
+            <DiffStatLabel additions={node.stat.additions} deletions={node.stat.deletions} />
+          </span>
+        )}
+      </button>
+    );
+  };
+
+  return <div className="space-y-0.5">{treeNodes.map((node) => renderTreeNode(node, 0))}</div>;
+});
+
+const ProposedPlanCard = memo(function ProposedPlanCard({
+  planMarkdown,
+  cwd,
+  workspaceRoot,
+}: {
+  planMarkdown: string;
+  cwd: string | undefined;
+  workspaceRoot: string | undefined;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
+  const [savePath, setSavePath] = useState("");
+  const [isSavingToWorkspace, setIsSavingToWorkspace] = useState(false);
+  const savePathInputId = useId();
+  const title = proposedPlanTitle(planMarkdown) ?? "Proposed plan";
+  const lineCount = planMarkdown.split("\n").length;
+  const canCollapse = planMarkdown.length > 900 || lineCount > 20;
+  const displayedPlanMarkdown = stripDisplayedPlanMarkdown(planMarkdown);
+  const collapsedPreview = canCollapse
+    ? buildCollapsedProposedPlanPreviewMarkdown(planMarkdown, { maxLines: 10 })
+    : null;
+  const downloadFilename = buildProposedPlanMarkdownFilename(planMarkdown);
+  const saveContents = normalizePlanMarkdownForExport(planMarkdown);
+
+  const handleDownload = () => {
+    downloadPlanAsTextFile(downloadFilename, saveContents);
+  };
+
+  const openSaveDialog = () => {
+    if (!workspaceRoot) {
+      toastManager.add({
+        type: "error",
+        title: "Workspace path is unavailable",
+        description: "This thread does not have a workspace path to save into.",
+      });
+      return;
+    }
+    setSavePath((existing) => (existing.length > 0 ? existing : downloadFilename));
+    setIsSaveDialogOpen(true);
+  };
+
+  const handleSaveToWorkspace = () => {
+    const api = readNativeApi();
+    const relativePath = savePath.trim();
+    if (!api || !workspaceRoot) {
+      return;
+    }
+    if (!relativePath) {
+      toastManager.add({
+        type: "warning",
+        title: "Enter a workspace path",
+      });
+      return;
+    }
+
+    setIsSavingToWorkspace(true);
+    void api.projects
+      .writeFile({
+        cwd: workspaceRoot,
+        relativePath,
+        contents: saveContents,
+      })
+      .then((result) => {
+        setIsSaveDialogOpen(false);
+        toastManager.add({
+          type: "success",
+          title: "Plan saved to workspace",
+          description: result.relativePath,
+        });
+      })
+      .catch((error) => {
+        toastManager.add({
+          type: "error",
+          title: "Could not save plan",
+          description: error instanceof Error ? error.message : "An error occurred while saving.",
+        });
+      })
+      .then(
+        () => {
+          setIsSavingToWorkspace(false);
+        },
+        () => {
+          setIsSavingToWorkspace(false);
+        },
+      );
+  };
+
+  return (
+    <div className="rounded-[24px] border border-border/80 bg-card/70 p-4 sm:p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Badge variant="secondary">Plan</Badge>
+          <p className="truncate text-sm font-medium text-foreground">{title}</p>
+        </div>
+        <Menu>
+          <MenuTrigger
+            render={<Button aria-label="Plan actions" size="icon-xs" variant="outline" />}
+          >
+            <EllipsisIcon aria-hidden="true" className="size-4" />
+          </MenuTrigger>
+          <MenuPopup align="end">
+            <MenuItem onClick={handleDownload}>Download as markdown</MenuItem>
+            <MenuItem onClick={openSaveDialog} disabled={!workspaceRoot || isSavingToWorkspace}>
+              Save to workspace
+            </MenuItem>
+          </MenuPopup>
+        </Menu>
+      </div>
+      <div className="mt-4">
+        <div className={cn("relative", canCollapse && !expanded && "max-h-104 overflow-hidden")}>
+          {canCollapse && !expanded ? (
+            <ChatMarkdown text={collapsedPreview ?? ""} cwd={cwd} isStreaming={false} />
+          ) : (
+            <ChatMarkdown text={displayedPlanMarkdown} cwd={cwd} isStreaming={false} />
+          )}
+          {canCollapse && !expanded ? (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-linear-to-t from-card/95 via-card/80 to-transparent" />
+          ) : null}
+        </div>
+        {canCollapse ? (
+          <div className="mt-4 flex justify-center">
+            <Button
+              size="sm"
+              variant="outline"
+              data-scroll-anchor-ignore
+              onClick={() => setExpanded((value) => !value)}
+            >
+              {expanded ? "Collapse plan" : "Expand plan"}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      <Dialog
+        open={isSaveDialogOpen}
+        onOpenChange={(open) => {
+          if (!isSavingToWorkspace) {
+            setIsSaveDialogOpen(open);
+          }
+        }}
+      >
+        <DialogPopup className="max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Save plan to workspace</DialogTitle>
+            <DialogDescription>
+              Enter a path relative to <code>{workspaceRoot ?? "the workspace"}</code>.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-3">
+            <label htmlFor={savePathInputId} className="grid gap-1.5">
+              <span className="text-xs font-medium text-foreground">Workspace path</span>
+              <Input
+                id={savePathInputId}
+                value={savePath}
+                onChange={(event) => setSavePath(event.target.value)}
+                placeholder={downloadFilename}
+                spellCheck={false}
+                disabled={isSavingToWorkspace}
+              />
+            </label>
+          </DialogPanel>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setIsSaveDialogOpen(false)}
+              disabled={isSavingToWorkspace}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => void handleSaveToWorkspace()}
+              disabled={isSavingToWorkspace}
+            >
+              {isSavingToWorkspace ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+    </div>
+  );
+});
+
+interface MessagesTimelineProps {
+  hasMessages: boolean;
+  isWorking: boolean;
+  activeTurnInProgress: boolean;
+  activeTurnStartedAt: string | null;
+  scrollContainer: HTMLDivElement | null;
+  timelineEntries: ReturnType<typeof deriveTimelineEntries>;
+  completionDividerBeforeEntryId: string | null;
+  completionSummary: string | null;
+  turnDiffSummaryByAssistantMessageId: Map<MessageId, TurnDiffSummary>;
+  nowIso: string;
+  expandedWorkGroups: Record<string, boolean>;
+  onToggleWorkGroup: (groupId: string) => void;
+  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+  revertTurnCountByUserMessageId: Map<MessageId, number>;
+  onRevertUserMessage: (messageId: MessageId) => void;
+  isRevertingCheckpoint: boolean;
+  onImageExpand: (preview: ExpandedImagePreview) => void;
+  markdownCwd: string | undefined;
+  resolvedTheme: "light" | "dark";
+  timestampFormat: TimestampFormat;
+  workspaceRoot: string | undefined;
+}
+
+type TimelineEntry = ReturnType<typeof deriveTimelineEntries>[number];
+type TimelineMessage = Extract<TimelineEntry, { kind: "message" }>["message"];
+type TimelineProposedPlan = Extract<TimelineEntry, { kind: "proposed-plan" }>["proposedPlan"];
+type TimelineWorkEntry = Extract<TimelineEntry, { kind: "work" }>["entry"];
+type TimelineRow =
+  | {
+      kind: "work";
+      id: string;
+      createdAt: string;
+      groupedEntries: TimelineWorkEntry[];
+    }
+  | {
+      kind: "message";
+      id: string;
+      createdAt: string;
+      message: TimelineMessage;
+      durationStart: string;
+      showCompletionDivider: boolean;
+    }
+  | {
+      kind: "proposed-plan";
+      id: string;
+      createdAt: string;
+      proposedPlan: TimelineProposedPlan;
+    }
+  | { kind: "working"; id: string; createdAt: string | null };
+
+function estimateTimelineProposedPlanHeight(proposedPlan: TimelineProposedPlan): number {
+  const estimatedLines = Math.max(1, Math.ceil(proposedPlan.planMarkdown.length / 72));
+  return 120 + Math.min(estimatedLines * 22, 880);
+}
+
+const MessagesTimeline = memo(function MessagesTimeline({
+  hasMessages,
+  isWorking,
+  activeTurnInProgress,
+  activeTurnStartedAt,
+  scrollContainer,
+  timelineEntries,
+  completionDividerBeforeEntryId,
+  completionSummary,
+  turnDiffSummaryByAssistantMessageId,
+  nowIso,
+  expandedWorkGroups,
+  onToggleWorkGroup,
+  onOpenTurnDiff,
+  revertTurnCountByUserMessageId,
+  onRevertUserMessage,
+  isRevertingCheckpoint,
+  onImageExpand,
+  markdownCwd,
+  resolvedTheme,
+  timestampFormat,
+  workspaceRoot,
+}: MessagesTimelineProps) {
+  const timelineRootRef = useRef<HTMLDivElement | null>(null);
+  const [timelineWidthPx, setTimelineWidthPx] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const timelineRoot = timelineRootRef.current;
+    if (!timelineRoot) return;
+
+    const updateWidth = (nextWidth: number) => {
+      setTimelineWidthPx((previousWidth) => {
+        if (previousWidth !== null && Math.abs(previousWidth - nextWidth) < 0.5) {
+          return previousWidth;
+        }
+        return nextWidth;
+      });
+    };
+
+    updateWidth(timelineRoot.getBoundingClientRect().width);
+
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      updateWidth(timelineRoot.getBoundingClientRect().width);
+    });
+    observer.observe(timelineRoot);
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMessages, isWorking]);
+
+  const rows = useMemo<TimelineRow[]>(() => {
+    const nextRows: TimelineRow[] = [];
+    const durationStartByMessageId = computeMessageDurationStart(
+      timelineEntries.flatMap((entry) => (entry.kind === "message" ? [entry.message] : [])),
+    );
+
+    for (let index = 0; index < timelineEntries.length; index += 1) {
+      const timelineEntry = timelineEntries[index];
+      if (!timelineEntry) {
+        continue;
+      }
+
+      if (timelineEntry.kind === "work") {
+        const groupedEntries = [timelineEntry.entry];
+        let cursor = index + 1;
+        while (cursor < timelineEntries.length) {
+          const nextEntry = timelineEntries[cursor];
+          if (!nextEntry || nextEntry.kind !== "work") break;
+          groupedEntries.push(nextEntry.entry);
+          cursor += 1;
+        }
+        nextRows.push({
+          kind: "work",
+          id: timelineEntry.id,
+          createdAt: timelineEntry.createdAt,
+          groupedEntries,
+        });
+        index = cursor - 1;
+        continue;
+      }
+
+      if (timelineEntry.kind === "proposed-plan") {
+        nextRows.push({
+          kind: "proposed-plan",
+          id: timelineEntry.id,
+          createdAt: timelineEntry.createdAt,
+          proposedPlan: timelineEntry.proposedPlan,
+        });
+        continue;
+      }
+
+      nextRows.push({
+        kind: "message",
+        id: timelineEntry.id,
+        createdAt: timelineEntry.createdAt,
+        message: timelineEntry.message,
+        durationStart:
+          durationStartByMessageId.get(timelineEntry.message.id) ?? timelineEntry.message.createdAt,
+        showCompletionDivider:
+          timelineEntry.message.role === "assistant" &&
+          completionDividerBeforeEntryId === timelineEntry.id,
+      });
+    }
+
+    if (isWorking) {
+      nextRows.push({
+        kind: "working",
+        id: "working-indicator-row",
+        createdAt: activeTurnStartedAt,
+      });
+    }
+
+    return nextRows;
+  }, [timelineEntries, completionDividerBeforeEntryId, isWorking, activeTurnStartedAt]);
+
+  const firstUnvirtualizedRowIndex = useMemo(() => {
+    const firstTailRowIndex = Math.max(rows.length - ALWAYS_UNVIRTUALIZED_TAIL_ROWS, 0);
+    if (!activeTurnInProgress) return firstTailRowIndex;
+
+    const turnStartedAtMs =
+      typeof activeTurnStartedAt === "string" ? Date.parse(activeTurnStartedAt) : Number.NaN;
+    let firstCurrentTurnRowIndex = -1;
+    if (!Number.isNaN(turnStartedAtMs)) {
+      firstCurrentTurnRowIndex = rows.findIndex((row) => {
+        if (row.kind === "working") return true;
+        if (!row.createdAt) return false;
+        const rowCreatedAtMs = Date.parse(row.createdAt);
+        return !Number.isNaN(rowCreatedAtMs) && rowCreatedAtMs >= turnStartedAtMs;
+      });
+    }
+
+    if (firstCurrentTurnRowIndex < 0) {
+      firstCurrentTurnRowIndex = rows.findIndex(
+        (row) => row.kind === "message" && row.message.streaming,
+      );
+    }
+
+    if (firstCurrentTurnRowIndex < 0) return firstTailRowIndex;
+
+    for (let index = firstCurrentTurnRowIndex - 1; index >= 0; index -= 1) {
+      const previousRow = rows[index];
+      if (!previousRow || previousRow.kind !== "message") continue;
+      if (previousRow.message.role === "user") {
+        return Math.min(index, firstTailRowIndex);
+      }
+      if (previousRow.message.role === "assistant" && !previousRow.message.streaming) {
+        break;
+      }
+    }
+
+    return Math.min(firstCurrentTurnRowIndex, firstTailRowIndex);
+  }, [activeTurnInProgress, activeTurnStartedAt, rows]);
+
+  const virtualizedRowCount = clamp(firstUnvirtualizedRowIndex, {
+    minimum: 0,
+    maximum: rows.length,
+  });
+
+  const rowVirtualizer = useVirtualizer({
+    count: virtualizedRowCount,
+    getScrollElement: () => scrollContainer,
+    // Use stable row ids so virtual measurements do not leak across thread switches.
+    getItemKey: (index: number) => rows[index]?.id ?? index,
+    estimateSize: (index: number) => {
+      const row = rows[index];
+      if (!row) return 96;
+      if (row.kind === "work") return 112;
+      if (row.kind === "proposed-plan") return estimateTimelineProposedPlanHeight(row.proposedPlan);
+      if (row.kind === "working") return 40;
+      return estimateTimelineMessageHeight(row.message, { timelineWidthPx });
+    },
+    measureElement: measureVirtualElement,
+    useAnimationFrameWithResizeObserver: true,
+    overscan: 8,
+  });
+  useEffect(() => {
+    if (timelineWidthPx === null) return;
+    rowVirtualizer.measure();
+  }, [rowVirtualizer, timelineWidthPx]);
+  useEffect(() => {
+    rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (_item, _delta, instance) => {
+      const viewportHeight = instance.scrollRect?.height ?? 0;
+      const scrollOffset = instance.scrollOffset ?? 0;
+      const remainingDistance = instance.getTotalSize() - (scrollOffset + viewportHeight);
+      return remainingDistance > AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
+    };
+    return () => {
+      rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = undefined;
+    };
+  }, [rowVirtualizer]);
+  const pendingMeasureFrameRef = useRef<number | null>(null);
+  const onTimelineImageLoad = useCallback(() => {
+    if (pendingMeasureFrameRef.current !== null) return;
+    pendingMeasureFrameRef.current = window.requestAnimationFrame(() => {
+      pendingMeasureFrameRef.current = null;
+      rowVirtualizer.measure();
+    });
+  }, [rowVirtualizer]);
+  useEffect(() => {
+    return () => {
+      const frame = pendingMeasureFrameRef.current;
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, []);
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const nonVirtualizedRows = rows.slice(virtualizedRowCount);
+  const [allDirectoriesExpandedByTurnId, setAllDirectoriesExpandedByTurnId] = useState<
+    Record<string, boolean>
+  >({});
+  const onToggleAllDirectories = useCallback((turnId: TurnId) => {
+    setAllDirectoriesExpandedByTurnId((current) => ({
+      ...current,
+      [turnId]: !(current[turnId] ?? true),
+    }));
+  }, []);
+
+  const renderRowContent = (row: TimelineRow) => (
+    <div
+      className="pb-4"
+      data-timeline-row-kind={row.kind}
+      data-message-id={row.kind === "message" ? row.message.id : undefined}
+      data-message-role={row.kind === "message" ? row.message.role : undefined}
+    >
+      {row.kind === "work" &&
+        (() => {
+          const groupId = row.id;
+          const groupedEntries = row.groupedEntries;
+          const isExpanded = expandedWorkGroups[groupId] ?? false;
+          const hasOverflow = groupedEntries.length > MAX_VISIBLE_WORK_LOG_ENTRIES;
+          const visibleEntries =
+            hasOverflow && !isExpanded
+              ? groupedEntries.slice(-MAX_VISIBLE_WORK_LOG_ENTRIES)
+              : groupedEntries;
+          const hiddenCount = groupedEntries.length - visibleEntries.length;
+          const onlyToolEntries = groupedEntries.every((entry) => entry.tone === "tool");
+          const showHeader = hasOverflow || !onlyToolEntries;
+          const groupLabel = onlyToolEntries ? "Tool calls" : "Work log";
+
+          return (
+            <div className="rounded-xl border border-border/45 bg-card/25 px-2 py-1.5">
+              {showHeader && (
+                <div className="mb-1.5 flex items-center justify-between gap-2 px-0.5">
+                  <p className="text-[9px] uppercase tracking-[0.16em] text-muted-foreground/55">
+                    {groupLabel} ({groupedEntries.length})
+                  </p>
+                  {hasOverflow && (
+                    <button
+                      type="button"
+                      className="text-[9px] uppercase tracking-[0.12em] text-muted-foreground/55 transition-colors duration-150 hover:text-foreground/75"
+                      onClick={() => onToggleWorkGroup(groupId)}
+                    >
+                      {isExpanded ? "Show less" : `Show ${hiddenCount} more`}
+                    </button>
+                  )}
+                </div>
+              )}
+              <div className="space-y-0.5">
+                {visibleEntries.map((workEntry, workEntryIndex) => {
+                  return isRichToolWorkEntry(workEntry) ? (
+                    <ToolWorkEntryRow
+                      key={`work-row:${workEntry.id}`}
+                      workEntry={workEntry}
+                      workEntryIndex={workEntryIndex}
+                      timestampFormat={timestampFormat}
+                    />
+                  ) : (
+                    <SimpleWorkEntryRow
+                      key={`work-row:${workEntry.id}`}
+                      workEntry={workEntry}
+                      workEntryIndex={workEntryIndex}
+                      timestampFormat={timestampFormat}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })()}
+
+      {row.kind === "message" &&
+        row.message.role === "user" &&
+        (() => {
+          const userImages = row.message.attachments ?? [];
+          const canRevertAgentWork = revertTurnCountByUserMessageId.has(row.message.id);
+          return (
+            <div className="flex justify-end">
+              <div className="group relative max-w-[80%] rounded-2xl rounded-br-sm border border-border bg-secondary px-4 py-3">
+                {userImages.length > 0 && (
+                  <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
+                    {userImages.map(
+                      (image: NonNullable<TimelineMessage["attachments"]>[number]) => (
+                        <div
+                          key={image.id}
+                          className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
+                        >
+                          {image.previewUrl ? (
+                            <button
+                              type="button"
+                              className="h-full w-full cursor-zoom-in"
+                              aria-label={`Preview ${image.name}`}
+                              onClick={() => {
+                                const preview = buildExpandedImagePreview(userImages, image.id);
+                                if (!preview) return;
+                                onImageExpand(preview);
+                              }}
+                            >
+                              <img
+                                src={image.previewUrl}
+                                alt={image.name}
+                                className="h-full max-h-[220px] w-full object-cover"
+                                onLoad={onTimelineImageLoad}
+                                onError={onTimelineImageLoad}
+                              />
+                            </button>
+                          ) : (
+                            <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
+                              {image.name}
+                            </div>
+                          )}
+                        </div>
+                      ),
+                    )}
+                  </div>
+                )}
+                {row.message.text && (
+                  <pre className="whitespace-pre-wrap wrap-break-word font-mono text-sm leading-relaxed text-foreground">
+                    {row.message.text}
+                  </pre>
+                )}
+                <div className="mt-1.5 flex items-center justify-end gap-2">
+                  <div className="flex items-center gap-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+                    {row.message.text && <MessageCopyButton text={row.message.text} />}
+                    {canRevertAgentWork && (
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="outline"
+                        disabled={isRevertingCheckpoint || isWorking}
+                        onClick={() => onRevertUserMessage(row.message.id)}
+                        title="Revert to this message"
+                      >
+                        <Undo2Icon className="size-3" />
+                      </Button>
+                    )}
+                  </div>
+                  <p className="text-right text-[10px] text-muted-foreground/30">
+                    {formatTimestamp(row.message.createdAt, timestampFormat)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          );
+        })()}
+
+      {row.kind === "message" &&
+        row.message.role === "assistant" &&
+        (() => {
+          const messageText = row.message.text || (row.message.streaming ? "" : "(empty response)");
+          return (
+            <>
+              {row.showCompletionDivider && (
+                <div className="my-3 flex items-center gap-3">
+                  <span className="h-px flex-1 bg-border" />
+                  <span className="rounded-full border border-border bg-background px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
+                    {completionSummary ? `Response • ${completionSummary}` : "Response"}
+                  </span>
+                  <span className="h-px flex-1 bg-border" />
+                </div>
+              )}
+              <div className="min-w-0 px-1 py-0.5">
+                <ChatMarkdown
+                  text={messageText}
+                  cwd={markdownCwd}
+                  isStreaming={Boolean(row.message.streaming)}
+                />
+                {(() => {
+                  const turnSummary = turnDiffSummaryByAssistantMessageId.get(row.message.id);
+                  if (!turnSummary) return null;
+                  const checkpointFiles = turnSummary.files;
+                  if (checkpointFiles.length === 0) return null;
+                  const summaryStat = summarizeTurnDiffStats(checkpointFiles);
+                  const changedFileCountLabel = String(checkpointFiles.length);
+                  const allDirectoriesExpanded =
+                    allDirectoriesExpandedByTurnId[turnSummary.turnId] ?? true;
+                  return (
+                    <div className="mt-2 rounded-lg border border-border/80 bg-card/45 p-2.5">
+                      <div className="mb-1.5 flex items-center justify-between gap-2">
+                        <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
+                          <span>Changed files ({changedFileCountLabel})</span>
+                          {hasNonZeroStat(summaryStat) && (
+                            <>
+                              <span className="mx-1">•</span>
+                              <DiffStatLabel
+                                additions={summaryStat.additions}
+                                deletions={summaryStat.deletions}
+                              />
+                            </>
+                          )}
+                        </p>
+                        <div className="flex items-center gap-1.5">
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="outline"
+                            onClick={() => onToggleAllDirectories(turnSummary.turnId)}
+                          >
+                            {allDirectoriesExpanded ? "Collapse all" : "Expand all"}
+                          </Button>
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="outline"
+                            onClick={() =>
+                              onOpenTurnDiff(turnSummary.turnId, checkpointFiles[0]?.path)
+                            }
+                          >
+                            View diff
+                          </Button>
+                        </div>
+                      </div>
+                      <ChangedFilesTree
+                        key={`changed-files-tree:${turnSummary.turnId}`}
+                        turnId={turnSummary.turnId}
+                        files={checkpointFiles}
+                        allDirectoriesExpanded={allDirectoriesExpanded}
+                        resolvedTheme={resolvedTheme}
+                        onOpenTurnDiff={onOpenTurnDiff}
+                      />
+                    </div>
+                  );
+                })()}
+                <p className="mt-1.5 text-[10px] text-muted-foreground/30">
+                  {formatMessageMeta(
+                    row.message.createdAt,
+                    row.message.streaming
+                      ? formatElapsed(row.durationStart, nowIso)
+                      : formatElapsed(row.durationStart, row.message.completedAt),
+                    timestampFormat,
+                  )}
+                </p>
+              </div>
+            </>
+          );
+        })()}
+
+      {row.kind === "proposed-plan" && (
+        <div className="min-w-0 px-1 py-0.5">
+          <ProposedPlanCard
+            planMarkdown={row.proposedPlan.planMarkdown}
+            cwd={markdownCwd}
+            workspaceRoot={workspaceRoot}
+          />
+        </div>
+      )}
+
+      {row.kind === "working" && (
+        <div className="py-0.5 pl-1.5">
+          <div className="flex items-center gap-2 pt-1 text-[11px] text-muted-foreground/70">
+            <span className="inline-flex items-center gap-[3px]">
+              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse" />
+              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:200ms]" />
+              <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:400ms]" />
+            </span>
+            <span>
+              {row.createdAt
+                ? `Working for ${formatWorkingTimer(row.createdAt, nowIso) ?? "0s"}`
+                : "Working..."}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  if (!hasMessages && !isWorking) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-muted-foreground/30">
+          Send a message to start the conversation.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={timelineRootRef}
+      data-timeline-root="true"
+      className="mx-auto w-full min-w-0 max-w-3xl overflow-x-hidden"
+    >
+      {virtualizedRowCount > 0 && (
+        <div className="relative" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
+          {virtualRows.map((virtualRow: VirtualItem) => {
+            const row = rows[virtualRow.index];
+            if (!row) return null;
+
+            return (
+              <div
+                key={`virtual-row:${row.id}`}
+                data-index={virtualRow.index}
+                ref={rowVirtualizer.measureElement}
+                className="absolute left-0 top-0 w-full"
+                style={{ transform: `translateY(${virtualRow.start}px)` }}
+              >
+                {renderRowContent(row)}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {nonVirtualizedRows.map((row) => (
+        <div key={`non-virtual-row:${row.id}`}>{renderRowContent(row)}</div>
+      ))}
+    </div>
+  );
+});
+
+function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {
+  value: ProviderKind;
+  label: string;
+  available: true;
+} {
+  return option.available && option.value !== "claudeCode";
+}
+
+const AVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter(isAvailableProviderOption);
+const UNAVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter((option) => !option.available);
+const COMING_SOON_PROVIDER_OPTIONS = [
+  { id: "opencode", label: "OpenCode", icon: OpenCodeIcon },
+  { id: "gemini", label: "Gemini", icon: Gemini },
+] as const;
+
+const PROVIDER_ICON_BY_PROVIDER: Record<ProviderPickerKind, Icon> = {
+  codex: OpenAI,
+  copilot: GitHubIcon,
+  claudeCode: ClaudeAI,
+  cursor: CursorIcon,
+};
+
+function resolveModelForProviderPicker(
+  provider: ProviderKind,
+  value: string,
+  options: ReadonlyArray<{ slug: string; name: string }>,
+): ModelSlug | null {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return null;
+  }
+
+  const direct = options.find((option) => option.slug === trimmedValue);
+  if (direct) {
+    return direct.slug;
+  }
+
+  const byName = options.find((option) => option.name.toLowerCase() === trimmedValue.toLowerCase());
+  if (byName) {
+    return byName.slug;
+  }
+
+  const normalized = normalizeModelSlug(trimmedValue, provider);
+  if (!normalized) {
+    return null;
+  }
+
+  const resolved = options.find((option) => option.slug === normalized);
+  if (resolved) {
+    return resolved.slug;
+  }
+
+  return null;
+}
+
+function formatCopilotBillingMultiplier(multiplier: number): string {
+  return `${new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(multiplier)}x`;
+}
+
+function formatCopilotQuotaLabel(key: string): string {
+  return key
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((segment) => segment[0]?.toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function normalizeCopilotRemainingPercentage(value: number): number {
+  const normalized = value <= 1 ? value * 100 : value;
+  return Math.min(100, Math.max(0, normalized));
+}
+
+function formatCopilotQuotaPercentage(value: number): string {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 }).format(value);
+}
+
+const COPILOT_QUOTA_PRIORITY = ["premium_interactions", "chat", "completions"] as const;
+
+function getCopilotQuotaPriority(key: string): number {
+  const index = COPILOT_QUOTA_PRIORITY.findIndex((candidate) => candidate === key);
+  return index === -1 ? Number.POSITIVE_INFINITY : index;
+}
+
+function pickCopilotQuotaSnapshot(
+  quotaSnapshots: ReadonlyArray<ServerProviderQuotaSnapshot> | undefined,
+): ServerProviderQuotaSnapshot | null {
+  if (!quotaSnapshots || quotaSnapshots.length === 0) return null;
+
+  return (
+    quotaSnapshots.toSorted((left, right) => {
+      const priorityDiff = getCopilotQuotaPriority(left.key) - getCopilotQuotaPriority(right.key);
+      if (priorityDiff !== 0) return priorityDiff;
+      return left.key.localeCompare(right.key);
+    })[0] ?? null
+  );
+}
+
+function formatCopilotQuotaResetDate(value: string | undefined): string | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return null;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(new Date(parsed));
+}
+
+function deriveCopilotQuotaSummary(
+  quotaSnapshots: ReadonlyArray<ServerProviderQuotaSnapshot> | undefined,
+): {
+  title: string;
+  detail: string;
+  remainingPercent: number;
+  progressTone: "default" | "warning" | "danger";
+} | null {
+  const snapshot = pickCopilotQuotaSnapshot(quotaSnapshots);
+  if (!snapshot) return null;
+
+  const remainingPercent = normalizeCopilotRemainingPercentage(snapshot.remainingPercentage);
+  const resetDate = formatCopilotQuotaResetDate(snapshot.resetDate);
+  const detailParts = [`${snapshot.remainingRequests}/${snapshot.entitlementRequests} remaining`];
+  if (resetDate) {
+    detailParts.push(`resets ${resetDate}`);
+  }
+
+  return {
+    title: formatCopilotQuotaLabel(snapshot.key),
+    detail: detailParts.join(" · "),
+    remainingPercent,
+    progressTone:
+      remainingPercent <= 10 ? "danger" : remainingPercent <= 25 ? "warning" : "default",
+  };
+}
+
+const ProviderModelPicker = memo(function ProviderModelPicker(props: {
+  provider: ProviderKind;
+  model: ModelSlug;
+  lockedProvider: ProviderKind | null;
+  modelOptionsByProvider: Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>>;
+  copilotModels: ReadonlyArray<ServerProviderModel>;
+  copilotQuotaSummary: {
+    title: string;
+    detail: string;
+    remainingPercent: number;
+    progressTone: "default" | "warning" | "danger";
+  } | null;
+  compact?: boolean;
+  disabled?: boolean;
+  onProviderModelChange: (provider: ProviderKind, model: ModelSlug) => void;
+}) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const selectedProviderOptions = props.modelOptionsByProvider[props.provider];
+  const selectedModelLabel =
+    selectedProviderOptions.find((option) => option.slug === props.model)?.name ?? props.model;
+  const copilotModelById = useMemo(
+    () => new Map(props.copilotModels.map((model) => [model.id, model])),
+    [props.copilotModels],
+  );
+  const selectedCopilotModel =
+    props.provider === "copilot" ? (copilotModelById.get(props.model) ?? null) : null;
+  const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[props.provider];
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={(open) => {
+        if (props.disabled) {
+          setIsMenuOpen(false);
+          return;
+        }
+        setIsMenuOpen(open);
+      }}
+    >
+      <MenuTrigger
+        render={
+          <Button
+            size="sm"
+            variant="ghost"
+            className={cn(
+              "min-w-0 shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80",
+              props.compact ? "max-w-42" : "sm:px-3",
+            )}
+            disabled={props.disabled}
+          />
+        }
+      >
+        <span
+          className={cn("flex min-w-0 items-center gap-2", props.compact ? "max-w-36" : undefined)}
+        >
+          <ProviderIcon aria-hidden="true" className="size-4 shrink-0 text-muted-foreground/70" />
+          <span className="truncate">{selectedModelLabel}</span>
+          {selectedCopilotModel?.billingMultiplier != null ? (
+            <span className="shrink-0 rounded-full border border-border/70 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+              {formatCopilotBillingMultiplier(selectedCopilotModel.billingMultiplier)}
+            </span>
+          ) : null}
+          <ChevronDownIcon aria-hidden="true" className="size-3 opacity-60" />
+        </span>
+      </MenuTrigger>
+      <MenuPopup align="start">
+        {AVAILABLE_PROVIDER_OPTIONS.map((option) => {
+          const OptionIcon = PROVIDER_ICON_BY_PROVIDER[option.value];
+          const isDisabledByProviderLock =
+            props.lockedProvider !== null && props.lockedProvider !== option.value;
+          return (
+            <MenuSub key={option.value}>
+              <MenuSubTrigger disabled={isDisabledByProviderLock}>
+                <OptionIcon
+                  aria-hidden="true"
+                  className="size-4 shrink-0 text-muted-foreground/85"
+                />
+                {option.label}
+              </MenuSubTrigger>
+              <MenuSubPopup className="[--available-height:min(24rem,70vh)]">
+                {option.value === "copilot" && props.copilotQuotaSummary ? (
+                  <div className="border-b border-border/60 px-3 py-2">
+                    <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/70">
+                      Usage remaining
+                    </p>
+                    <p className="mt-1 text-xs font-medium text-foreground/90">
+                      {props.copilotQuotaSummary.title}
+                    </p>
+                    <div className="mt-0.5 flex items-baseline justify-between gap-3">
+                      <p className="text-[11px] text-muted-foreground/80">
+                        {props.copilotQuotaSummary.detail}
+                      </p>
+                      <span className="shrink-0 text-[10px] font-medium tabular-nums uppercase tracking-[0.08em] text-muted-foreground/70">
+                        {formatCopilotQuotaPercentage(props.copilotQuotaSummary.remainingPercent)}%
+                      </span>
+                    </div>
+                    <div
+                      role="progressbar"
+                      aria-label={`${props.copilotQuotaSummary.title} quota remaining`}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={Math.round(props.copilotQuotaSummary.remainingPercent)}
+                      className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-black/10 dark:bg-white/15"
+                    >
+                      <div
+                        className={cn(
+                          "h-full rounded-full transition-[width,background-color] duration-200",
+                          props.copilotQuotaSummary.progressTone === "danger"
+                            ? "bg-red-500 dark:bg-red-400"
+                            : props.copilotQuotaSummary.progressTone === "warning"
+                              ? "bg-amber-500 dark:bg-amber-400"
+                              : "bg-black dark:bg-white",
+                        )}
+                        style={{
+                          width: `${Math.max(0, Math.min(100, props.copilotQuotaSummary.remainingPercent))}%`,
+                        }}
+                      />
+                    </div>
+                  </div>
+                ) : null}
+                <MenuGroup>
+                  <MenuRadioGroup
+                    value={props.provider === option.value ? props.model : ""}
+                    onValueChange={(value) => {
+                      if (props.disabled) return;
+                      if (isDisabledByProviderLock) return;
+                      if (!value) return;
+                      const resolvedModel = resolveModelForProviderPicker(
+                        option.value,
+                        value,
+                        props.modelOptionsByProvider[option.value],
+                      );
+                      if (!resolvedModel) return;
+                      props.onProviderModelChange(option.value, resolvedModel);
+                      setIsMenuOpen(false);
+                    }}
+                  >
+                    {props.modelOptionsByProvider[option.value].map((modelOption) => {
+                      const copilotModel =
+                        option.value === "copilot"
+                          ? (copilotModelById.get(modelOption.slug) ?? null)
+                          : null;
+                      return (
+                        <MenuRadioItem
+                          key={`${option.value}:${modelOption.slug}`}
+                          value={modelOption.slug}
+                          onClick={() => setIsMenuOpen(false)}
+                        >
+                          <span className="flex min-w-0 items-center gap-2">
+                            <span className="truncate">{modelOption.name}</span>
+                            {copilotModel?.billingMultiplier != null ? (
+                              <span className="ms-auto shrink-0 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+                                {formatCopilotBillingMultiplier(copilotModel.billingMultiplier)}
+                              </span>
+                            ) : null}
+                          </span>
+                        </MenuRadioItem>
+                      );
+                    })}
+                  </MenuRadioGroup>
+                </MenuGroup>
+              </MenuSubPopup>
+            </MenuSub>
+          );
+        })}
+        {UNAVAILABLE_PROVIDER_OPTIONS.length > 0 && <MenuDivider />}
+        {UNAVAILABLE_PROVIDER_OPTIONS.map((option) => {
+          const OptionIcon = PROVIDER_ICON_BY_PROVIDER[option.value];
+          return (
+            <MenuItem key={option.value} disabled>
+              <OptionIcon
+                aria-hidden="true"
+                className={cn(
+                  "size-4 shrink-0 opacity-80",
+                  option.value === "claudeCode" ? "" : "text-muted-foreground/85",
+                )}
+              />
+              <span>{option.label}</span>
+              <span className="ms-auto text-[11px] text-muted-foreground/80 uppercase tracking-[0.08em]">
+                Coming soon
+              </span>
+            </MenuItem>
+          );
+        })}
+        {UNAVAILABLE_PROVIDER_OPTIONS.length === 0 && <MenuDivider />}
+        {COMING_SOON_PROVIDER_OPTIONS.map((option) => {
+          const OptionIcon = option.icon;
+          return (
+            <MenuItem key={option.id} disabled>
+              <OptionIcon aria-hidden="true" className="size-4 shrink-0 opacity-80" />
+              <span>{option.label}</span>
+              <span className="ms-auto text-[11px] text-muted-foreground/80 uppercase tracking-[0.08em]">
+                Coming soon
+              </span>
+            </MenuItem>
+          );
+        })}
+      </MenuPopup>
+    </Menu>
+  );
+});
+
+const CompactComposerControlsMenu = memo(function CompactComposerControlsMenu(props: {
+  activePlan: boolean;
+  interactionMode: ProviderInteractionMode;
+  planSidebarOpen: boolean;
+  runtimeMode: RuntimeMode;
+  selectedEffort: CodexReasoningEffort | null;
+  selectedProvider: ProviderKind;
+  selectedCodexFastModeEnabled: boolean;
+  reasoningOptions: ReadonlyArray<CodexReasoningEffort>;
+  onEffortSelect: (effort: CodexReasoningEffort) => void;
+  onCodexFastModeChange: (enabled: boolean) => void;
+  onToggleInteractionMode: () => void;
+  onTogglePlanSidebar: () => void;
+  onToggleRuntimeMode: () => void;
+}) {
+  const defaultReasoningEffort = getDefaultReasoningEffort("codex");
+  const reasoningLabelByOption: Record<CodexReasoningEffort, string> = {
+    low: "Low",
+    medium: "Medium",
+    high: "High",
+    xhigh: "Extra High",
+  };
+
+  return (
+    <Menu>
+      <MenuTrigger
+        render={
+          <Button
+            size="sm"
+            variant="ghost"
+            className="shrink-0 px-2 text-muted-foreground/70 hover:text-foreground/80"
+            aria-label="More composer controls"
+          />
+        }
+      >
+        <EllipsisIcon aria-hidden="true" className="size-4" />
+      </MenuTrigger>
+      <MenuPopup align="start">
+        {props.selectedProvider === "codex" && props.selectedEffort != null ? (
+          <>
+            <MenuGroup>
+              <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Reasoning</div>
+              <MenuRadioGroup
+                value={props.selectedEffort}
+                onValueChange={(value) => {
+                  if (!value) return;
+                  const nextEffort = props.reasoningOptions.find((option) => option === value);
+                  if (!nextEffort) return;
+                  props.onEffortSelect(nextEffort);
+                }}
+              >
+                {props.reasoningOptions.map((effort) => (
+                  <MenuRadioItem key={effort} value={effort}>
+                    {reasoningLabelByOption[effort]}
+                    {effort === defaultReasoningEffort ? " (default)" : ""}
+                  </MenuRadioItem>
+                ))}
+              </MenuRadioGroup>
+            </MenuGroup>
+            <MenuDivider />
+            <MenuGroup>
+              <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Fast Mode</div>
+              <MenuRadioGroup
+                value={props.selectedCodexFastModeEnabled ? "on" : "off"}
+                onValueChange={(value) => {
+                  props.onCodexFastModeChange(value === "on");
+                }}
+              >
+                <MenuRadioItem value="off">off</MenuRadioItem>
+                <MenuRadioItem value="on">on</MenuRadioItem>
+              </MenuRadioGroup>
+            </MenuGroup>
+            <MenuDivider />
+          </>
+        ) : null}
+        <MenuGroup>
+          <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Mode</div>
+          <MenuRadioGroup
+            value={props.interactionMode}
+            onValueChange={(value) => {
+              if (!value || value === props.interactionMode) return;
+              props.onToggleInteractionMode();
+            }}
+          >
+            <MenuRadioItem value="default">Chat</MenuRadioItem>
+            <MenuRadioItem value="plan">Plan</MenuRadioItem>
+          </MenuRadioGroup>
+        </MenuGroup>
+        <MenuDivider />
+        <MenuGroup>
+          <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Access</div>
+          <MenuRadioGroup
+            value={props.runtimeMode}
+            onValueChange={(value) => {
+              if (!value || value === props.runtimeMode) return;
+              props.onToggleRuntimeMode();
+            }}
+          >
+            <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
+            <MenuRadioItem value="full-access">Full access</MenuRadioItem>
+          </MenuRadioGroup>
+        </MenuGroup>
+        {props.activePlan ? (
+          <>
+            <MenuDivider />
+            <MenuItem onClick={props.onTogglePlanSidebar}>
+              <ListTodoIcon className="size-4 shrink-0" />
+              {props.planSidebarOpen ? "Hide plan sidebar" : "Show plan sidebar"}
+            </MenuItem>
+          </>
+        ) : null}
+      </MenuPopup>
+    </Menu>
+  );
+});
+
+const InteractionModeToggleButton = memo(function InteractionModeToggleButton(props: {
+  interactionMode: ProviderInteractionMode;
+  onClick: () => void;
+}) {
+  const isPlanMode = props.interactionMode === "plan";
+  return (
+    <Button
+      variant="ghost"
+      className={cn(
+        "shrink-0 whitespace-nowrap px-2 sm:px-3",
+        isPlanMode
+          ? "text-ring-plan hover:text-ring-plan"
+          : "text-muted-foreground/70 hover:text-foreground/80",
+      )}
+      size="sm"
+      type="button"
+      onClick={props.onClick}
+      title={isPlanMode ? "return to normal chat mode" : "enter plan mode"}
+      aria-label={isPlanMode ? "Plan interaction mode button" : "Chat interaction mode button"}
+    >
+      <ListTodoIcon className="size-4 shrink-0" />
+      <span>{isPlanMode ? "Plan" : "Chat"}</span>
+    </Button>
+  );
+});
+
+const ModelTraitsPicker = memo(function ModelTraitsPicker(props: {
+  effort: CodexReasoningEffort;
+  defaultEffort: CodexReasoningEffort | null;
+  fastModeEnabled?: boolean;
+  options: ReadonlyArray<CodexReasoningEffort>;
+  onEffortChange: (effort: CodexReasoningEffort) => void;
+  onFastModeChange?: (enabled: boolean) => void;
+}) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const reasoningLabelByOption: Record<CodexReasoningEffort, string> = {
+    low: "Low",
+    medium: "Medium",
+    high: "High",
+    xhigh: "Extra High",
+  };
+  const triggerLabel = [
+    reasoningLabelByOption[props.effort],
+    ...(props.onFastModeChange && props.fastModeEnabled ? ["Fast"] : []),
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <Menu
+      open={isMenuOpen}
+      onOpenChange={(open) => {
+        setIsMenuOpen(open);
+      }}
+    >
+      <MenuTrigger
+        render={
+          <Button
+            size="sm"
+            variant="ghost"
+            className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
+          />
+        }
+      >
+        <span>{triggerLabel}</span>
+        <ChevronDownIcon aria-hidden="true" className="size-3 opacity-60" />
+      </MenuTrigger>
+      <MenuPopup align="start">
+        <MenuGroup>
+          <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Reasoning</div>
+          <MenuRadioGroup
+            value={props.effort}
+            onValueChange={(value) => {
+              if (!value) return;
+              const nextEffort = props.options.find((option) => option === value);
+              if (!nextEffort) return;
+              props.onEffortChange(nextEffort);
+            }}
+          >
+            {props.options.map((effort) => (
+              <MenuRadioItem key={effort} value={effort}>
+                {reasoningLabelByOption[effort]}
+                {effort === props.defaultEffort ? " (default)" : ""}
+              </MenuRadioItem>
+            ))}
+          </MenuRadioGroup>
+        </MenuGroup>
+        {props.onFastModeChange ? (
+          <>
+            <MenuDivider />
+            <MenuGroup>
+              <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Fast Mode</div>
+              <MenuRadioGroup
+                value={props.fastModeEnabled ? "on" : "off"}
+                onValueChange={(value) => {
+                  props.onFastModeChange?.(value === "on");
+                }}
+              >
+                <MenuRadioItem value="off">off</MenuRadioItem>
+                <MenuRadioItem value="on">on</MenuRadioItem>
+              </MenuRadioGroup>
+            </MenuGroup>
+          </>
+        ) : null}
+      </MenuPopup>
+    </Menu>
+  );
+});
+
+const OpenInPicker = memo(function OpenInPicker({
+  keybindings,
+  availableEditors,
+  openInCwd,
+}: {
+  keybindings: ResolvedKeybindingsConfig;
+  availableEditors: ReadonlyArray<EditorId>;
+  openInCwd: string | null;
+}) {
+  const [lastEditor, setLastEditor] = useState<EditorId>(() => {
+    const stored = localStorage.getItem(LAST_EDITOR_KEY);
+    return EDITORS.some((e) => e.id === stored) ? (stored as EditorId) : EDITORS[0].id;
+  });
+
+  const allOptions = useMemo<Array<{ label: string; Icon: Icon; value: EditorId }>>(
+    () => [
+      {
+        label: "Cursor",
+        Icon: CursorIcon,
+        value: "cursor",
+      },
+      {
+        label: "VS Code",
+        Icon: VisualStudioCode,
+        value: "vscode",
+      },
+      {
+        label: "Zed",
+        Icon: Zed,
+        value: "zed",
+      },
+      {
+        label: isMacPlatform(navigator.platform)
+          ? "Finder"
+          : isWindowsPlatform(navigator.platform)
+            ? "Explorer"
+            : "Files",
+        Icon: FolderClosedIcon,
+        value: "file-manager",
+      },
+    ],
+    [],
+  );
+  const options = useMemo(
+    () => allOptions.filter((option) => availableEditors.includes(option.value)),
+    [allOptions, availableEditors],
+  );
+
+  const effectiveEditor = options.some((option) => option.value === lastEditor)
+    ? lastEditor
+    : (options[0]?.value ?? null);
+  const primaryOption = options.find(({ value }) => value === effectiveEditor) ?? null;
+
+  const openInEditor = useCallback(
+    (editorId: EditorId | null) => {
+      const api = readNativeApi();
+      if (!api || !openInCwd) return;
+      const editor = editorId ?? effectiveEditor;
+      if (!editor) return;
+      void api.shell.openInEditor(openInCwd, editor);
+      localStorage.setItem(LAST_EDITOR_KEY, editor);
+      setLastEditor(editor);
+    },
+    [effectiveEditor, openInCwd, setLastEditor],
+  );
+
+  const openFavoriteEditorShortcutLabel = useMemo(
+    () => shortcutLabelForCommand(keybindings, "editor.openFavorite"),
+    [keybindings],
+  );
+
+  useEffect(() => {
+    const handler = (e: globalThis.KeyboardEvent) => {
+      const api = readNativeApi();
+      if (!isOpenFavoriteEditorShortcut(e, keybindings)) return;
+      if (!api || !openInCwd) return;
+      if (!effectiveEditor) return;
+
+      e.preventDefault();
+      void api.shell.openInEditor(openInCwd, effectiveEditor);
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [effectiveEditor, keybindings, openInCwd]);
+
+  return (
+    <Group aria-label="Subscription actions">
+      <Button
+        size="xs"
+        variant="outline"
+        disabled={!effectiveEditor || !openInCwd}
+        onClick={() => openInEditor(effectiveEditor)}
+      >
+        {primaryOption?.Icon && <primaryOption.Icon aria-hidden="true" className="size-3.5" />}
+        <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
+          Open
+        </span>
+      </Button>
+      <GroupSeparator className="hidden @sm/header-actions:block" />
+      <Menu>
+        <MenuTrigger render={<Button aria-label="Copy options" size="icon-xs" variant="outline" />}>
+          <ChevronDownIcon aria-hidden="true" className="size-4" />
+        </MenuTrigger>
+        <MenuPopup align="end">
+          {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
+          {options.map(({ label, Icon, value }) => (
+            <MenuItem key={value} onClick={() => openInEditor(value)}>
+              <Icon aria-hidden="true" className="text-muted-foreground" />
+              {label}
+              {value === effectiveEditor && openFavoriteEditorShortcutLabel && (
+                <MenuShortcut>{openFavoriteEditorShortcutLabel}</MenuShortcut>
+              )}
+            </MenuItem>
+          ))}
+        </MenuPopup>
+      </Menu>
+    </Group>
+  );
+});

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -170,6 +170,111 @@ function $createComposerMentionNode(path: string): ComposerMentionNode {
   return $applyNodeReplacement(new ComposerMentionNode(path));
 }
 
+type SerializedComposerSkillNode = Spread<
+  {
+    skillName: string;
+    type: "composer-skill";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+class ComposerSkillNode extends TextNode {
+  __skillName: string;
+
+  static override getType(): string {
+    return "composer-skill";
+  }
+
+  static override clone(node: ComposerSkillNode): ComposerSkillNode {
+    return new ComposerSkillNode(node.__skillName, node.__key);
+  }
+
+  static override importJSON(serializedNode: SerializedComposerSkillNode): ComposerSkillNode {
+    return $createComposerSkillNode(serializedNode.skillName);
+  }
+
+  constructor(skillName: string, key?: NodeKey) {
+    const normalizedName = skillName.startsWith("$") ? skillName.slice(1) : skillName;
+    super(`$${normalizedName}`, key);
+    this.__skillName = normalizedName;
+  }
+
+  override exportJSON(): SerializedComposerSkillNode {
+    return {
+      ...super.exportJSON(),
+      skillName: this.__skillName,
+      type: "composer-skill",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig): HTMLElement {
+    const dom = document.createElement("span");
+    dom.className =
+      "inline-flex select-none items-center gap-1 rounded-full bg-violet-500/15 px-2 py-px font-medium text-[12px] leading-[1.1] text-violet-600 dark:text-violet-400 align-middle";
+    dom.contentEditable = "false";
+    dom.setAttribute("spellcheck", "false");
+    renderSkillChipDom(dom, this.__skillName);
+    return dom;
+  }
+
+  override updateDOM(
+    prevNode: ComposerSkillNode,
+    dom: HTMLElement,
+    _config: EditorConfig,
+  ): boolean {
+    dom.contentEditable = "false";
+    if (prevNode.__text !== this.__text || prevNode.__skillName !== this.__skillName) {
+      renderSkillChipDom(dom, this.__skillName);
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+function $createComposerSkillNode(skillName: string): ComposerSkillNode {
+  return $applyNodeReplacement(new ComposerSkillNode(skillName));
+}
+
+function renderSkillChipDom(container: HTMLElement, skillName: string): void {
+  container.textContent = "";
+  container.style.setProperty("user-select", "none");
+  container.style.setProperty("-webkit-user-select", "none");
+
+  const icon = document.createElement("span");
+  icon.className = "inline-flex items-center justify-center";
+  icon.innerHTML = `<svg class="size-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>`;
+
+  const label = document.createElement("span");
+  label.className = "truncate select-none leading-tight";
+  label.textContent = formatSkillDisplayName(skillName);
+
+  container.append(icon, label);
+}
+
+function formatSkillDisplayName(name: string): string {
+  return name
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 function ComposerTerminalContextDecorator(props: { context: TerminalContextDraft }) {
   return <ComposerPendingTerminalContextChip context={props.context} />;
 }
@@ -234,11 +339,16 @@ function $createComposerTerminalContextNode(
   return $applyNodeReplacement(new ComposerTerminalContextNode(context));
 }
 
-type ComposerInlineTokenNode = ComposerMentionNode | ComposerTerminalContextNode;
+type ComposerInlineTokenNode =
+  | ComposerMentionNode
+  | ComposerSkillNode
+  | ComposerTerminalContextNode;
 
 function isComposerInlineTokenNode(candidate: unknown): candidate is ComposerInlineTokenNode {
   return (
-    candidate instanceof ComposerMentionNode || candidate instanceof ComposerTerminalContextNode
+    candidate instanceof ComposerMentionNode ||
+    candidate instanceof ComposerSkillNode ||
+    candidate instanceof ComposerTerminalContextNode
   );
 }
 
@@ -391,13 +501,10 @@ function getAbsoluteOffsetForPoint(node: LexicalNode, pointOffset: number): numb
   }
 
   if ($isTextNode(node)) {
-    if (node instanceof ComposerMentionNode) {
+    if (isComposerInlineTokenNode(node)) {
       return getAbsoluteOffsetForInlineTokenPoint(node, offset, pointOffset);
     }
     return offset + Math.min(pointOffset, node.getTextContentSize());
-  }
-  if (node instanceof ComposerTerminalContextNode) {
-    return getAbsoluteOffsetForInlineTokenPoint(node, offset, pointOffset);
   }
 
   if ($isLineBreakNode(node)) {
@@ -469,10 +576,7 @@ function findSelectionPointAtOffset(
   node: LexicalNode,
   remainingRef: { value: number },
 ): { key: string; offset: number; type: "text" | "element" } | null {
-  if (node instanceof ComposerMentionNode) {
-    return findSelectionPointForInlineToken(node, remainingRef);
-  }
-  if (node instanceof ComposerTerminalContextNode) {
+  if (isComposerInlineTokenNode(node)) {
     return findSelectionPointForInlineToken(node, remainingRef);
   }
 
@@ -601,6 +705,10 @@ function $setComposerEditorPrompt(
   for (const segment of segments) {
     if (segment.type === "mention") {
       paragraph.append($createComposerMentionNode(segment.path));
+      continue;
+    }
+    if (segment.type === "skill") {
+      paragraph.append($createComposerSkillNode(segment.name));
       continue;
     }
     if (segment.type === "terminal-context") {
@@ -1146,7 +1254,7 @@ export const ComposerPromptEditor = forwardRef<
     () => ({
       namespace: "t3tools-composer-editor",
       editable: true,
-      nodes: [ComposerMentionNode, ComposerTerminalContextNode],
+      nodes: [ComposerMentionNode, ComposerSkillNode, ComposerTerminalContextNode],
       editorState: () => {
         $setComposerEditorPrompt(initialValueRef.current, initialTerminalContextsRef.current);
       },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3,7 +3,9 @@ import {
   ChevronRightIcon,
   FolderIcon,
   GitPullRequestIcon,
+  PlugIcon,
   PlusIcon,
+  PuzzleIcon,
   RocketIcon,
   SettingsIcon,
   SquarePenIcon,
@@ -27,27 +29,29 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-
 import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import {
+  DEFAULT_RUNTIME_MODE,
   DEFAULT_MODEL_BY_PROVIDER,
   type DesktopUpdateState,
+  type ModelSlug,
+  type ProviderKind,
   ProjectId,
   ThreadId,
   type GitStatusResult,
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
+import { useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import { useAppSettings } from "../appSettings";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
-import { isMacPlatform, newCommandId, newProjectId } from "../lib/utils";
+import { isMacPlatform, newCommandId, newProjectId, newThreadId } from "../lib/utils";
 import { useStore } from "../store";
-import { shortcutLabelForCommand } from "../keybindings";
+import { isChatNewLocalShortcut, isChatNewShortcut, shortcutLabelForCommand } from "../keybindings";
 import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
 import { gitRemoveWorktreeMutationOptions, gitStatusQueryOptions } from "../lib/gitReactQuery";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
-import { useComposerDraftStore } from "../composerDraftStore";
-import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { type DraftThreadEnvMode, useComposerDraftStore } from "../composerDraftStore";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { toastManager } from "./ui/toast";
 import {
@@ -85,7 +89,6 @@ import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "
 import { isNonEmpty as isNonEmptyString } from "effect/String";
 import {
   resolveSidebarNewThreadEnvMode,
-  resolveThreadRowClassName,
   resolveThreadStatusPill,
   shouldClearThreadSelectionOnMouseDown,
 } from "./Sidebar.logic";
@@ -258,11 +261,17 @@ export default function Sidebar() {
   const toggleProject = useStore((store) => store.toggleProject);
   const reorderProjects = useStore((store) => store.reorderProjects);
   const clearComposerDraftForThread = useComposerDraftStore((store) => store.clearThreadDraft);
+  const draftByThreadId = useComposerDraftStore((store) => store.draftsByThreadId);
   const getDraftThreadByProjectId = useComposerDraftStore(
     (store) => store.getDraftThreadByProjectId,
   );
+  const getDraftThread = useComposerDraftStore((store) => store.getDraftThread);
   const terminalStateByThreadId = useTerminalStateStore((state) => state.terminalStateByThreadId);
   const clearTerminalState = useTerminalStateStore((state) => state.clearTerminalState);
+  const setProjectDraftThreadId = useComposerDraftStore((store) => store.setProjectDraftThreadId);
+  const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const setDraftProvider = useComposerDraftStore((store) => store.setProvider);
+  const setDraftModel = useComposerDraftStore((store) => store.setModel);
   const clearProjectDraftThreadId = useComposerDraftStore(
     (store) => store.clearProjectDraftThreadId,
   );
@@ -270,9 +279,9 @@ export default function Sidebar() {
     (store) => store.clearProjectDraftThreadById,
   );
   const navigate = useNavigate();
-  const isOnSettings = useLocation({ select: (loc) => loc.pathname === "/settings" });
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const isOnSettings = pathname === "/settings";
   const { settings: appSettings } = useAppSettings();
-  const { handleNewThread } = useHandleNewThread();
   const routeThreadId = useParams({
     strict: false,
     select: (params) => (params.threadId ? ThreadId.makeUnsafe(params.threadId) : null),
@@ -380,6 +389,124 @@ export default function Sidebar() {
       });
     });
   }, []);
+
+  const handleNewThread = useCallback(
+    (
+      projectId: ProjectId,
+      options?: {
+        branch?: string | null;
+        worktreePath?: string | null;
+        envMode?: DraftThreadEnvMode;
+        provider?: ProviderKind | null;
+        model?: ModelSlug | null;
+      },
+    ): Promise<void> => {
+      const activeThread = routeThreadId
+        ? (threads.find((thread) => thread.id === routeThreadId) ?? null)
+        : null;
+      const activeDraftState = routeThreadId ? (draftByThreadId[routeThreadId] ?? null) : null;
+      const activeDraftThread = routeThreadId ? getDraftThread(routeThreadId) : null;
+      const sourceProjectId = activeThread?.projectId ?? activeDraftThread?.projectId ?? null;
+      const shouldSeedFromActiveContext = sourceProjectId === projectId;
+      const nextProvider =
+        options?.provider !== undefined
+          ? (options.provider ?? null)
+          : shouldSeedFromActiveContext
+            ? (activeDraftState?.provider ?? activeThread?.session?.provider ?? null)
+            : null;
+      const nextModel =
+        options?.model !== undefined
+          ? (options.model ?? null)
+          : shouldSeedFromActiveContext
+            ? (activeDraftState?.model ?? activeThread?.model ?? null)
+            : null;
+      const hasBranchOption = options?.branch !== undefined;
+      const hasWorktreePathOption = options?.worktreePath !== undefined;
+      const hasEnvModeOption = options?.envMode !== undefined;
+      const hasProviderOption = nextProvider !== null;
+      const hasModelOption = nextModel !== null;
+      const storedDraftThread = getDraftThreadByProjectId(projectId);
+      if (storedDraftThread) {
+        return (async () => {
+          if (hasBranchOption || hasWorktreePathOption || hasEnvModeOption) {
+            setDraftThreadContext(storedDraftThread.threadId, {
+              ...(hasBranchOption ? { branch: options?.branch ?? null } : {}),
+              ...(hasWorktreePathOption ? { worktreePath: options?.worktreePath ?? null } : {}),
+              ...(hasEnvModeOption ? { envMode: options?.envMode } : {}),
+            });
+          }
+          if (hasProviderOption) {
+            setDraftProvider(storedDraftThread.threadId, nextProvider);
+          }
+          if (hasModelOption) {
+            setDraftModel(storedDraftThread.threadId, nextModel, nextProvider);
+          }
+          setProjectDraftThreadId(projectId, storedDraftThread.threadId);
+          if (routeThreadId === storedDraftThread.threadId) {
+            return;
+          }
+          await navigate({
+            to: "/$threadId",
+            params: { threadId: storedDraftThread.threadId },
+          });
+        })();
+      }
+      clearProjectDraftThreadId(projectId);
+
+      if (activeDraftThread && routeThreadId && activeDraftThread.projectId === projectId) {
+        if (hasBranchOption || hasWorktreePathOption || hasEnvModeOption) {
+          setDraftThreadContext(routeThreadId, {
+            ...(hasBranchOption ? { branch: options?.branch ?? null } : {}),
+            ...(hasWorktreePathOption ? { worktreePath: options?.worktreePath ?? null } : {}),
+            ...(hasEnvModeOption ? { envMode: options?.envMode } : {}),
+          });
+        }
+        if (hasProviderOption) {
+          setDraftProvider(routeThreadId, nextProvider);
+        }
+        if (hasModelOption) {
+          setDraftModel(routeThreadId, nextModel, nextProvider);
+        }
+        setProjectDraftThreadId(projectId, routeThreadId);
+        return Promise.resolve();
+      }
+      const threadId = newThreadId();
+      const createdAt = new Date().toISOString();
+      return (async () => {
+        setProjectDraftThreadId(projectId, threadId, {
+          createdAt,
+          branch: options?.branch ?? null,
+          worktreePath: options?.worktreePath ?? null,
+          envMode: options?.envMode ?? "local",
+          runtimeMode: DEFAULT_RUNTIME_MODE,
+        });
+        if (hasProviderOption) {
+          setDraftProvider(threadId, nextProvider);
+        }
+        if (hasModelOption) {
+          setDraftModel(threadId, nextModel, nextProvider);
+        }
+
+        await navigate({
+          to: "/$threadId",
+          params: { threadId },
+        });
+      })();
+    },
+    [
+      clearProjectDraftThreadId,
+      draftByThreadId,
+      getDraftThreadByProjectId,
+      navigate,
+      getDraftThread,
+      routeThreadId,
+      setDraftModel,
+      setDraftThreadContext,
+      setDraftProvider,
+      setProjectDraftThreadId,
+      threads,
+    ],
+  );
 
   const focusMostRecentThreadForProject = useCallback(
     (projectId: ProjectId) => {
@@ -862,7 +989,7 @@ export default function Sidebar() {
       const api = readNativeApi();
       if (!api) return;
       const clicked = await api.contextMenu.show(
-        [{ id: "delete", label: "Remove project", destructive: true }],
+        [{ id: "delete", label: "Delete", destructive: true }],
         position,
       );
       if (clicked !== "delete") return;
@@ -875,12 +1002,14 @@ export default function Sidebar() {
         toastManager.add({
           type: "warning",
           title: "Project is not empty",
-          description: "Delete all threads in this project before removing it.",
+          description: "Delete all threads in this project before deleting it.",
         });
         return;
       }
 
-      const confirmed = await api.dialogs.confirm(`Remove project "${project.name}"?`);
+      const confirmed = await api.dialogs.confirm(
+        [`Delete project "${project.name}"?`, "This action cannot be undone."].join("\n"),
+      );
       if (!confirmed) return;
 
       try {
@@ -895,11 +1024,11 @@ export default function Sidebar() {
           projectId,
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error removing project.";
+        const message = error instanceof Error ? error.message : "Unknown error deleting project.";
         console.error("Failed to remove project", { projectId, error });
         toastManager.add({
           type: "error",
-          title: `Failed to remove "${project.name}"`,
+          title: `Failed to delete "${project.name}"`,
           description: message,
         });
       }
@@ -988,6 +1117,37 @@ export default function Sidebar() {
   );
 
   useEffect(() => {
+    const onWindowKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && selectedThreadIds.size > 0) {
+        event.preventDefault();
+        clearSelection();
+        return;
+      }
+
+      const activeThread = routeThreadId
+        ? threads.find((thread) => thread.id === routeThreadId)
+        : undefined;
+      const activeDraftThread = routeThreadId ? getDraftThread(routeThreadId) : null;
+      if (isChatNewLocalShortcut(event, keybindings)) {
+        const projectId =
+          activeThread?.projectId ?? activeDraftThread?.projectId ?? projects[0]?.id;
+        if (!projectId) return;
+        event.preventDefault();
+        void handleNewThread(projectId);
+        return;
+      }
+
+      if (!isChatNewShortcut(event, keybindings)) return;
+      const projectId = activeThread?.projectId ?? activeDraftThread?.projectId ?? projects[0]?.id;
+      if (!projectId) return;
+      event.preventDefault();
+      void handleNewThread(projectId, {
+        branch: activeThread?.branch ?? activeDraftThread?.branch ?? null,
+        worktreePath: activeThread?.worktreePath ?? activeDraftThread?.worktreePath ?? null,
+        envMode: activeDraftThread?.envMode ?? (activeThread?.worktreePath ? "worktree" : "local"),
+      });
+    };
+
     const onMouseDown = (event: globalThis.MouseEvent) => {
       if (selectedThreadIds.size === 0) return;
       const target = event.target instanceof HTMLElement ? event.target : null;
@@ -995,11 +1155,22 @@ export default function Sidebar() {
       clearSelection();
     };
 
+    window.addEventListener("keydown", onWindowKeyDown);
     window.addEventListener("mousedown", onMouseDown);
     return () => {
+      window.removeEventListener("keydown", onWindowKeyDown);
       window.removeEventListener("mousedown", onMouseDown);
     };
-  }, [clearSelection, selectedThreadIds.size]);
+  }, [
+    clearSelection,
+    getDraftThread,
+    handleNewThread,
+    keybindings,
+    projects,
+    routeThreadId,
+    selectedThreadIds.size,
+    threads,
+  ]);
 
   useEffect(() => {
     if (!isElectron) return;
@@ -1150,7 +1321,7 @@ export default function Sidebar() {
       <Tooltip>
         <TooltipTrigger
           render={
-            <div className="flex min-w-0 flex-1 items-center gap-1 ml-1 cursor-pointer">
+            <div className="flex min-w-0 flex-1 items-center gap-1 mt-1.5 ml-1 cursor-pointer">
               <T3Wordmark />
               <span className="truncate text-sm font-medium tracking-tight text-muted-foreground">
                 Code
@@ -1200,6 +1371,36 @@ export default function Sidebar() {
           {wordmark}
         </SidebarHeader>
       )}
+
+      <div className="px-2 py-2">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              render={<button type="button" />}
+              isActive={pathname === "/skills"}
+              size="sm"
+              className="cursor-pointer gap-2 px-2 py-1.5 font-medium text-muted-foreground text-xs hover:bg-accent hover:text-foreground data-[active=true]:bg-accent data-[active=true]:text-foreground"
+              onClick={() => void navigate({ to: "/skills" })}
+            >
+              <PuzzleIcon className="size-3.5 shrink-0" />
+              <span>Skills</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              render={<button type="button" />}
+              isActive={pathname === "/mcp"}
+              size="sm"
+              className="cursor-pointer gap-2 px-2 py-1.5 font-medium text-muted-foreground text-xs hover:bg-accent hover:text-foreground data-[active=true]:bg-accent data-[active=true]:text-foreground"
+              onClick={() => void navigate({ to: "/mcp" })}
+            >
+              <PlugIcon className="size-3.5 shrink-0" />
+              <span>MCP Servers</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </div>
+      <SidebarSeparator />
 
       <SidebarContent className="gap-0">
         {showArm64IntelBuildWarning && arm64IntelBuildWarningDescription ? (
@@ -1444,10 +1645,13 @@ export default function Sidebar() {
                                       render={<div role="button" tabIndex={0} />}
                                       size="sm"
                                       isActive={isActive}
-                                      className={resolveThreadRowClassName({
-                                        isActive,
-                                        isSelected,
-                                      })}
+                                      className={`h-7 w-full translate-x-0 cursor-default justify-start px-2 text-left select-none hover:bg-accent hover:text-foreground focus-visible:ring-0 ${
+                                        isSelected
+                                          ? "bg-primary/15 text-foreground dark:bg-primary/10"
+                                          : isActive
+                                            ? "bg-accent/85 text-foreground font-medium dark:bg-accent/55"
+                                            : "text-muted-foreground"
+                                      }`}
                                       onClick={(event) => {
                                         handleThreadClick(
                                           event,
@@ -1585,7 +1789,7 @@ export default function Sidebar() {
                                         <span
                                           className={`text-[10px] ${
                                             isHighlighted
-                                              ? "text-foreground/72 dark:text-foreground/82"
+                                              ? "text-foreground/65"
                                               : "text-muted-foreground/40"
                                           }`}
                                         >

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -17,7 +17,7 @@ import {
   MenuSubTrigger,
   MenuTrigger,
 } from "../ui/menu";
-import { ClaudeAI, CursorIcon, Gemini, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, Gemini, GitHubIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
 import { cn } from "~/lib/utils";
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {
@@ -63,6 +63,7 @@ function resolveModelForProviderPicker(
 
 const PROVIDER_ICON_BY_PROVIDER: Record<ProviderPickerKind, Icon> = {
   codex: OpenAI,
+  copilot: GitHubIcon,
   claudeCode: ClaudeAI,
   cursor: CursorIcon,
 };

--- a/apps/web/src/composer-editor-mentions.test.ts
+++ b/apps/web/src/composer-editor-mentions.test.ts
@@ -12,9 +12,17 @@ describe("splitPromptIntoComposerSegments", () => {
     ]);
   });
 
-  it("does not convert an incomplete trailing mention token", () => {
+  it("converts a trailing mention token at end of input", () => {
     expect(splitPromptIntoComposerSegments("Inspect @AGENTS.md")).toEqual([
-      { type: "text", text: "Inspect @AGENTS.md" },
+      { type: "text", text: "Inspect " },
+      { type: "mention", path: "AGENTS.md" },
+    ]);
+  });
+
+  it("converts a trailing skill token at end of input", () => {
+    expect(splitPromptIntoComposerSegments("Use $reviewer")).toEqual([
+      { type: "text", text: "Use " },
+      { type: "skill", name: "reviewer" },
     ]);
   });
 

--- a/apps/web/src/composer-editor-mentions.ts
+++ b/apps/web/src/composer-editor-mentions.ts
@@ -13,11 +13,15 @@ export type ComposerPromptSegment =
       path: string;
     }
   | {
+      type: "skill";
+      name: string;
+    }
+  | {
       type: "terminal-context";
       context: TerminalContextDraft | null;
     };
 
-const MENTION_TOKEN_REGEX = /(^|\s)@([^\s@]+)(?=\s)/g;
+const CHIP_TOKEN_REGEX = /(^|\s)(?:@([^\s@]+)|\$([a-zA-Z][a-zA-Z0-9_-]*))(?=\s|$)/g;
 
 function pushTextSegment(segments: ComposerPromptSegment[], text: string): void {
   if (!text) return;
@@ -36,25 +40,28 @@ function splitPromptTextIntoComposerSegments(text: string): ComposerPromptSegmen
   }
 
   let cursor = 0;
-  for (const match of text.matchAll(MENTION_TOKEN_REGEX)) {
+  for (const match of text.matchAll(CHIP_TOKEN_REGEX)) {
     const fullMatch = match[0];
     const prefix = match[1] ?? "";
-    const path = match[2] ?? "";
+    const mentionPath = match[2];
+    const skillName = match[3];
     const matchIndex = match.index ?? 0;
-    const mentionStart = matchIndex + prefix.length;
-    const mentionEnd = mentionStart + fullMatch.length - prefix.length;
+    const tokenStart = matchIndex + prefix.length;
+    const tokenEnd = tokenStart + fullMatch.length - prefix.length;
 
-    if (mentionStart > cursor) {
-      pushTextSegment(segments, text.slice(cursor, mentionStart));
+    if (tokenStart > cursor) {
+      pushTextSegment(segments, text.slice(cursor, tokenStart));
     }
 
-    if (path.length > 0) {
-      segments.push({ type: "mention", path });
+    if (mentionPath && mentionPath.length > 0) {
+      segments.push({ type: "mention", path: mentionPath });
+    } else if (skillName && skillName.length > 0) {
+      segments.push({ type: "skill", name: skillName });
     } else {
-      pushTextSegment(segments, text.slice(mentionStart, mentionEnd));
+      pushTextSegment(segments, text.slice(tokenStart, tokenEnd));
     }
 
-    cursor = mentionEnd;
+    cursor = tokenEnd;
   }
 
   if (cursor < text.length) {

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -1,8 +1,8 @@
 import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
-export type ComposerTriggerKind = "path" | "slash-command" | "slash-model";
-export type ComposerSlashCommand = "model" | "plan" | "default";
+export type ComposerTriggerKind = "path" | "slash-command" | "slash-model" | "slash-skill";
+export type ComposerSlashCommand = "model" | "plan" | "default" | "skills";
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -11,10 +11,15 @@ export interface ComposerTrigger {
   rangeEnd: number;
 }
 
-const SLASH_COMMANDS: readonly ComposerSlashCommand[] = ["model", "plan", "default"];
-const isInlineTokenSegment = (
-  segment: { type: "text"; text: string } | { type: "mention" } | { type: "terminal-context" },
-): boolean => segment.type !== "text";
+type ComposerInlineSegment =
+  | { type: "text"; text: string }
+  | { type: "mention"; path: string }
+  | { type: "skill"; name: string }
+  | { type: "terminal-context" };
+
+const SLASH_COMMANDS: readonly ComposerSlashCommand[] = ["model", "plan", "default", "skills"];
+
+const isInlineTokenSegment = (segment: ComposerInlineSegment): boolean => segment.type !== "text";
 
 function clampCursor(text: string, cursor: number): number {
   if (!Number.isFinite(cursor)) return text.length;
@@ -39,6 +44,15 @@ function tokenStartForCursor(text: string, cursor: number): number {
   return index + 1;
 }
 
+function isCursorInsideActiveTrailingInlineQuery(text: string, cursor: number): boolean {
+  if (cursor !== text.length || cursor === 0) {
+    return false;
+  }
+  const tokenStart = tokenStartForCursor(text, cursor);
+  const token = text.slice(tokenStart, cursor);
+  return token.startsWith("@") || token.startsWith("$");
+}
+
 export function expandCollapsedComposerCursor(text: string, cursorInput: number): number {
   const collapsedCursor = clampCursor(text, cursorInput);
   const segments = splitPromptIntoComposerSegments(text);
@@ -52,6 +66,15 @@ export function expandCollapsedComposerCursor(text: string, cursorInput: number)
   for (const segment of segments) {
     if (segment.type === "mention") {
       const expandedLength = segment.path.length + 1;
+      if (remaining <= 1) {
+        return expandedCursor + (remaining === 0 ? 0 : expandedLength);
+      }
+      remaining -= 1;
+      expandedCursor += expandedLength;
+      continue;
+    }
+    if (segment.type === "skill") {
+      const expandedLength = segment.name.length + 1;
       if (remaining <= 1) {
         return expandedCursor + (remaining === 0 ? 0 : expandedLength);
       }
@@ -79,19 +102,12 @@ export function expandCollapsedComposerCursor(text: string, cursorInput: number)
   return expandedCursor;
 }
 
-function collapsedSegmentLength(
-  segment: { type: "text"; text: string } | { type: "mention" } | { type: "terminal-context" },
-): number {
-  if (segment.type === "text") {
-    return segment.text.length;
-  }
-  return 1;
+function collapsedSegmentLength(segment: ComposerInlineSegment): number {
+  return segment.type === "text" ? segment.text.length : 1;
 }
 
 function clampCollapsedComposerCursorForSegments(
-  segments: ReadonlyArray<
-    { type: "text"; text: string } | { type: "mention" } | { type: "terminal-context" }
-  >,
+  segments: ReadonlyArray<ComposerInlineSegment>,
   cursorInput: number,
 ): number {
   const collapsedLength = segments.reduce(
@@ -134,6 +150,18 @@ export function collapseExpandedComposerCursor(text: string, cursorInput: number
       collapsedCursor += 1;
       continue;
     }
+    if (segment.type === "skill") {
+      const expandedLength = segment.name.length + 1;
+      if (remaining === 0) {
+        return collapsedCursor;
+      }
+      if (remaining <= expandedLength) {
+        return collapsedCursor + 1;
+      }
+      remaining -= expandedLength;
+      collapsedCursor += 1;
+      continue;
+    }
     if (segment.type === "terminal-context") {
       if (remaining <= 1) {
         return collapsedCursor + remaining;
@@ -159,15 +187,24 @@ export function isCollapsedCursorAdjacentToInlineToken(
   cursorInput: number,
   direction: "left" | "right",
 ): boolean {
+  const rawCursor = clampCursor(text, cursorInput);
+  if (isCursorInsideActiveTrailingInlineQuery(text, rawCursor)) {
+    return false;
+  }
+
+  const collapsedCursor = clampCollapsedComposerCursor(text, cursorInput);
   const segments = splitPromptIntoComposerSegments(text);
   if (!segments.some(isInlineTokenSegment)) {
     return false;
   }
 
-  const cursor = clampCollapsedComposerCursorForSegments(segments, cursorInput);
+  const cursor = clampCollapsedComposerCursorForSegments(
+    segments as ReadonlyArray<ComposerInlineSegment>,
+    collapsedCursor,
+  );
   let collapsedOffset = 0;
 
-  for (const segment of segments) {
+  for (const segment of segments as ReadonlyArray<ComposerInlineSegment>) {
     if (isInlineTokenSegment(segment)) {
       if (direction === "left" && cursor === collapsedOffset + 1) {
         return true;
@@ -201,6 +238,14 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
           rangeEnd: cursor,
         };
       }
+      if (commandQuery.toLowerCase() === "skills") {
+        return {
+          kind: "slash-skill",
+          query: "",
+          rangeStart: lineStart,
+          rangeEnd: cursor,
+        };
+      }
       if (SLASH_COMMANDS.some((command) => command.startsWith(commandQuery.toLowerCase()))) {
         return {
           kind: "slash-command",
@@ -221,25 +266,44 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
         rangeEnd: cursor,
       };
     }
+
+    const skillsMatch = /^\/skills(?:\s+(.*))?$/.exec(linePrefix);
+    if (skillsMatch) {
+      return {
+        kind: "slash-skill",
+        query: (skillsMatch[1] ?? "").trim(),
+        rangeStart: lineStart,
+        rangeEnd: cursor,
+      };
+    }
   }
 
   const tokenStart = tokenStartForCursor(text, cursor);
   const token = text.slice(tokenStart, cursor);
-  if (!token.startsWith("@")) {
-    return null;
+  if (token.startsWith("@")) {
+    return {
+      kind: "path",
+      query: token.slice(1),
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
   }
 
-  return {
-    kind: "path",
-    query: token.slice(1),
-    rangeStart: tokenStart,
-    rangeEnd: cursor,
-  };
+  if (token.startsWith("/") && tokenStart > lineStart) {
+    return {
+      kind: "slash-skill",
+      query: token.slice(1),
+      rangeStart: tokenStart,
+      rangeEnd: cursor,
+    };
+  }
+
+  return null;
 }
 
 export function parseStandaloneComposerSlashCommand(
   text: string,
-): Exclude<ComposerSlashCommand, "model"> | null {
+): Exclude<ComposerSlashCommand, "model" | "skills"> | null {
   const match = /^\/(plan|default)\s*$/i.exec(text.trim());
   if (!match) {
     return null;

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1,5 +1,4 @@
 import {
-  DEFAULT_REASONING_EFFORT_BY_PROVIDER,
   ProjectId,
   REASONING_EFFORT_OPTIONS_BY_PROVIDER,
   ThreadId,
@@ -179,7 +178,11 @@ interface ComposerDraftStoreState {
   setPrompt: (threadId: ThreadId, prompt: string) => void;
   setTerminalContexts: (threadId: ThreadId, contexts: TerminalContextDraft[]) => void;
   setProvider: (threadId: ThreadId, provider: ProviderKind | null | undefined) => void;
-  setModel: (threadId: ThreadId, model: string | null | undefined) => void;
+  setModel: (
+    threadId: ThreadId,
+    model: string | null | undefined,
+    provider?: ProviderKind | null | undefined,
+  ) => void;
   setRuntimeMode: (threadId: ThreadId, runtimeMode: RuntimeMode | null | undefined) => void;
   setInteractionMode: (
     threadId: ThreadId,
@@ -330,7 +333,24 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
 }
 
 function normalizeProviderKind(value: unknown): ProviderKind | null {
-  return value === "codex" ? value : null;
+  return value === "codex" || value === "copilot" ? value : null;
+}
+
+function normalizeDraftModel(
+  value: string | null | undefined,
+  provider?: ProviderKind | null,
+): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (!provider) {
+    return trimmed;
+  }
+  return normalizeModelSlug(trimmed, provider) ?? trimmed;
 }
 
 function revokeObjectPreviewUrl(previewUrl: string): void {
@@ -1014,13 +1034,14 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           return { draftsByThreadId: nextDraftsByThreadId };
         });
       },
-      setModel: (threadId, model) => {
+      setModel: (threadId, model, provider) => {
         if (threadId.length === 0) {
           return;
         }
-        const normalizedModel = normalizeModelSlug(model) ?? null;
         set((state) => {
           const existing = state.draftsByThreadId[threadId];
+          const normalizedProvider = normalizeProviderKind(provider) ?? existing?.provider ?? null;
+          const normalizedModel = normalizeDraftModel(model, normalizedProvider);
           if (!existing && normalizedModel === null) {
             return state;
           }
@@ -1101,12 +1122,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
         if (threadId.length === 0) {
           return;
         }
-        const nextEffort =
-          effort &&
-          REASONING_EFFORT_VALUES.has(effort) &&
-          effort !== DEFAULT_REASONING_EFFORT_BY_PROVIDER.codex
-            ? effort
-            : null;
+        const nextEffort = effort && REASONING_EFFORT_VALUES.has(effort) ? effort : null;
         set((state) => {
           const existing = state.draftsByThreadId[threadId];
           if (!existing && nextEffort === null) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11,6 +11,7 @@
   --color-info-foreground: var(--info-foreground);
   --color-info: var(--info);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-ring-plan: var(--ring-plan);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -89,6 +90,7 @@
   --success-foreground: var(--color-emerald-700);
   --warning: var(--color-amber-500);
   --warning-foreground: var(--color-amber-700);
+  --ring-plan: var(--color-amber-500);
 
   @variant dark {
     color-scheme: dark;
@@ -117,6 +119,7 @@
     --success-foreground: var(--color-emerald-400);
     --warning: var(--color-amber-500);
     --warning-foreground: var(--color-amber-400);
+    --ring-plan: var(--color-amber-500);
   }
 }
 

--- a/apps/web/src/lib/mcpReactQuery.ts
+++ b/apps/web/src/lib/mcpReactQuery.ts
@@ -1,0 +1,99 @@
+import { mutationOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
+import { ensureNativeApi } from "../nativeApi";
+
+export const mcpQueryKeys = {
+  all: ["mcp"] as const,
+  list: () => ["mcp", "list"] as const,
+  browse: () => ["mcp", "browse"] as const,
+};
+
+export function mcpListQueryOptions() {
+  return queryOptions({
+    queryKey: mcpQueryKeys.list(),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      return api.mcp.list();
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function mcpBrowseQueryOptions() {
+  return queryOptions({
+    queryKey: mcpQueryKeys.browse(),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      return api.mcp.browse();
+    },
+    staleTime: 300_000,
+  });
+}
+
+export function invalidateMcpQueries(queryClient: QueryClient) {
+  return queryClient.invalidateQueries({ queryKey: mcpQueryKeys.all });
+}
+
+export function mcpToggleMutationOptions(opts: { queryClient: QueryClient }) {
+  return mutationOptions({
+    mutationFn: async (vars: { name: string; provider: "codex" | "copilot"; enabled: boolean }) => {
+      const api = ensureNativeApi();
+      return api.mcp.toggle(vars);
+    },
+    onSettled: async () => {
+      await invalidateMcpQueries(opts.queryClient);
+    },
+  });
+}
+
+export function mcpAddMutationOptions(opts: { queryClient: QueryClient }) {
+  return mutationOptions({
+    mutationFn: async (vars: {
+      name: string;
+      provider: "codex" | "copilot";
+      command?: string;
+      args?: string[];
+      url?: string;
+      headers?: Record<string, string>;
+      bearerToken?: string;
+    }) => {
+      const api = ensureNativeApi();
+      return api.mcp.add(vars);
+    },
+    onSettled: async () => {
+      await invalidateMcpQueries(opts.queryClient);
+    },
+  });
+}
+
+export function mcpRemoveMutationOptions(opts: { queryClient: QueryClient }) {
+  return mutationOptions({
+    mutationFn: async (vars: { name: string; provider: "codex" | "copilot" }) => {
+      const api = ensureNativeApi();
+      return api.mcp.remove(vars);
+    },
+    onSettled: async () => {
+      await invalidateMcpQueries(opts.queryClient);
+    },
+  });
+}
+
+export function mcpUpdateMutationOptions(opts: { queryClient: QueryClient }) {
+  return mutationOptions({
+    mutationFn: async (vars: {
+      name: string;
+      provider: "codex" | "copilot";
+      command?: string;
+      args?: string[];
+      url?: string;
+      headers?: Record<string, string>;
+      bearerToken?: string;
+    }) => {
+      const api = ensureNativeApi();
+      return api.mcp.update(vars);
+    },
+    onSettled: async () => {
+      await invalidateMcpQueries(opts.queryClient);
+    },
+  });
+}

--- a/apps/web/src/lib/skillsReactQuery.ts
+++ b/apps/web/src/lib/skillsReactQuery.ts
@@ -1,0 +1,85 @@
+import { mutationOptions, queryOptions, type QueryClient } from "@tanstack/react-query";
+import { ensureNativeApi } from "../nativeApi";
+
+export const skillsQueryKeys = {
+  all: ["skills"] as const,
+  list: () => ["skills", "list"] as const,
+  search: (query: string) => ["skills", "search", query] as const,
+  readContent: (skillName: string) => ["skills", "readContent", skillName] as const,
+};
+
+export function skillsListQueryOptions() {
+  return queryOptions({
+    queryKey: skillsQueryKeys.list(),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      return api.skills.list();
+    },
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function skillsSearchQueryOptions(query: string) {
+  return queryOptions({
+    queryKey: skillsQueryKeys.search(query),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      return api.skills.search({ query });
+    },
+    enabled: query.length >= 2,
+    staleTime: 60_000,
+  });
+}
+
+export function skillsReadContentQueryOptions(skillName: string) {
+  return queryOptions({
+    queryKey: skillsQueryKeys.readContent(skillName),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      return api.skills.readContent({ skillName });
+    },
+    enabled: skillName.length > 0,
+    staleTime: 60_000,
+  });
+}
+
+export function invalidateSkillsQueries(queryClient: QueryClient) {
+  return queryClient.invalidateQueries({ queryKey: skillsQueryKeys.all });
+}
+
+export function skillsToggleMutationOptions(opts: { queryClient: QueryClient }) {
+  return mutationOptions({
+    mutationFn: async (vars: { skillName: string; enabled: boolean }) => {
+      const api = ensureNativeApi();
+      return api.skills.toggle(vars);
+    },
+    onSettled: async () => {
+      await invalidateSkillsQueries(opts.queryClient);
+    },
+  });
+}
+
+export function skillsInstallMutationOptions(opts: { queryClient: QueryClient }) {
+  return mutationOptions({
+    mutationFn: async (vars: { source: string; skillName: string }) => {
+      const api = ensureNativeApi();
+      return api.skills.install(vars);
+    },
+    onSettled: async () => {
+      await invalidateSkillsQueries(opts.queryClient);
+    },
+  });
+}
+
+export function skillsUninstallMutationOptions(opts: { queryClient: QueryClient }) {
+  return mutationOptions({
+    mutationFn: async (vars: { skillName: string }) => {
+      const api = ensureNativeApi();
+      return api.skills.uninstall(vars);
+    },
+    onSettled: async () => {
+      await invalidateSkillsQueries(opts.queryClient);
+    },
+  });
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -11,7 +11,9 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ChatRouteImport } from './routes/_chat'
 import { Route as ChatIndexRouteImport } from './routes/_chat.index'
+import { Route as ChatSkillsRouteImport } from './routes/_chat.skills'
 import { Route as ChatSettingsRouteImport } from './routes/_chat.settings'
+import { Route as ChatMcpRouteImport } from './routes/_chat.mcp'
 import { Route as ChatThreadIdRouteImport } from './routes/_chat.$threadId'
 
 const ChatRoute = ChatRouteImport.update({
@@ -23,9 +25,19 @@ const ChatIndexRoute = ChatIndexRouteImport.update({
   path: '/',
   getParentRoute: () => ChatRoute,
 } as any)
+const ChatSkillsRoute = ChatSkillsRouteImport.update({
+  id: '/skills',
+  path: '/skills',
+  getParentRoute: () => ChatRoute,
+} as any)
 const ChatSettingsRoute = ChatSettingsRouteImport.update({
   id: '/settings',
   path: '/settings',
+  getParentRoute: () => ChatRoute,
+} as any)
+const ChatMcpRoute = ChatMcpRouteImport.update({
+  id: '/mcp',
+  path: '/mcp',
   getParentRoute: () => ChatRoute,
 } as any)
 const ChatThreadIdRoute = ChatThreadIdRouteImport.update({
@@ -37,26 +49,39 @@ const ChatThreadIdRoute = ChatThreadIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof ChatIndexRoute
   '/$threadId': typeof ChatThreadIdRoute
+  '/mcp': typeof ChatMcpRoute
   '/settings': typeof ChatSettingsRoute
+  '/skills': typeof ChatSkillsRoute
 }
 export interface FileRoutesByTo {
   '/$threadId': typeof ChatThreadIdRoute
+  '/mcp': typeof ChatMcpRoute
   '/settings': typeof ChatSettingsRoute
+  '/skills': typeof ChatSkillsRoute
   '/': typeof ChatIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_chat': typeof ChatRouteWithChildren
   '/_chat/$threadId': typeof ChatThreadIdRoute
+  '/_chat/mcp': typeof ChatMcpRoute
   '/_chat/settings': typeof ChatSettingsRoute
+  '/_chat/skills': typeof ChatSkillsRoute
   '/_chat/': typeof ChatIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/$threadId' | '/settings'
+  fullPaths: '/' | '/$threadId' | '/mcp' | '/settings' | '/skills'
   fileRoutesByTo: FileRoutesByTo
-  to: '/$threadId' | '/settings' | '/'
-  id: '__root__' | '/_chat' | '/_chat/$threadId' | '/_chat/settings' | '/_chat/'
+  to: '/$threadId' | '/mcp' | '/settings' | '/skills' | '/'
+  id:
+    | '__root__'
+    | '/_chat'
+    | '/_chat/$threadId'
+    | '/_chat/mcp'
+    | '/_chat/settings'
+    | '/_chat/skills'
+    | '/_chat/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -79,11 +104,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChatIndexRouteImport
       parentRoute: typeof ChatRoute
     }
+    '/_chat/skills': {
+      id: '/_chat/skills'
+      path: '/skills'
+      fullPath: '/skills'
+      preLoaderRoute: typeof ChatSkillsRouteImport
+      parentRoute: typeof ChatRoute
+    }
     '/_chat/settings': {
       id: '/_chat/settings'
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof ChatSettingsRouteImport
+      parentRoute: typeof ChatRoute
+    }
+    '/_chat/mcp': {
+      id: '/_chat/mcp'
+      path: '/mcp'
+      fullPath: '/mcp'
+      preLoaderRoute: typeof ChatMcpRouteImport
       parentRoute: typeof ChatRoute
     }
     '/_chat/$threadId': {
@@ -98,13 +137,17 @@ declare module '@tanstack/react-router' {
 
 interface ChatRouteChildren {
   ChatThreadIdRoute: typeof ChatThreadIdRoute
+  ChatMcpRoute: typeof ChatMcpRoute
   ChatSettingsRoute: typeof ChatSettingsRoute
+  ChatSkillsRoute: typeof ChatSkillsRoute
   ChatIndexRoute: typeof ChatIndexRoute
 }
 
 const ChatRouteChildren: ChatRouteChildren = {
   ChatThreadIdRoute: ChatThreadIdRoute,
+  ChatMcpRoute: ChatMcpRoute,
   ChatSettingsRoute: ChatSettingsRoute,
+  ChatSkillsRoute: ChatSkillsRoute,
   ChatIndexRoute: ChatIndexRoute,
 }
 

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,6 +1,14 @@
 import { ThreadId } from "@t3tools/contracts";
 import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
-import { Suspense, lazy, type ReactNode, useCallback, useEffect, useState } from "react";
+import {
+  Suspense,
+  lazy,
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 
 import ChatView from "../components/ChatView";
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
@@ -141,7 +149,7 @@ const DiffPanelInlineSidebar = (props: {
       open={diffOpen}
       onOpenChange={onOpenChange}
       className="w-auto min-h-0 flex-none bg-transparent"
-      style={{ "--sidebar-width": DIFF_INLINE_DEFAULT_WIDTH } as React.CSSProperties}
+      style={{ "--sidebar-width": DIFF_INLINE_DEFAULT_WIDTH } as CSSProperties}
     >
       <Sidebar
         side="right"

--- a/apps/web/src/routes/_chat.mcp.tsx
+++ b/apps/web/src/routes/_chat.mcp.tsx
@@ -1,0 +1,1290 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import {
+  CheckIcon,
+  ExternalLinkIcon,
+  GlobeIcon,
+  LoaderIcon,
+  PlugIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  SearchIcon,
+  SettingsIcon,
+  TerminalIcon,
+  Trash2Icon,
+} from "lucide-react";
+
+import type { McpCatalogEntry, McpServerConfig } from "@t3tools/contracts";
+import { isElectron } from "../env";
+import { GitHubIcon, OpenAI } from "../components/Icons";
+import { Input } from "../components/ui/input";
+import { Button } from "../components/ui/button";
+import { Switch } from "../components/ui/switch";
+import { SidebarInset } from "~/components/ui/sidebar";
+import {
+  Dialog,
+  DialogPopup,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogPanel,
+  DialogFooter,
+} from "~/components/ui/dialog";
+import {
+  mcpListQueryOptions,
+  mcpBrowseQueryOptions,
+  mcpToggleMutationOptions,
+  mcpAddMutationOptions,
+  mcpRemoveMutationOptions,
+  mcpUpdateMutationOptions,
+} from "../lib/mcpReactQuery";
+import { toastManager } from "../components/ui/toast";
+
+// ── Colors for server icons ─────────────────────────────────────────
+
+const SERVER_COLORS = [
+  "text-blue-500",
+  "text-violet-500",
+  "text-emerald-500",
+  "text-amber-500",
+  "text-rose-500",
+  "text-cyan-500",
+  "text-indigo-500",
+  "text-teal-500",
+  "text-orange-500",
+  "text-pink-500",
+];
+
+function serverColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return SERVER_COLORS[Math.abs(hash) % SERVER_COLORS.length]!;
+}
+
+function formatDisplayName(name: string): string {
+  return name
+    .split(/[-_]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function mutationErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+// ── Provider Badge ──────────────────────────────────────────────────
+
+function ProviderBadge({ provider }: { provider: "codex" | "copilot" }) {
+  const styles =
+    provider === "codex"
+      ? "bg-emerald-500/10 text-emerald-400 ring-emerald-500/20"
+      : "bg-blue-500/10 text-blue-400 ring-blue-500/20";
+  const Icon = provider === "codex" ? OpenAI : GitHubIcon;
+  const tooltip = provider === "codex" ? "Codex" : "GitHub Copilot";
+  return (
+    <span
+      title={tooltip}
+      className={`inline-flex items-center rounded-full p-0.5 ring-1 ring-inset ${styles}`}
+    >
+      <Icon className="size-3" />
+    </span>
+  );
+}
+
+// ── Server transport badge ──────────────────────────────────────────
+
+function TransportBadge({ server }: { server: McpServerConfig }) {
+  const isUrl = !!server.url && !server.command;
+  return (
+    <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground/60">
+      {isUrl ? (
+        <>
+          <GlobeIcon className="size-2.5" />
+          URL
+        </>
+      ) : (
+        <>
+          <TerminalIcon className="size-2.5" />
+          stdio
+        </>
+      )}
+    </span>
+  );
+}
+
+// ── Server Settings Editor (command/args or url/headers) ────────────
+
+function ServerSettingsEditor({
+  server,
+  onSave,
+  isSaving,
+  onClose,
+}: {
+  server: McpServerConfig;
+  onSave: (data: {
+    command?: string;
+    args?: string[];
+    url?: string;
+    headers?: Record<string, string>;
+    bearerToken?: string;
+  }) => void;
+  isSaving: boolean;
+  onClose: () => void;
+}) {
+  const isHttpServer = server.type === "http" || (!!server.url && !server.command);
+  const [command, setCommand] = useState(server.command ?? "");
+  const [argsText, setArgsText] = useState((server.args ?? []).join("\n"));
+  const [url, setUrl] = useState(server.url ?? "");
+  const [bearerToken, setBearerToken] = useState(server.bearerToken ?? "");
+  const [headersText, setHeadersText] = useState(
+    server.headers
+      ? Object.entries(server.headers)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join("\n")
+      : "",
+  );
+
+  const handleSave = () => {
+    if (isHttpServer) {
+      const trimmedUrl = url.trim();
+      const trimmedToken = bearerToken.trim();
+      const parsedHeaders: Record<string, string> = {};
+      for (const line of headersText.split("\n")) {
+        const idx = line.indexOf(":");
+        if (idx > 0) {
+          const key = line.slice(0, idx).trim();
+          const val = line.slice(idx + 1).trim();
+          if (key) parsedHeaders[key] = val;
+        }
+      }
+      onSave({
+        ...(trimmedUrl ? { url: trimmedUrl } : {}),
+        ...(trimmedToken ? { bearerToken: trimmedToken } : {}),
+        ...(Object.keys(parsedHeaders).length > 0 ? { headers: parsedHeaders } : {}),
+      });
+    } else {
+      const trimmedCmd = command.trim();
+      const parsedArgs = argsText
+        .split("\n")
+        .map((a) => a.trim())
+        .filter(Boolean);
+      onSave({
+        ...(trimmedCmd ? { command: trimmedCmd } : {}),
+        ...(parsedArgs.length > 0 ? { args: parsedArgs } : {}),
+      });
+    }
+  };
+
+  return (
+    <div className="mt-3 space-y-2.5 border-t border-border/50 pt-3">
+      <div className="flex items-center gap-2">
+        <SettingsIcon className="size-3 text-muted-foreground/60" />
+        <span className="text-[11px] font-medium text-muted-foreground">Server Configuration</span>
+      </div>
+
+      {isHttpServer ? (
+        <div className="space-y-2">
+          <div>
+            <label className="mb-1 block text-[10px] font-medium text-muted-foreground/70">
+              URL
+            </label>
+            <Input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://api.example.com/mcp/"
+              className="h-7 font-mono text-[11px]"
+            />
+          </div>
+          {server.provider === "codex" ? (
+            <div>
+              <label className="mb-1 block text-[10px] font-medium text-muted-foreground/70">
+                Bearer Token
+              </label>
+              <Input
+                value={bearerToken}
+                onChange={(e) => setBearerToken(e.target.value)}
+                placeholder="Token or env var name"
+                className="h-7 font-mono text-[11px]"
+              />
+            </div>
+          ) : (
+            <div>
+              <label className="mb-1 block text-[10px] font-medium text-muted-foreground/70">
+                Headers <span className="text-muted-foreground/40">(one per line, Key: Value)</span>
+              </label>
+              <textarea
+                value={headersText}
+                onChange={(e) => setHeadersText(e.target.value)}
+                placeholder={"Authorization: Bearer sk-...\nX-Custom: value"}
+                rows={3}
+                className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 font-mono text-[11px] text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <label className="mb-1 block text-[10px] font-medium text-muted-foreground/70">
+              Command
+            </label>
+            <Input
+              value={command}
+              onChange={(e) => setCommand(e.target.value)}
+              placeholder="npx"
+              className="h-7 font-mono text-[11px]"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-[10px] font-medium text-muted-foreground/70">
+              Arguments (one per line)
+            </label>
+            <textarea
+              value={argsText}
+              onChange={(e) => setArgsText(e.target.value)}
+              placeholder={"-y\n@scope/package\n--api-key=..."}
+              className="h-16 w-full resize-y rounded-md border border-border bg-background px-2 py-1.5 font-mono text-[11px] text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+              rows={3}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center justify-end gap-1.5">
+        <Button size="xs" variant="ghost" onClick={onClose} className="h-6 text-[11px]">
+          Cancel
+        </Button>
+        <Button
+          size="xs"
+          onClick={handleSave}
+          disabled={isSaving}
+          className="h-6 gap-1 text-[11px]"
+        >
+          {isSaving ? (
+            <LoaderIcon className="size-2.5 animate-spin" />
+          ) : (
+            <CheckIcon className="size-2.5" />
+          )}
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Tool Badges ─────────────────────────────────────────────────────
+
+const MAX_VISIBLE_TOOLS = 10;
+
+function ToolBadges({ tools }: { tools?: readonly string[] }) {
+  if (!tools || tools.length === 0) return null;
+
+  const visible = tools.slice(0, MAX_VISIBLE_TOOLS);
+  const overflow = tools.length - MAX_VISIBLE_TOOLS;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-1">
+      {visible.map((tool) => (
+        <span
+          key={tool}
+          className="inline-flex items-center rounded-md bg-foreground/5 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground ring-1 ring-inset ring-foreground/10"
+        >
+          {tool}
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span className="inline-flex items-center rounded-md bg-foreground/5 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground/60 ring-1 ring-inset ring-foreground/10">
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── Installed MCP Server Card ───────────────────────────────────────
+
+function McpServerCard({
+  server,
+  onToggle,
+  isToggling,
+  onRemove,
+  isRemoving,
+  onUpdate,
+  isUpdating,
+}: {
+  server: McpServerConfig;
+  onToggle: (name: string, provider: "codex" | "copilot", enabled: boolean) => void;
+  isToggling: boolean;
+  onRemove: (name: string, provider: "codex" | "copilot") => void;
+  isRemoving: boolean;
+  onUpdate: (
+    name: string,
+    provider: "codex" | "copilot",
+    data: {
+      command?: string;
+      args?: string[];
+      url?: string;
+      headers?: Record<string, string>;
+      bearerToken?: string;
+    },
+  ) => Promise<boolean>;
+  isUpdating: boolean;
+}) {
+  const [showSettings, setShowSettings] = useState(false);
+
+  const cmd = server.command
+    ? `${server.command} ${(server.args ?? []).join(" ")}`
+    : (server.url ?? "—");
+
+  return (
+    <div
+      className={`rounded-xl border border-border bg-card p-4 transition-colors ${!server.enabled ? "opacity-60" : ""}`}
+    >
+      <div className="flex items-start gap-3">
+        <PlugIcon className={`mt-0.5 size-5 shrink-0 ${serverColor(server.name)}`} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-foreground">{formatDisplayName(server.name)}</p>
+            <ProviderBadge provider={server.provider} />
+            <TransportBadge server={server} />
+          </div>
+          <p className="mt-0.5 truncate text-xs font-mono text-muted-foreground/70">{cmd}</p>
+          <ToolBadges {...(server.tools ? { tools: server.tools } : {})} />
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <button
+            type="button"
+            className={`inline-flex size-7 items-center justify-center rounded-md transition-colors ${
+              showSettings
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground/50 hover:bg-accent hover:text-foreground"
+            }`}
+            onClick={() => setShowSettings(!showSettings)}
+            aria-label={`Settings for ${server.name}`}
+          >
+            <SettingsIcon className="size-3.5" />
+          </button>
+          <Switch
+            checked={server.enabled}
+            onCheckedChange={(checked) => onToggle(server.name, server.provider, Boolean(checked))}
+            disabled={isToggling}
+            aria-label={`Toggle ${server.name}`}
+          />
+          <button
+            type="button"
+            className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground/50 transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+            onClick={() => onRemove(server.name, server.provider)}
+            disabled={isRemoving}
+            aria-label={`Remove ${server.name}`}
+          >
+            {isRemoving ? (
+              <LoaderIcon className="size-3.5 animate-spin" />
+            ) : (
+              <Trash2Icon className="size-3.5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {showSettings && (
+        <ServerSettingsEditor
+          server={server}
+          onSave={async (data) => {
+            const ok = await onUpdate(server.name, server.provider, data);
+            if (ok) setShowSettings(false);
+          }}
+          isSaving={isUpdating}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Catalog Card ────────────────────────────────────────────────────
+
+function CatalogCard({
+  entry,
+  installedProviders,
+  onInstall,
+  isInstalling,
+}: {
+  entry: McpCatalogEntry;
+  installedProviders: Set<string>;
+  onInstall: (entry: McpCatalogEntry, provider: "codex" | "copilot") => void;
+  isInstalling: boolean;
+}) {
+  const codexInstalled = installedProviders.has(`codex:${entry.name}`);
+  const copilotInstalled = installedProviders.has(`copilot:${entry.name}`);
+  const hasPrompts = entry.installPrompts && entry.installPrompts.length > 0;
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 transition-colors hover:bg-accent/50">
+      <div className="flex items-start gap-3">
+        <PlugIcon className={`mt-0.5 size-5 shrink-0 ${serverColor(entry.name)}`} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-foreground">{formatDisplayName(entry.name)}</p>
+            {entry.infoUrl && (
+              <a
+                href={entry.infoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-muted-foreground/40 transition-colors hover:text-muted-foreground"
+              >
+                <ExternalLinkIcon className="size-3" />
+              </a>
+            )}
+            {hasPrompts && (
+              <span className="text-[9px] text-muted-foreground/40">requires setup</span>
+            )}
+          </div>
+          <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{entry.description}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          {codexInstalled ? (
+            <span
+              title="Codex"
+              className="inline-flex items-center gap-0.5 rounded-full bg-emerald-500/10 p-1 text-emerald-400 ring-1 ring-inset ring-emerald-500/20"
+            >
+              <OpenAI className="size-3" />
+              <CheckIcon className="size-2" />
+            </span>
+          ) : (
+            <Button
+              size="xs"
+              variant="outline"
+              disabled={isInstalling}
+              onClick={() => onInstall(entry, "codex")}
+              className="size-6 p-0"
+              title="Install for Codex"
+              aria-label="Install for Codex"
+            >
+              {isInstalling ? (
+                <LoaderIcon className="size-2.5 animate-spin" />
+              ) : (
+                <OpenAI className="size-3 opacity-50" />
+              )}
+            </Button>
+          )}
+          {copilotInstalled ? (
+            <span
+              title="GitHub Copilot"
+              className="inline-flex items-center gap-0.5 rounded-full bg-blue-500/10 p-1 text-blue-400 ring-1 ring-inset ring-blue-500/20"
+            >
+              <GitHubIcon className="size-3" />
+              <CheckIcon className="size-2" />
+            </span>
+          ) : (
+            <Button
+              size="xs"
+              variant="outline"
+              disabled={isInstalling}
+              onClick={() => onInstall(entry, "copilot")}
+              className="size-6 p-0"
+              title="Install for GitHub Copilot"
+              aria-label="Install for GitHub Copilot"
+            >
+              {isInstalling ? (
+                <LoaderIcon className="size-2.5 animate-spin" />
+              ) : (
+                <GitHubIcon className="size-3 opacity-50" />
+              )}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Install Prompt Dialog ───────────────────────────────────────────
+
+function InstallPromptDialog({
+  open,
+  onOpenChange,
+  entry,
+  provider,
+  onConfirm,
+  isInstalling,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entry: McpCatalogEntry | null;
+  provider: "codex" | "copilot";
+  onConfirm: (
+    entry: McpCatalogEntry,
+    provider: "codex" | "copilot",
+    promptValues: string[],
+  ) => void;
+  isInstalling: boolean;
+}) {
+  const prompts = entry?.installPrompts ?? [];
+  const [values, setValues] = useState<string[]>([]);
+
+  // Reset values when dialog opens with a new entry
+  const entryName = entry?.name;
+  const promptCount = prompts.length;
+  useEffect(() => {
+    setValues(Array.from({ length: promptCount }, () => ""));
+  }, [entryName, promptCount]);
+
+  const updateValue = (index: number, value: string) => {
+    setValues((prev) => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  };
+
+  const canSubmit =
+    entry != null && prompts.every((p, i) => !p.required || (values[i] ?? "").trim().length > 0);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!entry || !canSubmit) return;
+    onConfirm(entry, provider, values);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isInstalling) {
+          onOpenChange(nextOpen);
+          if (!nextOpen) setValues(Array.from({ length: promptCount }, () => ""));
+        }
+      }}
+    >
+      <DialogPopup className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Install {entry ? formatDisplayName(entry.name) : ""}</DialogTitle>
+          <DialogDescription>
+            Configure required settings for{" "}
+            <span className="inline-flex items-center gap-1 align-middle font-medium">
+              {provider === "codex" ? (
+                <>
+                  <OpenAI className="size-3.5" /> Codex
+                </>
+              ) : (
+                <>
+                  <GitHubIcon className="size-3.5" /> GitHub Copilot
+                </>
+              )}
+            </span>
+            .
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel>
+          <form id="install-prompt-form" onSubmit={handleSubmit} className="space-y-4">
+            {prompts.map((prompt, i) => (
+              <div key={prompt.id}>
+                <label className="mb-1.5 block text-xs font-medium text-foreground">
+                  {prompt.label}
+                  {prompt.required && <span className="ml-0.5 text-destructive">*</span>}
+                </label>
+                <Input
+                  value={values[i] ?? ""}
+                  onChange={(e) => updateValue(i, e.target.value)}
+                  placeholder={prompt.placeholder}
+                  className="font-mono text-sm"
+                  required={prompt.required}
+                />
+              </div>
+            ))}
+          </form>
+        </DialogPanel>
+        <DialogFooter variant="bare">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              onOpenChange(false);
+              setValues(Array.from({ length: promptCount }, () => ""));
+            }}
+            disabled={isInstalling}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="install-prompt-form"
+            size="sm"
+            disabled={isInstalling || !canSubmit}
+          >
+            {isInstalling && <LoaderIcon className="mr-1.5 size-3.5 animate-spin" />}
+            Install
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+// ── Add Server Dialog ───────────────────────────────────────────────
+
+function AddServerDialog({
+  open,
+  onOpenChange,
+  onAdd,
+  isAdding,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdd: (data: {
+    name: string;
+    provider: "codex" | "copilot";
+    command?: string;
+    args?: string[];
+    url?: string;
+    headers?: Record<string, string>;
+    bearerToken?: string;
+  }) => void;
+  isAdding: boolean;
+}) {
+  const [name, setName] = useState("");
+  const [provider, setProvider] = useState<"codex" | "copilot">("codex");
+  const [command, setCommand] = useState("");
+  const [args, setArgs] = useState<string[]>([]);
+  const [url, setUrl] = useState("");
+  const [bearerToken, setBearerToken] = useState("");
+  const [headersText, setHeadersText] = useState("");
+  const [mode, setMode] = useState<"stdio" | "url">("stdio");
+
+  const resetForm = () => {
+    setName("");
+    setProvider("codex");
+    setCommand("");
+    setArgs([]);
+    setUrl("");
+    setBearerToken("");
+    setHeadersText("");
+    setMode("stdio");
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    const base = { name: name.trim(), provider } as const;
+
+    if (mode === "stdio") {
+      const trimmedCmd = command.trim();
+      onAdd({
+        ...base,
+        ...(trimmedCmd ? { command: trimmedCmd } : {}),
+        ...(args.length > 0 ? { args } : {}),
+      });
+    } else {
+      const trimmedUrl = url.trim();
+      const trimmedToken = bearerToken.trim();
+      const parsedHeaders: Record<string, string> = {};
+      for (const line of headersText.split("\n")) {
+        const idx = line.indexOf(":");
+        if (idx > 0) {
+          const key = line.slice(0, idx).trim();
+          const val = line.slice(idx + 1).trim();
+          if (key) parsedHeaders[key] = val;
+        }
+      }
+      onAdd({
+        ...base,
+        ...(trimmedUrl ? { url: trimmedUrl } : {}),
+        ...(trimmedToken ? { bearerToken: trimmedToken } : {}),
+        ...(Object.keys(parsedHeaders).length > 0 ? { headers: parsedHeaders } : {}),
+      });
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!isAdding) {
+          onOpenChange(nextOpen);
+          if (!nextOpen) resetForm();
+        }
+      }}
+    >
+      <DialogPopup className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add MCP Server</DialogTitle>
+          <DialogDescription>Configure a new MCP server for Codex or Copilot.</DialogDescription>
+        </DialogHeader>
+        <DialogPanel>
+          <form id="add-mcp-form" onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-foreground">
+                Server Name
+              </label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="my-server"
+                className="text-sm"
+                required
+              />
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-foreground">Provider</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setProvider("codex")}
+                  className={`flex flex-1 items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                    provider === "codex"
+                      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-400"
+                      : "border-border text-muted-foreground hover:bg-accent"
+                  }`}
+                  title="Codex"
+                >
+                  <OpenAI className="size-4" />
+                  Codex
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setProvider("copilot")}
+                  className={`flex flex-1 items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                    provider === "copilot"
+                      ? "border-blue-500/40 bg-blue-500/10 text-blue-400"
+                      : "border-border text-muted-foreground hover:bg-accent"
+                  }`}
+                  title="GitHub Copilot"
+                >
+                  <GitHubIcon className="size-4" />
+                  Copilot
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-foreground">Transport</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setMode("stdio")}
+                  className={`flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                    mode === "stdio"
+                      ? "border-foreground/20 bg-foreground/5 text-foreground"
+                      : "border-border text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  <TerminalIcon className="size-3.5" />
+                  Command (stdio)
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMode("url")}
+                  className={`flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium transition-colors ${
+                    mode === "url"
+                      ? "border-foreground/20 bg-foreground/5 text-foreground"
+                      : "border-border text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  <GlobeIcon className="size-3.5" />
+                  URL
+                </button>
+              </div>
+            </div>
+
+            {mode === "stdio" ? (
+              <div className="space-y-3">
+                <div>
+                  <label className="mb-1.5 block text-xs font-medium text-foreground">
+                    Command
+                  </label>
+                  <Input
+                    value={command}
+                    onChange={(e) => setCommand(e.target.value)}
+                    placeholder="npx"
+                    className="font-mono text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-xs font-medium text-foreground">
+                    Arguments (one per line)
+                  </label>
+                  <textarea
+                    value={args.join("\n")}
+                    onChange={(e) =>
+                      setArgs(
+                        e.target.value
+                          .split("\n")
+                          .map((a) => a.trim())
+                          .filter(Boolean),
+                      )
+                    }
+                    placeholder={"-y\n@scope/package\n--api-key=..."}
+                    className="w-full resize-y rounded-md border border-border bg-background px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+                    rows={3}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div>
+                  <label className="mb-1.5 block text-xs font-medium text-foreground">URL</label>
+                  <Input
+                    value={url}
+                    onChange={(e) => setUrl(e.target.value)}
+                    placeholder="https://api.example.com/mcp/"
+                    className="font-mono text-sm"
+                  />
+                </div>
+                {provider === "codex" ? (
+                  <div>
+                    <label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Bearer Token{" "}
+                      <span className="font-normal text-muted-foreground">(optional)</span>
+                    </label>
+                    <Input
+                      value={bearerToken}
+                      onChange={(e) => setBearerToken(e.target.value)}
+                      placeholder="Token or env var name"
+                      className="font-mono text-sm"
+                    />
+                  </div>
+                ) : (
+                  <div>
+                    <label className="mb-1.5 block text-xs font-medium text-foreground">
+                      Headers{" "}
+                      <span className="font-normal text-muted-foreground">
+                        (optional, one per line)
+                      </span>
+                    </label>
+                    <textarea
+                      value={headersText}
+                      onChange={(e) => setHeadersText(e.target.value)}
+                      placeholder={"Authorization: Bearer sk-...\nX-Custom: value"}
+                      rows={3}
+                      className="w-full resize-none rounded-md border border-border bg-background px-3 py-2 font-mono text-sm text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-1 focus:ring-ring"
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          </form>
+        </DialogPanel>
+        <DialogFooter variant="bare">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              onOpenChange(false);
+              resetForm();
+            }}
+            disabled={isAdding}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" form="add-mcp-form" size="sm" disabled={isAdding || !name.trim()}>
+            {isAdding && <LoaderIcon className="mr-1.5 size-3.5 animate-spin" />}
+            Add Server
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+// ── Main Route View ─────────────────────────────────────────────────
+
+function McpRouteView() {
+  const queryClient = useQueryClient();
+  const listQuery = useQuery(mcpListQueryOptions());
+  const browseQuery = useQuery(mcpBrowseQueryOptions());
+  const toggleMutation = useMutation(mcpToggleMutationOptions({ queryClient }));
+  const addMutation = useMutation(mcpAddMutationOptions({ queryClient }));
+  const removeMutation = useMutation(mcpRemoveMutationOptions({ queryClient }));
+  const updateMutation = useMutation(mcpUpdateMutationOptions({ queryClient }));
+
+  const [search, setSearch] = useState("");
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const [installPromptState, setInstallPromptState] = useState<{
+    entry: McpCatalogEntry;
+    provider: "codex" | "copilot";
+  } | null>(null);
+
+  const normalizedSearch = search.trim().toLowerCase();
+  const servers = listQuery.data?.servers;
+
+  const filteredServers = useMemo(() => {
+    if (!servers) return [];
+    if (!normalizedSearch) return servers;
+    return servers.filter(
+      (s) =>
+        s.name.toLowerCase().includes(normalizedSearch) ||
+        s.command?.toLowerCase().includes(normalizedSearch) ||
+        s.url?.toLowerCase().includes(normalizedSearch),
+    );
+  }, [normalizedSearch, servers]);
+
+  // Track installed servers per provider (provider:name)
+  const installedProviders = useMemo(() => {
+    if (!servers) return new Set<string>();
+    return new Set(servers.map((s) => `${s.provider}:${s.name}`));
+  }, [servers]);
+
+  const filteredCatalog = useMemo(() => {
+    const catalog = browseQuery.data?.servers;
+    if (!catalog) return [];
+    if (!normalizedSearch) return catalog;
+    return catalog.filter(
+      (e) =>
+        e.name.toLowerCase().includes(normalizedSearch) ||
+        e.description.toLowerCase().includes(normalizedSearch),
+    );
+  }, [browseQuery.data?.servers, normalizedSearch]);
+
+  const handleToggle = (name: string, provider: "codex" | "copilot", enabled: boolean) => {
+    toggleMutation.mutate(
+      { name, provider, enabled },
+      {
+        onError: (error) => {
+          toastManager.add({
+            type: "error",
+            title: "Toggle failed",
+            description: mutationErrorMessage(error),
+          });
+        },
+      },
+    );
+  };
+
+  const handleRemove = (name: string, provider: "codex" | "copilot") => {
+    removeMutation.mutate(
+      { name, provider },
+      {
+        onSuccess: (result) => {
+          toastManager.add({
+            type: result.success ? "success" : "error",
+            title: result.success ? "Server removed" : "Remove failed",
+            description: result.message,
+          });
+        },
+        onError: (error) => {
+          toastManager.add({
+            type: "error",
+            title: "Remove failed",
+            description: mutationErrorMessage(error),
+          });
+        },
+      },
+    );
+  };
+
+  const handleUpdate = (
+    name: string,
+    provider: "codex" | "copilot",
+    data: {
+      command?: string;
+      args?: string[];
+      url?: string;
+      headers?: Record<string, string>;
+      bearerToken?: string;
+    },
+  ): Promise<boolean> => {
+    return new Promise((resolve) => {
+      updateMutation.mutate(
+        { name, provider, ...data },
+        {
+          onSuccess: (result) => {
+            toastManager.add({
+              type: result.success ? "success" : "error",
+              title: result.success ? "Settings saved" : "Update failed",
+              description: result.message,
+            });
+            resolve(result.success);
+          },
+          onError: (error) => {
+            toastManager.add({
+              type: "error",
+              title: "Update failed",
+              description: mutationErrorMessage(error),
+            });
+            resolve(false);
+          },
+        },
+      );
+    });
+  };
+
+  const handleAddFromCatalog = (entry: McpCatalogEntry, provider: "codex" | "copilot") => {
+    // If entry has install prompts, show dialog first
+    if (entry.installPrompts && entry.installPrompts.length > 0) {
+      setInstallPromptState({ entry, provider });
+      return;
+    }
+    // No prompts needed — install directly
+    doInstallCatalog(entry, provider, []);
+  };
+
+  const doInstallCatalog = (
+    entry: McpCatalogEntry,
+    provider: "codex" | "copilot",
+    promptValues: string[],
+  ) => {
+    const extraArgs = promptValues.filter((v) => v.trim().length > 0);
+    addMutation.mutate(
+      {
+        name: entry.name,
+        provider,
+        ...(entry.command ? { command: entry.command } : {}),
+        ...(entry.args || extraArgs.length ? { args: [...(entry.args ?? []), ...extraArgs] } : {}),
+        ...(entry.mcpUrl ? { url: entry.mcpUrl } : {}),
+      },
+      {
+        onSuccess: (result) => {
+          if (result.success) setInstallPromptState(null);
+          toastManager.add({
+            type: result.success ? "success" : "error",
+            title: result.success ? "Server added" : "Add failed",
+            description: result.message,
+          });
+        },
+        onError: (error) => {
+          toastManager.add({
+            type: "error",
+            title: "Add failed",
+            description: mutationErrorMessage(error),
+          });
+        },
+      },
+    );
+  };
+
+  const handleAddManual = (data: {
+    name: string;
+    provider: "codex" | "copilot";
+    command?: string;
+    args?: string[];
+    url?: string;
+    headers?: Record<string, string>;
+    bearerToken?: string;
+  }) => {
+    addMutation.mutate(data, {
+      onSuccess: (result) => {
+        if (result.success) {
+          setShowAddDialog(false);
+          toastManager.add({
+            type: "success",
+            title: "Server added",
+            description: result.message,
+          });
+        } else {
+          toastManager.add({
+            type: "error",
+            title: "Add failed",
+            description: result.message,
+          });
+        }
+      },
+      onError: (error) => {
+        toastManager.add({
+          type: "error",
+          title: "Add failed",
+          description: mutationErrorMessage(error),
+        });
+      },
+    });
+  };
+
+  return (
+    <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
+        {isElectron && (
+          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+            <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
+              MCP Servers
+            </span>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto p-6">
+          <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+            <header className="space-y-1">
+              <h1 className="text-2xl font-semibold tracking-tight text-foreground">MCP Servers</h1>
+              <p className="text-sm text-muted-foreground">
+                Manage Model Context Protocol servers for Codex and Copilot.
+              </p>
+            </header>
+
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                className="inline-flex size-8 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+                onClick={() => void listQuery.refetch()}
+                disabled={listQuery.isFetching}
+                aria-label="Refresh MCP servers"
+              >
+                <RefreshCwIcon
+                  className={`size-3.5 ${listQuery.isFetching ? "animate-spin" : ""}`}
+                />
+              </button>
+              <div className="relative flex-1">
+                <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/50" />
+                <Input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search servers..."
+                  aria-label="Search MCP servers"
+                  className="pl-8"
+                />
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowAddDialog(true)}
+                className="gap-1.5"
+              >
+                <PlusIcon className="size-3.5" />
+                Add Server
+              </Button>
+            </div>
+
+            <AddServerDialog
+              open={showAddDialog}
+              onOpenChange={setShowAddDialog}
+              onAdd={handleAddManual}
+              isAdding={addMutation.isPending}
+            />
+
+            <InstallPromptDialog
+              open={installPromptState !== null}
+              onOpenChange={(open) => {
+                if (!open) setInstallPromptState(null);
+              }}
+              entry={installPromptState?.entry ?? null}
+              provider={installPromptState?.provider ?? "codex"}
+              onConfirm={doInstallCatalog}
+              isInstalling={addMutation.isPending}
+            />
+
+            {/* Installed Servers */}
+            <section>
+              <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground/70">
+                Installed
+              </h2>
+
+              {listQuery.isLoading ? (
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                  {Array.from({ length: 4 }, (_, i) => (
+                    <div
+                      key={i}
+                      className="h-[76px] animate-pulse rounded-xl border border-border bg-card"
+                    />
+                  ))}
+                </div>
+              ) : listQuery.isError ? (
+                <div className="rounded-xl border border-border bg-card p-6 text-center">
+                  <p className="text-sm text-destructive">Failed to load MCP servers.</p>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    className="mt-3"
+                    onClick={() => void listQuery.refetch()}
+                  >
+                    Retry
+                  </Button>
+                </div>
+              ) : filteredServers.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-border bg-card px-6 py-8 text-center">
+                  <PlugIcon className="mx-auto mb-2 size-8 text-muted-foreground/30" />
+                  <p className="text-sm text-muted-foreground">
+                    {search ? "No servers match your search." : "No MCP servers installed."}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground/60">
+                    {search
+                      ? "Try a different search term."
+                      : "Add servers from the catalog below or configure them manually."}
+                  </p>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                  {filteredServers.map((server) => (
+                    <McpServerCard
+                      key={`${server.provider}:${server.name}`}
+                      server={server}
+                      onToggle={handleToggle}
+                      isToggling={
+                        toggleMutation.isPending &&
+                        toggleMutation.variables?.name === server.name &&
+                        toggleMutation.variables?.provider === server.provider
+                      }
+                      onRemove={handleRemove}
+                      isRemoving={
+                        removeMutation.isPending &&
+                        removeMutation.variables?.name === server.name &&
+                        removeMutation.variables?.provider === server.provider
+                      }
+                      onUpdate={handleUpdate}
+                      isUpdating={
+                        updateMutation.isPending &&
+                        updateMutation.variables?.name === server.name &&
+                        updateMutation.variables?.provider === server.provider
+                      }
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {/* Catalog */}
+            <section>
+              <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground/70">
+                Browse Catalog
+              </h2>
+
+              {browseQuery.isLoading ? (
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                  {Array.from({ length: 6 }, (_, i) => (
+                    <div
+                      key={i}
+                      className="h-[76px] animate-pulse rounded-xl border border-border bg-card"
+                    />
+                  ))}
+                </div>
+              ) : browseQuery.isError ? (
+                <div className="rounded-xl border border-border bg-card p-6 text-center">
+                  <p className="text-sm text-destructive">Failed to load MCP catalog.</p>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    className="mt-3"
+                    onClick={() => void browseQuery.refetch()}
+                  >
+                    Retry
+                  </Button>
+                </div>
+              ) : filteredCatalog.length > 0 ? (
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                  {filteredCatalog.map((entry) => (
+                    <CatalogCard
+                      key={entry.name}
+                      entry={entry}
+                      installedProviders={installedProviders}
+                      onInstall={handleAddFromCatalog}
+                      isInstalling={
+                        addMutation.isPending && addMutation.variables?.name === entry.name
+                      }
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className="py-4 text-xs text-muted-foreground">No catalog entries found.</p>
+              )}
+            </section>
+          </div>
+        </div>
+      </div>
+    </SidebarInset>
+  );
+}
+
+export const Route = createFileRoute("/_chat/mcp")({
+  component: McpRouteView,
+});

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -102,6 +102,7 @@ function SettingsRouteView() {
     Record<ProviderKind, string>
   >({
     codex: "",
+    copilot: "",
   });
   const [customModelErrorByProvider, setCustomModelErrorByProvider] = useState<
     Partial<Record<ProviderKind, string | null>>

--- a/apps/web/src/routes/_chat.skills.tsx
+++ b/apps/web/src/routes/_chat.skills.tsx
@@ -1,0 +1,572 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeftIcon,
+  BoxIcon,
+  LoaderIcon,
+  RefreshCwIcon,
+  SearchIcon,
+  Trash2Icon,
+} from "lucide-react";
+
+import type { SkillMetadata, SkillSearchResultEntry } from "@t3tools/contracts";
+import { isElectron } from "../env";
+import { Input } from "../components/ui/input";
+import { Button } from "../components/ui/button";
+import { Switch } from "../components/ui/switch";
+import { SidebarInset } from "~/components/ui/sidebar";
+import {
+  skillsListQueryOptions,
+  skillsToggleMutationOptions,
+  skillsSearchQueryOptions,
+  skillsInstallMutationOptions,
+  skillsUninstallMutationOptions,
+  skillsReadContentQueryOptions,
+} from "../lib/skillsReactQuery";
+import { toastManager } from "../components/ui/toast";
+
+const ChatMarkdown = lazy(() => import("../components/ChatMarkdown"));
+
+// ── Deterministic color for skill icons ─────────────────────────────
+
+const SKILL_COLORS = [
+  "text-blue-500",
+  "text-violet-500",
+  "text-emerald-500",
+  "text-amber-500",
+  "text-rose-500",
+  "text-cyan-500",
+  "text-indigo-500",
+  "text-teal-500",
+  "text-orange-500",
+  "text-pink-500",
+];
+
+function skillColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return SKILL_COLORS[Math.abs(hash) % SKILL_COLORS.length]!;
+}
+
+const installCountFormatter = new Intl.NumberFormat();
+
+function formatSkillDisplayName(name: string): string {
+  return name
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function formatInstallCount(installs: number): string {
+  return `${installCountFormatter.format(installs)} installs`;
+}
+
+function mutationErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Something went wrong.";
+}
+
+// ── Skill Card ──────────────────────────────────────────────────────
+
+function SkillCard({
+  skill,
+  onClick,
+  onToggle,
+  isToggling,
+  onUninstall,
+  isUninstalling,
+}: {
+  skill: SkillMetadata;
+  onClick: () => void;
+  onToggle: (skillName: string, enabled: boolean) => void;
+  isToggling: boolean;
+  onUninstall: (skillName: string) => void;
+  isUninstalling: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:bg-accent/50">
+      <button
+        type="button"
+        className="flex min-w-0 flex-1 items-start gap-3 text-left"
+        onClick={onClick}
+      >
+        <BoxIcon className={`mt-0.5 size-5 shrink-0 ${skillColor(skill.name)}`} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-foreground">
+              {formatSkillDisplayName(skill.name)}
+            </p>
+          </div>
+          <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{skill.description}</p>
+        </div>
+      </button>
+      <div className="flex shrink-0 items-center gap-2">
+        <Switch
+          checked={skill.enabled}
+          onCheckedChange={(checked) => onToggle(skill.name, Boolean(checked))}
+          disabled={isToggling}
+          aria-label={`Toggle ${skill.name}`}
+        />
+        <button
+          type="button"
+          className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground/50 transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+          onClick={() => onUninstall(skill.name)}
+          disabled={isUninstalling}
+          aria-label={`Uninstall ${skill.name}`}
+        >
+          {isUninstalling ? (
+            <LoaderIcon className="size-3.5 animate-spin" />
+          ) : (
+            <Trash2Icon className="size-3.5" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Search Result Card ──────────────────────────────────────────────
+
+function SearchResultCard({
+  result,
+  onInstall,
+  isInstalling,
+}: {
+  result: SkillSearchResultEntry;
+  onInstall: (source: string, skillName: string) => void;
+  isInstalling: boolean;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-xl border border-border bg-card p-4">
+      <BoxIcon className={`mt-0.5 size-5 shrink-0 ${skillColor(result.name)}`} />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-foreground">{formatSkillDisplayName(result.name)}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">{result.source}</p>
+        <p className="mt-0.5 text-[10px] text-muted-foreground/60">
+          {formatInstallCount(result.installs)}
+        </p>
+      </div>
+      <Button
+        size="xs"
+        variant="outline"
+        disabled={isInstalling}
+        onClick={() => onInstall(result.source, result.name)}
+      >
+        {isInstalling ? <LoaderIcon className="size-3 animate-spin" /> : "Install"}
+      </Button>
+    </div>
+  );
+}
+
+// ── Skill Detail View ───────────────────────────────────────────────
+
+function SkillDetailView({
+  skill,
+  onBack,
+  onToggle,
+  isToggling,
+  onUninstall,
+  isUninstalling,
+}: {
+  skill: SkillMetadata;
+  onBack: () => void;
+  onToggle: (skillName: string, enabled: boolean) => void;
+  isToggling: boolean;
+  onUninstall: (skillName: string) => void;
+  isUninstalling: boolean;
+}) {
+  const contentQuery = useQuery(skillsReadContentQueryOptions(skill.name));
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-3 border-b border-border px-6 py-4">
+        <button
+          type="button"
+          className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={onBack}
+          aria-label="Back to skills"
+        >
+          <ArrowLeftIcon className="size-4" />
+        </button>
+        <BoxIcon className={`size-5 shrink-0 ${skillColor(skill.name)}`} />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h2 className="text-base font-semibold text-foreground">
+              {formatSkillDisplayName(skill.name)}
+            </h2>
+          </div>
+          {skill.description && (
+            <p className="text-xs text-muted-foreground">{skill.description}</p>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <Switch
+            checked={skill.enabled}
+            onCheckedChange={(checked) => onToggle(skill.name, Boolean(checked))}
+            disabled={isToggling}
+            aria-label={`Toggle ${skill.name}`}
+          />
+          <button
+            type="button"
+            className="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground/50 transition-colors hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+            onClick={() => onUninstall(skill.name)}
+            disabled={isUninstalling}
+            aria-label={`Uninstall ${skill.name}`}
+          >
+            {isUninstalling ? (
+              <LoaderIcon className="size-3.5 animate-spin" />
+            ) : (
+              <Trash2Icon className="size-3.5" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mx-auto max-w-3xl">
+          {contentQuery.isLoading ? (
+            <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+              <LoaderIcon className="size-4 animate-spin" />
+              Loading skill content...
+            </div>
+          ) : contentQuery.isError ? (
+            <div className="rounded-xl border border-border bg-card p-6 text-center">
+              <p className="text-sm text-destructive">Failed to load skill content.</p>
+              <Button
+                size="xs"
+                variant="outline"
+                className="mt-3"
+                onClick={() => void contentQuery.refetch()}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : contentQuery.data?.content ? (
+            <Suspense
+              fallback={
+                <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+                  <LoaderIcon className="size-4 animate-spin" />
+                  Rendering...
+                </div>
+              }
+            >
+              <ChatMarkdown text={contentQuery.data.content} cwd={undefined} />
+            </Suspense>
+          ) : (
+            <p className="py-8 text-sm text-muted-foreground">
+              No content available for this skill.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main View ───────────────────────────────────────────────────────
+
+function SkillsRouteView() {
+  const queryClient = useQueryClient();
+  const skillsQuery = useQuery(skillsListQueryOptions());
+  const toggleMutation = useMutation(skillsToggleMutationOptions({ queryClient }));
+  const installMutation = useMutation(skillsInstallMutationOptions({ queryClient }));
+  const uninstallMutation = useMutation(skillsUninstallMutationOptions({ queryClient }));
+
+  const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [selectedSkillName, setSelectedSkillName] = useState<string | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const normalizedSearch = search.trim();
+
+  useEffect(() => {
+    clearTimeout(debounceRef.current);
+    if (normalizedSearch.length < 2) {
+      setDebouncedSearch("");
+      return;
+    }
+    debounceRef.current = setTimeout(() => {
+      setDebouncedSearch(normalizedSearch);
+    }, 300);
+    return () => clearTimeout(debounceRef.current);
+  }, [normalizedSearch]);
+
+  const searchQuery = useQuery(skillsSearchQueryOptions(debouncedSearch));
+
+  const handleToggle = (skillName: string, enabled: boolean) => {
+    toggleMutation.mutate(
+      { skillName, enabled },
+      {
+        onError: (error) => {
+          toastManager.add({
+            type: "error",
+            title: "Toggle failed",
+            description: mutationErrorMessage(error),
+          });
+        },
+      },
+    );
+  };
+
+  const handleUninstall = (skillName: string) => {
+    uninstallMutation.mutate(
+      { skillName },
+      {
+        onSuccess: (result) => {
+          if (result.success) {
+            setSelectedSkillName(null);
+            toastManager.add({
+              type: "success",
+              title: "Skill uninstalled",
+              description: result.message,
+            });
+          } else {
+            toastManager.add({
+              type: "error",
+              title: "Uninstall failed",
+              description: result.message,
+            });
+          }
+        },
+        onError: (error) => {
+          toastManager.add({
+            type: "error",
+            title: "Uninstall failed",
+            description: mutationErrorMessage(error),
+          });
+        },
+      },
+    );
+  };
+
+  const handleInstall = (source: string, skillName: string) => {
+    installMutation.mutate(
+      { source, skillName },
+      {
+        onSuccess: (result) => {
+          if (result.success) {
+            toastManager.add({
+              type: "success",
+              title: "Skill installed",
+              description: result.message,
+            });
+          } else {
+            toastManager.add({
+              type: "error",
+              title: "Install failed",
+              description: result.message,
+            });
+          }
+        },
+        onError: (error) => {
+          toastManager.add({
+            type: "error",
+            title: "Install failed",
+            description: mutationErrorMessage(error),
+          });
+        },
+      },
+    );
+  };
+
+  const skills = skillsQuery.data?.skills;
+  const filteredSkills = useMemo(() => {
+    if (!skills) return [];
+    if (!normalizedSearch) return skills;
+    const lower = normalizedSearch.toLowerCase();
+    return skills.filter(
+      (skill) =>
+        skill.name.toLowerCase().includes(lower) || skill.description.toLowerCase().includes(lower),
+    );
+  }, [normalizedSearch, skills]);
+
+  // Filter out already-installed skills from search results
+  const installedNames = useMemo(() => {
+    if (!skills) return new Set<string>();
+    return new Set(skills.map((s) => s.name));
+  }, [skills]);
+  const onlineResults = useMemo(() => {
+    const results = searchQuery.data?.skills;
+    if (!results) return [];
+    return results.filter((r) => !installedNames.has(r.name));
+  }, [searchQuery.data?.skills, installedNames]);
+
+  // Resolve the selected skill from the current skills list
+  const selectedSkill = useMemo(() => {
+    if (!selectedSkillName || !skills) return null;
+    return skills.find((s) => s.name === selectedSkillName) ?? null;
+  }, [selectedSkillName, skills]);
+
+  // If the selected skill was uninstalled, go back to list
+  useEffect(() => {
+    if (selectedSkillName && skills && !skills.some((s) => s.name === selectedSkillName)) {
+      setSelectedSkillName(null);
+    }
+  }, [selectedSkillName, skills]);
+
+  return (
+    <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
+        {isElectron && (
+          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+            <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
+              Skills
+            </span>
+          </div>
+        )}
+
+        {selectedSkill ? (
+          <SkillDetailView
+            skill={selectedSkill}
+            onBack={() => setSelectedSkillName(null)}
+            onToggle={handleToggle}
+            isToggling={
+              toggleMutation.isPending && toggleMutation.variables?.skillName === selectedSkill.name
+            }
+            onUninstall={handleUninstall}
+            isUninstalling={
+              uninstallMutation.isPending &&
+              uninstallMutation.variables?.skillName === selectedSkill.name
+            }
+          />
+        ) : (
+          <div className="flex-1 overflow-y-auto p-6">
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+              <header className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight text-foreground">Skills</h1>
+                <p className="text-sm text-muted-foreground">Give your agent superpowers.</p>
+              </header>
+
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  className="inline-flex size-8 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-50"
+                  onClick={() => void skillsQuery.refetch()}
+                  disabled={skillsQuery.isFetching}
+                  aria-label="Refresh skills"
+                >
+                  <RefreshCwIcon
+                    className={`size-3.5 ${skillsQuery.isFetching ? "animate-spin" : ""}`}
+                  />
+                </button>
+                <div className="relative flex-1">
+                  <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground/50" />
+                  <Input
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search installed & skills.sh..."
+                    className="pl-8"
+                  />
+                </div>
+              </div>
+
+              {/* Installed Skills */}
+              <section>
+                <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground/70">
+                  Installed
+                </h2>
+
+                {skillsQuery.isLoading ? (
+                  <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                    {Array.from({ length: 6 }, (_, i) => (
+                      <div
+                        key={i}
+                        className="h-[76px] animate-pulse rounded-xl border border-border bg-card"
+                      />
+                    ))}
+                  </div>
+                ) : skillsQuery.isError ? (
+                  <div className="rounded-xl border border-border bg-card p-6 text-center">
+                    <p className="text-sm text-destructive">Failed to load skills.</p>
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      className="mt-3"
+                      onClick={() => void skillsQuery.refetch()}
+                    >
+                      Retry
+                    </Button>
+                  </div>
+                ) : filteredSkills.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-border bg-card px-6 py-8 text-center">
+                    <p className="text-sm text-muted-foreground">
+                      {search ? "No skills match your search." : "No skills installed yet."}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                    {filteredSkills.map((skill) => (
+                      <SkillCard
+                        key={skill.name}
+                        skill={skill}
+                        onClick={() => setSelectedSkillName(skill.name)}
+                        onToggle={handleToggle}
+                        isToggling={
+                          toggleMutation.isPending &&
+                          toggleMutation.variables?.skillName === skill.name
+                        }
+                        onUninstall={handleUninstall}
+                        isUninstalling={
+                          uninstallMutation.isPending &&
+                          uninstallMutation.variables?.skillName === skill.name
+                        }
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+
+              {/* Online Skills from skills.sh */}
+              {debouncedSearch.length >= 2 && (
+                <section>
+                  <h2 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground/70">
+                    From skills.sh
+                  </h2>
+
+                  {searchQuery.isLoading ? (
+                    <div className="flex items-center gap-2 py-4 text-xs text-muted-foreground">
+                      <LoaderIcon className="size-3 animate-spin" />
+                      Searching skills.sh...
+                    </div>
+                  ) : searchQuery.isError ? (
+                    <p className="py-4 text-xs text-destructive">
+                      Search failed. Check your internet connection and try again.
+                    </p>
+                  ) : onlineResults.length > 0 ? (
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                      {onlineResults.map((result) => (
+                        <SearchResultCard
+                          key={`${result.source}:${result.name}`}
+                          result={result}
+                          onInstall={handleInstall}
+                          isInstalling={
+                            installMutation.isPending &&
+                            installMutation.variables?.source === result.source &&
+                            installMutation.variables?.skillName === result.name
+                          }
+                        />
+                      ))}
+                    </div>
+                  ) : searchQuery.data ? (
+                    <p className="py-4 text-xs text-muted-foreground">
+                      {searchQuery.data.skills.length > 0
+                        ? "All matching skills are already installed."
+                        : `No skills found for \u201c${debouncedSearch}\u201d.`}
+                    </p>
+                  ) : null}
+                </section>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </SidebarInset>
+  );
+}
+
+export const Route = createFileRoute("/_chat/skills")({
+  component: SkillsRouteView,
+});

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -16,6 +16,7 @@ import {
   deriveTimelineEntries,
   deriveWorkLogEntries,
   findLatestProposedPlan,
+  hasToolActivitySince,
   hasActionableProposedPlan,
   hasToolActivityForTurn,
   isLatestTurnSettled,
@@ -502,12 +503,12 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.command).toBe("bun run lint");
   });
 
-  it("keeps compact Codex tool metadata used for icons and labels", () => {
+  it("keeps rich tool metadata used for tool rendering", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "tool-with-metadata",
         kind: "tool.completed",
-        summary: "bash",
+        summary: "bash complete",
         payload: {
           itemType: "command_execution",
           title: "bash",
@@ -528,9 +529,13 @@ describe("deriveWorkLogEntries", () => {
 
     const [entry] = deriveWorkLogEntries(activities, undefined);
     expect(entry).toMatchObject({
+      activityKind: "tool.completed",
       command: "bun run dev",
       detail: '{ "dev": "vite dev --port 3000" }',
+      exitCode: 0,
       itemType: "command_execution",
+      output: '{ "dev": "vite dev --port 3000" }',
+      toolStatus: "completed",
       toolTitle: "bash",
     });
   });
@@ -559,6 +564,77 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.changedFiles).toEqual([
       "apps/web/src/components/ChatView.tsx",
       "apps/web/src/session-logic.ts",
+    ]);
+  });
+
+  it("keeps tool item types for icon rendering", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "web-search-tool",
+        kind: "tool.completed",
+        summary: "Web search complete",
+        payload: {
+          itemType: "web_search",
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.activityKind).toBe("tool.completed");
+    expect(entry?.itemType).toBe("web_search");
+  });
+
+  it("maps request kinds for approval work log entries", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "approval-entry",
+        kind: "approval.requested",
+        summary: "File-read approval requested",
+        tone: "approval",
+        payload: {
+          requestType: "file_read_approval",
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.activityKind).toBe("approval.requested");
+    expect(entry?.requestKind).toBe("file-read");
+    expect(entry?.tone).toBe("info");
+  });
+
+  it("keeps multi-turn tool activity since the latest user message", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "before-user",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        turnId: "turn-1",
+        summary: "Old tool call",
+        kind: "tool.completed",
+        tone: "tool",
+      }),
+      makeActivity({
+        id: "after-user-first-turn",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        turnId: "turn-2",
+        summary: "First Copilot tool call",
+        kind: "tool.completed",
+        tone: "tool",
+      }),
+      makeActivity({
+        id: "after-user-second-turn",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        turnId: "turn-3",
+        summary: "Second Copilot tool call",
+        kind: "tool.completed",
+        tone: "tool",
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined, "2026-02-23T00:00:02.000Z");
+    expect(entries.map((entry) => entry.id)).toEqual([
+      "after-user-first-turn",
+      "after-user-second-turn",
     ]);
   });
 });
@@ -592,6 +668,7 @@ describe("deriveTimelineEntries", () => {
           createdAt: "2026-02-23T00:00:03.000Z",
           label: "Ran tests",
           tone: "tool",
+          activityKind: "tool.completed",
         },
       ],
     );
@@ -626,6 +703,30 @@ describe("hasToolActivityForTurn", () => {
 
     expect(hasToolActivityForTurn(activities, TurnId.makeUnsafe("turn-1"))).toBe(true);
     expect(hasToolActivityForTurn(activities, TurnId.makeUnsafe("turn-2"))).toBe(false);
+  });
+});
+
+describe("hasToolActivitySince", () => {
+  it("tracks tool activity across multiple turns since the latest user message", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "before-user",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        turnId: "turn-1",
+        kind: "tool.completed",
+        tone: "tool",
+      }),
+      makeActivity({
+        id: "after-user",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        turnId: "turn-2",
+        kind: "tool.completed",
+        tone: "tool",
+      }),
+    ];
+
+    expect(hasToolActivitySince(activities, "2026-02-23T00:00:02.000Z")).toBe(true);
+    expect(hasToolActivitySince(activities, "2026-02-23T00:00:04.000Z")).toBe(false);
   });
 });
 
@@ -727,13 +828,20 @@ describe("deriveActiveWorkStartedAt", () => {
 
 describe("PROVIDER_OPTIONS", () => {
   it("keeps Claude Code and Cursor visible as unavailable placeholders in the stack base", () => {
+    const copilot = PROVIDER_OPTIONS.find((option) => option.value === "copilot");
     const claude = PROVIDER_OPTIONS.find((option) => option.value === "claudeCode");
     const cursor = PROVIDER_OPTIONS.find((option) => option.value === "cursor");
     expect(PROVIDER_OPTIONS).toEqual([
       { value: "codex", label: "Codex", available: true },
+      { value: "copilot", label: "GitHub Copilot", available: true },
       { value: "claudeCode", label: "Claude Code", available: false },
       { value: "cursor", label: "Cursor", available: false },
     ]);
+    expect(copilot).toEqual({
+      value: "copilot",
+      label: "GitHub Copilot",
+      available: true,
+    });
     expect(claude).toEqual({
       value: "claudeCode",
       label: "Claude Code",

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -27,6 +27,7 @@ export const PROVIDER_OPTIONS: Array<{
   available: boolean;
 }> = [
   { value: "codex", label: "Codex", available: true },
+  { value: "copilot", label: "GitHub Copilot", available: true },
   { value: "claudeCode", label: "Claude Code", available: false },
   { value: "cursor", label: "Cursor", available: false },
 ];
@@ -36,10 +37,14 @@ export interface WorkLogEntry {
   createdAt: string;
   label: string;
   detail?: string;
+  output?: string;
   command?: string;
+  exitCode?: number;
   changedFiles?: ReadonlyArray<string>;
   tone: "thinking" | "tool" | "info" | "error";
+  activityKind: OrchestrationThreadActivity["kind"];
   toolTitle?: string;
+  toolStatus?: "inProgress" | "completed" | "failed" | "declined";
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
 }
@@ -419,10 +424,14 @@ export function hasActionableProposedPlan(
 export function deriveWorkLogEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   latestTurnId: TurnId | undefined,
+  sinceCreatedAt?: string,
 ): WorkLogEntry[] {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   return ordered
-    .filter((activity) => (latestTurnId ? activity.turnId === latestTurnId : true))
+    .filter((activity) =>
+      latestTurnId ? activity.turnId === latestTurnId || activity.turnId === null : true,
+    )
+    .filter((activity) => (sinceCreatedAt ? activity.createdAt >= sinceCreatedAt : true))
     .filter((activity) => activity.kind !== "tool.started")
     .filter((activity) => activity.kind !== "task.started" && activity.kind !== "task.completed")
     .filter((activity) => activity.summary !== "Checkpoint captured")
@@ -434,11 +443,14 @@ export function deriveWorkLogEntries(
       const command = extractToolCommand(payload);
       const changedFiles = extractChangedFiles(payload);
       const title = extractToolTitle(payload);
+      const status = extractToolStatus(payload);
+      const { output, exitCode } = extractToolOutputEnvelope(payload);
       const entry: WorkLogEntry = {
         id: activity.id,
         createdAt: activity.createdAt,
         label: activity.summary,
         tone: activity.tone === "approval" ? "info" : activity.tone,
+        activityKind: activity.kind,
       };
       const itemType = extractWorkLogItemType(payload);
       const requestKind = extractWorkLogRequestKind(payload);
@@ -451,11 +463,20 @@ export function deriveWorkLogEntries(
       if (command) {
         entry.command = command;
       }
+      if (output) {
+        entry.output = output;
+      }
+      if (exitCode !== undefined) {
+        entry.exitCode = exitCode;
+      }
       if (changedFiles.length > 0) {
         entry.changedFiles = changedFiles;
       }
       if (title) {
         entry.toolTitle = title;
+      }
+      if (status) {
+        entry.toolStatus = status;
       }
       if (itemType) {
         entry.itemType = itemType;
@@ -511,6 +532,42 @@ function extractToolTitle(payload: Record<string, unknown> | null): string | nul
   return asTrimmedString(payload?.title);
 }
 
+function extractToolStatus(
+  payload: Record<string, unknown> | null,
+): WorkLogEntry["toolStatus"] | undefined {
+  switch (payload?.status) {
+    case "in_progress":
+      return "inProgress";
+    case "inProgress":
+    case "completed":
+    case "failed":
+    case "declined":
+      return payload.status;
+    default:
+      return undefined;
+  }
+}
+
+function asInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function extractToolExitCode(payload: Record<string, unknown> | null): number | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const itemResult = asRecord(item?.result);
+  const dataResult = asRecord(data?.result);
+  const candidates = [
+    asInteger(itemResult?.exitCode),
+    asInteger(itemResult?.exit_code),
+    asInteger(dataResult?.exitCode),
+    asInteger(dataResult?.exit_code),
+    asInteger(data?.exitCode),
+    asInteger(data?.exit_code),
+  ];
+  return candidates.find((candidate) => candidate !== null) ?? null;
+}
+
 function stripTrailingExitCode(value: string): {
   output: string | null;
   exitCode?: number | undefined;
@@ -529,6 +586,35 @@ function stripTrailingExitCode(value: string): {
   return {
     output: normalizedOutput.length > 0 ? normalizedOutput : null,
     ...(Number.isInteger(exitCode) ? { exitCode } : {}),
+  };
+}
+
+function extractToolOutputEnvelope(payload: Record<string, unknown> | null): {
+  output?: string | undefined;
+  exitCode?: number | undefined;
+} {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const itemResult = asRecord(item?.result);
+  const dataResult = asRecord(data?.result);
+  const outputCandidates = [
+    asTrimmedString(itemResult?.content),
+    asTrimmedString(dataResult?.content),
+    asTrimmedString(data?.output),
+    asTrimmedString(data?.stdout),
+    asTrimmedString(data?.stderr),
+    asTrimmedString(payload?.detail),
+  ];
+  const rawOutput = outputCandidates.find((candidate) => candidate !== null) ?? null;
+  if (!rawOutput) {
+    const exitCode = extractToolExitCode(payload);
+    return exitCode === null ? {} : { exitCode };
+  }
+  const normalizedOutput = stripTrailingExitCode(rawOutput);
+  const exitCode = extractToolExitCode(payload) ?? normalizedOutput.exitCode;
+  return {
+    ...(normalizedOutput.output ? { output: normalizedOutput.output } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
   };
 }
 
@@ -641,6 +727,16 @@ export function hasToolActivityForTurn(
 ): boolean {
   if (!turnId) return false;
   return activities.some((activity) => activity.turnId === turnId && activity.tone === "tool");
+}
+
+export function hasToolActivitySince(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  sinceCreatedAt: string | undefined,
+): boolean {
+  return activities.some(
+    (activity) =>
+      activity.tone === "tool" && (sinceCreatedAt ? activity.createdAt >= sinceCreatedAt : true),
+  );
 }
 
 export function deriveTimelineEntries(

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -204,6 +204,43 @@ describe("store read model sync", () => {
     expect(next.threads[0]?.model).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
   });
 
+  it("preserves copilot provider models from the active session", () => {
+    const initialState = makeState(makeThread());
+    const readModel = makeReadModel(
+      makeReadModelThread({
+        model: "claude-sonnet-4.6",
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "ready",
+          providerName: "copilot",
+          runtimeMode: DEFAULT_RUNTIME_MODE,
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: "2026-02-27T00:00:00.000Z",
+        },
+      }),
+    );
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.threads[0]?.session?.provider).toBe("copilot");
+    expect(next.threads[0]?.model).toBe("claude-sonnet-4.6");
+  });
+
+  it("infers copilot for builtin copilot models without a session", () => {
+    const initialState = makeState(makeThread());
+    const readModel = makeReadModel(
+      makeReadModelThread({
+        model: "claude-sonnet-4.6",
+        session: null,
+      }),
+    );
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.threads[0]?.model).toBe("claude-sonnet-4.6");
+  });
+
   it("preserves the current project order when syncing incoming read model updates", () => {
     const project1 = ProjectId.makeUnsafe("project-1");
     const project2 = ProjectId.makeUnsafe("project-2");

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -189,20 +189,27 @@ function toLegacySessionStatus(
 }
 
 function toLegacyProvider(providerName: string | null): ProviderKind {
-  if (providerName === "codex") {
+  if (providerName === "codex" || providerName === "copilot") {
     return providerName;
   }
   return "codex";
 }
 
 const CODEX_MODEL_SLUGS = new Set<string>(getModelOptions("codex").map((option) => option.slug));
+const COPILOT_MODEL_SLUGS = new Set<string>(
+  getModelOptions("copilot").map((option) => option.slug),
+);
 
 function inferProviderForThreadModel(input: {
   readonly model: string;
   readonly sessionProviderName: string | null;
 }): ProviderKind {
-  if (input.sessionProviderName === "codex") {
+  if (input.sessionProviderName === "codex" || input.sessionProviderName === "copilot") {
     return input.sessionProviderName;
+  }
+  const normalizedCopilot = normalizeModelSlug(input.model, "copilot");
+  if (normalizedCopilot && COPILOT_MODEL_SLUGS.has(normalizedCopilot)) {
+    return "copilot";
   }
   const normalizedCodex = normalizeModelSlug(input.model, "codex");
   if (normalizedCodex && CODEX_MODEL_SLUGS.has(normalizedCodex)) {

--- a/apps/web/src/terminalStateStore.test.ts
+++ b/apps/web/src/terminalStateStore.test.ts
@@ -1,15 +1,47 @@
 import { ThreadId } from "@t3tools/contracts";
-import { beforeEach, describe, expect, it } from "vitest";
-
-import { selectThreadTerminalState, useTerminalStateStore } from "./terminalStateStore";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const THREAD_ID = ThreadId.makeUnsafe("thread-1");
 
+let selectThreadTerminalState: typeof import("./terminalStateStore").selectThreadTerminalState;
+let useTerminalStateStore: typeof import("./terminalStateStore").useTerminalStateStore;
+
+function createMemoryStorage(): Storage {
+  const backing = new Map<string, string>();
+  return {
+    get length() {
+      return backing.size;
+    },
+    clear() {
+      backing.clear();
+    },
+    getItem(key) {
+      return backing.get(key) ?? null;
+    },
+    key(index) {
+      return [...backing.keys()][index] ?? null;
+    },
+    removeItem(key) {
+      backing.delete(key);
+    },
+    setItem(key, value) {
+      backing.set(key, value);
+    },
+  };
+}
+
 describe("terminalStateStore actions", () => {
-  beforeEach(() => {
-    if (typeof localStorage !== "undefined") {
-      localStorage.clear();
-    }
+  beforeEach(async () => {
+    const storage = createMemoryStorage();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    localStorage.clear();
+    vi.resetModules();
+    const module = await import("./terminalStateStore");
+    selectThreadTerminalState = module.selectThreadTerminalState;
+    useTerminalStateStore = module.useTerminalStateStore;
     useTerminalStateStore.setState({ terminalStateByThreadId: {} });
   });
 

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -157,6 +157,22 @@ export function createWsNativeApi(): NativeApi {
         return showContextMenuFallback(items, position);
       },
     },
+    skills: {
+      list: () => transport.request(WS_METHODS.skillsList),
+      toggle: (input) => transport.request(WS_METHODS.skillsToggle, input),
+      search: (input) => transport.request(WS_METHODS.skillsSearch, input),
+      install: (input) => transport.request(WS_METHODS.skillsInstall, input),
+      uninstall: (input) => transport.request(WS_METHODS.skillsUninstall, input),
+      readContent: (input) => transport.request(WS_METHODS.skillsReadContent, input),
+    },
+    mcp: {
+      list: () => transport.request(WS_METHODS.mcpList),
+      add: (input) => transport.request(WS_METHODS.mcpAdd, input),
+      remove: (input) => transport.request(WS_METHODS.mcpRemove, input),
+      toggle: (input) => transport.request(WS_METHODS.mcpToggle, input),
+      update: (input) => transport.request(WS_METHODS.mcpUpdate, input),
+      browse: () => transport.request(WS_METHODS.mcpBrowse),
+    },
     server: {
       getConfig: () => transport.request(WS_METHODS.serverGetConfig),
       upsertKeybinding: (input) => transport.request(WS_METHODS.serverUpsertKeybinding, input),

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "@t3tools/desktop",
-      "version": "0.0.10",
+      "version": "0.1.25",
       "dependencies": {
         "effect": "catalog:",
         "electron": "40.6.0",
@@ -34,6 +34,7 @@
       "name": "@t3tools/marketing",
       "version": "0.0.0",
       "dependencies": {
+        "@t3tools/shared": "workspace:*",
         "astro": "^6.0.4",
       },
       "devDependencies": {
@@ -43,17 +44,20 @@
     },
     "apps/server": {
       "name": "t3",
-      "version": "0.0.10",
+      "version": "0.1.25",
       "bin": {
         "t3": "./dist/index.mjs",
       },
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "@effect/sql-sqlite-bun": "catalog:",
+        "@github/copilot": "1.0.7",
+        "@github/copilot-sdk": "0.1.32",
         "@pierre/diffs": "^1.1.0-beta.16",
         "effect": "catalog:",
         "node-pty": "^1.1.0",
         "open": "^10.1.0",
+        "smol-toml": "^1.6.0",
         "ws": "^8.18.0",
       },
       "devDependencies": {
@@ -72,7 +76,7 @@
     },
     "apps/web": {
       "name": "@t3tools/web",
-      "version": "0.0.10",
+      "version": "0.1.25",
       "dependencies": {
         "@base-ui/react": "^1.2.0",
         "@dnd-kit/core": "^6.3.1",
@@ -122,7 +126,7 @@
     },
     "packages/contracts": {
       "name": "@t3tools/contracts",
-      "version": "0.0.10",
+      "version": "0.1.25",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -166,6 +170,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@github/copilot-sdk@0.1.32": "patches/@github%2Fcopilot-sdk@0.1.32.patch",
+  },
   "overrides": {
     "vite": "^8.0.0",
   },
@@ -178,7 +185,7 @@
     "@types/node": "^24.10.13",
     "effect": "https://pkg.pr.new/Effect-TS/effect-smol/effect@8881a9b",
     "tsdown": "^0.20.3",
-    "typescript": "^5.7.3",
+    "typescript": "5.9.3",
     "vitest": "^4.0.0",
   },
   "packages": {
@@ -353,6 +360,22 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@github/copilot": ["@github/copilot@1.0.7", "", { "optionalDependencies": { "@github/copilot-darwin-arm64": "1.0.7", "@github/copilot-darwin-x64": "1.0.7", "@github/copilot-linux-arm64": "1.0.7", "@github/copilot-linux-x64": "1.0.7", "@github/copilot-win32-arm64": "1.0.7", "@github/copilot-win32-x64": "1.0.7" }, "bin": { "copilot": "npm-loader.js" } }, "sha512-KHBaJ1kbc19pqUMnB9LubPtwWVOaDCzWbzwsJss+DvHyCpr8wP8jR3GEZUnhq3rsuXI96ZKEeEozXM0NqxCAiw=="],
+
+    "@github/copilot-darwin-arm64": ["@github/copilot-darwin-arm64@1.0.7", "", { "os": "darwin", "cpu": "arm64", "bin": { "copilot-darwin-arm64": "copilot" } }, "sha512-yQITowpkQYamww59CwcG5JTWV9ahj7nMH6oqObMJaeqXnG7j7dqE/YhLkujQZ3XR8VXAoIa1rZ3TahdMu94gOA=="],
+
+    "@github/copilot-darwin-x64": ["@github/copilot-darwin-x64@1.0.7", "", { "os": "darwin", "cpu": "x64", "bin": { "copilot-darwin-x64": "copilot" } }, "sha512-23vP5bHaFA030nB3tr+dUUdRm2SqmQbs2fZUQ4F7JeYy59jp9hi8lBdaZp/TeQnjEirAUU9H2HZxsGRIIUWp7g=="],
+
+    "@github/copilot-linux-arm64": ["@github/copilot-linux-arm64@1.0.7", "", { "os": "linux", "cpu": "arm64", "bin": { "copilot-linux-arm64": "copilot" } }, "sha512-g0mB98oyXKcpd4sMNBc5n1h3UhLy9AGRlT//VL8BXPSzvlTH/dJP3fdx74pbLSgvz105to/YUMmEAFfv25VNaw=="],
+
+    "@github/copilot-linux-x64": ["@github/copilot-linux-x64@1.0.7", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linux-x64": "copilot" } }, "sha512-TRxzvTo9I4ehYJLFHTCJSJYQ4QnO/V9zebqwszxHpJRxuBd7FV4cxLmfOBqZcUpEpZgBH+VJ4OG98BPW7YEtJQ=="],
+
+    "@github/copilot-sdk": ["@github/copilot-sdk@0.1.32", "", { "dependencies": { "@github/copilot": "^1.0.2", "vscode-jsonrpc": "^8.2.1", "zod": "^4.3.6" } }, "sha512-mPWM0fw1Gqc/SW8nl45K8abrFH+92fO7y6tRtRl5imjS5hGapLf/dkX5WDrgPtlsflD0c41lFXVUri5NVJwtoA=="],
+
+    "@github/copilot-win32-arm64": ["@github/copilot-win32-arm64@1.0.7", "", { "os": "win32", "cpu": "arm64", "bin": { "copilot-win32-arm64": "copilot.exe" } }, "sha512-4yFgW1K0MlKBrK5BwMIj4nMu5KSFfytNXrs8iOpVgp7erEvKVyN7VXb6SWkoU3M9TfeNlqP6Uje2rxDvgR1u5w=="],
+
+    "@github/copilot-win32-x64": ["@github/copilot-win32-x64@1.0.7", "", { "os": "win32", "cpu": "x64", "bin": { "copilot-win32-x64": "copilot.exe" } }, "sha512-RDZlvPf/q6B54wLXJRmI39fc9+pwfcAjSwUqw0FeQruCTQgoUl8eo9NqeVWDFlr3RdzgVSMUiJHc3aiifVG6lA=="],
 
     "@hapi/address": ["@hapi/address@5.1.1", "", { "dependencies": { "@hapi/hoek": "^11.0.2" } }, "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA=="],
 
@@ -1816,7 +1839,7 @@
 
     "vscode-json-languageservice": ["vscode-json-languageservice@4.1.8", "", { "dependencies": { "jsonc-parser": "^3.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-nls": "^5.0.0", "vscode-uri": "^3.0.2" } }, "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg=="],
 
-    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.1", "", {}, "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ=="],
 
     "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
 
@@ -1987,6 +2010,8 @@
     "vite/rolldown": ["rolldown@1.0.0-rc.9", "", { "dependencies": { "@oxc-project/types": "=0.115.0", "@rolldown/pluginutils": "1.0.0-rc.9" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-x64": "1.0.0-rc.9", "@rolldown/binding-freebsd-x64": "1.0.0-rc.9", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q=="],
 
     "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "vscode-languageserver-protocol/vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 
     "yaml-language-server/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -29,6 +29,13 @@ This document covers how to run desktop releases from one tag, first without sig
 - Repository slug source:
   - `T3CODE_DESKTOP_UPDATE_REPOSITORY` (format `owner/repo`), if set.
   - otherwise `GITHUB_REPOSITORY` from GitHub Actions.
+  - otherwise the fork default `zortos293/t3code-copilot`, so local/manual desktop builds still publish updater metadata against this fork.
+- Release workflow default:
+  - `.github/workflows/release.yml` exports `T3CODE_DESKTOP_UPDATE_REPOSITORY` as `${{ vars.T3CODE_DESKTOP_UPDATE_REPOSITORY || github.repository }}`.
+  - leave it unset to use the current repository, or define the repository variable to point packaged apps at another release source.
+- Marketing release links:
+  - default to `zortos293/t3code-copilot`
+  - set `PUBLIC_T3CODE_RELEASE_REPOSITORY` at build time to override the releases page/API source
 - Temporary private-repo auth workaround:
   - set `T3CODE_DESKTOP_UPDATE_GITHUB_TOKEN` (or `GH_TOKEN`) in the desktop app runtime environment.
   - the app forwards it as an `Authorization: Bearer <token>` request header for updater HTTP calls.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@t3tools/monorepo",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zortos293/t3code-copilot"
+  },
   "workspaces": {
     "packages": [
       "apps/*",
@@ -69,5 +73,8 @@
     "workerDirectory": [
       "apps/web/public"
     ]
+  },
+  "patchedDependencies": {
+    "@github/copilot-sdk@0.1.32": "patches/@github%2Fcopilot-sdk@0.1.32.patch"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3tools/contracts",
-  "version": "0.0.10",
+  "version": "0.1.25",
   "private": true,
   "files": [
     "dist"
@@ -19,7 +19,7 @@
   "scripts": {
     "dev": "tsdown src/index.ts --format esm,cjs --dts --watch --clean",
     "build": "tsdown src/index.ts --format esm,cjs --dts --clean",
-    "prepare": "effect-language-service patch",
+    "prepare": "node ../../scripts/run-effect-language-service-patch.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -11,3 +11,5 @@ export * from "./git";
 export * from "./orchestration";
 export * from "./editor";
 export * from "./project";
+export * from "./skills";
+export * from "./mcp";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -24,6 +24,31 @@ import type {
   ProjectWriteFileInput,
   ProjectWriteFileResult,
 } from "./project";
+import type {
+  SkillsListResult,
+  SkillsToggleInput,
+  SkillsToggleResult,
+  SkillsSearchInput,
+  SkillsSearchResult,
+  SkillsInstallInput,
+  SkillsInstallResult,
+  SkillsUninstallInput,
+  SkillsUninstallResult,
+  SkillsReadContentInput,
+  SkillsReadContentResult,
+} from "./skills";
+import type {
+  McpListResult,
+  McpAddInput,
+  McpAddResult,
+  McpRemoveInput,
+  McpRemoveResult,
+  McpToggleInput,
+  McpToggleResult,
+  McpUpdateInput,
+  McpUpdateResult,
+  McpBrowseResult,
+} from "./mcp";
 import type { ServerConfig } from "./server";
 import type {
   TerminalClearInput,
@@ -155,6 +180,22 @@ export interface NativeApi {
       items: readonly ContextMenuItem<T>[],
       position?: { x: number; y: number },
     ) => Promise<T | null>;
+  };
+  skills: {
+    list: () => Promise<SkillsListResult>;
+    toggle: (input: SkillsToggleInput) => Promise<SkillsToggleResult>;
+    search: (input: SkillsSearchInput) => Promise<SkillsSearchResult>;
+    install: (input: SkillsInstallInput) => Promise<SkillsInstallResult>;
+    uninstall: (input: SkillsUninstallInput) => Promise<SkillsUninstallResult>;
+    readContent: (input: SkillsReadContentInput) => Promise<SkillsReadContentResult>;
+  };
+  mcp: {
+    list: () => Promise<McpListResult>;
+    add: (input: McpAddInput) => Promise<McpAddResult>;
+    remove: (input: McpRemoveInput) => Promise<McpRemoveResult>;
+    toggle: (input: McpToggleInput) => Promise<McpToggleResult>;
+    update: (input: McpUpdateInput) => Promise<McpUpdateResult>;
+    browse: () => Promise<McpBrowseResult>;
   };
   server: {
     getConfig: () => Promise<ServerConfig>;

--- a/packages/contracts/src/mcp.ts
+++ b/packages/contracts/src/mcp.ts
@@ -1,0 +1,139 @@
+import { Schema } from "effect";
+
+// ── Provider kind for MCP server source ──────────────────────────────
+
+export const McpProviderKind = Schema.Union([Schema.Literal("codex"), Schema.Literal("copilot")]);
+export type McpProviderKind = typeof McpProviderKind.Type;
+
+// ── MCP Server config (read from native CLI configs) ─────────────────
+
+export const McpServerConfig = Schema.Struct({
+  /** Unique server name (key in the config file). */
+  name: Schema.String,
+  /** Which CLI owns this server config. */
+  provider: McpProviderKind,
+  /** Whether the server is currently enabled (present in config). */
+  enabled: Schema.Boolean,
+  /** Transport type: "stdio" | "http". */
+  type: Schema.optional(Schema.String),
+  /** Stdio transport: the command to run. */
+  command: Schema.optional(Schema.String),
+  /** Stdio transport: command arguments. */
+  args: Schema.optional(Schema.Array(Schema.String)),
+  /** URL transport: remote MCP endpoint. */
+  url: Schema.optional(Schema.String),
+  /** HTTP transport: request headers (e.g. auth tokens). */
+  headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  /** Codex URL transport: bearer token or env var name for Authorization header. */
+  bearerToken: Schema.optional(Schema.String),
+  /** Declared tool names this server provides. */
+  tools: Schema.optional(Schema.Array(Schema.String)),
+});
+export type McpServerConfig = typeof McpServerConfig.Type;
+
+export const McpListResult = Schema.Struct({
+  servers: Schema.Array(McpServerConfig),
+});
+export type McpListResult = typeof McpListResult.Type;
+
+// ── Add MCP server ──────────────────────────────────────────────────
+
+export const McpAddInput = Schema.Struct({
+  name: Schema.String,
+  provider: McpProviderKind,
+  command: Schema.optional(Schema.String),
+  args: Schema.optional(Schema.Array(Schema.String)),
+  url: Schema.optional(Schema.String),
+  headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  bearerToken: Schema.optional(Schema.String),
+});
+export type McpAddInput = typeof McpAddInput.Type;
+
+export const McpAddResult = Schema.Struct({
+  success: Schema.Boolean,
+  message: Schema.String,
+});
+export type McpAddResult = typeof McpAddResult.Type;
+
+// ── Remove MCP server ───────────────────────────────────────────────
+
+export const McpRemoveInput = Schema.Struct({
+  name: Schema.String,
+  provider: McpProviderKind,
+});
+export type McpRemoveInput = typeof McpRemoveInput.Type;
+
+export const McpRemoveResult = Schema.Struct({
+  success: Schema.Boolean,
+  message: Schema.String,
+});
+export type McpRemoveResult = typeof McpRemoveResult.Type;
+
+// ── Toggle MCP server on/off ────────────────────────────────────────
+
+export const McpToggleInput = Schema.Struct({
+  name: Schema.String,
+  provider: McpProviderKind,
+  enabled: Schema.Boolean,
+});
+export type McpToggleInput = typeof McpToggleInput.Type;
+
+export const McpToggleResult = Schema.Struct({
+  name: Schema.String,
+  enabled: Schema.Boolean,
+});
+export type McpToggleResult = typeof McpToggleResult.Type;
+
+// ── Update MCP server config (command, args, url) ───────────────────
+
+export const McpUpdateInput = Schema.Struct({
+  name: Schema.String,
+  provider: McpProviderKind,
+  command: Schema.optional(Schema.String),
+  args: Schema.optional(Schema.Array(Schema.String)),
+  url: Schema.optional(Schema.String),
+  headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  bearerToken: Schema.optional(Schema.String),
+});
+export type McpUpdateInput = typeof McpUpdateInput.Type;
+
+export const McpUpdateResult = Schema.Struct({
+  success: Schema.Boolean,
+  message: Schema.String,
+});
+export type McpUpdateResult = typeof McpUpdateResult.Type;
+
+// ── Browse MCP catalog ──────────────────────────────────────────────
+
+export const McpInstallPrompt = Schema.Struct({
+  /** Unique identifier for this prompt. */
+  id: Schema.String,
+  /** Label shown to the user. */
+  label: Schema.String,
+  /** Placeholder hint text. */
+  placeholder: Schema.String,
+  /** Whether a value is required to install. */
+  required: Schema.Boolean,
+});
+export type McpInstallPrompt = typeof McpInstallPrompt.Type;
+
+export const McpCatalogEntry = Schema.Struct({
+  name: Schema.String,
+  description: Schema.String,
+  /** Stdio transport: the command to run. */
+  command: Schema.optional(Schema.String),
+  /** Stdio transport: base arguments (user-prompted values are appended). */
+  args: Schema.optional(Schema.Array(Schema.String)),
+  /** Documentation / info URL (GitHub, homepage). */
+  infoUrl: Schema.optional(Schema.String),
+  /** HTTP transport: remote MCP endpoint URL. */
+  mcpUrl: Schema.optional(Schema.String),
+  /** Prompts to collect from user before installing (values appended to args). */
+  installPrompts: Schema.optional(Schema.Array(McpInstallPrompt)),
+});
+export type McpCatalogEntry = typeof McpCatalogEntry.Type;
+
+export const McpBrowseResult = Schema.Struct({
+  servers: Schema.Array(McpCatalogEntry),
+});
+export type McpBrowseResult = typeof McpBrowseResult.Type;

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -9,9 +9,14 @@ export const CodexModelOptions = Schema.Struct({
   fastMode: Schema.optional(Schema.Boolean),
 });
 export type CodexModelOptions = typeof CodexModelOptions.Type;
+export const CopilotModelOptions = Schema.Struct({
+  reasoningEffort: Schema.optional(Schema.Literals(CODEX_REASONING_EFFORT_OPTIONS)),
+});
+export type CopilotModelOptions = typeof CopilotModelOptions.Type;
 
 export const ProviderModelOptions = Schema.Struct({
   codex: Schema.optional(CodexModelOptions),
+  copilot: Schema.optional(CopilotModelOptions),
 });
 export type ProviderModelOptions = typeof ProviderModelOptions.Type;
 
@@ -29,6 +34,29 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     { slug: "gpt-5.2-codex", name: "GPT-5.2 Codex" },
     { slug: "gpt-5.2", name: "GPT-5.2" },
   ],
+  copilot: [
+    { slug: "gpt-5.4", name: "GPT-5.4" },
+    { slug: "gpt-5.4-mini", name: "GPT-5.4 mini" },
+    { slug: "claude-sonnet-4.6", name: "Claude Sonnet 4.6" },
+    { slug: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+    { slug: "claude-haiku-4.5", name: "Claude Haiku 4.5" },
+    { slug: "claude-opus-4.6", name: "Claude Opus 4.6" },
+    { slug: "claude-opus-4.6-fast", name: "Claude Opus 4.6 (fast mode)" },
+    { slug: "claude-opus-4.5", name: "Claude Opus 4.5" },
+    { slug: "claude-sonnet-4", name: "Claude Sonnet 4" },
+    { slug: "gemini-3-pro-preview", name: "Gemini 3 Pro (Preview)" },
+    { slug: "gemini-3.1-pro", name: "Gemini 3.1 Pro" },
+    { slug: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+    { slug: "gpt-5.2-codex", name: "GPT-5.2 Codex" },
+    { slug: "gpt-5.2", name: "GPT-5.2" },
+    { slug: "gpt-5.1-codex-max", name: "GPT-5.1 Codex Max" },
+    { slug: "gpt-5.1-codex", name: "GPT-5.1 Codex" },
+    { slug: "gpt-5.1-codex-mini", name: "GPT-5.1 Codex Mini" },
+    { slug: "gpt-5.1", name: "GPT-5.1" },
+    { slug: "gpt-5-mini", name: "GPT-5 mini" },
+    { slug: "gpt-4.1", name: "GPT-4.1" },
+    { slug: "raptor-mini", name: "Raptor mini" },
+  ],
 } as const satisfies Record<ProviderKind, readonly ModelOption[]>;
 export type ModelOptionsByProvider = typeof MODEL_OPTIONS_BY_PROVIDER;
 
@@ -37,6 +65,7 @@ export type ModelSlug = BuiltInModelSlug | (string & {});
 
 export const DEFAULT_MODEL_BY_PROVIDER = {
   codex: "gpt-5.4",
+  copilot: "claude-sonnet-4.6",
 } as const satisfies Record<ProviderKind, ModelSlug>;
 
 export const DEFAULT_GIT_TEXT_GENERATION_MODEL = "gpt-5.4-mini" as const;
@@ -49,12 +78,33 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER = {
     "5.3-spark": "gpt-5.3-codex-spark",
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
+  copilot: {
+    "4.1": "gpt-4.1",
+    "5.4": "gpt-5.4",
+    "5.4-mini": "gpt-5.4-mini",
+    "5-mini": "gpt-5-mini",
+    "5.1": "gpt-5.1",
+    "5.1-codex": "gpt-5.1-codex",
+    "5.1-max": "gpt-5.1-codex-max",
+    "5.1-mini": "gpt-5.1-codex-mini",
+    "5.2": "gpt-5.2",
+    "5.2-codex": "gpt-5.2-codex",
+    "5.3": "gpt-5.3-codex",
+    haiku: "claude-haiku-4.5",
+    sonnet: "claude-sonnet-4.6",
+    opus: "claude-opus-4.6",
+    gemini: "gemini-3-pro-preview",
+    "gemini-3.1": "gemini-3.1-pro",
+    raptor: "raptor-mini",
+  },
 } as const satisfies Record<ProviderKind, Record<string, ModelSlug>>;
 
 export const REASONING_EFFORT_OPTIONS_BY_PROVIDER = {
   codex: CODEX_REASONING_EFFORT_OPTIONS,
+  copilot: [],
 } as const satisfies Record<ProviderKind, readonly CodexReasoningEffort[]>;
 
 export const DEFAULT_REASONING_EFFORT_BY_PROVIDER = {
   codex: "high",
+  copilot: null,
 } as const satisfies Record<ProviderKind, CodexReasoningEffort | null>;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -27,7 +27,7 @@ export const ORCHESTRATION_WS_CHANNELS = {
   domainEvent: "orchestration.domainEvent",
 } as const;
 
-export const ProviderKind = Schema.Literal("codex");
+export const ProviderKind = Schema.Union([Schema.Literal("codex"), Schema.Literal("copilot")]);
 export type ProviderKind = typeof ProviderKind.Type;
 export const ProviderApprovalPolicy = Schema.Literals([
   "untrusted",
@@ -43,13 +43,21 @@ export const ProviderSandboxMode = Schema.Literals([
 ]);
 export type ProviderSandboxMode = typeof ProviderSandboxMode.Type;
 export const DEFAULT_PROVIDER_KIND: ProviderKind = "codex";
-const CodexProviderStartOptions = Schema.Struct({
+export const CodexProviderStartOptions = Schema.Struct({
   binaryPath: Schema.optional(TrimmedNonEmptyString),
   homePath: Schema.optional(TrimmedNonEmptyString),
 });
-const ProviderStartOptions = Schema.Struct({
-  codex: Schema.optional(CodexProviderStartOptions),
+export type CodexProviderStartOptions = typeof CodexProviderStartOptions.Type;
+export const CopilotProviderStartOptions = Schema.Struct({
+  cliPath: Schema.optional(TrimmedNonEmptyString),
+  configDir: Schema.optional(TrimmedNonEmptyString),
 });
+export type CopilotProviderStartOptions = typeof CopilotProviderStartOptions.Type;
+export const ProviderStartOptions = Schema.Struct({
+  codex: Schema.optional(CodexProviderStartOptions),
+  copilot: Schema.optional(CopilotProviderStartOptions),
+});
+export type ProviderStartOptions = typeof ProviderStartOptions.Type;
 export const RuntimeMode = Schema.Literals(["approval-required", "full-access"]);
 export type RuntimeMode = typeof RuntimeMode.Type;
 export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -13,6 +13,7 @@ import {
   ChatAttachment,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
+  ProviderStartOptions,
   ProviderApprovalDecision,
   ProviderApprovalPolicy,
   ProviderInteractionMode,
@@ -46,17 +47,6 @@ export const ProviderSession = Schema.Struct({
   lastError: Schema.optional(TrimmedNonEmptyStringSchema),
 });
 export type ProviderSession = typeof ProviderSession.Type;
-
-const CodexProviderStartOptions = Schema.Struct({
-  binaryPath: Schema.optional(TrimmedNonEmptyStringSchema),
-  homePath: Schema.optional(TrimmedNonEmptyStringSchema),
-});
-
-export const ProviderStartOptions = Schema.Struct({
-  codex: Schema.optional(CodexProviderStartOptions),
-});
-export type ProviderStartOptions = typeof ProviderStartOptions.Type;
-
 export const ProviderSessionStartInput = Schema.Struct({
   threadId: ThreadId,
   provider: Schema.optional(ProviderKind),

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -20,6 +20,8 @@ const RuntimeEventRawSource = Schema.Literals([
   "codex.app-server.request",
   "codex.eventmsg",
   "codex.sdk.thread-event",
+  "copilot.sdk.session-event",
+  "copilot.sdk.synthetic",
 ]);
 export type RuntimeEventRawSource = typeof RuntimeEventRawSource.Type;
 

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -1,8 +1,9 @@
 import { Schema } from "effect";
-import { IsoDateTime, TrimmedNonEmptyString } from "./baseSchemas";
+import { IsoDateTime, NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas";
 import { KeybindingRule, ResolvedKeybindingsConfig } from "./keybindings";
 import { EditorId } from "./editor";
 import { ProviderKind } from "./orchestration";
+import { CODEX_REASONING_EFFORT_OPTIONS } from "./model";
 
 const KeybindingsMalformedConfigIssue = Schema.Struct({
   kind: Schema.Literal("keybindings.malformed-config"),
@@ -33,6 +34,31 @@ export const ServerProviderAuthStatus = Schema.Literals([
 ]);
 export type ServerProviderAuthStatus = typeof ServerProviderAuthStatus.Type;
 
+export const ServerProviderModelReasoningEffort = Schema.Literals(CODEX_REASONING_EFFORT_OPTIONS);
+export type ServerProviderModelReasoningEffort = typeof ServerProviderModelReasoningEffort.Type;
+
+export const ServerProviderModel = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  name: TrimmedNonEmptyString,
+  supportsReasoningEffort: Schema.Boolean,
+  supportedReasoningEfforts: Schema.optional(Schema.Array(ServerProviderModelReasoningEffort)),
+  defaultReasoningEffort: Schema.optional(ServerProviderModelReasoningEffort),
+  billingMultiplier: Schema.optional(Schema.Number),
+});
+export type ServerProviderModel = typeof ServerProviderModel.Type;
+
+export const ServerProviderQuotaSnapshot = Schema.Struct({
+  key: TrimmedNonEmptyString,
+  entitlementRequests: NonNegativeInt,
+  usedRequests: NonNegativeInt,
+  remainingRequests: NonNegativeInt,
+  remainingPercentage: Schema.Number,
+  overage: NonNegativeInt,
+  overageAllowedWithExhaustedQuota: Schema.Boolean,
+  resetDate: Schema.optional(IsoDateTime),
+});
+export type ServerProviderQuotaSnapshot = typeof ServerProviderQuotaSnapshot.Type;
+
 export const ServerProviderStatus = Schema.Struct({
   provider: ProviderKind,
   status: ServerProviderStatusState,
@@ -40,6 +66,8 @@ export const ServerProviderStatus = Schema.Struct({
   authStatus: ServerProviderAuthStatus,
   checkedAt: IsoDateTime,
   message: Schema.optional(TrimmedNonEmptyString),
+  models: Schema.optional(Schema.Array(ServerProviderModel)),
+  quotaSnapshots: Schema.optional(Schema.Array(ServerProviderQuotaSnapshot)),
 });
 export type ServerProviderStatus = typeof ServerProviderStatus.Type;
 

--- a/packages/contracts/src/skills.ts
+++ b/packages/contracts/src/skills.ts
@@ -1,0 +1,90 @@
+import { Schema } from "effect";
+
+// ── Skill metadata returned by list ─────────────────────────────────
+
+export const SkillMetadata = Schema.Struct({
+  name: Schema.String,
+  description: Schema.String,
+  enabled: Schema.Boolean,
+  agents: Schema.Array(Schema.String),
+});
+export type SkillMetadata = typeof SkillMetadata.Type;
+
+export const SkillsListResult = Schema.Struct({
+  skills: Schema.Array(SkillMetadata),
+});
+export type SkillsListResult = typeof SkillsListResult.Type;
+
+// ── Toggle skill on/off ─────────────────────────────────────────────
+
+export const SkillsToggleInput = Schema.Struct({
+  skillName: Schema.String,
+  enabled: Schema.Boolean,
+});
+export type SkillsToggleInput = typeof SkillsToggleInput.Type;
+
+export const SkillsToggleResult = Schema.Struct({
+  skillName: Schema.String,
+  enabled: Schema.Boolean,
+});
+export type SkillsToggleResult = typeof SkillsToggleResult.Type;
+
+// ── Search skills.sh registry (Phase 2) ─────────────────────────────
+
+export const SkillsSearchInput = Schema.Struct({
+  query: Schema.String,
+});
+export type SkillsSearchInput = typeof SkillsSearchInput.Type;
+
+export const SkillSearchResultEntry = Schema.Struct({
+  name: Schema.String,
+  source: Schema.String,
+  installs: Schema.Number,
+  url: Schema.String,
+});
+export type SkillSearchResultEntry = typeof SkillSearchResultEntry.Type;
+
+export const SkillsSearchResult = Schema.Struct({
+  skills: Schema.Array(SkillSearchResultEntry),
+});
+export type SkillsSearchResult = typeof SkillsSearchResult.Type;
+
+// ── Install skill from skills.sh (Phase 2) ──────────────────────────
+
+export const SkillsInstallInput = Schema.Struct({
+  source: Schema.String,
+  skillName: Schema.String,
+});
+export type SkillsInstallInput = typeof SkillsInstallInput.Type;
+
+export const SkillsInstallResult = Schema.Struct({
+  success: Schema.Boolean,
+  message: Schema.String,
+});
+export type SkillsInstallResult = typeof SkillsInstallResult.Type;
+
+// ── Uninstall skill ─────────────────────────────────────────────────
+
+export const SkillsUninstallInput = Schema.Struct({
+  skillName: Schema.String,
+});
+export type SkillsUninstallInput = typeof SkillsUninstallInput.Type;
+
+export const SkillsUninstallResult = Schema.Struct({
+  success: Schema.Boolean,
+  message: Schema.String,
+});
+export type SkillsUninstallResult = typeof SkillsUninstallResult.Type;
+
+// ── Read skill content ──────────────────────────────────────────────
+
+export const SkillsReadContentInput = Schema.Struct({
+  skillName: Schema.String,
+});
+export type SkillsReadContentInput = typeof SkillsReadContentInput.Type;
+
+export const SkillsReadContentResult = Schema.Struct({
+  skillName: Schema.String,
+  content: Schema.String,
+});
+export type SkillsReadContentResult = typeof SkillsReadContentResult.Type;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -36,6 +36,14 @@ import {
 import { KeybindingRule } from "./keybindings";
 import { ProjectSearchEntriesInput, ProjectWriteFileInput } from "./project";
 import { OpenInEditorInput } from "./editor";
+import {
+  SkillsToggleInput,
+  SkillsSearchInput,
+  SkillsInstallInput,
+  SkillsUninstallInput,
+  SkillsReadContentInput,
+} from "./skills";
+import { McpAddInput, McpRemoveInput, McpToggleInput, McpUpdateInput } from "./mcp";
 import { ServerConfigUpdatedPayload } from "./server";
 
 // ── WebSocket RPC Method Names ───────────────────────────────────────
@@ -71,6 +79,22 @@ export const WS_METHODS = {
   terminalClear: "terminal.clear",
   terminalRestart: "terminal.restart",
   terminalClose: "terminal.close",
+
+  // Skills methods
+  skillsList: "skills.list",
+  skillsToggle: "skills.toggle",
+  skillsSearch: "skills.search",
+  skillsInstall: "skills.install",
+  skillsUninstall: "skills.uninstall",
+  skillsReadContent: "skills.readContent",
+
+  // MCP methods
+  mcpList: "mcp.list",
+  mcpAdd: "mcp.add",
+  mcpRemove: "mcp.remove",
+  mcpToggle: "mcp.toggle",
+  mcpUpdate: "mcp.update",
+  mcpBrowse: "mcp.browse",
 
   // Server meta
   serverGetConfig: "server.getConfig",
@@ -135,6 +159,22 @@ const WebSocketRequestBody = Schema.Union([
   tagRequestBody(WS_METHODS.terminalClear, TerminalClearInput),
   tagRequestBody(WS_METHODS.terminalRestart, TerminalRestartInput),
   tagRequestBody(WS_METHODS.terminalClose, TerminalCloseInput),
+
+  // Skills methods
+  tagRequestBody(WS_METHODS.skillsList, Schema.Struct({})),
+  tagRequestBody(WS_METHODS.skillsToggle, SkillsToggleInput),
+  tagRequestBody(WS_METHODS.skillsSearch, SkillsSearchInput),
+  tagRequestBody(WS_METHODS.skillsInstall, SkillsInstallInput),
+  tagRequestBody(WS_METHODS.skillsUninstall, SkillsUninstallInput),
+  tagRequestBody(WS_METHODS.skillsReadContent, SkillsReadContentInput),
+
+  // MCP methods
+  tagRequestBody(WS_METHODS.mcpList, Schema.Struct({})),
+  tagRequestBody(WS_METHODS.mcpAdd, McpAddInput),
+  tagRequestBody(WS_METHODS.mcpRemove, McpRemoveInput),
+  tagRequestBody(WS_METHODS.mcpToggle, McpToggleInput),
+  tagRequestBody(WS_METHODS.mcpUpdate, McpUpdateInput),
+  tagRequestBody(WS_METHODS.mcpBrowse, Schema.Struct({})),
 
   // Server meta
   tagRequestBody(WS_METHODS.serverGetConfig, Schema.Struct({})),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./githubRepository": {
+      "types": "./src/githubRepository.ts",
+      "import": "./src/githubRepository.ts"
+    },
     "./model": {
       "types": "./src/model.ts",
       "import": "./src/model.ts"
@@ -34,7 +38,7 @@
     }
   },
   "scripts": {
-    "prepare": "effect-language-service patch",
+    "prepare": "node ../../scripts/run-effect-language-service-patch.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/shared/src/githubRepository.test.ts
+++ b/packages/shared/src/githubRepository.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_GITHUB_REPOSITORY,
+  formatGitHubRepository,
+  parseGitHubRepository,
+} from "./githubRepository";
+
+describe("parseGitHubRepository", () => {
+  it("parses valid owner/repo slugs", () => {
+    expect(parseGitHubRepository("zortos293/t3code-copilot")).toEqual({
+      owner: "zortos293",
+      repo: "t3code-copilot",
+    });
+  });
+
+  it("rejects invalid repository slugs", () => {
+    expect(parseGitHubRepository("")).toBeNull();
+    expect(parseGitHubRepository("zortos293")).toBeNull();
+    expect(parseGitHubRepository("zortos293/t3code-copilot/releases")).toBeNull();
+    expect(parseGitHubRepository("zortos293 /t3code-copilot")).toBeNull();
+  });
+});
+
+describe("formatGitHubRepository", () => {
+  it("round-trips the default repository slug", () => {
+    const repository = parseGitHubRepository(DEFAULT_GITHUB_REPOSITORY);
+    expect(repository).not.toBeNull();
+    expect(formatGitHubRepository(repository!)).toBe(DEFAULT_GITHUB_REPOSITORY);
+  });
+});

--- a/packages/shared/src/githubRepository.ts
+++ b/packages/shared/src/githubRepository.ts
@@ -1,0 +1,29 @@
+export interface GitHubRepositorySlug {
+  readonly owner: string;
+  readonly repo: string;
+}
+
+export const DEFAULT_GITHUB_REPOSITORY = "zortos293/t3code-copilot";
+
+export function parseGitHubRepository(
+  value: string | null | undefined,
+): GitHubRepositorySlug | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const match = trimmed.match(/^([^/\s]+)\/([^/\s]+)$/);
+  if (!match?.[1] || !match[2]) {
+    return null;
+  }
+
+  return {
+    owner: match[1],
+    repo: match[2],
+  };
+}
+
+export function formatGitHubRepository(repository: GitHubRepositorySlug): string {
+  return `${repository.owner}/${repository.repo}`;
+}

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -16,6 +16,12 @@ describe("normalizeModelSlug", () => {
     expect(normalizeModelSlug("gpt-5.3")).toBe("gpt-5.3-codex");
   });
 
+  it("maps copilot aliases to canonical slugs", () => {
+    expect(normalizeModelSlug("5.4-mini", "copilot")).toBe("gpt-5.4-mini");
+    expect(normalizeModelSlug("gemini-3.1", "copilot")).toBe("gemini-3.1-pro");
+    expect(normalizeModelSlug("raptor", "copilot")).toBe("raptor-mini");
+  });
+
   it("returns null for empty or missing values", () => {
     expect(normalizeModelSlug("")).toBeNull();
     expect(normalizeModelSlug("   ")).toBeNull();
@@ -50,6 +56,13 @@ describe("resolveModelSlug", () => {
       expect(resolveModelSlug(model.slug)).toBe(model.slug);
     }
   });
+
+  it("resolves supported copilot model options", () => {
+    for (const model of MODEL_OPTIONS_BY_PROVIDER.copilot) {
+      expect(resolveModelSlug(model.slug, "copilot")).toBe(model.slug);
+    }
+  });
+
   it("keeps codex defaults for backward compatibility", () => {
     expect(getDefaultModel()).toBe(DEFAULT_MODEL_BY_PROVIDER.codex);
     expect(getModelOptions()).toEqual(MODEL_OPTIONS_BY_PROVIDER.codex);

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -12,6 +12,7 @@ type CatalogProvider = keyof typeof MODEL_OPTIONS_BY_PROVIDER;
 
 const MODEL_SLUG_SET_BY_PROVIDER: Record<CatalogProvider, ReadonlySet<ModelSlug>> = {
   codex: new Set(MODEL_OPTIONS_BY_PROVIDER.codex.map((option) => option.slug)),
+  copilot: new Set(MODEL_OPTIONS_BY_PROVIDER.copilot.map((option) => option.slug)),
 };
 
 export function getModelOptions(provider: ProviderKind = "codex") {

--- a/patches/@github%2Fcopilot-sdk@0.1.32.patch
+++ b/patches/@github%2Fcopilot-sdk@0.1.32.patch
@@ -1,0 +1,10 @@
+diff --git a/dist/session.js b/dist/session.js
+index 1b92b458d7ebe6555be516dad26b1abf40efc64e..ae64f5d7e2cc6d4a41f70d42e3529ff3945c0446 100644
+--- a/dist/session.js
++++ b/dist/session.js
+@@ -1,4 +1,4 @@
+-import { ConnectionError, ResponseError } from "vscode-jsonrpc/node";
++import { ConnectionError, ResponseError } from "vscode-jsonrpc/node.js";
+ import { createSessionRpc } from "./generated/rpc.js";
+ class CopilotSession {
+   /**

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -10,6 +10,7 @@ import serverPackageJson from "../apps/server/package.json" with { type: "json" 
 
 import { BRAND_ASSET_PATHS } from "./lib/brand-assets.ts";
 import { resolveCatalogDependencies } from "./lib/resolve-catalog.ts";
+import { DEFAULT_GITHUB_REPOSITORY, parseGitHubRepository } from "@t3tools/shared/githubRepository";
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -164,17 +165,37 @@ interface ResolvedBuildOptions {
   readonly verbose: boolean;
 }
 
+function resolveBundledCopilotPlatformPackages(
+  platform: typeof BuildPlatform.Type,
+  arch: typeof BuildArch.Type,
+): ReadonlyArray<string> {
+  if (platform === "mac") {
+    if (arch === "universal") {
+      return ["@github/copilot-darwin-arm64", "@github/copilot-darwin-x64"];
+    }
+    return [arch === "arm64" ? "@github/copilot-darwin-arm64" : "@github/copilot-darwin-x64"];
+  }
+
+  if (platform === "linux") {
+    return [arch === "arm64" ? "@github/copilot-linux-arm64" : "@github/copilot-linux-x64"];
+  }
+
+  return [arch === "arm64" ? "@github/copilot-win32-arm64" : "@github/copilot-win32-x64"];
+}
+
 interface StagePackageJson {
   readonly name: string;
   readonly version: string;
   readonly buildVersion: string;
   readonly t3codeCommitHash: string;
+  readonly packageManager?: string;
   readonly private: true;
   readonly description: string;
   readonly author: string;
   readonly main: string;
   readonly build: Record<string, unknown>;
   readonly dependencies: Record<string, unknown>;
+  readonly patchedDependencies?: Record<string, string>;
   readonly devDependencies: {
     readonly electron: string;
   };
@@ -425,19 +446,17 @@ function resolveGitHubPublishConfig():
       readonly releaseType: "release";
     }
   | undefined {
-  const rawRepo =
+  const repository = parseGitHubRepository(
     process.env.T3CODE_DESKTOP_UPDATE_REPOSITORY?.trim() ||
-    process.env.GITHUB_REPOSITORY?.trim() ||
-    "";
-  if (!rawRepo) return undefined;
-
-  const [owner, repo, ...rest] = rawRepo.split("/");
-  if (!owner || !repo || rest.length > 0) return undefined;
+      process.env.GITHUB_REPOSITORY?.trim() ||
+      DEFAULT_GITHUB_REPOSITORY,
+  );
+  if (!repository) return undefined;
 
   return {
     provider: "github",
-    owner,
-    repo,
+    owner: repository.owner,
+    repo: repository.repo,
     releaseType: "release",
   };
 }
@@ -452,6 +471,7 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     appId: "com.t3tools.t3code",
     productName,
     artifactName: "T3-Code-${version}-${arch}.${ext}",
+    asarUnpack: ["node_modules/@github/copilot*/**/*"],
     directories: {
       buildResources: "apps/desktop/resources",
     },
@@ -559,6 +579,18 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
         cause,
       }),
   });
+  const bundledCopilotVersion = serverDependencies["@github/copilot"];
+  if (typeof bundledCopilotVersion !== "string" || bundledCopilotVersion.trim().length === 0) {
+    return yield* new BuildScriptError({
+      message: "Could not resolve bundled @github/copilot version from apps/server/package.json.",
+    });
+  }
+  const bundledCopilotPlatformDependencies = Object.fromEntries(
+    resolveBundledCopilotPlatformPackages(options.platform, options.arch).map((dependencyName) => [
+      dependencyName,
+      bundledCopilotVersion,
+    ]),
+  );
 
   const appVersion = options.version ?? serverPackageJson.version;
   const commitHash = resolveGitCommitHash(repoRoot);
@@ -617,11 +649,22 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   // electron-builder is filtering out stageResourcesDir directory in the AppImage for production
   yield* fs.copy(stageResourcesDir, path.join(stageAppDir, "apps/desktop/prod-resources"));
 
+  const rootPatchedDependencies = rootPackageJson.patchedDependencies;
+  if (rootPatchedDependencies) {
+    for (const relativePatchPath of Object.values(rootPatchedDependencies)) {
+      const sourcePatchPath = path.join(repoRoot, relativePatchPath);
+      const targetPatchPath = path.join(stageAppDir, relativePatchPath);
+      yield* fs.makeDirectory(path.dirname(targetPatchPath), { recursive: true });
+      yield* fs.copyFile(sourcePatchPath, targetPatchPath);
+    }
+  }
+
   const stagePackageJson: StagePackageJson = {
     name: "t3-code-desktop",
     version: appVersion,
     buildVersion: appVersion,
     t3codeCommitHash: commitHash,
+    packageManager: rootPackageJson.packageManager,
     private: true,
     description: "T3 Code desktop build",
     author: "T3 Tools",
@@ -634,8 +677,10 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     ),
     dependencies: {
       ...resolvedServerDependencies,
+      ...bundledCopilotPlatformDependencies,
       ...resolvedDesktopRuntimeDependencies,
     },
+    patchedDependencies: rootPatchedDependencies,
     devDependencies: {
       electron: electronVersion,
     },

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -17,6 +17,7 @@ const workspaceFiles = [
   "packages/shared/package.json",
   "scripts/package.json",
 ] as const;
+const workspaceDirectories = ["patches"] as const;
 
 function copyWorkspaceManifestFixture(targetRoot: string): void {
   for (const relativePath of workspaceFiles) {
@@ -24,6 +25,12 @@ function copyWorkspaceManifestFixture(targetRoot: string): void {
     const destinationPath = resolve(targetRoot, relativePath);
     mkdirSync(dirname(destinationPath), { recursive: true });
     cpSync(sourcePath, destinationPath);
+  }
+
+  for (const relativePath of workspaceDirectories) {
+    const sourcePath = resolve(repoRoot, relativePath);
+    const destinationPath = resolve(targetRoot, relativePath);
+    cpSync(sourcePath, destinationPath, { recursive: true });
   }
 }
 

--- a/scripts/run-effect-language-service-patch.mjs
+++ b/scripts/run-effect-language-service-patch.mjs
@@ -1,0 +1,36 @@
+import { spawnSync } from "node:child_process";
+
+if (process.env.EFFECT_LANGUAGE_SERVICE_PATCH !== "1") {
+  process.exit(0);
+}
+
+const result = spawnSync("effect-language-service", ["patch"], {
+  encoding: "utf8",
+  shell: process.platform === "win32",
+  stdio: "pipe",
+});
+
+if (result.stdout) {
+  process.stdout.write(result.stdout);
+}
+if (result.stderr) {
+  process.stderr.write(result.stderr);
+}
+
+if (result.status === 0) {
+  process.exit(0);
+}
+
+const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
+if (output.includes("UnableToFindPositionToPatchError")) {
+  console.warn(
+    "[effect-language-service] Skipping patch because the installed TypeScript version is not patchable by this release.",
+  );
+  process.exit(0);
+}
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
Base Setup (similar to @zortos293's repo)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub Copilot as a provider with login, model selection, and MCP/skills management
> - Adds the Copilot provider end-to-end: contracts, server health checks, session adapter ([CopilotAdapter.ts](https://github.com/pingdotgg/t3code/pull/1206/files#diff-d1fdd1ff48ff201b33512aada0688992230a399ec0b6482437aabdd0768bc6d9)), and registry wiring so Copilot runs alongside Codex
> - Adds Skills and MCP management: new server services ([SkillsManager.ts](https://github.com/pingdotgg/t3code/pull/1206/files#diff-d7d8c872bf73bc6b26e7875a44724147fe933a8742b3c8945234afd7c21f04e2), [McpManager.ts](https://github.com/pingdotgg/t3code/pull/1206/files#diff-e5f0c79d0ddce93a61fbb85931494278a81ae740d988335002eb0eb099afca60)), WebSocket routing, and dedicated UI routes ([_chat.skills.tsx](https://github.com/pingdotgg/t3code/pull/1206/files#diff-dc671ef740f5dea5f9605476644671bc5d45ce8f652ec3a0e2255f1c05e37143), [_chat.mcp.tsx](https://github.com/pingdotgg/t3code/pull/1206/files#diff-9416893a1aa884ed6ab2729b7d4f1f7a48829e07320f9fce52f637fb7a2206f7))
> - Extends contracts ([model.ts](https://github.com/pingdotgg/t3code/pull/1206/files#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959), [orchestration.ts](https://github.com/pingdotgg/t3code/pull/1206/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af), [mcp.ts](https://github.com/pingdotgg/t3code/pull/1206/files#diff-31eb17f71e9872283265f1da590d5b0f59c370d2be08db8ef8e0845c2bb5682b)) and app settings to cover Copilot model aliases, custom models, CLI path, and config dir
> - Adds `$skill` inline token support in the composer, a `/skills` slash command, and skill chips rendering in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/1206/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4)
> - Adds manual macOS update installer for unsigned builds with Admin fallback and structured backend restart policy with exponential backoff and fatal-failure threshold
> - Risk: Copilot adapter and health check spawn the Copilot CLI at startup; missing or misconfigured CLI will surface as a degraded/unavailable provider status rather than a hard error
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9660d9d. 40 files reviewed, 13 issues evaluated, 2 issues filtered, 7 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/ChatView.tsx — 2 comments posted, 5 evaluated, 2 filtered</summary>
>
> - [line 705](https://github.com/pingdotgg/t3code/blob/9660d9d53665a5ad4c1a9bdce13e134b98a962cb/apps/web/src/components/ChatView.tsx#L705): The import at line 169 references `CollapsibleContent` but the `./ui/collapsible` module (shown in references) only exports `CollapsiblePanel`, not `CollapsibleContent`. This will cause `CollapsibleContent` to be `undefined`, and using it at line 705 (`<CollapsibleContent>{expandedDetails}</CollapsibleContent>`) will fail at runtime. <b>[ Failed validation ]</b>
> - [line 6497](https://github.com/pingdotgg/t3code/blob/9660d9d53665a5ad4c1a9bdce13e134b98a962cb/apps/web/src/components/ChatView.tsx#L6497): The type guard claims to narrow `option.value` to `ProviderKind`, but only explicitly excludes `"claudeCode"` while `ProviderPickerKind` is `ProviderKind | "claudeCode" | "cursor"`. If `"cursor"` were to become available (`available: true`) in `PROVIDER_OPTIONS`, this function would return `true` for it, but the type assertion that `value: ProviderKind` would be incorrect since `"cursor"` is not part of `ProviderKind`. The check should also exclude `"cursor"` to match the type guard's claim. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->