### PR TITLE
🐛 fix: prevent checkpoint timeout when running from home directory

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -10,6 +10,7 @@
  * @module CheckpointStoreLive
  */
 import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
 
 import { Effect, Layer, FileSystem, Path } from "effect";
 
@@ -24,6 +25,11 @@ const makeCheckpointStore = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const git = yield* GitService;
+
+  const isHomeDirectory = (cwd: string): boolean => {
+    const home = homedir();
+    return cwd === home;
+  };
 
   const resolveHeadCommit = (cwd: string): Effect.Effect<string | null, GitCommandError> =>
     git
@@ -75,21 +81,36 @@ const makeCheckpointStore = Effect.gen(function* () {
       );
 
   const isGitRepository: CheckpointStoreShape["isGitRepository"] = (cwd) =>
-    git
-      .execute({
-        operation: "CheckpointStore.isGitRepository",
-        cwd,
-        args: ["rev-parse", "--is-inside-work-tree"],
-        allowNonZeroExit: true,
-      })
-      .pipe(
-        Effect.map((result) => result.code === 0 && result.stdout.trim() === "true"),
-        Effect.catch(() => Effect.succeed(false)),
-      );
+    Effect.gen(function* () {
+      // Never treat home directory as a valid git workspace for checkpointing
+      if (isHomeDirectory(cwd)) {
+        return false;
+      }
+      return yield* git
+        .execute({
+          operation: "CheckpointStore.isGitRepository",
+          cwd,
+          args: ["rev-parse", "--is-inside-work-tree"],
+          allowNonZeroExit: true,
+        })
+        .pipe(
+          Effect.map((result) => result.code === 0 && result.stdout.trim() === "true"),
+          Effect.catch(() => Effect.succeed(false)),
+        );
+    });
 
   const captureCheckpoint: CheckpointStoreShape["captureCheckpoint"] = (input) =>
     Effect.gen(function* () {
       const operation = "CheckpointStore.captureCheckpoint";
+
+      // Skip checkpointing from home directory - it contains too many files and will timeout
+      if (isHomeDirectory(input.cwd)) {
+        yield* Effect.logWarning("Skipping checkpoint from home directory", {
+          cwd: input.cwd,
+          reason: "Home directory contains too many files; checkpointing would timeout",
+        });
+        return;
+      }
 
       yield* Effect.acquireUseRelease(
         fs.makeTempDirectory({ prefix: "t3-fs-checkpoint-" }),


### PR DESCRIPTION
## Summary

- Prevents git timeout when T3 is run from home directory
- Detects home directory using `homedir()` from `node:os`
- Skips checkpointing with warning log instead of letting 30-second timeout occur
- Returns `false` for `isGitRepository` on home directories

## Changes

This PR adds early detection of home directories to prevent the `git add -A -- .` command from timing out. Home directories typically contain thousands of files (Applications, .npm, .cache, etc.) which makes staging extremely slow.

The checkpoint system is designed for project-level work where git repositories have a manageable number of tracked files—not for entire home directories.

### Files Modified

- `apps/server/src/checkpointing/Layers/CheckpointStore.ts`:
  - Added `isHomeDirectory()` helper function
  - Updated `isGitRepository()` to return `false` for home directories
  - Updated `captureCheckpoint()` to skip with warning for home directories

## Test Plan

- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Manual testing: Run T3 from home directory and verify warning appears instead of timeout
- [x] Manual testing: Run T3 from a project directory and verify checkpointing still works

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (added inline comments explaining the fix)
- [x] No new warnings generated (typecheck passes)
- [ ] Tests added/updated (no existing tests for this specific scenario)

## Related Issue

Resolves #1227

## Notes

This is a small, focused bug fix that aligns with the contribution guidelines:
- Small reliability fix (prevents timeout crashes)
- Minimal code change (32 lines added, 11 removed)
- Clear explanation of what and why
- No scope expansion or feature creep

If running from home directory, users should navigate to a project directory first (e.g., `cd ~/my-project && npx t3`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix checkpoint timeout when running from the home directory
> Running the app from the home directory could trigger a checkpoint timeout because git operations on `~` are slow or hang. `isGitRepository` now short-circuits to `false` and `captureCheckpoint` exits early with a warning log when `cwd` matches `os.homedir()`, skipping all git index and commit logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54c00d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->