### PR TITLE
feat(diff): add line wrap toggle

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -517,24 +517,18 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
           <Columns2Icon className="size-3" />
         </Toggle>
       </ToggleGroup>
-      <ToggleGroup
+      <Toggle
         className="shrink-0 [-webkit-app-region:no-drag]"
         variant="outline"
         size="xs"
-        value={[diffOverflowMode]}
-        onValueChange={(value) => {
-          const next = value[0];
-          if (next === "wrap") {
-            setDiffOverflowMode("wrap");
-          } else {
-            setDiffOverflowMode("scroll");
-          }
+        aria-label="Toggle line wrapping"
+        pressed={diffOverflowMode === "wrap"}
+        onPressedChange={(pressed) => {
+          setDiffOverflowMode(pressed ? "wrap" : "scroll");
         }}
       >
-        <Toggle aria-label="Toggle line wrapping" value="wrap">
-          <WrapTextIcon className="size-3" />
-        </Toggle>
-      </ToggleGroup>
+        <WrapTextIcon className="size-3" />
+      </Toggle>
     </>
   );
 


### PR DESCRIPTION
## What Changed

Adds a new toggle button in the diff view header that toggle line wrapping in the diff. This is next to the split/unified toggle group and follows the same styling.

## Why

When the diff panel width is small and the lines are long, the changes are out of view making review hard. This was especially bad when using split view.

## UI Changes

Line wrapping off
<img width="566" height="740" alt="diff-wrap-scroll" src="https://github.com/user-attachments/assets/e361651e-4a5e-479b-90de-87c63d48080b" />

Line wrapping on
<img width="560" height="859" alt="diff-wrap-wrapped" src="https://github.com/user-attachments/assets/e7c59958-1419-472a-bae9-1ff45e54383a" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add line wrap toggle to DiffPanel
> Adds a toggle button to the `DiffPanel` header using `WrapTextIcon` that switches between `scroll` and `wrap` overflow modes. The selected mode is passed as an `overflow` option to each `FileDiff`, controlling whether long lines scroll horizontally or wrap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87fad1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->