### PR TITLE
fix: add license field to npm package

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,12 +1,12 @@
 {
   "name": "t3",
   "version": "0.0.13",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/pingdotgg/t3code",
     "directory": "apps/server"
   },
-  "license": "MIT",
   "bin": {
     "t3": "./dist/index.mjs"
   },


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Added `"license"` field to `t3` npm package

## Why

It is recommended to have `"license"` for npm packages

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add MIT license field to server npm package manifest
> Adds the `license` field set to `MIT` in [package.json](https://github.com/pingdotgg/t3code/pull/1272/files#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2) to satisfy npm package metadata requirements.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbaa1d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->