### PR TITLE
[agent] fix(web): include Claude models in git text generation model picker

### DIFF
--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -126,11 +126,13 @@ function SettingsRouteView() {
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
   const availableEditors = serverConfigQuery.data?.availableEditors;
 
-  const gitTextGenerationModelOptions = getAppModelOptions(
-    "codex",
-    settings.customCodexModels,
-    settings.textGenerationModel,
-  );
+  const gitTextGenerationModelOptions = (() => {
+    const codexOptions = getAppModelOptions("codex", settings.customCodexModels, settings.textGenerationModel);
+    const seen = new Set(codexOptions.map((o) => o.slug));
+    const claudeOptions = getAppModelOptions("claudeAgent", settings.customClaudeModels, settings.textGenerationModel)
+      .filter((o) => !seen.has(o.slug));
+    return [...codexOptions, ...claudeOptions];
+  })();
   const selectedGitTextGenerationModelLabel =
     gitTextGenerationModelOptions.find(
       (option) =>


### PR DESCRIPTION
## Summary

- The "Text generation model" dropdown in Settings → Git only listed Codex models
- With Claude now a first-class provider (#179), users should be able to select Claude models for auto-generated commit messages, PR titles, and branch names
- Merges both Codex and Claude model lists (with dedup) into the picker

Fixes #1221

See also #1219 for default model/provider settings (separate concern, but related).

## Changes

One file changed (`apps/web/src/routes/_chat.settings.tsx`):
- `gitTextGenerationModelOptions` now combines models from both providers instead of hardcoding `"codex"`

> This PR was generated by AI (Claude Code). All code changes were authored by Claude Opus 4.6.

## Test plan

- [ ] Open Settings → Git → Text generation model dropdown
- [ ] Verify Claude models (Opus 4.6, Sonnet 4.6, Haiku 4.5) appear alongside Codex models
- [ ] Select a Claude model, verify it persists
- [ ] Verify "Restore default" still works

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>