### PR TITLE
Add resizable chat sidebar

### DIFF
--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -16,7 +16,7 @@ import { Sidebar, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
-const THREAD_SIDEBAR_MIN_WIDTH = 16 * 16;
+const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 
 function ChatRouteGlobalShortcuts() {


### PR DESCRIPTION
Closes https://github.com/pingdotgg/t3code/issues/213

## What Changed

- Added desktop resize support to the main left chat sidebar.
- Reused the existing shared `Sidebar` resize rail instead of introducing a new layout system.
- Persisted the sidebar width in local storage with `chat_thread_sidebar_width`.
- Added a minimum remaining width check for the main content area so resizing cannot collapse the chat view into an unusable layout.
- Kept mobile/sidebar sheet behavior unchanged.

## Why

Issue threads requested a resizable sidebar because long project and thread names are getting truncated. The codebase already had a resize-capable sidebar primitive used by the inline diff panel, so the lowest-risk approach was to wire the main chat sidebar into that existing mechanism.

This keeps the change small, consistent with existing behavior, and avoids adding new dependencies or maintaining a second resize implementation. The width guard is there to preserve predictable layout behavior under narrower desktop viewports.

## UI Changes

- Before: left sidebar width was fixed.
- After: 


https://github.com/user-attachments/assets/57e2bdfe-4b40-4c32-8cca-b3068348b50e



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add resizable sidebar to chat layout
> Makes the chat thread sidebar user-resizable via a drag rail. The sidebar persists its width to `localStorage` under the key `chat_thread_sidebar_width`, enforces a minimum sidebar width of 256px, and rejects resize attempts that would shrink the main content area below 640px.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb0fe0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->