### PR TITLE
Add VS Code Insiders and VSCodium to Open In editor picker

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -40,6 +40,24 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
         args: ["/tmp/workspace"],
       });
 
+      const vscodeInsidersLaunch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "vscode-insiders" },
+        "darwin",
+      );
+      assert.deepEqual(vscodeInsidersLaunch, {
+        command: "code-insiders",
+        args: ["/tmp/workspace"],
+      });
+
+      const vscodiumLaunch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "vscodium" },
+        "darwin",
+      );
+      assert.deepEqual(vscodiumLaunch, {
+        command: "codium",
+        args: ["/tmp/workspace"],
+      });
+
       const zedLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace", editor: "zed" },
         "darwin",
@@ -77,6 +95,24 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       );
       assert.deepEqual(vscodeLineAndColumn, {
         command: "code",
+        args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
+      });
+
+      const vscodeInsidersLineAndColumn = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "vscode-insiders" },
+        "darwin",
+      );
+      assert.deepEqual(vscodeInsidersLineAndColumn, {
+        command: "code-insiders",
+        args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
+      });
+
+      const vscodiumLineAndColumn = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "vscodium" },
+        "darwin",
+      );
+      assert.deepEqual(vscodiumLineAndColumn, {
+        command: "codium",
         args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
       });
 
@@ -220,13 +256,14 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
       const path = yield* Path.Path;
       const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-editors-" });
 
-      yield* fs.writeFileString(path.join(dir, "cursor.CMD"), "@echo off\r\n");
+      yield* fs.writeFileString(path.join(dir, "code-insiders.CMD"), "@echo off\r\n");
+      yield* fs.writeFileString(path.join(dir, "codium.CMD"), "@echo off\r\n");
       yield* fs.writeFileString(path.join(dir, "explorer.CMD"), "MZ");
       const editors = resolveAvailableEditors("win32", {
         PATH: dir,
         PATHEXT: ".COM;.EXE;.BAT;.CMD",
       });
