### PR TITLE
fix(server): auto-recover from corrupted SQLite database on startup

### DIFF
--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -1,8 +1,30 @@
 import { Effect, Layer, FileSystem, Path } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
+import { openSync, readSync, closeSync } from "node:fs";
 
 import { runMigrations } from "../Migrations.ts";
 import { ServerConfig } from "../../config.ts";
+
+// First 16 bytes of every valid SQLite database file
+const SQLITE_MAGIC = "SQLite format 3\0";
+
+/** Check whether the file at `dbPath` starts with the SQLite magic header. */
+const isSqliteFileValid = (dbPath: string): Effect.Effect<boolean> =>
+  Effect.sync(() => {
+    try {
+      const fd = openSync(dbPath, "r");
+      try {
+        const buf = Buffer.alloc(16);
+        const bytesRead = readSync(fd, buf, 0, 16, 0);
+        if (bytesRead < 16) return false;
+        return buf.toString("ascii", 0, 16) === SQLITE_MAGIC;
+      } finally {
+        closeSync(fd);
+      }
+    } catch {
+      return false;
+    }
+  });
 
 type RuntimeSqliteLayerConfig = {
   readonly filename: string;
@@ -40,6 +62,27 @@ export const makeSqlitePersistenceLive = (dbPath: string) =>
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     yield* fs.makeDirectory(path.dirname(dbPath), { recursive: true });
+
+    // Detect and recover from a corrupted database file.
+    // A valid SQLite file must start with "SQLite format 3\0".
+    // If the header is invalid, back up the corrupted file and let
+    // a fresh database be created so the app can start.
+    const fileExists = yield* fs.exists(dbPath);
+    if (fileExists) {
+      const valid = yield* isSqliteFileValid(dbPath);
+      if (!valid) {
+        const backupPath = `${dbPath}.corrupted.${Date.now()}`;
+        yield* Effect.logWarning(
+          `Corrupted database detected at ${dbPath}. ` +
+            `Backing up to ${backupPath} and creating a fresh database. ` +
+            `Session history will be reset.`,
+        );
+        yield* fs.rename(dbPath, backupPath);
+        // Remove stale WAL/SHM journal files from the corrupted database
+        yield* fs.remove(`${dbPath}-wal`).pipe(Effect.ignore);
+        yield* fs.remove(`${dbPath}-shm`).pipe(Effect.ignore);
+      }
+    }
 
     return Layer.provideMerge(setup, makeRuntimeSqliteLayer({ filename: dbPath }));
   }).pipe(Layer.unwrap);

--- a/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.ts
@@ -86,7 +86,10 @@ const makeWithDatabase = (
 
     const makeConnection = Effect.gen(function* () {
       const scope = yield* Effect.scope;
-      const db = openDatabase();
+      const db = yield* Effect.try({
+        try: () => openDatabase(),
+        catch: (cause) => new SqlError({ cause, message: "Failed to open database" }),
+      }).pipe(Effect.orDie);
       yield* Scope.addFinalizer(
         scope,
         Effect.sync(() => db.close()),


### PR DESCRIPTION
Refs #961

## Problem

When `state.sqlite` becomes corrupted (truncated, overwritten, or contains non-SQLite data), the backend server crashes immediately on startup. The desktop app then restarts the backend in a loop, producing endless `backend exited unexpectedly (code=1)` messages with no recovery path. Users are stuck unless they manually find and delete the database file.

The root cause is two-fold:

1. `makeSqlitePersistenceLive` in `Sqlite.ts` blindly passes the database path to the SQLite client with no pre-flight validation
2. `NodeSqliteClient.ts` calls `openDatabase()` as a bare synchronous call inside `Effect.gen` - when it throws, the error becomes an unhandled defect that crashes the process

## Fix

### Corruption detection and auto-recovery (`Sqlite.ts`)

Before opening the database, `makeSqlitePersistenceLive` now validates the file header. Every valid SQLite file starts with the 16-byte magic string `SQLite format 3\0`. If the file exists but has an invalid header:

- The corrupted file is renamed to `state.sqlite.corrupted.<timestamp>` (preserving it for debugging)
- Stale WAL and SHM journal files are cleaned up
- A warning is logged explaining what happened
- A fresh database is created and migrations run normally

### Safety net for database open errors (`NodeSqliteClient.ts`)

The bare `openDatabase()` call is now wrapped in `Effect.try` with `Effect.orDie`, so any throw during database construction produces a properly reported defect with a clear `"Failed to open database"` message instead of an opaque crash.

## Testing

Manually verified with a corrupted database file:

```bash
echo "not a db" > ~/.t3/userdata/state.sqlite
t3code
```

**Before:** crash loop, `file is not a database` repeated every ~500ms, process killed  
**After:**
```
WARN: Corrupted database detected at /path/state.sqlite. Backing up to /path/state.sqlite.corrupted.1774012943326 and creating a fresh database. Session history will be reset.
INFO: Running migrations...
INFO: Migrations ran successfully
```

Header validation was also tested against:
- Corrupted file (garbage text) → detected, recovered
- Empty file (0 bytes) → detected, recovered
- Valid SQLite database → passes, opened normally
- Non-existent file → skipped, fresh database created

## Scope

This is complementary to #964 (draft), which handles the web/UI recovery view for bootstrap snapshot failures. This PR fixes the server side so the backend never gets stuck in a crash loop.

## Test plan

- [ ] Corrupt `state.sqlite` with `echo "not a db" > ~/.t3/userdata/state.sqlite`, start app, verify recovery
- [ ] Delete `state.sqlite` entirely, start app, verify fresh database is created
- [ ] Start app with a valid existing database, verify normal startup (no false positives)
- [ ] Verify backed up `.corrupted.<timestamp>` file is created alongside the new database

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-recover from corrupted SQLite database on server startup
> - On startup, `makeSqlitePersistenceLive` in [Sqlite.ts](https://github.com/pingdotgg/t3code/pull/1231/files#diff-47b4fe6e24808f5d59f5b97892cce0d736c01e7a8323b77e0c6a3751ff7ba7fa) validates the existing database file by checking the 16-byte SQLite magic header before initializing.
> - If the header is invalid, the file is renamed to a timestamped `.corrupted` backup and any `-wal`/`-shm` sidecar files are removed (best-effort), then a fresh database is created and a warning is logged.
> - In [NodeSqliteClient.ts](https://github.com/pingdotgg/t3code/pull/1231/files#diff-cf61d9fd2d48cc7f6a5d0ebaaa66f8c39d982f536913a6fb92196591465087aa), `openDatabase()` is now wrapped in `Effect.try` so failures produce a `SqlError` with the message `'Failed to open database'` before terminating the fiber.
> - Behavioral Change: On first startup after corruption, session history is lost and replaced with a fresh database.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 33283db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->