### PR TITLE
Add protected auth flow for remote web access

### DIFF
--- a/REMOTE.md
+++ b/REMOTE.md
@@ -14,7 +14,7 @@ The T3 Code CLI accepts the following configuration options, available either as
 | `--base-dir <path>`     | `T3CODE_HOME`         | Base directory.                    |
 | `--dev-url <url>`       | `VITE_DEV_SERVER_URL` | Dev web URL redirect/proxy target. |
 | `--no-browser`          | `T3CODE_NO_BROWSER`   | Disable auto-open browser.         |
-| `--auth-token <token>`  | `T3CODE_AUTH_TOKEN`   | WebSocket auth token.              |
+| `--auth-token <token>`  | `T3CODE_AUTH_TOKEN`   | Web-mode HTTP/WebSocket auth token. |
 
 > TIP: Use the `--help` flag to see all available options and their descriptions.
 
@@ -23,6 +23,7 @@ The T3 Code CLI accepts the following configuration options, available either as
 - Always set `--auth-token` before exposing the server outside localhost.
 - Treat the token like a password.
 - Prefer binding to trusted interfaces (LAN IP or Tailnet IP) instead of opening all interfaces unless needed.
+- In built web mode, the token protects both the web UI HTTP routes and WebSocket connections.
 
 ## 1) Build + run server for remote access
 
@@ -34,19 +35,22 @@ TOKEN="$(openssl rand -hex 24)"
 bun run --cwd apps/server start -- --host 0.0.0.0 --port 3773 --auth-token "$TOKEN" --no-browser
 ```
 
-Then open on your phone:
+Then open the tokenized link from your startup log, or construct it like this:
 
-`http://<your-machine-ip>:3773`
+`http://<your-machine-ip>:3773/?token=<your-token>`
 
 Example:
 
-`http://192.168.1.42:3773`
+`http://192.168.1.42:3773/?token=0123456789abcdef`
 
 Notes:
 
 - `--host 0.0.0.0` listens on all IPv4 interfaces.
 - `--no-browser` prevents local auto-open, which is usually better for headless/remote sessions.
 - Ensure your OS firewall allows inbound TCP on the selected port.
+- On first successful visit, T3 Code stores an auth cookie in the browser and redirects to a clean URL without `token=...`.
+- If the server later starts with a different auth token, the old cookie is invalidated and the browser will ask for the new token again.
+- If someone opens the app without a valid tokenized link or cookie, they will see a token entry page.
 
 ## 2) Tailnet / Tailscale access
 
@@ -58,8 +62,8 @@ TOKEN="$(openssl rand -hex 24)"
 bun run --cwd apps/server start -- --host "$(tailscale ip -4)" --port 3773 --auth-token "$TOKEN" --no-browser
 ```
 
-Open from any device in your tailnet:
+Open the tokenized link from any device in your tailnet:
 
-`http://<tailnet-ip>:3773`
+`http://<tailnet-ip>:3773/?token=<your-token>`
 
 You can also bind `--host 0.0.0.0` and connect through the Tailnet IP, but binding directly to the Tailnet IP limits exposure.

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -19,6 +19,7 @@ import { Server, type ServerShape } from "./wsServer";
 
 const start = vi.fn(() => undefined);
 const stop = vi.fn(() => undefined);
+const openBrowser = vi.fn((_target: string) => undefined);
 let resolvedConfig: ServerConfigShape | null = null;
 const serverStart = Effect.acquireRelease(
   Effect.gen(function* () {
@@ -48,7 +49,10 @@ const testLayer = Layer.mergeAll(
     stopSignal: Effect.void,
   } satisfies ServerShape),
   Layer.succeed(Open, {
-    openBrowser: (_target: string) => Effect.void,
+    openBrowser: (target: string) =>
+      Effect.sync(() => {
+        openBrowser(target);
+      }),
     openInEditor: () => Effect.void,
   } satisfies OpenShape),
   AnalyticsService.layerTest,
@@ -78,6 +82,7 @@ beforeEach(() => {
   resolvedConfig = null;
   start.mockImplementation(() => undefined);
   stop.mockImplementation(() => undefined);
+  openBrowser.mockImplementation(() => undefined);
   findAvailablePort.mockImplementation((preferred: number) => Effect.succeed(preferred));
 });
 
@@ -175,6 +180,33 @@ it.layer(testLayer)("server CLI command", (it) => {
 
       assert.equal(start.mock.calls.length, 1);
       assert.equal(resolvedConfig?.noBrowser, true);
+    }),
+  );
+
+  it.effect("opens a tokenized share link in protected built web mode", () =>
+    Effect.gen(function* () {
+      yield* runCli(["--mode", "web", "--port", "4010", "--auth-token", "auth-secret"], {
+        T3CODE_NO_BROWSER: "false",
+      });
+
+      assert.deepStrictEqual(openBrowser.mock.calls, [
+        ["http://localhost:4010/?token=auth-secret"],
+      ]);
+    }),
+  );
+
+  it.effect("keeps browser auto-open on localhost for wildcard protected web hosts", () =>
+    Effect.gen(function* () {
+      yield* runCli(
+        ["--mode", "web", "--port", "4010", "--host", "0.0.0.0", "--auth-token", "auth-secret"],
+        {
+          T3CODE_NO_BROWSER: "false",
+        },
+      );
+
+      assert.deepStrictEqual(openBrowser.mock.calls, [
+        ["http://localhost:4010/?token=auth-secret"],
+      ]);
     }),
   );
 

--- a/apps/server/src/main.test.ts
+++ b/apps/server/src/main.test.ts
@@ -195,6 +195,28 @@ it.layer(testLayer)("server CLI command", (it) => {
     }),
   );
 
