### PR TITLE
fix(web): filter model picker by server provider health status

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1018,6 +1018,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const effectivePathQuery = pathTriggerQuery.length > 0 ? debouncedPathQuery : "";
   const branchesQuery = useQuery(gitBranchesQueryOptions(gitCwd));
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const providerStatuses = serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES;
   const workspaceEntriesQuery = useQuery(
     projectSearchEntriesQueryOptions({
       cwd: gitCwd,
@@ -1107,7 +1108,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const keybindings = serverConfigQuery.data?.keybindings ?? EMPTY_KEYBINDINGS;
   const availableEditors = serverConfigQuery.data?.availableEditors ?? EMPTY_AVAILABLE_EDITORS;
-  const providerStatuses = serverConfigQuery.data?.providers ?? EMPTY_PROVIDER_STATUSES;
   const activeProviderStatus = useMemo(
     () => providerStatuses.find((status) => status.provider === selectedProvider) ?? null,
     [selectedProvider, providerStatuses],
@@ -3780,6 +3780,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                           model={selectedModelForPickerWithCustomFallback}
                           lockedProvider={lockedProvider}
                           modelOptionsByProvider={modelOptionsByProvider}
+                          providerStatuses={providerStatuses}
                           {...(composerProviderState.modelPickerIconClassName
                             ? {
                                 activeProviderIconClassName:

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -1,6 +1,6 @@
-import { type ModelSlug, type ProviderKind } from "@t3tools/contracts";
+import { type ModelSlug, type ProviderKind, type ServerProviderStatus } from "@t3tools/contracts";
 import { resolveSelectableModel } from "@t3tools/shared/model";
-import { memo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { type ProviderPickerKind, PROVIDER_OPTIONS } from "../../session-logic";
 import { ChevronDownIcon } from "lucide-react";
 import { Button } from "../ui/button";
@@ -54,11 +54,37 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   lockedProvider: ProviderKind | null;
   modelOptionsByProvider: Record<ProviderKind, ReadonlyArray<{ slug: string; name: string }>>;
   activeProviderIconClassName?: string;
+  providerStatuses?: ReadonlyArray<ServerProviderStatus>;
   compact?: boolean;
   disabled?: boolean;
   onProviderModelChange: (provider: ProviderKind, model: ModelSlug) => void;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  // Derive which providers are unavailable based on server health checks.
+  // When providerStatuses is not provided, all statically-available providers remain selectable.
+  const unavailableProviders = useMemo(() => {
+    if (!props.providerStatuses || props.providerStatuses.length === 0) {
+      return null;
+    }
+    return new Set(
+      props.providerStatuses.filter((status) => !status.available).map((status) => status.provider),
+    );
+  }, [props.providerStatuses]);
+
+  const effectiveAvailableOptions = useMemo(() => {
+    if (!unavailableProviders) return AVAILABLE_PROVIDER_OPTIONS;
+    return AVAILABLE_PROVIDER_OPTIONS.filter((option) => !unavailableProviders.has(option.value));
+  }, [unavailableProviders]);
+
+  const effectiveUnavailableOptions = useMemo(() => {
+    if (!unavailableProviders) return UNAVAILABLE_PROVIDER_OPTIONS;
+    const healthUnavailable = AVAILABLE_PROVIDER_OPTIONS.filter((option) =>
+      unavailableProviders.has(option.value),
+    );
+    return [...healthUnavailable, ...UNAVAILABLE_PROVIDER_OPTIONS];
+  }, [unavailableProviders]);
+
   const activeProvider = props.lockedProvider ?? props.provider;
   const selectedProviderOptions = props.modelOptionsByProvider[activeProvider];
   const selectedModelLabel =
@@ -139,7 +165,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
           </MenuGroup>
         ) : (
           <>
-            {AVAILABLE_PROVIDER_OPTIONS.map((option) => {
+            {effectiveAvailableOptions.map((option) => {
               const OptionIcon = PROVIDER_ICON_BY_PROVIDER[option.value];
               return (
                 <MenuSub key={option.value}>
@@ -174,9 +200,14 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
                 </MenuSub>
               );
             })}
-            {UNAVAILABLE_PROVIDER_OPTIONS.length > 0 && <MenuDivider />}
-            {UNAVAILABLE_PROVIDER_OPTIONS.map((option) => {
+            {effectiveUnavailableOptions.length > 0 && <MenuDivider />}
+            {effectiveUnavailableOptions.map((option) => {
               const OptionIcon = PROVIDER_ICON_BY_PROVIDER[option.value];
+              // Providers that are statically available but failed server health checks
+              // show "Not installed"; providers not yet supported show "Coming soon".
+              const isHealthUnavailable = AVAILABLE_PROVIDER_OPTIONS.some(
+                (available) => available.value === option.value,
+              );
               return (
                 <MenuItem key={option.value} disabled>
                   <OptionIcon
@@ -185,12 +216,12 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
                   />
                   <span>{option.label}</span>
                   <span className="ms-auto text-[11px] text-muted-foreground/80 uppercase tracking-[0.08em]">
-                    Coming soon
+                    {isHealthUnavailable ? "Not installed" : "Coming soon"}
                   </span>
                 </MenuItem>
               );
             })}
-            {UNAVAILABLE_PROVIDER_OPTIONS.length === 0 && <MenuDivider />}
+            {effectiveUnavailableOptions.length === 0 && <MenuDivider />}
             {COMING_SOON_PROVIDER_OPTIONS.map((option) => {
               const OptionIcon = option.icon;
               return (


### PR DESCRIPTION
## Summary

- Thread `providerStatuses` from the server config query into `ProviderModelPicker` so it can dynamically hide providers whose CLI binary is missing
- Providers that fail the server health check (`available: false`) are shown as disabled with a **"Not installed"** label instead of remaining selectable
- Static unavailable providers (Cursor) retain their "Coming soon" label
- The `providerStatuses` prop is optional — when omitted the component falls back to the existing static lists, preserving backward compatibility

## Context

When `codex` is not installed but Claude Code is, the model picker still showed Codex as a selectable provider. The server already performs health checks and sends `ServerProviderStatus[]` to the client, but this data was only used for the `ProviderHealthBanner` warning display — not for filtering the picker itself.

## Changes

| File | Change |
|------|--------|
| `apps/web/src/components/chat/ProviderModelPicker.tsx` | Accept optional `providerStatuses` prop, compute dynamic available/unavailable lists via `useMemo`, show "Not installed" for health-unavailable providers |
| `apps/web/src/components/ChatView.tsx` | Pass `providerStatuses` to `ProviderModelPicker` (1 line), move `providerStatuses` derivation earlier to keep variable ordering clean (move, not logic change) |

## Known limitation

If the user has a provider selected and it becomes unavailable mid-session (e.g. CLI uninstalled while t3code is open), the picker button still shows that provider's icon/model until the user manually switches. This is a pre-existing condition not introduced by this change. A follow-up could auto-switch to the first available provider.

## Test plan

- [ ] Verify `bun fmt`, `bun lint`, `bun typecheck` pass (confirmed locally — the `@t3tools/scripts` typecheck failure is pre-existing on `main`)
- [ ] Open t3code without `codex` installed → Codex should appear disabled with "Not installed"
- [ ] Open t3code without `claude` installed → Claude should appear disabled with "Not installed"
- [ ] Open t3code with both CLIs installed → Both providers remain selectable (no regression)
- [ ] Existing `ProviderModelPicker.browser.tsx` tests pass unchanged (prop is optional)

Fixes #1332

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change that only affects which provider options are selectable in the model picker based on server-reported availability.
> 
> **Overview**
> Provider/model picker options are now filtered using server-reported `providerStatuses`, hiding providers that fail health checks from the selectable list.
> 
> Health-unavailable providers are shown as disabled with a **"Not installed"** badge (while statically unsupported providers remain **"Coming soon"**), and `ChatView` now passes `providerStatuses` into `ProviderModelPicker` via an optional prop for backwards compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca34f5f47ce38a11757941ab15ac37ea189eef53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter model picker options by server provider health status
> - [`ProviderModelPicker`](https://github.com/pingdotgg/t3code/pull/1378/files#diff-01e915fe10bb55b513fb511c18383cd09199ea82c807cdf1fa405ba3261b0a40) now accepts an optional `providerStatuses` prop and uses `useMemo` to derive effective available/unavailable provider lists based on server-reported health.
> - Providers that fail server health checks are moved out of the selectable list and shown as disabled with a 'Not installed' label instead of 'Coming soon'.
> - [`ChatView`](https://github.com/pingdotgg/t3code/pull/1378/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) derives `providerStatuses` from `serverConfigQuery` and passes it down to `ProviderModelPicker`.
> - When `providerStatuses` is not provided, behavior falls back to the previous static availability lists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca34f5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->