### PR TITLE
fix(web): prevent provider model submenu overlap

### DIFF
--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -71,6 +71,51 @@ describe("ProviderModelPicker", () => {
     }
   });
 
+  it("opens provider submenus with a visible gap from the parent menu", async () => {
+    const mounted = await mountPicker({
+      provider: "claudeAgent",
+      model: "claude-opus-4-6",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+      const providerTrigger = page.getByRole("menuitem", { name: "Codex" });
+      await providerTrigger.hover();
+
+      await vi.waitFor(() => {
+        expect(document.body.textContent ?? "").toContain("GPT-5 Codex");
+      });
+
+      const providerTriggerElement = Array.from(
+        document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+      ).find((element) => element.textContent?.includes("Codex"));
+      if (!providerTriggerElement) {
+        throw new Error("Expected the Codex provider trigger to be mounted.");
+      }
+
+      const providerTriggerRect = providerTriggerElement.getBoundingClientRect();
+      const modelElement = Array.from(
+        document.querySelectorAll<HTMLElement>('[role="menuitemradio"]'),
+      ).find((element) => element.textContent?.includes("GPT-5 Codex"));
+      if (!modelElement) {
+        throw new Error("Expected the submenu model option to be mounted.");
+      }
+
+      const submenuPopup = modelElement.closest('[data-slot="menu-sub-content"]');
+      if (!(submenuPopup instanceof HTMLElement)) {
+        throw new Error("Expected submenu popup to be mounted.");
+      }
+
+      const submenuRect = submenuPopup.getBoundingClientRect();
+
+      expect(submenuRect.left).toBeGreaterThanOrEqual(providerTriggerRect.right);
+      expect(submenuRect.left - providerTriggerRect.right).toBeGreaterThanOrEqual(2);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("shows models directly when the provider is locked mid-thread", async () => {
     const mounted = await mountPicker({
       provider: "claudeAgent",

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -153,7 +153,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
                     />
                     {option.label}
                   </MenuSubTrigger>
-                  <MenuSubPopup className="[--available-height:min(24rem,70vh)]">
+                  <MenuSubPopup className="[--available-height:min(24rem,70vh)]" sideOffset={4}>
                     <MenuGroup>
                       <MenuRadioGroup
                         value={props.provider === option.value ? props.model : ""}


### PR DESCRIPTION
## What Changed

- Adjusted provider submenu positioning so the model submenu opens adjacent to the parent provider list instead of overlapping it.
- Added a browser regression test covering submenu placement in the provider/model picker.

## Why

The provider/model selector could render its nested submenu on top of the parent menu, which made the control look visually broken and harder to scan.

This keeps the change small and targeted to submenu positioning only.

Fixes #1401 

## UI Changes

### Before:
<img width="680" height="390" alt="before" src="https://github.com/user-attachments/assets/1157a72e-c019-4ac6-8147-f523c90568ec" />

### After:
<img width="854" height="389" alt="after" src="https://github.com/user-attachments/assets/cd25d6b6-12ce-41ae-b37a-5de3fb07d248" />

### Hover interaction
![provider-submenu-hover](https://github.com/user-attachments/assets/2ef83a39-9533-42db-a11d-44bf8ca67f54)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix provider model submenu overlap by adding a side offset gap
> Adds `sideOffset={4}` to the `MenuSubPopup` in [ProviderModelPicker.tsx](https://github.com/pingdotgg/t3code/pull/1403/files#diff-01e915fe10bb55b513fb511c18383cd09199ea82c807cdf1fa405ba3261b0a40) so the submenu renders with a visible horizontal gap from the parent menu instead of overlapping it. A browser test is added to assert the submenu's left edge is at least 2px to the right of the trigger's right edge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2530b6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->