+  it.effect("does not tokenize browser auto-open when a dev server url is configured", () =>
+    Effect.gen(function* () {
+      yield* runCli(
+        [
+          "--mode",
+          "web",
+          "--port",
+          "4010",
+          "--dev-url",
+          "http://127.0.0.1:5173",
+          "--auth-token",
+          "auth-secret",
+        ],
+        {
+          T3CODE_NO_BROWSER: "false",
+        },
+      );
+
+      assert.deepStrictEqual(openBrowser.mock.calls, [["http://127.0.0.1:5173/"]]);
+    }),
+  );
+
   it.effect("keeps browser auto-open on localhost for wildcard protected web hosts", () =>
     Effect.gen(function* () {
       yield* runCli(

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -27,6 +27,7 @@ import { Server } from "./wsServer";
 import { ServerLoggerLive } from "./serverLogger";
 import { AnalyticsServiceLayerLive } from "./telemetry/Layers/AnalyticsService";
 import { AnalyticsService } from "./telemetry/Services/AnalyticsService";
+import { isProtectedWebAuthEnabled } from "./webAuth";
 
 export class StartupError extends Data.TaggedError("StartupError")<{
   readonly message: string;
@@ -264,8 +265,7 @@ const makeServerProgram = (input: CliInput) =>
       config.host && config.host.length > 0
         ? `http://${formatHostForUrl(config.host)}:${config.port}`
         : undefined;
-    const protectedWebAuthEnabled =
-      config.mode === "web" && !config.devUrl && typeof config.authToken === "string";
+    const protectedWebAuthEnabled = isProtectedWebAuthEnabled(config);
     const openBaseUrl = config.host && !isWildcardHost(config.host) ? hostUrl! : localUrl;
     const shareBaseUrl = hostUrl ?? localUrl;
     const openUrl =

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -206,6 +206,13 @@ const isWildcardHost = (host: string | undefined): boolean =>
 const formatHostForUrl = (host: string): string =>
   host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 
+const tokenizedUrl = (baseUrl: string, authToken: string | undefined): string => {
+  if (!authToken) return baseUrl;
+  const url = new URL(baseUrl);
+  url.searchParams.set("token", authToken);
+  return url.toString();
+};
+
 export const recordStartupHeartbeat = Effect.gen(function* () {
   const analytics = yield* AnalyticsService;
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
@@ -253,23 +260,35 @@ const makeServerProgram = (input: CliInput) =>
     yield* Effect.forkChild(recordStartupHeartbeat);
 
     const localUrl = `http://localhost:${config.port}`;
-    const bindUrl =
-      config.host && !isWildcardHost(config.host)
+    const hostUrl =
+      config.host && config.host.length > 0
         ? `http://${formatHostForUrl(config.host)}:${config.port}`
-        : localUrl;
+        : undefined;
+    const protectedWebAuthEnabled =
+      config.mode === "web" && !config.devUrl && typeof config.authToken === "string";
+    const openBaseUrl = config.host && !isWildcardHost(config.host) ? hostUrl! : localUrl;
+    const shareBaseUrl = hostUrl ?? localUrl;
+    const openUrl =
+      protectedWebAuthEnabled && config.authToken
+        ? tokenizedUrl(openBaseUrl, config.authToken)
+        : (config.devUrl?.toString() ?? openBaseUrl);
+    const shareableUrl =
+      protectedWebAuthEnabled && config.authToken
+        ? tokenizedUrl(shareBaseUrl, config.authToken)
+        : undefined;
     const { authToken, devUrl, ...safeConfig } = config;
     yield* Effect.logInfo("T3 Code running", {
       ...safeConfig,
       devUrl: devUrl?.toString(),
       authEnabled: Boolean(authToken),
+      ...(shareableUrl ? { shareableUrl } : {}),
     });
 
     if (!config.noBrowser) {
-      const target = config.devUrl?.toString() ?? bindUrl;
-      yield* openDeps.openBrowser(target).pipe(
+      yield* openDeps.openBrowser(openUrl).pipe(
         Effect.catch(() =>
           Effect.logInfo("browser auto-open unavailable", {
-            hint: `Open ${target} in your browser.`,
+            hint: `Open ${openUrl} in your browser.`,
           }),
         ),
       );

--- a/apps/server/src/webAuth.test.ts
+++ b/apps/server/src/webAuth.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import type { ServerConfigShape } from "./config";
+import { isProtectedWebAuthEnabled } from "./webAuth";
+
+const makeConfig = (overrides: Partial<ServerConfigShape> = {}): ServerConfigShape => ({
+  mode: "web",
+  port: 3773,
+  cwd: "/tmp/t3-test-workspace",
+  host: undefined,
+  baseDir: "/tmp/t3-test-home",
+  stateDir: "/tmp/t3-test-home/userdata",
+  dbPath: "/tmp/t3-test-home/userdata/state.sqlite",
+  logsDir: "/tmp/t3-test-home/logs",
+  serverLogPath: "/tmp/t3-test-home/logs/server.log",
+  providerLogsDir: "/tmp/t3-test-home/logs/provider",
+  providerEventLogPath: "/tmp/t3-test-home/logs/provider/events.log",
+  terminalLogsDir: "/tmp/t3-test-home/logs/terminals",
+  attachmentsDir: "/tmp/t3-test-home/attachments",
+  keybindingsConfigPath: "/tmp/t3-test-home/keybindings.json",
+  worktreesDir: "/tmp/t3-test-home/worktrees",
+  anonymousIdPath: "/tmp/t3-test-home/userdata/anonymous-id",
+  staticDir: undefined,
+  devUrl: undefined,
+  noBrowser: true,
+  authToken: "auth-secret",
+  autoBootstrapProjectFromCwd: true,
+  logWebSocketEvents: false,
+  ...overrides,
+});
+
+describe("isProtectedWebAuthEnabled", () => {
+  it("returns true for built web mode with an auth token", () => {
+    expect(isProtectedWebAuthEnabled(makeConfig())).toBe(true);
+  });
+
+  it("returns false when a dev server url is present", () => {
+    expect(
+      isProtectedWebAuthEnabled(
+        makeConfig({
+          devUrl: new URL("http://localhost:5173"),
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false without an auth token", () => {
+    expect(
+      isProtectedWebAuthEnabled(
+        makeConfig({
+          authToken: undefined,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false outside web mode", () => {
+    expect(
+      isProtectedWebAuthEnabled(
+        makeConfig({
+          mode: "desktop",
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/webAuth.ts
+++ b/apps/server/src/webAuth.ts
@@ -1,0 +1,223 @@
+import type http from "node:http";
+
+import type { ServerConfigShape } from "./config";
+
+export const AUTH_COOKIE_NAME = "t3code_auth";
+export const AUTH_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+const AUTH_COOKIE_MAX_AGE_PAST = 0;
+
+export function isProtectedWebAuthEnabled(config: ServerConfigShape): boolean {
+  return (
+    config.mode === "web" && config.devUrl === undefined && typeof config.authToken === "string"
+  );
+}
+
+export function parseCookies(cookieHeader: string | undefined): Map<string, string> {
+  const cookies = new Map<string, string>();
+  if (!cookieHeader) return cookies;
+
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.length === 0) continue;
+    const separator = trimmed.indexOf("=");
+    if (separator <= 0) continue;
+    const name = trimmed.slice(0, separator).trim();
+    const rawValue = trimmed.slice(separator + 1).trim();
+    try {
+      cookies.set(name, decodeURIComponent(rawValue));
+    } catch {
+      cookies.set(name, rawValue);
+    }
+  }
+
+  return cookies;
+}
+
+export function isSecureRequest(request: http.IncomingMessage): boolean {
+  const forwardedProto = request.headers["x-forwarded-proto"];
+  if (typeof forwardedProto === "string") {
+    const proto = forwardedProto.split(",")[0]?.trim().toLowerCase();
+    if (proto === "https") return true;
+  }
+  return Boolean((request.socket as { encrypted?: boolean }).encrypted);
+}
+
+export function createAuthCookieHeader(token: string, secure: boolean): string {
+  const attributes = [
+    `${AUTH_COOKIE_NAME}=${encodeURIComponent(token)}`,
+    "Path=/",
+    `Max-Age=${AUTH_COOKIE_MAX_AGE_SECONDS}`,
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (secure) {
+    attributes.push("Secure");
+  }
+  return attributes.join("; ");
+}
+
+export function createExpiredAuthCookieHeader(secure: boolean): string {
+  const attributes = [
+    `${AUTH_COOKIE_NAME}=`,
+    "Path=/",
+    `Max-Age=${AUTH_COOKIE_MAX_AGE_PAST}`,
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (secure) {
+    attributes.push("Secure");
+  }
+  return attributes.join("; ");
+}
+
+export function appendSetCookieHeader(
+  headers: Record<string, string | string[]>,
+  cookie: string,
+): Record<string, string | string[]> {
+  const existing = headers["Set-Cookie"];
+  if (!existing) {
+    headers["Set-Cookie"] = cookie;
+    return headers;
+  }
+  headers["Set-Cookie"] = Array.isArray(existing) ? [...existing, cookie] : [existing, cookie];
+  return headers;
+}
+
+export function sanitizeNextPath(candidate: string | null | undefined): string {
+  if (!candidate || typeof candidate !== "string") return "/";
+  if (!candidate.startsWith("/")) return "/";
+  if (candidate.startsWith("//")) return "/";
+
+  try {
+    const parsed = new URL(candidate, "http://localhost");
+    if (parsed.origin !== "http://localhost") return "/";
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return "/";
+  }
+}
+
+export function removeTokenFromRequestUrl(url: URL): string {
+  const next = new URL(url.pathname + url.search, "http://localhost");
+  next.searchParams.delete("token");
+  const search = next.searchParams.toString();
+  return `${next.pathname}${search.length > 0 ? `?${search}` : ""}`;
+}
+
+export function requestPrefersHtml(request: http.IncomingMessage, url: URL): boolean {
+  const method = request.method?.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") return false;
+  if (url.pathname.startsWith("/api/")) return false;
+  if (url.pathname.startsWith("/attachments/")) return false;
+
+  const accept = request.headers.accept?.toLowerCase() ?? "";
+  if (accept.includes("text/html") || accept.includes("application/xhtml+xml")) {
+    return true;
+  }
+
+  if (url.pathname === "/") return true;
+
+  const lastSegment = url.pathname.split("/").at(-1) ?? "";
+  return !lastSegment.includes(".");
+}
+
+function escapeHtml(input: string): string {
+  return input
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function renderAuthPage(input: {
+  readonly nextPath: string;
+  readonly error?: string;
+}): string {
+  const errorMarkup = input.error
+    ? `<p style="margin:0 0 16px;color:#b91c1c;font-size:14px;">${escapeHtml(input.error)}</p>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>T3 Code Sign In</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #f3f4f6;
+        color: #111827;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background:
+          radial-gradient(circle at top, rgba(14, 165, 233, 0.12), transparent 36%),
+          linear-gradient(180deg, #f8fafc, #eef2ff 70%, #e5e7eb);
+        padding: 24px;
+      }
+      main {
+        width: min(100%, 420px);
+        border-radius: 20px;
+        background: rgba(255, 255, 255, 0.96);
+        border: 1px solid rgba(148, 163, 184, 0.28);
+        box-shadow: 0 24px 64px rgba(15, 23, 42, 0.12);
+        padding: 28px;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 24px;
+      }
+      p {
+        margin: 0 0 20px;
+        color: #475569;
+        line-height: 1.5;
+      }
+      label {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 14px;
+        font-weight: 600;
+      }
+      input {
+        width: 100%;
+        box-sizing: border-box;
+        border: 1px solid #cbd5e1;
+        border-radius: 12px;
+        padding: 12px 14px;
+        font-size: 15px;
+      }
+      button {
+        width: 100%;
+        margin-top: 16px;
+        border: 0;
+        border-radius: 12px;
+        background: #0f172a;
+        color: white;
+        font-weight: 600;
+        font-size: 15px;
+        padding: 12px 14px;
+        cursor: pointer;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Open T3 Code</h1>
+      <p>Use your access link or enter the auth token to continue.</p>
+      ${errorMarkup}
+      <form method="post" action="/auth/login">
+        <input type="hidden" name="next" value="${escapeHtml(input.nextPath)}" />
+        <label for="token">Auth token</label>
+        <input id="token" name="token" type="password" autocomplete="current-password" required />
+        <button type="submit">Continue</button>
+      </form>
+    </main>
+  </body>
+</html>`;
+}

--- a/apps/server/src/webAuth.ts
+++ b/apps/server/src/webAuth.ts
@@ -135,7 +135,7 @@ export function renderAuthPage(input: {
   readonly error?: string;
 }): string {
   const errorMarkup = input.error
-    ? `<p style="margin:0 0 16px;color:#b91c1c;font-size:14px;">${escapeHtml(input.error)}</p>`
+    ? `<div class="auth-alert" role="alert">${escapeHtml(input.error)}</div>`
     : "";
 
   return `<!doctype html>
@@ -144,80 +144,235 @@ export function renderAuthPage(input: {
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>T3 Code Sign In</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..800;1,9..40,300..800&display=swap"
+    />
     <style>
       :root {
-        color-scheme: light;
-        font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        background: #f3f4f6;
-        color: #111827;
+        color-scheme: dark;
+        font-family:
+          "DM Sans",
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          system-ui,
+          sans-serif;
+        --bg: color-mix(in srgb, #09090b 95%, white);
+        --bg-elevated: color-mix(in srgb, var(--bg) 92%, white);
+        --panel: rgba(24, 24, 27, 0.86);
+        --panel-border: rgba(255, 255, 255, 0.08);
+        --panel-highlight: rgba(255, 255, 255, 0.05);
+        --text: #f5f5f5;
+        --muted: rgba(245, 245, 245, 0.62);
+        --input-bg: rgba(255, 255, 255, 0.05);
+        --input-border: rgba(255, 255, 255, 0.08);
+        --ring: rgba(88, 115, 255, 0.7);
+        --primary: oklch(0.588 0.217 264);
+        --primary-hover: color-mix(in srgb, var(--primary) 88%, white);
+        --danger-bg: rgba(239, 68, 68, 0.12);
+        --danger-border: rgba(239, 68, 68, 0.32);
+        --danger-text: #fca5a5;
+        background: var(--bg);
+        color: var(--text);
+      }
+      html {
+        min-height: 100%;
+        background: var(--bg);
       }
       body {
         margin: 0;
         min-height: 100vh;
-        display: grid;
-        place-items: center;
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
         background:
-          radial-gradient(circle at top, rgba(14, 165, 233, 0.12), transparent 36%),
-          linear-gradient(180deg, #f8fafc, #eef2ff 70%, #e5e7eb);
+          radial-gradient(circle at top, rgba(88, 115, 255, 0.16), transparent 34%),
+          radial-gradient(circle at 20% 100%, rgba(255, 255, 255, 0.06), transparent 30%),
+          linear-gradient(145deg, color-mix(in srgb, var(--bg) 88%, black) 0%, var(--bg) 58%);
         padding: 24px;
       }
+      body::before,
+      body::after {
+        content: "";
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+      }
+      body::before {
+        opacity: 0.55;
+        background:
+          radial-gradient(circle at top, rgba(59, 130, 246, 0.18), transparent 18rem),
+          radial-gradient(circle at 82% 18%, rgba(255, 255, 255, 0.05), transparent 24rem);
+      }
+      body::after {
+        opacity: 0.035;
+        background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+        background-repeat: repeat;
+        background-size: 256px 256px;
+      }
       main {
-        width: min(100%, 420px);
-        border-radius: 20px;
-        background: rgba(255, 255, 255, 0.96);
-        border: 1px solid rgba(148, 163, 184, 0.28);
-        box-shadow: 0 24px 64px rgba(15, 23, 42, 0.12);
-        padding: 28px;
+        position: relative;
+        width: min(100%, 28rem);
+        border-radius: 1.5rem;
+        border: 1px solid var(--panel-border);
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 28%),
+          var(--panel);
+        box-shadow:
+          0 1px 0 var(--panel-highlight) inset,
+          0 24px 80px rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(18px);
+        padding: 1.75rem;
       }
-      h1 {
-        margin: 0 0 8px;
-        font-size: 24px;
+      .eyebrow {
+        margin: 0 0 0.75rem;
+        color: var(--muted);
+        font-size: 0.7rem;
+        font-weight: 700;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
       }
-      p {
-        margin: 0 0 20px;
-        color: #475569;
+      .title {
+        margin: 0;
+        font-size: clamp(1.9rem, 6vw, 2.25rem);
+        line-height: 1.05;
+        letter-spacing: -0.04em;
+        font-weight: 700;
+      }
+      .subtitle {
+        margin: 0.75rem 0 1.5rem;
+        color: var(--muted);
         line-height: 1.5;
+        font-size: 0.98rem;
       }
       label {
         display: block;
-        margin-bottom: 8px;
-        font-size: 14px;
+        margin-bottom: 0.5rem;
+        color: rgba(245, 245, 245, 0.92);
+        font-size: 0.83rem;
         font-weight: 600;
+        letter-spacing: 0.01em;
       }
       input {
         width: 100%;
         box-sizing: border-box;
-        border: 1px solid #cbd5e1;
-        border-radius: 12px;
-        padding: 12px 14px;
-        font-size: 15px;
+        margin: 0;
+        border: 1px solid var(--input-border);
+        border-radius: 0.75rem;
+        background: var(--input-bg);
+        color: var(--text);
+        padding: 0.85rem 0.95rem;
+        font-family: "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+        font-size: 0.95rem;
+        line-height: 1.4;
+        outline: none;
+        transition:
+          border-color 160ms ease,
+          box-shadow 160ms ease,
+          background-color 160ms ease;
+      }
+      input::placeholder {
+        color: rgba(245, 245, 245, 0.32);
+      }
+      input:focus {
+        border-color: rgba(88, 115, 255, 0.72);
+        box-shadow: 0 0 0 3px rgba(88, 115, 255, 0.18);
+        background: rgba(255, 255, 255, 0.07);
       }
       button {
         width: 100%;
-        margin-top: 16px;
-        border: 0;
-        border-radius: 12px;
-        background: #0f172a;
+        margin-top: 1rem;
+        border: 1px solid rgba(88, 115, 255, 0.78);
+        border-radius: 0.75rem;
+        background: var(--primary);
         color: white;
         font-weight: 600;
-        font-size: 15px;
-        padding: 12px 14px;
+        font-size: 0.95rem;
+        padding: 0.85rem 1rem;
         cursor: pointer;
+        box-shadow:
+          0 1px 0 rgba(255, 255, 255, 0.16) inset,
+          0 10px 28px rgba(88, 115, 255, 0.28);
+        transition:
+          background-color 160ms ease,
+          transform 160ms ease,
+          box-shadow 160ms ease;
+      }
+      button:hover {
+        background: var(--primary-hover);
+        transform: translateY(-1px);
+      }
+      button:focus-visible {
+        outline: none;
+        box-shadow:
+          0 1px 0 rgba(255, 255, 255, 0.16) inset,
+          0 0 0 3px rgba(88, 115, 255, 0.18),
+          0 10px 28px rgba(88, 115, 255, 0.28);
+      }
+      button:active {
+        transform: translateY(0);
+      }
+      .auth-alert {
+        margin: 0 0 1rem;
+        border: 1px solid var(--danger-border);
+        border-radius: 0.875rem;
+        background: var(--danger-bg);
+        color: var(--danger-text);
+        padding: 0.8rem 0.95rem;
+        font-size: 0.88rem;
+        line-height: 1.45;
+      }
+      .auth-form {
+        display: grid;
+        gap: 0.2rem;
+      }
+      .auth-shell {
+        position: relative;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+      }
+      @media (max-width: 640px) {
+        body {
+          padding: 1rem;
+          align-items: flex-start;
+        }
+        main {
+          margin-top: min(14vh, 5rem);
+          padding: 1.25rem;
+        }
+        .subtitle {
+          font-size: 0.94rem;
+        }
       }
     </style>
   </head>
   <body>
-    <main>
-      <h1>Open T3 Code</h1>
-      <p>Use your access link or enter the auth token to continue.</p>
-      ${errorMarkup}
-      <form method="post" action="/auth/login">
+    <div class="auth-shell">
+      <main data-auth-page="t3code-sign-in">
+        <p class="eyebrow">T3 Code Secure Access</p>
+        <h1 class="title">Open T3 Code</h1>
+        <p class="subtitle">Use your access link or enter the auth token to continue.</p>
+        ${errorMarkup}
+        <form method="post" action="/auth/login" class="auth-form">
         <input type="hidden" name="next" value="${escapeHtml(input.nextPath)}" />
         <label for="token">Auth token</label>
-        <input id="token" name="token" type="password" autocomplete="current-password" required />
+        <input
+          id="token"
+          name="token"
+          type="password"
+          autocomplete="current-password"
+          spellcheck="false"
+          required
+        />
         <button type="submit">Continue</button>
-      </form>
-    </main>
+        </form>
+      </main>
+    </div>
   </body>
 </html>`;
 }

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -280,10 +280,22 @@ function asWebSocketResponse(message: unknown): WebSocketResponse | null {
   return message as WebSocketResponse;
 }
 
-function connectWsOnce(port: number, token?: string): Promise<WebSocket> {
+function connectWsOnce(
+  port: number,
+  options: {
+    token?: string;
+    headers?: Record<string, string>;
+  } = {},
+): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const query = token ? `?token=${encodeURIComponent(token)}` : "";
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/${query}`);
+    const query = options.token ? `?token=${encodeURIComponent(options.token)}` : "";
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/${query}`, {
+      headers: options.headers,
+    });
+    const timeoutId = setTimeout(() => {
+      ws.close();
+      reject(new Error("WebSocket connection failed"));
+    }, 500);
     const channels: SocketChannels = {
       push: { queue: [], waiters: [] },
       response: { queue: [], waiters: [] },
@@ -302,17 +314,32 @@ function connectWsOnce(port: number, token?: string): Promise<WebSocket> {
       }
     });
 
-    ws.once("open", () => resolve(ws));
-    ws.once("error", () => reject(new Error("WebSocket connection failed")));
+    ws.once("open", () => {
+      clearTimeout(timeoutId);
+      resolve(ws);
+    });
+    ws.once("error", () => {
+      clearTimeout(timeoutId);
+      ws.close();
+      reject(new Error("WebSocket connection failed"));
+    });
   });
 }
 
-async function connectWs(port: number, token?: string, attempts = 5): Promise<WebSocket> {
+async function connectWs(
+  port: number,
+  options: {
+    token?: string;
+    headers?: Record<string, string>;
+    attempts?: number;
+  } = {},
+): Promise<WebSocket> {
+  const attempts = options.attempts ?? 5;
   let lastError: unknown = new Error("WebSocket connection failed");
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
-      return await connectWsOnce(port, token);
+      return await connectWsOnce(port, options);
     } catch (error) {
       lastError = error;
       if (attempt < attempts - 1) {
@@ -327,9 +354,12 @@ async function connectWs(port: number, token?: string, attempts = 5): Promise<We
 /** Connect and wait for the server.welcome push. Returns [ws, welcomeData]. */
 async function connectAndAwaitWelcome(
   port: number,
-  token?: string,
+  options: {
+    token?: string;
+    headers?: Record<string, string>;
+  } = {},
 ): Promise<[WebSocket, WsPushMessage<typeof WS_CHANNELS.serverWelcome>]> {
-  const ws = await connectWs(port, token);
+  const ws = await connectWs(port, options);
   const welcome = await waitForPush(ws, WS_CHANNELS.serverWelcome);
   return [ws, welcome];
 }
@@ -401,14 +431,20 @@ async function rewriteKeybindingsAndWaitForPush(
 async function requestPath(
   port: number,
   requestPath: string,
-): Promise<{ statusCode: number; body: string }> {
+  options: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  } = {},
+): Promise<{ statusCode: number; body: string; headers: Http.IncomingHttpHeaders }> {
   return new Promise((resolve, reject) => {
     const req = Http.request(
       {
         hostname: "127.0.0.1",
         port,
         path: requestPath,
-        method: "GET",
+        method: options.method ?? "GET",
+        headers: options.headers,
       },
       (res) => {
         const chunks: Buffer[] = [];
@@ -419,13 +455,20 @@ async function requestPath(
           resolve({
             statusCode: res.statusCode ?? 0,
             body: Buffer.concat(chunks).toString("utf8"),
+            headers: res.headers,
           });
         });
       },
     );
     req.once("error", reject);
-    req.end();
+    req.end(options.body);
   });
+}
+
+function firstSetCookie(headers: Http.IncomingHttpHeaders): string | null {
+  const header = headers["set-cookie"];
+  if (!header) return null;
+  return Array.isArray(header) ? (header[0] ?? null) : header;
 }
 
 function compileKeybindings(bindings: KeybindingsConfig): ResolvedKeybindingsConfig {
@@ -567,6 +610,8 @@ describe("WebSocket Server", () => {
 
   async function closeTestServer() {
     if (!serverScope) return;
+    server?.closeAllConnections?.();
+    server?.closeIdleConnections?.();
     const scope = serverScope;
     serverScope = null;
     await Effect.runPromise(Scope.close(scope, Exit.void));
@@ -574,7 +619,7 @@ describe("WebSocket Server", () => {
 
   afterEach(async () => {
     for (const ws of connections) {
-      ws.close();
+      ws.terminate();
     }
     connections.length = 0;
     await closeTestServer();
@@ -583,7 +628,7 @@ describe("WebSocket Server", () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
     vi.restoreAllMocks();
-  });
+  }, 30_000);
 
   it("sends welcome message on connect", async () => {
     server = await createTestServer({ cwd: "/test/project" });
@@ -659,6 +704,130 @@ describe("WebSocket Server", () => {
     const response = await fetch(`http://127.0.0.1:${port}/`);
     expect(response.status).toBe(200);
     expect(await response.text()).toContain("static-root");
+  });
+
+  it("renders auth page for unauthorized document requests in protected web mode", async () => {
+    const staticDir = makeTempDir("t3code-static-auth-page-");
+    fs.writeFileSync(path.join(staticDir, "index.html"), "<h1>secret</h1>", "utf8");
+
+    server = await createTestServer({
+      cwd: "/test/project",
+      staticDir,
+      authToken: "secret-token",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const response = await requestPath(port, "/");
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toContain("Open T3 Code");
+    expect(response.body).toContain('name="token"');
+  });
+
+  it("returns 401 for unauthorized protected asset requests", async () => {
+    const baseDir = makeTempDir("t3code-state-auth-attachments-");
+    const { attachmentsDir } = deriveServerPathsSync(baseDir, undefined);
+    const attachmentPath = path.join(attachmentsDir, "thread-a", "message-a", "0.png");
+    fs.mkdirSync(path.dirname(attachmentPath), { recursive: true });
+    fs.writeFileSync(attachmentPath, Buffer.from("hello-attachment"));
+
+    server = await createTestServer({
+      cwd: "/test/project",
+      baseDir,
+      authToken: "secret-token",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const response = await requestPath(port, "/attachments/thread-a/message-a/0.png");
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toBe("Unauthorized");
+  });
+
+  it("returns 401 for unauthorized protected favicon requests", async () => {
+    server = await createTestServer({
+      cwd: "/test/project",
+      authToken: "secret-token",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const response = await requestPath(port, "/api/project-favicon?cwd=%2Ftest%2Fproject");
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toBe("Unauthorized");
+  });
+
+  it("accepts tokenized web links, sets auth cookie, and redirects to a clean URL", async () => {
+    const staticDir = makeTempDir("t3code-static-auth-redirect-");
+    fs.writeFileSync(path.join(staticDir, "index.html"), "<h1>secret</h1>", "utf8");
+
+    server = await createTestServer({
+      cwd: "/test/project",
+      staticDir,
+      authToken: "secret-token",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const response = await requestPath(port, "/settings?foo=bar&token=secret-token");
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/settings?foo=bar");
+    expect(firstSetCookie(response.headers)).toContain("t3code_auth=secret-token");
+  });
+
+  it("supports form login and then serves protected content with the auth cookie", async () => {
+    const staticDir = makeTempDir("t3code-static-auth-login-");
+    fs.writeFileSync(path.join(staticDir, "index.html"), "<h1>secret</h1>", "utf8");
+
+    server = await createTestServer({
+      cwd: "/test/project",
+      staticDir,
+      authToken: "secret-token",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const loginResponse = await requestPath(port, "/auth/login", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: "token=secret-token&next=%2F",
+    });
+    expect(loginResponse.statusCode).toBe(302);
+    expect(loginResponse.headers.location).toBe("/");
+    const authCookie = firstSetCookie(loginResponse.headers);
+    expect(authCookie).toContain("t3code_auth=secret-token");
+
+    const authedResponse = await requestPath(port, "/", {
+      headers: {
+        cookie: authCookie?.split(";")[0] ?? "",
+      },
+    });
+    expect(authedResponse.statusCode).toBe(200);
+    expect(authedResponse.body).toContain("secret");
+  });
+
+  it("clears stale auth cookies and re-prompts for the token", async () => {
+    const staticDir = makeTempDir("t3code-static-auth-stale-");
+    fs.writeFileSync(path.join(staticDir, "index.html"), "<h1>secret</h1>", "utf8");
+
+    server = await createTestServer({
+      cwd: "/test/project",
+      staticDir,
+      authToken: "new-token",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const response = await requestPath(port, "/", {
+      headers: {
+        cookie: "t3code_auth=old-token",
+      },
+    });
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toContain("Open T3 Code");
+    expect(firstSetCookie(response.headers)).toContain("Max-Age=0");
   });
 
   it("rejects static path traversal attempts", async () => {
@@ -1908,7 +2077,68 @@ describe("WebSocket Server", () => {
 
     await expect(connectWs(port)).rejects.toThrow("WebSocket connection failed");
 
-    const [authorizedWs] = await connectAndAwaitWelcome(port, "secret-token");
+    const [authorizedWs] = await connectAndAwaitWelcome(port, { token: "secret-token" });
+    connections.push(authorizedWs);
+  });
+
+  it("accepts websocket connections authenticated by cookie in protected web mode", async () => {
+    server = await createTestServer({ cwd: "/test", authToken: "secret-token" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const [authorizedWs] = await connectAndAwaitWelcome(port, {
+      headers: {
+        cookie: "t3code_auth=secret-token",
+        origin: `http://127.0.0.1:${port}`,
+      },
+    });
+    connections.push(authorizedWs);
+  });
+
+  it("rejects websocket cookie auth with a mismatched origin", async () => {
+    server = await createTestServer({ cwd: "/test", authToken: "secret-token" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    await expect(
+      connectWs(port, {
+        headers: {
+          cookie: "t3code_auth=secret-token",
+          origin: "http://example.com",
+        },
+      }),
+    ).rejects.toThrow("WebSocket connection failed");
+  });
+
+  it("does not accept stale websocket auth cookies", async () => {
+    server = await createTestServer({ cwd: "/test", authToken: "secret-token" });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    await expect(
+      connectWs(port, {
+        headers: {
+          cookie: "t3code_auth=old-token",
+          origin: `http://127.0.0.1:${port}`,
+        },
+      }),
+    ).rejects.toThrow("WebSocket connection failed");
+  });
+
+  it("does not enforce web auth in dev-url mode", async () => {
+    server = await createTestServer({
+      cwd: "/test",
+      authToken: "secret-token",
+      devUrl: "http://localhost:5173",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const response = await requestPath(port, "/");
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("http://localhost:5173/");
+
+    const [authorizedWs] = await connectAndAwaitWelcome(port);
     connections.push(authorizedWs);
   });
 });

--- a/apps/server/src/wsServer.test.ts
+++ b/apps/server/src/wsServer.test.ts
@@ -721,6 +721,7 @@ describe("WebSocket Server", () => {
     const response = await requestPath(port, "/");
     expect(response.statusCode).toBe(401);
     expect(response.body).toContain("Open T3 Code");
+    expect(response.body).toContain('data-auth-page="t3code-sign-in"');
     expect(response.body).toContain('name="token"');
   });
 
@@ -806,6 +807,32 @@ describe("WebSocket Server", () => {
     });
     expect(authedResponse.statusCode).toBe(200);
     expect(authedResponse.body).toContain("secret");
+  });
+
+  it("re-renders the auth page with an error for invalid token submissions", async () => {
+    const staticDir = makeTempDir("t3code-static-auth-invalid-");
+    fs.writeFileSync(path.join(staticDir, "index.html"), "<h1>secret</h1>", "utf8");
+
+    server = await createTestServer({
+      cwd: "/test/project",
+      staticDir,
+      authToken: "secret-token",
+    });
+    const addr = server.address();
+    const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+
+    const response = await requestPath(port, "/auth/login", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: "token=wrong-token&next=%2Fsettings",
+    });
+    expect(response.statusCode).toBe(401);
+    expect(response.body).toContain("Open T3 Code");
+    expect(response.body).toContain('role="alert"');
+    expect(response.body).toContain("Invalid auth token.");
+    expect(response.body).toContain('value="/settings"');
   });
 
   it("clears stale auth cookies and re-prompts for the token", async () => {

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -7,7 +7,9 @@
  * @module Server
  */
 import http from "node:http";
+import type net from "node:net";
 import type { Duplex } from "node:stream";
+import { Buffer } from "node:buffer";
 
 import Mime from "@effect/platform-node/Mime";
 import {
@@ -78,6 +80,19 @@ import { expandHomePath } from "./os-jank.ts";
 import { makeServerPushBus } from "./wsServer/pushBus.ts";
 import { makeServerReadiness } from "./wsServer/readiness.ts";
 import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
+import {
+  appendSetCookieHeader,
+  AUTH_COOKIE_NAME,
+  createAuthCookieHeader,
+  createExpiredAuthCookieHeader,
+  isProtectedWebAuthEnabled,
+  isSecureRequest,
+  parseCookies,
+  removeTokenFromRequestUrl,
+  renderAuthPage,
+  requestPrefersHtml,
+  sanitizeNextPath,
+} from "./webAuth.ts";
 
 /**
  * ServerShape - Service API for server lifecycle control.
@@ -119,6 +134,49 @@ function rejectUpgrade(socket: Duplex, statusCode: number, message: string): voi
       "\r\n" +
       message,
   );
+  const closeableSocket = socket as Duplex & {
+    destroySoon?: () => void;
+    destroy: () => void;
+  };
+  if (typeof closeableSocket.destroySoon === "function") {
+    closeableSocket.destroySoon();
+    return;
+  }
+  closeableSocket.destroy();
+}
+
+function readRequestBody(request: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    request.on("data", (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      size += buffer.length;
+      if (size > 32_768) {
+        reject(new Error("Request body too large"));
+        request.destroy();
+        return;
+      }
+      chunks.push(buffer);
+    });
+    request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    request.on("error", reject);
+  });
+}
+
+function requestHostMatchesOrigin(request: http.IncomingMessage): boolean {
+  const originHeader = request.headers.origin;
+  const hostHeader = request.headers.host;
+  if (typeof originHeader !== "string" || typeof hostHeader !== "string") {
+    return false;
+  }
+
+  try {
+    const origin = new URL(originHeader);
+    return origin.host === hostHeader;
+  } catch {
+    return false;
+  }
 }
 
 function websocketRawToString(raw: unknown): string | null {
@@ -248,6 +306,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     logWebSocketEvents,
     autoBootstrapProjectFromCwd,
   } = serverConfig;
+  const protectedWebAuthEnabled = isProtectedWebAuthEnabled(serverConfig);
   const availableEditors = resolveAvailableEditors();
 
   const gitManager = yield* GitManager;
@@ -257,6 +316,48 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   const git = yield* GitCore;
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
+
+  const getRequestAuthState = (request: http.IncomingMessage, url: URL) => {
+    if (!protectedWebAuthEnabled || !authToken) {
+      return {
+        authorized: true,
+        staleCookie: false,
+        authenticatedBy: "disabled" as const,
+      };
+    }
+
+    const queryToken = url.searchParams.get("token");
+    if (queryToken === authToken) {
+      return {
+        authorized: true,
+        staleCookie: false,
+        authenticatedBy: "query" as const,
+      };
+    }
+
+    const cookieToken = parseCookies(request.headers.cookie).get(AUTH_COOKIE_NAME);
+    if (!cookieToken) {
+      return {
+        authorized: false,
+        staleCookie: false,
+        authenticatedBy: "none" as const,
+      };
+    }
+
+    if (cookieToken === authToken) {
+      return {
+        authorized: true,
+        staleCookie: false,
+        authenticatedBy: "cookie" as const,
+      };
+    }
+
+    return {
+      authorized: false,
+      staleCookie: true,
+      authenticatedBy: "stale-cookie" as const,
+    };
+  };
 
   yield* keybindingsManager.syncDefaultKeybindingsOnStartup.pipe(
     Effect.catch((error) =>
@@ -271,6 +372,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   const providerStatuses = yield* providerHealth.getStatuses;
 
   const clients = yield* Ref.make(new Set<WebSocket>());
+  const sockets = yield* Ref.make(new Set<net.Socket>());
   const logger = createLogger("ws");
   const readiness = yield* makeServerReadiness;
 
@@ -414,7 +516,7 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   const httpServer = http.createServer((req, res) => {
     const respond = (
       statusCode: number,
-      headers: Record<string, string>,
+      headers: Record<string, string | string[]>,
       body?: string | Uint8Array,
     ) => {
       res.writeHead(statusCode, headers);
@@ -424,6 +526,84 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     void Effect.runPromise(
       Effect.gen(function* () {
         const url = new URL(req.url ?? "/", `http://localhost:${port}`);
+        const requestAuthState = getRequestAuthState(req, url);
+        const clearStaleCookieHeader = requestAuthState.staleCookie
+          ? createExpiredAuthCookieHeader(isSecureRequest(req))
+          : null;
+
+        if (
+          protectedWebAuthEnabled &&
+          req.method === "POST" &&
+          url.pathname === "/auth/login" &&
+          authToken
+        ) {
+          const bodyText = yield* Effect.tryPromise({
+            try: () => readRequestBody(req),
+            catch: (cause) =>
+              new RouteRequestError({
+                message: `Failed to read auth request: ${String(cause)}`,
+              }),
+          });
+          const form = new URLSearchParams(bodyText);
+          const submittedToken = form.get("token");
+          const nextPath = sanitizeNextPath(form.get("next"));
+          if (submittedToken !== authToken) {
+            const headers: Record<string, string | string[]> = {
+              "Content-Type": "text/html; charset=utf-8",
+            };
+            if (clearStaleCookieHeader) {
+              appendSetCookieHeader(headers, clearStaleCookieHeader);
+            }
+            respond(
+              401,
+              headers,
+              renderAuthPage({
+                nextPath,
+                error: "Invalid auth token.",
+              }),
+            );
+            return;
+          }
+
+          const headers: Record<string, string | string[]> = {
+            Location: nextPath,
+          };
+          appendSetCookieHeader(headers, createAuthCookieHeader(authToken, isSecureRequest(req)));
+          respond(302, headers);
+          return;
+        }
+
+        if (protectedWebAuthEnabled && authToken && requestAuthState.authenticatedBy === "query") {
+          const cleanedLocation = removeTokenFromRequestUrl(url);
+          const headers: Record<string, string | string[]> = {
+            Location: cleanedLocation,
+          };
+          appendSetCookieHeader(headers, createAuthCookieHeader(authToken, isSecureRequest(req)));
+          respond(302, headers);
+          return;
+        }
+
+        if (protectedWebAuthEnabled && !requestAuthState.authorized) {
+          const headers: Record<string, string | string[]> = {};
+          if (clearStaleCookieHeader) {
+            appendSetCookieHeader(headers, clearStaleCookieHeader);
+          }
+          if (requestPrefersHtml(req, url)) {
+            headers["Content-Type"] = "text/html; charset=utf-8";
+            respond(
+              401,
+              headers,
+              renderAuthPage({
+                nextPath: sanitizeNextPath(`${url.pathname}${url.search}`),
+              }),
+            );
+            return;
+          }
+          headers["Content-Type"] = "text/plain";
+          respond(401, headers, "Unauthorized");
+          return;
+        }
+
         if (tryHandleProjectFaviconRequest(url, res)) {
           return;
         }
@@ -595,6 +775,18 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
     Effect.flatMap(Effect.forEach((client) => Effect.sync(() => client.close()))),
     Effect.flatMap(() => Ref.set(clients, new Set())),
   );
+  const closeAllSockets = Ref.get(sockets).pipe(
+    Effect.flatMap(
+      Effect.forEach((socket) =>
+        Effect.sync(() => {
+          if (!socket.destroyed) {
+            socket.destroy();
+          }
+        }),
+      ),
+    ),
+    Effect.flatMap(() => Ref.set(sockets, new Set())),
+  );
 
   const listenOptions = host ? { host, port } : { port };
 
@@ -701,7 +893,11 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   yield* readiness.markHttpListening;
 
   yield* Effect.addFinalizer(() =>
-    Effect.all([closeAllClients, closeWebSocketServer.pipe(Effect.ignoreCause({ log: true }))]),
+    Effect.all([
+      closeAllClients,
+      closeAllSockets,
+      closeWebSocketServer.pipe(Effect.ignoreCause({ log: true })),
+    ]),
   );
 
   const routeRequest = Effect.fnUntraced(function* (ws: WebSocket, request: WebSocketRequest) {
@@ -938,7 +1134,31 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
   httpServer.on("upgrade", (request, socket, head) => {
     socket.on("error", () => {}); // Prevent unhandled `EPIPE`/`ECONNRESET` from crashing the process if the client disconnects mid-handshake
 
-    if (authToken) {
+    if (protectedWebAuthEnabled && authToken) {
+      let providedToken: string | null = null;
+      let cookieToken: string | undefined;
+      try {
+        const url = new URL(request.url ?? "/", `http://localhost:${port}`);
+        providedToken = url.searchParams.get("token");
+        cookieToken = parseCookies(request.headers.cookie).get(AUTH_COOKIE_NAME);
+      } catch {
+        rejectUpgrade(socket, 400, "Invalid WebSocket URL");
+        return;
+      }
+
+      const tokenAuthorized = providedToken === authToken;
+      const cookieAuthorized = cookieToken === authToken;
+
+      if (!tokenAuthorized && cookieAuthorized && !requestHostMatchesOrigin(request)) {
+        rejectUpgrade(socket, 401, "Unauthorized WebSocket origin");
+        return;
+      }
+
+      if (!tokenAuthorized && !cookieAuthorized) {
+        rejectUpgrade(socket, 401, "Unauthorized WebSocket connection");
+        return;
+      }
+    } else if (authToken && serverConfig.mode === "desktop") {
       let providedToken: string | null = null;
       try {
         const url = new URL(request.url ?? "/", `http://localhost:${port}`);
@@ -956,6 +1176,25 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
 
     wss.handleUpgrade(request, socket, head, (ws) => {
       wss.emit("connection", ws, request);
+    });
+  });
+
+  httpServer.on("connection", (socket) => {
+    void runPromise(
+      Ref.update(sockets, (current) => {
+        const next = new Set(current);
+        next.add(socket);
+        return next;
+      }),
+    );
+    socket.on("close", () => {
+      void runPromise(
+        Ref.update(sockets, (current) => {
+          const next = new Set(current);
+          next.delete(socket);
+          return next;
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## What Changed

In built web mode, `--auth-token` now protects both HTTP routes and WebSocket connections instead of only gating the socket handshake.

Unauthorized browser requests now render a dedicated sign-in page. Tokenized links like `/?token=...` are accepted once, stored in an auth cookie, and redirected to a clean URL without the token. This also adds form-based token entry, stale-cookie invalidation after token changes, origin checks for cookie-authenticated WebSocket upgrades, startup/browser-open handling for protected links, and docs/tests covering the remote access flow.

## Why

Previously, remote protection in web mode was incomplete: a token was required for the WebSocket connection, but the HTTP app surface was still reachable without authentication. That made the security model inconsistent and awkward for real remote access, especially on phones or shared links.

This change makes built web mode behave like users expect: the token gates access to the whole app, not just the live session channel. The tokenized-link-to-cookie flow keeps first-time access simple while removing the token from the URL after login and re-prompting cleanly when the token rotates.

Related issues:
- Fixes [#257](https://github.com/pingdotgg/t3code/issues/257)
- Addresses [#227](https://github.com/pingdotgg/t3code/issues/227)

## UI Changes

This PR adds a dedicated protected sign-in page for built web mode.

<img width="1288" height="951" alt="Screenshot 2026-03-24 at 20 43 26" src="https://github.com/user-attachments/assets/b5245fde-90a4-4793-b6e0-815c90c53b73" />

Before:
- No protected entry page for unauthorized browser requests.

After:
- A branded sign-in page with token entry and invalid-token feedback, followed by redirect back to the requested path after successful auth.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication for both HTTP routing and WebSocket upgrades in web mode; regressions could lock users out or unintentionally expose the UI if the new checks are incorrect.
> 
> **Overview**
> In **built web mode**, `--auth-token` now protects the full HTTP surface (not just the WebSocket handshake): unauthorized document requests return a new sign-in page, and non-document routes return `401 Unauthorized`.
> 
> Introduces a token-to-cookie flow: visiting `/?token=...` sets an `HttpOnly` auth cookie and redirects to a clean URL, plus `POST /auth/login` for manual token entry and stale-cookie invalidation when the server token changes.
> 
> WebSocket upgrades in protected web mode accept either a query token or a valid auth cookie, with an added *Origin/Host match* requirement for cookie-authenticated upgrades. Startup behavior is updated to log/auto-open a tokenized share URL when protection is enabled (skipping tokenization in dev-url mode and keeping wildcard hosts opening on `localhost`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 822c09499c36325ebef188af0193e9f212baacaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add protected auth flow for remote web access with token-based cookies and WebSocket gating
> - Adds a new [webAuth.ts](https://github.com/pingdotgg/t3code/pull/1362/files#diff-47ac8b510cb716151734994468df5263d15759bb545263336d51dfdab8d953b6) module with helpers for cookie management, auth state evaluation, HTML auth page rendering, and request utilities.
> - HTTP requests in built web mode with an auth token now require authentication: unauthorized HTML requests receive a login page (401), other routes receive plain `Unauthorized`; valid token in query sets an auth cookie and redirects to a clean URL; `POST /auth/login` accepts a token form submission and sets the cookie.
> - WebSocket upgrades in protected web mode accept either a token query parameter or a valid auth cookie with a matching `Origin` host, rejecting stale or mismatched-origin cookies.
> - On startup, the server auto-opens and logs a tokenized URL when protected web auth is enabled; wildcard host bindings still target localhost; dev server URLs skip tokenization.
> - Risk: existing clients accessing the web UI or WebSocket without a token or cookie will receive 401 responses after this change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 822c094.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->