### PR TITLE
fix(web): add connection status banner to thread view #1270

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -162,6 +162,7 @@ import {
   renderProviderTraitsMenuContent,
   renderProviderTraitsPicker,
 } from "./chat/composerProviderRegistry";
+import { ConnectionStatusBanner } from "./chat/ConnectionStatusBanner";
 import { ProviderHealthBanner } from "./chat/ProviderHealthBanner";
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
 import {
@@ -3496,6 +3497,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       </header>
 
       {/* Error banner */}
+      <ConnectionStatusBanner />
       <ProviderHealthBanner status={activeProviderStatus} />
       <ThreadErrorBanner
         error={activeThread.error}

--- a/apps/web/src/components/chat/ConnectionStatusBanner.test.tsx
+++ b/apps/web/src/components/chat/ConnectionStatusBanner.test.tsx
@@ -1,0 +1,51 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { ConnectionStatusBanner } from "./ConnectionStatusBanner";
+
+// Mock wsNativeApi
+vi.mock("../../wsNativeApi", () => {
+  return {
+    onTransportStateChange: vi.fn(() => {
+      return () => {};
+    }),
+  };
+});
+
+describe("ConnectionStatusBanner", () => {
+  beforeAll(() => {
+    vi.stubGlobal("navigator", {
+      onLine: true,
+    });
+  });
+
+  it("renders nothing when online and transport is open", () => {
+    const markup = renderToStaticMarkup(
+      <ConnectionStatusBanner initialIsOnline={true} initialTransportState="open" />,
+    );
+    expect(markup).toBe("");
+  });
+
+  it("renders offline message when initialIsOnline is false", async () => {
+    const markup = renderToStaticMarkup(
+      <ConnectionStatusBanner initialIsOnline={false} initialTransportState="open" />,
+    );
+    expect(markup).toContain("No internet connection");
+    expect(markup).toContain("T3 Code is offline");
+  });
+
+  it("renders disconnected message when initialTransportState is closed", async () => {
+    const markup = renderToStaticMarkup(
+      <ConnectionStatusBanner initialIsOnline={true} initialTransportState="closed" />,
+    );
+    expect(markup).toContain("Disconnected from server");
+    expect(markup).toContain("connection to the T3 Code server was lost");
+  });
+
+  it("renders reconnecting message when initialTransportState is reconnecting", async () => {
+    const markup = renderToStaticMarkup(
+      <ConnectionStatusBanner initialIsOnline={true} initialTransportState="reconnecting" />,
+    );
+    expect(markup).toContain("Disconnected from server");
+    expect(markup).toContain("Attempting to reconnect");
+  });
+});

--- a/apps/web/src/components/chat/ConnectionStatusBanner.test.tsx
+++ b/apps/web/src/components/chat/ConnectionStatusBanner.test.tsx
@@ -48,4 +48,11 @@ describe("ConnectionStatusBanner", () => {
     expect(markup).toContain("Disconnected from server");
     expect(markup).toContain("Attempting to reconnect");
   });
+
+  it("renders nothing when transport is disposed", () => {
+    const markup = renderToStaticMarkup(
+      <ConnectionStatusBanner initialIsOnline={true} initialTransportState="disposed" />,
+    );
+    expect(markup).toBe("");
+  });
 });

--- a/apps/web/src/components/chat/ConnectionStatusBanner.tsx
+++ b/apps/web/src/components/chat/ConnectionStatusBanner.tsx
@@ -1,0 +1,62 @@
+import { memo, useEffect, useState } from "react";
+import { onTransportStateChange, type TransportState } from "../../wsNativeApi";
+import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
+import { WifiOffIcon, CloudOffIcon } from "lucide-react";
+
+export const ConnectionStatusBanner = memo(function ConnectionStatusBanner({
+  initialIsOnline,
+  initialTransportState,
+}: {
+  initialIsOnline?: boolean;
+  initialTransportState?: TransportState;
+}) {
+  const [isOnline, setIsOnline] = useState(
+    initialIsOnline ?? (typeof navigator !== "undefined" ? navigator.onLine : true),
+  );
+  const [transportState, setTransportState] = useState<TransportState>(
+    initialTransportState ?? "open",
+  );
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    const unsub = onTransportStateChange((state) => {
+      setTransportState(state);
+    });
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+      unsub();
+    };
+  }, []);
+
+  const shouldShow =
+    !isOnline ||
+    (transportState !== "open" && transportState !== "connecting" && transportState !== "disposed");
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  const title = !isOnline ? "No internet connection" : "Disconnected from server";
+  const message = !isOnline
+    ? "T3 Code is offline. Please check your internet connection."
+    : transportState === "reconnecting"
+      ? "Attempting to reconnect to the T3 Code server..."
+      : "The connection to the T3 Code server was lost.";
+
+  return (
+    <div className="pt-3 mx-auto max-w-3xl">
+      <Alert variant="warning">
+        {!isOnline ? <WifiOffIcon className="size-4" /> : <CloudOffIcon className="size-4" />}
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription>{message}</AlertDescription>
+      </Alert>
+    </div>
+  );
+});

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -11,9 +11,8 @@ import {
 } from "@t3tools/contracts";
 
 import { showContextMenuFallback } from "./contextMenuFallback";
