### PR TITLE
Confirm before running git init

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -19,6 +19,15 @@ import { useAppSettings } from "~/appSettings";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "~/components/ui/alert-dialog";
+import {
   Dialog,
   DialogDescription,
   DialogFooter,
@@ -161,6 +170,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
     [activeThreadId],
   );
   const queryClient = useQueryClient();
+  const [confirmInitOpen, setConfirmInitOpen] = useState(false);
   const [isCommitDialogOpen, setIsCommitDialogOpen] = useState(false);
   const [dialogCommitMessage, setDialogCommitMessage] = useState("");
   const [excludedFiles, setExcludedFiles] = useState<ReadonlySet<string>>(new Set());
@@ -632,19 +642,45 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
     [gitCwd, threadToastData],
   );
 
+  const confirmGitInit = useCallback(() => {
+    if (initMutation.isPending) return;
+    setConfirmInitOpen(false);
+    initMutation.mutate();
+  }, [initMutation]);
+
   if (!gitCwd) return null;
 
   return (
     <>
       {!isRepo ? (
-        <Button
-          variant="outline"
-          size="xs"
-          disabled={initMutation.isPending}
-          onClick={() => initMutation.mutate()}
-        >
-          {initMutation.isPending ? "Initializing..." : "Initialize Git"}
-        </Button>
+        <>
+          <Button
+            variant="outline"
+            size="xs"
+            disabled={initMutation.isPending}
+            onClick={() => setConfirmInitOpen(true)}
+          >
+            {initMutation.isPending ? "Initializing..." : "Initialize Git"}
+          </Button>
+          <AlertDialog open={confirmInitOpen} onOpenChange={setConfirmInitOpen}>
+            <AlertDialogPopup>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Initialize Git repository?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will run{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs">git init</code> in{" "}
+                  <code className="rounded bg-muted px-1 py-0.5 text-xs break-all">{gitCwd}</code>
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+                <Button disabled={initMutation.isPending} onClick={confirmGitInit}>
+                  Initialize
+                </Button>
+              </AlertDialogFooter>
+            </AlertDialogPopup>
+          </AlertDialog>
+        </>
       ) : (
         <Group aria-label="Git actions">
           {quickActionDisabledReason ? (


### PR DESCRIPTION
## Summary
- require a confirmation dialog before initializing Git from the header action
- show the target path and command in the dialog copy

Closes https://github.com/pingdotgg/t3code/issues/1316

https://github.com/user-attachments/assets/f198e0f5-c07d-4174-994a-616111110ee2


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require confirmation before running `git init` in GitActionsControl
> Replaces the direct `git init` button action with an AlertDialog that shows the command and target path before proceeding. A memoized `confirmGitInit` callback closes the dialog and triggers the mutation, ignoring clicks if initialization is already pending.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa5b029.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->