### PR TITLE
feat(web): add local typography settings

### DIFF
--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   AppSettingsSchema,
+  DEFAULT_TERMINAL_FONT_SIZE,
   DEFAULT_TIMESTAMP_FORMAT,
+  DEFAULT_UI_FONT_SIZE,
   getAppModelOptions,
   getCustomModelOptionsByProvider,
   getCustomModelsByProvider,
@@ -215,6 +217,10 @@ describe("AppSettingsSchema", () => {
       confirmThreadDelete: false,
       enableAssistantStreaming: false,
       timestampFormat: DEFAULT_TIMESTAMP_FORMAT,
+      uiFontSize: DEFAULT_UI_FONT_SIZE,
+      terminalFontSize: DEFAULT_TERMINAL_FONT_SIZE,
+      uiFontFamily: "",
+      monoFontFamily: "",
       customCodexModels: [],
       customClaudeModels: [],
     });

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -13,10 +13,18 @@ import { EnvMode } from "./components/BranchToolbar.logic";
 const APP_SETTINGS_STORAGE_KEY = "t3code:app-settings:v1";
 const MAX_CUSTOM_MODEL_COUNT = 32;
 export const MAX_CUSTOM_MODEL_LENGTH = 256;
+export const MAX_FONT_FAMILY_LENGTH = 256;
 
 export const TimestampFormat = Schema.Literals(["locale", "12-hour", "24-hour"]);
 export type TimestampFormat = typeof TimestampFormat.Type;
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
+export const UiFontSize = Schema.Literals(["sm", "md", "lg"]);
+export type UiFontSize = typeof UiFontSize.Type;
+export const DEFAULT_UI_FONT_SIZE: UiFontSize = "md";
+
+export const TerminalFontSize = Schema.Literals(["sm", "md", "lg", "xl"]);
+export type TerminalFontSize = typeof TerminalFontSize.Type;
+export const DEFAULT_TERMINAL_FONT_SIZE: TerminalFontSize = "md";
 type CustomModelSettingsKey = "customCodexModels" | "customClaudeModels";
 export type ProviderCustomModelConfig = {
   provider: ProviderKind;
@@ -53,6 +61,14 @@ export const AppSettingsSchema = Schema.Struct({
   confirmThreadDelete: Schema.Boolean.pipe(withDefaults(() => true)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => false)),
   timestampFormat: TimestampFormat.pipe(withDefaults(() => DEFAULT_TIMESTAMP_FORMAT)),
+  uiFontSize: UiFontSize.pipe(withDefaults(() => DEFAULT_UI_FONT_SIZE)),
+  terminalFontSize: TerminalFontSize.pipe(withDefaults(() => DEFAULT_TERMINAL_FONT_SIZE)),
+  uiFontFamily: Schema.String.check(Schema.isMaxLength(MAX_FONT_FAMILY_LENGTH)).pipe(
+    withDefaults(() => ""),
+  ),
+  monoFontFamily: Schema.String.check(Schema.isMaxLength(MAX_FONT_FAMILY_LENGTH)).pipe(
+    withDefaults(() => ""),
+  ),
   customCodexModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   customClaudeModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   textGenerationModel: Schema.optional(TrimmedNonEmptyString),

--- a/apps/web/src/appTypography.test.ts
+++ b/apps/web/src/appTypography.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getTerminalFontSizePx,
+  getUiFontSizePx,
+  normalizeFontFamilyOverride,
+} from "./appTypography";
+
+describe("normalizeFontFamilyOverride", () => {
+  it("treats blank and whitespace-only values as no override", () => {
+    expect(normalizeFontFamilyOverride("")).toBeNull();
+    expect(normalizeFontFamilyOverride("   ")).toBeNull();
+    expect(normalizeFontFamilyOverride(undefined)).toBeNull();
+  });
+
+  it("trims non-empty font family overrides", () => {
+    expect(normalizeFontFamilyOverride("  Inter, system-ui, sans-serif  ")).toBe(
+      "Inter, system-ui, sans-serif",
+    );
+  });
+});
+
+describe("font size helpers", () => {
+  it("maps interface sizes to conservative root pixel values", () => {
+    expect(getUiFontSizePx("sm")).toBe(15);
+    expect(getUiFontSizePx("md")).toBe(16);
+    expect(getUiFontSizePx("lg")).toBe(17);
+  });
+
+  it("maps terminal sizes to xterm pixel values", () => {
+    expect(getTerminalFontSizePx("sm")).toBe(11);
+    expect(getTerminalFontSizePx("md")).toBe(12);
+    expect(getTerminalFontSizePx("lg")).toBe(13);
+    expect(getTerminalFontSizePx("xl")).toBe(14);
+  });
+});

--- a/apps/web/src/appTypography.ts
+++ b/apps/web/src/appTypography.ts
@@ -1,0 +1,106 @@
+import { useLayoutEffect } from "react";
+import {
+  DEFAULT_TERMINAL_FONT_SIZE,
+  type TerminalFontSize,
+  type UiFontSize,
+  useAppSettings,
+} from "./appSettings";
+
+export const UI_FONT_SIZE_OPTIONS: ReadonlyArray<{ value: UiFontSize; label: string }> = [
+  { value: "sm", label: "Small" },
+  { value: "md", label: "Default" },
+  { value: "lg", label: "Large" },
+];
+
+export const TERMINAL_FONT_SIZE_OPTIONS: ReadonlyArray<{
+  value: TerminalFontSize;
+  label: string;
+}> = [
+  { value: "sm", label: "Small" },
+  { value: "md", label: "Default" },
+  { value: "lg", label: "Large" },
+  { value: "xl", label: "Extra large" },
+];
+
+const DEFAULT_MONO_FONT_FAMILY =
+  '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace';
+
+const UI_FONT_SIZE_PX: Record<UiFontSize, number> = {
+  sm: 15,
+  md: 16,
+  lg: 17,
+};
+
+const TERMINAL_FONT_SIZE_PX: Record<TerminalFontSize, number> = {
+  sm: 11,
+  md: 12,
+  lg: 13,
+  xl: 14,
+};
+
+export function normalizeFontFamilyOverride(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized && normalized.length > 0 ? normalized : null;
+}
+
+export function getUiFontSizePx(value: UiFontSize): number {
+  return UI_FONT_SIZE_PX[value];
+}
+
+export function getTerminalFontSizePx(value: TerminalFontSize): number {
+  return TERMINAL_FONT_SIZE_PX[value];
+}
+
+function setRootStyleProperty(name: string, value: string | null): void {
+  if (value === null) {
+    document.documentElement.style.removeProperty(name);
+    return;
+  }
+
+  document.documentElement.style.setProperty(name, value);
+}
+
+function parsePx(value: string, fallback: number): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function useAppTypography(): void {
+  const { settings } = useAppSettings();
+
+  useLayoutEffect(() => {
+    setRootStyleProperty("--app-ui-font-size", `${getUiFontSizePx(settings.uiFontSize)}px`);
+    setRootStyleProperty(
+      "--app-terminal-font-size",
+      `${getTerminalFontSizePx(settings.terminalFontSize)}px`,
+    );
+    setRootStyleProperty(
+      "--app-ui-font-family",
+      normalizeFontFamilyOverride(settings.uiFontFamily),
+    );
+    setRootStyleProperty(
+      "--app-mono-font-family",
+      normalizeFontFamilyOverride(settings.monoFontFamily),
+    );
+  }, [
+    settings.monoFontFamily,
+    settings.terminalFontSize,
+    settings.uiFontFamily,
+    settings.uiFontSize,
+  ]);
+}
+
+export function readTerminalTypographyFromApp(): { fontFamily: string; fontSize: number } {
+  const rootStyles = getComputedStyle(document.documentElement);
+  const fontFamily =
+    rootStyles.getPropertyValue("--app-mono-font-family").trim() || DEFAULT_MONO_FONT_FAMILY;
+  const fontSize = parsePx(
+    rootStyles.getPropertyValue("--app-terminal-font-size"),
+    getTerminalFontSizePx(DEFAULT_TERMINAL_FONT_SIZE),
+  );
+
+  return {
+    fontFamily,
+    fontSize,
+  };
+}

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { ThreadId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vitest";
 
 import {
+  applyTerminalAppearanceUpdate,
   resolveTerminalSelectionActionPosition,
   shouldHandleTerminalSelectionMouseUp,
+  syncTerminalGeometryWithBackend,
   terminalSelectionActionDelayForClickCount,
 } from "./ThreadTerminalDrawer";
 
@@ -71,5 +74,122 @@ describe("resolveTerminalSelectionActionPosition", () => {
     expect(shouldHandleTerminalSelectionMouseUp(true, 0)).toBe(true);
     expect(shouldHandleTerminalSelectionMouseUp(false, 0)).toBe(false);
     expect(shouldHandleTerminalSelectionMouseUp(true, 1)).toBe(false);
+  });
+});
+
+describe("applyTerminalAppearanceUpdate", () => {
+  it("refreshes in place when only the theme changes", () => {
+    const refresh = vi.fn();
+    const terminal = {
+      options: {
+        theme: { background: "#000000" },
+        fontFamily: "Menlo, monospace",
+        fontSize: 12,
+      },
+      rows: 30,
+      refresh,
+    };
+
+    const result = applyTerminalAppearanceUpdate({
+      terminal,
+      theme: { background: "#ffffff" },
+      typography: { fontFamily: "Menlo, monospace", fontSize: 12 },
+    });
+
+    expect(result).toBe("refresh");
+    expect(terminal.options.theme).toEqual({ background: "#ffffff" });
+    expect(refresh).toHaveBeenCalledWith(0, 29);
+  });
+
+  it("requests geometry sync when the terminal font changes", () => {
+    const refresh = vi.fn();
+    const terminal = {
+      options: {
+        theme: { background: "#000000" },
+        fontFamily: "Menlo, monospace",
+        fontSize: 12,
+      },
+      rows: 30,
+      refresh,
+    };
+
+    const result = applyTerminalAppearanceUpdate({
+      terminal,
+      theme: { background: "#000000" },
+      typography: { fontFamily: '"SF Mono", Menlo, monospace', fontSize: 14 },
+    });
+
+    expect(result).toBe("geometry");
+    expect(terminal.options.fontFamily).toBe('"SF Mono", Menlo, monospace');
+    expect(terminal.options.fontSize).toBe(14);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("syncTerminalGeometryWithBackend", () => {
+  it("uses post-fit geometry and keeps the terminal pinned to the bottom when already at the bottom", () => {
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const resize = vi.fn().mockResolvedValue(undefined);
+    const scrollToBottom = vi.fn();
+    const terminal = {
+      buffer: { active: { viewportY: 12, baseY: 12 } },
+      cols: 80,
+      rows: 24,
+      scrollToBottom,
+    };
+    const fitAddon = {
+      fit: vi.fn(() => {
+        terminal.cols = 120;
+        terminal.rows = 40;
+      }),
+    };
+
+    syncTerminalGeometryWithBackend({
+      api: { terminal: { resize } },
+      terminal,
+      fitAddon,
+      threadId,
+      terminalId: "default",
+    });
+
+    expect(fitAddon.fit).toHaveBeenCalledTimes(1);
+    expect(scrollToBottom).toHaveBeenCalledTimes(1);
+    expect(resize).toHaveBeenCalledWith({
+      threadId,
+      terminalId: "default",
+      cols: 120,
+      rows: 40,
+    });
+  });
+
+  it("does not force-scroll when the terminal is not at the bottom", () => {
+    const threadId = ThreadId.makeUnsafe("thread-2");
+    const resize = vi.fn().mockResolvedValue(undefined);
+    const scrollToBottom = vi.fn();
+    const terminal = {
+      buffer: { active: { viewportY: 4, baseY: 12 } },
+      cols: 90,
+      rows: 30,
+      scrollToBottom,
+    };
+    const fitAddon = {
+      fit: vi.fn(),
+    };
+
+    syncTerminalGeometryWithBackend({
+      api: { terminal: { resize } },
+      terminal,
+      fitAddon,
+      threadId,
+      terminalId: "secondary",
+    });
+
+    expect(scrollToBottom).not.toHaveBeenCalled();
+    expect(resize).toHaveBeenCalledWith({
+      threadId,
+      terminalId: "secondary",
+      cols: 90,
+      rows: 30,
+    });
   });
 });

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -13,6 +13,7 @@ import {
 } from "react";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
+import { readTerminalTypographyFromApp } from "../appTypography";
 import { openInPreferredEditor } from "../editorPreferences";
 import {
   extractTerminalLinks,
@@ -109,6 +110,87 @@ function terminalThemeFromApp(): ITheme {
   };
 }
 
+interface TerminalGeometrySyncApi {
+  terminal: {
+    resize(args: {
+      threadId: ThreadId;
+      terminalId: string;
+      cols: number;
+      rows: number;
+    }): Promise<unknown>;
+  };
+}
+
+interface TerminalGeometrySyncTerminal {
+  buffer: {
+    active: {
+      viewportY: number;
+      baseY: number;
+    };
+  };
+  cols: number;
+  rows: number;
+  scrollToBottom(): void;
+}
+
+interface TerminalGeometrySyncFitAddon {
+  fit(): void;
+}
+
+export function syncTerminalGeometryWithBackend(options: {
+  api: TerminalGeometrySyncApi;
+  terminal: TerminalGeometrySyncTerminal;
+  fitAddon: TerminalGeometrySyncFitAddon;
+  threadId: ThreadId;
+  terminalId: string;
+}): void {
+  const { api, terminal, fitAddon, threadId, terminalId } = options;
+  const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
+  fitAddon.fit();
+  if (wasAtBottom) {
+    terminal.scrollToBottom();
+  }
+  void api.terminal
+    .resize({
+      threadId,
+      terminalId,
+      cols: terminal.cols,
+      rows: terminal.rows,
+    })
+    .catch(() => undefined);
+}
+
+interface TerminalAppearanceUpdateTerminal {
+  options: {
+    theme?: ITheme | undefined;
+    fontFamily?: string | undefined;
+    fontSize?: number | undefined;
+  };
+  rows: number;
+  refresh(start: number, end: number): void;
+}
+
+export function applyTerminalAppearanceUpdate(options: {
+  terminal: TerminalAppearanceUpdateTerminal;
+  theme: ITheme;
+  typography: { fontFamily: string; fontSize: number };
+}): "refresh" | "geometry" {
+  const { terminal, theme, typography } = options;
+  terminal.options.theme = theme;
+
+  const fontFamilyChanged = terminal.options.fontFamily !== typography.fontFamily;
+  const fontSizeChanged = terminal.options.fontSize !== typography.fontSize;
+
+  if (!fontFamilyChanged && !fontSizeChanged) {
+    terminal.refresh(0, Math.max(terminal.rows - 1, 0));
+    return "refresh";
+  }
+
+  terminal.options.fontFamily = typography.fontFamily;
+  terminal.options.fontSize = typography.fontSize;
+  return "geometry";
+}
+
 function getTerminalSelectionRect(mountElement: HTMLElement): DOMRect | null {
   const selection = window.getSelection();
   if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
@@ -190,8 +272,6 @@ interface TerminalViewportProps {
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   focusRequestId: number;
   autoFocus: boolean;
-  resizeEpoch: number;
-  drawerHeight: number;
 }
 
 function TerminalViewport({
@@ -204,8 +284,6 @@ function TerminalViewport({
   onAddTerminalContext,
   focusRequestId,
   autoFocus,
-  resizeEpoch,
-  drawerHeight,
 }: TerminalViewportProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
@@ -238,13 +316,14 @@ function TerminalViewport({
 
     let disposed = false;
 
+    const terminalTypography = readTerminalTypographyFromApp();
     const fitAddon = new FitAddon();
     const terminal = new Terminal({
       cursorBlink: true,
       lineHeight: 1.2,
-      fontSize: 12,
+      fontSize: terminalTypography.fontSize,
       scrollback: 5_000,
-      fontFamily: '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+      fontFamily: terminalTypography.fontFamily,
       theme: terminalThemeFromApp(),
     });
     terminal.loadAddon(fitAddon);
@@ -256,6 +335,27 @@ function TerminalViewport({
 
     const api = readNativeApi();
     if (!api) return;
+    let geometrySyncFrame: number | null = null;
+
+    const scheduleGeometrySync = () => {
+      if (geometrySyncFrame !== null) {
+        return;
+      }
+
+      geometrySyncFrame = window.requestAnimationFrame(() => {
+        geometrySyncFrame = null;
+        const latestTerminal = terminalRef.current;
+        const latestFitAddon = fitAddonRef.current;
+        if (!latestTerminal || !latestFitAddon) return;
+        syncTerminalGeometryWithBackend({
+          api,
+          terminal: latestTerminal,
+          fitAddon: latestFitAddon,
+          threadId,
+          terminalId,
+        });
+      });
+    };
 
     const clearSelectionAction = () => {
       selectionActionRequestIdRef.current += 1;
@@ -458,16 +558,33 @@ function TerminalViewport({
     window.addEventListener("mouseup", handleMouseUp);
     mount.addEventListener("pointerdown", handlePointerDown);
 
-    const themeObserver = new MutationObserver(() => {
+    const syncTerminalAppearance = () => {
       const activeTerminal = terminalRef.current;
       if (!activeTerminal) return;
-      activeTerminal.options.theme = terminalThemeFromApp();
-      activeTerminal.refresh(0, activeTerminal.rows - 1);
-    });
-    themeObserver.observe(document.documentElement, {
+
+      const action = applyTerminalAppearanceUpdate({
+        terminal: activeTerminal,
+        theme: terminalThemeFromApp(),
+        typography: readTerminalTypographyFromApp(),
+      });
+
+      if (action === "geometry") {
+        scheduleGeometrySync();
+      }
+    };
+
+    const appearanceObserver = new MutationObserver(syncTerminalAppearance);
+    appearanceObserver.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ["class", "style"],
     });
+    let containerResizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      containerResizeObserver = new ResizeObserver(() => {
+        scheduleGeometrySync();
+      });
+      containerResizeObserver.observe(mount);
+    }
 
     const openTerminal = async () => {
       try {
@@ -563,20 +680,13 @@ function TerminalViewport({
       const activeTerminal = terminalRef.current;
       const activeFitAddon = fitAddonRef.current;
       if (!activeTerminal || !activeFitAddon) return;
-      const wasAtBottom =
-        activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
-      activeFitAddon.fit();
-      if (wasAtBottom) {
-        activeTerminal.scrollToBottom();
-      }
-      void api.terminal
-        .resize({
-          threadId,
-          terminalId,
-          cols: activeTerminal.cols,
-          rows: activeTerminal.rows,
-        })
-        .catch(() => undefined);
+      syncTerminalGeometryWithBackend({
+        api,
+        terminal: activeTerminal,
+        fitAddon: activeFitAddon,
+        threadId,
+        terminalId,
+      });
     }, 30);
     void openTerminal();
 
@@ -592,7 +702,11 @@ function TerminalViewport({
       }
       window.removeEventListener("mouseup", handleMouseUp);
       mount.removeEventListener("pointerdown", handlePointerDown);
-      themeObserver.disconnect();
+      if (geometrySyncFrame !== null) {
+        window.cancelAnimationFrame(geometrySyncFrame);
+      }
+      appearanceObserver.disconnect();
+      containerResizeObserver?.disconnect();
       terminalRef.current = null;
       fitAddonRef.current = null;
       terminal.dispose();
@@ -614,30 +728,6 @@ function TerminalViewport({
     };
   }, [autoFocus, focusRequestId]);
 
-  useEffect(() => {
-    const api = readNativeApi();
-    const terminal = terminalRef.current;
-    const fitAddon = fitAddonRef.current;
-    if (!api || !terminal || !fitAddon) return;
-    const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
-    const frame = window.requestAnimationFrame(() => {
-      fitAddon.fit();
-      if (wasAtBottom) {
-        terminal.scrollToBottom();
-      }
-      void api.terminal
-        .resize({
-          threadId,
-          terminalId,
-          cols: terminal.cols,
-          rows: terminal.rows,
-        })
-        .catch(() => undefined);
-    });
-    return () => {
-      window.cancelAnimationFrame(frame);
-    };
-  }, [drawerHeight, resizeEpoch, terminalId, threadId]);
   return (
     <div ref={containerRef} className="relative h-full w-full overflow-hidden rounded-[4px]" />
   );
@@ -714,7 +804,6 @@ export default function ThreadTerminalDrawer({
   onAddTerminalContext,
 }: ThreadTerminalDrawerProps) {
   const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height));
-  const [resizeEpoch, setResizeEpoch] = useState(0);
   const drawerHeightRef = useRef(drawerHeight);
   const lastSyncedHeightRef = useRef(clampDrawerHeight(height));
   const onHeightChangeRef = useRef(onHeightChange);
@@ -905,7 +994,6 @@ export default function ThreadTerminalDrawer({
         return;
       }
       syncHeight(drawerHeightRef.current);
-      setResizeEpoch((value) => value + 1);
     },
     [syncHeight],
   );
@@ -921,7 +1009,6 @@ export default function ThreadTerminalDrawer({
       if (!resizeStateRef.current) {
         syncHeight(clampedHeight);
       }
-      setResizeEpoch((value) => value + 1);
     };
     window.addEventListener("resize", onWindowResize);
     return () => {
@@ -1015,8 +1102,6 @@ export default function ThreadTerminalDrawer({
                         onAddTerminalContext={onAddTerminalContext}
                         focusRequestId={focusRequestId}
                         autoFocus={terminalId === resolvedActiveTerminalId}
-                        resizeEpoch={resizeEpoch}
-                        drawerHeight={drawerHeight}
                       />
                     </div>
                   </div>
@@ -1035,8 +1120,6 @@ export default function ThreadTerminalDrawer({
                   onAddTerminalContext={onAddTerminalContext}
                   focusRequestId={focusRequestId}
                   autoFocus
-                  resizeEpoch={resizeEpoch}
-                  drawerHeight={drawerHeight}
                 />
               </div>
             )}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -29,6 +29,8 @@
   --color-card: var(--card);
   --color-foreground: var(--foreground);
   --color-background: var(--background);
+  --font-sans: var(--app-ui-font-family);
+  --font-mono: var(--app-mono-font-family);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -89,6 +91,12 @@
   --success-foreground: var(--color-emerald-700);
   --warning: var(--color-amber-500);
   --warning-foreground: var(--color-amber-700);
+  --app-ui-font-family:
+    "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --app-mono-font-family:
+    "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  --app-ui-font-size: 16px;
+  --app-terminal-font-size: 12px;
 
   @variant dark {
     color-scheme: dark;
@@ -120,14 +128,12 @@
   }
 }
 
+html {
+  font-size: var(--app-ui-font-size);
+}
+
 body {
-  font-family:
-    "DM Sans",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    system-ui,
-    sans-serif;
+  font-family: var(--app-ui-font-family);
   margin: 0;
   padding: 0;
   min-height: 100vh;
@@ -157,10 +163,12 @@ body::after {
 }
 
 pre,
-code,
-textarea,
-input {
-  font-family: "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+code {
+  font-family: var(--app-mono-font-family);
+}
+
+.xterm .xterm-helper-textarea {
+  font-family: var(--app-mono-font-family);
 }
 
 /* Window drag region (frameless titlebar) */

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef } from "react";
 import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import { Throttler } from "@tanstack/react-pacer";
 
+import { useAppTypography } from "../appTypography";
 import { APP_DISPLAY_NAME } from "../branding";
 import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
@@ -36,6 +37,8 @@ export const Route = createRootRouteWithContext<{
 });
 
 function RootRouteView() {
+  useAppTypography();
+
   if (!readNativeApi()) {
     return (
       <div className="flex h-screen flex-col bg-background text-foreground">

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -8,10 +8,16 @@ import {
   getCustomModelsForProvider,
   getDefaultCustomModelsForProvider,
   MAX_CUSTOM_MODEL_LENGTH,
+  MAX_FONT_FAMILY_LENGTH,
   MODEL_PROVIDER_SETTINGS,
   patchCustomModels,
   useAppSettings,
 } from "../appSettings";
+import {
+  normalizeFontFamilyOverride,
+  TERMINAL_FONT_SIZE_OPTIONS,
+  UI_FONT_SIZE_OPTIONS,
+} from "../appTypography";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
@@ -85,6 +91,19 @@ function SettingsRouteView() {
       (option) =>
         option.slug === (settings.textGenerationModel ?? DEFAULT_GIT_TEXT_GENERATION_MODEL),
     )?.name ?? settings.textGenerationModel;
+  const selectedUiFontSizeLabel =
+    UI_FONT_SIZE_OPTIONS.find((option) => option.value === settings.uiFontSize)?.label ??
+    settings.uiFontSize;
+  const selectedTerminalFontSizeLabel =
+    TERMINAL_FONT_SIZE_OPTIONS.find((option) => option.value === settings.terminalFontSize)
+      ?.label ?? settings.terminalFontSize;
+  const hasTypographyOverrides =
+    settings.uiFontSize !== defaults.uiFontSize ||
+    settings.terminalFontSize !== defaults.terminalFontSize ||
+    (normalizeFontFamilyOverride(settings.uiFontFamily) ?? "") !==
+      (normalizeFontFamilyOverride(defaults.uiFontFamily) ?? "") ||
+    (normalizeFontFamilyOverride(settings.monoFontFamily) ?? "") !==
+      (normalizeFontFamilyOverride(defaults.monoFontFamily) ?? "");
 
   const openKeybindingsFile = useCallback(() => {
     if (!keybindingsConfigPath) return;
@@ -240,8 +259,8 @@ function SettingsRouteView() {
                   <div>
                     <p className="text-sm font-medium text-foreground">Timestamp format</p>
                     <p className="text-xs text-muted-foreground">
-                      System default follows your browser or OS time format. <code>12-hour</code>{" "}
-                      and <code>24-hour</code> force the hour cycle.
+                      System default follows your browser or OS time format. "12-hour" and "24-hour"
+                      force the hour cycle.
                     </p>
                   </div>
                   <Select
@@ -301,7 +320,7 @@ function SettingsRouteView() {
                     spellCheck={false}
                   />
                   <span className="text-xs text-muted-foreground">
-                    Leave blank to use <code>codex</code> from your PATH.
+                    Leave blank to use codex from your PATH.
                   </span>
                 </label>
 
@@ -322,7 +341,7 @@ function SettingsRouteView() {
                 <div className="flex flex-col gap-3 text-xs text-muted-foreground sm:flex-row sm:items-start sm:justify-between">
                   <div className="min-w-0 flex-1">
                     <p>Binary source</p>
-                    <p className="mt-1 break-all font-mono text-[11px] text-foreground">
+                    <p className="mt-1 break-all text-[11px] text-foreground">
                       {codexBinaryPath || "PATH"}
                     </p>
                   </div>
@@ -340,6 +359,146 @@ function SettingsRouteView() {
                     Reset codex overrides
                   </Button>
                 </div>
+              </div>
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <div className="mb-4">
+                <h2 className="text-sm font-medium text-foreground">Typography</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Adjust local interface scale and font stacks for this device. Uses installed fonts
+                  only.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex items-center justify-between rounded-lg border border-border bg-background px-3 py-2">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">Interface font size</p>
+                    <p className="text-xs text-muted-foreground">
+                      Changes the app's text size and spacing.
+                    </p>
+                  </div>
+                  <Select
+                    value={settings.uiFontSize}
+                    onValueChange={(value) => {
+                      if (value !== "sm" && value !== "md" && value !== "lg") return;
+                      updateSettings({
+                        uiFontSize: value,
+                      });
+                    }}
+                  >
+                    <SelectTrigger className="w-44" aria-label="Interface font size">
+                      <SelectValue>{selectedUiFontSizeLabel}</SelectValue>
+                    </SelectTrigger>
+                    <SelectPopup align="end">
+                      {UI_FONT_SIZE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectPopup>
+                  </Select>
+                </div>
+
+                <div className="flex items-center justify-between rounded-lg border border-border bg-background px-3 py-2">
+                  <div>
+                    <p className="text-sm font-medium text-foreground">Terminal font size</p>
+                    <p className="text-xs text-muted-foreground">
+                      Changes text size only in the built-in terminal drawer.
+                    </p>
+                  </div>
+                  <Select
+                    value={settings.terminalFontSize}
+                    onValueChange={(value) => {
+                      if (value !== "sm" && value !== "md" && value !== "lg" && value !== "xl")
+                        return;
+                      updateSettings({
+                        terminalFontSize: value,
+                      });
+                    }}
+                  >
+                    <SelectTrigger className="w-44" aria-label="Terminal font size">
+                      <SelectValue>{selectedTerminalFontSizeLabel}</SelectValue>
+                    </SelectTrigger>
+                    <SelectPopup align="end">
+                      {TERMINAL_FONT_SIZE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectPopup>
+                  </Select>
+                </div>
+
+                <label htmlFor="ui-font-family" className="block space-y-1">
+                  <span className="text-xs font-medium text-foreground">Interface font family</span>
+                  <Input
+                    id="ui-font-family"
+                    value={settings.uiFontFamily}
+                    onChange={(event) =>
+                      updateSettings({
+                        uiFontFamily: event.target.value,
+                      })
+                    }
+                    onBlur={(event) =>
+                      updateSettings({
+                        uiFontFamily: normalizeFontFamilyOverride(event.target.value) ?? "",
+                      })
+                    }
+                    placeholder="Inter, system-ui, sans-serif"
+                    spellCheck={false}
+                    maxLength={MAX_FONT_FAMILY_LENGTH}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    Applies to the app interface. Leave blank to use defaults.
+                  </span>
+                </label>
+
+                <label htmlFor="mono-font-family" className="block space-y-1">
+                  <span className="text-xs font-medium text-foreground">
+                    Code and terminal font family
+                  </span>
+                  <Input
+                    id="mono-font-family"
+                    value={settings.monoFontFamily}
+                    onChange={(event) =>
+                      updateSettings({
+                        monoFontFamily: event.target.value,
+                      })
+                    }
+                    onBlur={(event) =>
+                      updateSettings({
+                        monoFontFamily: normalizeFontFamilyOverride(event.target.value) ?? "",
+                      })
+                    }
+                    placeholder={'"SF Mono", Menlo, monospace'}
+                    spellCheck={false}
+                    maxLength={MAX_FONT_FAMILY_LENGTH}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    Applies to code blocks, inline code, and terminals. Leave blank to use defaults.
+                  </span>
+                </label>
+
+                {hasTypographyOverrides ? (
+                  <div className="flex justify-end">
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      onClick={() =>
+                        updateSettings({
+                          uiFontSize: defaults.uiFontSize,
+                          terminalFontSize: defaults.terminalFontSize,
+                          uiFontFamily: defaults.uiFontFamily,
+                          monoFontFamily: defaults.monoFontFamily,
+                        })
+                      }
+                    >
+                      Restore default
+                    </Button>
+                  </div>
+                ) : null}
               </div>
             </section>
 


### PR DESCRIPTION
Add local typography settings for the app UI so users can tune interface scale, font family, and terminal typography without editing config files. This responds directly to requests for UI font size and custom font support, while keeping the scope local-only and avoiding remote font loading.

## Feedback requested
I'd appreciate feedback mainly on product fit and scope:
- whether the split between interface font vs. code and terminal font feels right
- whether the mono font family should continue to affect existing monospace UI surfaces outside explicit code blocks and the terminal, or whether that scope should be narrowed further
- whether live terminal updates are the right behavior, or if the terminal should require a reopen
- Interface font size currently scales the rem/inherited UI, but not every existing px-sized surface. If you want broader coverage, I can follow up by converting representative fixed-size UI text to participate in the interface scale.

## Suggested review order
1. `apps/web/src/appSettings.ts` and `apps/web/src/appTypography.ts`
2. `apps/web/src/index.css` and `apps/web/src/routes/__root.tsx`
3. `apps/web/src/routes/_chat.settings.tsx`
4. `apps/web/src/components/ThreadTerminalDrawer.tsx`
5. the focused tests

## What changed
- persist four local settings: `uiFontSize`, `terminalFontSize`, `uiFontFamily`, and `monoFontFamily`
- apply typography through root CSS custom properties
- keep normal UI inputs and the composer on the interface font
- keep inline code, fenced code, the built-in terminal, and existing monospace UI surfaces on the mono font
- update xterm in place and re-fit geometry when terminal typography changes

## Scope boundaries
This PR intentionally does **not** add remote font loading, server-side settings sync, or broader theming work. It is meant to stay narrowly focused on local typography preferences.

## Verification
I ran:
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `cd apps/web && bun run test src/appSettings.test.ts src/appTypography.test.ts src/components/ThreadTerminalDrawer.test.ts`

I also manually checked the feature locally in the dev app:
- typography controls render in Settings
- interface and mono font scopes apply to the expected surfaces
- terminal typography updates live without recreating the terminal drawer

## Test gap
I did not use repo-root `bun run test` as a PR gate here because the current upstream `main` checkout already has unrelated red `apps/server` tests in my environment. The failures reproduce outside this branch and are not in files touched by this PR.

## Screenshots
These visuals are meant to show the new Typography settings surface and the visible difference between the default, large, and small interface font sizes.

### Settings screen
Before:
![Before settings](https://raw.githubusercontent.com/Danielalnajjar/t3code/pr-assets-typography-settings/pr-assets/typography/Before%20Settings.png)

After:
![After settings](https://raw.githubusercontent.com/Danielalnajjar/t3code/pr-assets-typography-settings/pr-assets/typography/After%20Settings.png)

### Interface font size examples
Small:
![Small font size](https://raw.githubusercontent.com/Danielalnajjar/t3code/pr-assets-typography-settings/pr-assets/typography/Small%20Font.png)

Default:
![Default font size](https://raw.githubusercontent.com/Danielalnajjar/t3code/pr-assets-typography-settings/pr-assets/typography/Default.png)

Large:
![Large font size](https://raw.githubusercontent.com/Danielalnajjar/t3code/pr-assets-typography-settings/pr-assets/typography/Large%20Font.png)

### Video
https://github.com/user-attachments/assets/c6054f00-9a28-425d-871a-36b6ca905538

### Living plan file use for implementation
[18-local-typography-settings.md](https://github.com/user-attachments/files/26195042/18-local-typography-settings.md)

## Related
- Builds on #254, which asks for settings font size options and custom font support.
- Builds on #418, which asks for broader UI customization, including font family and font size controls.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local typography settings for UI font size, terminal font size, and font family overrides
> - Adds `uiFontSize`, `terminalFontSize`, `uiFontFamily`, and `monoFontFamily` fields to [`AppSettingsSchema`](https://github.com/pingdotgg/t3code/pull/1337/files#diff-4f500b80c5f743d5b39d3f07498169da0c26f4bf9b5a2127453a90c04a4c49cc), with defaults of `md` size and empty family overrides.
> - Introduces [`useAppTypography`](https://github.com/pingdotgg/t3code/pull/1337/files#diff-977448c1fbb6022304e2c713d65b5c5850efd4e78b24c7fde695a94ba48c263e) hook that writes CSS variables (`--app-ui-font-size`, `--app-terminal-font-size`, `--app-ui-font-family`, `--app-mono-font-family`) to the document root and keeps them in sync with settings changes.
> - Updates [`index.css`](https://github.com/pingdotgg/t3code/pull/1337/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to drive base font size and family from these CSS variables, including code blocks and terminal textarea.
> - Adds a Typography section to the Settings route where users can select font sizes and enter optional font family stacks, with a reset button to restore defaults.
> - Refactors [`ThreadTerminalDrawer`](https://github.com/pingdotgg/t3code/pull/1337/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) to read font settings from CSS variables on mount and react to style/theme mutations via observers, replacing the `resizeEpoch`/`drawerHeight` prop approach.
> - Behavioral Change: existing persisted settings missing the new keys will receive default values on next decode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d388c21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->
