### PR TITLE
Add RTL document direction detection

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,11 +10,16 @@ import { isElectron } from "./env";
 import { getRouter } from "./router";
 import { APP_DISPLAY_NAME } from "./branding";
 
+// Electron loads the app from a file-backed shell, so hash history avoids path resolution issues.
 const history = isElectron ? createHashHistory() : createBrowserHistory();
 
 const router = getRouter(history);
+const preferredLocale = navigator.languages.find((locale) => locale.trim().length > 0) ?? navigator.language;
 
 document.title = APP_DISPLAY_NAME;
+document.documentElement.dir = /^(ar|dv|fa|he|ku|ps|sd|ug|ur|yi)(-|_|$)/iu.test(preferredLocale)
+  ? "rtl"
+  : "ltr";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- detect common RTL locales from the browser preferred language list
- set `document.documentElement.dir` to `rtl` at app startup
- keep the change limited to a few lines in the web entrypoint

## Testing
- not run (kept minimal; no dependency install in this environment)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add RTL document direction detection based on browser locale
> In [main.tsx](https://github.com/pingdotgg/t3code/pull/1320/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b), sets `document.documentElement.dir` to `"rtl"` or `"ltr"` at startup based on the user's browser language. The detected locale is derived from `navigator.languages` (first non-empty entry) with a fallback to `navigator.language`, and is matched against a regex covering ar, dv, fa, he, ku, ps, sd, ug, ur, and yi.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c042dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->