### PR TITLE
Add configurable default provider and model

### DIFF
--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { Option, Schema } from "effect";
 import {
+  ProviderKind as ProviderKindSchema,
   TrimmedNonEmptyString,
   type ProviderKind,
   type ProviderStartOptions,
@@ -61,6 +62,9 @@ export const AppSettingsSchema = Schema.Struct({
   customCodexModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   customClaudeModels: Schema.Array(Schema.String).pipe(withDefaults(() => [])),
   textGenerationModel: Schema.optional(TrimmedNonEmptyString),
+  defaultProvider: Schema.optional(ProviderKindSchema),
+  defaultCodexModel: Schema.optional(TrimmedNonEmptyString),
+  defaultClaudeModel: Schema.optional(TrimmedNonEmptyString),
 });
 export type AppSettings = typeof AppSettingsSchema.Type;
 export interface AppModelOption {
@@ -224,6 +228,27 @@ export function getCustomModelOptionsByProvider(
     codex: getAppModelOptions("codex", customModelsByProvider.codex),
     claudeAgent: getAppModelOptions("claudeAgent", customModelsByProvider.claudeAgent),
   };
+}
+
+export function getConfiguredDefaultProvider(
+  settings: Pick<AppSettings, "defaultProvider">,
+): ProviderKind {
+  return settings.defaultProvider ?? "codex";
+}
+
+export function getConfiguredDefaultModel(
+  settings: Pick<AppSettings, "defaultCodexModel" | "defaultClaudeModel">,
+  provider: ProviderKind,
+): string {
+  const configuredModel =
+    provider === "codex" ? settings.defaultCodexModel : settings.defaultClaudeModel;
+  if (configuredModel) {
+    const normalized = normalizeModelSlug(configuredModel, provider);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return getDefaultModel(provider);
 }
 
 export function getProviderStartOptions(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -23,7 +23,6 @@ import {
 } from "@t3tools/contracts";
 import {
   applyClaudePromptEffortPrefix,
-  getDefaultModel,
   normalizeModelSlug,
   resolveModelSlugForProvider,
 } from "@t3tools/shared/model";
@@ -121,6 +120,8 @@ import { SidebarTrigger } from "./ui/sidebar";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import {
+  getConfiguredDefaultModel,
+  getConfiguredDefaultProvider,
   getCustomModelOptionsByProvider,
   getCustomModelsByProvider,
   getProviderStartOptions,
@@ -594,10 +595,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const lockedProvider: ProviderKind | null = hasThreadStarted
     ? (sessionProvider ?? selectedProviderByThreadId ?? null)
     : null;
-  const selectedProvider: ProviderKind = lockedProvider ?? selectedProviderByThreadId ?? "codex";
+  const configuredDefaultProvider = getConfiguredDefaultProvider(settings);
+  const selectedProvider: ProviderKind =
+    lockedProvider ?? selectedProviderByThreadId ?? configuredDefaultProvider;
   const baseThreadModel = resolveModelSlugForProvider(
     selectedProvider,
-    activeThread?.model ?? activeProject?.model ?? getDefaultModel(selectedProvider),
+    activeThread?.model ??
+      activeProject?.model ??
+      getConfiguredDefaultModel(settings, selectedProvider),
   );
   const customModelsByProvider = useMemo(() => getCustomModelsByProvider(settings), [settings]);
   const selectedModel = useMemo(() => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -27,7 +27,6 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-
 import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { CSS } from "@dnd-kit/utilities";
 import {
-  DEFAULT_MODEL_BY_PROVIDER,
   type DesktopUpdateState,
   ProjectId,
   ThreadId,
@@ -36,7 +35,11 @@ import {
 } from "@t3tools/contracts";
 import { useMutation, useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate, useParams } from "@tanstack/react-router";
-import { useAppSettings } from "../appSettings";
+import {
+  getConfiguredDefaultModel,
+  getConfiguredDefaultProvider,
+  useAppSettings,
+} from "../appSettings";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
 import { isLinuxPlatform, isMacPlatform, newCommandId, newProjectId } from "../lib/utils";
@@ -434,7 +437,7 @@ export default function Sidebar() {
           projectId,
           title,
           workspaceRoot: cwd,
-          defaultModel: DEFAULT_MODEL_BY_PROVIDER.codex,
+          defaultModel: getConfiguredDefaultModel(appSettings, getConfiguredDefaultProvider(appSettings)),
           createdAt,
         });
         await handleNewThread(projectId, {

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -2,10 +2,16 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDownIcon, PlusIcon, RotateCcwIcon, Undo2Icon, XIcon } from "lucide-react";
 import { type ReactNode, useCallback, useState } from "react";
-import { type ProviderKind, DEFAULT_GIT_TEXT_GENERATION_MODEL } from "@t3tools/contracts";
+import {
+  type ProviderKind,
+  DEFAULT_GIT_TEXT_GENERATION_MODEL,
+  DEFAULT_MODEL_BY_PROVIDER,
+} from "@t3tools/contracts";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 import {
   getAppModelOptions,
+  getConfiguredDefaultModel,
+  getConfiguredDefaultProvider,
   getCustomModelsForProvider,
   MAX_CUSTOM_MODEL_LENGTH,
   MODEL_PROVIDER_SETTINGS,
@@ -228,6 +234,26 @@ function SettingsRouteView() {
   const selectedGitTextGenerationModelLabel =
     gitTextGenerationModelOptions.find((option) => option.slug === currentGitTextGenerationModel)
       ?.name ?? currentGitTextGenerationModel;
+
+  const configuredDefaultProvider = getConfiguredDefaultProvider(settings);
+  const isDefaultProviderDirty = settings.defaultProvider !== defaults.defaultProvider;
+  const configuredDefaultModel = getConfiguredDefaultModel(settings, configuredDefaultProvider);
+  const builtInDefaultModel = DEFAULT_MODEL_BY_PROVIDER[configuredDefaultProvider];
+  const isDefaultModelDirty =
+    isDefaultProviderDirty ||
+    settings.defaultCodexModel !== defaults.defaultCodexModel ||
+    settings.defaultClaudeModel !== defaults.defaultClaudeModel;
+  const defaultModelOptions = getAppModelOptions(
+    configuredDefaultProvider,
+    configuredDefaultProvider === "codex"
+      ? settings.customCodexModels
+      : settings.customClaudeModels,
+    configuredDefaultModel,
+  );
+  const selectedDefaultModelLabel =
+    defaultModelOptions.find((option) => option.slug === configuredDefaultModel)?.name ??
+    configuredDefaultModel;
+
   const selectedCustomModelProviderSettings = MODEL_PROVIDER_SETTINGS.find(
     (providerSettings) => providerSettings.provider === selectedCustomModelProvider,
   )!;
@@ -259,6 +285,7 @@ function SettingsRouteView() {
     ...(settings.confirmThreadDelete !== defaults.confirmThreadDelete
       ? ["Delete confirmation"]
       : []),
+    ...(isDefaultModelDirty ? ["Default model"] : []),
     ...(isGitTextGenerationModelDirty ? ["Git writing model"] : []),
     ...(settings.customCodexModels.length > 0 || settings.customClaudeModels.length > 0
       ? ["Custom models"]
@@ -600,6 +627,74 @@ function SettingsRouteView() {
             </SettingsSection>
 
             <SettingsSection title="Models">
+              <SettingsRow
+                title="Default model"
+                description="The model and provider used for new threads when no other selection is active."
+                resetAction={
+                  isDefaultModelDirty ? (
+                    <SettingResetButton
+                      label="default model"
+                      onClick={() =>
+                        updateSettings({
+                          defaultProvider: defaults.defaultProvider,
+                          defaultCodexModel: defaults.defaultCodexModel,
+                          defaultClaudeModel: defaults.defaultClaudeModel,
+                        })
+                      }
+                    />
+                  ) : null
+                }
+                control={
+                  <div className="flex w-full gap-2 sm:w-auto">
+                    <Select
+                      value={configuredDefaultProvider}
+                      onValueChange={(value) => {
+                        if (value !== "codex" && value !== "claudeAgent") return;
+                        updateSettings({ defaultProvider: value });
+                      }}
+                    >
+                      <SelectTrigger className="w-full sm:w-28" aria-label="Default provider">
+                        <SelectValue>
+                          {configuredDefaultProvider === "claudeAgent" ? "Claude" : "Codex"}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectPopup align="end" alignItemWithTrigger={false}>
+                        <SelectItem hideIndicator value="codex">
+                          Codex
+                        </SelectItem>
+                        <SelectItem hideIndicator value="claudeAgent">
+                          Claude
+                        </SelectItem>
+                      </SelectPopup>
+                    </Select>
+                    <Select
+                      value={configuredDefaultModel}
+                      onValueChange={(value) => {
+                        if (!value) return;
+                        const normalized = normalizeModelSlug(value, configuredDefaultProvider);
+                        if (!normalized) return;
+                        updateSettings(
+                          configuredDefaultProvider === "codex"
+                            ? { defaultCodexModel: normalized === builtInDefaultModel ? undefined : normalized }
+                            : { defaultClaudeModel: normalized === builtInDefaultModel ? undefined : normalized },
+                        );
+                      }}
+                    >
+                      <SelectTrigger className="w-full sm:w-52" aria-label="Default model">
+                        <SelectValue>{selectedDefaultModelLabel}</SelectValue>
+                      </SelectTrigger>
+                      <SelectPopup align="end" alignItemWithTrigger={false}>
+                        {defaultModelOptions.map((option) => (
+                          <SelectItem hideIndicator key={option.slug} value={option.slug}>
+                            {option.name}
+                          </SelectItem>
+                        ))}
+                      </SelectPopup>
+                    </Select>
+                  </div>
+                }
+              />
+
               <SettingsRow
                 title="Git writing model"
                 description="Used for generated commit messages, PR titles, and branch names."


### PR DESCRIPTION
- Let users choose the default provider for new threads
- Persist provider-specific default models in app settings
- Surface the new default model controls in Settings

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the fallback provider/model selection used when creating or starting new threads/projects, which can subtly alter behavior for users with existing settings or custom models.
> 
> **Overview**
> Adds new persisted app settings (`defaultProvider`, `defaultCodexModel`, `defaultClaudeModel`) plus helpers (`getConfiguredDefaultProvider`/`getConfiguredDefaultModel`) to resolve normalized defaults with safe fallbacks.
> 
> Updates thread/project creation and chat composer initialization to use these configured defaults instead of hard-coded `codex`/`getDefaultModel` fallbacks, and surfaces a new **Default model** picker (provider + model) in Settings with reset/dirty-state handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 145f056eb7edb7912139e3b86a8866a7f980f862. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable default provider and model to app settings
> - Adds `defaultProvider`, `defaultCodexModel`, and `defaultClaudeModel` fields to `AppSettingsSchema` in [appSettings.ts](https://github.com/pingdotgg/t3code/pull/1358/files#diff-4f500b80c5f743d5b39d3f07498169da0c26f4bf9b5a2127453a90c04a4c49cc), with helpers `getConfiguredDefaultProvider` and `getConfiguredDefaultModel` to resolve effective defaults.
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1358/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to use the configured defaults instead of hardcoded Codex provider/model when no thread or explicit selection exists.
> - Updates [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1358/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to apply the configured default model when creating new projects.
> - Adds a "Default model" row to the Settings page in [_chat.settings.tsx](https://github.com/pingdotgg/t3code/pull/1358/files#diff-0707e8295d0df761e405e66f02211b55d56c6eaea1ac3cb99562525a9c589cc6) with provider and model selectors, including a reset action.
> - Behavioral Change: new projects and new chat sessions now start with the user-configured provider and model rather than always defaulting to Codex.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 145f056.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->