### PR TITLE
Fix Codex provider banner for custom overrides

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -5,6 +5,7 @@ import {
   AppSettingsSchema,
   DEFAULT_TIMESTAMP_FORMAT,
   getAppModelOptions,
+  getCodexProviderOverrides,
   normalizeCustomModelSlugs,
   resolveAppModelSelection,
 } from "./appSettings";
@@ -110,6 +111,29 @@ describe("AppSettingsSchema", () => {
       timestampFormat: DEFAULT_TIMESTAMP_FORMAT,
       customCodexModels: [],
       customClaudeModels: [],
+    });
+  });
+});
+
+describe("getCodexProviderOverrides", () => {
+  it("returns undefined when both overrides are blank", () => {
+    expect(
+      getCodexProviderOverrides({
+        codexBinaryPath: "   ",
+        codexHomePath: "",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns trimmed override values", () => {
+    expect(
+      getCodexProviderOverrides({
+        codexBinaryPath: " /usr/local/bin/codex ",
+        codexHomePath: " /Users/test/.codex ",
+      }),
+    ).toEqual({
+      binaryPath: "/usr/local/bin/codex",
+      homePath: "/Users/test/.codex",
     });
   });
 });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 import { Option, Schema } from "effect";
-import { TrimmedNonEmptyString, type ProviderKind } from "@t3tools/contracts";
+import {
+  TrimmedNonEmptyString,
+  type ProviderKind,
+  type ProviderStartOptions,
+} from "@t3tools/contracts";
 import { getDefaultModel, getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 import { useLocalStorage } from "./hooks/useLocalStorage";
 import { EnvMode } from "./components/BranchToolbar.logic";
@@ -87,6 +91,29 @@ function normalizeAppSettings(settings: AppSettings): AppSettings {
     customClaudeModels: normalizeCustomModelSlugs(settings.customClaudeModels, "claudeAgent"),
   };
 }
+
+function trimToUndefined(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+export function getCodexProviderOverrides(settings: {
+  codexBinaryPath: AppSettings["codexBinaryPath"];
+  codexHomePath: AppSettings["codexHomePath"];
+}): NonNullable<ProviderStartOptions["codex"]> | undefined {
+  const binaryPath = trimToUndefined(settings.codexBinaryPath);
+  const homePath = trimToUndefined(settings.codexHomePath);
+
+  if (!binaryPath && !homePath) {
+    return undefined;
+  }
+
+  return {
+    ...(binaryPath ? { binaryPath } : {}),
+    ...(homePath ? { homePath } : {}),
+  };
+}
+
 export function getAppModelOptions(
   provider: ProviderKind,
   customModels: readonly string[],

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,7 +1,23 @@
-import { ThreadId } from "@t3tools/contracts";
+import { ThreadId, type ServerProviderStatus } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { buildExpiredTerminalContextToastCopy, deriveComposerSendState } from "./ChatView.logic";
+import {
+  buildExpiredTerminalContextToastCopy,
+  deriveComposerSendState,
+  resolveProviderHealthBannerStatus,
+} from "./ChatView.logic";
+
+function makeProviderStatus(overrides: Partial<ServerProviderStatus> = {}): ServerProviderStatus {
+  return {
+    provider: "codex",
+    status: "error",
+    available: false,
+    authStatus: "unknown",
+    checkedAt: "2026-03-20T00:00:00.000Z",
+    message: "Codex CLI (`codex`) is not installed or not on PATH.",
+    ...overrides,
+  };
+}
 
 describe("deriveComposerSendState", () => {
   it("treats expired terminal pills as non-sendable content", () => {
@@ -65,5 +81,35 @@ describe("buildExpiredTerminalContextToastCopy", () => {
       title: "Expired terminal contexts omitted from message",
       description: "Re-add it if you want that terminal output included.",
     });
+  });
+});
+
+describe("resolveProviderHealthBannerStatus", () => {
+  it("keeps the server status when no local Codex overrides are configured", () => {
+    const status = makeProviderStatus();
+
+    expect(resolveProviderHealthBannerStatus(status, false)).toEqual(status);
+  });
+
+  it("hides Codex status when a custom binary path is configured", () => {
+    expect(resolveProviderHealthBannerStatus(makeProviderStatus(), true)).toBeNull();
+  });
+
+  it("hides Codex status when a custom CODEX_HOME is configured", () => {
+    expect(
+      resolveProviderHealthBannerStatus(
+        makeProviderStatus({ status: "warning", available: true }),
+        true,
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps non-Codex provider status visible even with Codex overrides", () => {
+    const status = makeProviderStatus({
+      provider: "claudeAgent",
+      message: "Claude Agent CLI (`claude`) is not installed or not on PATH.",
+    });
+
+    expect(resolveProviderHealthBannerStatus(status, true)).toEqual(status);
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,4 +1,9 @@
-import { ProjectId, type ProviderKind, type ThreadId } from "@t3tools/contracts";
+import {
+  ProjectId,
+  type ProviderKind,
+  type ServerProviderStatus,
+  type ThreadId,
+} from "@t3tools/contracts";
 import { type ChatMessage, type Thread } from "../types";
 import { randomUUID } from "~/lib/utils";
 import { getAppModelOptions } from "../appSettings";
@@ -129,6 +134,13 @@ export function getCustomModelOptionsByProvider(settings: {
     codex: getAppModelOptions("codex", settings.customCodexModels),
     claudeAgent: getAppModelOptions("claudeAgent", settings.customClaudeModels),
   };
+}
+
+export function resolveProviderHealthBannerStatus(
+  status: ServerProviderStatus | null,
+  hasCodexOverrides: boolean,
+): ServerProviderStatus | null {
+  return status?.provider === "codex" && hasCodexOverrides ? null : status;
 }
 
 export function deriveComposerSendState(options: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -126,7 +126,11 @@ import {
 import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
-import { resolveAppModelSelection, useAppSettings } from "../appSettings";
+import {
+  getCodexProviderOverrides,
+  resolveAppModelSelection,
+  useAppSettings,
+} from "../appSettings";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import {
   type ComposerImageAttachment,
@@ -173,6 +177,7 @@ import {
   LastInvokedScriptByProjectSchema,
   PullRequestDialogState,
   readFileAsDataUrl,
+  resolveProviderHealthBannerStatus,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
   SendPhase,
@@ -662,17 +667,18 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
     return undefined;
   }, [draftModelOptions, selectedModel, selectedProvider]);
-  const providerOptionsForDispatch = useMemo(() => {
-    if (!settings.codexBinaryPath && !settings.codexHomePath) {
-      return undefined;
-    }
-    return {
-      codex: {
-        ...(settings.codexBinaryPath ? { binaryPath: settings.codexBinaryPath } : {}),
-        ...(settings.codexHomePath ? { homePath: settings.codexHomePath } : {}),
-      },
-    };
-  }, [settings.codexBinaryPath, settings.codexHomePath]);
+  const codexProviderOverrides = useMemo(
+    () =>
+      getCodexProviderOverrides({
+        codexBinaryPath: settings.codexBinaryPath,
+        codexHomePath: settings.codexHomePath,
+      }),
+    [settings.codexBinaryPath, settings.codexHomePath],
+  );
+  const providerOptionsForDispatch = useMemo(
+    () => (codexProviderOverrides ? { codex: codexProviderOverrides } : undefined),
+    [codexProviderOverrides],
+  );
   const selectedModelForPicker = selectedModel;
   const modelOptionsByProvider = useMemo(
     () => getCustomModelOptionsByProvider(settings),
@@ -1150,9 +1156,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const availableEditors = serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
   const providerStatuses = serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES;
   const activeProvider = activeThread?.session?.provider ?? "codex";
-  const activeProviderStatus = useMemo(
-    () => providerStatuses.find((status) => status.provider === activeProvider) ?? null,
-    [activeProvider, providerStatuses],
+  const hasCodexProviderOverrides = codexProviderOverrides !== undefined;
+  const activeProviderBannerStatus = useMemo(
+    () =>
+      resolveProviderHealthBannerStatus(
+        providerStatuses.find((status) => status.provider === activeProvider) ?? null,
+        hasCodexProviderOverrides,
+      ),
+    [activeProvider, hasCodexProviderOverrides, providerStatuses],
   );
   const activeProjectCwd = activeProject?.cwd ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
@@ -3528,7 +3539,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       </header>
 
       {/* Error banner */}
-      <ProviderHealthBanner status={activeProviderStatus} />
+      <ProviderHealthBanner status={activeProviderBannerStatus} />
       <ThreadErrorBanner
         error={activeThread.error}
         onDismiss={() => setThreadError(activeThread.id, null)}


### PR DESCRIPTION
## What Changed
- normalized Codex binary and home overrides into a shared app settings helper
- suppressed the Codex provider banner when local Codex overrides are configured
- added focused tests for override normalization and banner suppression

## Why
The server provider health snapshot uses the default Codex environment, while new sessions can use browser-configured Codex overrides. This removes the false unavailable banner in that override case and keeps the override handling consistent in one place.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex provider banner to hide health status when custom overrides are configured
> - Adds `getCodexProviderOverrides` in [appSettings.ts](https://github.com/pingdotgg/t3code/pull/1218/files#diff-4f500b80c5f743d5b39d3f07498169da0c26f4bf9b5a2127453a90c04a4c49cc) to trim `codexBinaryPath` and `codexHomePath` from `AppSettings`, returning `undefined` when both are blank.
> - Adds `resolveProviderHealthBannerStatus` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/1218/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to suppress the Codex provider health banner when local overrides are present; other providers are unaffected.
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1218/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to use both utilities, so `ProviderHealthBanner` no longer shows Codex health when a custom binary path or `CODEX_HOME` is configured.
> - Behavioral Change: the Codex health banner is now hidden whenever `codexBinaryPath` or `codexHomePath` is set to a non-blank value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8485a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->