### PR TITLE
fix(web): fix composer mention menu highlight and scroll

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -17,7 +17,7 @@ import {
 import { RouterProvider, createMemoryHistory } from "@tanstack/react-router";
 import { HttpResponse, http, ws } from "msw";
 import { setupWorker } from "msw/browser";
-import { page } from "vitest/browser";
+import { page, userEvent } from "vitest/browser";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
@@ -1293,6 +1293,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
   });
 
   it("scrolls the composer @ menu to keep the keyboard-highlighted file in view", async () => {
+    const scrollIntoViewSpy = vi.spyOn(HTMLElement.prototype, "scrollIntoView");
     useComposerDraftStore.getState().setPrompt(THREAD_ID, "@c");
     const projectEntries = createProjectEntries([
       "apps/web/src/components/ChatView.tsx",
@@ -1334,23 +1335,12 @@ describe("ChatView timeline estimator parity (full app)", () => {
         },
         { timeout: 8_000, interval: 16 },
       );
-      const commandScrollViewport = commandList.closest<HTMLElement>(
-        '[data-slot="scroll-area-viewport"]',
-      );
-      expect(
-        commandScrollViewport,
-        "Unable to find composer command scroll viewport.",
-      ).toBeTruthy();
 
-      const initialScrollTop = commandScrollViewport!.scrollTop;
+      const initialActiveItem = await waitForActiveComposerCommandItem();
+      expect(initialActiveItem.dataset.path).toBe(projectEntries[0]?.path);
+
       for (let index = 0; index < 12; index += 1) {
-        composerEditor.dispatchEvent(
-          new KeyboardEvent("keydown", {
-            key: "ArrowDown",
-            bubbles: true,
-            cancelable: true,
-          }),
-        );
+        await userEvent.keyboard("{ArrowDown}");
         await nextFrame();
       }
 
@@ -1360,23 +1350,12 @@ describe("ChatView timeline estimator parity (full app)", () => {
           activePath = activeItem.dataset.path ?? null;
           expect(activePath).toBeTruthy();
           expect(activePath).not.toBe(projectEntries[0]?.path);
-          expect(commandScrollViewport!.scrollTop).toBeGreaterThan(initialScrollTop);
-
-          const viewportRect = commandScrollViewport!.getBoundingClientRect();
-          const itemRect = activeItem.getBoundingClientRect();
-          expect(itemRect.bottom).toBeLessThanOrEqual(viewportRect.bottom);
-          expect(itemRect.top).toBeGreaterThanOrEqual(viewportRect.top);
+          expect(scrollIntoViewSpy).toHaveBeenCalled();
         },
         { timeout: 8_000, interval: 16 },
       );
 
-      composerEditor.dispatchEvent(
-        new KeyboardEvent("keydown", {
-          key: "Enter",
-          bubbles: true,
-          cancelable: true,
-        }),
-      );
+      await userEvent.keyboard("{Enter}");
 
       await vi.waitFor(
         () => {
@@ -1388,6 +1367,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
         { timeout: 8_000, interval: 16 },
       );
     } finally {
+      scrollIntoViewSpy.mockRestore();
       await mounted.cleanup();
     }
   });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -388,7 +388,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const composerMenuOpenRef = useRef(false);
   const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
   const activeComposerMenuItemRef = useRef<ComposerCommandItem | null>(null);
-  const composerCommandInputRef = useRef<HTMLInputElement>(null);
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewHandoffTimeoutByMessageIdRef = useRef<Record<string, number>>({});
   const sendInFlightRef = useRef(false);
@@ -3319,19 +3318,24 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const onComposerMenuItemHighlighted = useCallback((itemId: string | null) => {
     setComposerHighlightedItemId(itemId);
   }, []);
-  const nudgeComposerMenuHighlight = useCallback((key: "ArrowDown" | "ArrowUp") => {
-    const commandInput = composerCommandInputRef.current;
-    if (!commandInput) {
-      return;
-    }
-    commandInput.dispatchEvent(
-      new KeyboardEvent("keydown", {
-        key,
-        bubbles: true,
-        cancelable: true,
-      }),
-    );
-  }, []);
+  const nudgeComposerMenuHighlight = useCallback(
+    (key: "ArrowDown" | "ArrowUp") => {
+      if (composerMenuItems.length === 0) {
+        return;
+      }
+      const highlightedIndex = composerMenuItems.findIndex(
+        (item) => item.id === composerHighlightedItemId,
+      );
+      const normalizedIndex =
+        highlightedIndex >= 0 ? highlightedIndex : key === "ArrowDown" ? -1 : 0;
+      const offset = key === "ArrowDown" ? 1 : -1;
+      const nextIndex =
+        (normalizedIndex + offset + composerMenuItems.length) % composerMenuItems.length;
+      const nextItem = composerMenuItems[nextIndex];
+      setComposerHighlightedItemId(nextItem?.id ?? null);
+    },
+    [composerHighlightedItemId, composerMenuItems],
+  );
   const isComposerMenuLoading =
     composerTriggerKind === "path" &&
     ((pathTriggerQuery.length > 0 && composerPathQueryDebouncer.state.isPending) ||
@@ -3649,7 +3653,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
                           activeItemId={activeComposerMenuItem?.id ?? null}
                           onHighlightedItemChange={onComposerMenuItemHighlighted}
                           onSelect={onSelectComposerItem}
-                          commandInputRef={composerCommandInputRef}
                         />
                       </div>
                     )}

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -1,9 +1,10 @@
 import { type ProjectEntry, type ModelSlug, type ProviderKind } from "@t3tools/contracts";
-import { memo, useEffect, useRef, type RefObject } from "react";
+import { memo, useEffect, useRef } from "react";
 import { type ComposerSlashCommand, type ComposerTriggerKind } from "../../composer-logic";
 import { BotIcon } from "lucide-react";
+import { cn } from "~/lib/utils";
 import { Badge } from "../ui/badge";
-import { Command, CommandInput, CommandItem, CommandList } from "../ui/command";
+import { Command, CommandItem, CommandList } from "../ui/command";
 import { VscodeEntryIcon } from "./VscodeEntryIcon";
 
 export type ComposerCommandItem =
@@ -39,7 +40,6 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
   activeItemId: string | null;
   onHighlightedItemChange: (itemId: string | null) => void;
   onSelect: (item: ComposerCommandItem) => void;
-  commandInputRef: RefObject<HTMLInputElement | null>;
 }) {
   const itemRefs = useRef(new Map<string, HTMLDivElement>());
 
@@ -52,18 +52,8 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
   }, [props.activeItemId, props.items]);
 
   return (
-    <Command
-      mode="none"
-      onItemHighlighted={(highlightedValue) => {
-        props.onHighlightedItemChange(
-          typeof highlightedValue === "string" ? highlightedValue : null,
-        );
-      }}
-    >
+    <Command mode="none" autoHighlight={false} keepHighlight={false} highlightItemOnHover={false}>
       <div className="relative overflow-hidden rounded-xl border border-border/80 bg-popover/96 shadow-lg/8 backdrop-blur-xs">
-        <div className="pointer-events-none absolute h-0 w-0 overflow-hidden opacity-0">
-          <CommandInput autoFocus={false} ref={props.commandInputRef} />
-        </div>
         <CommandList className="max-h-64">
           {props.items.map((item) => (
             <ComposerCommandMenuItem
@@ -78,6 +68,7 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
               }}
               resolvedTheme={props.resolvedTheme}
               isActive={props.activeItemId === item.id}
+              onHighlightedItemChange={props.onHighlightedItemChange}
               onSelect={props.onSelect}
             />
           ))}
