### PR TITLE
fix(threads): Keep active-turn runtime errors from ending sessions

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -207,6 +207,42 @@ describe("classifyCodexStderrLine", () => {
   });
 });
 
+describe("process stderr events", () => {
+  it("emits classified stderr lines as notifications", () => {
+    const manager = new CodexAppServerManager();
+    const emitEvent = vi
+      .spyOn(manager as unknown as { emitEvent: (...args: unknown[]) => void }, "emitEvent")
+      .mockImplementation(() => {});
+
+    (
+      manager as unknown as {
+        emitNotificationEvent: (
+          context: { session: { threadId: ThreadId } },
+          method: string,
+          message: string,
+        ) => void;
+      }
+    ).emitNotificationEvent(
+      {
+        session: {
+          threadId: asThreadId("thread-1"),
+        },
+      },
+      "process/stderr",
+      "fatal: permission denied",
+    );
+
+    expect(emitEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "notification",
+        method: "process/stderr",
+        threadId: "thread-1",
+        message: "fatal: permission denied",
+      }),
+    );
+  });
+});
+
 describe("normalizeCodexModelSlug", () => {
   it("maps 5.3 aliases to gpt-5.3-codex", () => {
     expect(normalizeCodexModelSlug("5.3")).toBe("gpt-5.3-codex");

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1046,7 +1046,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
           continue;
         }
 
-        this.emitErrorEvent(context, "process/stderr", classified.message);
+        this.emitNotificationEvent(context, "process/stderr", classified.message);
       }
     });
 
@@ -1346,6 +1346,22 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     this.emitEvent({
       id: EventId.makeUnsafe(randomUUID()),
       kind: "error",
+      provider: "codex",
+      threadId: context.session.threadId,
+      createdAt: new Date().toISOString(),
+      method,
+      message,
+    });
+  }
+
+  private emitNotificationEvent(
+    context: CodexSessionContext,
+    method: string,
+    message: string,
+  ): void {
+    this.emitEvent({
+      id: EventId.makeUnsafe(randomUUID()),
+      kind: "notification",
       provider: "codex",
       threadId: context.session.threadId,
       createdAt: new Date().toISOString(),

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -474,6 +474,40 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("maps process stderr notifications to runtime.warning", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      lifecycleManager.emit("event", {
+        id: asEventId("evt-process-stderr"),
+        kind: "notification",
+        provider: "codex",
+        threadId: asThreadId("thread-1"),
+        createdAt: new Date().toISOString(),
+        method: "process/stderr",
+        turnId: asTurnId("turn-1"),
+        message: "The filename or extension is too long. (os error 206)",
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      assert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      assert.equal(firstEvent.value.type, "runtime.warning");
+      if (firstEvent.value.type !== "runtime.warning") {
+        return;
+      }
+      assert.equal(firstEvent.value.turnId, "turn-1");
+      assert.equal(
+        firstEvent.value.payload.message,
+        "The filename or extension is too long. (os error 206)",
+      );
+    }),
+  );
+
   it.effect("preserves request type when mapping serverRequest/resolved", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1267,6 +1267,19 @@ function mapToRuntimeEvents(
     ];
   }
 
+  if (event.method === "process/stderr") {
+    return [
+      {
+        type: "runtime.warning",
+        ...runtimeEventBase(event, canonicalThreadId),
+        payload: {
+          message: event.message ?? "Codex process stderr",
+          ...(event.payload !== undefined ? { detail: event.payload } : {}),
+        },
+      },
+    ];
+  }
+
   if (event.method === "windows/worldWritableWarning") {
     return [
       {


### PR DESCRIPTION
## Summary

Closes #490

This keeps active Codex turns projected as running when a non-terminal `runtime.error` arrives mid-turn.

Previously, runtime ingestion treated any `runtime.error` as a terminal session error. In cases like Windows `os error 206` (`The filename or extension is too long`), Codex could continue running in the background while the UI was projected as stopped/errored, leaving the session desynced and no longer stoppable from the UI.

## What Changed

- changed provider runtime ingestion so `runtime.error` does not force the session into `error` while the active turn is still running
- preserved existing terminal lifecycle handling from:
  - `turn.completed` with failed state
  - `session.state.changed` with `error`
  - `session.exited`
- added tests covering:
  - `runtime.error` with no active turn still marks the session as errored
  - `runtime.error` for the active turn keeps the session running and records the runtime error activity

## Why

This is a small reliability fix.

It keeps session state predictable under failure conditions and prevents the UI from desyncing from the actual Codex runtime when a mid-turn exec error is advisory rather than terminal.

## Scope

This PR is intentionally narrow and only changes runtime session projection behavior for active-turn `runtime.error` events.

## Testing

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun x vitest run apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts`

## Notes

No UI change screenshots are included because this PR does not change visuals directly.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep active-turn runtime errors from ending sessions by emitting stderr as warnings
> - Classified stderr lines from the codex process are now emitted as `notification` events (method `process/stderr`) instead of error events in [`codexAppServerManager.ts`](https://github.com/pingdotgg/t3code/pull/1261/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9).
> - [`CodexAdapter.ts`](https://github.com/pingdotgg/t3code/pull/1261/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) maps these `process/stderr` notifications to `runtime.warning` runtime events, carrying the stderr message and turnId.
> - Behavioral Change: stderr output during an active turn no longer triggers session-ending error handling; it surfaces as a warning instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df84b76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reclassifies Codex subprocess stderr output from error events to notifications and maps them to `runtime.warning`, reducing chances of falsely marking sessions as failed; changes are small and covered by tests but affect runtime event semantics.
> 
> **Overview**
> Codex app-server stderr handling is softened so *classified stderr lines* no longer emit `kind: "error"` events; they now emit `kind: "notification"` events via a new `emitNotificationEvent` and use the `process/stderr` method.
> 
> `CodexAdapter` now maps `process/stderr` notifications into canonical `runtime.warning` events, and new tests verify both the manager event kind and the adapter mapping behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df84b765bbc7a79b91760b06045ef9e8c180c66c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->