### PR TITLE
fix(web): improve chat header badge and title flex distribution

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -661,7 +661,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
                 }
               >
                 <GitQuickActionIcon quickAction={quickAction} />
-                <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
+                <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">
                   {quickAction.label}
                 </span>
               </PopoverTrigger>
@@ -677,12 +677,12 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
               onClick={runQuickAction}
             >
               <GitQuickActionIcon quickAction={quickAction} />
-              <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
+              <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">
                 {quickAction.label}
               </span>
             </Button>
           )}
-          <GroupSeparator className="hidden @sm/header-actions:block" />
+          <GroupSeparator className="hidden @3xl/header-actions:block" />
           <Menu
             onOpenChange={(open) => {
               if (open) void invalidateGitQueries(queryClient);

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -277,11 +277,11 @@ export default function ProjectScriptsControl({
             title={`Run ${primaryScript.name}`}
           >
             <ScriptIcon icon={primaryScript.icon} />
-            <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
+            <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">
               {primaryScript.name}
             </span>
           </Button>
-          <GroupSeparator className="hidden @sm/header-actions:block" />
+          <GroupSeparator className="hidden @3xl/header-actions:block" />
           <Menu highlightItemOnHover={false}>
             <MenuTrigger
               render={<Button size="icon-xs" variant="outline" aria-label="Script actions" />}
@@ -342,7 +342,7 @@ export default function ProjectScriptsControl({
       ) : (
         <Button size="xs" variant="outline" onClick={openAddDialog} title="Add action">
           <PlusIcon className="size-3.5" />
-          <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
+          <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">
             Add action
           </span>
         </Button>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -54,7 +54,7 @@ export const ChatHeader = memo(function ChatHeader({
   onToggleDiff,
 }: ChatHeaderProps) {
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-2">
+    <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
         <SidebarTrigger className="size-7 shrink-0 md:hidden" />
         <h2
@@ -64,8 +64,8 @@ export const ChatHeader = memo(function ChatHeader({
           {activeThreadTitle}
         </h2>
         {activeProjectName && (
-          <Badge variant="outline" className="min-w-0 shrink truncate">
-            {activeProjectName}
+          <Badge variant="outline" className="min-w-0 shrink overflow-hidden">
+            <span className="min-w-0 truncate">{activeProjectName}</span>
           </Badge>
         )}
         {activeProjectName && !isGitRepo && (
@@ -74,7 +74,7 @@ export const ChatHeader = memo(function ChatHeader({
           </Badge>
         )}
       </div>
-      <div className="@container/header-actions flex min-w-0 flex-1 items-center justify-end gap-2 @sm/header-actions:gap-3">
+      <div className="flex shrink-0 items-center justify-end gap-2 @3xl/header-actions:gap-3">
         {activeProjectScripts && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -101,11 +101,11 @@ export const OpenInPicker = memo(function OpenInPicker({
         onClick={() => openInEditor(preferredEditor)}
       >
         {primaryOption?.Icon && <primaryOption.Icon aria-hidden="true" className="size-3.5" />}
-        <span className="sr-only @sm/header-actions:not-sr-only @sm/header-actions:ml-0.5">
+        <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">
           Open
         </span>
       </Button>
-      <GroupSeparator className="hidden @sm/header-actions:block" />
+      <GroupSeparator className="hidden @3xl/header-actions:block" />
       <Menu>
         <MenuTrigger render={<Button aria-label="Copy options" size="icon-xs" variant="outline" />}>
           <ChevronDownIcon aria-hidden="true" className="size-4" />


### PR DESCRIPTION
## What Changed

Moved the `@container/header-actions` query from the action buttons div to the parent header wrapper, and changed the action buttons container from `flex-1` to `shrink-0` so it sizes to its actual content instead of claiming a fixed 50% of the header.

Also fixed the project badge truncation so it clips from the right with an ellipsis instead of clipping from both sides.

The container query breakpoint was updated from `@sm` (24rem) to `@3xl` (48rem) across the four affected files since the container is now the full header width instead of just the right half.

## Why

The chat header splits into two sections: title + badge on the left, action buttons on the right. Both had `flex-1`, which gave them a rigid 50/50 split regardless of content. When action labels collapsed at smaller widths, the right side kept its 50% allocation as empty space while the badge and title were still being truncated. This same rigid split also caused buttons to overlap before the compact layout kicked in.

The badge also used `truncate` directly on the Badge component (which is `inline-flex justify-center`), so `text-overflow: ellipsis` didn't work and the centered text got clipped from both sides.

This is a follow-up to #1039, which addressed the same problem but has gone stale.

Builds on the earlier header overlap reports in #626 and #806.
Fixes #399, fixes #426, and fixes #713.

## UI Changes

**Before:**

https://github.com/user-attachments/assets/09c90149-eb82-42b3-b464-6f3e2937c9b6

**After:**

https://github.com/user-attachments/assets/ccfb3da6-07cd-43a8-aa7f-22d6b536f642

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat header badge truncation and action label visibility breakpoints
> - Moves the `@container/header-actions` query scope from the right-side action container to the outer header element in [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/1309/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c), so all child components share the same container query context.
> - Changes action label and separator visibility from `@sm/header-actions` to `@3xl/header-actions` across [GitActionsControl](https://github.com/pingdotgg/t3code/pull/1309/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f), [ProjectScriptsControl](https://github.com/pingdotgg/t3code/pull/1309/files#diff-e891caffa18ba1b7506cceb8fe52ad48887e3161ef59bee56d37cd57b61c511b), and [OpenInPicker](https://github.com/pingdotgg/t3code/pull/1309/files#diff-e2a98d212ae98eb3ec0902f11d6e8f0daeb2b1729c80a65a8792371f7605e802), delaying when button labels and separators appear.
> - Fixes project name truncation in the `Badge` by wrapping text in an inner `span` with `truncate`, replacing `truncate` on the badge itself to prevent layout shifts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 187776d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->