### PR TITLE
fix(ChatView): update scroll button styles to improve user interaction

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3586,7 +3586,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                 <button
                   type="button"
                   onClick={() => scrollMessagesToBottom("smooth")}
-                  className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
+                  className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
                 >
                   <ChevronDownIcon className="size-3.5" />
                   Scroll to bottom


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed
Fixes #1243

- Update the hover effect on `scroll to bottom` button in ChatView.tsx.
- Change cursor to pointer on hover

<!-- Describe the change clearly and keep scope tight. -->

## Why
Improves visibility of the button when hovering, prev bg was changing to a transparent color.

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes
### Before:
<img width="181" height="80" alt="image" src="https://github.com/user-attachments/assets/949a8256-6b77-4409-96fd-f2d3e83cf110" />

### After:
<img width="176" height="66" alt="image" src="https://github.com/user-attachments/assets/cb596119-9883-4b11-bdf4-c5fba4053837" />


<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update 'Scroll to bottom' button hover styles in ChatView
> Replaces accent background/text hover classes with border color, foreground text, and pointer cursor classes on the scroll button in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1246/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfd26f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->