### PR TITLE
Support configured system editors

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -121,6 +121,54 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       });
     }),
   );
+
+  it.effect("uses the configured system editor from VISUAL or EDITOR", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-open-configured-editor-" });
+      const editorPath = path.join(dir, "custom editor.CMD");
+      yield* fs.writeFileString(editorPath, "@echo off\r\n");
+      const launch = yield* resolveEditorLaunch(
+        { cwd: "C:\\workspace", editor: "system-editor" },
+        "win32",
+        {
+          PATH: dir,
+          PATHEXT: ".COM;.EXE;.BAT;.CMD",
+          VISUAL: `"${editorPath}" --reuse-window`,
+        },
+      );
+      assert.deepEqual(launch, {
+        command: editorPath,
+        args: ["--reuse-window", "C:\\workspace"],
+      });
+    }),
+  );
+
+  it.effect(
+    "uses configured known editor commands even when the default binary is unavailable",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-open-configured-vscode-" });
+        const editorPath = path.join(dir, "code.CMD");
+        yield* fs.writeFileString(editorPath, "@echo off\r\n");
+        const launch = yield* resolveEditorLaunch(
+          { cwd: "C:\\workspace\\src\\open.ts:71:5", editor: "vscode" },
+          "win32",
+          {
+            PATH: "",
+            PATHEXT: ".COM;.EXE;.BAT;.CMD",
+            VISUAL: `"${editorPath}" --reuse-window`,
+          },
+        );
+        assert.deepEqual(launch, {
+          command: editorPath,
+          args: ["--reuse-window", "--goto", "C:\\workspace\\src\\open.ts:71:5"],
+        });
+      }),
+  );
 });
 
 it.layer(NodeServices.layer)("launchDetached", (it) => {
@@ -227,6 +275,38 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
         PATHEXT: ".COM;.EXE;.BAT;.CMD",
       });
       assert.deepEqual(editors, ["cursor", "file-manager"]);
+    }),
+  );
+
+  it.effect("adds the configured system editor when it is available but unknown", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-editors-" });
+
+      yield* fs.writeFileString(path.join(dir, "custom-editor"), "#!/bin/sh\n");
+      yield* fs.writeFileString(path.join(dir, "cursor"), "#!/bin/sh\n");
+      const editors = resolveAvailableEditors("linux", {
+        PATH: dir,
+        VISUAL: "custom-editor --reuse-window",
+      });
+      assert.deepEqual(editors, ["cursor", "system-editor"]);
+    }),
+  );
+
+  it.effect("reuses built-in editor ids when VISUAL points at a known editor path", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-editors-known-" });
+      const editorPath = path.join(dir, "code.CMD");
+      yield* fs.writeFileString(editorPath, "@echo off\r\n");
+      const editors = resolveAvailableEditors("win32", {
+        PATH: "",
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+        VISUAL: `"${editorPath}" --reuse-window`,
+      });
+      assert.deepEqual(editors, ["vscode"]);
     }),
   );
 });

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -38,6 +38,13 @@ interface CommandAvailabilityOptions {
 }
 
 const LINE_COLUMN_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
