### PR TITLE
fix(git): increase commit timeout for slow pre-commit hooks

### DIFF
--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -813,7 +813,7 @@ const makeGitCore = Effect.gen(function* () {
       if (trimmedBody.length > 0) {
         args.push("-m", trimmedBody);
       }
-      yield* runGit("GitCore.commit.commit", cwd, args);
+      yield* executeGit("GitCore.commit.commit", cwd, args, { timeoutMs: 120_000 });
       const commitSha = yield* runGitStdout("GitCore.commit.revParseHead", cwd, [
         "rev-parse",
         "HEAD",


### PR DESCRIPTION
## What Changed

Increased the `git commit` command timeout from 30s to 120s.

## Why

Repositories with slow pre-commit hooks (linting, type-checking, formatting) regularly exceed the hardcoded 30s default timeout, causing the commit to fail with a timeout error in the UI. The hook itself succeeds — it just needs more time.

The 120s limit matches common CI expectations for pre-commit hook runtimes while still catching genuinely stuck processes.

Only the commit path is changed. All other git operations keep the existing 30s default.

Fixes #1194

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase git commit timeout to 120 seconds for slow pre-commit hooks
> Replaces `runGit` with `executeGit` in `GitCore.commit` to pass an explicit `timeoutMs: 120000` option, up from the previous default. This prevents premature failures when pre-commit hooks take a long time to run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f13bf0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->