-      assert.deepEqual(editors, ["cursor", "file-manager"]);
+      assert.deepEqual(editors, ["vscode-insiders", "vscodium", "file-manager"]);
     }),
   );
 });

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -39,10 +39,8 @@ interface CommandAvailabilityOptions {
 
 const LINE_COLUMN_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
 
-function shouldUseGotoFlag(editorId: EditorId, target: string): boolean {
-  return (
-    (editorId === "cursor" || editorId === "vscode") && LINE_COLUMN_SUFFIX_PATTERN.test(target)
-  );
+function shouldUseGotoFlag(editor: (typeof EDITORS)[number], target: string): boolean {
+  return editor.supportsGoto && LINE_COLUMN_SUFFIX_PATTERN.test(target);
 }
 
 function fileManagerCommandForPlatform(platform: NodeJS.Platform): string {
@@ -213,7 +211,7 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
   }
 
   if (editorDef.command) {
-    return shouldUseGotoFlag(editorDef.id, input.cwd)
+    return shouldUseGotoFlag(editorDef, input.cwd)
       ? { command: editorDef.command, args: ["--goto", input.cwd] }
       : { command: editorDef.command, args: [input.cwd] };
   }

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -356,6 +356,25 @@ function withProjectScripts(
   };
 }
 
+function setDraftThreadWithoutWorktree(): void {
+  useComposerDraftStore.setState({
+    draftThreadsByThreadId: {
+      [THREAD_ID]: {
+        projectId: PROJECT_ID,
+        createdAt: NOW_ISO,
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        branch: null,
+        worktreePath: null,
+        envMode: "local",
+      },
+    },
+    projectDraftThreadIdByProjectId: {
+      [PROJECT_ID]: THREAD_ID,
+    },
+  });
+}
+
 function createSnapshotWithLongProposedPlan(): OrchestrationReadModel {
   const snapshot = createSnapshotForTargetUser({
     targetMessageId: "msg-user-plan-target" as MessageId,
@@ -1011,22 +1030,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
   );
 
   it("opens the project cwd for draft threads without a worktree path", async () => {
-    useComposerDraftStore.setState({
-      draftThreadsByThreadId: {
-        [THREAD_ID]: {
-          projectId: PROJECT_ID,
-          createdAt: NOW_ISO,
-          runtimeMode: "full-access",
-          interactionMode: "default",
-          branch: null,
-          worktreePath: null,
-          envMode: "local",
-        },
-      },
-      projectDraftThreadIdByProjectId: {
-        [PROJECT_ID]: THREAD_ID,
-      },
-    });
+    setDraftThreadWithoutWorktree();
 
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
@@ -1058,6 +1062,153 @@ describe("ChatView timeline estimator parity (full app)", () => {
             _tag: WS_METHODS.shellOpenInEditor,
             cwd: "/repo/project",
             editor: "vscode",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("opens the project cwd with VS Code Insiders when it is the only available editor", async () => {
+    setDraftThreadWithoutWorktree();
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["vscode-insiders"],
+        };
+      },
+    });
+
+    try {
+      const openButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Open",
+          ) as HTMLButtonElement | null,
+        "Unable to find Open button.",
+      );
+      openButton.click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenInEditor,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenInEditor,
+            cwd: "/repo/project",
+            editor: "vscode-insiders",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("filters the open picker menu and opens VSCodium from the menu", async () => {
+    setDraftThreadWithoutWorktree();
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["vscode-insiders", "vscodium"],
+        };
+      },
+    });
+
+    try {
+      const menuButton = await waitForElement(
+        () => document.querySelector('button[aria-label="Copy options"]'),
+        "Unable to find Open picker button.",
+      );
+      (menuButton as HTMLButtonElement).click();
+
+      await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll('[data-slot="menu-item"]')).find((item) =>
+            item.textContent?.includes("VS Code Insiders"),
+          ) ?? null,
+        "Unable to find VS Code Insiders menu item.",
+      );
+
+      expect(
+        Array.from(document.querySelectorAll('[data-slot="menu-item"]')).some((item) =>
+          item.textContent?.includes("Zed"),
+        ),
+      ).toBe(false);
+
+      const vscodiumItem = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll('[data-slot="menu-item"]')).find((item) =>
+            item.textContent?.includes("VSCodium"),
+          ) ?? null,
+        "Unable to find VSCodium menu item.",
+      );
+      (vscodiumItem as HTMLElement).click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenInEditor,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenInEditor,
+            cwd: "/repo/project",
+            editor: "vscodium",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("falls back to the first installed editor when the stored favorite is unavailable", async () => {
+    localStorage.setItem("t3code:last-editor", "vscodium");
+    setDraftThreadWithoutWorktree();
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["vscode-insiders"],
+        };
+      },
+    });
+
+    try {
+      const openButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Open",
+          ) as HTMLButtonElement | null,
+        "Unable to find Open button.",
+      );
+      openButton.click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenInEditor,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenInEditor,
+            cwd: "/repo/project",
+            editor: "vscode-insiders",
           });
         },
         { timeout: 8_000, interval: 16 },

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -23,6 +23,16 @@ const resolveOptions = (platform: string, availableEditors: ReadonlyArray<Editor
       value: "vscode",
     },
     {
+      label: "VS Code Insiders",
+      Icon: VisualStudioCode,
+      value: "vscode-insiders",
+    },
+    {
+      label: "VSCodium",
+      Icon: VisualStudioCode,
+      value: "vscodium",
+    },
+    {
       label: "Zed",
       Icon: Zed,
       value: "zed",

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -2,11 +2,18 @@ import { Schema } from "effect";
 import { TrimmedNonEmptyString } from "./baseSchemas";
 
 export const EDITORS = [
-  { id: "cursor", label: "Cursor", command: "cursor" },
-  { id: "vscode", label: "VS Code", command: "code" },
-  { id: "zed", label: "Zed", command: "zed" },
-  { id: "antigravity", label: "Antigravity", command: "agy" },
-  { id: "file-manager", label: "File Manager", command: null },
+  { id: "cursor", label: "Cursor", command: "cursor", supportsGoto: true },
+  { id: "vscode", label: "VS Code", command: "code", supportsGoto: true },
+  {
+    id: "vscode-insiders",
+    label: "VS Code Insiders",
+    command: "code-insiders",
+    supportsGoto: true,
+  },
+  { id: "vscodium", label: "VSCodium", command: "codium", supportsGoto: true },
+  { id: "zed", label: "Zed", command: "zed", supportsGoto: false },
+  { id: "antigravity", label: "Antigravity", command: "agy", supportsGoto: false },
+  { id: "file-manager", label: "File Manager", command: null, supportsGoto: false },
 ] as const;
 
 export const EditorId = Schema.Literals(EDITORS.map((e) => e.id));


### PR DESCRIPTION
Adds `VS Code Insiders` and `VSCodium` to the existing Open In editor flow.
![open-picker-demo](https://github.com/user-attachments/assets/73e58638-ba3b-4bb8-b3b9-280680f232ae)

What changed:
- extend shared editor contracts with `vscode-insiders` and `vscodium`
- use per-editor `supportsGoto` metadata so `--goto` works for both editors
- update the web Open menu to surface the new editors when installed
- add server and browser tests for availability detection, picker filtering, and open dispatch

Why:
- this follows the existing editor integration pattern instead of introducing a separate code path
- the change is scoped to the current Open In feature only
- behavior stays predictable: editors only appear when their CLI is available on `PATH`

Validation:
- `bun run test src/open.test.ts` in `apps/server`
- `bun run test:browser src/components/ChatView.browser.tsx` in `apps/web`
- `bun fmt`
- `bun lint`
- `bun typecheck`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to editor picker/launch wiring and editor availability detection, with added test coverage; main risk is incorrect CLI mapping or `--goto` behavior for the new editors.
> 
> **Overview**
> Adds **VS Code Insiders** (`code-insiders`) and **VSCodium** (`codium`) as supported targets in the “Open in editor” flow, surfacing them in the web picker only when detected as installed.
> 
> Extends the shared `EDITORS` contract with per-editor `supportsGoto` metadata and updates server launch resolution to use it so line/column paths use `--goto` for all supporting editors. Updates/expands server + browser tests to cover availability detection, picker filtering, selection/fallback behavior, and open dispatch for the new editors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78661af7b09e0de65e50eb4a543113d9ee87ced4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add VS Code Insiders and VSCodium to the Open In editor picker
> - Adds `vscode-insiders` and `vscodium` editor definitions to [`packages/contracts/src/editor.ts`](https://github.com/pingdotgg/t3code/pull/1392/files#diff-952d09e8dcc92b201e44f8f0b5edc71af952e9af9479b5853c41ce6e93d636f7), each with `supportsGoto=true`, and exposes them in the picker in [`apps/web/src/components/chat/OpenInPicker.tsx`](https://github.com/pingdotgg/t3code/pull/1392/files#diff-e2a98d212ae98eb3ec0902f11d6e8f0daeb2b1729c80a65a8792371f7605e802).
> - Refactors `shouldUseGotoFlag` in [`apps/server/src/open.ts`](https://github.com/pingdotgg/t3code/pull/1392/files#diff-67f3655f84064d89de7cec58f5e8d2b9d406dd21986dcefc77c335e3036b65be) to accept a full editor definition object and use the `supportsGoto` flag, replacing the previous hardcoded check for `cursor` and `vscode`.
> - Adds a `supportsGoto` boolean to all existing editor definitions (`zed`, `antigravity`, and `file-manager` set to `false`).
> - Behavioral Change: `--goto` is now driven by `supportsGoto` on the editor definition rather than a hardcoded id list, so any future editor with `supportsGoto=true` will automatically get line/column support.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78661af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->