### PR TITLE
fix(web): reset send phase when latest turn settles

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2093,6 +2093,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
   ]);
 
   useEffect(() => {
+    if (sendPhase === "idle") {
+      return;
+    }
+    if (!latestTurnSettled) {
+      return;
+    }
+    resetSendPhase();
+  }, [latestTurnSettled, resetSendPhase, sendPhase]);
+
+  useEffect(() => {
     if (!activeThreadId) return;
     const previous = terminalOpenByThreadRef.current[activeThreadId] ?? false;
     const current = Boolean(terminalState.terminalOpen);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -57,6 +57,7 @@ import {
   deriveWorkLogEntries,
   hasActionableProposedPlan,
   hasToolActivityForTurn,
+  hasSettledLatestTurnAdvanced,
   isLatestTurnSettled,
   formatElapsed,
 } from "../session-logic";
@@ -2102,17 +2103,18 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (sendPhase === "idle") {
       return;
     }
-    if (!latestTurnSettled) {
-      return;
-    }
-
-    const latestTurnId = activeLatestTurn?.turnId ?? null;
-    if (latestTurnId === sendBaselineTurnIdRef.current) {
+    if (
+      !hasSettledLatestTurnAdvanced(
+        activeLatestTurn,
+        activeThread?.session ?? null,
+        sendBaselineTurnIdRef.current,
+      )
+    ) {
       return;
     }
 
     resetSendPhase();
-  }, [activeLatestTurn?.turnId, latestTurnSettled, resetSendPhase, sendPhase]);
+  }, [activeLatestTurn, activeThread?.session, resetSendPhase, sendPhase]);
 
   useEffect(() => {
     if (!activeThreadId) return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -388,6 +388,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewHandoffTimeoutByMessageIdRef = useRef<Record<string, number>>({});
   const sendInFlightRef = useRef(false);
+  const sendBaselineTurnIdRef = useRef<TurnId | null>(null);
   const dragDepthRef = useRef(0);
   const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
   const setMessagesScrollContainerRef = useCallback((element: HTMLDivElement | null) => {
@@ -2061,12 +2062,17 @@ export default function ChatView({ threadId }: ChatViewProps) {
     };
   }, [phase]);
 
-  const beginSendPhase = useCallback((nextPhase: Exclude<SendPhase, "idle">) => {
-    setSendStartedAt((current) => current ?? new Date().toISOString());
-    setSendPhase(nextPhase);
-  }, []);
+  const beginSendPhase = useCallback(
+    (nextPhase: Exclude<SendPhase, "idle">) => {
+      sendBaselineTurnIdRef.current = activeLatestTurn?.turnId ?? null;
+      setSendStartedAt((current) => current ?? new Date().toISOString());
+      setSendPhase(nextPhase);
+    },
+    [activeLatestTurn?.turnId],
+  );
 
   const resetSendPhase = useCallback(() => {
+    sendBaselineTurnIdRef.current = null;
     setSendPhase("idle");
     setSendStartedAt(null);
   }, []);
@@ -2099,8 +2105,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (!latestTurnSettled) {
       return;
     }
+
+    const latestTurnId = activeLatestTurn?.turnId ?? null;
+    if (latestTurnId === sendBaselineTurnIdRef.current) {
+      return;
+    }
+
     resetSendPhase();
-  }, [latestTurnSettled, resetSendPhase, sendPhase]);
+  }, [activeLatestTurn?.turnId, latestTurnSettled, resetSendPhase, sendPhase]);
 
   useEffect(() => {
     if (!activeThreadId) return;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2093,14 +2093,28 @@ export default function ChatView({ threadId }: ChatViewProps) {
   ]);
 
   useEffect(() => {
-    if (sendPhase === "idle") {
-      return;
-    }
-    if (!latestTurnSettled) {
-      return;
-    }
-    resetSendPhase();
-  }, [latestTurnSettled, resetSendPhase, sendPhase]);
+  if (sendPhase === "idle") {
+    return;
+  }
+  if (!latestTurnSettled) {
+    return;
+  }
+  if (!sendStartedAt || !activeLatestTurn?.completedAt) {
+    return;
+  }
+
+  const sendStartedAtMs = Date.parse(sendStartedAt);
+  const turnCompletedAtMs = Date.parse(activeLatestTurn.completedAt);
+  if (Number.isNaN(sendStartedAtMs) || Number.isNaN(turnCompletedAtMs)) {
+    return;
+  }
+  if (turnCompletedAtMs < sendStartedAtMs) {
+    return;
+  }
+
+  resetSendPhase();
+}, [activeLatestTurn?.completedAt, latestTurnSettled, resetSendPhase, sendPhase, sendStartedAt]);
+
 
   useEffect(() => {
     if (!activeThreadId) return;

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -139,6 +139,17 @@ export function isLatestTurnSettled(
   return true;
 }
 
+export function hasSettledLatestTurnAdvanced(
+  latestTurn: LatestTurnTiming | null,
+  session: SessionActivityState | null,
+  baselineTurnId: TurnId | null,
+): boolean {
+  if (!isLatestTurnSettled(latestTurn, session)) {
+    return false;
+  }
+  return (latestTurn?.turnId ?? null) !== baselineTurnId;
+}
+
 export function deriveActiveWorkStartedAt(
   latestTurn: LatestTurnTiming | null,
   session: SessionActivityState | null,


### PR DESCRIPTION
## Summary

This is a small, focused bug fix for a chat flow issue where the send button can remain in a loading state after the assistant has already finished responding.

The change is limited to `apps/web/src/components/ChatView.tsx`.

## Problem

In some chat sessions, a thread can finish rendering the assistant response, but the composer can still behave as if a send is in progress. In that state:

- the send button keeps spinning
- the user cannot send another message in the same thread
- navigating away from the thread and back clears the issue

This was first observed on Windows, but it is not Windows-exclusive and can also occur in the web build.

That suggests the local `ChatView` send state can remain stuck even after the turn has already settled.

## What changed

Added a small `useEffect` in `ChatView` that resets `sendPhase` back to `"idle"` whenever:

- `sendPhase` is still active
- `latestTurnSettled` becomes true

This keeps the local send state aligned with the actual turn lifecycle and avoids requiring a thread remount to recover.

## Why this should exist

`ChatView` already clears `sendPhase` for some intermediate states such as:

- thread entering `running`
- pending approval
- pending user input
- thread error

But it did not explicitly clear the local send state once the turn had fully settled. If that earlier transition is missed, the local spinner can stay stuck until the component unmounts/remounts.

This change closes that gap with a minimal, targeted fix.

## Before / After

Before:

![Before](https://github.com/user-attachments/assets/42264977-a901-4daf-8978-15ecdb6d69d4)


After:

![After](https://github.com/user-attachments/assets/15f68c48-ff2c-4ed4-bc55-472990c8527a)


## Manual test

1. Open a thread.
2. Send a message.
3. Wait for the assistant to fully finish.
4. Without leaving the thread, send another message immediately.

Expected result after this change:

- the send button stops spinning once the turn is settled
- the next message can be sent in the same thread without navigating away and back

## Scope

- single-file change
- no backend or protocol changes
- no unrelated cleanup



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state fix limited to `ChatView` send lifecycle; main risk is prematurely clearing the send spinner if turn IDs are mis-tracked.
> 
> **Overview**
> Prevents the chat composer send button from getting stuck in a loading state by **resetting `sendPhase` once a send results in a new, settled turn**.
> 
> `ChatView` now records a baseline `turnId` when sending begins and adds an effect to call `resetSendPhase()` when `isLatestTurnSettled` is true *and* the latest settled turn’s `turnId` differs from the baseline. `session-logic` adds `hasSettledLatestTurnAdvanced()` to encapsulate that check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b71f7b5b90b54c0da2f0ddb3c70d5243c31ef25c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset send phase in `ChatView` when the latest turn settles and advances
> - Adds a `sendBaselineTurnIdRef` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1393/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to record the active turn ID at the moment a send begins.
> - A new `useEffect` calls `resetSendPhase` automatically when `hasSettledLatestTurnAdvanced` returns true — i.e., the latest turn is settled and its ID has moved past the baseline.
> - Adds `hasSettledLatestTurnAdvanced` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/1393/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) as a small utility that combines `isLatestTurnSettled` with a turn ID advancement check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b71f7b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->