### PR TITLE
fix: serve project favicons with correct mime type

### DIFF
--- a/apps/server/src/projectFaviconRoute.test.ts
+++ b/apps/server/src/projectFaviconRoute.test.ts
@@ -117,6 +117,25 @@ describe("tryHandleProjectFaviconRequest", () => {
     });
   });
 
+  it("serves jpeg icons discovered from source metadata with the correct content type", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-jpeg-");
+    const iconPath = path.join(projectDir, "public", "brand", "logo.jpeg");
+    fs.mkdirSync(path.dirname(iconPath), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, "index.html"),
+      '<link rel="icon" href="/brand/logo.jpeg">',
+    );
+    fs.writeFileSync(iconPath, "jpeg-favicon", "utf8");
+
+    await withRouteServer(async (baseUrl) => {
+      const pathname = `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}`;
+      const response = await request(baseUrl, pathname);
+      expect(response.statusCode).toBe(200);
+      expect(response.contentType).toContain("image/jpeg");
+      expect(response.body).toBe("jpeg-favicon");
+    });
+  });
+
   it("resolves icon link when href appears before rel in HTML", async () => {
     const projectDir = makeTempDir("t3code-favicon-route-html-order-");
     const iconPath = path.join(projectDir, "public", "brand", "logo.svg");

--- a/apps/server/src/projectFaviconRoute.ts
+++ b/apps/server/src/projectFaviconRoute.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 const FAVICON_MIME_TYPES: Record<string, string> = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
   ".svg": "image/svg+xml",
   ".ico": "image/x-icon",
 };

--- a/apps/server/src/projectFaviconRoute.ts
+++ b/apps/server/src/projectFaviconRoute.ts
@@ -1,14 +1,7 @@
 import fs from "node:fs";
 import http from "node:http";
 import path from "node:path";
-
-const FAVICON_MIME_TYPES: Record<string, string> = {
-  ".png": "image/png",
-  ".jpg": "image/jpeg",
-  ".jpeg": "image/jpeg",
-  ".svg": "image/svg+xml",
-  ".ico": "image/x-icon",
-};
+import Mime from "@effect/platform-node/Mime";
 
 const FALLBACK_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 
@@ -72,8 +65,7 @@ function isPathWithinProject(projectCwd: string, candidatePath: string): boolean
 }
 
 function serveFaviconFile(filePath: string, res: http.ServerResponse): void {
-  const ext = path.extname(filePath).toLowerCase();
-  const contentType = FAVICON_MIME_TYPES[ext] ?? "application/octet-stream";
+  const contentType = Mime.getType(filePath) ?? "application/octet-stream";
   fs.readFile(filePath, (readErr, data) => {
     if (readErr) {
       res.writeHead(500, { "Content-Type": "text/plain" });


### PR DESCRIPTION
## Summary
- serve project favicons with `Mime.getType(...)` instead of a hand-written extension map
- keep regression coverage for a `.jpeg` icon discovered from project HTML metadata

## Why
The project favicon proxy resolves arbitrary `rel="icon"` hrefs from user projects. The original implementation used a smaller custom MIME map than the rest of the server, which caused `.jpeg` favicons to fall back to `application/octet-stream`.

This change fixes the `.jpeg` case and removes the duplicate MIME lookup logic so the favicon route stays aligned with the server's other file-serving paths.

## Verification
- bun run vitest apps/server/src/projectFaviconRoute.test.ts
- bun fmt
- bun lint
- bun typecheck