### PR TITLE
fix: enable custom model selection for Claude Code provider

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -493,7 +493,7 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
-  it("rejects a first turn when requested provider conflicts with the thread model", async () => {
+  it("allows a first turn when requested provider differs from thread model", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
 
@@ -515,34 +515,15 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await Effect.runPromise(harness.engine.getReadModel());
-      const thread = readModel.threads.find(
-        (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
-      );
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
 
-    expect(harness.startSession).not.toHaveBeenCalled();
-    expect(harness.sendTurn).not.toHaveBeenCalled();
-
-    const readModel = await Effect.runPromise(harness.engine.getReadModel());
-    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
-    expect(thread?.session).toBeNull();
-    expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      summary: "Provider turn start failed",
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
-      },
+    // First turn should succeed and bind to the requested provider
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      provider: "claudeAgent",
     });
   });
 
-  it("rejects a turn when the requested model belongs to a different provider", async () => {
+  it("allows a first turn when model belongs to a different provider", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
 
@@ -564,28 +545,11 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await Effect.runPromise(harness.engine.getReadModel());
-      const thread = readModel.threads.find(
-        (entry) => entry.id === ThreadId.makeUnsafe("thread-1"),
-      );
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
 
-    expect(harness.startSession).not.toHaveBeenCalled();
-    expect(harness.sendTurn).not.toHaveBeenCalled();
-
-    const readModel = await Effect.runPromise(harness.engine.getReadModel());
-    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
-    expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("does not belong to provider 'codex'"),
-      },
+    // First turn should succeed and infer claudeAgent from the model
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      provider: "claudeAgent",
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -26,7 +26,7 @@ import {
   ProviderCommandReactor,
   type ProviderCommandReactorShape,
 } from "../Services/ProviderCommandReactor.ts";
-import { inferProviderForModel } from "@t3tools/shared/model";
+import { inferProviderForModel, isKnownModelSlug } from "@t3tools/shared/model";
 
 type ProviderIntentEvent = Extract<
   OrchestrationEvent,
@@ -233,26 +233,44 @@ const make = Effect.gen(function* () {
     )
       ? thread.session.providerName
       : undefined;
-    const threadProvider: ProviderKind = currentProvider ?? inferProviderForModel(thread.model);
-    if (options?.provider !== undefined && options.provider !== threadProvider) {
+    // Determine the effective thread provider based on session state.
+    // First turn (no session): trust explicit options.provider, then options.model, then fallback.
+    // Subsequent turns: enforce binding — no provider switching allowed after session is established.
+    const threadProvider: ProviderKind =
+      currentProvider ??
+      (options?.provider ?? null) ??
+      (options?.model ? inferProviderForModel(options.model, "codex") : null) ??
+      "codex";
+
+    // Only enforce binding when session already exists.
+    if (currentProvider !== undefined && options?.provider !== undefined && options.provider !== currentProvider) {
       return yield* new ProviderAdapterRequestError({
-        provider: threadProvider,
+        provider: currentProvider,
         method: "thread.turn.start",
-        detail: `Thread '${threadId}' is bound to provider '${threadProvider}' and cannot switch to '${options.provider}'.`,
+        detail: `Thread '${threadId}' is bound to provider '${currentProvider}' and cannot switch to '${options.provider}'.`,
       });
     }
-    if (
-      options?.model !== undefined &&
-      inferProviderForModel(options.model, threadProvider) !== threadProvider
-    ) {
-      return yield* new ProviderAdapterRequestError({
-        provider: threadProvider,
-        method: "thread.turn.start",
-        detail: `Model '${options.model}' does not belong to provider '${threadProvider}' for thread '${threadId}'.`,
-      });
+
+    // Binding check for model vs provider mismatch only when session exists.
+    if (currentProvider !== undefined && options?.model !== undefined) {
+      const modelProvider = inferProviderForModel(options.model, currentProvider);
+      if (modelProvider !== currentProvider) {
+        return yield* new ProviderAdapterRequestError({
+          provider: currentProvider,
+          method: "thread.turn.start",
+          detail: `Model '${options.model}' does not belong to provider '${currentProvider}' for thread '${threadId}'.`,
+        });
+      }
     }
-    const preferredProvider: ProviderKind = currentProvider ?? threadProvider;
-    const desiredModel = options?.model ?? thread.model;
+
+    const preferredProvider: ProviderKind = currentProvider ?? (options?.provider ?? threadProvider);
+    // Only pass known model slugs to the SDK. Unknown custom models (e.g., "MiniMax-M2.7")
+    // should be left for the SDK to resolve via ANTHROPIC_MODEL env var.
+    const optionsModel = options?.model;
+    const desiredModel =
+      optionsModel && isKnownModelSlug(optionsModel, preferredProvider)
+        ? optionsModel
+        : (thread.model ?? null) ?? undefined;
     const effectiveCwd = resolveThreadWorkspaceCwd({
       thread,
       projects: readModel.projects,

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -27,6 +27,7 @@ import Migration0012 from "./Migrations/012_ProjectionThreadsInteractionMode.ts"
 import Migration0013 from "./Migrations/013_ProjectionThreadProposedPlans.ts";
 import Migration0014 from "./Migrations/014_ProjectionThreadProposedPlanImplementation.ts";
 import Migration0015 from "./Migrations/015_ProjectionTurnsSourceProposedPlan.ts";
+import Migration0016 from "./Migrations/016_ProjectionThreadsModelNullable.ts";
 import { Effect } from "effect";
 
 /**
@@ -55,6 +56,7 @@ const loader = Migrator.fromRecord({
   "13_ProjectionThreadProposedPlans": Migration0013,
   "14_ProjectionThreadProposedPlanImplementation": Migration0014,
   "15_ProjectionTurnsSourceProposedPlan": Migration0015,
+  "16_ProjectionThreadsModelNullable": Migration0016,
 });
 
 /**

--- a/apps/server/src/persistence/Migrations/016_ProjectionThreadsModelNullable.ts
+++ b/apps/server/src/persistence/Migrations/016_ProjectionThreadsModelNullable.ts
@@ -1,0 +1,64 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  // SQLite doesn't support ALTER TABLE to change NOT NULL to nullable,
+  // so we need to recreate the table
+  yield* sql`
+    ALTER TABLE projection_threads RENAME TO projection_threads_old
+  `;
+
+  yield* sql`
+    CREATE TABLE projection_threads (
+      thread_id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      model TEXT,
+      runtime_mode TEXT NOT NULL,
+      interaction_mode TEXT NOT NULL,
+      branch TEXT,
+      worktree_path TEXT,
+      latest_turn_id TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      deleted_at TEXT
+    )
+  `;
+
+  yield* sql`
+    INSERT INTO projection_threads (
+      thread_id,
+      project_id,
+      title,
+      model,
+      runtime_mode,
+      interaction_mode,
+      branch,
+      worktree_path,
+      latest_turn_id,
+      created_at,
+      updated_at,
+      deleted_at
+    )
+    SELECT
+      thread_id,
+      project_id,
+      title,
+      model,
+      runtime_mode,
+      interaction_mode,
+      branch,
+      worktree_path,
+      latest_turn_id,
+      created_at,
+      updated_at,
+      deleted_at
+    FROM projection_threads_old
+  `;
+
+  yield* sql`
+    DROP TABLE projection_threads_old
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreads.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreads.ts
@@ -23,7 +23,7 @@ export const ProjectionThread = Schema.Struct({
   threadId: ThreadId,
   projectId: ProjectId,
   title: Schema.String,
-  model: Schema.String,
+  model: Schema.NullOr(Schema.String),
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode,
   branch: Schema.NullOr(Schema.String),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -61,6 +61,7 @@ import {
   Queue,
   Random,
   Ref,
+  Schema,
   Stream,
 } from "effect";
 
@@ -79,22 +80,25 @@ import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogg
 
 const PROVIDER = "claudeAgent" as const;
 
+const SettingsJsonSchema = Schema.Struct({
+  env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+});
+
 /**
  * Reads the `env` block from `~/.claude/settings.json` and returns it as a
  * plain object. This is needed because GUI applications on macOS don't inherit
  * shell environment variables, so the Claude binary would not receive API
  * credentials from settings.json when spawned programmatically.
  */
-function getClaudeEnvFromSettings(): Record<string, string> {
-  try {
+const getClaudeEnvFromSettings = Effect.try({
+  try: () => {
     const settingsPath = path.join(os.homedir(), ".claude", "settings.json");
     const content = fs.readFileSync(settingsPath, "utf-8");
-    const parsed = JSON.parse(content) as { env?: Record<string, string> };
-    return parsed.env ?? {};
-  } catch {
-    return {};
-  }
-}
+    const decoded = Schema.decodeUnknownSync(SettingsJsonSchema)(content);
+    return decoded.env ?? {};
+  },
+  catch: () => ({} as Record<string, string>),
+});
 
 type ClaudeTextStreamKind = Extract<RuntimeContentStreamKind, "assistant_text" | "reasoning_text">;
 type ClaudeToolResultStreamKind = Extract<
@@ -2596,7 +2600,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(newSessionId ? { sessionId: newSessionId } : {}),
           includePartialMessages: true,
           canUseTool,
-          env: { ...process.env, ...getClaudeEnvFromSettings() },
+          env: (() => {
+            const result = Effect.runSync(Effect.result(getClaudeEnvFromSettings));
+            return result._tag === "Success" ? result.success : {};
+          })(),
           settingSources: ["user"],
           ...(input.cwd ? { additionalDirectories: [input.cwd] } : {}),
         };

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -17,6 +17,9 @@ import {
   type SDKResultMessage,
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   ApprovalRequestId,
   type CanonicalItemType,
@@ -75,6 +78,24 @@ import { ClaudeAdapter, type ClaudeAdapterShape } from "../Services/ClaudeAdapte
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
 
 const PROVIDER = "claudeAgent" as const;
+
+/**
+ * Reads the `env` block from `~/.claude/settings.json` and returns it as a
+ * plain object. This is needed because GUI applications on macOS don't inherit
+ * shell environment variables, so the Claude binary would not receive API
+ * credentials from settings.json when spawned programmatically.
+ */
+function getClaudeEnvFromSettings(): Record<string, string> {
+  try {
+    const settingsPath = path.join(os.homedir(), ".claude", "settings.json");
+    const content = fs.readFileSync(settingsPath, "utf-8");
+    const parsed = JSON.parse(content) as { env?: Record<string, string> };
+    return parsed.env ?? {};
+  } catch {
+    return {};
+  }
+}
+
 type ClaudeTextStreamKind = Extract<RuntimeContentStreamKind, "assistant_text" | "reasoning_text">;
 type ClaudeToolResultStreamKind = Extract<
   RuntimeContentStreamKind,
@@ -2575,7 +2596,8 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(newSessionId ? { sessionId: newSessionId } : {}),
           includePartialMessages: true,
           canUseTool,
-          env: process.env,
+          env: { ...process.env, ...getClaudeEnvFromSettings() },
+          settingSources: ["user"],
           ...(input.cwd ? { additionalDirectories: [input.cwd] } : {}),
         };
 

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -631,13 +631,13 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         (project) => project.workspaceRoot === cwd && project.deletedAt === null,
       );
       let bootstrapProjectId: ProjectId;
-      let bootstrapProjectDefaultModel: string;
+      let bootstrapProjectDefaultModel: string | undefined;
 
       if (!existingProject) {
         const createdAt = new Date().toISOString();
         bootstrapProjectId = ProjectId.makeUnsafe(crypto.randomUUID());
         const bootstrapProjectTitle = path.basename(cwd) || "project";
-        bootstrapProjectDefaultModel = "gpt-5-codex";
+        bootstrapProjectDefaultModel = undefined;
         yield* orchestrationEngine.dispatch({
           type: "project.create",
           commandId: CommandId.makeUnsafe(crypto.randomUUID()),
@@ -649,7 +649,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         });
       } else {
         bootstrapProjectId = existingProject.id;
-        bootstrapProjectDefaultModel = existingProject.defaultModel ?? "gpt-5-codex";
+        bootstrapProjectDefaultModel = existingProject.defaultModel ?? undefined;
       }
 
       const existingThread = snapshot.threads.find(
@@ -664,7 +664,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
           threadId,
           projectId: bootstrapProjectId,
           title: "New thread",
-          model: bootstrapProjectDefaultModel,
+          model: bootstrapProjectDefaultModel ?? null,
           interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
           runtimeMode: "full-access",
           branch: null,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -273,7 +273,9 @@ export const OrchestrationThread = Schema.Struct({
   id: ThreadId,
   projectId: ProjectId,
   title: TrimmedNonEmptyString,
-  model: TrimmedNonEmptyString,
+  model: Schema.NullOr(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(() => null),
+  ),
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode.pipe(
     Schema.withDecodingDefault(() => DEFAULT_PROVIDER_INTERACTION_MODE),
@@ -332,7 +334,7 @@ const ThreadCreateCommand = Schema.Struct({
   threadId: ThreadId,
   projectId: ProjectId,
   title: TrimmedNonEmptyString,
-  model: TrimmedNonEmptyString,
+  model: Schema.NullOr(TrimmedNonEmptyString),
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode.pipe(
     Schema.withDecodingDefault(() => DEFAULT_PROVIDER_INTERACTION_MODE),
@@ -634,7 +636,9 @@ export const ThreadCreatedPayload = Schema.Struct({
   threadId: ThreadId,
   projectId: ProjectId,
   title: TrimmedNonEmptyString,
-  model: TrimmedNonEmptyString,
+  model: Schema.NullOr(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(() => null),
+  ),
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(() => DEFAULT_RUNTIME_MODE)),
   interactionMode: ProviderInteractionMode.pipe(
     Schema.withDecodingDefault(() => DEFAULT_PROVIDER_INTERACTION_MODE),

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -20,6 +20,12 @@ const MODEL_SLUG_SET_BY_PROVIDER: Record<ProviderKind, ReadonlySet<ModelSlug>> =
   codex: new Set(MODEL_OPTIONS_BY_PROVIDER.codex.map((option) => option.slug)),
 };
 
+export function isKnownModelSlug(model: string | null | undefined, provider: ProviderKind): boolean {
+  if (typeof model !== "string") return false;
+  const normalized = normalizeModelSlug(model, provider);
+  return normalized !== null && MODEL_SLUG_SET_BY_PROVIDER[provider].has(normalized);
+}
+
 const CLAUDE_OPUS_4_6_MODEL = "claude-opus-4-6";
 const CLAUDE_SONNET_4_6_MODEL = "claude-sonnet-4-6";
 const CLAUDE_HAIKU_4_5_MODEL = "claude-haiku-4-5";


### PR DESCRIPTION
## What Changed

  - Allow threads to be created without a hardcoded model (model is now nullable)
  - Defer provider binding to first turn instead of thread creation, so users can switch to custom models (MiniMax, etc.) before sending their first message
  - Fix GUI app authentication by reading API credentials from `~/.claude/settings.json`
  - Enable skills loading from `settings.json` via `settingSources: ["user"]`

## Why

  - Threads were previously hardcoded to `gpt-5-codex` at creation, preventing users from selecting custom models like MiniMax, GLM, etc. Additionally, provider binding happened at thread creation which rejected any different model on the first turn.

  - This fix defers provider binding to the first turn, allowing users to explicitly select their desired model and provider before the session is bound. The fix also ensures GUI apps can authenticate properly and load skills from the user's settings.

## Checklist

  - [x] This PR is small and focused
  - [x] I explained what changed and why
  - [ ] I included before/after screenshots for any UI changes
  - [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable custom model selection for the Claude Code provider on first turn
> - Provider/model binding constraints in `ProviderCommandReactor` are now enforced only after a session exists; first turns can specify a provider or model that differs from the thread's configured model.
> - Adds `isKnownModelSlug` to [model.ts](https://github.com/pingdotgg/t3code/pull/1229/files#diff-6319cd97b4ed5842958c7fbc93b4ed733efa158c2b1ad15c1d54bcddea713505) to validate model slugs per provider; unknown slugs on first turn are not forwarded to the SDK.
> - Makes `projection_threads.model` nullable via a new DB migration ([016](https://github.com/pingdotgg/t3code/pull/1229/files#diff-ccd8bd27ef8b2b6833a074f99c95e15fa5b92c78fc74b1c10b026c5a0b21ab59)) and updates related schemas in contracts and persistence layers.
> - Replaces `process.env` with environment variables sourced from `~/.claude/settings.json` when invoking the Claude Agent SDK in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/1229/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc).
> - Behavioral Change: auto-bootstrapped threads in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/1229/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) may now be created with `model = null` when no project default model exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 594b628.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->