### PR TITLE
fix(web): auto-scroll composer autocomplete list on keyboard navigation

### DIFF
--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -1,5 +1,5 @@
 import { type ProjectEntry, type ModelSlug, type ProviderKind } from "@t3tools/contracts";
-import { memo } from "react";
+import { memo, useEffect, useRef } from "react";
 import { type ComposerSlashCommand, type ComposerTriggerKind } from "../../composer-logic";
 import { BotIcon } from "lucide-react";
 import { cn } from "~/lib/utils";
@@ -82,8 +82,17 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
   isActive: boolean;
   onSelect: (item: ComposerCommandItem) => void;
 }) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (props.isActive) {
+      ref.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [props.isActive]);
+
   return (
     <CommandItem
+      ref={ref}
       value={props.item.id}
       className={cn(
         "cursor-pointer select-none gap-2",


### PR DESCRIPTION
## What Changed

Added `scrollIntoView({ block: "nearest" })` to the active item in the composer `@`-mention autocomplete dropdown when navigating with arrow keys.

Single file changed: `ComposerCommandMenu.tsx` (+9 lines).

## Why

When the autocomplete list has more items than fit in the visible area (`max-h-64`), pressing ArrowDown/ArrowUp updates the highlighted item but does not scroll the list. The selected item moves off-screen while the viewport stays fixed, making keyboard navigation unusable for items below the fold.

The keyboard navigation is handled manually via `nudgeComposerMenuHighlight` in `ChatView.tsx` (not through base-ui's built-in keyboard handling), so base-ui's auto-scroll never fires. This fix adds an explicit `scrollIntoView` call on the active item.

## UI Changes

### Before

https://github.com/user-attachments/assets/eae4c900-b930-4d6b-b4fc-f7bcc2842518

### After

https://github.com/user-attachments/assets/c0374ac1-56bf-4f00-9293-7c16e8143bdf

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-scroll active item in composer autocomplete list on keyboard navigation
> When navigating the composer command menu with the keyboard, the active item now calls `scrollIntoView` to stay visible within the scrollable container. This is implemented in `ComposerCommandMenuItem` via a `useEffect` that triggers whenever `isActive` becomes true.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2db97dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->