### PR TITLE
fix(terminal): strip OSC/DA query responses from persisted history

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -242,6 +242,23 @@ async function defaultSubprocessChecker(terminalPid: number): Promise<boolean> {
   return checkPosixSubprocessActivity(terminalPid);
 }
 
+/**
+ * Strip terminal query responses (OSC color reports, DA responses) that
+ * should be consumed by the terminal emulator but leak into the saved
+ * history when the session is restored. These appear as visible gibberish
+ * like `10;rgb:f5f5/f5f5/f5f5` to the user.
+ */
+function stripTerminalQueryResponses(data: string): string {
+  // OSC responses: \x1b] ... ST  where ST is \x1b\\ or \x07
+  // Examples: \x1b]10;rgb:f5f5/f5f5/f5f5\x1b\\  (foreground color report)
+  //           \x1b]11;rgb:1616/1616/1616\x07      (background color report)
+  // DA responses: \x1b[ ... c   (Device Attributes)
+  // Example: \x1b[?1;2c
+  return data
+    .replace(/\x1b\][^\x07\x1b]*(?:\x1b\\|\x07)/g, "")
+    .replace(/\x1b\[\?[\d;]*c/g, "");
+}
+
 function capHistory(history: string, maxLines: number): string {
   if (history.length === 0) return history;
   const hasTrailingNewline = history.endsWith("\n");
@@ -694,7 +711,8 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
   }
 
   private onProcessData(session: TerminalSessionState, data: string): void {
-    session.history = capHistory(`${session.history}${data}`, this.historyLineLimit);
+    const cleanData = stripTerminalQueryResponses(data);
+    session.history = capHistory(`${session.history}${cleanData}`, this.historyLineLimit);
     session.updatedAt = new Date().toISOString();
     this.queuePersist(session.threadId, session.terminalId, session.history);
     this.emitEvent({

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -915,7 +915,7 @@ export class TerminalManagerRuntime extends EventEmitter<TerminalManagerEvents> 
     const nextPath = this.historyPath(threadId, terminalId);
     try {
       const raw = await fs.promises.readFile(nextPath, "utf8");
-      const capped = capHistory(raw, this.historyLineLimit);
+      const capped = capHistory(stripTerminalQueryResponses(raw), this.historyLineLimit);
       if (capped !== raw) {
         await fs.promises.writeFile(nextPath, capped, "utf8");
       }


### PR DESCRIPTION
## Summary

Terminal sessions show gibberish like `10;rgb:f5f5/f5f5/f5f5` after restore.

## Root Cause

When the terminal emulator queries colors (OSC 10/11) or device attributes (DA), the terminal responds with escape sequences. These responses are saved into `session.history` and replayed on restore. Since the xterm.js instance during restore doesn't consume them as query responses, they appear as visible text.

## Fix

Strip OSC color report responses (`\e]10;...\e\\`, `\e]11;...\e\\`) and DA responses (`\e[?1;2c`) from data before persisting to history. Live output to the terminal emitter is unchanged so xterm.js can still process them in real-time.

## Test plan

- Start a terminal session, let it run
- Restart the app or reload the session
- Verify no escape code gibberish appears in the restored terminal

Fixes #1238

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip OSC and Device Attributes query responses from persisted terminal history
> - Adds `stripTerminalQueryResponses` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/1295/files#diff-51f9668a4493e7cf6ec7c836a4af9946110091ee50cd822c9c4a4d5bdcedf496) that removes OSC sequences (ESC ] ... ESC \ or BEL) and DA responses (ESC [ ? digits/semicolons c) via regex.
> - `onProcessData` sanitizes data before appending to `session.history`; the raw data is still emitted on the `output` event.
> - `readHistory` sanitizes history loaded from disk and rewrites the file if the sanitized content differs from what was stored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1b2c83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->