### PR TITLE
fix(web): hide mobile sidebar after thread actions

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -6,6 +6,7 @@ import {
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
+  shouldHideSidebarAfterThreadAction,
   shouldClearThreadSelectionOnMouseDown,
 } from "./Sidebar.logic";
 
@@ -81,6 +82,16 @@ describe("resolveSidebarNewThreadEnvMode", () => {
         defaultEnvMode: "worktree",
       }),
     ).toBe("local");
+  });
+});
+
+describe("shouldHideSidebarAfterThreadAction", () => {
+  it("hides the sidebar after thread actions on mobile", () => {
+    expect(shouldHideSidebarAfterThreadAction(true)).toBe(true);
+  });
+
+  it("keeps the sidebar open after thread actions on desktop", () => {
+    expect(shouldHideSidebarAfterThreadAction(false)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -59,6 +59,10 @@ export function resolveSidebarNewThreadEnvMode(input: {
   return input.requestedEnvMode ?? input.defaultEnvMode;
 }
 
+export function shouldHideSidebarAfterThreadAction(isMobile: boolean): boolean {
+  return isMobile;
+}
+
 export function resolveThreadRowClassName(input: {
   isActive: boolean;
   isSelected: boolean;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -88,9 +88,11 @@ import {
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
+  shouldHideSidebarAfterThreadAction,
   shouldClearThreadSelectionOnMouseDown,
 } from "./Sidebar.logic";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { useSidebar } from "~/components/ui/sidebar";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_PREVIEW_LIMIT = 6;
@@ -253,6 +255,7 @@ function SortableProjectItem({
 }
 
 export default function Sidebar() {
+  const { isMobile, setOpenMobile } = useSidebar();
   const projects = useStore((store) => store.projects);
   const threads = useStore((store) => store.threads);
   const markThreadUnread = useStore((store) => store.markThreadUnread);
@@ -382,6 +385,13 @@ export default function Sidebar() {
       });
     });
   }, []);
+
+  const hideSidebarAfterThreadAction = useCallback(() => {
+    if (!shouldHideSidebarAfterThreadAction(isMobile)) {
+      return;
+    }
+    setOpenMobile(false);
+  }, [isMobile, setOpenMobile]);
 
   const focusMostRecentThreadForProject = useCallback(
     (projectId: ProjectId) => {
@@ -844,6 +854,7 @@ export default function Sidebar() {
         clearSelection();
       }
       setSelectionAnchor(threadId);
+      hideSidebarAfterThreadAction();
       void navigate({
         to: "/$threadId",
         params: { threadId },
@@ -855,6 +866,7 @@ export default function Sidebar() {
       rangeSelectTo,
       selectedThreadIds.size,
       setSelectionAnchor,
+      hideSidebarAfterThreadAction,
       toggleThreadSelection,
     ],
   );
@@ -1424,6 +1436,7 @@ export default function Sidebar() {
                                     onClick={(event) => {
                                       event.preventDefault();
                                       event.stopPropagation();
+                                      hideSidebarAfterThreadAction();
                                       void handleNewThread(project.id, {
                                         envMode: resolveSidebarNewThreadEnvMode({
                                           defaultEnvMode: appSettings.defaultThreadEnvMode,
@@ -1492,6 +1505,7 @@ export default function Sidebar() {
                                           clearSelection();
                                         }
                                         setSelectionAnchor(thread.id);
+                                        hideSidebarAfterThreadAction();
                                         void navigate({
                                           to: "/$threadId",
                                           params: { threadId: thread.id },


### PR DESCRIPTION
## Summary
Hide the off-canvas sidebar on narrow screens after users create a new thread or select an existing one. This keeps the selected thread content visible immediately instead of leaving the mobile navigation open. Fixes #1258.

## Changes
- close the mobile sidebar before navigating after thread selection
- close the mobile sidebar when creating a new thread from the sidebar
- add logic coverage for mobile-only sidebar hiding behavior


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide mobile sidebar after thread actions in the Sidebar component
> On mobile, the sidebar now closes when a user opens a thread (via click or Enter/Space) or creates a new thread from a project card. A new `shouldHideSidebarAfterThreadAction` helper in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/1259/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) wraps the `isMobile` boolean to centralize the condition. On desktop, sidebar behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73de16b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->