### PR TITLE
fix(provider,claude): handle prompt stream interrupt on session stop

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1153,6 +1153,73 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("stopSession does not throw into the SDK prompt consumer", () => {
+    // The SDK consumes user messages via `for await (... of prompt)`.
+    // Stopping a session must end that loop cleanly — not throw an error.
+    //
+    // FakeClaudeQuery.close() masks this by resolving pending iterators
+    // before the shutdown propagates. Override it to match real SDK behavior
+    // where close() does not resolve the prompt consumer.
+    const query = new FakeClaudeQuery();
+    (query as { close: () => void }).close = () => {
+      query.closeCalls += 1;
+    };
+
+    let promptConsumerError: unknown = undefined;
+
+    const layer = makeClaudeAdapterLive({
+      createQuery: (input) => {
+        // Simulate the SDK consuming the prompt iterable
+        (async () => {
+          try {
+            for await (const _message of input.prompt) {
+              /* SDK processes user messages */
+            }
+          } catch (error) {
+            promptConsumerError = error;
+          }
+        })();
+        return query;
+      },
+    }).pipe(
+      Layer.provideMerge(ServerConfig.layerTest("/tmp/claude-adapter-test", "/tmp")),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = Effect.runFork(
+        Stream.runForEach(adapter.streamEvents, () => Effect.void),
+      );
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.stopSession(THREAD_ID);
+
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.yieldNow;
+      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 50)));
+
+      runtimeEventsFiber.interruptUnsafe();
+
+      assert.equal(
+        promptConsumerError,
+        undefined,
+        `Prompt consumer should not receive a thrown error on session stop, ` +
+          `but got: "${promptConsumerError instanceof Error ? promptConsumerError.message : String(promptConsumerError)}"`,
+      );
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(layer),
+    );
+  });
+
   it.effect("forwards Claude task progress summaries for subagent updates", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2258,6 +2258,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         const prompt = Stream.fromQueue(promptQueue).pipe(
           Stream.filter((item) => item.type === "message"),
           Stream.map((item) => item.message),
+          Stream.catchCause((cause) =>
+            Cause.hasInterruptsOnly(cause) ? Stream.empty : Stream.failCause(cause),
+          ),
           Stream.toAsyncIterable,
         );
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Added a `Stream.catchCause` clause to the prompt stream pipeline in `ClaudeAdapter.ts` that converts interrupt-only causes into a clean end-of-stream signal before Stream.toAsyncIterable`.
- Added a regression test that verifies `stopSession` cleanly ends the prompt async iterable instead of throwing into the SDK's consumer.

## Why

When the message queue is shut down (deleting a thread with an active session, or shutting down the server with an active session), the cancellation is passed to the SDK loop and since it's a thrown "error", the loop raises it, causing a crash.

Mitigation is to properly handle the cancellation event **before** passing it to the SDK, so that we stay in Effect's boundary and properly end the stream.

Fixes #1273 

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt-stream shutdown semantics during `stopSession` by swallowing interrupt-only failures; risk is mainly around subtle stream/lifecycle behavior potentially masking real errors or affecting prompt delivery.
> 
> **Overview**
> Fixes `ClaudeAdapter` session shutdown so stopping a session cleanly ends the SDK prompt async-iterator instead of throwing an interrupt error into the SDK consumer.
> 
> Adds a regression test that simulates real SDK `for await (... of prompt)` consumption and verifies `stopSession` does not surface an exception, while still rethrowing non-interrupt prompt stream failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee20a29bdb25f8c628e98189ac9fc52df6af9fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix prompt stream interrupt handling in `ClaudeAdapter` on session stop
> When a session is stopped, the Claude prompt stream was propagating the interrupt as an error to the SDK prompt consumer. A `Stream.catchCause` stage is added in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/1365/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) that swallows interrupt-only causes and returns an empty stream, while re-raising non-interrupt failures. A new test in [ClaudeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/1365/files#diff-1657a55ebc1e3682293aa20a7f71a55adf8de546f36af50f289dca9da45b0b6f) verifies that `stopSession` no longer throws into the prompt consumer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ee20a29.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->