### PR TITLE
Fix websocket reconnect state timing

### DIFF
--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -253,4 +253,19 @@ describe("WsTransport", () => {
     await expect(requestPromise).rejects.toThrow("WebSocket connection closed.");
     transport.dispose();
   });
+
+  it("reports reconnecting as soon as a reconnect is scheduled", () => {
+    vi.useFakeTimers();
+    const transport = new WsTransport("ws://localhost:3020");
+    const socket = getSocket();
+    socket.open();
+
+    socket.close();
+
+    expect(transport.getState()).toBe("reconnecting");
+    expect(sockets).toHaveLength(1);
+
+    transport.dispose();
+    vi.useRealTimers();
+  });
 });

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -296,6 +296,7 @@ export class WsTransport {
       return;
     }
 
+    this.state = "reconnecting";
     const delay =
       RECONNECT_DELAYS_MS[Math.min(this.reconnectAttempt, RECONNECT_DELAYS_MS.length - 1)] ??
       RECONNECT_DELAYS_MS[0]!;


### PR DESCRIPTION
## What Changed

Updated the web socket transport to report `reconnecting` as soon as a reconnect attempt is scheduled, instead of waiting until the next socket attempt starts.

Added a regression test covering the backoff window after a socket close.

## Why

After a socket close, the transport scheduled a reconnect timer but kept reporting `closed` until the timer fired. That made the transport state inaccurate during reconnect backoff.

This keeps the state machine aligned with the actual retry lifecycle without changing transport behavior beyond the reported state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the reported `WsTransport` state during reconnect backoff and adds a regression test; no protocol, request handling, or retry timing behavior changes.
> 
> **Overview**
> Updates `WsTransport` to switch to `reconnecting` immediately when a reconnect timer is scheduled (instead of remaining `closed` until the next `connect()` call).
> 
> Adds a Vitest regression test using fake timers to assert the transport reports `reconnecting` right after a socket close and before the next WebSocket attempt is created.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63c72b9f0c61300f6e36fa3d908a5bf22fd6203a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `WsTransport` to report 'reconnecting' state immediately when reconnect is scheduled
> Previously, `WsTransport.getState()` would not return `'reconnecting'` until a later phase of the reconnect flow. Now `this.state` is set to `'reconnecting'` at the start of `scheduleReconnect()`, before the delay is calculated and the timeout is set. A new test in [wsTransport.test.ts](https://github.com/pingdotgg/t3code/pull/1391/files#diff-7c6ed9129e00d65af355f5c56dbbace125d2af92ee10372a5479c1907600adee) uses fake timers to assert the state is correct immediately after socket close.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 63c72b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->