### PR TITLE
fix(claude): map TodoWrite updates to plan events

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1119,12 +1119,6 @@ describe("ClaudeAdapterLive", () => {
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
       const planUpdated = runtimeEvents.find((event) => event.type === "turn.plan.updated");
-      const toolCompleted = runtimeEvents.find(
-        (event) =>
-          event.type === "item.completed" &&
-          event.payload.itemType === "plan" &&
-          (event.payload.data as { toolName?: string } | undefined)?.toolName === "todowrite",
-      );
 
       assert.equal(planUpdated?.type, "turn.plan.updated");
       if (planUpdated?.type === "turn.plan.updated") {
@@ -1134,8 +1128,6 @@ describe("ClaudeAdapterLive", () => {
           { step: "Emit runtime plan update", status: "inProgress" },
         ]);
       }
-
-      assert.equal(toolCompleted?.type, "item.completed");
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1041,6 +1041,107 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("emits plan updates for TodoWrite tool results regardless of tool name casing", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 8).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "make a plan",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-todowrite",
+        uuid: "stream-todowrite-start",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "tool-todowrite-1",
+            name: "todowrite",
+            input: {
+              todos: [
+                {
+                  content: "Inspect provider events",
+                  status: "completed",
+                },
+                {
+                  content: "Emit runtime plan update",
+                  status: "in_progress",
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "user",
+        session_id: "sdk-session-todowrite",
+        uuid: "user-todowrite-result",
+        parent_tool_use_id: null,
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-todowrite-1",
+              content: "Plan updated",
+            },
+          ],
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-todowrite",
+        uuid: "result-todowrite",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const planUpdated = runtimeEvents.find((event) => event.type === "turn.plan.updated");
+      const toolCompleted = runtimeEvents.find(
+        (event) =>
+          event.type === "item.completed" &&
+          event.payload.itemType === "plan" &&
+          (event.payload.data as { toolName?: string } | undefined)?.toolName === "todowrite",
+      );
+
+      assert.equal(planUpdated?.type, "turn.plan.updated");
+      if (planUpdated?.type === "turn.plan.updated") {
+        assert.equal(String(planUpdated.turnId), String(turn.turnId));
+        assert.deepEqual(planUpdated.payload.plan, [
+          { step: "Inspect provider events", status: "completed" },
+          { step: "Emit runtime plan update", status: "inProgress" },
+        ]);
+      }
+
+      assert.equal(toolCompleted?.type, "item.completed");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("treats user-aborted Claude results as interrupted without a runtime error", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1788,7 +1788,11 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             result: toolResult.block,
           };
 
-          if (tool.toolName === "TodoWrite" && !toolResult.isError && context.turnState) {
+          if (
+            tool.toolName.toLowerCase() === "todowrite" &&
+            !toolResult.isError &&
+            context.turnState
+          ) {
             const steps = Array.isArray(tool.input["todos"]) ? tool.input["todos"] : [];
             const planStamp = yield* makeEventStamp();
             yield* offerRuntimeEvent({
@@ -1821,48 +1825,22 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 payload: message,
               },
             });
-            context.inFlightTools.delete(index);
-            continue;
-          }
-
-          const updatedStamp = yield* makeEventStamp();
-          yield* offerRuntimeEvent({
-            type: "item.updated",
-            eventId: updatedStamp.eventId,
-            provider: PROVIDER,
-            createdAt: updatedStamp.createdAt,
-            threadId: context.session.threadId,
-            ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
-            itemId: asRuntimeItemId(tool.itemId),
-            payload: {
-              itemType: tool.itemType,
-              status: toolResult.isError ? "failed" : "inProgress",
-              title: tool.title,
-              ...(tool.detail ? { detail: tool.detail } : {}),
-              data: toolData,
-            },
-            providerRefs: nativeProviderRefs(context, { providerItemId: tool.itemId }),
-            raw: {
-              source: "claude.sdk.message",
-              method: "claude/user",
-              payload: message,
-            },
-          });
-
-          const streamKind = toolResultStreamKind(tool.itemType);
-          if (streamKind && toolResult.text.length > 0 && context.turnState) {
-            const deltaStamp = yield* makeEventStamp();
+          } else {
+            const updatedStamp = yield* makeEventStamp();
             yield* offerRuntimeEvent({
-              type: "content.delta",
-              eventId: deltaStamp.eventId,
+              type: "item.updated",
+              eventId: updatedStamp.eventId,
               provider: PROVIDER,
-              createdAt: deltaStamp.createdAt,
+              createdAt: updatedStamp.createdAt,
               threadId: context.session.threadId,
-              turnId: context.turnState.turnId,
+              ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
               itemId: asRuntimeItemId(tool.itemId),
               payload: {
-                streamKind,
-                delta: toolResult.text,
+                itemType: tool.itemType,
+                status: toolResult.isError ? "failed" : "inProgress",
+                title: tool.title,
+                ...(tool.detail ? { detail: tool.detail } : {}),
+                data: toolData,
               },
               providerRefs: nativeProviderRefs(context, { providerItemId: tool.itemId }),
               raw: {
@@ -1871,6 +1849,30 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 payload: message,
               },
             });
+
+            const streamKind = toolResultStreamKind(tool.itemType);
+            if (streamKind && toolResult.text.length > 0 && context.turnState) {
+              const deltaStamp = yield* makeEventStamp();
+              yield* offerRuntimeEvent({
+                type: "content.delta",
+                eventId: deltaStamp.eventId,
+                provider: PROVIDER,
+                createdAt: deltaStamp.createdAt,
+                threadId: context.session.threadId,
+                turnId: context.turnState.turnId,
+                itemId: asRuntimeItemId(tool.itemId),
+                payload: {
+                  streamKind,
+                  delta: toolResult.text,
+                },
+                providerRefs: nativeProviderRefs(context, { providerItemId: tool.itemId }),
+                raw: {
+                  source: "claude.sdk.message",
+                  method: "claude/user",
+                  payload: message,
+                },
+              });
+            }
           }
 
           const completedStamp = yield* makeEventStamp();

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1789,7 +1789,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           };
 
           if (
-            tool.toolName.toLowerCase() === "todowrite" &&
+            tool.toolName.toLowerCase().includes("todowrite") &&
             !toolResult.isError &&
             context.turnState
           ) {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -406,9 +406,6 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
 
 function classifyToolItemType(toolName: string): CanonicalItemType {
   const normalized = toolName.toLowerCase();
-  if (normalized.includes("todowrite")) {
-    return "plan";
-  }
   if (normalized.includes("agent")) {
     return "collab_agent_tool_call";
   }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -406,6 +406,9 @@ function readClaudeResumeState(resumeCursor: unknown): ClaudeResumeState | undef
 
 function classifyToolItemType(toolName: string): CanonicalItemType {
   const normalized = toolName.toLowerCase();
+  if (normalized.includes("todowrite")) {
+    return "plan";
+  }
   if (normalized.includes("agent")) {
     return "collab_agent_tool_call";
   }
@@ -1784,6 +1787,43 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             input: tool.input,
             result: toolResult.block,
           };
+
+          if (tool.toolName === "TodoWrite" && !toolResult.isError && context.turnState) {
+            const steps = Array.isArray(tool.input["todos"]) ? tool.input["todos"] : [];
+            const planStamp = yield* makeEventStamp();
+            yield* offerRuntimeEvent({
+              type: "turn.plan.updated",
+              eventId: planStamp.eventId,
+              provider: PROVIDER,
+              createdAt: planStamp.createdAt,
+              threadId: context.session.threadId,
+              turnId: asCanonicalTurnId(context.turnState.turnId),
+              payload: {
+                plan: steps
+                  .filter(
+                    (entry): entry is Record<string, unknown> =>
+                      typeof entry === "object" && entry !== null,
+                  )
+                  .map((entry) => ({
+                    step: typeof entry.content === "string" ? entry.content : "step",
+                    status:
+                      entry.status === "completed"
+                        ? "completed"
+                        : entry.status === "in_progress"
+                          ? "inProgress"
+                          : "pending",
+                  })),
+              },
+              providerRefs: nativeProviderRefs(context, { providerItemId: tool.itemId }),
+              raw: {
+                source: "claude.sdk.message",
+                method: "claude/user",
+                payload: message,
+              },
+            });
+            context.inFlightTools.delete(index);
+            continue;
+          }
 
           const updatedStamp = yield* makeEventStamp();
           yield* offerRuntimeEvent({


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->
Maps successful Claude `TodoWrite` results to `turn.plan.updated` events so Claude todo updates flow through the existing plan event path.

Validated with `bun fmt`, `bun lint`, and `bun typecheck`.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->
Without this mapping, successful Claude `TodoWrite` updates do not flow through the existing plan event path, which can leave plan todos missing.

## UI Changes

Shows how TodoWrite was previously ignored by the plan sidebar panel vs now.

### Before:
![Before](https://github.com/user-attachments/assets/9b7dde1d-242a-40c7-a740-6954b192d6c9)

### After:
![After](https://github.com/user-attachments/assets/4666a89d-6586-436b-aaed-2cec2889f451)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime event stream for successful Claude `TodoWrite` tool results by emitting `turn.plan.updated` (and skipping prior `item.updated`/`content.delta` emissions), which may affect downstream consumers that relied on the old item update events.
> 
> **Overview**
> Successful Claude tool results whose `toolName` contains `todowrite` (case-insensitive) are now converted into `turn.plan.updated` events, with the plan derived from `tool.input.todos` and statuses normalized to `completed`/`inProgress`/`pending`.
> 
> Adds a regression test ensuring lowercase/variant `todowrite` tool names still produce the expected `turn.plan.updated` payload and `turnId` linkage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4bbd92c060c12dc6298d01460e0062918514a5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Map `TodoWrite` tool results to `turn.plan.updated` events in `ClaudeAdapter`
> - `classifyToolItemType` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/1387/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) now returns `'plan'` for any tool whose normalized name includes `'todowrite'`.
> - When a successful `todowrite` tool result is received, the adapter emits a `turn.plan.updated` event built from `tool.input.todos`, mapping each item to a `{step, status}` pair with status normalized to `completed`, `inProgress`, or `pending`.
> - The subsequent `item.completed` emission is preserved; the prior `item.updated`/`content.delta` sequence is skipped for `todowrite` tools.
> - Behavioral Change: `todowrite` tool results no longer emit `item.updated` or `content.delta` events.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4bbd92.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->