### PR TITLE
fix (git): Truncate oversized git output for commit generation

### DIFF
--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -802,6 +802,8 @@ const makeGitCore = Effect.gen(function* () {
         cwd,
         ["diff", "--cached", "--patch", "--minimal"],
         {
+          // Stay close to the later 50k char limit while keeping a little room for UTF-8 variance.
+          maxOutputBytes: 60_000,
           truncateOutput: true,
         },
       ).pipe(Effect.map((result) => result.stdout));

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -21,6 +21,8 @@ interface ExecuteGitOptions {
   timeoutMs?: number | undefined;
   allowNonZeroExit?: boolean | undefined;
   fallbackErrorMessage?: string | undefined;
+  maxOutputBytes?: number | undefined;
+  truncateOutput?: boolean | undefined;
 }
 
 function parseBranchAb(value: string): { ahead: number; behind: number } {
@@ -237,6 +239,8 @@ const makeGitCore = Effect.gen(function* () {
         args,
         allowNonZeroExit: true,
         ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+        ...(options.maxOutputBytes !== undefined ? { maxOutputBytes: options.maxOutputBytes } : {}),
+        ...(options.truncateOutput !== undefined ? { truncateOutput: options.truncateOutput } : {}),
       })
       .pipe(
         Effect.flatMap((result) => {
@@ -793,12 +797,14 @@ const makeGitCore = Effect.gen(function* () {
         return null;
       }
 
-      const stagedPatch = yield* runGitStdout("GitCore.prepareCommitContext.stagedPatch", cwd, [
-        "diff",
-        "--cached",
-        "--patch",
-        "--minimal",
-      ]);
+      const stagedPatch = yield* executeGit(
+        "GitCore.prepareCommitContext.stagedPatch",
+        cwd,
+        ["diff", "--cached", "--patch", "--minimal"],
+        {
+          truncateOutput: true,
+        },
+      ).pipe(Effect.map((result) => result.stdout));
 
       return {
         stagedSummary,

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -729,6 +729,40 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("creates a commit when the staged patch exceeds the capture limit", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      fs.writeFileSync(path.join(repoDir, "huge.txt"), "line\n".repeat(250_000));
+      let generatedPatchLength = 0;
+
+      const { manager } = yield* makeManager({
+        textGeneration: {
+          generateCommitMessage: (input) =>
+            Effect.sync(() => {
+              generatedPatchLength = input.stagedPatch.length;
+              return {
+                subject: "Commit huge patch",
+                body: "",
+              };
+            }),
+        },
+      });
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit",
+      });
+
+      expect(result.commit.status).toBe("created");
+      expect(generatedPatchLength).toBe(50_013);
+      expect(
+        yield* runGit(repoDir, ["log", "-1", "--pretty=%s"]).pipe(
+          Effect.map((gitResult) => gitResult.stdout.trim()),
+        ),
+      ).toBe("Commit huge patch");
+    }),
+  );
+
   it.effect("uses custom commit message when provided", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/Layers/GitService.test.ts
+++ b/apps/server/src/git/Layers/GitService.test.ts
@@ -37,6 +37,23 @@ layer("GitServiceLive", (it) => {
     }),
   );
 
+  it.effect("runGit can truncate oversized output when requested", () =>
+    Effect.gen(function* () {
+      const gitService = yield* GitService;
+      const result = yield* gitService.execute({
+        operation: "GitProcess.test.truncateOutput",
+        cwd: process.cwd(),
+        args: ["--version", "--build-options"],
+        maxOutputBytes: 16,
+        truncateOutput: true,
+      });
+
+      assert.equal(result.code, 0);
+      assert.ok(result.stdout.length <= 16);
+      assert.equal(result.stdoutTruncated, true);
+    }),
+  );
+
   it.effect("runGit fails with GitCommandError when non-zero exits are not allowed", () =>
     Effect.gen(function* () {
       const gitService = yield* GitService;

--- a/apps/server/src/git/Layers/GitService.test.ts
+++ b/apps/server/src/git/Layers/GitService.test.ts
@@ -49,7 +49,7 @@ layer("GitServiceLive", (it) => {
       });
 
       assert.equal(result.code, 0);
-      assert.ok(result.stdout.length <= 16);
+      assert.ok(Buffer.byteLength(result.stdout, "utf8") <= 16);
       assert.equal(result.stdoutTruncated, true);
     }),
   );

--- a/apps/server/src/git/Layers/GitService.ts
+++ b/apps/server/src/git/Layers/GitService.ts
@@ -19,6 +19,11 @@ import {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 
+interface CollectedOutput {
+  text: string;
+  truncated: boolean;
+}
+
 function quoteGitCommand(args: ReadonlyArray<string>): string {
   return `git ${args.join(" ")}`;
 }
@@ -43,15 +48,30 @@ const collectOutput = Effect.fn(function* <E>(
   input: Pick<ExecuteGitInput, "operation" | "cwd" | "args">,
   stream: Stream.Stream<Uint8Array, E>,
   maxOutputBytes: number,
-): Effect.fn.Return<string, GitCommandError> {
+  truncateOutput: boolean,
+): Effect.fn.Return<CollectedOutput, GitCommandError> {
   const decoder = new TextDecoder();
   let bytes = 0;
   let text = "";
+  let truncated = false;
 
   yield* Stream.runForEach(stream, (chunk) =>
     Effect.gen(function* () {
-      bytes += chunk.byteLength;
-      if (bytes > maxOutputBytes) {
+      if (truncated) {
+        return;
+      }
+
+      const nextBytes = bytes + chunk.byteLength;
+      if (nextBytes > maxOutputBytes) {
+        if (truncateOutput) {
+          const remainingBytes = maxOutputBytes - bytes;
+          if (remainingBytes > 0) {
+            text += decoder.decode(chunk.subarray(0, remainingBytes), { stream: true });
+            bytes = maxOutputBytes;
+          }
+          truncated = true;
+          return;
+        }
         return yield* new GitCommandError({
           operation: input.operation,
           command: quoteGitCommand(input.args),
@@ -59,12 +79,13 @@ const collectOutput = Effect.fn(function* <E>(
           detail: `${quoteGitCommand(input.args)} output exceeded ${maxOutputBytes} bytes and was truncated.`,
         });
       }
+      bytes = nextBytes;
       text += decoder.decode(chunk, { stream: true });
     }),
   ).pipe(Effect.mapError(toGitCommandError(input, "output stream failed.")));
 
   text += decoder.decode();
-  return text;
+  return { text, truncated };
 });
 
 const makeGitService = Effect.gen(function* () {
@@ -77,6 +98,7 @@ const makeGitService = Effect.gen(function* () {
     } as const;
     const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const maxOutputBytes = input.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+    const truncateOutput = input.truncateOutput ?? false;
 
     const commandEffect = Effect.gen(function* () {
       const child = yield* commandSpawner
@@ -90,8 +112,8 @@ const makeGitService = Effect.gen(function* () {
 
       const [stdout, stderr, exitCode] = yield* Effect.all(
         [
-          collectOutput(commandInput, child.stdout, maxOutputBytes),
-          collectOutput(commandInput, child.stderr, maxOutputBytes),
+          collectOutput(commandInput, child.stdout, maxOutputBytes, truncateOutput),
+          collectOutput(commandInput, child.stderr, maxOutputBytes, truncateOutput),
           child.exitCode.pipe(
             Effect.map((value) => Number(value)),
             Effect.mapError(toGitCommandError(commandInput, "failed to report exit code.")),
@@ -101,7 +123,7 @@ const makeGitService = Effect.gen(function* () {
       );
 
       if (!input.allowNonZeroExit && exitCode !== 0) {
-        const trimmedStderr = stderr.trim();
+        const trimmedStderr = stderr.text.trim();
         return yield* new GitCommandError({
           operation: commandInput.operation,
           command: quoteGitCommand(commandInput.args),
@@ -113,7 +135,13 @@ const makeGitService = Effect.gen(function* () {
         });
       }
 
-      return { code: exitCode, stdout, stderr } satisfies ExecuteGitResult;
+      return {
+        code: exitCode,
+        stdout: stdout.text,
+        stderr: stderr.text,
+        stdoutTruncated: stdout.truncated,
+        stderrTruncated: stderr.truncated,
+      } satisfies ExecuteGitResult;
     });
 
     return yield* commandEffect.pipe(

--- a/apps/server/src/git/Services/GitService.ts
+++ b/apps/server/src/git/Services/GitService.ts
@@ -19,12 +19,15 @@ export interface ExecuteGitInput {
   readonly allowNonZeroExit?: boolean;
   readonly timeoutMs?: number;
   readonly maxOutputBytes?: number;
+  readonly truncateOutput?: boolean;
 }
 
 export interface ExecuteGitResult {
   readonly code: number;
   readonly stdout: string;
   readonly stderr: string;
+  readonly stdoutTruncated?: boolean;
+  readonly stderrTruncated?: boolean;
 }
 
 /**


### PR DESCRIPTION
## What Changed

- added opt-in truncation support to the git command execution layer
- used that truncation path when reading the staged patch for commit preparation
- added tests covering truncated git output and large staged commit generation

## Why

The commit flow currently reads the full staged patch before generating a commit message. If `git diff --cached --patch --minimal` exceeds the output cap, commit preparation fails even though Git could still commit successfully.

This change keeps the behavior strict for normal git commands, but lets commit preparation degrade gracefully for very large staged diffs. That makes the commit feature more reliable in real user repos, especially when large generated changes or line-ending churn produce oversized patches.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] ~I included before/after screenshots for any UI changes~ **No UI Changes Made**
- [ ] ~I included a video for animation/interaction changes~ **No UI Changes Made**


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Truncate oversized `git diff` output in `GitCore.prepareCommitContext` for commit generation
> - Adds `truncateOutput` and `maxOutputBytes` options to `GitService.execute` and the `executeGit` helper, returning `stdoutTruncated`/`stderrTruncated` flags on the result.
> - `prepareCommitContext` now captures the staged patch with a 60,000-byte limit and truncates instead of failing when the diff is large.
> - Behavioral Change: previously, an oversized staged diff would cause a `GitCommandError`; now it is silently truncated to ~60k bytes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aa74227.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core git execution layer to optionally truncate stdout/stderr instead of failing when output exceeds limits, which could mask important error details if enabled incorrectly. Scope is limited and opt-in, but touches shared command execution used across git features.
> 
> **Overview**
> **Commit generation no longer fails on huge staged diffs.** `GitService.execute` now supports `truncateOutput` with `stdoutTruncated`/`stderrTruncated` flags, allowing callers to cap output at `maxOutputBytes` without throwing.
> 
> `GitCore.prepareCommitContext` switches staged patch capture to this truncation mode (60KB cap) so oversized `git diff --cached --patch` output is truncated and commit message generation can continue. Tests were added to cover both truncated git output and the large-staged-patch commit flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa742270c0309a24382129a5ef5e0189d495dc1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->