### PR TITLE
fix(web): verify composer attachment persistence after flush

### DIFF
--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1,4 +1,3 @@
-import * as Schema from "effect/Schema";
 import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -7,7 +6,7 @@ import {
   type ComposerImageAttachment,
   useComposerDraftStore,
 } from "./composerDraftStore";
-import { removeLocalStorageItem, setLocalStorageItem } from "./hooks/useLocalStorage";
+import { removeLocalStorageItem } from "./hooks/useLocalStorage";
 import {
   INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
   insertInlineTerminalContextPlaceholder,
@@ -204,26 +203,49 @@ describe("composerDraftStore syncPersistedAttachments", () => {
     removeLocalStorageItem(COMPOSER_DRAFT_STORAGE_KEY);
   });
 
-  it("treats malformed persisted draft storage as empty", async () => {
+  it("keeps attachments persisted after flushing the pending draft write", async () => {
     const image = makeImage({
       id: "img-persisted",
       previewUrl: "blob:persisted",
     });
     useComposerDraftStore.getState().addImage(threadId, image);
-    setLocalStorageItem(
-      COMPOSER_DRAFT_STORAGE_KEY,
+
+    useComposerDraftStore.getState().syncPersistedAttachments(threadId, [
       {
-        version: 2,
-        state: {
-          draftsByThreadId: {
-            [threadId]: {
-              attachments: "not-an-array",
-            },
-          },
-        },
+        id: image.id,
+        name: image.name,
+        mimeType: image.mimeType,
+        sizeBytes: image.sizeBytes,
+        dataUrl: image.previewUrl,
       },
-      Schema.Unknown,
-    );
+    ]);
+    await Promise.resolve();
+
+    expect(
+      useComposerDraftStore.getState().draftsByThreadId[threadId]?.persistedAttachments,
+    ).toEqual([
+      {
+        id: image.id,
+        name: image.name,
+        mimeType: image.mimeType,
+        sizeBytes: image.sizeBytes,
+        dataUrl: image.previewUrl,
+      },
+    ]);
+    expect(
+      useComposerDraftStore.getState().draftsByThreadId[threadId]?.nonPersistedImageIds,
+    ).toEqual([]);
+  });
+
+  it("marks attachments non-persisted when flushing draft storage fails", async () => {
+    const image = makeImage({
+      id: "img-persisted",
+      previewUrl: "blob:persisted",
+    });
+    useComposerDraftStore.getState().addImage(threadId, image);
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("Quota exceeded");
+    });
 
     useComposerDraftStore.getState().syncPersistedAttachments(threadId, [
       {
@@ -242,6 +264,8 @@ describe("composerDraftStore syncPersistedAttachments", () => {
     expect(
       useComposerDraftStore.getState().draftsByThreadId[threadId]?.nonPersistedImageIds,
     ).toEqual([image.id]);
+
+    setItemSpy.mockRestore();
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -846,6 +846,15 @@ function readPersistedAttachmentIdsFromStorage(threadId: ThreadId): string[] {
   }
 }
 
+function flushComposerDraftStorage(): boolean {
+  try {
+    composerDebouncedStorage.flush();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function hydreatePersistedComposerImageAttachment(
   attachment: PersistedComposerImageAttachment,
 ): File | null {
@@ -1662,7 +1671,10 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           return { draftsByThreadId: nextDraftsByThreadId };
         });
         Promise.resolve().then(() => {
-          const persistedIdSet = new Set(readPersistedAttachmentIdsFromStorage(threadId));
+          const didFlushPersistedDraft = flushComposerDraftStorage();
+          const persistedIdSet = didFlushPersistedDraft
+            ? new Set(readPersistedAttachmentIdsFromStorage(threadId))
+            : new Set<string>();
           set((state) => {
             const current = state.draftsByThreadId[threadId];
             if (!current) {


### PR DESCRIPTION
Fixes #1304

## What Changed

Fixed composer image attachment persistence verification in `apps/web`.

The draft store now flushes pending debounced composer draft writes before checking which attachment IDs actually landed in persisted storage. This removes the false warning state where image attachments were marked non-persisted simply because the storage write had not fired yet.

Also added regression coverage for:
- successful persistence after flushing the pending write
- real persistence failure when storage flush/write throws

## Why

The previous logic staged persisted attachments in Zustand state and then immediately checked storage on the next microtask. That check raced the 300ms debounced persistence write and could conclude that attachments were not saved even though the write was only still pending.

This made the orange warning badge show up incorrectly and undermined image draft persistence across refresh/navigation.

Flushing only at the point of attachment verification keeps normal draft persistence debounced for performance, while making the warning badge reflect actual storage failure.

## UI Changes

None


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer attachment persistence after flushing debounced draft storage
> - Adds `flushComposerDraftStorage` in [composerDraftStore.ts](https://github.com/pingdotgg/t3code/pull/1305/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a) that wraps `composerDebouncedStorage.flush()` in a try/catch, returning a boolean for success or failure.
> - `syncPersistedAttachments` now calls this flush before reading persisted attachment IDs from storage; if the flush fails, all attachments are treated as non-persisted.
> - Adds two tests in [composerDraftStore.test.ts](https://github.com/pingdotgg/t3code/pull/1305/files#diff-61714da43700c6105d471eadf7c6f4e80aee8189d14bed8e4362b66dded855e1) verifying attachments remain persisted on successful flush and are marked non-persisted when storage throws.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a25a63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->