### PR TITLE
fix(web): clear composer border after picker dismissal

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3607,7 +3607,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
               >
                 <div
                   className={cn(
-                    "rounded-[20px] border bg-card transition-colors duration-200 focus-within:border-ring/45",
+                    "rounded-[20px] border bg-card transition-colors duration-200 has-focus-visible:border-ring/45",
                     isDragOverComposer ? "border-primary/70 bg-accent/30" : "border-border",
                     composerProviderState.composerSurfaceClassName,
                   )}


### PR DESCRIPTION
## What Changed

Replaced `focus-within:border-ring/45` with `has-focus-visible:border-ring/45` on the composer container in `ChatView.tsx`.

## Why

The composer border highlights when the editor is active using `focus-within`, which maps to CSS `:focus-within`. This works well for the editor itself but it also activates when toolbar buttons (like the model or effort picker) receive focus. So if a user opens a picker and then clicks outside to dismiss it, the blue border can stick around since focus remains on the trigger button.

Swapping to `has-focus-visible` (css `:has(:focus-visible)`) narrows this to keyboard-intent focus only. Buttons clicked with a mouse aren't marked as focus-visible, which avoids the border staying after dismissal. Clicking into the editor still shows the border since browsers treat editable elements as focus-visible.

## UI Changes

### Before

https://github.com/user-attachments/assets/2100a9a8-0682-4a22-876d-d43d5be01222

### After

https://github.com/user-attachments/assets/b7c3ceb6-a904-4ab4-96ab-54794aa23b31

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling change that alters when the composer shows its focus border; main risk is inconsistent `:has(:focus-visible)` support or unintended focus styling regressions across browsers.
> 
> **Overview**
> Updates the chat composer container styling in `ChatView.tsx` to use `has-focus-visible:border-ring/45` instead of `focus-within:border-ring/45`, so the blue border highlight only appears for *keyboard-visible* focus and clears when pickers/toolbar buttons are dismissed via pointer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7aababb991bf4610d656f45985ad2bd6f88e8c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer border highlight to clear on picker dismissal in `ChatView`
> Changes the Tailwind variant on the composer container in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1382/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) from `focus-within:border-ring/45` to `has-focus-visible:border-ring/45`. This ensures the border highlight only appears when a descendant has keyboard-visible focus, so it clears correctly when a picker (e.g. emoji picker) is dismissed via pointer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7aabab.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->