### PR TITLE
Add VS Code Insiders and VSCodium to Open In editor picker

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -34,6 +34,24 @@ describe("resolveEditorLaunch", () => {
         args: ["/tmp/workspace"],
       });
 
+      const vscodeInsidersLaunch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "vscode-insiders" },
+        "darwin",
+      );
+      assert.deepEqual(vscodeInsidersLaunch, {
+        command: "code-insiders",
+        args: ["/tmp/workspace"],
+      });
+
+      const vscodiumLaunch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "vscodium" },
+        "darwin",
+      );
+      assert.deepEqual(vscodiumLaunch, {
+        command: "codium",
+        args: ["/tmp/workspace"],
+      });
+
       const zedLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace", editor: "zed" },
         "darwin",
@@ -71,6 +89,24 @@ describe("resolveEditorLaunch", () => {
       );
       assert.deepEqual(vscodeLineAndColumn, {
         command: "code",
+        args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
+      });
+
+      const vscodeInsidersLineAndColumn = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "vscode-insiders" },
+        "darwin",
+      );
+      assert.deepEqual(vscodeInsidersLineAndColumn, {
+        command: "code-insiders",
+        args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
+      });
+
+      const vscodiumLineAndColumn = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "vscodium" },
+        "darwin",
+      );
+      assert.deepEqual(vscodiumLineAndColumn, {
+        command: "codium",
         args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
       });
 
