### PR TITLE
Use secret release app ID in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,7 +312,7 @@ jobs:
         name: Mint release app token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 


### PR DESCRIPTION
## Summary
- Switch the release workflow to read `RELEASE_APP_ID` from secrets instead of repository variables.
- Keep the release app private key sourced from secrets as before.
- Align token minting with the existing secret-based release credential flow.

## Testing
- Not run (workflow-only change).
- Reviewed `.github/workflows/release.yml` diff for the token minting input update.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Read release app ID from secrets context in release workflow
> Changes the `app-id` input for the 'Mint release app token' step in [release.yml](.github/workflows/release.yml) from `vars.RELEASE_APP_ID` to `secrets.RELEASE_APP_ID`, treating the app ID as a secret rather than a public variable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e9de9fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->