### PR TITLE
fix: treat errored chat sessions as disconnected

### DIFF
--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
+  derivePhase,
   PROVIDER_OPTIONS,
   derivePendingApprovals,
   derivePendingUserInputs,
@@ -21,6 +22,7 @@ import {
   hasToolActivityForTurn,
   isLatestTurnSettled,
 } from "./session-logic";
+import type { ThreadSession } from "./types";
 
 function makeActivity(overrides: {
   id?: string;
@@ -171,6 +173,21 @@ describe("derivePendingApprovals", () => {
     ];
 
     expect(derivePendingApprovals(activities)).toEqual([]);
+  });
+});
+
+describe("derivePhase", () => {
+  it("treats errored sessions as disconnected instead of ready", () => {
+    const session: ThreadSession = {
+      provider: "codex",
+      status: "error",
+      orchestrationStatus: "error",
+      createdAt: "2026-02-23T00:00:00.000Z",
+      updatedAt: "2026-02-23T00:00:01.000Z",
+      lastError: "Provider crashed",
+    };
+
+    expect(derivePhase(session)).toBe("disconnected");
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -865,7 +865,9 @@ export function inferCheckpointTurnCountByTurnId(
 }
 
 export function derivePhase(session: ThreadSession | null): SessionPhase {
-  if (!session || session.status === "closed") return "disconnected";
+  if (!session || session.status === "closed" || session.status === "error") {
+    return "disconnected";
+  }
   if (session.status === "connecting") return "connecting";
   if (session.status === "running") return "running";
   return "ready";


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Updated `derivePhase()` in the web app to treat `session.status === "error"` as `"disconnected"` instead of `"ready"`
- Added a regression test covering the errored-session case

## Why

The chat UI was treating provider/runtime failures as a normal ready state because errored sessions fell through the phase mapping. That left the composer in regular ready-state UI after a session failure.

Mapping errored sessions to `"disconnected"` keeps the chat view aligned with the actual backend session state and avoids presenting a failed thread as ready for normal interaction.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `derivePhase` to return 'disconnected' for errored chat sessions
> Previously, `derivePhase` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/1245/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) only returned `'disconnected'` for `null` or `'closed'` sessions, so sessions with `status: 'error'` incorrectly returned `'ready'`. The fix adds `'error'` to the disconnected condition, matching it with the null/closed cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b6d83e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->