### PR TITLE
Fix Ctrl keybinding in terminal on Windows

### DIFF
--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -439,11 +439,11 @@ describe("terminalNavigationShortcutData", () => {
   it("maps Ctrl+Arrow on non-macOS to word movement", () => {
     assert.strictEqual(
       terminalNavigationShortcutData(event({ key: "ArrowLeft", ctrlKey: true }), "Win32"),
-      "\u001bb",
+      "\u001b[1;5D",
     );
     assert.strictEqual(
       terminalNavigationShortcutData(event({ key: "ArrowRight", ctrlKey: true }), "Linux"),
-      "\u001bf",
+      "\u001b[1;5C",
     );
   });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -28,6 +28,8 @@ interface ShortcutMatchOptions {
 
 const TERMINAL_WORD_BACKWARD = "\u001bb";
 const TERMINAL_WORD_FORWARD = "\u001bf";
+const TERMINAL_WORD_BACKWARD_CTRL = "\u001b[1;5D";
+const TERMINAL_WORD_FORWARD_CTRL = "\u001b[1;5C";
 const TERMINAL_LINE_START = "\u0001";
 const TERMINAL_LINE_END = "\u0005";
 
@@ -269,8 +271,11 @@ export function terminalNavigationShortcutData(
     return null;
   }
 
-  const moveWord = key === "arrowleft" ? TERMINAL_WORD_BACKWARD : TERMINAL_WORD_FORWARD;
-  const moveLine = key === "arrowleft" ? TERMINAL_LINE_START : TERMINAL_LINE_END;
+  const moveWord =
+    key === "arrowleft" ? TERMINAL_WORD_BACKWARD : TERMINAL_WORD_FORWARD;
+  const moveLine =
+    key === "arrowleft" ? TERMINAL_LINE_START : TERMINAL_LINE_END;
+  const moveWordCtrl = key === "arrowleft" ? TERMINAL_WORD_BACKWARD_CTRL : TERMINAL_WORD_FORWARD_CTRL;
 
   if (isMacPlatform(platform)) {
     if (event.altKey && !event.metaKey && !event.ctrlKey) {
@@ -280,15 +285,12 @@ export function terminalNavigationShortcutData(
       return moveLine;
     }
     return null;
+  } else {
+    
+    if (event.ctrlKey && !event.metaKey && !event.altKey) {
+      return moveWordCtrl;
+    }
+    return null;
   }
-
-  if (event.ctrlKey && !event.metaKey && !event.altKey) {
-    return moveWord;
-  }
-
-  if (event.altKey && !event.metaKey && !event.ctrlKey) {
-    return moveWord;
-  }
-
-  return null;
+ 
 }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Changed `keybindings.ts` and its test to properly handle `ctrl + rightArrow`, `ctrl + leftArrow`.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->
Currently the terminal interprets `ctrl + right arrow` and `ctrl + left arrow` on Windows as `b` and `f`, rather than moving the caret to the next/previous word. This fixes that to no longer interpret the sequence as `b` and `f`

I assume that Linux keyboards would handle the terminal ctrl inputs in the same way

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->
### Before:

https://github.com/user-attachments/assets/bd5c5279-f9c4-4596-9654-596d4aef6535


https://github.com/user-attachments/assets/4c60b7e0-38e2-4282-8075-18f47a75b214


## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to terminal escape sequences for non-macOS Ctrl+Arrow navigation, covered by updated unit tests.
> 
> **Overview**
> Fixes non-macOS terminal word navigation so `Ctrl+ArrowLeft/Right` emits the expected control-modified arrow escape sequences (`\u001b[1;5D` / `\u001b[1;5C`) instead of `Alt`-style word jumps.
> 
> Updates `terminalNavigationShortcutData` to return the new sequences only for `Ctrl+Arrow` on Windows/Linux, and adjusts tests to assert the corrected output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30f0822944f8137b9988bfa7833040930f956595. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Ctrl+Arrow keybindings in terminal on Windows
> On non-macOS, `Ctrl+ArrowLeft/Right` now sends `\u001b[1;5D`/`\u001b[1;5C` (standard xterm control sequences for word movement) instead of the previously used `\u001bb`/`\u001bf` (which are Alt/Option-based sequences). `Alt+Arrow` on non-macOS no longer produces a word-move sequence and now returns null. macOS behavior (Option+Arrow for word, Cmd+Arrow for line) is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30f0822.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->