-import { WsTransport } from "./wsTransport";
-
-export type TransportState = "connecting" | "open" | "reconnecting" | "closed" | "disposed";
+import { WsTransport, type TransportState } from "./wsTransport";
+export type { TransportState };
 
 let instance: { api: NativeApi; transport: WsTransport } | null = null;
 const welcomeListeners = new Set<(payload: WsWelcomePayload) => void>();

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -13,6 +13,8 @@ import {
 import { showContextMenuFallback } from "./contextMenuFallback";
 import { WsTransport } from "./wsTransport";
 
+export type TransportState = "connecting" | "open" | "reconnecting" | "closed" | "disposed";
+
 let instance: { api: NativeApi; transport: WsTransport } | null = null;
 const welcomeListeners = new Set<(payload: WsWelcomePayload) => void>();
 const serverConfigUpdatedListeners = new Set<(payload: ServerConfigUpdatedPayload) => void>();
@@ -62,6 +64,17 @@ export function onServerConfigUpdated(
   return () => {
     serverConfigUpdatedListeners.delete(listener);
   };
+}
+
+/**
+ * Subscribe to WebSocket transport state changes.
+ */
+export function onTransportStateChange(listener: (state: TransportState) => void): () => void {
+  if (!instance) {
+    // Force instance creation if it doesn't exist
+    createWsNativeApi();
+  }
+  return instance!.transport.onStateChange(listener);
 }
 
 export function createWsNativeApi(): NativeApi {

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -25,7 +25,7 @@ interface RequestOptions {
   readonly timeoutMs?: number | null;
 }
 
-type TransportState = "connecting" | "open" | "reconnecting" | "closed" | "disposed";
+export type TransportState = "connecting" | "open" | "reconnecting" | "closed" | "disposed";
 
 const REQUEST_TIMEOUT_MS = 60_000;
 const RECONNECT_DELAYS_MS = [500, 1_000, 2_000, 4_000, 8_000];
@@ -78,8 +78,8 @@ export class WsTransport {
   }
 
   onStateChange(listener: (state: TransportState) => void): () => void {
-    this.stateListeners.add(listener);
     listener(this.state);
+    this.stateListeners.add(listener);
     return () => {
       this.stateListeners.delete(listener);
     };
@@ -173,7 +173,7 @@ export class WsTransport {
 
   dispose() {
     this.disposed = true;
-    this.state = "disposed";
+    this.setState("disposed");
     if (this.reconnectTimer !== null) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -55,6 +55,7 @@ export class WsTransport {
   private nextId = 1;
   private readonly pending = new Map<string, PendingRequest>();
   private readonly listeners = new Map<string, Set<(message: WsPush) => void>>();
+  private readonly stateListeners = new Set<(state: TransportState) => void>();
   private readonly latestPushByChannel = new Map<string, WsPush>();
   private readonly outboundQueue: string[] = [];
   private reconnectAttempt = 0;
@@ -74,6 +75,26 @@ export class WsTransport {
           ? envUrl
           : `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.hostname}:${window.location.port}`);
     this.connect();
+  }
+
+  onStateChange(listener: (state: TransportState) => void): () => void {
+    this.stateListeners.add(listener);
+    listener(this.state);
+    return () => {
+      this.stateListeners.delete(listener);
+    };
+  }
+
+  private setState(next: TransportState) {
+    if (this.state === next) return;
+    this.state = next;
+    for (const listener of this.stateListeners) {
+      try {
+        listener(next);
+      } catch {
+        // Swallow listener errors
+      }
+    }
   }
 
   async request<T = unknown>(
@@ -174,12 +195,12 @@ export class WsTransport {
       return;
     }
 
-    this.state = this.reconnectAttempt > 0 ? "reconnecting" : "connecting";
+    this.setState(this.reconnectAttempt > 0 ? "reconnecting" : "connecting");
     const ws = new WebSocket(this.url);
 
     ws.addEventListener("open", () => {
       this.ws = ws;
-      this.state = "open";
+      this.setState("open");
       this.reconnectAttempt = 0;
       this.flushQueue();
     });
@@ -201,10 +222,10 @@ export class WsTransport {
         }
       }
       if (this.disposed) {
-        this.state = "disposed";
+        this.setState("disposed");
         return;
       }
-      this.state = "closed";
+      this.setState("closed");
       this.scheduleReconnect();
     });
 


### PR DESCRIPTION
FIX: #1270

## What Changed

Adds a `ConnectionStatusBanner` component that surfaces offline and disconnected states to the user in the chat interface.

- **`ConnectionStatusBanner`** — new component rendered in the `ChatView` top header to display offline/disconnected states
- **`WsTransport`** — now tracks and emits transport state changes internally
- **Native API** — exposes `onTransportStateChange` so the UI layer can react to connection changes
- **Tests** — unit tests added for `ConnectionStatusBanner` logic
- **Vitest config** — fixes alias resolution for web app packages

## Why

Users had no visibility into connection issues during a chat session — the app would silently fail or behave unexpectedly when the WebSocket dropped or the device went offline. This PR wires up transport state through to the UI so users get clear, timely feedback about their connection status, reducing confusion and support load.

The banner approach keeps the signal non-blocking and contextually placed (top of chat), which is a common, well-understood pattern for connectivity feedback.

## UI Changes

Screenshot:
<img width="649" height="275" alt="no-internet-warning" src="https://github.com/user-attachments/assets/79f4cdb2-010b-43ec-bbe4-78abb49c4d7a" />

Video:
https://github.com/user-attachments/assets/78df905c-fd43-4831-834d-909eb4944f28

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core WebSocket transport state machine and adds new state-listener callbacks, which could affect reconnect/dispose behavior if notifications are incorrect. UI changes are straightforward but depend on accurate transport state transitions.
> 
> **Overview**
> Adds a new `ConnectionStatusBanner` to `ChatView` to warn users when the browser is offline or when the WebSocket transport is `closed`/`reconnecting`.
> 
> Plumbs transport connectivity to the UI by exporting `TransportState`, adding `WsTransport.onStateChange()` + centralized `setState()` notifications, and exposing `onTransportStateChange()` from `wsNativeApi` (forcing instance creation if needed). Includes unit tests covering banner render behavior across online/offline and transport states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aa07e196035d8fcbdfebf78edfa8c2cfb8ee025. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add connection status banner to thread view for offline and WebSocket disconnect states
> - Adds [`ConnectionStatusBanner`](https://github.com/pingdotgg/t3code/pull/1369/files#diff-5fbf63628c14de5faa7b659498ea19b8d4d70c66950db3ee9a56f54c4461935d), a memoized React component that shows a warning alert when the browser is offline or the WebSocket transport is closed/reconnecting.
> - Subscribes to navigator online/offline events and WebSocket transport state via a new `onTransportStateChange` function added to [`wsNativeApi.ts`](https://github.com/pingdotgg/t3code/pull/1369/files#diff-eae2e1e3878c14b7af9318605dd9eed50d08123751d3748fb1feadf12daa30f4).
> - Extends [`WsTransport`](https://github.com/pingdotgg/t3code/pull/1369/files#diff-2129bf8b884f9eac0205e2de5672354ffe759743b6538d8dee077fb1944d1506) with a listener set and `onStateChange` method; all state transitions now go through a single `setState` notifier that invokes registered listeners.
> - Renders the banner in [`ChatView`](https://github.com/pingdotgg/t3code/pull/1369/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) above the existing `ProviderHealthBanner`.
> - Behavioral Change: `WsTransport` now calls registered listeners on every state transition, including immediately upon subscription with the current state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3aa07e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->