### PR TITLE
fix: make web static title stage-neutral

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,7 +11,7 @@
       href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..800;1,9..40,300..800&display=swap"
       rel="stylesheet"
     />
-    <title>T3 Code (Alpha)</title>
+    <title>T3 Code</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -243,7 +243,7 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
       a({ node: _node, href, ...props }) {
         const targetPath = resolveMarkdownFileLinkTarget(href, cwd);
         if (!targetPath) {
-          return <a {...props} href={href} target="_blank" rel="noreferrer" />;
+          return <a {...props} href={href} target="_blank" rel="noopener noreferrer" />;
         }
 
         return (


### PR DESCRIPTION
## Summary
- change the static web HTML title from `T3 Code (Alpha)` to `T3 Code`

## Why
The runtime app title is stage-dependent in `branding.ts` and gets set by `main.tsx`, but `index.html` hardcoded the Alpha label. That made the initial tab title wrong in development before the app bootstrapped and corrected it.

## Verification
- bun fmt
- bun lint
- bun typecheck

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove '(Alpha)' stage label from web page title
> - Updates the static title in [index.html](https://github.com/pingdotgg/t3code/pull/1317/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f) from `T3 Code (Alpha)` to `T3 Code`.
> - Adds `noopener` to the `rel` attribute on external links in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/1317/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05), changing it from `noreferrer` to `noopener noreferrer`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67b7313.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->