### PR TITLE
fix(web): prevent iOS auto-zoom on chat input focus

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1093,7 +1093,7 @@ function ComposerPromptEditorInner({
           contentEditable={
             <ContentEditable
               className={cn(
-                "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-[14px] leading-relaxed text-foreground focus:outline-none",
+                "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-[16px] sm:text-[14px] leading-relaxed text-foreground focus:outline-none",
                 className,
               )}
               data-testid="composer-editor"
@@ -1104,7 +1104,7 @@ function ComposerPromptEditorInner({
           }
           placeholder={
             terminalContexts.length > 0 ? null : (
-              <div className="pointer-events-none absolute inset-0 text-[14px] leading-relaxed text-muted-foreground/35">
+              <div className="pointer-events-none absolute inset-0 text-[16px] sm:text-[14px] leading-relaxed text-muted-foreground/35">
                 {placeholder}
               </div>
             )


### PR DESCRIPTION
## Summary

Fixes the iOS auto-zoom that occurs when focusing the chat composer input, causing layout shifts and broken sticky headers.

## Root Cause

iOS Safari/Chrome automatically zoom into input fields with `font-size` below 16px. The composer editor (`ComposerPromptEditor.tsx`) used `text-[14px]`, which triggers this behavior on mobile devices.

## Fix

- Set composer `font-size` to `16px` on mobile viewports, `14px` on `sm+` (matching placeholder)
- Add `maximum-scale=1` to the viewport meta tag to prevent auto-zoom on all inputs

## Test plan

- Open t3code on iOS Safari/Chrome
- Tap the chat input
- Verify no zoom occurs and sticky header/footer stay in place

Fixes #1265

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent iOS auto-zoom on chat input focus
> - Sets `font-size` to 16px (iOS's zoom threshold) on the chat input in [`ComposerPromptEditor.tsx`](https://github.com/pingdotgg/t3code/pull/1292/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4), reverting to 14px at the `sm` breakpoint and above.
> - Adds `maximum-scale=1.0` to the viewport meta tag in [`index.html`](https://github.com/pingdotgg/t3code/pull/1292/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f) as a secondary safeguard.
> - Behavioral Change: `maximum-scale=1.0` disables user-initiated pinch-to-zoom on all browsers that respect it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47f5a8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->