### PR TITLE
fix(checkpointing): skip checkpoint when cwd is the home directory

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -10,6 +10,7 @@
  * @module CheckpointStoreLive
  */
 import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
 
 import { Effect, Layer, FileSystem, Path } from "effect";
 
@@ -90,6 +91,19 @@ const makeCheckpointStore = Effect.gen(function* () {
   const captureCheckpoint: CheckpointStoreShape["captureCheckpoint"] = (input) =>
     Effect.gen(function* () {
       const operation = "CheckpointStore.captureCheckpoint";
+
+      // Skip checkpointing for the home directory — git add -A on ~/ scans
+      // thousands of unrelated files and will time out.
+      const resolvedCwd = yield* Effect.try(() => path.resolve(input.cwd));
+      const home = yield* Effect.try(() => homedir());
+      if (resolvedCwd === home) {
+        return yield* new CheckpointInvariantError({
+          operation,
+          detail:
+            "Skipping checkpoint: working directory is the home directory. " +
+            "Please open a specific project folder instead.",
+        });
+      }
 
       yield* Effect.acquireUseRelease(
         fs.makeTempDirectory({ prefix: "t3-fs-checkpoint-" }),


### PR DESCRIPTION
## Summary

When T3 Code is launched from the home directory (`~/`), the checkpoint system runs `git add -A -- .` which scans the entire home directory (Applications, .npm, .cache, .cargo, etc.), exceeding the 30-second timeout and crashing the session.

## Fix

Before capturing a checkpoint, check if the resolved `cwd` matches `os.homedir()`. If so, skip checkpointing with a descriptive `CheckpointInvariantError` instead of timing out.

## Test plan

- Run `npx t3` from `~/` — checkpoint should be skipped with a warning, session should continue
- Run from a project folder — checkpoint should work normally

Fixes #1227

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip checkpoint in `captureCheckpoint` when `cwd` resolves to the home directory
> Adds an early guard in `captureCheckpoint` in [CheckpointStore.ts](https://github.com/pingdotgg/t3code/pull/1294/files#diff-246091edd41db39269d7b4458744037fe70cb1d30ee21e10ad8ad4ad80e2d705) that compares the resolved `cwd` against the user's home directory via `homedir()`. If they match, the function short-circuits with a `CheckpointInvariantError` before any git operations or temp directory creation occur.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 057b369.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->