### PR TITLE
feat(git): symlink .env files into new worktrees

### DIFF
--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1624,7 +1624,9 @@ export const makeGitCore = (options?: { executeOverride?: GitCoreShape["execute"
 
         // Symlink git-ignored .env* files from the source repo into the worktree
         // so that environment configuration is available in worktree sessions.
-        yield* symlinkEnvFiles(input.cwd, worktreePath);
+        // Wrapped in Effect.ignore so a discovery failure (e.g. git timeout)
+        // does not break the already-succeeded worktree creation.
+        yield* symlinkEnvFiles(input.cwd, worktreePath).pipe(Effect.ignore);
 
         return {
           worktree: {


### PR DESCRIPTION
## Summary

- When creating a new worktree, automatically symlink git-ignored `.env*` files from the source repository into the worktree at the same relative paths
- Uses `git ls-files --others --ignored --exclude-standard` to discover env files, respecting the project's `.gitignore` rules (no false positives from `node_modules`, etc.)
- Ensures environment configuration (database URLs, API keys, etc.) is immediately available in worktree sessions without manual copying

## Motivation

Currently, when T3 Code creates a worktree for a PR or branch, the new worktree has no `.env` files. Users have to manually copy them over every time, which is error-prone and tedious. Since `.env` files are git-ignored, they aren't part of the worktree checkout. Symlinking them means changes to env config in the main repo are automatically reflected in all worktrees.

## Test plan

- [ ] Create a project with `.env` and `.env.local` files that are git-ignored
- [ ] Create a new worktree via T3 Code
- [ ] Verify `.env` and `.env.local` are symlinked in the worktree
- [ ] Verify nested `.env` files (e.g., `packages/api/.env`) are also symlinked
- [ ] Verify files in `node_modules` or other ignored dirs are NOT symlinked
- [ ] Verify worktree creation still works for repos with no `.env` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Symlink git-ignored `.env*` files into new worktrees on creation
> - Adds `GitCore.symlinkEnvFiles` in [GitCore.ts](https://github.com/pingdotgg/t3code/pull/1360/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865), which uses `git ls-files --others --ignored --exclude-standard` to discover `.env*` files and symlinks each into the target worktree, preserving directory structure.
> - `GitCore.createWorktree` now calls `symlinkEnvFiles` after `git worktree add` so environment files are available in new worktrees without being committed.
> - All directory creation, symlink, and discovery errors are swallowed via `Effect.ignore` and do not affect worktree creation success.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b87978.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the worktree creation flow to perform additional filesystem operations (directory creation + symlinks) and relies on `git ls-files` output, which could behave differently across platforms or repo configurations despite errors being ignored.
> 
> **Overview**
> When `createWorktree` succeeds, it now **discovers git-ignored `.env*` files** in the source repo via `git ls-files --others --ignored --exclude-standard` and **symlinks them into the new worktree** at matching relative paths.
> 
> The new `symlinkEnvFiles` helper ensures parent directories exist and suppresses errors so env-file discovery/symlinking failures don’t prevent worktree creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b8797862ea6b73e684d5e45f48ce91082d50475. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->