### PR TITLE
refactor(web): remove redundant add-project cancel button

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1934,7 +1934,6 @@ export default function Sidebar() {
                   </Tooltip>
                 </div>
               </div>
-
               {shouldShowProjectPathEntry && (
                 <div className="mb-2 px-1">
                   {isElectron && (
@@ -1985,18 +1984,6 @@ export default function Sidebar() {
                       {addProjectError}
                     </p>
                   )}
-                  <div className="mt-1.5 px-0.5">
-                    <button
-                      type="button"
-                      className="text-[11px] text-muted-foreground/50 transition-colors hover:text-muted-foreground"
-                      onClick={() => {
-                        setAddingProject(false);
-                        setAddProjectError(null);
-                      }}
-                    >
-                      Cancel
-                    </button>
-                  </div>
                 </div>
               )}
 


### PR DESCRIPTION
## What Changed

Removed the extra inline `Cancel` button from the add-project form in the sidebar.

## Why

There is already another cancel button. The add-project toggle button switches into the cancel action when the form is open.
The inline `Cancel` button duplicates behavior that is already exposed by this add-project toggle. (You can also press `Esc` to cancel btw)
Removing it simplifies the UI and reduces duplicate controls for the same action.

## UI Changes

Before:
<img width="366" height="125" alt="image" src="https://github.com/user-attachments/assets/daded380-e06f-4c16-a07e-58bb39728246" />

After:
<img width="365" height="91" alt="image" src="https://github.com/user-attachments/assets/9da6287d-859e-44a9-9568-a9b75b207277" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Cancel button from add-project panel in Sidebar
> Removes the inline Cancel button from the add-project UI in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1302/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1). Risk: users can no longer dismiss the add-project panel via this button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc67e4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI simplification in the sidebar add-project form; main behavioral change is removing one way to cancel/clear errors, relying on the existing toggle button and `Esc` instead.
> 
> **Overview**
> **Simplifies the sidebar add-project UI** by removing the inline `Cancel` button from the add-project form in `Sidebar.tsx`.
> 
> Canceling add-project mode (and clearing `addProjectError`) is now done via the existing add-project toggle button (plus icon) or the `Escape` key, reducing duplicated controls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc67e4d11c0549e649aaac04d6d68fae8fbefeb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->