### PR TITLE
Clarify running-turn stop messaging

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,7 +1,11 @@
 import { ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { buildExpiredTerminalContextToastCopy, deriveComposerSendState } from "./ChatView.logic";
+import {
+  buildExpiredTerminalContextToastCopy,
+  buildRunningTurnBlockedMessage,
+  deriveComposerSendState,
+} from "./ChatView.logic";
 
 describe("deriveComposerSendState", () => {
   it("treats expired terminal pills as non-sendable content", () => {
@@ -65,5 +69,19 @@ describe("buildExpiredTerminalContextToastCopy", () => {
       title: "Expired terminal contexts omitted from message",
       description: "Re-add it if you want that terminal output included.",
     });
+  });
+});
+
+describe("buildRunningTurnBlockedMessage", () => {
+  it("explains when a turn is still running", () => {
+    expect(buildRunningTurnBlockedMessage(false)).toBe(
+      "A turn is still running. Stop it before sending another prompt.",
+    );
+  });
+
+  it("explains when a long-running command is keeping the turn active", () => {
+    expect(buildRunningTurnBlockedMessage(true)).toBe(
+      "A long-running command is still active. Stop the current turn before sending another prompt.",
+    );
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -160,3 +160,9 @@ export function buildExpiredTerminalContextToastCopy(
     description: "Re-add it if you want that terminal output included.",
   };
 }
+
+export function buildRunningTurnBlockedMessage(hasRunningSubprocess: boolean): string {
+  return hasRunningSubprocess
+    ? "A long-running command is still active. Stop the current turn before sending another prompt."
+    : "A turn is still running. Stop it before sending another prompt.";
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -164,6 +164,7 @@ import { ProviderHealthBanner } from "./chat/ProviderHealthBanner";
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
 import {
   buildExpiredTerminalContextToastCopy,
+  buildRunningTurnBlockedMessage,
   buildLocalDraftThread,
   buildTemporaryWorktreeBranchName,
   cloneComposerImageForRetry,
@@ -661,6 +662,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const isSendBusy = sendPhase !== "idle";
   const isPreparingWorktree = sendPhase === "preparing-worktree";
   const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const hasRunningTerminalSubprocess = terminalState.runningTerminalIds.length > 0;
+  const runningTurnBlockedMessage = buildRunningTurnBlockedMessage(hasRunningTerminalSubprocess);
   const nowIso = new Date(nowTick).toISOString();
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
@@ -2346,6 +2349,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
     e?.preventDefault();
     const api = readNativeApi();
     if (!api || !activeThread || isSendBusy || isConnecting || sendInFlightRef.current) return;
+    if (phase === "running") {
+      setThreadError(activeThread.id, runningTurnBlockedMessage);
+      return;
+    }
     if (activePendingProgress) {
       onAdvanceActivePendingUserInput();
       return;
@@ -3931,22 +3938,29 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             </Button>
                           </div>
                         ) : phase === "running" ? (
-                          <button
-                            type="button"
-                            className="flex size-8 cursor-pointer items-center justify-center rounded-full bg-rose-500/90 text-white transition-all duration-150 hover:bg-rose-500 hover:scale-105 sm:h-8 sm:w-8"
-                            onClick={() => void onInterrupt()}
-                            aria-label="Stop generation"
-                          >
-                            <svg
-                              width="12"
-                              height="12"
-                              viewBox="0 0 12 12"
-                              fill="currentColor"
-                              aria-hidden="true"
+                          <div className="flex items-center gap-2">
+                            <span className="hidden max-w-52 text-right text-xs text-muted-foreground/70 sm:inline">
+                              {runningTurnBlockedMessage}
+                            </span>
+                            <button
+                              type="button"
+                              className="flex h-9 cursor-pointer items-center justify-center gap-2 rounded-full bg-rose-500/90 px-3 text-white transition-all duration-150 hover:bg-rose-500 hover:scale-105 sm:h-8"
+                              onClick={() => void onInterrupt()}
+                              aria-label="Stop generation"
+                              title={runningTurnBlockedMessage}
                             >
-                              <rect x="2" y="2" width="8" height="8" rx="1.5" />
-                            </svg>
-                          </button>
+                              <svg
+                                width="12"
+                                height="12"
+                                viewBox="0 0 12 12"
+                                fill="currentColor"
+                                aria-hidden="true"
+                              >
+                                <rect x="2" y="2" width="8" height="8" rx="1.5" />
+                              </svg>
+                              <span className="hidden sm:inline">Stop</span>
+                            </button>
+                          </div>
                         ) : pendingUserInputs.length === 0 ? (
                           showPlanFollowUpPrompt ? (
                             prompt.trim().length > 0 ? (


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

This updates the running-turn composer state to show a clearer blocked-send message, with specific wording when a long-running terminal command is still active. It also makes the stop action more explicit in the composer UI so it is easier to understand how to unblock the thread.

## Why

When a turn was already running, the blocked state did not clearly explain whether the user was waiting on normal generation or on a long-running command. This makes that state easier to understand and makes the stop path more obvious, which should reduce confusion when a thread appears stuck.

## UI Changes

<img width="1053" height="299" alt="image" src="https://github.com/user-attachments/assets/2afecb49-3f8c-486f-ae14-053e2f4ca7ef" />

## Checklist

- [1 ] This PR is small and focused
- [ 2] I explained what changed and why
- [ 3] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add contextual stop messaging to ChatView when a turn is running
> - Adds `buildRunningTurnBlockedMessage` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/1300/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) that returns one of two messages depending on whether a long-running terminal subprocess is active.
> - In [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1300/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), attempting to send while a turn is running now sets a thread error with this message instead of silently blocking.
> - The running-state UI replaces the bare stop icon with a labeled stop button, explanatory text (hidden on small screens), and a tooltip using the same message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f734a2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->