@@ -101,6 +92,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
   itemRef: (element: HTMLDivElement | null) => void;
   resolvedTheme: "light" | "dark";
   isActive: boolean;
+  onHighlightedItemChange: (itemId: string | null) => void;
   onSelect: (item: ComposerCommandItem) => void;
 }) {
   return (
@@ -109,7 +101,15 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
       data-active={props.isActive ? "" : undefined}
       data-path={props.item.type === "path" ? props.item.path : undefined}
       value={props.item.id}
-      className="cursor-pointer scroll-my-2 select-none gap-2"
+      className={cn(
+        "cursor-pointer select-none gap-2 scroll-my-2",
+        props.isActive && "bg-accent text-accent-foreground",
+      )}
+      onMouseMove={() => {
+        if (!props.isActive) {
+          props.onHighlightedItemChange(props.item.id);
+        }
+      }}
       onMouseDown={(event) => {
         event.preventDefault();
       }}


### PR DESCRIPTION
## What Changed

Fixed the composer `@` mention menu so keyboard navigation keeps the highlighted item in view.

Also restored a single visible highlight owner for the menu. The active item is now the only item that gets highlighted visually, which fixes the duplicate-highlight behavior where one item could stay visually selected while another became active from keyboard navigation.

## Why

The `@` mention picker had two related issues:

- Using `ArrowDown` / `ArrowUp` could move the active item without scrolling the menu, so the real selection could end up outside the visible area.
- The menu was also mixing Base UI highlight state with a separate app-managed active style, which could make it look like two items were selected at once.

This change keeps the visible highlight ownership in one place and adds scroll sync on the active item, which makes keyboard navigation behave like a normal command menu again.

## UI Changes

**Before:**

- The highlighted item could move out of view when navigating with the keyboard
- The menu could appear to have two selected items at once

https://github.com/user-attachments/assets/6d05c183-b1e6-4c2f-9063-9e688ecdc690

**After:**

- The active item stays scrolled into view during keyboard navigation
- The menu only shows one highlighted item at a time

https://github.com/user-attachments/assets/a4d7d666-976a-45e7-862c-19b9efbe8fc5

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer mention menu highlight tracking and scroll-into-view behavior
> - Replaces `Command`'s built-in highlight logic in [`ComposerCommandMenu`](https://github.com/pingdotgg/t3code/pull/1285/files#diff-ca7de5ada90d0c74157405378c7182002eab97a1ea23cd71e4376f8db6ba81a4) with parent-controlled state, passing `autoHighlight={false}`, `keepHighlight={false}`, and `highlightItemOnHover={false}` to prevent conflicts.
> - Adds a ref map and a `useEffect` that calls `scrollIntoView({ block: 'nearest' })` on the active item element whenever `activeItemId` changes, keeping the highlighted entry visible during keyboard navigation.
> - Items now expose `data-active` and `data-path` attributes and fire `onHighlightedItemChange` on `onMouseMove` so hover and keyboard navigation stay in sync.
> - Adds a browser test in [`ChatView.browser.tsx`](https://github.com/pingdotgg/t3code/pull/1285/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) that seeds project entries, simulates `ArrowDown` presses, and asserts `scrollIntoView` is called and the selected path is inserted into the draft prompt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c7c97b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->