### PR TITLE
Add a collapse-idle action to the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  collectSidebarNonIdleProjectIds,
   createThreadJumpHintVisibilityController,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
@@ -394,6 +395,54 @@ describe("isContextMenuPointerDown", () => {
   });
 });
 
+describe("collectSidebarNonIdleProjectIds", () => {
+  const projectA = "project-a" as never;
+  const projectB = "project-b" as never;
+  const threadA = { id: "thread-a" as never, projectId: projectA };
+  const threadB = { id: "thread-b" as never, projectId: projectB };
+  const workingStatus = {
+    label: "Working" as const,
+    colorClass: "text-sky-600",
+    dotClass: "bg-sky-500",
+    pulse: true,
+  };
+
+  it("preserves a project when one of its threads has a running terminal", () => {
+    const ids = collectSidebarNonIdleProjectIds({
+      activeProjectId: null,
+      threads: [threadA],
+      threadStatusById: new Map([[threadA.id, null]]),
+      runningTerminalThreadIds: new Set([threadA.id]),
+    });
+
+    expect(ids).toEqual(new Set([projectA]));
+  });
+
+  it("excludes projects that have neither thread status nor running terminals", () => {
+    const ids = collectSidebarNonIdleProjectIds({
+      activeProjectId: null,
+      threads: [threadA, threadB],
+      threadStatusById: new Map([
+        [threadA.id, null],
+        [threadB.id, workingStatus],
+      ]),
+      runningTerminalThreadIds: new Set(),
+    });
+
+    expect(ids).toEqual(new Set([projectB]));
+  });
+
+  it("preserves the active project even without thread status or terminal activity", () => {
+    const ids = collectSidebarNonIdleProjectIds({
+      activeProjectId: projectA,
+      threads: [threadA],
+      threadStatusById: new Map([[threadA.id, null]]),
+      runningTerminalThreadIds: new Set(),
+    });
+
+    expect(ids).toEqual(new Set([projectA]));
+  });
+});
 describe("resolveThreadStatusPill", () => {
   const baseThread = {
     hasActionableProposedPlan: false,

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import type { ProjectId, ThreadId } from "@t3tools/contracts";
 import type { SidebarThreadSummary, Thread } from "../types";
 import { cn } from "../lib/utils";
 import { isLatestTurnSettled } from "../session-logic";
@@ -277,6 +278,26 @@ export function isContextMenuPointerDown(input: {
   return input.isMac && input.button === 0 && input.ctrlKey;
 }
 
+export function collectSidebarNonIdleProjectIds(input: {
+  activeProjectId: ProjectId | null;
+  threads: readonly Pick<Thread, "id" | "projectId">[];
+  threadStatusById: ReadonlyMap<ThreadId, ThreadStatusPill | null>;
+  runningTerminalThreadIds: ReadonlySet<ThreadId>;
+}): Set<ProjectId> {
+  const ids = new Set<ProjectId>();
+  if (input.activeProjectId) {
+    ids.add(input.activeProjectId);
+  }
+
+  for (const thread of input.threads) {
+    const threadStatus = input.threadStatusById.get(thread.id) ?? null;
+    if (threadStatus !== null || input.runningTerminalThreadIds.has(thread.id)) {
+      ids.add(thread.projectId);
+    }
+  }
+
+  return ids;
+}
 export function resolveThreadRowClassName(input: {
   isActive: boolean;
   isSelected: boolean;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import {
   ArchiveIcon,
   ArrowUpDownIcon,
   ChevronRightIcon,
+  FoldVerticalIcon,
   FolderIcon,
   GitPullRequestIcon,
   PlusIcon,
@@ -115,6 +116,7 @@ import {
   isContextMenuPointerDown,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadSeedContext,
+  collectSidebarNonIdleProjectIds,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
@@ -153,7 +155,6 @@ interface TerminalStatusIndicator {
   colorClass: string;
   pulse: boolean;
 }
-
 interface PrStatusIndicator {
   label: "PR open" | "PR closed" | "PR merged";
   colorClass: string;
@@ -213,7 +214,6 @@ function terminalStatusFromRunningIds(
     pulse: true,
   };
 }
-
 function prStatusIndicator(pr: ThreadPr): PrStatusIndicator | null {
   if (!pr) return null;
 
@@ -685,6 +685,7 @@ export default function Sidebar() {
     })),
   );
   const markThreadUnread = useUiStateStore((store) => store.markThreadUnread);
+  const setProjectExpanded = useUiStateStore((store) => store.setProjectExpanded);
   const toggleProject = useUiStateStore((store) => store.toggleProject);
   const reorderProjects = useUiStateStore((store) => store.reorderProjects);
   const clearComposerDraftForThread = useComposerDraftStore((store) => store.clearDraftThread);
@@ -773,6 +774,41 @@ export default function Sidebar() {
       },
     }),
     [platform, routeTerminalOpen],
+  );
+  const threadStatusById = useMemo(() => {
+    const map = new Map<ThreadId, ReturnType<typeof resolveThreadStatusPill>>();
+    for (const thread of sidebarThreads) {
+      map.set(
+        thread.id,
+        resolveThreadStatusPill({
+          thread: {
+            ...thread,
+            lastVisitedAt: threadLastVisitedAtById[thread.id],
+          },
+        }),
+      );
+    }
+    return map;
+  }, [sidebarThreads, threadLastVisitedAtById]);
+  const runningTerminalThreadIds = useMemo(() => {
+    const ids = new Set<ThreadId>();
+    for (const thread of sidebarThreads) {
+      if (selectThreadTerminalState(terminalStateByThreadId, thread.id).runningTerminalIds.length) {
+        ids.add(thread.id);
+      }
+    }
+    return ids;
+  }, [sidebarThreads, terminalStateByThreadId]);
+  const activeProjectId = activeThread?.projectId ?? activeDraftThread?.projectId ?? null;
+  const nonIdleProjectIds = useMemo(
+    () =>
+      collectSidebarNonIdleProjectIds({
+        activeProjectId,
+        threads: sidebarThreads,
+        threadStatusById,
+        runningTerminalThreadIds,
+      }),
+    [activeProjectId, runningTerminalThreadIds, sidebarThreads, threadStatusById],
   );
   const openPrLink = useCallback((event: MouseEvent<HTMLElement>, prUrl: string) => {
     event.preventDefault();
@@ -1902,6 +1938,15 @@ export default function Sidebar() {
     [toggleProject],
   );
 
+  const handleCollapseIdleProjects = useCallback(() => {
+    for (const project of sidebarProjects) {
+      if (!project.expanded || nonIdleProjectIds.has(project.id)) {
+        continue;
+      }
+      setProjectExpanded(project.id, false);
+    }
+  }, [nonIdleProjectIds, setProjectExpanded, sidebarProjects]);
+
   useEffect(() => {
     const onMouseDown = (event: globalThis.MouseEvent) => {
       if (selectedThreadIds.size === 0) return;
@@ -2112,11 +2157,11 @@ export default function Sidebar() {
               </SidebarGroup>
             ) : null}
             <SidebarGroup className="px-2 py-2">
-              <div className="mb-1 flex items-center justify-between pl-2 pr-1.5">
+              <div className="mb-1 flex items-center justify-between px-2">
                 <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
                   Projects
                 </span>
-                <div className="flex items-center gap-1">
+                <div className="flex items-center gap-0.5">
                   <ProjectSortMenu
                     projectSortOrder={appSettings.sidebarProjectSortOrder}
                     threadSortOrder={appSettings.sidebarThreadSortOrder}
@@ -2127,6 +2172,21 @@ export default function Sidebar() {
                       updateSettings({ sidebarThreadSortOrder: sortOrder });
                     }}
                   />
+                  <Tooltip>
+                    <TooltipTrigger
+                      render={
+                        <button
+                          type="button"
+                          aria-label="Collapse idle projects"
+                          className="inline-flex size-5 cursor-pointer items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+                          onClick={handleCollapseIdleProjects}
+                        />
+                      }
+                    >
+                      <FoldVerticalIcon className="size-3.5" />
+                    </TooltipTrigger>
+                    <TooltipPopup side="top">Collapse idle projects</TooltipPopup>
+                  </Tooltip>
                   <Tooltip>
                     <TooltipTrigger
                       render={


### PR DESCRIPTION
## What Changed

- Added a `Collapse idle projects` action to the sidebar header.
- The action collapses expanded projects that are idle _(not the active project and no thread status or running terminal)_ while keeping the currently active project open.

## Why

The sidebar can accumulate a lot of expanded projects during _normal_ use. This adds a one-click cleanup path without collapsing the project you are currently in or other projects that still have visible thread activity.

## UI Changes

Video:

https://github.com/user-attachments/assets/0296c52f-f2f1-4517-a90f-588c2cd40e9e



Sorry that the mouse cursor is not visible in the recording.

Screenshot:

<img width="76" height="40" alt="image" src="https://github.com/user-attachments/assets/d2ac4020-3dcd-4e03-ade1-19fe5e8cf0ba" />


Added this tiny icon. Open for suggestions on a more fitting icon.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [/] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a 'Collapse idle projects' button to the sidebar
> Adds a `FoldVerticalIcon` button to the Projects section header in the sidebar. Clicking it collapses all expanded projects that have no running terminals and no active thread status, while keeping the currently active project and any projects with activity expanded. The logic is extracted into a `collectSidebarNonIdleProjectIds` utility in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/1210/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) with corresponding tests in [Sidebar.logic.test.ts](https://github.com/pingdotgg/t3code/pull/1210/files#diff-32549f6f09ae3a1d9d846a62727c17b9f9ec246030982995fd972b497a87335a).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7c33165. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary> (Automatic summaries will resume when PR exits draft mode or review begins).
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that adds a new sidebar action and supporting helper logic; main risk is minor behavioral/performance regressions in how project “activity” is detected for collapsing.
> 
> **Overview**
> Adds a **“Collapse idle projects”** button to the sidebar Projects header that collapses currently-expanded projects that have no active signal.
> 
> Introduces `collectSidebarNonIdleProjectIds` (with tests) and sidebar wiring to keep the active project, projects with non-null thread status pills, or projects with running terminal threads from being collapsed; includes minor header spacing tweaks and a new `FoldVerticalIcon` tooltip button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a622281c1d262081c7b5e29b9cacf9dc0bd4270. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->