### PR TITLE
fix: stop working timer when turn completes despite stale session status

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -684,10 +684,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [threadActivities],
   );
   // phase === "running" alone isn't sufficient: the session can stay "running" even after
-  // the latest turn has completed (server status lag) or while waiting for user input.
-  // Only treat the agent as "working" if the turn has no completedAt yet and no pending questions.
-  const isActivelyRunning =
-    phase === "running" && pendingUserInputs.length === 0 && !activeLatestTurn?.completedAt;
+  // the latest turn has completed (server lifecycle guard can reject status updates while
+  // completedAt is set through a separate path) or while waiting for user input.
+  // Use completedAt on the latest turn as the reliable completion signal.
+  const turnDone = !!activeLatestTurn?.completedAt;
+  const isActivelyRunning = phase === "running" && pendingUserInputs.length === 0 && !turnDone;
   const isWorking = isActivelyRunning || isSendBusy || isConnecting || isRevertingCheckpoint;
   const activePendingUserInput = pendingUserInputs[0] ?? null;
   const activePendingDraftAnswers = useMemo(

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -115,7 +115,11 @@ export function resolveThreadStatusPill(input: {
     };
   }
 
-  if (thread.session?.status === "running" && !thread.latestTurn?.completedAt) {
+  // Use completedAt as the reliable completion signal — activeTurnId can be permanently
+  // stale when the server lifecycle guard rejects status updates.
+  const sidebarTurnDone = !!thread.latestTurn?.completedAt;
+
+  if (thread.session?.status === "running" && !sidebarTurnDone) {
     return {
       label: "Working",
       colorClass: "text-sky-600 dark:text-sky-300/80",


### PR DESCRIPTION
## What Changed

Two locations showed a stale "Working" state after the agent finished responding:

1. **`ChatView.tsx`** — "Working for Xm Xs" timer in the main chat area
2. **`Sidebar.logic.ts`** — "Working" pill on thread list items

## Root Cause

The server's `shouldApplyThreadLifecycle` guard in `ProviderRuntimeIngestion.ts` can reject `turn.completed` events when turn IDs don't match. When this happens:
- `session.status` stays stuck on `"running"` indefinitely
- `session.activeTurnId` becomes permanently stale

However, `latestTurn.completedAt` is set through a **separate, independent path** (`thread.turn.diff.complete`) that bypasses this guard — so the frontend has a reliable signal that the turn is done.

## Fix

Use `completedAt` on the latest turn as the reliable completion signal, rather than depending solely on `session.status`:

```typescript
// ChatView.tsx
const turnDone = !!activeLatestTurn?.completedAt;
const isActivelyRunning =
  phase === "running" && pendingUserInputs.length === 0 && !turnDone;
const isWorking = isActivelyRunning || isSendBusy || isConnecting || isRevertingCheckpoint;

// Sidebar.logic.ts
const sidebarTurnDone = !!thread.latestTurn?.completedAt;
if (thread.session?.status === "running" && !sidebarTurnDone) { ... }
```

This also correctly suppresses the working indicator when the agent is blocked waiting for user input (`pendingUserInputs.length > 0`), since that check was already present.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

Fixes #1069, closes #1335