### PR TITLE
fix(claude): load Claude SDK filesystem setting sources

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -272,8 +272,29 @@ describe("ClaudeAdapterLive", () => {
       });
 
       const createInput = harness.getLastCreateQueryInput();
+      assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
       assert.equal(createInput?.options.permissionMode, "bypassPermissions");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, true);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("loads Claude filesystem settings sources for SDK sessions", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "approval-required",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
+      assert.equal(createInput?.options.permissionMode, undefined);
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -15,6 +15,7 @@ import {
   type PermissionUpdate,
   type SDKMessage,
   type SDKResultMessage,
+  type SettingSource,
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
@@ -426,6 +427,11 @@ const SUPPORTED_CLAUDE_IMAGE_MIME_TYPES = new Set([
   "image/png",
   "image/webp",
 ]);
+const CLAUDE_SETTING_SOURCES = [
+  "user",
+  "project",
+  "local",
+] as const satisfies ReadonlyArray<SettingSource>;
 
 function buildPromptText(input: ProviderSendTurnInput): string {
   const requestedEffort = resolveReasoningEffortForProvider(
@@ -2562,6 +2568,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(input.cwd ? { cwd: input.cwd } : {}),
           ...(input.model ? { model: input.model } : {}),
           pathToClaudeCodeExecutable: providerOptions?.binaryPath ?? "claude",
+          settingSources: [...CLAUDE_SETTING_SOURCES],
           ...(effectiveEffort ? { effort: effectiveEffort } : {}),
           ...(permissionMode ? { permissionMode } : {}),
           ...(permissionMode === "bypassPermissions"


### PR DESCRIPTION
Fixes #1267
Refs #1257

## What Changed

Claude session startup now passes `settingSources: ["user", "project", "local"]` to the Anthropic SDK in `ClaudeAdapter`.

That tells the SDK to load Claude Code's normal filesystem-backed settings when T3 launches a Claude session, instead of only relying on the options T3 passes directly.

I kept this intentionally small:
- no custom settings parser in T3
- no Claude-specific config UI
- no behavior changes outside Claude session startup

## Why

This came out of two bug reports:

- #1267: Claude provider ignores `~/.claude/settings.json` env, so proxy-backed Claude fails
- #1257: Claude Code doesn't support AWS Bedrock usage

The common pattern in both reports is: Claude works fine in the CLI on the same machine, but Claude launched through T3 misses config that normally comes from Claude's settings files.

Auth is the most obvious failure mode.

In my own setup, I use Claude via API config in `~/.claude/settings.json`, and at work that meant Claude worked normally in the CLI but T3-backed Claude sessions did not. The practical symptom looks like auth/login trouble because the Claude session T3 starts is missing settings that the normal Claude CLI session sees.

After auth, this also affects the broader class of Claude filesystem settings, including `env`-backed provider configuration. That lines up with the Bedrock / alternate provider reports too: if the Claude session launched by T3 does not load the same Claude settings sources as the CLI, you can end up with a session that behaves like it is using the wrong auth/provider path.

The reason I took this approach instead of adding T3-side parsing is that Anthropic's SDK already exposes the setting source mechanism directly:
- https://platform.claude.com/docs/en/agent-sdk/typescript
- https://docs.anthropic.com/en/docs/claude-code/settings

So this patch just opts T3 into the SDK's documented settings-loading path rather than re-implementing Claude's config resolution in app code.

## Manual validation

I manually tested this against a few different real-world Claude setups:

- regular Anthropic Pro plan auth
- my work setup, where Claude is configured through `~/.claude/settings.json` to use a corporate Anthropic API proxy
- Vertex AI, also configured through `~/.claude/settings.json`

I also tried different permutations of Claude settings sources/files while checking the same basic behavior each time: if Claude already worked in the CLI on that machine, T3-backed Claude sessions should pick up the same config path instead of failing because auth/provider settings were missing.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load Claude SDK filesystem setting sources for all sessions
> Adds a `CLAUDE_SETTING_SOURCES` constant (`['user', 'project', 'local']`) in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/1334/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) and passes it as `settingSources` in the options for every Claude SDK query session. This applies regardless of permission mode, including both full-access and approval-required runtime policies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c07b51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
