### PR TITLE
Prefer Claude user ID for telemetry identity

### DIFF
--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -9,6 +9,10 @@ const CodexAuthJsonSchema = Schema.Struct({
   }),
 });
 
+const ClaudeJsonSchema = Schema.Struct({
+  userID: Schema.String,
+});
+
 class IdentifyUserError extends Schema.TaggedErrorClass<IdentifyUserError>()("IdentifyUserError", {
   message: Schema.String,
   cause: Schema.optional(Schema.Defect),
@@ -37,6 +41,19 @@ const getCodexAccountId = Effect.gen(function* () {
   return authJson.tokens.account_id;
 });
 
+const getClaudeUserId = Effect.gen(function* () {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const claudeJsonPath = path.join(homedir(), ".claude.json");
+  const claudeJson = yield* Effect.flatMap(
+    fileSystem.readFileString(claudeJsonPath),
+    Schema.decodeEffect(Schema.fromJsonString(ClaudeJsonSchema)),
+  );
+
+  return claudeJson.userID;
+});
+
 const upsertAnonymousId = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
@@ -59,12 +76,18 @@ const upsertAnonymousId = Effect.gen(function* () {
 /**
  * getTelemetryIdentifier - Users are "identified" by finding the first match of the following, then hashing the value.
  * 1. ~/.codex/auth.json tokens.account_id
- * 2. ~/.t3/telemetry/anonymous-id
+ * 2. ~/.claude.json userID
+ * 3. ~/.t3/telemetry/anonymous-id
  */
 export const getTelemetryIdentifier = Effect.gen(function* () {
   const codexAccountId = yield* Effect.result(getCodexAccountId);
   if (codexAccountId._tag === "Success") {
     return yield* hash(codexAccountId.success);
+  }
+
+  const claudeUserId = yield* Effect.result(getClaudeUserId);
+  if (claudeUserId._tag === "Success") {
+    return yield* hash(claudeUserId.success);
   }
 
   const anonymousId = yield* Effect.result(upsertAnonymousId);


### PR DESCRIPTION
- Read `~/.claude.json` when Codex account ID is unavailable
- Fall back to the existing anonymous telemetry ID

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer Claude user ID from `~/.claude.json` for telemetry identity
> Updates `getTelemetryIdentifier` in [Identify.ts](https://github.com/pingdotgg/t3code/pull/1249/files#diff-a50c9348071512e0bea296dca3a49a3f8fe4e903cf32378d3d94c5341161b174) to check `~/.claude.json` for a `userID` field after the Codex account ID but before falling back to the anonymous ID. A new `getClaudeUserId` effect reads and decodes the file using `ClaudeJsonSchema`, and the resulting ID is hashed like other identifiers. Risk: adds a file read and JSON decode on every telemetry identifier resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98c8c03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->