### PR TITLE
fix: quote editor launch args with spaces on Windows

### DIFF
--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -234,10 +234,14 @@ export const launchDetached = (launch: EditorLaunch) =>
     yield* Effect.callback<void, OpenError>((resume) => {
       let child;
       try {
-        child = spawn(launch.command, [...launch.args], {
+        const useShell = process.platform === "win32";
+        const args = useShell
+          ? launch.args.map((a) => (a.includes(" ") ? `"${a}"` : a))
+          : [...launch.args];
+        child = spawn(launch.command, args, {
           detached: true,
           stdio: "ignore",
-          shell: process.platform === "win32",
+          shell: useShell,
         });
       } catch (error) {
         return resume(


### PR DESCRIPTION
## What Changed

Quote arguments containing spaces when launching editors on Windows.

## Why

On Windows, `spawn` uses `shell: true` to resolve `.cmd`/`.bat` editor commands (like `code.cmd` for VS Code). This causes the shell to split path arguments at spaces, so a path like `C:\Users\John Doe\project` opens two separate buffers instead of one.

## Prior attempts

- #775 quoted args on all platforms, which broke macOS (quotes became part of the path string when `shell: false`)
- #849 quoted all args on Windows, even those without spaces

This PR only quotes args that contain spaces, and only when `shell: true` (Windows). Non-Windows platforms pass args as arrays and are unaffected.

Fixes #757

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why