### PR TITLE
fix(web): prevent desktop header overlap when sidebar is collapsed

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -19,6 +19,7 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
 
 ```json
 [
+  { "key": "mod+b", "command": "sidebar.toggle" },
   { "key": "mod+j", "command": "terminal.toggle" },
   { "key": "mod+d", "command": "terminal.split", "when": "terminalFocus" },
   { "key": "mod+n", "command": "terminal.new", "when": "terminalFocus" },
@@ -46,6 +47,7 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 
 ### Available Commands
 
+- `sidebar.toggle`: open/close the main thread sidebar in both desktop and web
 - `terminal.toggle`: open/close terminal drawer
 - `terminal.split`: split terminal (in focused terminal context by default)
 - `terminal.new`: create new terminal (in focused terminal context by default)

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -75,6 +75,23 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
 
   it.effect("compiles valid rule with parsed when AST", () =>
     Effect.sync(() => {
+      const compiledSidebar = compileResolvedKeybindingRule({
+        key: "mod+b",
+        command: "sidebar.toggle",
+      });
+
+      assert.deepEqual(compiledSidebar, {
+        command: "sidebar.toggle",
+        shortcut: {
+          key: "b",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          modKey: true,
+        },
+      });
+
       const compiled = compileResolvedKeybindingRule({
         key: "mod+d",
         command: "terminal.split",

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -65,6 +65,7 @@ type WhenToken =
   | { type: "rparen" };
 
 export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
+  { key: "mod+b", command: "sidebar.toggle" },
   { key: "mod+j", command: "terminal.toggle" },
   { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
   { key: "mod+n", command: "terminal.new", when: "terminalFocus" },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3486,10 +3486,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
       {/* Top bar */}
       <header
         className={cn(
-          "border-b border-border px-3",
+          "border-b border-border",
           isElectron
             ? cn("drag-region flex h-[52px] items-center pr-5", sidebarOpen ? "pl-5" : "pl-[90px]")
-            : "py-2 sm:py-3",
+            : "px-3 py-2 sm:px-5 sm:py-3",
         )}
       >
         <ChatHeader

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -117,7 +117,8 @@ import {
   projectScriptIdFromCommand,
   setupProjectScript,
 } from "~/projectScripts";
-import { SidebarTrigger } from "./ui/sidebar";
+import { SidebarToggleButton } from "./SidebarToggleButton";
+import { useSidebar } from "./ui/sidebar";
 import { newCommandId, newMessageId, newThreadId } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 import {
@@ -241,6 +242,7 @@ interface ChatViewProps {
 }
 
 export default function ChatView({ threadId }: ChatViewProps) {
+  const { open: sidebarOpen } = useSidebar();
   const threads = useStore((store) => store.threads);
   const projects = useStore((store) => store.projects);
   const markThreadVisited = useStore((store) => store.markThreadVisited);
@@ -1127,6 +1129,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const isGitRepo = branchesQuery.data?.isRepo ?? true;
   const terminalToggleShortcutLabel = useMemo(
     () => shortcutLabelForCommand(keybindings, "terminal.toggle"),
+    [keybindings],
+  );
+  const sidebarToggleShortcutLabel = useMemo(
+    () => shortcutLabelForCommand(keybindings, "sidebar.toggle"),
     [keybindings],
   );
   const splitTerminalShortcutLabel = useMemo(
@@ -3442,15 +3448,27 @@ export default function ChatView({ threadId }: ChatViewProps) {
     return (
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-muted-foreground/40">
         {!isElectron && (
-          <header className="border-b border-border px-3 py-2 md:hidden">
+          <header className="border-b border-border px-3 py-2">
             <div className="flex items-center gap-2">
-              <SidebarTrigger className="size-7 shrink-0" />
+              <SidebarToggleButton
+                className="size-7 shrink-0"
+                shortcutLabel={sidebarToggleShortcutLabel}
+              />
               <span className="text-sm font-medium text-foreground">Threads</span>
             </div>
           </header>
         )}
         {isElectron && (
-          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+          <div
+            className={cn(
+              "drag-region flex h-[52px] shrink-0 items-center gap-2 border-b border-border px-5",
+              !sidebarOpen && "pl-[90px]",
+            )}
+          >
+            <SidebarToggleButton
+              className="size-7 shrink-0 no-drag"
+              shortcutLabel={sidebarToggleShortcutLabel}
+            />
             <span className="text-xs text-muted-foreground/50">No active thread</span>
           </div>
         )}
@@ -3468,8 +3486,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
       {/* Top bar */}
       <header
         className={cn(
-          "border-b border-border px-3 sm:px-5",
-          isElectron ? "drag-region flex h-[52px] items-center" : "py-2 sm:py-3",
+          "border-b border-border px-3",
+          isElectron
+            ? cn("drag-region flex h-[52px] items-center pr-5", sidebarOpen ? "pl-5" : "pl-[90px]")
+            : "py-2 sm:py-3",
         )}
       >
         <ChatHeader
@@ -3486,6 +3506,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           availableEditors={availableEditors}
           terminalAvailable={activeProject !== undefined}
           terminalOpen={terminalState.terminalOpen}
+          sidebarToggleShortcutLabel={sidebarToggleShortcutLabel}
           terminalToggleShortcutLabel={terminalToggleShortcutLabel}
           diffToggleShortcutLabel={diffPanelShortcutLabel}
           gitCwd={gitCwd}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -85,7 +85,6 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
   SidebarSeparator,
-  SidebarTrigger,
 } from "./ui/sidebar";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
@@ -1593,7 +1592,6 @@ export default function Sidebar() {
 
   const wordmark = (
     <div className="flex items-center gap-2">
-      <SidebarTrigger className="shrink-0 md:hidden" />
       <Tooltip>
         <TooltipTrigger
           render={

--- a/apps/web/src/components/SidebarToggleButton.tsx
+++ b/apps/web/src/components/SidebarToggleButton.tsx
@@ -1,0 +1,20 @@
+import { SidebarTrigger } from "./ui/sidebar";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+
+interface SidebarToggleButtonProps {
+  className?: string;
+  shortcutLabel?: string | null;
+}
+
+export function SidebarToggleButton({ className, shortcutLabel = null }: SidebarToggleButtonProps) {
+  const tooltipLabel = shortcutLabel ? `Toggle sidebar (${shortcutLabel})` : "Toggle sidebar";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={<SidebarTrigger aria-label="Toggle sidebar" className={className} />}
+      />
+      <TooltipPopup side="bottom">{tooltipLabel}</TooltipPopup>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -10,8 +10,8 @@ import { DiffIcon, TerminalSquareIcon } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
+import { SidebarToggleButton } from "../SidebarToggleButton";
 import { Toggle } from "../ui/toggle";
-import { SidebarTrigger } from "../ui/sidebar";
 import { OpenInPicker } from "./OpenInPicker";
 
 interface ChatHeaderProps {
@@ -26,6 +26,7 @@ interface ChatHeaderProps {
   availableEditors: ReadonlyArray<EditorId>;
   terminalAvailable: boolean;
   terminalOpen: boolean;
+  sidebarToggleShortcutLabel: string | null;
   terminalToggleShortcutLabel: string | null;
   diffToggleShortcutLabel: string | null;
   gitCwd: string | null;
@@ -50,6 +51,7 @@ export const ChatHeader = memo(function ChatHeader({
   availableEditors,
   terminalAvailable,
   terminalOpen,
+  sidebarToggleShortcutLabel,
   terminalToggleShortcutLabel,
   diffToggleShortcutLabel,
   gitCwd,
@@ -64,7 +66,10 @@ export const ChatHeader = memo(function ChatHeader({
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
-        <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+        <SidebarToggleButton
+          className="size-7 shrink-0"
+          shortcutLabel={sidebarToggleShortcutLabel}
+        />
         <h2
           className="min-w-0 shrink truncate text-sm font-medium text-foreground"
           title={activeThreadTitle}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -303,7 +303,8 @@ function Sidebar({
 }
 
 function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar, openMobile } = useSidebar();
+  const { isMobile, open, openMobile, toggleSidebar } = useSidebar();
+  const isOpen = isMobile ? openMobile : open;
 
   return (
     <Button
@@ -318,7 +319,7 @@ function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<t
       variant="ghost"
       {...props}
     >
-      {openMobile ? <PanelLeftCloseIcon /> : <PanelLeftIcon />}
+      {isOpen ? <PanelLeftCloseIcon /> : <PanelLeftIcon />}
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -12,6 +12,7 @@ import {
   isChatNewLocalShortcut,
   isDiffToggleShortcut,
   isOpenFavoriteEditorShortcut,
+  isSidebarToggleShortcut,
   isTerminalClearShortcut,
   isTerminalCloseShortcut,
   isTerminalNewShortcut,
@@ -76,6 +77,7 @@ function compile(bindings: TestBinding[]): ResolvedKeybindingsConfig {
 }
 
 const DEFAULT_BINDINGS = compile([
+  { shortcut: modShortcut("b"), command: "sidebar.toggle" },
   { shortcut: modShortcut("j"), command: "terminal.toggle" },
   {
     shortcut: modShortcut("d"),
@@ -101,6 +103,24 @@ const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("n", { shiftKey: true }), command: "chat.newLocal" },
   { shortcut: modShortcut("o"), command: "editor.openFavorite" },
 ]);
+
+describe("isSidebarToggleShortcut", () => {
+  it("matches Cmd+B on macOS", () => {
+    assert.isTrue(
+      isSidebarToggleShortcut(event({ key: "b", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+    );
+  });
+
+  it("matches Ctrl+B on non-macOS", () => {
+    assert.isTrue(
+      isSidebarToggleShortcut(event({ key: "b", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Win32",
+      }),
+    );
+  });
+});
 
 describe("isTerminalToggleShortcut", () => {
   it("matches Cmd+J on macOS", () => {
@@ -236,6 +256,10 @@ describe("shortcutLabelForCommand", () => {
 
   it("returns labels for non-terminal commands", () => {
     assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "chat.new", "MacIntel"), "⇧⌘O");
+    assert.strictEqual(
+      shortcutLabelForCommand(DEFAULT_BINDINGS, "sidebar.toggle", "MacIntel"),
+      "⌘B",
+    );
     assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "diff.toggle", "Linux"), "Ctrl+D");
     assert.strictEqual(
       shortcutLabelForCommand(DEFAULT_BINDINGS, "editor.openFavorite", "Linux"),

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -174,6 +174,14 @@ export function isTerminalToggleShortcut(
   return matchesCommandShortcut(event, keybindings, "terminal.toggle", options);
 }
 
+export function isSidebarToggleShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "sidebar.toggle", options);
+}
+
 export function isTerminalSplitShortcut(
   event: ShortcutEventLike,
   keybindings: ResolvedKeybindingsConfig,

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -1,22 +1,46 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
 
+import { SidebarToggleButton } from "../components/SidebarToggleButton";
 import { isElectron } from "../env";
-import { SidebarTrigger } from "../components/ui/sidebar";
+import { shortcutLabelForCommand } from "../keybindings";
+import { serverConfigQueryOptions } from "../lib/serverReactQuery";
+import { cn } from "../lib/utils";
+import { useSidebar } from "../components/ui/sidebar";
 
 function ChatIndexRouteView() {
+  const { open: sidebarOpen } = useSidebar();
+  const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const sidebarToggleShortcutLabel = shortcutLabelForCommand(
+    serverConfigQuery.data?.keybindings ?? [],
+    "sidebar.toggle",
+  );
+
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-muted-foreground/40">
       {!isElectron && (
-        <header className="border-b border-border px-3 py-2 md:hidden">
+        <header className="border-b border-border px-3 py-2">
           <div className="flex items-center gap-2">
-            <SidebarTrigger className="size-7 shrink-0" />
+            <SidebarToggleButton
+              className="size-7 shrink-0"
+              shortcutLabel={sidebarToggleShortcutLabel}
+            />
             <span className="text-sm font-medium text-foreground">Threads</span>
           </div>
         </header>
       )}
 
       {isElectron && (
-        <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+        <div
+          className={cn(
+            "drag-region flex h-[52px] shrink-0 items-center gap-2 border-b border-border px-5",
+            !sidebarOpen && "pl-[90px]",
+          )}
+        >
+          <SidebarToggleButton
+            className="size-7 shrink-0 no-drag"
+            shortcutLabel={sidebarToggleShortcutLabel}
+          />
           <span className="text-xs text-muted-foreground/50">No active thread</span>
         </div>
       )}

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -13,6 +13,7 @@ import {
   useAppSettings,
 } from "../appSettings";
 import { APP_VERSION } from "../branding";
+import { SidebarToggleButton } from "../components/SidebarToggleButton";
 import { Button } from "../components/ui/button";
 import { Collapsible, CollapsibleContent } from "../components/ui/collapsible";
 import { Input } from "../components/ui/input";
@@ -23,16 +24,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../components/ui/select";
-import { SidebarTrigger } from "../components/ui/sidebar";
 import { Switch } from "../components/ui/switch";
 import { SidebarInset } from "../components/ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../components/ui/tooltip";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
+import { shortcutLabelForCommand } from "../keybindings";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { cn } from "../lib/utils";
 import { ensureNativeApi, readNativeApi } from "../nativeApi";
+import { useSidebar } from "../components/ui/sidebar";
 
 const THEME_OPTIONS = [
   {
@@ -186,6 +188,7 @@ function SettingResetButton({ label, onClick }: { label: string; onClick: () => 
 }
 
 function SettingsRouteView() {
+  const { open: sidebarOpen } = useSidebar();
   const { theme, setTheme } = useTheme();
   const { settings, defaults, updateSettings, resetSettings } = useAppSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
@@ -212,6 +215,10 @@ function SettingsRouteView() {
   const codexHomePath = settings.codexHomePath;
   const claudeBinaryPath = settings.claudeBinaryPath;
   const keybindingsConfigPath = serverConfigQuery.data?.keybindingsConfigPath ?? null;
+  const sidebarToggleShortcutLabel = shortcutLabelForCommand(
+    serverConfigQuery.data?.keybindings ?? [],
+    "sidebar.toggle",
+  );
   const availableEditors = serverConfigQuery.data?.availableEditors;
 
   const gitTextGenerationModelOptions = getAppModelOptions(
@@ -385,7 +392,10 @@ function SettingsRouteView() {
         {!isElectron && (
           <header className="border-b border-border px-3 py-2 sm:px-5">
             <div className="flex items-center gap-2">
-              <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+              <SidebarToggleButton
+                className="size-7 shrink-0"
+                shortcutLabel={sidebarToggleShortcutLabel}
+              />
               <span className="text-sm font-medium text-foreground">Settings</span>
               <div className="ms-auto flex items-center gap-2">
                 <Button
@@ -403,7 +413,16 @@ function SettingsRouteView() {
         )}
 
         {isElectron && (
-          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+          <div
+            className={cn(
+              "drag-region flex h-[52px] shrink-0 items-center gap-2 border-b border-border px-5",
+              !sidebarOpen && "pl-[90px]",
+            )}
+          >
+            <SidebarToggleButton
+              className="size-7 shrink-0 no-drag"
+              shortcutLabel={sidebarToggleShortcutLabel}
+            />
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
             </span>

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -12,7 +12,7 @@ import { selectThreadTerminalState, useTerminalStateStore } from "../terminalSta
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { resolveSidebarNewThreadEnvMode } from "~/components/Sidebar.logic";
 import { useAppSettings } from "~/appSettings";
-import { Sidebar, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
+import { Sidebar, SidebarProvider, SidebarRail, useSidebar } from "~/components/ui/sidebar";
 
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
@@ -20,6 +20,7 @@ const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 
 function ChatRouteGlobalShortcuts() {
+  const { toggleSidebar } = useSidebar();
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
   const selectedThreadIdsSize = useThreadSelectionStore((state) => state.selectedThreadIds.size);
   const { activeDraftThread, activeThread, handleNewThread, projects, routeThreadId } =
@@ -43,15 +44,21 @@ function ChatRouteGlobalShortcuts() {
         return;
       }
 
-      const projectId = activeThread?.projectId ?? activeDraftThread?.projectId ?? projects[0]?.id;
-      if (!projectId) return;
-
       const command = resolveShortcutCommand(event, keybindings, {
         context: {
           terminalFocus: isTerminalFocused(),
           terminalOpen,
         },
       });
+      if (command === "sidebar.toggle") {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleSidebar();
+        return;
+      }
+
+      const projectId = activeThread?.projectId ?? activeDraftThread?.projectId ?? projects[0]?.id;
+      if (!projectId) return;
 
       if (command === "chat.newLocal") {
         event.preventDefault();
@@ -87,6 +94,7 @@ function ChatRouteGlobalShortcuts() {
     projects,
     selectedThreadIdsSize,
     terminalOpen,
+    toggleSidebar,
     appSettings.defaultThreadEnvMode,
   ]);
 

--- a/apps/web/src/terminalStateStore.test.ts
+++ b/apps/web/src/terminalStateStore.test.ts
@@ -7,7 +7,7 @@ const THREAD_ID = ThreadId.makeUnsafe("thread-1");
 
 describe("terminalStateStore actions", () => {
   beforeEach(() => {
-    if (typeof localStorage !== "undefined") {
+    if (typeof localStorage !== "undefined" && typeof localStorage.clear === "function") {
       localStorage.clear();
     }
     useTerminalStateStore.setState({ terminalStateByThreadId: {} });

--- a/apps/web/src/terminalStateStore.ts
+++ b/apps/web/src/terminalStateStore.ts
@@ -26,6 +26,27 @@ interface ThreadTerminalState {
 }
 
 const TERMINAL_STATE_STORAGE_KEY = "t3code:terminal-state:v1";
+const noopStorage = {
+  getItem: () => null,
+  removeItem: () => undefined,
+  setItem: () => undefined,
+};
+
+function getTerminalStateStorage() {
+  if (typeof localStorage === "undefined") {
+    return noopStorage;
+  }
+
+  if (
+    typeof localStorage.getItem !== "function" ||
+    typeof localStorage.setItem !== "function" ||
+    typeof localStorage.removeItem !== "function"
+  ) {
+    return noopStorage;
+  }
+
+  return localStorage;
+}
 
 function normalizeTerminalIds(terminalIds: string[]): string[] {
   const ids = [...new Set(terminalIds.map((id) => id.trim()).filter((id) => id.length > 0))];
@@ -542,7 +563,7 @@ export const useTerminalStateStore = create<TerminalStateStoreState>()(
     {
       name: TERMINAL_STATE_STORAGE_KEY,
       version: 1,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(getTerminalStateStorage),
       partialize: (state) => ({
         terminalStateByThreadId: state.terminalStateByThreadId,
       }),

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -23,6 +23,12 @@ const decodeResolvedRule = Schema.decodeUnknownEffect(ResolvedKeybindingRule as 
 
 it.effect("parses keybinding rules", () =>
   Effect.gen(function* () {
+    const parsedSidebar = yield* decode(KeybindingRule, {
+      key: "mod+b",
+      command: "sidebar.toggle",
+    });
+    assert.strictEqual(parsedSidebar.command, "sidebar.toggle");
+
     const parsed = yield* decode(KeybindingRule, {
       key: "mod+j",
       command: "terminal.toggle",
@@ -110,6 +116,17 @@ it.effect("parses resolved keybindings arrays", () =>
   Effect.gen(function* () {
     const parsed = yield* decode(ResolvedKeybindingsConfig, [
       {
+        command: "sidebar.toggle",
+        shortcut: {
+          key: "b",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          modKey: true,
+        },
+      },
+      {
         command: "terminal.toggle",
         shortcut: {
           key: "j",
@@ -121,7 +138,7 @@ it.effect("parses resolved keybindings arrays", () =>
         },
       },
     ]);
-    assert.lengthOf(parsed, 1);
+    assert.lengthOf(parsed, 2);
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -8,6 +8,7 @@ export const MAX_SCRIPT_ID_LENGTH = 24;
 export const MAX_KEYBINDINGS_COUNT = 256;
 
 const STATIC_KEYBINDING_COMMANDS = [
+  "sidebar.toggle",
   "terminal.toggle",
   "terminal.split",
   "terminal.new",


### PR DESCRIPTION
## What Changed

This PR fixes the new sidebar toggle behavior on desktop so header content no longer renders underneath the macOS traffic lights / toggle area when the thread sidebar is collapsed.

It also adds the sidebar toggle interaction itself across web and desktop:

- added a first-class `sidebar.toggle` keybinding command
- added default `mod+b` shortcut support
- added an external sidebar toggle button next to thread/header content
- fixed collapsed desktop header spacing for:
  - active thread header
  - no active thread header
  - settings header

The open-sidebar layout was left unchanged.

## Why

The new sidebar toggle behavior introduced a desktop layout regression: when the sidebar was collapsed, header text like the active thread title or `No active thread` could slide underneath the top-left window controls area.

This approach fixes that by reusing the existing sidebar open/collapsed state and applying the same safe-area inset already used by the desktop sidebar header. That keeps the fix small, predictable, and aligned with the current UI system without introducing a new store, IPC surface, or alternate layout path.

## UI Changes

Before:
- When the sidebar was collapsed on desktop, the active thread title and some header text could render underneath the macOS traffic lights / toggle area.

After:
- Header content stays clear of the top-left controls area when the sidebar is collapsed.
- Open-sidebar layout remains unchanged.
- The sidebar can be toggled via both the external header button and `Command+B` / `Ctrl+B`.

Before/after screenshots included.
Video included for the sidebar toggle interaction.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/input risk: changes global keyboard shortcut handling and Electron header layout, which could introduce shortcut conflicts or regressions in sidebar/drag-region spacing, but no security- or data-sensitive logic is touched.
> 
> **Overview**
> Adds a first-class `sidebar.toggle` command with default `mod+b`, updating contracts, server defaults, docs, and tests.
> 
> Introduces a reusable `SidebarToggleButton` (tooltip shows the shortcut label) and wires it into chat, index, and settings headers, while fixing the sidebar trigger icon logic to reflect open/closed state on both mobile and desktop.
> 
> Fixes an Electron-only layout regression by adjusting header left padding based on sidebar open state so header content doesn’t render under the collapsed-sidebar/traffic-lights area, and hardens terminal state persistence by using a safe `localStorage` fallback when storage APIs are unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc025219f91b533b4164391e3115c01f9d14c7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop header overlap by adding sidebar toggle button with keyboard shortcut support
> - Adds a new `SidebarToggleButton` component that wraps the existing trigger in a tooltip showing 'Toggle sidebar' and an optional shortcut label.
> - Binds `Mod+B` to `sidebar.toggle` in default keybindings and adds global keydown handling in chat routes to trigger the toggle.
> - Updates `ChatView`, `ChatHeader`, and settings/index route headers to use `SidebarToggleButton` and adjust padding based on sidebar open state, fixing the overlap when the sidebar is collapsed.
> - Removes the old `SidebarTrigger` from the sidebar header; toggle responsibility now lives in each consuming view.
> - Fixes `SidebarTrigger` icon to correctly reflect open/closed state on both mobile and desktop by deriving `isOpen` from `isMobile ? openMobile : open`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9dc0252.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->