### PR TITLE
new "+" option to create an empty dir

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -47,6 +47,7 @@ import { isArm64HostRunningIntelBuild, resolveDesktopRuntimeInfo } from "./runti
 syncShellEnvironment();
 
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
+const GET_DOCUMENTS_PATH_CHANNEL = "desktop:get-documents-path";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
@@ -1084,6 +1085,16 @@ function registerIpcHandlers(): void {
         });
     if (result.canceled) return null;
     return result.filePaths[0] ?? null;
+  });
+
+  ipcMain.removeHandler(GET_DOCUMENTS_PATH_CHANNEL);
+  ipcMain.handle(GET_DOCUMENTS_PATH_CHANNEL, async () => {
+    try {
+      const documentsPath = app.getPath("documents");
+      return typeof documentsPath === "string" && documentsPath.length > 0 ? documentsPath : null;
+    } catch {
+      return null;
+    }
   });
 
   ipcMain.removeHandler(CONFIRM_CHANNEL);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from "electron";
 import type { DesktopBridge } from "@t3tools/contracts";
 
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
+const GET_DOCUMENTS_PATH_CHANNEL = "desktop:get-documents-path";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
@@ -16,6 +17,7 @@ const wsUrl = process.env.T3CODE_DESKTOP_WS_URL ?? null;
 contextBridge.exposeInMainWorld("desktopBridge", {
   getWsUrl: () => wsUrl,
   pickFolder: () => ipcRenderer.invoke(PICK_FOLDER_CHANNEL),
+  getDocumentsPath: () => ipcRenderer.invoke(GET_DOCUMENTS_PATH_CHANNEL),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),
   showContextMenu: (items, position) => ipcRenderer.invoke(CONTEXT_MENU_CHANNEL, items, position),

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -1641,6 +1641,49 @@ describe("WebSocket Server", () => {
     expect(fs.existsSync(path.join(workspace, "..", "escape.md"))).toBe(false);
   });
 
+  it("supports projects.createDirectory within the workspace root", async () => {
+    const workspace = makeTempDir("t3code-ws-create-directory-");
+
+    server = await createTestServer({ cwd: "/test" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const [ws] = await connectAndAwaitWelcome(port);
+    connections.push(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.projectsCreateDirectory, {
+      cwd: workspace,
+      relativePath: "sandboxes/fresh-room",
+    });
+
+    expect(response.error).toBeUndefined();
+    expect(response.result).toEqual({
+      relativePath: "sandboxes/fresh-room",
+      absolutePath: path.join(workspace, "sandboxes", "fresh-room"),
+    });
+    expect(fs.existsSync(path.join(workspace, "sandboxes", "fresh-room"))).toBe(true);
+  });
+
+  it("rejects projects.createDirectory when the target already exists", async () => {
+    const workspace = makeTempDir("t3code-ws-create-directory-existing-");
+    fs.mkdirSync(path.join(workspace, "existing"), { recursive: true });
+
+    server = await createTestServer({ cwd: "/test" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const [ws] = await connectAndAwaitWelcome(port);
+    connections.push(ws);
+
+    const response = await sendRequest(ws, WS_METHODS.projectsCreateDirectory, {
+      cwd: workspace,
+      relativePath: "existing",
+    });
+
+    expect(response.result).toBeUndefined();
+    expect(response.error?.message).toContain("Workspace directory already exists");
+  });
+
   it("routes git core methods over websocket", async () => {
     const listBranches = vi.fn(() =>
       Effect.succeed({

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -776,6 +776,47 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         return { relativePath: target.relativePath };
       }
 
+      case WS_METHODS.projectsCreateDirectory: {
+        const body = stripRequestTag(request.body);
+        const target = yield* resolveWorkspaceWritePath({
+          workspaceRoot: body.cwd,
+          relativePath: body.relativePath,
+          path,
+        });
+
+        const existingEntry = yield* Effect.result(fileSystem.stat(target.absolutePath));
+        if (Result.isSuccess(existingEntry)) {
+          return yield* new RouteRequestError({
+            message: `Workspace directory already exists: ${target.relativePath}`,
+          });
+        }
+
+        yield* fileSystem
+          .makeDirectory(path.dirname(target.absolutePath), { recursive: true })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new RouteRequestError({
+                  message: `Failed to prepare workspace directory path: ${String(cause)}`,
+                }),
+            ),
+          );
+
+        yield* fileSystem.makeDirectory(target.absolutePath, { recursive: false }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new RouteRequestError({
+                message: `Failed to create workspace directory: ${String(cause)}`,
+              }),
+          ),
+        );
+
+        return {
+          relativePath: target.relativePath,
+          absolutePath: target.absolutePath,
+        };
+      }
+
       case WS_METHODS.shellOpenInEditor: {
         const body = stripRequestTag(request.body);
         return yield* openInEditor(body);

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -35,6 +35,7 @@ import {
   FileSystem,
   Layer,
   Path,
+  PlatformError,
   Ref,
   Result,
   Schema,
@@ -788,6 +789,17 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
         if (Result.isSuccess(existingEntry)) {
           return yield* new RouteRequestError({
             message: `Workspace directory already exists: ${target.relativePath}`,
+          });
+        }
+        if (
+          !(
+            existingEntry.failure instanceof PlatformError.PlatformError &&
+            existingEntry.failure.reason instanceof PlatformError.SystemError &&
+            existingEntry.failure.reason._tag === "NotFound"
+          )
+        ) {
+          return yield* new RouteRequestError({
+            message: `Failed to inspect workspace directory: ${String(existingEntry.failure)}`,
           });
         }
 

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -211,6 +211,7 @@ describe("AppSettingsSchema", () => {
     ).toMatchObject({
       codexBinaryPath: "/usr/local/bin/codex",
       codexHomePath: "",
+      newProjectBasePath: "",
       defaultThreadEnvMode: "local",
       confirmThreadDelete: false,
       enableAssistantStreaming: false,

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -49,6 +49,7 @@ const withDefaults =
 export const AppSettingsSchema = Schema.Struct({
   codexBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   codexHomePath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
+  newProjectBasePath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   defaultThreadEnvMode: EnvMode.pipe(withDefaults(() => "local" as const satisfies EnvMode)),
   confirmThreadDelete: Schema.Boolean.pipe(withDefaults(() => true)),
   enableAssistantStreaming: Schema.Boolean.pipe(withDefaults(() => false)),

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2,6 +2,8 @@ import {
   ArrowLeftIcon,
   ChevronRightIcon,
   FolderIcon,
+  FolderOpenIcon,
+  FolderPlusIcon,
   GitPullRequestIcon,
   PlusIcon,
   RocketIcon,
@@ -64,6 +66,17 @@ import {
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Collapsible, CollapsibleContent } from "./ui/collapsible";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import {
   SidebarContent,
@@ -272,7 +285,7 @@ export default function Sidebar() {
   );
   const navigate = useNavigate();
   const isOnSettings = useLocation({ select: (loc) => loc.pathname === "/settings" });
-  const { settings: appSettings } = useAppSettings();
+  const { settings: appSettings, updateSettings } = useAppSettings();
   const { handleNewThread } = useHandleNewThread();
   const routeThreadId = useParams({
     strict: false,
@@ -285,11 +298,22 @@ export default function Sidebar() {
   const queryClient = useQueryClient();
   const removeWorktreeMutation = useMutation(gitRemoveWorktreeMutationOptions({ queryClient }));
   const [addingProject, setAddingProject] = useState(false);
+  const [isAddProjectMenuOpen, setIsAddProjectMenuOpen] = useState(false);
   const [newCwd, setNewCwd] = useState("");
   const [isPickingFolder, setIsPickingFolder] = useState(false);
   const [isAddingProject, setIsAddingProject] = useState(false);
   const [addProjectError, setAddProjectError] = useState<string | null>(null);
   const addProjectInputRef = useRef<HTMLInputElement | null>(null);
+  const addProjectMenuCloseTimerRef = useRef<number | null>(null);
+  const [isCreateProjectDialogOpen, setIsCreateProjectDialogOpen] = useState(false);
+  const [createProjectDirectoryPath, setCreateProjectDirectoryPath] = useState("");
+  const [newProjectDirectoryName, setNewProjectDirectoryName] = useState("");
+  const [isCreatingProjectDirectory, setIsCreatingProjectDirectory] = useState(false);
+  const [isPickingCreateProjectDirectoryPath, setIsPickingCreateProjectDirectoryPath] =
+    useState(false);
+  const [createProjectDirectoryError, setCreateProjectDirectoryError] = useState<string | null>(
+    null,
+  );
   const [renamingThreadId, setRenamingThreadId] = useState<ThreadId | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
   const [expandedThreadListsByProject, setExpandedThreadListsByProject] = useState<
@@ -403,11 +427,11 @@ export default function Sidebar() {
   );
 
   const addProjectFromPath = useCallback(
-    async (rawCwd: string) => {
+    async (rawCwd: string): Promise<{ ok: boolean; error?: string }> => {
       const cwd = rawCwd.trim();
-      if (!cwd || isAddingProject) return;
+      if (!cwd || isAddingProject) return { ok: false };
       const api = readNativeApi();
-      if (!api) return;
+      if (!api) return { ok: false, error: "Native API not available." };
 
       setIsAddingProject(true);
       const finishAddingProject = () => {
@@ -421,7 +445,7 @@ export default function Sidebar() {
       if (existing) {
         focusMostRecentThreadForProject(existing.id);
         finishAddingProject();
-        return;
+        return { ok: true };
       }
 
       const projectId = newProjectId();
@@ -453,9 +477,10 @@ export default function Sidebar() {
         } else {
           setAddProjectError(description);
         }
-        return;
+        return { ok: false, error: description };
       }
       finishAddingProject();
+      return { ok: true };
     },
     [
       focusMostRecentThreadForProject,
@@ -472,6 +497,26 @@ export default function Sidebar() {
   };
 
   const canAddProject = newCwd.trim().length > 0 && !isAddingProject;
+  const newProjectBasePath = appSettings.newProjectBasePath.trim();
+
+  const cancelAddProjectMenuClose = useCallback(() => {
+    if (addProjectMenuCloseTimerRef.current === null) return;
+    window.clearTimeout(addProjectMenuCloseTimerRef.current);
+    addProjectMenuCloseTimerRef.current = null;
+  }, []);
+
+  const openAddProjectMenu = useCallback(() => {
+    cancelAddProjectMenuClose();
+    setIsAddProjectMenuOpen(true);
+  }, [cancelAddProjectMenuClose]);
+
+  const scheduleAddProjectMenuClose = useCallback(() => {
+    cancelAddProjectMenuClose();
+    addProjectMenuCloseTimerRef.current = window.setTimeout(() => {
+      setIsAddProjectMenuOpen(false);
+      addProjectMenuCloseTimerRef.current = null;
+    }, 120);
+  }, [cancelAddProjectMenuClose]);
 
   const handlePickFolder = async () => {
     const api = readNativeApi();
@@ -492,6 +537,7 @@ export default function Sidebar() {
   };
 
   const handleStartAddProject = () => {
+    setIsAddProjectMenuOpen(false);
     setAddProjectError(null);
     if (shouldBrowseForProjectImmediately) {
       void handlePickFolder();
@@ -499,6 +545,110 @@ export default function Sidebar() {
     }
     setAddingProject((prev) => !prev);
   };
+
+  const closeCreateProjectDialog = useCallback((open: boolean) => {
+    setIsCreateProjectDialogOpen(open);
+    if (!open) {
+      setCreateProjectDirectoryPath("");
+      setNewProjectDirectoryName("");
+      setCreateProjectDirectoryError(null);
+      setIsCreatingProjectDirectory(false);
+      setIsPickingCreateProjectDirectoryPath(false);
+    }
+  }, []);
+
+  const handleStartCreateProjectDirectory = useCallback(() => {
+    setIsAddProjectMenuOpen(false);
+    setAddProjectError(null);
+    setCreateProjectDirectoryPath(newProjectBasePath);
+    setNewProjectDirectoryName("");
+    setCreateProjectDirectoryError(null);
+    setIsCreateProjectDialogOpen(true);
+
+    if (newProjectBasePath) {
+      return;
+    }
+
+    const api = readNativeApi();
+    if (!api) {
+      return;
+    }
+
+    void api.dialogs.getDocumentsPath().then((documentsPath) => {
+      if (!documentsPath) return;
+      setCreateProjectDirectoryPath((current) =>
+        current.trim().length > 0 ? current : documentsPath,
+      );
+    });
+  }, [newProjectBasePath]);
+
+  const handlePickCreateProjectDirectoryPath = useCallback(async () => {
+    const api = readNativeApi();
+    if (!api || isPickingCreateProjectDirectoryPath) return;
+
+    setIsPickingCreateProjectDirectoryPath(true);
+    try {
+      const pickedPath = await api.dialogs.pickFolder();
+      if (pickedPath) {
+        setCreateProjectDirectoryPath(pickedPath);
+        setCreateProjectDirectoryError(null);
+      }
+    } finally {
+      setIsPickingCreateProjectDirectoryPath(false);
+    }
+  }, [isPickingCreateProjectDirectoryPath]);
+
+  const handleCreateProjectDirectory = useCallback(async () => {
+    const basePath = createProjectDirectoryPath.trim();
+    const relativePath = newProjectDirectoryName.trim();
+    if (!basePath || !relativePath || isCreatingProjectDirectory || isAddingProject) {
+      if (!basePath) {
+        setCreateProjectDirectoryError("Enter a directory path.");
+      }
+      if (!relativePath) {
+        setCreateProjectDirectoryError("Enter a directory name.");
+      }
+      return;
+    }
+
+    const api = readNativeApi();
+    if (!api) return;
+
+    setIsCreatingProjectDirectory(true);
+    setCreateProjectDirectoryError(null);
+
+    try {
+      const result = await api.projects.createDirectory({
+        cwd: basePath,
+        relativePath,
+      });
+      const addedProject = await addProjectFromPath(result.absolutePath);
+      if (!addedProject.ok) {
+        setCreateProjectDirectoryError(addedProject.error ?? "Unable to open the new project.");
+        setIsCreatingProjectDirectory(false);
+        return;
+      }
+      closeCreateProjectDialog(false);
+    } catch (error) {
+      setCreateProjectDirectoryError(
+        error instanceof Error ? error.message : "Unable to create the directory.",
+      );
+      setIsCreatingProjectDirectory(false);
+    }
+  }, [
+    addProjectFromPath,
+    closeCreateProjectDialog,
+    createProjectDirectoryPath,
+    isAddingProject,
+    isCreatingProjectDirectory,
+    newProjectDirectoryName,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      cancelAddProjectMenuClose();
+    };
+  }, [cancelAddProjectMenuClose]);
 
   const cancelRename = useCallback(() => {
     setRenamingThreadId(null);
@@ -1232,28 +1382,59 @@ export default function Sidebar() {
             <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
               Projects
             </span>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    type="button"
-                    aria-label={shouldShowProjectPathEntry ? "Cancel add project" : "Add project"}
-                    aria-pressed={shouldShowProjectPathEntry}
-                    className="inline-flex size-5 cursor-pointer items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
-                    onClick={handleStartAddProject}
+            <div onMouseEnter={openAddProjectMenu} onMouseLeave={scheduleAddProjectMenuClose}>
+              <Menu open={isAddProjectMenuOpen} onOpenChange={setIsAddProjectMenuOpen}>
+                <MenuTrigger
+                  render={
+                    <button
+                      type="button"
+                      aria-label="Add project"
+                      aria-expanded={isAddProjectMenuOpen}
+                      className="inline-flex size-5 cursor-pointer items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+                      onClick={() => setIsAddProjectMenuOpen((open) => !open)}
+                    />
+                  }
+                >
+                  <PlusIcon
+                    className={`size-3.5 transition-transform duration-150 ${
+                      isAddProjectMenuOpen || shouldShowProjectPathEntry ? "rotate-90" : "rotate-0"
+                    }`}
                   />
-                }
-              >
-                <PlusIcon
-                  className={`size-3.5 transition-transform duration-150 ${
-                    shouldShowProjectPathEntry ? "rotate-45" : "rotate-0"
-                  }`}
-                />
-              </TooltipTrigger>
-              <TooltipPopup side="right">
-                {shouldShowProjectPathEntry ? "Cancel add project" : "Add project"}
-              </TooltipPopup>
-            </Tooltip>
+                </MenuTrigger>
+                <MenuPopup
+                  align="end"
+                  className="w-64"
+                  onMouseEnter={openAddProjectMenu}
+                  onMouseLeave={scheduleAddProjectMenuClose}
+                >
+                  <MenuItem className="items-start py-2.5" onClick={handleStartAddProject}>
+                    <FolderOpenIcon className="mt-0.5 size-4" />
+                    <span className="flex flex-col gap-0.5">
+                      <span className="text-sm font-medium text-foreground">
+                        Open existing directory
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        Add a project from a folder you already have.
+                      </span>
+                    </span>
+                  </MenuItem>
+                  <MenuItem
+                    className="items-start py-2.5"
+                    onClick={handleStartCreateProjectDirectory}
+                  >
+                    <FolderPlusIcon className="mt-0.5 size-4" />
+                    <span className="flex flex-col gap-0.5">
+                      <span className="text-sm font-medium text-foreground">
+                        Create new empty directory
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        Make a fresh folder inside your default project path.
+                      </span>
+                    </span>
+                  </MenuItem>
+                </MenuPopup>
+              </Menu>
+            </div>
           </div>
 
           {shouldShowProjectPathEntry && (
@@ -1702,6 +1883,102 @@ export default function Sidebar() {
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>
+      <Dialog open={isCreateProjectDialogOpen} onOpenChange={closeCreateProjectDialog}>
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>Create new empty directory</DialogTitle>
+            <DialogDescription>
+              Choose where the new folder should live, then name the project and T3 Code will open
+              it right away.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-5 pt-0" scrollFade={false}>
+            <div className="space-y-2">
+              <span className="text-xs font-medium text-foreground">Directory path</span>
+              <div className="flex gap-2">
+                <Input
+                  value={createProjectDirectoryPath}
+                  onChange={(event) => {
+                    setCreateProjectDirectoryPath(event.target.value);
+                    if (createProjectDirectoryError) {
+                      setCreateProjectDirectoryError(null);
+                    }
+                  }}
+                  placeholder="/Users/you/Documents"
+                  spellCheck={false}
+                  autoFocus
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handlePickCreateProjectDirectoryPath()}
+                  disabled={isPickingCreateProjectDirectoryPath}
+                >
+                  {isPickingCreateProjectDirectoryPath ? "Selecting..." : "Select"}
+                </Button>
+              </div>
+              {!newProjectBasePath && createProjectDirectoryPath.trim() ? (
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="outline"
+                    onClick={() =>
+                      updateSettings({
+                        newProjectBasePath: createProjectDirectoryPath.trim(),
+                      })
+                    }
+                  >
+                    Set as default
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+
+            <label htmlFor="new-project-directory-name" className="block space-y-2">
+              <span className="text-xs font-medium text-foreground">Project name</span>
+              <Input
+                id="new-project-directory-name"
+                value={newProjectDirectoryName}
+                onChange={(event) => {
+                  setNewProjectDirectoryName(event.target.value);
+                  if (createProjectDirectoryError) {
+                    setCreateProjectDirectoryError(null);
+                  }
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") return;
+                  event.preventDefault();
+                  void handleCreateProjectDirectory();
+                }}
+                placeholder="my-new-project"
+                spellCheck={false}
+              />
+            </label>
+
+            {createProjectDirectoryError ? (
+              <p className="text-xs text-destructive">{createProjectDirectoryError}</p>
+            ) : null}
+          </DialogPanel>
+          <DialogFooter variant="bare" className="pt-0">
+            <Button type="button" variant="outline" onClick={() => closeCreateProjectDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => void handleCreateProjectDirectory()}
+              disabled={
+                !createProjectDirectoryPath.trim() ||
+                !newProjectDirectoryName.trim() ||
+                isCreatingProjectDirectory ||
+                isAddingProject
+              }
+            >
+              {isCreatingProjectDirectory || isAddingProject ? "Creating..." : "OK"}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
     </>
   );
 }

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -18,6 +18,15 @@ import { useTheme } from "../hooks/useTheme";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { ensureNativeApi } from "../nativeApi";
 import { Button } from "../components/ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "../components/ui/dialog";
 import { Input } from "../components/ui/input";
 import {
   Select,
@@ -60,6 +69,9 @@ function SettingsRouteView() {
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);
   const [openKeybindingsError, setOpenKeybindingsError] = useState<string | null>(null);
+  const [isProjectBasePathDialogOpen, setIsProjectBasePathDialogOpen] = useState(false);
+  const [isPickingProjectBasePath, setIsPickingProjectBasePath] = useState(false);
+  const [projectBasePathDraft, setProjectBasePathDraft] = useState("");
   const [customModelInputByProvider, setCustomModelInputByProvider] = useState<
     Record<ProviderKind, string>
   >({
@@ -72,6 +84,7 @@ function SettingsRouteView() {
 
   const codexBinaryPath = settings.codexBinaryPath;
   const codexHomePath = settings.codexHomePath;
+  const newProjectBasePath = settings.newProjectBasePath;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
   const availableEditors = serverConfigQuery.data?.availableEditors;
 
@@ -173,6 +186,43 @@ function SettingsRouteView() {
     [settings, updateSettings],
   );
 
+  const openProjectBasePathDialog = useCallback(() => {
+    setProjectBasePathDraft(settings.newProjectBasePath);
+    setIsProjectBasePathDialogOpen(true);
+  }, [settings.newProjectBasePath]);
+
+  const closeProjectBasePathDialog = useCallback((open: boolean) => {
+    setIsProjectBasePathDialogOpen(open);
+    if (!open) {
+      setIsPickingProjectBasePath(false);
+      setProjectBasePathDraft("");
+    }
+  }, []);
+
+  const saveProjectBasePath = useCallback(() => {
+    const normalizedPath = projectBasePathDraft.trim();
+    updateSettings({
+      newProjectBasePath: normalizedPath,
+    });
+    setProjectBasePathDraft(normalizedPath);
+    setIsProjectBasePathDialogOpen(false);
+  }, [projectBasePathDraft, updateSettings]);
+
+  const pickProjectBasePath = useCallback(async () => {
+    if (isPickingProjectBasePath) return;
+
+    setIsPickingProjectBasePath(true);
+    try {
+      const api = ensureNativeApi();
+      const pickedPath = await api.dialogs.pickFolder();
+      if (!pickedPath) return;
+
+      setProjectBasePathDraft(pickedPath);
+    } finally {
+      setIsPickingProjectBasePath(false);
+    }
+  }, [isPickingProjectBasePath]);
+
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
@@ -272,6 +322,48 @@ function SettingsRouteView() {
                       onClick={() =>
                         updateSettings({
                           timestampFormat: defaults.timestampFormat,
+                        })
+                      }
+                    >
+                      Restore default
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            </section>
+
+            <section className="rounded-2xl border border-border bg-card p-5">
+              <div className="mb-4">
+                <h2 className="text-sm font-medium text-foreground">Projects</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Optionally choose where newly created empty project folders should live by
+                  default. If unset, the create-project dialog starts in your Documents folder.
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground">
+                      New project directory base path
+                    </p>
+                    <p className="mt-1 break-all font-mono text-[11px] text-muted-foreground">
+                      {newProjectBasePath || "Not set"}
+                    </p>
+                  </div>
+                  <Button size="xs" variant="outline" onClick={openProjectBasePathDialog}>
+                    {newProjectBasePath ? "Edit path" : "Set path"}
+                  </Button>
+                </div>
+
+                {newProjectBasePath ? (
+                  <div className="flex justify-end">
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      onClick={() =>
+                        updateSettings({
+                          newProjectBasePath: defaults.newProjectBasePath,
                         })
                       }
                     >
@@ -720,6 +812,57 @@ function SettingsRouteView() {
           </div>
         </div>
       </div>
+
+      <Dialog open={isProjectBasePathDialogOpen} onOpenChange={closeProjectBasePathDialog}>
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>Default new project path</DialogTitle>
+            <DialogDescription>
+              Enter the full base path where new empty project folders should be created.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4 pt-0" scrollFade={false}>
+            <label htmlFor="new-project-base-path" className="block space-y-2">
+              <span className="text-xs font-medium text-foreground">Full path</span>
+              <div className="flex gap-2">
+                <Input
+                  id="new-project-base-path"
+                  value={projectBasePathDraft}
+                  onChange={(event) => setProjectBasePathDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter") return;
+                    event.preventDefault();
+                    saveProjectBasePath();
+                  }}
+                  placeholder="/Users/you/Developer/sandboxes"
+                  spellCheck={false}
+                  autoFocus
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void pickProjectBasePath()}
+                  disabled={isPickingProjectBasePath}
+                >
+                  {isPickingProjectBasePath ? "Selecting..." : "Select"}
+                </Button>
+              </div>
+            </label>
+          </DialogPanel>
+          <DialogFooter variant="bare" className="pt-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => closeProjectBasePathDialog(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="button" onClick={saveProjectBasePath}>
+              Save path
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
     </SidebarInset>
   );
 }

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -320,6 +320,42 @@ describe("wsNativeApi", () => {
     });
   });
 
+  it("forwards workspace directory creation to the websocket project method", async () => {
+    requestMock.mockResolvedValue({
+      relativePath: "sandbox",
+      absolutePath: "/tmp/project/sandbox",
+    });
+    const { createWsNativeApi } = await import("./wsNativeApi");
+
+    const api = createWsNativeApi();
+    await api.projects.createDirectory({
+      cwd: "/tmp/project",
+      relativePath: "sandbox",
+    });
+
+    expect(requestMock).toHaveBeenCalledWith(WS_METHODS.projectsCreateDirectory, {
+      cwd: "/tmp/project",
+      relativePath: "sandbox",
+    });
+  });
+
+  it("reads the desktop documents path when the bridge is available", async () => {
+    const getDocumentsPath = vi.fn().mockResolvedValue("/Users/davis/Documents");
+    Object.defineProperty(getWindowForTest(), "desktopBridge", {
+      configurable: true,
+      writable: true,
+      value: {
+        getDocumentsPath,
+      },
+    });
+
+    const { createWsNativeApi } = await import("./wsNativeApi");
+    const api = createWsNativeApi();
+
+    await expect(api.dialogs.getDocumentsPath()).resolves.toBe("/Users/davis/Documents");
+    expect(getDocumentsPath).toHaveBeenCalledTimes(1);
+  });
+
   it("forwards full-thread diff requests to the orchestration websocket method", async () => {
     requestMock.mockResolvedValue({ diff: "patch" });
     const { createWsNativeApi } = await import("./wsNativeApi");

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -94,6 +94,10 @@ export function createWsNativeApi(): NativeApi {
         if (!window.desktopBridge) return null;
         return window.desktopBridge.pickFolder();
       },
+      getDocumentsPath: async () => {
+        if (!window.desktopBridge) return null;
+        return window.desktopBridge.getDocumentsPath();
+      },
       confirm: async (message) => {
         if (window.desktopBridge) {
           return window.desktopBridge.confirm(message);
@@ -114,6 +118,7 @@ export function createWsNativeApi(): NativeApi {
     projects: {
       searchEntries: (input) => transport.request(WS_METHODS.projectsSearchEntries, input),
       writeFile: (input) => transport.request(WS_METHODS.projectsWriteFile, input),
+      createDirectory: (input) => transport.request(WS_METHODS.projectsCreateDirectory, input),
     },
     shell: {
       openInEditor: (cwd, editor) =>

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -19,6 +19,8 @@ import type {
   GitStatusResult,
 } from "./git";
 import type {
+  ProjectCreateDirectoryInput,
+  ProjectCreateDirectoryResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
   ProjectWriteFileInput,
@@ -97,6 +99,7 @@ export interface DesktopUpdateActionResult {
 export interface DesktopBridge {
   getWsUrl: () => string | null;
   pickFolder: () => Promise<string | null>;
+  getDocumentsPath: () => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;
   showContextMenu: <T extends string>(
@@ -114,6 +117,7 @@ export interface DesktopBridge {
 export interface NativeApi {
   dialogs: {
     pickFolder: () => Promise<string | null>;
+    getDocumentsPath: () => Promise<string | null>;
     confirm: (message: string) => Promise<boolean>;
   };
   terminal: {
@@ -128,6 +132,7 @@ export interface NativeApi {
   projects: {
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;
+    createDirectory: (input: ProjectCreateDirectoryInput) => Promise<ProjectCreateDirectoryResult>;
   };
   shell: {
     openInEditor: (cwd: string, editor: EditorId) => Promise<void>;

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -37,3 +37,15 @@ export const ProjectWriteFileResult = Schema.Struct({
   relativePath: TrimmedNonEmptyString,
 });
 export type ProjectWriteFileResult = typeof ProjectWriteFileResult.Type;
+
+export const ProjectCreateDirectoryInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+  relativePath: TrimmedNonEmptyString.check(Schema.isMaxLength(PROJECT_WRITE_FILE_PATH_MAX_LENGTH)),
+});
+export type ProjectCreateDirectoryInput = typeof ProjectCreateDirectoryInput.Type;
+
+export const ProjectCreateDirectoryResult = Schema.Struct({
+  relativePath: TrimmedNonEmptyString,
+  absolutePath: TrimmedNonEmptyString,
+});
+export type ProjectCreateDirectoryResult = typeof ProjectCreateDirectoryResult.Type;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -34,7 +34,11 @@ import {
   TerminalWriteInput,
 } from "./terminal";
 import { KeybindingRule } from "./keybindings";
-import { ProjectSearchEntriesInput, ProjectWriteFileInput } from "./project";
+import {
+  ProjectCreateDirectoryInput,
+  ProjectSearchEntriesInput,
+  ProjectWriteFileInput,
+} from "./project";
 import { OpenInEditorInput } from "./editor";
 import { ServerConfigUpdatedPayload } from "./server";
 
@@ -47,6 +51,7 @@ export const WS_METHODS = {
   projectsRemove: "projects.remove",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
+  projectsCreateDirectory: "projects.createDirectory",
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
@@ -111,6 +116,7 @@ const WebSocketRequestBody = Schema.Union([
   // Project Search
   tagRequestBody(WS_METHODS.projectsSearchEntries, ProjectSearchEntriesInput),
   tagRequestBody(WS_METHODS.projectsWriteFile, ProjectWriteFileInput),
+  tagRequestBody(WS_METHODS.projectsCreateDirectory, ProjectCreateDirectoryInput),
 
   // Shell methods
   tagRequestBody(WS_METHODS.shellOpenInEditor, OpenInEditorInput),


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

added a new modal for creating and opening a new directory at the same time. also added a "default path" setting

<img width="756" height="540" alt="image" src="https://github.com/user-attachments/assets/c9b3dbdc-f8dd-42a4-a51a-5d8793430159" />

## Why

spinning up a new project is annoying

## UI Changes

<img width="391" height="294" alt="image" src="https://github.com/user-attachments/assets/db204dfa-e513-4d8f-aac0-0590b3f1cc18" />

## Checklist

- [ x] This PR is small and focused
- [ x] I explained what changed and why
- [ x] I included before/after screenshots for any UI changes
- [ x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sidebar option to create a new empty project directory
> - Adds a "+" menu to the sidebar's projects section with two actions: open an existing directory or create a new empty directory.
> - The create-directory dialog lets users pick a base path (defaulting to `settings.newProjectBasePath` or the OS Documents folder) and enter a project name, then calls `api.projects.createDirectory` and opens the result.
> - Adds a `newProjectBasePath` field to app settings and a new Projects section in the settings page for managing the default base path.
> - Implements the `projects.createDirectory` WebSocket method in the server, rejecting requests if the target directory already exists.
> - Exposes `desktopBridge.getDocumentsPath()` via IPC so the renderer can fall back to the OS Documents path when no default is configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ca37b7b. 13 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->