### PR TITLE
feat: dynamic slash command discovery in composer autocomplete

### DIFF
--- a/apps/server/src/slashCommandScanner.ts
+++ b/apps/server/src/slashCommandScanner.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { SlashCommandEntry, SlashCommandListResult } from "@t3tools/contracts";
+
+const CACHE_TTL_MS = 30_000;
+const cache = new Map<string, { result: SlashCommandListResult; scannedAt: number }>();
+
+/** Scan a commands/ directory for .md files (recurses into subdirectories). */
+async function scanCommandsDir(
+  dir: string,
+  source: "user" | "project",
+  prefix = "",
+): Promise<SlashCommandEntry[]> {
+  const entries: SlashCommandEntry[] = [];
+  let dirEntries;
+  try {
+    dirEntries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return entries;
+  }
+  for (const entry of dirEntries) {
+    if (entry.name.startsWith(".")) continue;
+    if (entry.isDirectory()) {
+      const nested = await scanCommandsDir(
+        path.join(dir, entry.name),
+        source,
+        prefix ? `${prefix}/${entry.name}` : entry.name,
+      );
+      entries.push(...nested);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      const name = prefix
+        ? `${prefix}/${entry.name.replace(/\.md$/, "")}`
+        : entry.name.replace(/\.md$/, "");
+
+      const description = await readFirstLine(path.join(dir, entry.name));
+      entries.push({ name, source, ...(description ? { description } : {}) });
+    }
+  }
+  return entries;
+}
+
+/** Scan a skills/ directory for subdirectories containing SKILL.md with YAML frontmatter. */
+async function scanSkillsDir(
+  dir: string,
+  source: "user" | "project",
+): Promise<SlashCommandEntry[]> {
+  const entries: SlashCommandEntry[] = [];
+  let dirEntries;
+  try {
+    dirEntries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return entries;
+  }
+  for (const entry of dirEntries) {
+    if (!entry.isDirectory() || entry.name.startsWith(".")) continue;
+    const skillMdPath = path.join(dir, entry.name, "SKILL.md");
+    try {
+      const content = await readHead(skillMdPath, 1024);
+      if (!content) continue;
+      const parsed = parseSkillFrontmatter(content);
+      if (!parsed) continue;
+      entries.push({
+        name: parsed.name,
+        source,
+        ...(parsed.description ? { description: parsed.description.slice(0, 120) } : {}),
+      });
+      // Skills can contain sub-skills as .md files alongside SKILL.md
+      const subFiles = await fs.readdir(path.join(dir, entry.name), { withFileTypes: true });
+      for (const sub of subFiles) {
+        if (!sub.isFile() || !sub.name.endsWith(".md") || sub.name === "SKILL.md") continue;
+        const subName = `${parsed.name}/${sub.name.replace(/\.md$/, "")}`;
+        const subDesc = await readFirstLine(path.join(dir, entry.name, sub.name));
+        entries.push({ name: subName, source, ...(subDesc ? { description: subDesc } : {}) });
+      }
+    } catch {
+      // Skip unreadable skills
+    }
+  }
+  return entries;
+}
+
+/** Read the first N bytes of a file, returning the string or undefined on error. */
+async function readHead(filePath: string, bytes: number): Promise<string | undefined> {
+  try {
+    const fh = await fs.open(filePath, "r");
+    try {
+      const buf = Buffer.alloc(bytes);
+      const { bytesRead } = await fh.read(buf, 0, bytes, 0);
+      return buf.toString("utf-8", 0, bytesRead);
+    } finally {
+      await fh.close();
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read the first non-empty, non-heading, non-template-variable line as a description. */
+async function readFirstLine(filePath: string): Promise<string | undefined> {
+  const head = await readHead(filePath, 256);
+  if (!head) return undefined;
+  const firstLine = head.split("\n")[0]?.trim();
+  if (firstLine && !firstLine.startsWith("$") && !firstLine.startsWith("#") && !firstLine.startsWith("---")) {
+    return firstLine.slice(0, 120);
+  }
+  return undefined;
+}
+
+/** Parse YAML frontmatter from a SKILL.md file to extract name and description. */
+function parseSkillFrontmatter(content: string): { name: string; description?: string } | null {
+  const fmMatch = /^---\s*\n([\s\S]*?)\n---/.exec(content);
+  if (!fmMatch) return null;
+  const fm = fmMatch[1] ?? "";
+  const nameMatch = /^name:\s*(.+)$/m.exec(fm);
+  if (!nameMatch) return null;
+  const name = nameMatch[1]?.trim().replace(/^["']|["']$/g, "");
+  if (!name) return null;
+  const descMatch = /^description:\s*(.+)$/m.exec(fm);
+  const description = descMatch?.[1]?.trim().replace(/^["']|["']$/g, "");
+  return { name, ...(description ? { description } : {}) };
+}
+
+/** Built-in Claude Code skills that are bundled inside the CLI binary. */
+const BUILTIN_CLAUDE_SKILLS: SlashCommandEntry[] = [
+  { name: "batch", source: "user", description: "Research and plan a large-scale change, then execute it in parallel across isolated worktree agents" },
+  { name: "claude-api", source: "user", description: "Build apps with the Claude API or Anthropic SDK" },
+  { name: "claude-in-chrome", source: "user", description: "Automate your Chrome browser to interact with web pages" },
+  { name: "debug", source: "user", description: "Enable debug logging for this session and help diagnose issues" },
+  { name: "loop", source: "user", description: "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo)" },
+  { name: "schedule", source: "user", description: "Create, update, list, or run scheduled remote agents on a cron schedule" },
+  { name: "simplify", source: "user", description: "Review changed code for reuse, quality, and efficiency, then fix any issues found" },
+];
+
+export async function listSlashCommands(cwd: string): Promise<SlashCommandListResult> {
+  const cached = cache.get(cwd);
+  if (cached && Date.now() - cached.scannedAt < CACHE_TTL_MS) {
+    return cached.result;
+  }
+
+  const homeDir = os.homedir();
+  const claudeDir = path.join(homeDir, ".claude");
+  const projectClaudeDir = path.join(cwd, ".claude");
+
+  const [userCommands, projectCommands, userSkills, projectSkills] = await Promise.all([
+    scanCommandsDir(path.join(claudeDir, "commands"), "user"),
+    scanCommandsDir(path.join(projectClaudeDir, "commands"), "project"),
+    scanSkillsDir(path.join(claudeDir, "skills"), "user"),
+    scanSkillsDir(path.join(projectClaudeDir, "skills"), "project"),
+  ]);
+
+  // Built-ins < user < project (later entries override earlier ones)
+  const byName = new Map<string, SlashCommandEntry>();
+  for (const cmd of BUILTIN_CLAUDE_SKILLS) byName.set(cmd.name, cmd);
+  for (const cmd of userCommands) byName.set(cmd.name, cmd);
+  for (const cmd of userSkills) byName.set(cmd.name, cmd);
+  for (const cmd of projectCommands) byName.set(cmd.name, cmd);
+  for (const cmd of projectSkills) byName.set(cmd.name, cmd);
+
+  const result: SlashCommandListResult = {
+    commands: Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name)),
+  };
+
+  cache.set(cwd, { result, scannedAt: Date.now() });
+  if (cache.size > 8) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+
+  return result;
+}

--- a/apps/server/src/wsServer.ts
+++ b/apps/server/src/wsServer.ts
@@ -49,6 +49,7 @@ import { createLogger } from "./logger";
 import { GitManager } from "./git/Services/GitManager.ts";
 import { TerminalManager } from "./terminal/Services/Manager.ts";
 import { Keybindings } from "./keybindings";
+import { listSlashCommands } from "./slashCommandScanner";
 import { searchWorkspaceEntries } from "./workspaceEntries";
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
@@ -780,6 +781,17 @@ export const createServer = Effect.fn(function* (): Effect.fn.Return<
           ),
         );
         return { relativePath: target.relativePath };
+      }
+
+      case WS_METHODS.projectsListCommands: {
+        const body = stripRequestTag(request.body);
+        return yield* Effect.tryPromise({
+          try: () => listSlashCommands(body.cwd),
+          catch: (cause) =>
+            new RouteRequestError({
+              message: `Failed to list slash commands: ${String(cause)}`,
+            }),
+        });
       }
 
       case WS_METHODS.shellOpenInEditor: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -32,7 +32,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { gitBranchesQueryOptions, gitCreateWorktreeMutationOptions } from "~/lib/gitReactQuery";
-import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
+import {
+  projectSearchEntriesQueryOptions,
+  projectSlashCommandsQueryOptions,
+} from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
 import { isElectron } from "../env";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
@@ -191,6 +194,8 @@ const IMAGE_ONLY_BOOTSTRAP_PROMPT =
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_KEYBINDINGS: ResolvedKeybindingsConfig = [];
 const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
+const EMPTY_CUSTOM_COMMANDS: readonly { name: string; source: string; description?: string }[] = [];
+const BUILTIN_COMMAND_NAMES = new Set(["model", "plan", "default"]);
 const EMPTY_AVAILABLE_EDITORS: EditorId[] = [];
 const EMPTY_PROVIDER_STATUSES: ServerProviderStatus[] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
@@ -1040,6 +1045,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }),
   );
   const workspaceEntries = workspaceEntriesQuery.data?.entries ?? EMPTY_PROJECT_ENTRIES;
