### PR TITLE
fix(server): handle JSON-RPC error responses without a message field

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -935,6 +935,47 @@ describe("collab child conversation routing", () => {
   });
 });
 
+describe("handleResponse", () => {
+  function createHandleResponseHarness() {
+    const manager = new CodexAppServerManager();
+    const resolve = vi.fn();
+    const reject = vi.fn();
+    const timeout = setTimeout(() => {}, 10_000);
+    const pending = new Map<string, { method: string; timeout: ReturnType<typeof setTimeout>; resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+    pending.set("1", { method: "test/method", timeout, resolve, reject });
+    const context = { pending } as unknown;
+
+    const handleResponse = (
+      manager as unknown as {
+        handleResponse: (context: unknown, response: { id: string | number; result?: unknown; error?: { code?: number; message?: string } }) => void;
+      }
+    ).handleResponse.bind(manager);
+
+    return { handleResponse, context, pending, resolve, reject, timeout };
+  }
+
+  it("resolves the pending request on a successful response", () => {
+    const { handleResponse, context, resolve, reject } = createHandleResponseHarness();
+    handleResponse(context, { id: 1, result: { ok: true } });
+    expect(resolve).toHaveBeenCalledWith({ ok: true });
+    expect(reject).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the response has an error with a message", () => {
+    const { handleResponse, context, resolve, reject } = createHandleResponseHarness();
+    handleResponse(context, { id: 1, error: { code: -32600, message: "Invalid request" } });
+    expect(reject).toHaveBeenCalledWith(expect.objectContaining({ message: "test/method failed: Invalid request" }));
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the response has an error with a code but no message", () => {
+    const { handleResponse, context, resolve, reject } = createHandleResponseHarness();
+    handleResponse(context, { id: 1, error: { code: -32600 } });
+    expect(reject).toHaveBeenCalledWith(expect.objectContaining({ message: "test/method failed: error code -32600" }));
+    expect(resolve).not.toHaveBeenCalled();
+  });
+});
+
 describe.skipIf(!process.env.CODEX_BINARY_PATH)("startSession live Codex resume", () => {
   it("keeps prior thread history when resuming with a changed runtime mode", async () => {
     const workspaceDir = mkdtempSync(path.join(os.tmpdir(), "codex-live-resume-"));

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1283,8 +1283,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     clearTimeout(pending.timeout);
     context.pending.delete(key);
 
-    if (response.error?.message) {
-      pending.reject(new Error(`${pending.method} failed: ${String(response.error.message)}`));
+    if (response.error) {
+      const detail = response.error.message ?? `error code ${response.error.code}`;
+      pending.reject(new Error(`${pending.method} failed: ${detail}`));
       return;
     }
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

`handleResponse` in `codexAppServerManager.ts` now checks for `response.error` instead of `response.error?.message` when deciding whether to reject a pending JSON-RPC request.

## Why

The `JsonRpcError` type defines `message` as optional (`message?: string`). If the Codex app-server sends an error response that has a `code` but no `message` (or an empty string message), the old condition `response.error?.message` evaluates to falsy, causing the code to fall through to `pending.resolve(response.result)`. This silently treats the error as a successful response with an `undefined` result, which can cause unpredictable failures downstream far from the actual source of the problem.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `handleResponse` to reject JSON-RPC error responses that lack a message field
> Previously, a JSON-RPC error response without a `message` field would fall through to resolve the pending request instead of rejecting it. Now, any response containing an error object triggers a rejection, using `error.message` if present or falling back to `"error code <code>"` when only a code is available. Tests covering all three cases (success, error with message, error with code only) are added in [codexAppServerManager.test.ts](https://github.com/pingdotgg/t3code/pull/1247/files#diff-e0b57ec17b32e60d14081ebeb4bcfb13db511905869ef4ffbd669b229c0bb2c1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb7f34f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->