+const CONFIGURED_EDITOR_ENV_KEYS = ["VISUAL", "EDITOR"] as const;
+const SHELL_WORD_PATTERN = /"([^"]*)"|'([^']*)'|([^\s]+)/g;
+
+interface ResolvedConfiguredEditor {
+  readonly editorId: EditorId;
+  readonly launch: EditorLaunch;
+}
 
 function shouldUseGotoFlag(editorId: EditorId, target: string): boolean {
   return (
@@ -62,6 +69,65 @@ function stripWrappingQuotes(value: string): string {
 
 function resolvePathEnvironmentVariable(env: NodeJS.ProcessEnv): string {
   return env.PATH ?? env.Path ?? env.path ?? "";
+}
+
+function tokenizeCommand(value: string): ReadonlyArray<string> {
+  const tokens: string[] = [];
+  for (const match of value.matchAll(SHELL_WORD_PATTERN)) {
+    const token = match[1] ?? match[2] ?? match[3];
+    if (!token) {
+      continue;
+    }
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+function resolveCommandIdentity(command: string): string {
+  const trimmed = command.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+  const parts = trimmed.split(/[\\/]/);
+  const lastSegment = parts[parts.length - 1] ?? trimmed;
+  const extension = extname(lastSegment);
+  const commandName = extension.length > 0 ? lastSegment.slice(0, -extension.length) : lastSegment;
+  return commandName.toLowerCase();
+}
+
+function resolveConfiguredEditor(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): ResolvedConfiguredEditor | null {
+  for (const envKey of CONFIGURED_EDITOR_ENV_KEYS) {
+    const rawValue = env[envKey]?.trim();
+    if (!rawValue) {
+      continue;
+    }
+
+    const [command, ...args] = tokenizeCommand(rawValue);
+    if (!command) {
+      continue;
+    }
+    if (!isCommandAvailable(command, { platform, env })) {
+      continue;
+    }
+
+    const builtInEditor = EDITORS.find(
+      (editor) =>
+        editor.command &&
+        resolveCommandIdentity(editor.command) === resolveCommandIdentity(command),
+    );
+    return {
+      editorId: builtInEditor?.id ?? "system-editor",
+      launch: {
+        command,
+        args,
+      },
+    };
+  }
+
+  return null;
 }
 
 function resolveWindowsPathExtensions(env: NodeJS.ProcessEnv): ReadonlyArray<string> {
@@ -166,12 +232,23 @@ export function resolveAvailableEditors(
   env: NodeJS.ProcessEnv = process.env,
 ): ReadonlyArray<EditorId> {
   const available: EditorId[] = [];
+  const configuredEditor = resolveConfiguredEditor(env, platform);
 
   for (const editor of EDITORS) {
-    const command = editor.command ?? fileManagerCommandForPlatform(platform);
-    if (isCommandAvailable(command, { platform, env })) {
+    if (editor.id === "system-editor") {
+      continue;
+    }
+
+    const command =
+      editor.id === "file-manager" ? fileManagerCommandForPlatform(platform) : editor.command;
+    const isConfiguredEditor = configuredEditor?.editorId === editor.id;
+    if ((command && isCommandAvailable(command, { platform, env })) || isConfiguredEditor) {
       available.push(editor.id);
     }
+  }
+
+  if (configuredEditor?.editorId === "system-editor") {
+    available.push("system-editor");
   }
 
   return available;
@@ -206,10 +283,30 @@ export class Open extends ServiceMap.Service<Open, OpenShape>()("t3/open") {}
 export const resolveEditorLaunch = Effect.fnUntraced(function* (
   input: OpenInEditorInput,
   platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
 ): Effect.fn.Return<EditorLaunch, OpenError> {
   const editorDef = EDITORS.find((editor) => editor.id === input.editor);
   if (!editorDef) {
     return yield* new OpenError({ message: `Unknown editor: ${input.editor}` });
+  }
+
+  const configuredEditor = resolveConfiguredEditor(env, platform);
+  if (configuredEditor && configuredEditor.editorId === input.editor) {
+    return shouldUseGotoFlag(input.editor, input.cwd)
+      ? {
+          command: configuredEditor.launch.command,
+          args: [...configuredEditor.launch.args, "--goto", input.cwd],
+        }
+      : {
+          command: configuredEditor.launch.command,
+          args: [...configuredEditor.launch.args, input.cwd],
+        };
+  }
+
+  if (editorDef.id === "system-editor") {
+    return yield* new OpenError({
+      message: "System editor is not configured. Set VISUAL or EDITOR to use it.",
+    });
   }
 
   if (editorDef.command) {

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -6,7 +6,7 @@ import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { Group, GroupSeparator } from "../ui/group";
 import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "../ui/menu";
-import { AntigravityIcon, CursorIcon, Icon, VisualStudioCode, Zed } from "../Icons";
+import { AntigravityIcon, CursorIcon, Icon, OpenCodeIcon, VisualStudioCode, Zed } from "../Icons";
 import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 
@@ -31,6 +31,11 @@ const resolveOptions = (platform: string, availableEditors: ReadonlyArray<Editor
       label: "Antigravity",
       Icon: AntigravityIcon,
       value: "antigravity",
+    },
+    {
+      label: "System Editor",
+      Icon: OpenCodeIcon,
+      value: "system-editor",
     },
     {
       label: isMacPlatform(platform)

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -6,6 +6,7 @@ export const EDITORS = [
   { id: "vscode", label: "VS Code", command: "code" },
   { id: "zed", label: "Zed", command: "zed" },
   { id: "antigravity", label: "Antigravity", command: "agy" },
+  { id: "system-editor", label: "System Editor", command: null },
   { id: "file-manager", label: "File Manager", command: null },
 ] as const;
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

This updates the open-in-editor flow to respect VISUAL and EDITOR when resolving available editors and launching files. If the configured command matches a known editor, the existing editor option is reused. If it points to another runnable editor, a System Editor option is shown instead. The change also adds tests covering configured known editors and unknown configured commands.

## Why

Users with a preferred editor configured through VISUAL or EDITOR could still be blocked by the current hardcoded editor detection flow. This keeps the existing behavior for known editors while allowing configured system editors to work without requiring a dedicated built-in entry first.


## Checklist

- [1 ] This PR is small and focused
- [1 ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add system editor support via VISUAL/EDITOR environment variables
> - Reads `VISUAL` and `EDITOR` env vars to detect a user-configured system editor, tokenizing the command with basic quote handling and matching it against known built-in editor IDs.
> - Adds `'system-editor'` as a recognized editor ID in the contracts and surfaces it as a "System Editor" option in the editor picker when available.
> - `resolveAvailableEditors` now includes the configured editor even when its default binary is not on PATH, and lists `'system-editor'` for unknown-but-available commands.
> - `resolveEditorLaunch` uses the configured command and args when launching `'system-editor'`, applies `--goto` for file:line:col targets, and returns an explicit error if `'system-editor'` is requested but no env var is configured.
> - Behavioral Change: known editors (e.g. VS Code) can now launch via the configured `VISUAL`/`EDITOR` path instead of their default binary when the default is absent from PATH.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f9c2f48.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->