+  const slashCommandsQuery = useQuery(
+    projectSlashCommandsQueryOptions(activeProject?.cwd ?? null),
+  );
+  const customCommands = slashCommandsQuery.data?.commands ?? EMPTY_CUSTOM_COMMANDS;
   const composerMenuItems = useMemo<ComposerCommandItem[]>(() => {
     if (!composerTrigger) return [];
     if (composerTrigger.kind === "path") {
@@ -1054,7 +1063,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
 
     if (composerTrigger.kind === "slash-command") {
-      const slashCommandItems = [
+      const builtInItems: Array<Extract<ComposerCommandItem, { type: "slash-command" }>> = [
         {
           id: "slash:model",
           type: "slash-command",
@@ -1076,13 +1085,25 @@ export default function ChatView({ threadId }: ChatViewProps) {
           label: "/default",
           description: "Switch this thread back to normal chat mode",
         },
-      ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
+      ];
+      const customItems: Array<Extract<ComposerCommandItem, { type: "slash-command" }>> =
+        customCommands
+          .filter((cmd) => !BUILTIN_COMMAND_NAMES.has(cmd.name))
+          .map((cmd) => ({
+            id: `slash:custom:${cmd.name}`,
+            type: "slash-command",
+            command: cmd.name,
+            label: `/${cmd.name}`,
+            description:
+              cmd.description ?? (cmd.source === "project" ? "Project command" : "User command"),
+          }));
+      const allItems = [...builtInItems, ...customItems];
       const query = composerTrigger.query.trim().toLowerCase();
       if (!query) {
-        return [...slashCommandItems];
+        return allItems;
       }
-      return slashCommandItems.filter(
-        (item) => item.command.includes(query) || item.label.slice(1).includes(query),
+      return allItems.filter(
+        (item) => item.command.toLowerCase().includes(query) || item.label.slice(1).toLowerCase().includes(query),
       );
     }
 
@@ -1102,7 +1123,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         label: name,
         description: `${providerLabel} · ${slug}`,
       }));
-  }, [composerTrigger, searchableModelOptions, workspaceEntries]);
+  }, [composerTrigger, searchableModelOptions, workspaceEntries, customCommands]);
   const composerMenuOpen = Boolean(composerTrigger);
   const activeComposerMenuItem = useMemo(
     () =>
@@ -3292,10 +3313,28 @@ export default function ChatView({ threadId }: ChatViewProps) {
           }
           return;
         }
