### PR TITLE
Preserve git action progress until HTTP completion

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -347,13 +347,16 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
           progress.lastOutputLine = null;
           break;
         case "action_finished":
-          progress.phaseStartedAtMs = null;
-          progress.hookStartedAtMs = null;
-          break;
+          // Don't clear timestamps here — the HTTP response handler (line 496)
+          // sets activeGitActionProgressRef to null and shows the success toast.
+          // Clearing timestamps early causes the "Running for Xs" description
+          // to disappear before the success state renders, leaving a bare
+          // "Pushing..." toast in the gap between the WS event and HTTP response.
+          return;
         case "action_failed":
-          progress.phaseStartedAtMs = null;
-          progress.hookStartedAtMs = null;
-          break;
+          // Same reasoning as action_finished — let the HTTP error handler
+          // manage the final toast state to avoid a flash of bare title.
+          return;
       }
 
       updateActiveProgressToast();


### PR DESCRIPTION
## Summary
- Keep git action toast progress visible after `action_finished` and `action_failed` WebSocket events.
- Defer clearing progress timestamps until the HTTP success/error handler updates the final toast state.
- Prevents a brief flash where the toast loses its elapsed-time text before completion is rendered.

## Testing
- Not run (PR description only).
- Verified the change is limited to `apps/web/src/components/GitActionsControl.tsx` and only adjusts toast state timing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts when toast progress timestamps are cleared; potential impact is limited to git action progress toast rendering timing.
> 
> **Overview**
> Prevents the git action progress toast from losing its elapsed-time description between `action_finished`/`action_failed` WebSocket events and the final HTTP success/error response.
> 
> This changes the progress event handler in `GitActionsControl.tsx` to *not* clear progress timestamps on WS completion events, deferring final toast state management to the HTTP handlers to avoid a brief “bare title” toast flash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 650c9c773b0526279072736495cebf62378c0a1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve git action progress display until HTTP response completes
> Previously, `action_finished` and `action_failed` WebSocket events in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/1388/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) immediately cleared timing fields and updated the loading toast, causing the running duration to disappear before the HTTP response arrived. Now both events return early without modifying state, leaving the HTTP response handler to finalize the toast and clear `activeGitActionProgressRef`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 650c9c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->