### PR TITLE
Support deferred plan implementation in draft threads

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -26,6 +26,7 @@ import {
   type TerminalContextDraft,
 } from "../lib/terminalContext";
 import { isMacPlatform } from "../lib/utils";
+import { buildPlanImplementationPrompt } from "../proposedPlan";
 import { getRouter } from "../router";
 import { useStore } from "../store";
 import { estimateTimelineMessageHeight } from "./timelineHeight";
@@ -381,6 +382,47 @@ function createSnapshotWithLongProposedPlan(): OrchestrationReadModel {
   };
 }
 
+function createSnapshotWithActionablePlan(): OrchestrationReadModel {
+  const snapshot = createSnapshotForTargetUser({
+    targetMessageId: "msg-user-plan-actionable-target" as MessageId,
+    targetText: "plan thread",
+  });
+  const thread = snapshot.threads[0]!;
+  return {
+    ...snapshot,
+    threads: [
+      {
+        ...thread,
+        interactionMode: "plan",
+        latestTurn: {
+          turnId: "turn-plan-actionable" as never,
+          state: "completed",
+          requestedAt: isoAt(119),
+          startedAt: isoAt(120),
+          completedAt: isoAt(180),
+          assistantMessageId: null,
+        },
+        proposedPlans: [
+          {
+            id: "plan-browser-test" as never,
+            turnId: "turn-plan-actionable" as never,
+            planMarkdown: "# Ship plan mode follow-up\n\n- Step 1\n- Step 2",
+            implementedAt: null,
+            implementationThreadId: null,
+            createdAt: isoAt(170),
+            updatedAt: isoAt(171),
+          },
+        ],
+        session: {
+          ...thread.session!,
+          status: "ready",
+          activeTurnId: null,
+        },
+      },
+    ],
+  };
+}
+
 function resolveWsRpc(body: WsRequestEnvelope["body"]): unknown {
   const tag = body._tag;
   if (tag === ORCHESTRATION_WS_METHODS.getSnapshot) {
@@ -560,6 +602,16 @@ async function waitForSendButton(): Promise<HTMLButtonElement> {
   return waitForElement(
     () => document.querySelector<HTMLButtonElement>('button[aria-label="Send message"]'),
     "Unable to find send button.",
+  );
+}
+
+async function waitForButtonByText(text: string): Promise<HTMLButtonElement> {
+  return waitForElement(
+    () =>
+      Array.from(document.querySelectorAll("button")).find(
+        (button) => button.textContent?.trim() === text,
+      ) as HTMLButtonElement | null,
+    `Unable to find ${text} button.`,
   );
 }
 
@@ -1592,6 +1644,133 @@ describe("ChatView timeline estimator parity (full app)", () => {
         "Shortcut should create a fresh draft instead of reusing the promoted thread.",
       );
       expect(freshThreadPath).not.toBe(promotedThreadPath);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("defers plan implementation into a draft thread and sends selected adapter settings on Implement", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotWithActionablePlan(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          providers: [
+            ...nextFixture.serverConfig.providers,
+            {
+              provider: "claudeAgent",
+              status: "ready",
+              available: true,
+              authStatus: "authenticated",
+              checkedAt: NOW_ISO,
+            },
+          ],
+        };
+      },
+    });
+
+    try {
+      const implementationMenuButton = await waitForElement(
+        () =>
+          document.querySelector<HTMLButtonElement>('button[aria-label="Implementation actions"]'),
+        "Unable to find implementation actions button.",
+      );
+      implementationMenuButton.click();
+
+      const implementInNewThreadButton = await waitForButtonByText("Implement in a new thread");
+      implementInNewThreadButton.click();
+
+      const draftThreadPath = await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Route should change to a deferred implementation draft thread UUID.",
+      );
+      const draftThreadId = draftThreadPath.slice(1) as ThreadId;
+
+      expect(
+        wsRequests.some(
+          (request) =>
+            request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+            (request.command as { type?: string } | undefined)?.type === "thread.create",
+        ),
+      ).toBe(false);
+      expect(
+        wsRequests.some(
+          (request) =>
+            request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+            (request.command as { type?: string } | undefined)?.type === "thread.turn.start",
+        ),
+      ).toBe(false);
+
+      const composerEditor = await waitForComposerEditor();
+      await vi.waitFor(
+        () => {
+          expect(composerEditor.textContent).toContain(
+            buildPlanImplementationPrompt("# Ship plan mode follow-up\n\n- Step 1\n- Step 2"),
+          );
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+      await expect.element(page.getByRole("button", { name: "Implement" })).toBeInTheDocument();
+      expect(document.querySelector('button[aria-label="Send message"]')).toBeNull();
+      expect(document.body.textContent).not.toContain("Implement in a new thread");
+
+      const providerPickerButton = await waitForElement(
+        () =>
+          Array.from(
+            document.querySelectorAll<HTMLButtonElement>(
+              '[data-chat-composer-footer="true"] button',
+            ),
+          ).find((button) => button.textContent?.includes("GPT-5")) ?? null,
+        "Unable to find provider/model picker trigger.",
+      );
+      providerPickerButton.click();
+      await vi.waitFor(() => {
+        const text = document.body.textContent ?? "";
+        expect(text).toContain("Codex");
+        expect(text).toContain("Claude");
+      });
+      await page.getByText("Claude").click();
+      await page.getByRole("menuitemradio", { name: "Claude Opus 4.6" }).click();
+
+      await vi.waitFor(() => {
+        expect(useComposerDraftStore.getState().draftsByThreadId[draftThreadId]).toMatchObject({
+          provider: "claudeAgent",
+          model: "claude-opus-4-6",
+          deferredPlanImplementation: {
+            sourceThreadId: THREAD_ID,
+            sourcePlanId: "plan-browser-test",
+          },
+        });
+      });
+
+      const implementButton = await waitForButtonByText("Implement");
+      implementButton.click();
+
+      await vi.waitFor(
+        () => {
+          const dispatchRequests = wsRequests.filter(
+            (request) => request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand,
+          ) as Array<{ command?: Record<string, unknown> }>;
+          expect(
+            dispatchRequests.some((request) => request.command?.type === "thread.create"),
+          ).toBe(true);
+          const turnStartRequest = dispatchRequests.find(
+            (request) => request.command?.type === "thread.turn.start",
+          );
+          expect(turnStartRequest?.command).toMatchObject({
+            threadId: draftThreadId,
+            provider: "claudeAgent",
+            model: "claude-opus-4-6",
+            sourceProposedPlan: {
+              threadId: THREAD_ID,
+              planId: "plan-browser-test",
+            },
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -240,7 +240,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const threads = useStore((store) => store.threads);
   const projects = useStore((store) => store.projects);
   const markThreadVisited = useStore((store) => store.markThreadVisited);
-  const syncServerReadModel = useStore((store) => store.syncServerReadModel);
   const setStoreThreadError = useStore((store) => store.setError);
   const setStoreThreadBranch = useStore((store) => store.setThreadBranch);
   const { settings } = useAppSettings();
@@ -271,6 +270,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
   const setComposerDraftProvider = useComposerDraftStore((store) => store.setProvider);
   const setComposerDraftModel = useComposerDraftStore((store) => store.setModel);
+  const setComposerDraftModelOptions = useComposerDraftStore((store) => store.setModelOptions);
   const setComposerDraftRuntimeMode = useComposerDraftStore((store) => store.setRuntimeMode);
   const setComposerDraftInteractionMode = useComposerDraftStore(
     (store) => store.setInteractionMode,
@@ -298,11 +298,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const clearComposerDraftContent = useComposerDraftStore((store) => store.clearComposerContent);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const createProjectDraftThread = useComposerDraftStore((store) => store.createProjectDraftThread);
   const getDraftThreadByProjectId = useComposerDraftStore(
     (store) => store.getDraftThreadByProjectId,
   );
   const getDraftThread = useComposerDraftStore((store) => store.getDraftThread);
   const setProjectDraftThreadId = useComposerDraftStore((store) => store.setProjectDraftThreadId);
+  const setDeferredPlanImplementation = useComposerDraftStore(
+    (store) => store.setDeferredPlanImplementation,
+  );
   const clearProjectDraftThreadId = useComposerDraftStore(
     (store) => store.clearProjectDraftThreadId,
   );
@@ -563,6 +567,55 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [openOrReuseProjectDraftThread],
   );
 
+  const allocateImplementationDraftThread = useCallback((): ThreadId | null => {
+    if (!activeProject) {
+      return null;
+    }
+
+    const currentDraftThread = getDraftThread(threadId);
+    if (!isServerThread && currentDraftThread?.projectId === activeProject.id) {
+      return threadId;
+    }
+
+    const storedDraftThread = getDraftThreadByProjectId(activeProject.id);
+    if (storedDraftThread) {
+      if (storedDraftThread.threadId === threadId) {
+        return storedDraftThread.threadId;
+      }
+      const storedDraft =
+        useComposerDraftStore.getState().draftsByThreadId[storedDraftThread.threadId];
+      const storedDraftHasSendableContent = deriveComposerSendState({
+        prompt: storedDraft?.prompt ?? "",
+        imageCount: storedDraft?.images.length ?? 0,
+        terminalContexts: storedDraft?.terminalContexts ?? [],
+      }).hasSendableContent;
+      if (!storedDraftHasSendableContent && storedDraft?.deferredPlanImplementation == null) {
+        return storedDraftThread.threadId;
+      }
+    }
+
+    clearProjectDraftThreadId(activeProject.id);
+    return createProjectDraftThread(activeProject.id, {
+      createdAt: new Date().toISOString(),
+      runtimeMode,
+      interactionMode: DEFAULT_INTERACTION_MODE,
+      branch: activeThread?.branch ?? null,
+      worktreePath: activeThread?.worktreePath ?? null,
+      envMode: activeThread?.worktreePath ? "worktree" : "local",
+    });
+  }, [
+    activeProject,
+    activeThread?.branch,
+    activeThread?.worktreePath,
+    clearProjectDraftThreadId,
+    createProjectDraftThread,
+    getDraftThread,
+    getDraftThreadByProjectId,
+    isServerThread,
+    runtimeMode,
+    threadId,
+  ]);
+
   useEffect(() => {
     if (!activeThread?.id) return;
     if (!latestTurnSettled) return;
@@ -740,18 +793,25 @@ export default function ChatView({ threadId }: ChatViewProps) {
     () => deriveActivePlanState(threadActivities, activeLatestTurn?.turnId ?? undefined),
     [activeLatestTurn?.turnId, threadActivities],
   );
+  const activeDeferredPlanImplementation = composerDraft.deferredPlanImplementation ?? null;
   const showPlanFollowUpPrompt =
     pendingUserInputs.length === 0 &&
     interactionMode === "plan" &&
     latestTurnSettled &&
     hasActionableProposedPlan(activeProposedPlan);
+  const showDeferredImplementationPrompt =
+    pendingUserInputs.length === 0 &&
+    activeDeferredPlanImplementation !== null &&
+    !showPlanFollowUpPrompt;
   const activePendingApproval = pendingApprovals[0] ?? null;
   const isComposerApprovalState = activePendingApproval !== null;
   const hasComposerHeader =
     isComposerApprovalState ||
     pendingUserInputs.length > 0 ||
-    (showPlanFollowUpPrompt && activeProposedPlan !== null);
-  const composerFooterHasWideActions = showPlanFollowUpPrompt || activePendingProgress !== null;
+    (showPlanFollowUpPrompt && activeProposedPlan !== null) ||
+    showDeferredImplementationPrompt;
+  const composerFooterHasWideActions =
+    showPlanFollowUpPrompt || showDeferredImplementationPrompt || activePendingProgress !== null;
   const lastSyncedPendingInputRef = useRef<{
     requestId: string | null;
     questionId: string | null;
@@ -2350,7 +2410,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       onAdvanceActivePendingUserInput();
       return;
     }
-    const promptForSend = promptRef.current;
+    let promptForSend = promptRef.current;
     const {
       trimmedPrompt: trimmed,
       sendableTerminalContexts: sendableComposerTerminalContexts,
@@ -2377,8 +2437,27 @@ export default function ChatView({ threadId }: ChatViewProps) {
       });
       return;
     }
+    if (showDeferredImplementationPrompt && activeDeferredPlanImplementation) {
+      const seededImplementationPrompt = buildPlanImplementationPrompt(
+        activeDeferredPlanImplementation.planMarkdown,
+      );
+      const deferredImplementationText = trimmed.length > 0 ? trimmed : seededImplementationPrompt;
+      promptRef.current = "";
+      clearComposerDraftContent(activeThread.id);
+      setComposerHighlightedItemId(null);
+      setComposerCursor(0);
+      setComposerTrigger(null);
+      promptForSend = deferredImplementationText;
+    }
+    const hasDeferredImplementationFallback =
+      showDeferredImplementationPrompt &&
+      activeDeferredPlanImplementation !== null &&
+      trimmed.length === 0;
+    const effectiveTrimmedPrompt = promptForSend.trim();
     const standaloneSlashCommand =
-      composerImages.length === 0 && sendableComposerTerminalContexts.length === 0
+      !showDeferredImplementationPrompt &&
+      composerImages.length === 0 &&
+      sendableComposerTerminalContexts.length === 0
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
@@ -2390,7 +2469,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setComposerTrigger(null);
       return;
     }
-    if (!hasSendableContent) {
+    if (!hasSendableContent && !hasDeferredImplementationFallback) {
       if (expiredTerminalContextCount > 0) {
         const toastCopy = buildExpiredTerminalContextToastCopy(
           expiredTerminalContextCount,
@@ -2527,7 +2606,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
           firstComposerImageName = firstComposerImage.name;
         }
       }
-      let titleSeed = trimmed;
+      let titleSeed = activeDeferredPlanImplementation?.planMarkdown
+        ? buildPlanImplementationThreadTitle(activeDeferredPlanImplementation.planMarkdown)
+        : effectiveTrimmedPrompt;
       if (!titleSeed) {
         if (firstComposerImageName) {
           titleSeed = `Image: ${firstComposerImageName}`;
@@ -2625,9 +2706,20 @@ export default function ChatView({ threadId }: ChatViewProps) {
         assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
         runtimeMode,
         interactionMode,
+        ...(activeDeferredPlanImplementation
+          ? {
+              sourceProposedPlan: {
+                threadId: activeDeferredPlanImplementation.sourceThreadId,
+                planId: activeDeferredPlanImplementation.sourcePlanId,
+              },
+            }
+          : {}),
         createdAt: messageCreatedAt,
       });
       turnStartSucceeded = true;
+      if (activeDeferredPlanImplementation) {
+        setDeferredPlanImplementation(threadIdForSend, null);
+      }
     })().catch(async (err: unknown) => {
       if (createdServerThreadForLocalDraft && !turnStartSucceeded) {
         await api.orchestration
@@ -2963,9 +3055,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
 
   const onImplementPlanInNewThread = useCallback(async () => {
-    const api = readNativeApi();
     if (
-      !api ||
       !activeThread ||
       !activeProject ||
       !activeProposedPlan ||
@@ -2977,116 +3067,50 @@ export default function ChatView({ threadId }: ChatViewProps) {
       return;
     }
 
-    const createdAt = new Date().toISOString();
-    const nextThreadId = newThreadId();
     const planMarkdown = activeProposedPlan.planMarkdown;
-    const implementationPrompt = buildPlanImplementationPrompt(planMarkdown);
-    const outgoingImplementationPrompt = formatOutgoingPrompt({
-      provider: selectedProvider,
-      effort: selectedPromptEffort,
-      text: implementationPrompt,
+    const nextThreadId = allocateImplementationDraftThread();
+    if (!nextThreadId) {
+      return;
+    }
+
+    setComposerDraftPrompt(nextThreadId, buildPlanImplementationPrompt(planMarkdown));
+    setComposerDraftProvider(nextThreadId, selectedProvider);
+    setComposerDraftModel(nextThreadId, selectedModel);
+    setComposerDraftModelOptions(nextThreadId, selectedModelOptionsForDispatch);
+    setComposerDraftRuntimeMode(nextThreadId, runtimeMode);
+    setComposerDraftInteractionMode(nextThreadId, "default");
+    setDeferredPlanImplementation(nextThreadId, {
+      sourceThreadId: activeThread.id,
+      sourcePlanId: activeProposedPlan.id,
+      planMarkdown,
     });
-    const nextThreadTitle = truncateTitle(buildPlanImplementationThreadTitle(planMarkdown));
-    const nextThreadModel: ModelSlug =
-      selectedModel ||
-      (activeThread.model as ModelSlug) ||
-      (activeProject.model as ModelSlug) ||
-      DEFAULT_MODEL_BY_PROVIDER.codex;
 
-    sendInFlightRef.current = true;
-    beginSendPhase("sending-turn");
-    const finish = () => {
-      sendInFlightRef.current = false;
-      resetSendPhase();
-    };
-
-    await api.orchestration
-      .dispatchCommand({
-        type: "thread.create",
-        commandId: newCommandId(),
-        threadId: nextThreadId,
-        projectId: activeProject.id,
-        title: nextThreadTitle,
-        model: nextThreadModel,
-        runtimeMode,
-        interactionMode: "default",
-        branch: activeThread.branch,
-        worktreePath: activeThread.worktreePath,
-        createdAt,
-      })
-      .then(() => {
-        return api.orchestration.dispatchCommand({
-          type: "thread.turn.start",
-          commandId: newCommandId(),
-          threadId: nextThreadId,
-          message: {
-            messageId: newMessageId(),
-            role: "user",
-            text: outgoingImplementationPrompt,
-            attachments: [],
-          },
-          provider: selectedProvider,
-          model: selectedModel || undefined,
-          ...(selectedModelOptionsForDispatch
-            ? { modelOptions: selectedModelOptionsForDispatch }
-            : {}),
-          ...(providerOptionsForDispatch ? { providerOptions: providerOptionsForDispatch } : {}),
-          assistantDeliveryMode: settings.enableAssistantStreaming ? "streaming" : "buffered",
-          runtimeMode,
-          interactionMode: "default",
-          createdAt,
-        });
-      })
-      .then(() => api.orchestration.getSnapshot())
-      .then((snapshot) => {
-        syncServerReadModel(snapshot);
-        // Signal that the plan sidebar should open on the new thread.
-        planSidebarOpenOnNextThreadRef.current = true;
-        return navigate({
-          to: "/$threadId",
-          params: { threadId: nextThreadId },
-        });
-      })
-      .catch(async (err) => {
-        await api.orchestration
-          .dispatchCommand({
-            type: "thread.delete",
-            commandId: newCommandId(),
-            threadId: nextThreadId,
-          })
-          .catch(() => undefined);
-        await api.orchestration
-          .getSnapshot()
-          .then((snapshot) => {
-            syncServerReadModel(snapshot);
-          })
-          .catch(() => undefined);
-        toastManager.add({
-          type: "error",
-          title: "Could not start implementation thread",
-          description:
-            err instanceof Error ? err.message : "An error occurred while creating the new thread.",
-        });
-      })
-      .then(finish, finish);
+    // Signal that the plan sidebar should open on the new thread.
+    planSidebarOpenOnNextThreadRef.current = true;
+    await navigate({
+      to: "/$threadId",
+      params: { threadId: nextThreadId },
+    });
   }, [
     activeProject,
     activeProposedPlan,
     activeThread,
-    beginSendPhase,
+    allocateImplementationDraftThread,
     isConnecting,
     isSendBusy,
     isServerThread,
     navigate,
-    resetSendPhase,
     runtimeMode,
-    selectedPromptEffort,
     selectedModel,
     selectedModelOptionsForDispatch,
-    providerOptionsForDispatch,
     selectedProvider,
-    settings.enableAssistantStreaming,
-    syncServerReadModel,
+    setComposerDraftInteractionMode,
+    setComposerDraftModel,
+    setComposerDraftModelOptions,
+    setComposerDraftPrompt,
+    setComposerDraftProvider,
+    setComposerDraftRuntimeMode,
+    setDeferredPlanImplementation,
   ]);
 
   const onProviderModelSelect = useCallback(
@@ -3612,6 +3636,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
                         planTitle={proposedPlanTitle(activeProposedPlan.planMarkdown) ?? null}
                       />
                     </div>
+                  ) : showDeferredImplementationPrompt && activeDeferredPlanImplementation ? (
+                    <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
+                      <ComposerPlanFollowUpBanner
+                        key={`${activeDeferredPlanImplementation.sourceThreadId}:${activeDeferredPlanImplementation.sourcePlanId}`}
+                        planTitle={
+                          proposedPlanTitle(activeDeferredPlanImplementation.planMarkdown) ?? null
+                        }
+                      />
+                    </div>
                   ) : null}
                   <div
                     className={cn(
@@ -3727,11 +3760,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             "Resolve this approval request to continue")
                           : activePendingProgress
                             ? "Type your own answer, or leave this blank to use the selected option"
-                            : showPlanFollowUpPrompt && activeProposedPlan
-                              ? "Add feedback to refine the plan, or leave this blank to implement it"
-                              : phase === "disconnected"
-                                ? "Ask for follow-up changes or attach images"
-                                : "Ask anything, @tag files/folders, or use / to show available commands"
+                            : showDeferredImplementationPrompt && activeDeferredPlanImplementation
+                              ? "Review or edit the implementation prompt, then click Implement"
+                              : showPlanFollowUpPrompt && activeProposedPlan
+                                ? "Add feedback to refine the plan, or leave this blank to implement it"
+                                : phase === "disconnected"
+                                  ? "Ask for follow-up changes or attach images"
+                                  : "Ask anything, @tag files/folders, or use / to show available commands"
                       }
                       disabled={isConnecting || isComposerApprovalState}
                     />
@@ -3993,6 +4028,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
                                 </Menu>
                               </div>
                             )
+                          ) : showDeferredImplementationPrompt ? (
+                            <Button
+                              type="submit"
+                              size="sm"
+                              className="h-9 rounded-full px-4 sm:h-8"
+                              disabled={isSendBusy || isConnecting}
+                            >
+                              {isConnecting || isSendBusy ? "Sending..." : "Implement"}
+                            </Button>
                           ) : (
                             <button
                               type="submit"

--- a/apps/web/src/components/chat/ClaudeTraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/ClaudeTraitsPicker.browser.tsx
@@ -36,6 +36,7 @@ async function mountPicker(props?: {
     },
     runtimeMode: null,
     interactionMode: null,
+    deferredPlanImplementation: null,
   };
   useComposerDraftStore.setState({
     draftsByThreadId,

--- a/apps/web/src/components/chat/CodexTraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/CodexTraitsPicker.browser.tsx
@@ -32,6 +32,7 @@ async function mountPicker(props: {
     },
     runtimeMode: null,
     interactionMode: null,
+    deferredPlanImplementation: null,
   };
   useComposerDraftStore.setState({
     draftsByThreadId,

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
@@ -32,6 +32,7 @@ async function mountMenu(props?: {
     modelOptions: props?.modelOptions ?? null,
     runtimeMode: null,
     interactionMode: null,
+    deferredPlanImplementation: null,
   };
   useComposerDraftStore.setState({
     draftsByThreadId,

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1,5 +1,5 @@
 import * as Schema from "effect/Schema";
-import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { type OrchestrationProposedPlanId, ProjectId, ThreadId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -71,6 +71,8 @@ function resetComposerDraftStore() {
     stickyModelOptions: {},
   });
 }
+
+const DEFERRED_PLAN_ID = "plan-1" as OrchestrationProposedPlanId;
 
 describe("composerDraftStore addImages", () => {
   const threadId = ThreadId.makeUnsafe("thread-dedupe");
@@ -909,6 +911,117 @@ describe("composerDraftStore runtime and interaction settings", () => {
     store.setInteractionMode(threadId, null);
 
     expect(useComposerDraftStore.getState().draftsByThreadId[threadId]).toBeUndefined();
+  });
+});
+
+describe("composerDraftStore deferred plan implementation", () => {
+  const threadId = ThreadId.makeUnsafe("thread-deferred-plan");
+
+  beforeEach(() => {
+    resetComposerDraftStore();
+  });
+
+  it("persists and hydrates deferred implementation metadata", () => {
+    const store = useComposerDraftStore.getState();
+    store.setDeferredPlanImplementation(threadId, {
+      sourceThreadId: ThreadId.makeUnsafe("thread-source"),
+      sourcePlanId: DEFERRED_PLAN_ID,
+      planMarkdown: "# Plan\n\n- step 1",
+    });
+
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        partialize: (state: ReturnType<typeof useComposerDraftStore.getState>) => unknown;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+    const persistedState = persistApi.getOptions().partialize(useComposerDraftStore.getState()) as {
+      draftsByThreadId?: Record<string, { deferredPlanImplementation?: Record<string, unknown> }>;
+    };
+
+    expect(persistedState.draftsByThreadId?.[threadId]?.deferredPlanImplementation).toEqual({
+      sourceThreadId: "thread-source",
+      sourcePlanId: "plan-1",
+      planMarkdown: "# Plan\n\n- step 1",
+    });
+
+    const mergedState = persistApi
+      .getOptions()
+      .merge(persistedState, useComposerDraftStore.getInitialState());
+
+    expect(mergedState.draftsByThreadId[threadId]?.deferredPlanImplementation).toEqual({
+      sourceThreadId: "thread-source",
+      sourcePlanId: "plan-1",
+      planMarkdown: "# Plan\n\n- step 1",
+    });
+  });
+
+  it("clears deferred implementation metadata when the draft is cleared", () => {
+    const store = useComposerDraftStore.getState();
+    store.setDeferredPlanImplementation(threadId, {
+      sourceThreadId: ThreadId.makeUnsafe("thread-source"),
+      sourcePlanId: DEFERRED_PLAN_ID,
+      planMarkdown: "# Plan\n\n- step 1",
+    });
+
+    store.clearThreadDraft(threadId);
+
+    expect(useComposerDraftStore.getState().draftsByThreadId[threadId]).toBeUndefined();
+  });
+
+  it("migrates older persisted snapshots with metadata absent", () => {
+    const persistApi = useComposerDraftStore.persist as unknown as {
+      getOptions: () => {
+        migrate: (persistedState: unknown, version: number) => unknown;
+        merge: (
+          persistedState: unknown,
+          currentState: ReturnType<typeof useComposerDraftStore.getState>,
+        ) => ReturnType<typeof useComposerDraftStore.getState>;
+      };
+    };
+
+    const migratedState = persistApi.getOptions().migrate(
+      {
+        draftsByThreadId: {
+          [threadId]: {
+            prompt: "hello",
+            attachments: [],
+          },
+        },
+        draftThreadsByThreadId: {},
+        projectDraftThreadIdByProjectId: {},
+        stickyModel: null,
+        stickyModelOptions: {},
+      },
+      2,
+    );
+    const mergedState = persistApi
+      .getOptions()
+      .merge(migratedState, useComposerDraftStore.getInitialState());
+
+    expect(mergedState.draftsByThreadId[threadId]?.deferredPlanImplementation).toBeNull();
+  });
+
+  it("retains a draft when only deferred implementation metadata exists", () => {
+    const store = useComposerDraftStore.getState();
+    store.setDeferredPlanImplementation(threadId, {
+      sourceThreadId: ThreadId.makeUnsafe("thread-source"),
+      sourcePlanId: DEFERRED_PLAN_ID,
+      planMarkdown: "# Plan\n\n- step 1",
+    });
+
+    store.clearComposerContent(threadId);
+
+    expect(useComposerDraftStore.getState().draftsByThreadId[threadId]).toMatchObject({
+      deferredPlanImplementation: {
+        sourceThreadId: "thread-source",
+        sourcePlanId: "plan-1",
+        planMarkdown: "# Plan\n\n- step 1",
+      },
+    });
   });
 });
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -3,6 +3,7 @@ import {
   type ClaudeCodeEffort,
   type CodexReasoningEffort,
   DEFAULT_REASONING_EFFORT_BY_PROVIDER,
+  type OrchestrationProposedPlanId,
   ProjectId,
   ProviderInteractionMode,
   ProviderKind,
@@ -14,6 +15,7 @@ import * as Schema from "effect/Schema";
 import * as Equal from "effect/Equal";
 import { DeepMutable } from "effect/Types";
 import { normalizeModelSlug } from "@t3tools/shared/model";
+import { randomUUID } from "~/lib/utils";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatImageAttachment } from "./types";
 import {
@@ -26,7 +28,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { createDebouncedStorage, createMemoryStorage } from "./lib/storage";
 
 export const COMPOSER_DRAFT_STORAGE_KEY = "t3code:composer-drafts:v1";
-const COMPOSER_DRAFT_STORAGE_VERSION = 2;
+const COMPOSER_DRAFT_STORAGE_VERSION = 3;
 const DraftThreadEnvModeSchema = Schema.Literals(["local", "worktree"]);
 export type DraftThreadEnvMode = typeof DraftThreadEnvModeSchema.Type;
 
@@ -78,6 +80,13 @@ const PersistedComposerThreadDraftState = Schema.Struct({
   modelOptions: Schema.optionalKey(ProviderModelOptions),
   runtimeMode: Schema.optionalKey(RuntimeMode),
   interactionMode: Schema.optionalKey(ProviderInteractionMode),
+  deferredPlanImplementation: Schema.optionalKey(
+    Schema.Struct({
+      sourceThreadId: ThreadId,
+      sourcePlanId: Schema.String,
+      planMarkdown: Schema.String,
+    }),
+  ),
 });
 type PersistedComposerThreadDraftState = typeof PersistedComposerThreadDraftState.Type;
 
@@ -126,6 +135,11 @@ interface ComposerThreadDraftState {
   modelOptions: ProviderModelOptions | null;
   runtimeMode: RuntimeMode | null;
   interactionMode: ProviderInteractionMode | null;
+  deferredPlanImplementation: {
+    sourceThreadId: ThreadId;
+    sourcePlanId: OrchestrationProposedPlanId;
+    planMarkdown: string;
+  } | null;
 }
 
 export interface DraftThreadState {
@@ -162,6 +176,17 @@ interface ComposerDraftStoreState {
       interactionMode?: ProviderInteractionMode;
     },
   ) => void;
+  createProjectDraftThread: (
+    projectId: ProjectId,
+    options?: {
+      branch?: string | null;
+      worktreePath?: string | null;
+      createdAt?: string;
+      envMode?: DraftThreadEnvMode;
+      runtimeMode?: RuntimeMode;
+      interactionMode?: ProviderInteractionMode;
+    },
+  ) => ThreadId;
   setDraftThreadContext: (
     threadId: ThreadId,
     options: {
@@ -199,6 +224,17 @@ interface ComposerDraftStoreState {
   setInteractionMode: (
     threadId: ThreadId,
     interactionMode: ProviderInteractionMode | null | undefined,
+  ) => void;
+  setDeferredPlanImplementation: (
+    threadId: ThreadId,
+    metadata:
+      | {
+          sourceThreadId: ThreadId;
+          sourcePlanId: OrchestrationProposedPlanId;
+          planMarkdown: string;
+        }
+      | null
+      | undefined,
   ) => void;
   addImage: (threadId: ThreadId, image: ComposerImageAttachment) => void;
   addImages: (threadId: ThreadId, images: ComposerImageAttachment[]) => void;
@@ -250,6 +286,7 @@ const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   modelOptions: null,
   runtimeMode: null,
   interactionMode: null,
+  deferredPlanImplementation: null,
 });
 
 function createEmptyThreadDraft(): ComposerThreadDraftState {
@@ -264,6 +301,7 @@ function createEmptyThreadDraft(): ComposerThreadDraftState {
     modelOptions: null,
     runtimeMode: null,
     interactionMode: null,
+    deferredPlanImplementation: null,
   };
 }
 
@@ -334,8 +372,36 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
     draft.model === null &&
     draft.modelOptions === null &&
     draft.runtimeMode === null &&
-    draft.interactionMode === null
+    draft.interactionMode === null &&
+    draft.deferredPlanImplementation === null
   );
+}
+
+function normalizeDeferredPlanImplementation(
+  value: unknown,
+): ComposerThreadDraftState["deferredPlanImplementation"] {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  const sourceThreadId = candidate.sourceThreadId;
+  const sourcePlanId = candidate.sourcePlanId;
+  const planMarkdown = candidate.planMarkdown;
+  if (
+    typeof sourceThreadId !== "string" ||
+    sourceThreadId.length === 0 ||
+    typeof sourcePlanId !== "string" ||
+    sourcePlanId.length === 0 ||
+    typeof planMarkdown !== "string" ||
+    planMarkdown.length === 0
+  ) {
+    return null;
+  }
+  return {
+    sourceThreadId: sourceThreadId as ThreadId,
+    sourcePlanId: sourcePlanId as OrchestrationProposedPlanId,
+    planMarkdown,
+  };
 }
 
 function normalizeProviderKind(value: unknown): ProviderKind | null {
@@ -669,6 +735,9 @@ function normalizePersistedDraftsByThreadId(
         ? draftCandidate.interactionMode
         : null;
     const modelOptions = resolveModelOptions(draftCandidate, provider);
+    const deferredPlanImplementation = normalizeDeferredPlanImplementation(
+      draftCandidate.deferredPlanImplementation,
+    );
     const prompt = ensureInlineTerminalContextPlaceholders(
       promptCandidate,
       terminalContexts.length,
@@ -681,7 +750,8 @@ function normalizePersistedDraftsByThreadId(
       !model &&
       modelOptions === null &&
       !runtimeMode &&
-      !interactionMode
+      !interactionMode &&
+      deferredPlanImplementation === null
     ) {
       continue;
     }
@@ -694,6 +764,7 @@ function normalizePersistedDraftsByThreadId(
       ...(modelOptions ? { modelOptions } : {}),
       ...(runtimeMode ? { runtimeMode } : {}),
       ...(interactionMode ? { interactionMode } : {}),
+      ...(deferredPlanImplementation ? { deferredPlanImplementation } : {}),
     };
   }
 
@@ -757,7 +828,8 @@ function partializeComposerDraftStoreState(
       draft.model === null &&
       draft.modelOptions === null &&
       draft.runtimeMode === null &&
-      draft.interactionMode === null
+      draft.interactionMode === null &&
+      draft.deferredPlanImplementation === null
     ) {
       continue;
     }
@@ -782,6 +854,9 @@ function partializeComposerDraftStoreState(
       ...(draft.provider ? { provider: draft.provider } : {}),
       ...(draft.runtimeMode ? { runtimeMode: draft.runtimeMode } : {}),
       ...(draft.interactionMode ? { interactionMode: draft.interactionMode } : {}),
+      ...(draft.deferredPlanImplementation
+        ? { deferredPlanImplementation: draft.deferredPlanImplementation }
+        : {}),
     };
     persistedDraftsByThreadId[threadId as ThreadId] = persistedDraft;
   }
@@ -917,6 +992,9 @@ function toHydratedThreadDraft(
     modelOptions: persistedDraft.modelOptions ?? null,
     runtimeMode: persistedDraft.runtimeMode ?? null,
     interactionMode: persistedDraft.interactionMode ?? null,
+    deferredPlanImplementation: normalizeDeferredPlanImplementation(
+      persistedDraft.deferredPlanImplementation,
+    ),
   };
 }
 
@@ -950,6 +1028,14 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           return null;
         }
         return get().draftThreadsByThreadId[threadId] ?? null;
+      },
+      createProjectDraftThread: (projectId, options) => {
+        if (projectId.length === 0) {
+          throw new Error("Project ID is required to create a draft thread.");
+        }
+        const threadId = ThreadId.makeUnsafe(randomUUID());
+        get().setProjectDraftThreadId(projectId, threadId, options);
+        return threadId;
       },
       setProjectDraftThreadId: (projectId, threadId, options) => {
         if (projectId.length === 0 || threadId.length === 0) {
@@ -1404,6 +1490,33 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
           const nextDraft: ComposerThreadDraftState = {
             ...base,
             interactionMode: nextInteractionMode,
+          };
+          const nextDraftsByThreadId = { ...state.draftsByThreadId };
+          if (shouldRemoveDraft(nextDraft)) {
+            delete nextDraftsByThreadId[threadId];
+          } else {
+            nextDraftsByThreadId[threadId] = nextDraft;
+          }
+          return { draftsByThreadId: nextDraftsByThreadId };
+        });
+      },
+      setDeferredPlanImplementation: (threadId, metadata) => {
+        if (threadId.length === 0) {
+          return;
+        }
+        const nextMetadata = normalizeDeferredPlanImplementation(metadata);
+        set((state) => {
+          const existing = state.draftsByThreadId[threadId];
+          if (!existing && nextMetadata === null) {
+            return state;
+          }
+          const base = existing ?? createEmptyThreadDraft();
+          if (Equal.equals(base.deferredPlanImplementation, nextMetadata)) {
+            return state;
+          }
+          const nextDraft: ComposerThreadDraftState = {
+            ...base,
+            deferredPlanImplementation: nextMetadata,
           };
           const nextDraftsByThreadId = { ...state.draftsByThreadId };
           if (shouldRemoveDraft(nextDraft)) {


### PR DESCRIPTION
- Create implementation drafts from proposed plans instead of sending immediately
- Persist deferred plan metadata in composer drafts
- Add browser coverage for selecting provider/model and dispatching the deferred turn

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Changed `"Implement in a new thread"` to create a local implementation draft instead of immediately dispatching `thread.create` and `thread.turn.start`.
- Seeded the destination draft with the generated implementation prompt, current provider/model/model options/runtime mode, and deferred proposed-plan linkage metadata.
- Kept the provider/model picker unlocked on that draft so the first send can switch adapters before the new thread starts.
- Rendered implementation-mode composer UI on deferred drafts, including the plan follow-up banner and a single `Implement` CTA.
- Extended the local-draft first-send path to include `sourceProposedPlan` when starting the deferred implementation turn.
- Persisted deferred implementation metadata in the composer draft store, including hydration, migration, and cleanup behavior.
- Added browser coverage for the deferred draft handoff, unlocked provider/model selection, and dispatching the deferred first turn with the selected adapter/model.

## Why

The previous flow started a new server thread immediately, which locked in the source thread’s adapter choice before the user could review or change it, which made sense when only one adapter was available. That made `"Implement in a new thread"` inconsistent with the draft-thread model used elsewhere and prevented switching to another provider, including Claude, before sending which some users may prefer (Planning in Opus / Implementing in Gpt 5.4, or vice versa).

This change moves the action into the existing local-draft flow so the implementation prompt is still prefilled, but the user keeps control over the first-send configuration. It also preserves the original proposed-plan linkage by deferring `sourceProposedPlan` until the implementation turn actually starts.

## UI Changes

- `"Implement in a new thread"` now navigates to a draft-thread route with the implementation prompt prefilled instead of starting work immediately.
- The destination composer shows implementation-mode UI with an `Implement` button.
- The provider/model picker remains unlocked until the first turn starts.

## Images and Gif Video
Gif video due to my FFmpeg install being broken
<img width="3200" height="2200" alt="01-source-plan-thread" src="https://github.com/user-attachments/assets/637ebd4d-09b3-4b16-af89-a283546f2b52" />
<img width="3200" height="2200" alt="02-source-plan-menu-open" src="https://github.com/user-attachments/assets/73a30f78-cb1e-439d-a635-42d5f7c6ae90" />
<img width="3200" height="2200" alt="03-draft-implementation-thread" src="https://github.com/user-attachments/assets/f97f0127-55f1-4c13-bffd-b7cc280032a5" />
<img width="3200" height="2200" alt="04-unlocked-provider-picker" src="https://github.com/user-attachments/assets/e0ed0692-7650-4b3b-a977-a8b3bb7c3aa5" />
<img width="3200" height="2200" alt="05-claude-model-options" src="https://github.com/user-attachments/assets/0a84120e-fa44-44ce-b21e-c1145bc3c807" />
<img width="3200" height="2200" alt="06-claude-selected-implement-draft" src="https://github.com/user-attachments/assets/bec96de6-5415-4cf5-9eee-1512ab70ab56" />
![deferred-implementation-flow](https://github.com/user-attachments/assets/63cfb3ba-a3cc-4d0b-8b71-611015380909)


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer plan implementation into a draft thread until the user clicks 'Implement'
> - Clicking 'Implement in a new thread' now navigates to a local draft thread pre-seeded with the plan implementation prompt instead of immediately dispatching server commands.
> - The draft stores the selected provider/model and `deferredPlanImplementation` metadata (source thread ID, plan ID, plan markdown); when the user clicks 'Implement', the app dispatches `thread.create` then `thread.turn.start` with `sourceProposedPlan` attached.
> - `composerDraftStore` gains `createProjectDraftThread` and `setDeferredPlanImplementation` APIs, bumps its storage version to 3, and persists/hydrates deferred metadata; drafts containing only deferred metadata are preserved instead of pruned.
> - The composer shows a `ComposerPlanFollowUpBanner` and an 'Implement' submit button during deferred state, and allows sending even when the text field is otherwise empty (prompt is seeded from the plan).
> - Behavioral Change: `onImplementPlanInNewThread` no longer creates a server thread immediately; server work is deferred until the user explicitly submits the draft.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d67869.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->