-        void handleInteractionModeChange(item.command === "plan" ? "plan" : "default");
-        const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
-          expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
-        });
+        if (item.command === "plan" || item.command === "default") {
+          void handleInteractionModeChange(item.command === "plan" ? "plan" : "default");
+          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+            expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+          });
+          if (applied) {
+            setComposerHighlightedItemId(null);
+          }
+          return;
+        }
+        const replacement = `/${item.command} `;
+        const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+          snapshot.value,
+          trigger.rangeEnd,
+          replacement,
+        );
+        const applied = applyPromptReplacement(
+          trigger.rangeStart,
+          replacementRangeEnd,
+          replacement,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+        );
         if (applied) {
           setComposerHighlightedItemId(null);
         }

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -1,5 +1,5 @@
 import { type ProjectEntry, type ModelSlug, type ProviderKind } from "@t3tools/contracts";
-import { memo } from "react";
+import { memo, useEffect, useRef } from "react";
 import { type ComposerSlashCommand, type ComposerTriggerKind } from "../../composer-logic";
 import { BotIcon } from "lucide-react";
 import { cn } from "~/lib/utils";
@@ -82,8 +82,15 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
   isActive: boolean;
   onSelect: (item: ComposerCommandItem) => void;
 }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (props.isActive) {
+      ref.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [props.isActive]);
   return (
     <CommandItem
+      ref={ref}
       value={props.item.id}
       className={cn(
         "cursor-pointer select-none gap-2",

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -2,7 +2,7 @@ import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
 export type ComposerTriggerKind = "path" | "slash-command" | "slash-model";
-export type ComposerSlashCommand = "model" | "plan" | "default";
+export type ComposerSlashCommand = "model" | "plan" | "default" | (string & {});
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -11,7 +11,6 @@ export interface ComposerTrigger {
   rangeEnd: number;
 }
 
-const SLASH_COMMANDS: readonly ComposerSlashCommand[] = ["model", "plan", "default"];
 const isInlineTokenSegment = (
   segment: { type: "text"; text: string } | { type: "mention" } | { type: "terminal-context" },
 ): boolean => segment.type !== "text";
@@ -201,15 +200,12 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
           rangeEnd: cursor,
         };
       }
-      if (SLASH_COMMANDS.some((command) => command.startsWith(commandQuery.toLowerCase()))) {
-        return {
-          kind: "slash-command",
-          query: commandQuery,
-          rangeStart: lineStart,
-          rangeEnd: cursor,
-        };
-      }
-      return null;
+      return {
+        kind: "slash-command",
+        query: commandQuery,
+        rangeStart: lineStart,
+        rangeEnd: cursor,
+      };
     }
 
     const modelMatch = /^\/model(?:\s+(.*))?$/.exec(linePrefix);
