### PR TITLE
fix(web): apply sticky model when reusing existing draft thread

### DIFF
--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -63,6 +63,13 @@ export function useHandleNewThread() {
               ...(hasEnvModeOption ? { envMode: options?.envMode } : {}),
             });
           }
+          if (stickyModel) {
+            setProvider(storedDraftThread.threadId, inferProviderForModel(stickyModel));
+            setModel(storedDraftThread.threadId, stickyModel);
+          }
+          if (Object.keys(stickyModelOptions).length > 0) {
+            setModelOptions(storedDraftThread.threadId, stickyModelOptions);
+          }
           setProjectDraftThreadId(projectId, storedDraftThread.threadId);
           if (routeThreadId === storedDraftThread.threadId) {
             return;

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -95,6 +95,13 @@ export function useHandleNewThread() {
             ...(hasEnvModeOption ? { envMode: options?.envMode } : {}),
           });
         }
+        if (stickyModel) {
+          setProvider(routeThreadId, inferProviderForModel(stickyModel));
+          setModel(routeThreadId, stickyModel);
+        }
+        if (Object.keys(stickyModelOptions).length > 0) {
+          setModelOptions(routeThreadId, stickyModelOptions);
+        }
         setProjectDraftThreadId(projectId, routeThreadId);
         return Promise.resolve();
       }


### PR DESCRIPTION
## Summary

Fixes the model selection resetting to GPT 5.4 when creating a new thread.

## Root Cause

`handleNewThread()` in `useHandleNewThread.ts` has 3 code paths:
1. **Reuse stored draft thread** (line 57) — sticky model was **NOT** applied
2. **Reuse active draft in same project** (line 79) — sticky model was **NOT** applied
3. **Create brand new thread** (line 95) — sticky model was applied

When a user clicks "New Thread" and a draft already exists for that project, path 1 was taken — navigating to the old draft without updating its model to match the user's last selection.

## Fix

Apply `stickyModel` and `stickyModelOptions` to the draft thread in the stored draft path (path 1), matching the behavior already present in path 3.

## Test plan

1. Select Claude Opus 4.6 and create a thread
2. Click "New Thread" on the same project
3. Verify the model picker shows Claude Opus 4.6 (not GPT 5.4)

Fixes #1276

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply sticky model when reusing an existing draft thread
> When `handleNewThread` reuses an existing draft thread (stored or current route), it now sets the thread's provider and model from the composer's sticky model preference and applies any sticky model options. Previously, sticky model preferences were ignored in these reuse paths, so the thread would not reflect the user's saved model choice.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf46b91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->