@@ -208,13 +244,14 @@ describe("resolveAvailableEditors", () => {
   it("returns only editors whose launch commands are available", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-editors-"));
     try {
-      fs.writeFileSync(path.join(dir, "cursor.CMD"), "@echo off\r\n", "utf8");
+      fs.writeFileSync(path.join(dir, "code-insiders.CMD"), "@echo off\r\n", "utf8");
+      fs.writeFileSync(path.join(dir, "codium.CMD"), "@echo off\r\n", "utf8");
       fs.writeFileSync(path.join(dir, "explorer.EXE"), "MZ", "utf8");
       const editors = resolveAvailableEditors("win32", {
         PATH: dir,
         PATHEXT: ".COM;.EXE;.BAT;.CMD",
       });
-      assert.deepEqual(editors, ["cursor", "file-manager"]);
+      assert.deepEqual(editors, ["vscode-insiders", "vscodium", "file-manager"]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -39,10 +39,8 @@ interface CommandAvailabilityOptions {
 
 const LINE_COLUMN_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
 
-function shouldUseGotoFlag(editorId: EditorId, target: string): boolean {
-  return (
-    (editorId === "cursor" || editorId === "vscode") && LINE_COLUMN_SUFFIX_PATTERN.test(target)
-  );
+function shouldUseGotoFlag(editor: (typeof EDITORS)[number], target: string): boolean {
+  return editor.supportsGoto && LINE_COLUMN_SUFFIX_PATTERN.test(target);
 }
 
 function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
@@ -213,7 +211,7 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
   }
 
   if (editorDef.command) {
-    return shouldUseGotoFlag(editorDef.id, input.cwd)
+    return shouldUseGotoFlag(editorDef, input.cwd)
       ? { command: editorDef.command, args: ["--goto", input.cwd] }
       : { command: editorDef.command, args: [input.cwd] };
   }

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -298,6 +298,25 @@ function createDraftOnlySnapshot(): OrchestrationReadModel {
   };
 }
 
+function setDraftThreadWithoutWorktree(): void {
+  useComposerDraftStore.setState({
+    draftThreadsByThreadId: {
+      [THREAD_ID]: {
+        projectId: PROJECT_ID,
+        createdAt: NOW_ISO,
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: null,
+        worktreePath: null,
+        envMode: "local",
+      },
+    },
+    projectDraftThreadIdByProjectId: {
+      [PROJECT_ID]: THREAD_ID,
+    },
+  });
+}
+
 function createSnapshotWithLongProposedPlan(): OrchestrationReadModel {
   const snapshot = createSnapshotForTargetUser({
     targetMessageId: "msg-user-plan-target" as MessageId,
@@ -873,22 +892,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
   );
 
   it("opens the project cwd for draft threads without a worktree path", async () => {
-    useComposerDraftStore.setState({
-      draftThreadsByThreadId: {
-        [THREAD_ID]: {
-          projectId: PROJECT_ID,
-          createdAt: NOW_ISO,
-          runtimeMode: "full-access",
-          interactionMode: "default",
-          branch: null,
-          worktreePath: null,
-          envMode: "local",
-        },
-      },
-      projectDraftThreadIdByProjectId: {
-        [PROJECT_ID]: THREAD_ID,
-      },
-    });
+    setDraftThreadWithoutWorktree();
 
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
@@ -920,6 +924,153 @@ describe("ChatView timeline estimator parity (full app)", () => {
             _tag: WS_METHODS.shellOpenInEditor,
             cwd: "/repo/project",
             editor: "vscode",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("opens the project cwd with VS Code Insiders when it is the only available editor", async () => {
+    setDraftThreadWithoutWorktree();
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["vscode-insiders"],
+        };
+      },
+    });
+
+    try {
+      const openButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Open",
+          ) as HTMLButtonElement | null,
+        "Unable to find Open button.",
+      );
+      openButton.click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenInEditor,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenInEditor,
+            cwd: "/repo/project",
+            editor: "vscode-insiders",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("filters the open picker menu and opens VSCodium from the menu", async () => {
+    setDraftThreadWithoutWorktree();
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["vscode-insiders", "vscodium"],
+        };
+      },
+    });
+
+    try {
+      const menuButton = await waitForElement(
+        () => document.querySelector('button[aria-label="Copy options"]'),
+        "Unable to find Open picker button.",
+      );
+      (menuButton as HTMLButtonElement).click();
+
+      await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll('[data-slot="menu-item"]')).find((item) =>
+            item.textContent?.includes("VS Code Insiders"),
+          ) ?? null,
+        "Unable to find VS Code Insiders menu item.",
+      );
+
+      expect(
+        Array.from(document.querySelectorAll('[data-slot="menu-item"]')).some((item) =>
+          item.textContent?.includes("Zed"),
+        ),
+      ).toBe(false);
+
+      const vscodiumItem = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll('[data-slot="menu-item"]')).find((item) =>
+            item.textContent?.includes("VSCodium"),
+          ) ?? null,
+        "Unable to find VSCodium menu item.",
+      );
+      (vscodiumItem as HTMLElement).click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenInEditor,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenInEditor,
+            cwd: "/repo/project",
+            editor: "vscodium",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("falls back to the first installed editor when the stored favorite is unavailable", async () => {
+    localStorage.setItem("t3code:last-editor", "vscodium");
+    setDraftThreadWithoutWorktree();
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["vscode-insiders"],
+        };
+      },
+    });
+
+    try {
+      const openButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Open",
+          ) as HTMLButtonElement | null,
+        "Unable to find Open button.",
+      );
+      openButton.click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenInEditor,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenInEditor,
+            cwd: "/repo/project",
+            editor: "vscode-insiders",
           });
         },
         { timeout: 8_000, interval: 16 },

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -38,6 +38,16 @@ export const OpenInPicker = memo(function OpenInPicker({
         value: "vscode",
       },
       {
+        label: "VS Code Insiders",
+        Icon: VisualStudioCode,
+        value: "vscode-insiders",
+      },
+      {
+        label: "VSCodium",
+        Icon: VisualStudioCode,
+        value: "vscodium",
+      },
+      {
         label: "Zed",
         Icon: Zed,
         value: "zed",

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -2,10 +2,17 @@ import { Schema } from "effect";
 import { TrimmedNonEmptyString } from "./baseSchemas";
 
 export const EDITORS = [
-  { id: "cursor", label: "Cursor", command: "cursor" },
-  { id: "vscode", label: "VS Code", command: "code" },
-  { id: "zed", label: "Zed", command: "zed" },
-  { id: "file-manager", label: "File Manager", command: null },
+  { id: "cursor", label: "Cursor", command: "cursor", supportsGoto: true },
+  { id: "vscode", label: "VS Code", command: "code", supportsGoto: true },
+  {
+    id: "vscode-insiders",
+    label: "VS Code Insiders",
+    command: "code-insiders",
+    supportsGoto: true,
+  },
+  { id: "vscodium", label: "VSCodium", command: "codium", supportsGoto: true },
+  { id: "zed", label: "Zed", command: "zed", supportsGoto: false },
+  { id: "file-manager", label: "File Manager", command: null, supportsGoto: false },
 ] as const;
 
 export const EditorId = Schema.Literals(EDITORS.map((e) => e.id));


### PR DESCRIPTION
Adds `VS Code Insiders` and `VSCodium` to the existing Open In editor flow.
![open-picker-demo](https://github.com/user-attachments/assets/cea7f3bd-0170-44ad-adfa-6346cf445ed6)

What changed:
- extend shared editor contracts with `vscode-insiders` and `vscodium`
- use per-editor `supportsGoto` metadata so `--goto` works for both editors
- update the web Open menu to surface the new editors when installed
- add server and browser tests for availability detection, picker filtering, and open dispatch

Why:
- this follows the existing editor integration pattern instead of introducing a separate code path
- the change is scoped to the current Open In feature only
- behavior stays predictable: editors only appear when their CLI is available on `PATH`

Validation:
- `bun run test src/open.test.ts` in `apps/server`
- `bun run test:browser src/components/ChatView.browser.tsx` in `apps/web`
- `bun fmt`
- `bun lint`
- `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands the editor command surface and changes `--goto` flag selection logic, which could break editor launching if metadata or command names are wrong.
> 
> **Overview**
> Adds `vscode-insiders` and `vscodium` as first-class editor IDs in the shared `EDITORS` contract (with per-editor `supportsGoto` metadata).
> 
> Updates server-side open logic to decide `--goto` based on `supportsGoto` (instead of hardcoded editor IDs) and extends availability/launch tests to cover the new editors and Windows PATH detection.
> 
> Extends the web `OpenInPicker` menu to surface the new editors when installed, and adds browser tests covering picker filtering, open dispatch for draft threads, and fallback when a stored favorite editor is unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4879d259dac6ddda3cd87108db6b19c5e2cfa634. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add VS Code Insiders and VSCodium to the editor picker
> - Adds `vscode-insiders` and `vscodium` as selectable editors in [OpenInPicker.tsx](https://github.com/pingdotgg/t3code/pull/1389/files#diff-e2a98d212ae98eb3ec0902f11d6e8f0daeb2b1729c80a65a8792371f7605e802) and registers them in the [EDITORS constant](https://github.com/pingdotgg/t3code/pull/1389/files#diff-952d09e8dcc92b201e44f8f0b5edc71af952e9af9479b5853c41ce6e93d636f7) with their respective CLI commands (`code-insiders`, `codium`).
> - Introduces a `supportsGoto` boolean on each editor descriptor, replacing the hardcoded `cursor`/`vscode` id checks in `shouldUseGotoFlag` so any editor with `supportsGoto: true` receives the `--goto` flag for line/column targets.
> - Extends server-side availability detection and picker filtering to recognize `code-insiders.CMD` / `codium.CMD` on Windows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4879d25.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->