@@ -239,7 +235,7 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
 
 export function parseStandaloneComposerSlashCommand(
   text: string,
-): Exclude<ComposerSlashCommand, "model"> | null {
+): "plan" | "default" | null {
   const match = /^\/(plan|default)\s*$/i.exec(text.trim());
   if (!match) {
     return null;

--- a/apps/web/src/lib/projectReactQuery.ts
+++ b/apps/web/src/lib/projectReactQuery.ts
@@ -1,4 +1,4 @@
-import type { ProjectSearchEntriesResult } from "@t3tools/contracts";
+import type { ProjectSearchEntriesResult, SlashCommandListResult } from "@t3tools/contracts";
 import { queryOptions } from "@tanstack/react-query";
 import { ensureNativeApi } from "~/nativeApi";
 
@@ -6,6 +6,7 @@ export const projectQueryKeys = {
   all: ["projects"] as const,
   searchEntries: (cwd: string | null, query: string, limit: number) =>
     ["projects", "search-entries", cwd, query, limit] as const,
+  slashCommands: (cwd: string | null) => ["projects", "slashCommands", cwd] as const,
 };
 
 const DEFAULT_SEARCH_ENTRIES_LIMIT = 80;
@@ -39,5 +40,23 @@ export function projectSearchEntriesQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.cwd !== null && input.query.length > 0,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_ENTRIES_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_ENTRIES_RESULT,
+  });
+}
+
+const EMPTY_SLASH_COMMANDS_RESULT: SlashCommandListResult = { commands: [] };
+
+export function projectSlashCommandsQueryOptions(cwd: string | null) {
+  return queryOptions({
+    queryKey: projectQueryKeys.slashCommands(cwd),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      if (!cwd) {
+        throw new Error("Slash command listing is unavailable.");
+      }
+      return api.projects.listCommands({ cwd });
+    },
+    enabled: cwd !== null,
+    staleTime: 30_000,
+    placeholderData: (previous) => previous ?? EMPTY_SLASH_COMMANDS_RESULT,
   });
 }

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -126,6 +126,7 @@ export function createWsNativeApi(): NativeApi {
     projects: {
       searchEntries: (input) => transport.request(WS_METHODS.projectsSearchEntries, input),
       writeFile: (input) => transport.request(WS_METHODS.projectsWriteFile, input),
+      listCommands: (input) => transport.request(WS_METHODS.projectsListCommands, input),
     },
     shell: {
       openInEditor: (cwd, editor) =>

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -24,6 +24,8 @@ import type {
   ProjectSearchEntriesResult,
   ProjectWriteFileInput,
   ProjectWriteFileResult,
+  SlashCommandListInput,
+  SlashCommandListResult,
 } from "./project";
 import type { ServerConfig } from "./server";
 import type {
@@ -129,6 +131,7 @@ export interface NativeApi {
   projects: {
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;
+    listCommands: (input: SlashCommandListInput) => Promise<SlashCommandListResult>;
   };
   shell: {
     openInEditor: (cwd: string, editor: EditorId) => Promise<void>;

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -37,3 +37,22 @@ export const ProjectWriteFileResult = Schema.Struct({
   relativePath: TrimmedNonEmptyString,
 });
 export type ProjectWriteFileResult = typeof ProjectWriteFileResult.Type;
+
+// ── Slash Command Discovery ─────────────────────────────────────────
+
+export const SlashCommandEntry = Schema.Struct({
+  name: TrimmedNonEmptyString,
+  source: Schema.Literals(["user", "project"]),
+  description: Schema.optional(TrimmedNonEmptyString),
+});
+export type SlashCommandEntry = typeof SlashCommandEntry.Type;
+
+export const SlashCommandListInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+});
+export type SlashCommandListInput = typeof SlashCommandListInput.Type;
+
+export const SlashCommandListResult = Schema.Struct({
+  commands: Schema.Array(SlashCommandEntry),
+});
+export type SlashCommandListResult = typeof SlashCommandListResult.Type;

--- a/packages/contracts/src/ws.ts
+++ b/packages/contracts/src/ws.ts
@@ -35,7 +35,7 @@ import {
   TerminalWriteInput,
 } from "./terminal";
 import { KeybindingRule } from "./keybindings";
-import { ProjectSearchEntriesInput, ProjectWriteFileInput } from "./project";
+import { ProjectSearchEntriesInput, ProjectWriteFileInput, SlashCommandListInput } from "./project";
 import { OpenInEditorInput } from "./editor";
 import { ServerConfigUpdatedPayload } from "./server";
 
@@ -48,6 +48,7 @@ export const WS_METHODS = {
   projectsRemove: "projects.remove",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
+  projectsListCommands: "projects.listCommands",
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
@@ -113,6 +114,7 @@ const WebSocketRequestBody = Schema.Union([
   // Project Search
   tagRequestBody(WS_METHODS.projectsSearchEntries, ProjectSearchEntriesInput),
   tagRequestBody(WS_METHODS.projectsWriteFile, ProjectWriteFileInput),
+  tagRequestBody(WS_METHODS.projectsListCommands, SlashCommandListInput),
 
   // Shell methods
   tagRequestBody(WS_METHODS.shellOpenInEditor, OpenInEditorInput),


### PR DESCRIPTION
## Summary

- Custom slash commands and skills now appear in the composer `/` autocomplete
- Scans `~/.claude/commands/`, `~/.claude/skills/`, and project-level equivalents
- Includes hardcoded built-in Claude Code skills (`/simplify`, `/batch`, `/loop`, etc.)
- Fixes arrow-key scrolling in the command menu

## Why

The composer autocomplete was hardcoded to 3 commands (`/model`, `/plan`, `/default`). Custom commands from `.claude/commands/` worked when typed as plain text but weren't discoverable. This makes them visible and selectable.

## What changed

| Area | Change |
|------|--------|
| `packages/contracts/` | `SlashCommandEntry` schema, `projects.listCommands` WS method |
| `apps/server/src/slashCommandScanner.ts` | New file — scans commands/ and skills/ directories with 30s cache |
| `apps/server/src/wsServer.ts` | Route handler for new method |
| `apps/web/src/composer-logic.ts` | `/` trigger now matches any command, not just 3 hardcoded ones |
| `apps/web/src/components/ChatView.tsx` | Fetches + merges custom commands into autocomplete menu |
| `apps/web/src/components/chat/ComposerCommandMenu.tsx` | `scrollIntoView` on highlighted item |

## Before / After

**Before:** Typing `/` shows only `/model`, `/plan`, `/default`
**After:** Typing `/` shows all custom commands, installed skills, and built-in Claude Code skills

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new WebSocket RPC and server-side filesystem scanning of user/project `.claude` directories to power composer autocomplete, which could affect performance or expose unexpected command names if path handling is wrong. UI behavior changes in the composer selection flow and menu navigation, but no auth or persistent data writes are introduced.
> 
> **Overview**
> Adds *dynamic slash command discovery* so the composer `/` autocomplete can show custom commands and skills, not just hardcoded entries.
> 
> The server now implements `projects.listCommands` via a new `slashCommandScanner` that scans user and project `.claude/commands` (markdown files) and `.claude/skills` (`SKILL.md` frontmatter + sub-files), merges them with a small built-in list, and caches results briefly.
> 
> The web app fetches these commands via a new React Query hook / native WS API method, merges them into the composer menu (keeping `/model`, `/plan`, `/default` special-cased), loosens trigger parsing to allow arbitrary slash commands, and fixes keyboard navigation scrolling by auto-scrolling the active menu item into view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 874aaf9c2a7d820c25226b9ed7ce6b7415e97966. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dynamic slash command discovery to composer autocomplete
> - Introduces [slashCommandScanner.ts](https://github.com/pingdotgg/t3code/pull/1412/files#diff-cc5e60b3ee44f238d7d7d50748e2dc5e2ab03a2531f4af797726d244703cc03c) that scans `~/.claude` and `./.claude` directories for `commands/*.md` and `skills/*/SKILL.md` files, building a sorted, deduplicated command list with a 30s TTL cache per `cwd`.
> - Adds a `projects.listCommands` WebSocket endpoint in [wsServer.ts](https://github.com/pingdotgg/t3code/pull/1412/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) and exposes it via `api.projects.listCommands` in [wsNativeApi.ts](https://github.com/pingdotgg/t3code/pull/1412/files#diff-eae2e1e3878c14b7af9318605dd9eed50d08123751d3748fb1feadf12daa30f4).
> - Updates the composer in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1412/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to fetch and display project/user-defined commands alongside built-ins when typing `/`; selecting a custom command inserts `/<name> ` into the prompt.
> - Extends trigger detection in [composer-logic.ts](https://github.com/pingdotgg/t3code/pull/1412/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6) so any `/<text>` input opens the slash-command menu, not just known commands; only `/plan` and `/default` retain mode-switching behavior.
> - Adds auto-scroll to the active item in [ComposerCommandMenu.tsx](https://github.com/pingdotgg/t3code/pull/1412/files#diff-ca7de5ada90d0c74157405378c7182002eab97a1ea23cd71e4376f8db6ba81a4) when navigating the list.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 874aaf9. 10 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->