### PR TITLE
fix: use TanStack title metadata for root route

### DIFF
--- a/apps/web/src/routes/__root.test.ts
+++ b/apps/web/src/routes/__root.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { APP_DISPLAY_NAME } from "../branding";
+import { getRootRouteHead } from "./rootRouteHead";
+
+describe("getRootRouteHead", () => {
+  it("uses TanStack Router title metadata instead of a title-named meta tag", () => {
+    expect(getRootRouteHead()).toEqual({
+      meta: [{ title: APP_DISPLAY_NAME }],
+    });
+  });
+});

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -24,15 +24,14 @@ import { onServerConfigUpdated, onServerWelcome } from "../wsNativeApi";
 import { providerQueryKeys } from "../lib/providerReactQuery";
 import { projectQueryKeys } from "../lib/projectReactQuery";
 import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
+import { getRootRouteHead } from "./rootRouteHead";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
 }>()({
   component: RootRouteView,
   errorComponent: RootRouteErrorView,
-  head: () => ({
-    meta: [{ name: "title", content: APP_DISPLAY_NAME }],
-  }),
+  head: () => getRootRouteHead(),
 });
 
 function RootRouteView() {

--- a/apps/web/src/routes/rootRouteHead.ts
+++ b/apps/web/src/routes/rootRouteHead.ts
@@ -1,0 +1,7 @@
+import { APP_DISPLAY_NAME } from "../branding";
+
+export function getRootRouteHead() {
+  return {
+    meta: [{ title: APP_DISPLAY_NAME }],
+  };
+}


### PR DESCRIPTION
## Summary
- switch the root route head config to TanStack Router title metadata
- extract the root head shape into a small helper and cover it with a focused test

## Why
The root route was returning `meta: [{ name: "title", content: ... }]`, which produces a normal meta tag instead of TanStack Router's title metadata entry. The app also sets `document.title` on the client, but the route head shape itself was still malformed.

## Verification
- bun run vitest apps/web/src/routes/__root.test.ts
- bun fmt
- bun lint
- bun typecheck

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix root route title metadata to use TanStack `title` field
> Changes the root route head config from `{ name: 'title', content: APP_DISPLAY_NAME }` to `{ title: APP_DISPLAY_NAME }` inside the meta array, matching TanStack Router's expected format. Extracts the logic into a new helper [`getRootRouteHead`](https://github.com/pingdotgg/t3code/pull/1314/files#diff-f8026425c1838981211a8223794b1bfb4b210fb091f5cef001db1db1a984e79a) and adds a Vitest test to cover it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5147cfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->