### PR TITLE
feat: add Claude Code skills and slash command support

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -48,6 +48,7 @@ import {
   parseThreadSegmentFromAttachmentId,
   toSafeThreadAttachmentSegment,
 } from "../../attachmentStore.ts";
+import { legacySubThreadCreatedToThreadCreated } from "../legacyThreadEvents.ts";
 
 export const ORCHESTRATION_PROJECTOR_NAMES = {
   projects: "projection.projects",
@@ -432,6 +433,34 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
           });
           return;
 
+        case "thread.sub-thread-created": {
+          const parentRow = yield* projectionThreadRepository.getById({
+            threadId: event.payload.threadId,
+          });
+          if (Option.isNone(parentRow)) {
+            return;
+          }
+          const payload = legacySubThreadCreatedToThreadCreated({
+            parentProjectId: parentRow.value.projectId,
+            payload: event.payload,
+          });
+          yield* projectionThreadRepository.upsert({
+            threadId: payload.threadId,
+            projectId: payload.projectId,
+            title: payload.title,
+            model: payload.model,
+            runtimeMode: payload.runtimeMode,
+            interactionMode: payload.interactionMode,
+            branch: payload.branch,
+            worktreePath: payload.worktreePath,
+            latestTurnId: null,
+            createdAt: payload.createdAt,
+            updatedAt: payload.updatedAt,
+            deletedAt: null,
+          });
+          return;
+        }
+
         case "thread.meta-updated": {
           const existingRow = yield* projectionThreadRepository.getById({
             threadId: event.payload.threadId,
@@ -765,6 +794,7 @@ const makeOrchestrationProjectionPipeline = Effect.gen(function* () {
         runtimeMode: event.payload.session.runtimeMode,
         activeTurnId: event.payload.session.activeTurnId,
         lastError: event.payload.session.lastError,
+        providerRuntimeInfo: event.payload.session.providerRuntimeInfo ?? null,
         updatedAt: event.payload.session.updatedAt,
       });
     });

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -158,17 +158,19 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           runtime_mode,
           active_turn_id,
           last_error,
+          provider_runtime_info_json,
           updated_at
         )
         VALUES (
           'thread-1',
           'running',
-          'codex',
+          'claudeAgent',
           'provider-session-1',
           'provider-thread-1',
           'approval-required',
           'turn-1',
           NULL,
+          '{"claudeAgent":{"slashCommands":["/plan","/review"],"skills":["project-audit"],"tools":["Skill","Bash"],"plugins":["filesystem"],"claudeCodeVersion":"1.2.3","cwd":"/tmp/project-1","settingSources":["user","project","local"]}}',
           '2026-02-24T00:00:07.000Z'
         )
       `;
@@ -327,10 +329,21 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           session: {
             threadId: ThreadId.makeUnsafe("thread-1"),
             status: "running",
-            providerName: "codex",
+            providerName: "claudeAgent",
             runtimeMode: "approval-required",
             activeTurnId: asTurnId("turn-1"),
             lastError: null,
+            providerRuntimeInfo: {
+              claudeAgent: {
+                slashCommands: ["/plan", "/review"],
+                skills: ["project-audit"],
+                tools: ["Skill", "Bash"],
+                plugins: ["filesystem"],
+                claudeCodeVersion: "1.2.3",
+                cwd: "/tmp/project-1",
+                settingSources: ["user", "project", "local"],
+              },
+            },
             updatedAt: "2026-02-24T00:00:07.000Z",
           },
         },

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -31,11 +31,11 @@ import {
 } from "../../persistence/Errors.ts";
 import { ProjectionCheckpoint } from "../../persistence/Services/ProjectionCheckpoints.ts";
 import { ProjectionProject } from "../../persistence/Services/ProjectionProjects.ts";
+import { ProjectionThreadSessionDbRowSchema } from "../../persistence/Schemas/ProjectionThreadSessions.ts";
 import { ProjectionState } from "../../persistence/Services/ProjectionState.ts";
 import { ProjectionThreadActivity } from "../../persistence/Services/ProjectionThreadActivities.ts";
 import { ProjectionThreadMessage } from "../../persistence/Services/ProjectionThreadMessages.ts";
 import { ProjectionThreadProposedPlan } from "../../persistence/Services/ProjectionThreadProposedPlans.ts";
-import { ProjectionThreadSession } from "../../persistence/Services/ProjectionThreadSessions.ts";
 import { ProjectionThread } from "../../persistence/Services/ProjectionThreads.ts";
 import { ORCHESTRATION_PROJECTOR_NAMES } from "./ProjectionPipeline.ts";
 import {
@@ -68,7 +68,6 @@ const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
     sequence: Schema.NullOr(NonNegativeInt),
   }),
 );
-const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession;
 const ProjectionCheckpointDbRowSchema = ProjectionCheckpoint.mapFields(
   Struct.assign({
     files: Schema.fromJsonString(Schema.Array(OrchestrationCheckpointFile)),
@@ -253,11 +252,10 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           thread_id AS "threadId",
           status,
           provider_name AS "providerName",
-          provider_session_id AS "providerSessionId",
-          provider_thread_id AS "providerThreadId",
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          provider_runtime_info_json AS "providerRuntimeInfo",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         ORDER BY thread_id ASC
@@ -488,6 +486,22 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             checkpointsByThread.set(row.threadId, threadCheckpoints);
           }
 
+          for (const row of sessionRows) {
+            updatedAt = maxIso(updatedAt, row.updatedAt);
+            sessionsByThread.set(row.threadId, {
+              threadId: row.threadId,
+              status: row.status,
+              providerName: row.providerName,
+              runtimeMode: row.runtimeMode,
+              activeTurnId: row.activeTurnId,
+              lastError: row.lastError,
+              ...(row.providerRuntimeInfo !== null
+                ? { providerRuntimeInfo: row.providerRuntimeInfo }
+                : {}),
+              updatedAt: row.updatedAt,
+            });
+          }
+
           for (const row of latestTurnRows) {
             updatedAt = maxIso(updatedAt, row.requestedAt);
             if (row.startedAt !== null) {
@@ -521,19 +535,6 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                     },
                   }
                 : {}),
-            });
-          }
-
-          for (const row of sessionRows) {
-            updatedAt = maxIso(updatedAt, row.updatedAt);
-            sessionsByThread.set(row.threadId, {
-              threadId: row.threadId,
-              status: row.status,
-              providerName: row.providerName,
-              runtimeMode: row.runtimeMode,
-              activeTurnId: row.activeTurnId,
-              lastError: row.lastError,
-              updatedAt: row.updatedAt,
             });
           }
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -726,6 +726,74 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("restarts claude sessions when claude setting sources change", async () => {
+    const harness = await createHarness({ threadModelSelection: { provider: "claudeAgent", model: "claude-sonnet-4-6" } });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-claude-setting-sources-1"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-claude-setting-sources-1"),
+          role: "user",
+          text: "first claude turn",
+          attachments: [],
+        },
+        provider: "claudeAgent",
+        model: "claude-sonnet-4-6",
+        providerOptions: {
+          claudeAgent: {
+            settingSources: ["user", "project", "local"],
+          },
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-turn-start-claude-setting-sources-2"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-claude-setting-sources-2"),
+          role: "user",
+          text: "second claude turn",
+          attachments: [],
+        },
+        provider: "claudeAgent",
+        model: "claude-sonnet-4-6",
+        providerOptions: {
+          claudeAgent: {
+            settingSources: ["project"],
+          },
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      provider: "claudeAgent",
+      resumeCursor: { opaque: "resume-1" },
+      providerOptions: {
+        claudeAgent: {
+          settingSources: ["project"],
+        },
+      },
+    });
+  });
+
   it("restarts the provider session when runtime mode is updated on the thread", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -15,6 +15,7 @@ import {
 } from "@t3tools/contracts";
 import { Cache, Cause, Duration, Effect, Equal, Layer, Option, Schema, Stream } from "effect";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { normalizeClaudeSettingSources } from "@t3tools/shared/claude";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
@@ -74,6 +75,30 @@ const HANDLED_TURN_START_KEY_TTL = Duration.minutes(30);
 const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
 const WORKTREE_BRANCH_PREFIX = "t3code";
 const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(`^${WORKTREE_BRANCH_PREFIX}\\/[0-9a-f]{8}$`);
+
+function normalizeClaudeProviderStartOptions(
+  input: ProviderStartOptions["claudeAgent"] | undefined,
+): Record<string, unknown> {
+  return {
+    ...(input?.binaryPath !== undefined ? { binaryPath: input.binaryPath } : {}),
+    ...(input?.permissionMode !== undefined ? { permissionMode: input.permissionMode } : {}),
+    ...(input?.maxThinkingTokens !== undefined
+      ? { maxThinkingTokens: input.maxThinkingTokens }
+      : {}),
+    settingSources: normalizeClaudeSettingSources(input?.settingSources),
+  };
+}
+
+function sameClaudeProviderOptions(
+  left: ProviderStartOptions | undefined,
+  right: ProviderStartOptions | undefined,
+): boolean {
+  return (
+    JSON.stringify(normalizeClaudeProviderStartOptions(left?.claudeAgent)) ===
+    JSON.stringify(normalizeClaudeProviderStartOptions(right?.claudeAgent))
+  );
+}
+
 
 function isUnknownPendingApprovalRequestError(cause: Cause.Cause<ProviderServiceError>): boolean {
   const error = Cause.squash(cause);
@@ -302,12 +327,18 @@ const make = Effect.gen(function* () {
         currentProvider === "claudeAgent" &&
         requestedModelSelection !== undefined &&
         !Equal.equals(previousModelSelection, requestedModelSelection);
+      const previousProviderOptions = threadProviderOptions.get(threadId);
+      const shouldRestartForProviderOptionsChange =
+        currentProvider === "claudeAgent" &&
+        options?.providerOptions !== undefined &&
+        !sameClaudeProviderOptions(previousProviderOptions, options.providerOptions);
 
       if (
         !runtimeModeChanged &&
         !providerChanged &&
         !shouldRestartForModelChange &&
-        !shouldRestartForModelSelectionChange
+        !shouldRestartForModelSelectionChange &&
+        !shouldRestartForProviderOptionsChange
       ) {
         return existingSessionThreadId;
       }
@@ -328,6 +359,7 @@ const make = Effect.gen(function* () {
         modelChanged,
         shouldRestartForModelChange,
         shouldRestartForModelSelectionChange,
+        shouldRestartForProviderOptionsChange,
         hasResumeCursor: resumeCursor !== undefined,
       });
       const restartedSession = yield* startProviderSession(
@@ -669,6 +701,9 @@ const make = Effect.gen(function* () {
         runtimeMode: thread.session?.runtimeMode ?? DEFAULT_RUNTIME_MODE,
         activeTurnId: null,
         lastError: thread.session?.lastError ?? null,
+        ...(thread.session?.providerRuntimeInfo !== undefined
+          ? { providerRuntimeInfo: thread.session.providerRuntimeInfo }
+          : {}),
         updatedAt: now,
       },
       createdAt: now,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -288,6 +288,51 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it("persists provider runtime info from session.configured events", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "session.configured",
+      eventId: asEventId("evt-session-configured"),
+      provider: "claudeAgent",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      payload: {
+        config: {
+          providerRuntimeInfo: {
+            claudeAgent: {
+              slashCommands: ["/plan", "/review"],
+              skills: ["project-audit"],
+              tools: ["Skill", "Bash"],
+              plugins: ["filesystem"],
+              claudeCodeVersion: "1.2.3",
+              cwd: "/tmp/workspace",
+              settingSources: ["user", "project", "local"],
+            },
+          },
+        },
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      Boolean(entry.session?.providerRuntimeInfo?.claudeAgent),
+    );
+
+    expect(thread.session?.providerName).toBe("claudeAgent");
+    expect(thread.session?.providerRuntimeInfo).toEqual({
+      claudeAgent: {
+        slashCommands: ["/plan", "/review"],
+        skills: ["project-audit"],
+        tools: ["Skill", "Bash"],
+        plugins: ["filesystem"],
+        claudeCodeVersion: "1.2.3",
+        cwd: "/tmp/workspace",
+        settingSources: ["user", "project", "local"],
+      },
+    });
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -7,13 +7,14 @@ import {
   type OrchestrationProposedPlanId,
   CheckpointRef,
   isToolLifecycleItemType,
+  ProviderRuntimeInfo,
   ThreadId,
   type ThreadTokenUsageSnapshot,
   TurnId,
   type OrchestrationThreadActivity,
   type ProviderRuntimeEvent,
 } from "@t3tools/contracts";
-import { Cache, Cause, Duration, Effect, Layer, Option, Ref, Stream } from "effect";
+import { Cache, Cause, Duration, Effect, Layer, Option, Ref, Schema, Stream } from "effect";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
@@ -117,6 +118,28 @@ function runtimePayloadRecord(event: ProviderRuntimeEvent): Record<string, unkno
     return undefined;
   }
   return payload as Record<string, unknown>;
+}
+
+const decodeProviderRuntimeInfo = Schema.decodeUnknownSync(ProviderRuntimeInfo);
+
+function providerRuntimeInfoFromConfiguredEvent(
+  event: Extract<ProviderRuntimeEvent, { type: "session.configured" }>,
+): ProviderRuntimeInfo | undefined {
+  const config = runtimePayloadRecord(event)?.config;
+  if (!config || typeof config !== "object") {
+    return undefined;
+  }
+
+  const providerRuntimeInfo = (config as Record<string, unknown>).providerRuntimeInfo;
+  if (!providerRuntimeInfo || typeof providerRuntimeInfo !== "object") {
+    return undefined;
+  }
+
+  try {
+    return decodeProviderRuntimeInfo(providerRuntimeInfo);
+  } catch {
+    return undefined;
+  }
 }
 
 function normalizeRuntimeTurnState(
@@ -953,6 +976,28 @@ const make = Effect.gen(function* () {
           ? yield* getSourceProposedPlanReferenceForAcceptedTurnStart(thread.id, eventTurnId)
           : null;
 
+      if (event.type === "session.configured") {
+        const providerRuntimeInfo = providerRuntimeInfoFromConfiguredEvent(event);
+        if (providerRuntimeInfo) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.session.set",
+            commandId: providerCommandId(event, "thread-session-configured"),
+            threadId: thread.id,
+            session: {
+              threadId: thread.id,
+              status: thread.session?.status ?? "ready",
+              providerName: event.provider,
+              runtimeMode: thread.session?.runtimeMode ?? "full-access",
+              activeTurnId: thread.session?.activeTurnId ?? null,
+              lastError: thread.session?.lastError ?? null,
+              providerRuntimeInfo,
+              updatedAt: now,
+            },
+            createdAt: now,
+          });
+        }
+      }
+
       if (
         event.type === "session.started" ||
         event.type === "session.state.changed" ||
@@ -1025,6 +1070,9 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: nextActiveTurnId,
               lastError,
+              ...(thread.session?.providerRuntimeInfo !== undefined
+                ? { providerRuntimeInfo: thread.session.providerRuntimeInfo }
+                : {}),
               updatedAt: now,
             },
             createdAt: now,
@@ -1194,6 +1242,9 @@ const make = Effect.gen(function* () {
               runtimeMode: thread.session?.runtimeMode ?? "full-access",
               activeTurnId: eventTurnId ?? null,
               lastError: runtimeErrorMessage,
+              ...(thread.session?.providerRuntimeInfo !== undefined
+                ? { providerRuntimeInfo: thread.session.providerRuntimeInfo }
+                : {}),
               updatedAt: now,
             },
             createdAt: now,

--- a/apps/server/src/orchestration/Schemas.ts
+++ b/apps/server/src/orchestration/Schemas.ts
@@ -3,6 +3,7 @@ import {
   ProjectMetaUpdatedPayload as ContractsProjectMetaUpdatedPayloadSchema,
   ProjectDeletedPayload as ContractsProjectDeletedPayloadSchema,
   ThreadCreatedPayload as ContractsThreadCreatedPayloadSchema,
+  ThreadSubThreadCreatedPayload as ContractsThreadSubThreadCreatedPayloadSchema,
   ThreadMetaUpdatedPayload as ContractsThreadMetaUpdatedPayloadSchema,
   ThreadRuntimeModeSetPayload as ContractsThreadRuntimeModeSetPayloadSchema,
   ThreadInteractionModeSetPayload as ContractsThreadInteractionModeSetPayloadSchema,
@@ -26,6 +27,7 @@ export const ProjectMetaUpdatedPayload = ContractsProjectMetaUpdatedPayloadSchem
 export const ProjectDeletedPayload = ContractsProjectDeletedPayloadSchema;
 
 export const ThreadCreatedPayload = ContractsThreadCreatedPayloadSchema;
+export const ThreadSubThreadCreatedPayload = ContractsThreadSubThreadCreatedPayloadSchema;
 export const ThreadMetaUpdatedPayload = ContractsThreadMetaUpdatedPayloadSchema;
 export const ThreadRuntimeModeSetPayload = ContractsThreadRuntimeModeSetPayloadSchema;
 export const ThreadInteractionModeSetPayload = ContractsThreadInteractionModeSetPayloadSchema;

--- a/apps/server/src/orchestration/legacyThreadEvents.ts
+++ b/apps/server/src/orchestration/legacyThreadEvents.ts
@@ -1,0 +1,20 @@
+import type { ProjectId } from "@t3tools/contracts";
+import { ThreadCreatedPayload, ThreadSubThreadCreatedPayload } from "@t3tools/contracts";
+
+export function legacySubThreadCreatedToThreadCreated(input: {
+  readonly parentProjectId: ProjectId;
+  readonly payload: typeof ThreadSubThreadCreatedPayload.Type;
+}): typeof ThreadCreatedPayload.Type {
+  return {
+    threadId: input.payload.subThreadId,
+    projectId: input.parentProjectId,
+    title: input.payload.title,
+    modelSelection: { provider: "codex", model: input.payload.model },
+    runtimeMode: input.payload.runtimeMode,
+    interactionMode: input.payload.interactionMode,
+    branch: input.payload.branch,
+    worktreePath: input.payload.worktreePath,
+    createdAt: input.payload.createdAt,
+    updatedAt: input.payload.updatedAt,
+  };
+}

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -97,6 +97,67 @@ describe("orchestration projector", () => {
     ]);
   });
 
+  it("applies legacy thread.sub-thread-created events using the parent project", async () => {
+    const now = new Date().toISOString();
+    const model = await Effect.runPromise(
+      projectEvent(
+        createEmptyReadModel(now),
+        makeEvent({
+          sequence: 1,
+          type: "thread.created",
+          aggregateKind: "thread",
+          aggregateId: "thread-parent",
+          occurredAt: now,
+          commandId: "cmd-thread-parent",
+          payload: {
+            threadId: "thread-parent",
+            projectId: "project-1",
+            title: "Parent",
+            modelSelection: { provider: "codex", model: "gpt-5-codex" },
+            runtimeMode: "full-access",
+            branch: null,
+            worktreePath: null,
+            createdAt: now,
+            updatedAt: now,
+          },
+        }),
+      ),
+    );
+
+    const next = await Effect.runPromise(
+      projectEvent(
+        model,
+        makeEvent({
+          sequence: 2,
+          type: "thread.sub-thread-created",
+          aggregateKind: "thread",
+          aggregateId: "thread-parent",
+          occurredAt: now,
+          commandId: "cmd-thread-child",
+          payload: {
+            threadId: "thread-parent",
+            subThreadId: "thread-child",
+            title: "Child",
+            model: "gpt-5-codex",
+            runtimeMode: "approval-required",
+            interactionMode: "default",
+            createdAt: now,
+            updatedAt: now,
+          },
+        }),
+      ),
+    );
+
+    const child = next.threads.find((thread) => thread.id === "thread-child");
+    expect(child).toMatchObject({
+      id: "thread-child",
+      projectId: "project-1",
+      title: "Child",
+      runtimeMode: "approval-required",
+      interactionMode: "default",
+    });
+  });
+
   it("fails when event payload cannot be decoded by runtime schema", async () => {
     const now = new Date().toISOString();
     const model = createEmptyReadModel(now);

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -22,8 +22,10 @@ import {
   ThreadRuntimeModeSetPayload,
   ThreadRevertedPayload,
   ThreadSessionSetPayload,
+  ThreadSubThreadCreatedPayload,
   ThreadTurnDiffCompletedPayload,
 } from "./Schemas.ts";
+import { legacySubThreadCreatedToThreadCreated } from "./legacyThreadEvents.ts";
 
 type ThreadPatch = Partial<Omit<OrchestrationThread, "id" | "projectId">>;
 const MAX_THREAD_MESSAGES = 2_000;
@@ -41,6 +43,35 @@ function updateThread(
   patch: ThreadPatch,
 ): OrchestrationThread[] {
   return threads.map((thread) => (thread.id === threadId ? { ...thread, ...patch } : thread));
+}
+
+function buildProjectedThread(
+  payload: Schema.Schema.Type<typeof ThreadCreatedPayload>,
+  eventType: OrchestrationEvent["type"],
+): Effect.Effect<OrchestrationThread, OrchestrationProjectorDecodeError> {
+  return decodeForEvent(
+    OrchestrationThread,
+    {
+      id: payload.threadId,
+      projectId: payload.projectId,
+      title: payload.title,
+      modelSelection: payload.modelSelection,
+      runtimeMode: payload.runtimeMode,
+      interactionMode: payload.interactionMode,
+      branch: payload.branch,
+      worktreePath: payload.worktreePath,
+      latestTurn: null,
+      createdAt: payload.createdAt,
+      updatedAt: payload.updatedAt,
+      deletedAt: null,
+      messages: [],
+      activities: [],
+      checkpoints: [],
+      session: null,
+    },
+    eventType,
+    "thread",
+  );
 }
 
 function decodeForEvent<A>(
@@ -246,28 +277,34 @@ export function projectEvent(
           event.type,
           "payload",
         );
-        const thread: OrchestrationThread = yield* decodeForEvent(
-          OrchestrationThread,
-          {
-            id: payload.threadId,
-            projectId: payload.projectId,
-            title: payload.title,
-            modelSelection: payload.modelSelection,
-            runtimeMode: payload.runtimeMode,
-            interactionMode: payload.interactionMode,
-            branch: payload.branch,
-            worktreePath: payload.worktreePath,
-            latestTurn: null,
-            createdAt: payload.createdAt,
-            updatedAt: payload.updatedAt,
-            deletedAt: null,
-            messages: [],
-            activities: [],
-            checkpoints: [],
-            session: null,
-          },
+        const thread = yield* buildProjectedThread(payload, event.type);
+        const existing = nextBase.threads.find((entry) => entry.id === thread.id);
+        return {
+          ...nextBase,
+          threads: existing
+            ? nextBase.threads.map((entry) => (entry.id === thread.id ? thread : entry))
+            : [...nextBase.threads, thread],
+        };
+      });
+
+    case "thread.sub-thread-created":
+      return Effect.gen(function* () {
+        const payload = yield* decodeForEvent(
+          ThreadSubThreadCreatedPayload,
+          event.payload,
           event.type,
-          "thread",
+          "payload",
+        );
+        const parentThread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+        if (!parentThread) {
+          return nextBase;
+        }
+        const thread = yield* buildProjectedThread(
+          legacySubThreadCreatedToThreadCreated({
+            parentProjectId: parentThread.projectId,
+            payload,
+          }),
+          event.type,
         );
         const existing = nextBase.threads.find((entry) => entry.id === thread.id);
         return {

--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.test.ts
@@ -1,4 +1,4 @@
-import { CommandId, EventId, ProjectId } from "@t3tools/contracts";
+import { CommandId, EventId, ProjectId, ThreadId } from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import { Effect, Layer, Schema, Stream } from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
@@ -113,6 +113,125 @@ layer("OrchestrationEventStore", (it) => {
             "OrchestrationEventStore.readFromSequence:decodeRows",
           ),
         );
+      }
+    }),
+  );
+
+  it.effect("replays legacy thread.sub-thread-created rows", () =>
+    Effect.gen(function* () {
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const now = new Date().toISOString();
+      const beforeRows = yield* sql<{ readonly maxSequence: number | null }>`
+        SELECT MAX(sequence) AS "maxSequence"
+        FROM orchestration_events
+      `;
+      const sequenceExclusive = beforeRows[0]?.maxSequence ?? 0;
+
+      yield* sql`
+        INSERT INTO orchestration_events (
+          event_id,
+          aggregate_kind,
+          stream_id,
+          stream_version,
+          event_type,
+          occurred_at,
+          command_id,
+          causation_event_id,
+          correlation_id,
+          actor_kind,
+          payload_json,
+          metadata_json
+        )
+        VALUES (
+          ${EventId.makeUnsafe("evt-store-legacy-subthread")},
+          ${"thread"},
+          ${ThreadId.makeUnsafe("thread-parent")},
+          ${0},
+          ${"thread.sub-thread-created"},
+          ${now},
+          ${CommandId.makeUnsafe("cmd-store-legacy-subthread")},
+          ${null},
+          ${null},
+          ${"server"},
+          ${JSON.stringify({
+            threadId: "thread-parent",
+            subThreadId: "thread-child",
+            title: "Child thread",
+            model: "gpt-5-codex",
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            createdAt: now,
+            updatedAt: now,
+          })},
+          ${"{}"}
+        )
+      `;
+
+      const replayed = yield* Stream.runCollect(
+        eventStore.readFromSequence(sequenceExclusive, 10),
+      ).pipe(Effect.map((chunk) => Array.from(chunk)));
+      assert.equal(replayed.length, 1);
+      assert.equal(replayed[0]?.type, "thread.sub-thread-created");
+      if (replayed[0]?.type === "thread.sub-thread-created") {
+        assert.equal(String(replayed[0].payload.subThreadId), "thread-child");
+      }
+    }),
+  );
+
+  it.effect("replays legacy thread.provider-skills-set rows", () =>
+    Effect.gen(function* () {
+      const eventStore = yield* OrchestrationEventStore;
+      const sql = yield* SqlClient.SqlClient;
+      const now = new Date().toISOString();
+      const beforeRows = yield* sql<{ readonly maxSequence: number | null }>`
+        SELECT MAX(sequence) AS "maxSequence"
+        FROM orchestration_events
+      `;
+      const sequenceExclusive = beforeRows[0]?.maxSequence ?? 0;
+
+      yield* sql`
+        INSERT INTO orchestration_events (
+          event_id,
+          aggregate_kind,
+          stream_id,
+          stream_version,
+          event_type,
+          occurred_at,
+          command_id,
+          causation_event_id,
+          correlation_id,
+          actor_kind,
+          payload_json,
+          metadata_json
+        )
+        VALUES (
+          ${EventId.makeUnsafe("evt-store-legacy-provider-skills")},
+          ${"thread"},
+          ${ThreadId.makeUnsafe("thread-skills")},
+          ${0},
+          ${"thread.provider-skills-set"},
+          ${now},
+          ${null},
+          ${null},
+          ${null},
+          ${"server"},
+          ${JSON.stringify({
+            threadId: "thread-skills",
+            skills: [{ name: "review" }, { name: "commit" }],
+          })},
+          ${"{}"}
+        )
+      `;
+
+      const replayed = yield* Stream.runCollect(
+        eventStore.readFromSequence(sequenceExclusive, 10),
+      ).pipe(Effect.map((chunk) => Array.from(chunk)));
+      assert.equal(replayed.length, 1);
+      assert.equal(replayed[0]?.type, "thread.provider-skills-set");
+      if (replayed[0]?.type === "thread.provider-skills-set") {
+        assert.equal(String(replayed[0].payload.threadId), "thread-skills");
+        assert.deepEqual(replayed[0].payload.skills, [{ name: "review" }, { name: "commit" }]);
       }
     }),
   );

--- a/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadSessions.ts
@@ -3,9 +3,9 @@ import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 import { Effect, Layer } from "effect";
 
 import { toPersistenceSqlError } from "../Errors.ts";
+import { ProjectionThreadSessionDbRowSchema } from "../Schemas/ProjectionThreadSessions.ts";
 
 import {
-  ProjectionThreadSession,
   ProjectionThreadSessionRepository,
   type ProjectionThreadSessionRepositoryShape,
   DeleteProjectionThreadSessionInput,
@@ -16,7 +16,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
 
   const upsertProjectionThreadSessionRow = SqlSchema.void({
-    Request: ProjectionThreadSession,
+    Request: ProjectionThreadSessionDbRowSchema,
     execute: (row) =>
       sql`
         INSERT INTO projection_thread_sessions (
@@ -26,6 +26,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode,
           active_turn_id,
           last_error,
+          provider_runtime_info_json,
           updated_at
         )
         VALUES (
@@ -35,6 +36,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           ${row.runtimeMode},
           ${row.activeTurnId},
           ${row.lastError},
+          ${row.providerRuntimeInfo},
           ${row.updatedAt}
         )
         ON CONFLICT (thread_id)
@@ -44,13 +46,14 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode = excluded.runtime_mode,
           active_turn_id = excluded.active_turn_id,
           last_error = excluded.last_error,
+          provider_runtime_info_json = excluded.provider_runtime_info_json,
           updated_at = excluded.updated_at
       `,
   });
 
   const getProjectionThreadSessionRow = SqlSchema.findOneOption({
     Request: GetProjectionThreadSessionInput,
-    Result: ProjectionThreadSession,
+    Result: ProjectionThreadSessionDbRowSchema,
     execute: ({ threadId }) =>
       sql`
         SELECT
@@ -60,6 +63,7 @@ const makeProjectionThreadSessionRepository = Effect.gen(function* () {
           runtime_mode AS "runtimeMode",
           active_turn_id AS "activeTurnId",
           last_error AS "lastError",
+          provider_runtime_info_json AS "providerRuntimeInfo",
           updated_at AS "updatedAt"
         FROM projection_thread_sessions
         WHERE thread_id = ${threadId}

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -29,6 +29,7 @@ import Migration0013 from "./Migrations/013_ProjectionThreadProposedPlans.ts";
 import Migration0014 from "./Migrations/014_ProjectionThreadProposedPlanImplementation.ts";
 import Migration0015 from "./Migrations/015_ProjectionTurnsSourceProposedPlan.ts";
 import Migration0016 from "./Migrations/016_CanonicalizeModelSelections.ts";
+import Migration0018 from "./Migrations/018_ProjectionThreadSessionProviderRuntimeInfo.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -57,6 +58,7 @@ export const migrationEntries = [
   [14, "ProjectionThreadProposedPlanImplementation", Migration0014],
   [15, "ProjectionTurnsSourceProposedPlan", Migration0015],
   [16, "CanonicalizeModelSelections", Migration0016],
+  [18, "ProjectionThreadSessionProviderRuntimeInfo", Migration0018],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/018_ProjectionThreadSessionProviderRuntimeInfo.ts
+++ b/apps/server/src/persistence/Migrations/018_ProjectionThreadSessionProviderRuntimeInfo.ts
@@ -1,0 +1,18 @@
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const columns = yield* sql<{ readonly name: string }>`
+    PRAGMA table_info(projection_thread_sessions)
+  `;
+  if (columns.some((column) => column.name === "provider_runtime_info_json")) {
+    return;
+  }
+
+  yield* sql`
+    ALTER TABLE projection_thread_sessions
+    ADD COLUMN provider_runtime_info_json TEXT
+  `;
+});

--- a/apps/server/src/persistence/Schemas/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Schemas/ProjectionThreadSessions.ts
@@ -1,0 +1,10 @@
+import { ProviderRuntimeInfo } from "@t3tools/contracts";
+import { Schema, Struct } from "effect";
+
+import { ProjectionThreadSession } from "../Services/ProjectionThreadSessions.ts";
+
+export const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession.mapFields(
+  Struct.assign({
+    providerRuntimeInfo: Schema.NullOr(Schema.fromJsonString(ProviderRuntimeInfo)),
+  }),
+);

--- a/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadSessions.ts
@@ -10,6 +10,7 @@ import {
   RuntimeMode,
   IsoDateTime,
   OrchestrationSessionStatus,
+  ProviderRuntimeInfo,
   ThreadId,
   TurnId,
 } from "@t3tools/contracts";
@@ -25,6 +26,7 @@ export const ProjectionThreadSession = Schema.Struct({
   runtimeMode: RuntimeMode,
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(Schema.String),
+  providerRuntimeInfo: Schema.NullOr(ProviderRuntimeInfo),
   updatedAt: IsoDateTime,
 });
 export type ProjectionThreadSession = typeof ProjectionThreadSession.Type;

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -293,8 +293,102 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
+      assert.deepEqual(createInput?.options.tools, {
+        type: "preset",
+        preset: "claude_code",
+      });
+      assert.deepEqual(createInput?.options.systemPrompt, {
+        type: "preset",
+        preset: "claude_code",
+      });
+      assert.deepEqual(createInput?.options.allowedTools, ["Skill"]);
       assert.equal(createInput?.options.permissionMode, undefined);
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("allows overriding Claude setting sources per session", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "approval-required",
+        providerOptions: {
+          claudeAgent: {
+            settingSources: ["project"],
+          },
+        },
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.deepEqual(createInput?.options.settingSources, ["project"]);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("filters environment variables passed to Claude", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const previousClaudeEnv = process.env.CLAUDE_TEST_ALLOWED;
+      const previousAnthropicEnv = process.env.ANTHROPIC_TEST_ALLOWED;
+      const previousSshAgentEnv = process.env.SSH_AUTH_SOCK;
+      const previousGitSshCommandEnv = process.env.GIT_SSH_COMMAND;
+      const previousSecretEnv = process.env.AWS_SECRET_ACCESS_KEY;
+      process.env.CLAUDE_TEST_ALLOWED = "yes";
+      process.env.ANTHROPIC_TEST_ALLOWED = "yes";
+      process.env.SSH_AUTH_SOCK = "/tmp/test-ssh-agent.sock";
+      process.env.GIT_SSH_COMMAND = "ssh -i ~/.ssh/test";
+      process.env.AWS_SECRET_ACCESS_KEY = "should-not-pass";
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          if (previousClaudeEnv === undefined) {
+            delete process.env.CLAUDE_TEST_ALLOWED;
+          } else {
+            process.env.CLAUDE_TEST_ALLOWED = previousClaudeEnv;
+          }
+          if (previousAnthropicEnv === undefined) {
+            delete process.env.ANTHROPIC_TEST_ALLOWED;
+          } else {
+            process.env.ANTHROPIC_TEST_ALLOWED = previousAnthropicEnv;
+          }
+          if (previousSshAgentEnv === undefined) {
+            delete process.env.SSH_AUTH_SOCK;
+          } else {
+            process.env.SSH_AUTH_SOCK = previousSshAgentEnv;
+          }
+          if (previousGitSshCommandEnv === undefined) {
+            delete process.env.GIT_SSH_COMMAND;
+          } else {
+            process.env.GIT_SSH_COMMAND = previousGitSshCommandEnv;
+          }
+          if (previousSecretEnv === undefined) {
+            delete process.env.AWS_SECRET_ACCESS_KEY;
+          } else {
+            process.env.AWS_SECRET_ACCESS_KEY = previousSecretEnv;
+          }
+        }),
+      );
+
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "approval-required",
+      });
+
+      const env = harness.getLastCreateQueryInput()?.options.env ?? {};
+      assert.equal(env.CLAUDE_TEST_ALLOWED, "yes");
+      assert.equal(env.ANTHROPIC_TEST_ALLOWED, "yes");
+      assert.equal(env.SSH_AUTH_SOCK, "/tmp/test-ssh-agent.sock");
+      assert.equal(env.GIT_SSH_COMMAND, "ssh -i ~/.ssh/test");
+      assert.equal("AWS_SECRET_ACCESS_KEY" in env, false);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -780,6 +874,77 @@ describe("ClaudeAdapterLive", () => {
         assert.equal(String(turnCompleted.turnId), String(turn.turnId));
         assert.equal(turnCompleted.payload.state, "completed");
       }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("emits claude runtime capabilities from system init as session.configured", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "approval-required",
+      });
+
+      yield* Stream.take(adapter.streamEvents, 3).pipe(Stream.runDrain);
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "hello",
+        attachments: [],
+      });
+      yield* Stream.take(adapter.streamEvents, 1).pipe(Stream.runDrain);
+      const configuredEventFiber = yield* Stream.filter(
+        adapter.streamEvents,
+        (event) => event.type === "session.configured",
+      ).pipe(Stream.runHead, Effect.forkChild);
+      yield* Effect.yieldNow;
+
+      harness.query.emit({
+        type: "system",
+        subtype: "init",
+        apiKeySource: "user",
+        claude_code_version: "1.2.3",
+        cwd: "/tmp/claude-workspace",
+        tools: ["Bash", "Skill"],
+        mcp_servers: [{ name: "filesystem", status: "connected" }],
+        model: "claude-sonnet-4-6",
+        permissionMode: "default",
+        slash_commands: ["/plan", "/review"],
+        output_style: "default",
+        skills: ["project-audit"],
+        plugins: [{ name: "local-plugin", path: "/tmp/plugin" }],
+        uuid: "system-init-1",
+        session_id: "sdk-session-init-1",
+      } as unknown as SDKMessage);
+
+      const configuredOption = yield* Fiber.join(configuredEventFiber);
+      if (
+        configuredOption._tag !== "Some" ||
+        configuredOption.value.type !== "session.configured"
+      ) {
+        assert.fail("Expected session.configured event");
+        return;
+      }
+      const configured = configuredOption.value;
+
+      assert.deepEqual(configured.payload.config, {
+        providerRuntimeInfo: {
+          claudeAgent: {
+            slashCommands: ["/plan", "/review"],
+            skills: ["project-audit"],
+            tools: ["Bash", "Skill"],
+            plugins: ["local-plugin"],
+            claudeCodeVersion: "1.2.3",
+            cwd: "/tmp/claude-workspace",
+            settingSources: ["user", "project", "local"],
+          },
+        },
+      });
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),
@@ -2131,6 +2296,98 @@ describe("ClaudeAdapterLive", () => {
 
       const permissionResult = yield* Effect.promise(() => permissionPromise);
       assert.equal((permissionResult as PermissionResult).behavior, "allow");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("allows Skill immediately in approval-required sessions", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "approval-required",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.deepEqual(createInput?.options.allowedTools, ["Skill"]);
+      const canUseTool = createInput?.options.canUseTool;
+      assert.equal(typeof canUseTool, "function");
+      if (!canUseTool) {
+        return;
+      }
+
+      const permissionResult = yield* Effect.promise(() =>
+        canUseTool(
+          "Skill",
+          { command: "/review" },
+          {
+            signal: new AbortController().signal,
+            toolUseID: "tool-skill-allowed",
+          },
+        ),
+      );
+
+      assert.deepEqual(permissionResult, {
+        behavior: "allow",
+        updatedInput: { command: "/review" },
+      } satisfies PermissionResult);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("denies Skill in full-access unless the env flag is enabled", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const previousValue = process.env.T3CODE_CLAUDE_SKILLS_FULL_ACCESS;
+      delete process.env.T3CODE_CLAUDE_SKILLS_FULL_ACCESS;
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          if (previousValue === undefined) {
+            delete process.env.T3CODE_CLAUDE_SKILLS_FULL_ACCESS;
+          } else {
+            process.env.T3CODE_CLAUDE_SKILLS_FULL_ACCESS = previousValue;
+          }
+        }),
+      );
+
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.allowedTools, undefined);
+      const canUseTool = createInput?.options.canUseTool;
+      assert.equal(typeof canUseTool, "function");
+      if (!canUseTool) {
+        return;
+      }
+
+      const permissionResult = yield* Effect.promise(() =>
+        canUseTool(
+          "Skill",
+          { command: "/review" },
+          {
+            signal: new AbortController().signal,
+            toolUseID: "tool-skill-denied",
+          },
+        ),
+      );
+
+      assert.deepEqual(permissionResult, {
+        behavior: "deny",
+        message:
+          "Claude Skills are blocked in full-access until T3CODE_CLAUDE_SKILLS_FULL_ACCESS=1. Use approval-required to run this skill.",
+      } satisfies PermissionResult);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -22,6 +22,7 @@ import {
   ApprovalRequestId,
   type CanonicalItemType,
   type CanonicalRequestType,
+  type ClaudeRuntimeCapabilities,
   EventId,
   type ProviderApprovalDecision,
   ProviderItemId,
@@ -46,6 +47,7 @@ import {
   getModelCapabilities,
   trimOrNull,
 } from "@t3tools/shared/model";
+import { normalizeClaudeSettingSources } from "@t3tools/shared/claude";
 import {
   Cause,
   DateTime,
@@ -143,6 +145,7 @@ interface ClaudeSessionContext {
   session: ProviderSession;
   readonly promptQueue: Queue.Queue<PromptQueueItem>;
   readonly query: ClaudeQueryRuntime;
+  readonly settingSources: ReadonlyArray<SettingSource>;
   streamFiber: Fiber.Fiber<void, Error> | undefined;
   readonly startedAt: string;
   readonly basePermissionMode: PermissionMode | undefined;
@@ -513,11 +516,251 @@ const SUPPORTED_CLAUDE_IMAGE_MIME_TYPES = new Set([
   "image/png",
   "image/webp",
 ]);
-const CLAUDE_SETTING_SOURCES = [
-  "user",
-  "project",
-  "local",
-] as const satisfies ReadonlyArray<SettingSource>;
+const CLAUDE_TOOLS_PRESET = {
+  type: "preset",
+  preset: "claude_code",
+} as const satisfies NonNullable<ClaudeQueryOptions["tools"]>;
+const CLAUDE_SYSTEM_PROMPT_PRESET = {
+  type: "preset",
+  preset: "claude_code",
+} as const satisfies Exclude<ClaudeQueryOptions["systemPrompt"], string>;
+const CLAUDE_SKILLS_FULL_ACCESS_ENV = "T3CODE_CLAUDE_SKILLS_FULL_ACCESS";
+const CLAUDE_ENV_EXACT_ALLOWLIST = new Set([
+  "CI",
+  "COLORTERM",
+  "EDITOR",
+  "FORCE_COLOR",
+  "GIT_ASKPASS",
+  "GIT_SSH",
+  "GIT_SSH_COMMAND",
+  "GPG_TTY",
+  "HOME",
+  "LANG",
+  "LOGNAME",
+  "NO_COLOR",
+  "PATH",
+  "PWD",
+  "SHELL",
+  "SSH_AGENT_PID",
+  "SSH_ASKPASS",
+  "SSH_AUTH_SOCK",
+  "TEMP",
+  "TERM",
+  "TERM_PROGRAM",
+  "TMP",
+  "TMPDIR",
+  "USER",
+  "VISUAL",
+  "XDG_CACHE_HOME",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+]);
+const CLAUDE_ENV_PROXY_NAMES = new Set([
+  "ALL_PROXY",
+  "all_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "NO_PROXY",
+  "no_proxy",
+]);
+
+function sanitizeClaudeEnv(env: NodeJS.ProcessEnv): NonNullable<ClaudeQueryOptions["env"]> {
+  const filtered: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(env)) {
+    if (typeof value !== "string" || value.length === 0) {
+      continue;
+    }
+
+    const allowed =
+      CLAUDE_ENV_EXACT_ALLOWLIST.has(name) ||
+      CLAUDE_ENV_PROXY_NAMES.has(name) ||
+      name.startsWith("ANTHROPIC_") ||
+      name.startsWith("CLAUDE_") ||
+      name.startsWith("LC_") ||
+      name.startsWith("TMP");
+
+    if (allowed) {
+      filtered[name] = value;
+    }
+  }
+
+  return filtered;
+}
+
+function normalizeClaudeStringList(
+  value: unknown,
+  options?: {
+    readonly prependSlash?: boolean;
+    readonly objectKeys?: ReadonlyArray<string>;
+  },
+): {
+  readonly entries: Array<string>;
+  readonly malformed: boolean;
+} {
+  if (value === undefined) {
+    return {
+      entries: [],
+      malformed: false,
+    };
+  }
+
+  if (!Array.isArray(value)) {
+    return {
+      entries: [],
+      malformed: true,
+    };
+  }
+
+  const entries: Array<string> = [];
+  const seen = new Set<string>();
+  let malformed = false;
+  const objectKeys = options?.objectKeys ?? ["name", "command", "label", "id", "title"];
+
+  for (const item of value) {
+    let candidate: string | undefined;
+    if (typeof item === "string") {
+      candidate = item;
+    } else if (item && typeof item === "object") {
+      const record = item as Record<string, unknown>;
+      for (const key of objectKeys) {
+        const entry = record[key];
+        if (typeof entry === "string") {
+          candidate = entry;
+          break;
+        }
+      }
+    }
+
+    const normalizedCandidate = candidate?.trim();
+    if (!normalizedCandidate) {
+      malformed = true;
+      continue;
+    }
+
+    const normalized = options?.prependSlash
+      ? normalizedCandidate.startsWith("/")
+        ? normalizedCandidate
+        : `/${normalizedCandidate}`
+      : normalizedCandidate;
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    entries.push(normalized);
+  }
+
+  return {
+    entries,
+    malformed,
+  };
+}
+
+function normalizeOptionalClaudeString(value: unknown): {
+  readonly value: string | null;
+  readonly malformed: boolean;
+} {
+  if (value === undefined || value === null) {
+    return {
+      value: null,
+      malformed: false,
+    };
+  }
+  if (typeof value !== "string") {
+    return {
+      value: null,
+      malformed: true,
+    };
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0
+    ? {
+        value: trimmed,
+        malformed: false,
+      }
+    : {
+        value: null,
+        malformed: true,
+      };
+}
+
+function buildClaudeRuntimeCapabilities(
+  initMessage: Record<string, unknown>,
+  settingSources: ReadonlyArray<SettingSource>,
+): {
+  readonly capabilities: ClaudeRuntimeCapabilities;
+  readonly warnings: Array<{
+    readonly message: string;
+    readonly detail: unknown;
+  }>;
+} {
+  const slashCommands = normalizeClaudeStringList(initMessage.slash_commands, {
+    prependSlash: true,
+  });
+  const skills = normalizeClaudeStringList(initMessage.skills);
+  const tools = normalizeClaudeStringList(initMessage.tools);
+  const plugins = normalizeClaudeStringList(initMessage.plugins, {
+    objectKeys: ["name", "id", "label", "title", "path"],
+  });
+  const claudeCodeVersion = normalizeOptionalClaudeString(initMessage.claude_code_version);
+  const cwd = normalizeOptionalClaudeString(initMessage.cwd);
+  const warnings: Array<{
+    readonly message: string;
+    readonly detail: unknown;
+  }> = [];
+
+  if (slashCommands.malformed) {
+    warnings.push({
+      message: "Claude init payload contained malformed slash command entries.",
+      detail: initMessage.slash_commands,
+    });
+  }
+  if (skills.malformed) {
+    warnings.push({
+      message: "Claude init payload contained malformed skill entries.",
+      detail: initMessage.skills,
+    });
+  }
+  if (tools.malformed) {
+    warnings.push({
+      message: "Claude init payload contained malformed tool entries.",
+      detail: initMessage.tools,
+    });
+  }
+  if (plugins.malformed) {
+    warnings.push({
+      message: "Claude init payload contained malformed plugin entries.",
+      detail: initMessage.plugins,
+    });
+  }
+  if (claudeCodeVersion.malformed) {
+    warnings.push({
+      message: "Claude init payload contained an invalid claude_code_version value.",
+      detail: initMessage.claude_code_version,
+    });
+  }
+  if (cwd.malformed) {
+    warnings.push({
+      message: "Claude init payload contained an invalid cwd value.",
+      detail: initMessage.cwd,
+    });
+  }
+
+  return {
+    capabilities: {
+      slashCommands: slashCommands.entries,
+      skills: skills.entries,
+      tools: tools.entries,
+      plugins: plugins.entries,
+      claudeCodeVersion: claudeCodeVersion.value,
+      cwd: cwd.value,
+      settingSources: [...settingSources],
+    },
+    warnings,
+  };
+}
 
 function buildPromptText(input: ProviderSendTurnInput): string {
   const rawEffort =
@@ -1994,15 +2237,27 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         };
 
         switch (message.subtype) {
-          case "init":
+          case "init": {
+            const { capabilities, warnings } = buildClaudeRuntimeCapabilities(
+              message as Record<string, unknown>,
+              context.settingSources,
+            );
+            for (const warning of warnings) {
+              yield* emitRuntimeWarning(context, warning.message, warning.detail);
+            }
             yield* offerRuntimeEvent({
               ...base,
               type: "session.configured",
               payload: {
-                config: message as Record<string, unknown>,
+                config: {
+                  providerRuntimeInfo: {
+                    claudeAgent: capabilities,
+                  },
+                },
               },
             });
             return;
+          }
           case "status":
             yield* offerRuntimeEvent({
               ...base,
@@ -2609,6 +2864,20 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 } satisfies PermissionResult;
               }
 
+              if (toolName === "Skill" && !skillsExecutionEnabled) {
+                return {
+                  behavior: "deny",
+                  message: `Claude Skills are blocked in full-access until ${CLAUDE_SKILLS_FULL_ACCESS_ENV}=1. Use approval-required to run this skill.`,
+                } satisfies PermissionResult;
+              }
+
+              if (toolName === "Skill") {
+                return {
+                  behavior: "allow",
+                  updatedInput: toolInput,
+                } satisfies PermissionResult;
+              }
+
               const runtimeMode = input.runtimeMode ?? "full-access";
               if (runtimeMode === "full-access") {
                 return {
@@ -2740,6 +3009,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
             ? modelSelection.options.thinking
             : undefined;
         const effectiveEffort = getEffectiveClaudeCodeEffort(effort);
+        const settingSources = normalizeClaudeSettingSources(providerOptions?.settingSources);
+        const skillsAllowedInFullAccess = process.env[CLAUDE_SKILLS_FULL_ACCESS_ENV] === "1";
+        const skillsExecutionEnabled =
+          input.runtimeMode === "approval-required" || skillsAllowedInFullAccess;
         const permissionMode =
           toPermissionMode(providerOptions?.permissionMode) ??
           (input.runtimeMode === "full-access" ? "bypassPermissions" : undefined);
@@ -2752,7 +3025,9 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(input.cwd ? { cwd: input.cwd } : {}),
           ...(modelSelection?.model ? { model: modelSelection.model } : {}),
           pathToClaudeCodeExecutable: providerOptions?.binaryPath ?? "claude",
-          settingSources: [...CLAUDE_SETTING_SOURCES],
+          tools: CLAUDE_TOOLS_PRESET,
+          systemPrompt: CLAUDE_SYSTEM_PROMPT_PRESET,
+          settingSources,
           ...(effectiveEffort ? { effort: effectiveEffort } : {}),
           ...(permissionMode ? { permissionMode } : {}),
           ...(permissionMode === "bypassPermissions"
@@ -2764,9 +3039,10 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           ...(Object.keys(settings).length > 0 ? { settings } : {}),
           ...(existingResumeSessionId ? { resume: existingResumeSessionId } : {}),
           ...(newSessionId ? { sessionId: newSessionId } : {}),
+          ...(skillsExecutionEnabled ? { allowedTools: ["Skill"] } : {}),
           includePartialMessages: true,
           canUseTool,
-          env: process.env,
+          env: sanitizeClaudeEnv(process.env),
           ...(input.cwd ? { additionalDirectories: [input.cwd] } : {}),
         };
 
@@ -2809,6 +3085,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
           session,
           promptQueue,
           query: queryRuntime,
+          settingSources,
           streamFiber: undefined,
           startedAt,
           basePermissionMode: permissionMode,
@@ -2855,6 +3132,7 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
                 ? { maxThinkingTokens: providerOptions.maxThinkingTokens }
                 : {}),
               ...(fastMode ? { fastMode: true } : {}),
+              settingSources,
             },
           },
           providerRefs: {},

--- a/apps/web/src/appSettings.test.ts
+++ b/apps/web/src/appSettings.test.ts
@@ -1,10 +1,12 @@
 import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
+import { DEFAULT_CLAUDE_SETTING_SOURCES } from "@t3tools/contracts";
 
 import {
   AppSettingsSchema,
   DEFAULT_SIDEBAR_PROJECT_SORT_ORDER,
   DEFAULT_SIDEBAR_THREAD_SORT_ORDER,
+  normalizeClaudeSettingSources,
   DEFAULT_TIMESTAMP_FORMAT,
   getAppModelOptions,
   getCustomModelOptionsByProvider,
@@ -136,12 +138,14 @@ describe("getProviderStartOptions", () => {
     expect(
       getProviderStartOptions({
         claudeBinaryPath: "/usr/local/bin/claude",
+        claudeSettingSources: [...DEFAULT_CLAUDE_SETTING_SOURCES],
         codexBinaryPath: "",
         codexHomePath: "/Users/you/.codex",
       }),
     ).toEqual({
       claudeAgent: {
         binaryPath: "/usr/local/bin/claude",
+        settingSources: ["user", "project", "local"],
       },
       codex: {
         homePath: "/Users/you/.codex",
@@ -149,14 +153,33 @@ describe("getProviderStartOptions", () => {
     });
   });
 
-  it("returns undefined when no provider overrides are configured", () => {
+  it("always includes claude setting sources so reverting to defaults can restart sessions", () => {
     expect(
       getProviderStartOptions({
         claudeBinaryPath: "",
+        claudeSettingSources: [...DEFAULT_CLAUDE_SETTING_SOURCES],
         codexBinaryPath: "",
         codexHomePath: "",
       }),
-    ).toBeUndefined();
+    ).toEqual({
+      claudeAgent: {
+        settingSources: ["user", "project", "local"],
+      },
+    });
+  });
+});
+
+describe("normalizeClaudeSettingSources", () => {
+  it("deduplicates and restores the canonical source order", () => {
+    expect(normalizeClaudeSettingSources(["local", "project", "local", "user"])).toEqual([
+      "user",
+      "project",
+      "local",
+    ]);
+  });
+
+  it("falls back to the default sources when the selection is empty", () => {
+    expect(normalizeClaudeSettingSources([])).toEqual(["user", "project", "local"]);
   });
 });
 
@@ -252,6 +275,7 @@ describe("AppSettingsSchema", () => {
       ),
     ).toMatchObject({
       claudeBinaryPath: "",
+      claudeSettingSources: ["user", "project", "local"],
       codexBinaryPath: "/usr/local/bin/codex",
       codexHomePath: "",
       defaultThreadEnvMode: "local",

--- a/apps/web/src/appSettings.ts
+++ b/apps/web/src/appSettings.ts
@@ -1,6 +1,8 @@
 import { useCallback } from "react";
 import { Option, Schema } from "effect";
 import {
+  DEFAULT_CLAUDE_SETTING_SOURCES,
+  ClaudeSettingSource,
   TrimmedNonEmptyString,
   type ProviderKind,
   type ProviderStartOptions,
@@ -11,6 +13,7 @@ import {
   normalizeModelSlug,
   resolveSelectableModel,
 } from "@t3tools/shared/model";
+import { normalizeClaudeSettingSources } from "@t3tools/shared/claude";
 import { useLocalStorage } from "./hooks/useLocalStorage";
 import { EnvMode } from "./components/BranchToolbar.logic";
 
@@ -58,6 +61,9 @@ const withDefaults =
 
 export const AppSettingsSchema = Schema.Struct({
   claudeBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
+  claudeSettingSources: Schema.Array(ClaudeSettingSource).pipe(
+    withDefaults(() => [...DEFAULT_CLAUDE_SETTING_SOURCES]),
+  ),
   codexBinaryPath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   codexHomePath: Schema.String.check(Schema.isMaxLength(4096)).pipe(withDefaults(() => "")),
   defaultThreadEnvMode: EnvMode.pipe(withDefaults(() => "local" as const satisfies EnvMode)),
@@ -105,6 +111,8 @@ const PROVIDER_CUSTOM_MODEL_CONFIG: Record<ProviderKind, ProviderCustomModelConf
 };
 export const MODEL_PROVIDER_SETTINGS = Object.values(PROVIDER_CUSTOM_MODEL_CONFIG);
 
+export { normalizeClaudeSettingSources } from "@t3tools/shared/claude";
+
 export function normalizeCustomModelSlugs(
   models: Iterable<string | null | undefined>,
   provider: ProviderKind = "codex",
@@ -137,6 +145,7 @@ export function normalizeCustomModelSlugs(
 function normalizeAppSettings(settings: AppSettings): AppSettings {
   return {
     ...settings,
+    claudeSettingSources: normalizeClaudeSettingSources(settings.claudeSettingSources),
     customCodexModels: normalizeCustomModelSlugs(settings.customCodexModels, "codex"),
     customClaudeModels: normalizeCustomModelSlugs(settings.customClaudeModels, "claudeAgent"),
   };
@@ -240,8 +249,11 @@ export function getCustomModelOptionsByProvider(
 }
 
 export function getProviderStartOptions(
-  settings: Pick<AppSettings, "claudeBinaryPath" | "codexBinaryPath" | "codexHomePath">,
-): ProviderStartOptions | undefined {
+  settings: Pick<
+    AppSettings,
+    "claudeBinaryPath" | "claudeSettingSources" | "codexBinaryPath" | "codexHomePath"
+  >,
+): ProviderStartOptions {
   const providerOptions: ProviderStartOptions = {
     ...(settings.codexBinaryPath || settings.codexHomePath
       ? {
@@ -251,16 +263,12 @@ export function getProviderStartOptions(
           },
         }
       : {}),
-    ...(settings.claudeBinaryPath
-      ? {
-          claudeAgent: {
-            binaryPath: settings.claudeBinaryPath,
-          },
-        }
-      : {}),
+    claudeAgent: {
+      ...(settings.claudeBinaryPath ? { binaryPath: settings.claudeBinaryPath } : {}),
+      settingSources: normalizeClaudeSettingSources(settings.claudeSettingSources),
+    },
   };
-
-  return Object.keys(providerOptions).length > 0 ? providerOptions : undefined;
+  return providerOptions;
 }
 
 export function useAppSettings() {

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,7 +1,11 @@
 import { ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { buildExpiredTerminalContextToastCopy, deriveComposerSendState } from "./ChatView.logic";
+import {
+  buildExpiredTerminalContextToastCopy,
+  deriveComposerSendState,
+  resolveProviderSlashCommandBypassForRetry,
+} from "./ChatView.logic";
 
 describe("deriveComposerSendState", () => {
   it("treats expired terminal pills as non-sendable content", () => {
@@ -65,5 +69,37 @@ describe("buildExpiredTerminalContextToastCopy", () => {
       title: "Expired terminal contexts omitted from message",
       description: "Re-add it if you want that terminal output included.",
     });
+  });
+});
+
+describe("resolveProviderSlashCommandBypassForRetry", () => {
+  it("preserves a selected Claude slash command when the prompt still targets it", () => {
+    expect(
+      resolveProviderSlashCommandBypassForRetry({
+        provider: "claudeAgent",
+        selectedSlashCommand: "/plan",
+        trimmedPrompt: "/plan add regression coverage",
+      }),
+    ).toBe("/plan");
+  });
+
+  it("does not preserve bypass for non-Claude providers", () => {
+    expect(
+      resolveProviderSlashCommandBypassForRetry({
+        provider: "codex",
+        selectedSlashCommand: "/plan",
+        trimmedPrompt: "/plan add regression coverage",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not preserve bypass when the prompt no longer starts with the selected command", () => {
+    expect(
+      resolveProviderSlashCommandBypassForRetry({
+        provider: "claudeAgent",
+        selectedSlashCommand: "/plan",
+        trimmedPrompt: "plain text follow-up",
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,8 +1,9 @@
-import { ProjectId, type ModelSelection, type ThreadId } from "@t3tools/contracts";
+import { ProjectId, type ModelSelection, type ProviderKind, type ThreadId } from "@t3tools/contracts";
 import { type ChatMessage, type Thread } from "../types";
 import { randomUUID } from "~/lib/utils";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
 import { Schema } from "effect";
+import { normalizeSlashCommandToken } from "../composer-logic";
 import {
   filterTerminalContextsWithText,
   stripInlineTerminalContextPlaceholders,
@@ -79,6 +80,22 @@ export type SendPhase = "idle" | "preparing-worktree" | "sending-turn";
 export interface PullRequestDialogState {
   initialReference: string | null;
   key: number;
+}
+
+export function resolveProviderSlashCommandBypassForRetry(input: {
+  provider: ProviderKind;
+  selectedSlashCommand: string | null | undefined;
+  trimmedPrompt: string;
+}): string | null {
+  if (input.provider !== "claudeAgent") {
+    return null;
+  }
+
+  const selectedSlashCommand = normalizeSlashCommandToken(input.selectedSlashCommand);
+  const promptSlashCommand = normalizeSlashCommandToken(input.trimmedPrompt);
+  return selectedSlashCommand !== null && promptSlashCommand === selectedSlashCommand
+    ? selectedSlashCommand
+    : null;
 }
 
 export function readFileAsDataUrl(file: File): Promise<string> {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -40,9 +40,11 @@ import {
   clampCollapsedComposerCursor,
   type ComposerTrigger,
   collapseExpandedComposerCursor,
-  detectComposerTrigger,
+  detectComposerTriggerWithProviderSlashBypass,
   expandCollapsedComposerCursor,
+  LOCAL_APP_SLASH_COMMANDS,
   parseStandaloneComposerSlashCommand,
+  promptStartsWithSlashCommand,
   replaceTextRange,
 } from "../composer-logic";
 import {
@@ -178,6 +180,7 @@ import {
   LastInvokedScriptByProjectSchema,
   PullRequestDialogState,
   readFileAsDataUrl,
+  resolveProviderSlashCommandBypassForRetry,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
   SendPhase,
@@ -210,7 +213,6 @@ function formatOutgoingPrompt(params: {
 const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
-
 const extendReplacementRangeForTrailingSpace = (
   text: string,
   rangeEnd: number,
@@ -357,11 +359,23 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const [attachmentPreviewHandoffByMessageId, setAttachmentPreviewHandoffByMessageId] = useState<
     Record<string, string[]>
   >({});
+  const selectedProviderRef = useRef<ProviderKind>("codex");
+  const selectedProviderSlashCommandRef = useRef<string | null>(null);
+  const detectComposerTriggerForCurrentContext = useCallback(
+    (text: string, cursor: number) =>
+      detectComposerTriggerWithProviderSlashBypass({
+        text,
+        cursor,
+        provider: selectedProviderRef.current,
+        bypassSlashCommand: selectedProviderSlashCommandRef.current,
+      }),
+    [],
+  );
   const [composerCursor, setComposerCursor] = useState(() =>
     collapseExpandedComposerCursor(prompt, prompt.length),
   );
   const [composerTrigger, setComposerTrigger] = useState<ComposerTrigger | null>(() =>
-    detectComposerTrigger(prompt, prompt.length),
+    detectComposerTriggerForCurrentContext(prompt, prompt.length),
   );
   const [lastInvokedScriptByProjectId, setLastInvokedScriptByProjectId] = useLocalStorage(
     LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
@@ -453,13 +467,19 @@ export default function ChatView({ threadId }: ChatViewProps) {
       removeComposerDraftTerminalContext(threadId, contextId);
       setComposerCursor(nextPrompt.cursor);
       setComposerTrigger(
-        detectComposerTrigger(
+        detectComposerTriggerForCurrentContext(
           nextPrompt.prompt,
           expandCollapsedComposerCursor(nextPrompt.prompt, nextPrompt.cursor),
         ),
       );
     },
-    [composerTerminalContexts, removeComposerDraftTerminalContext, setPrompt, threadId],
+    [
+      composerTerminalContexts,
+      detectComposerTriggerForCurrentContext,
+      removeComposerDraftTerminalContext,
+      setPrompt,
+      threadId,
+    ],
   );
 
   const serverThread = threads.find((t) => t.id === threadId);
@@ -611,6 +631,27 @@ export default function ChatView({ threadId }: ChatViewProps) {
     : null;
   const selectedProvider: ProviderKind =
     lockedProvider ?? selectedProviderByThreadId ?? threadProvider ?? "codex";
+  selectedProviderRef.current = selectedProvider;
+  const activeClaudeRuntimeInfo =
+    selectedProvider === "claudeAgent"
+      ? (activeThread?.session?.providerRuntimeInfo?.claudeAgent ?? null)
+      : null;
+  useEffect(() => {
+    selectedProviderSlashCommandRef.current = null;
+  }, [activeThread?.id]);
+
+  useEffect(() => {
+    const selectedProviderSlashCommand = selectedProviderSlashCommandRef.current;
+    if (!selectedProviderSlashCommand) {
+      return;
+    }
+    if (
+      selectedProvider !== "claudeAgent" ||
+      !promptStartsWithSlashCommand(prompt, selectedProviderSlashCommand)
+    ) {
+      selectedProviderSlashCommandRef.current = null;
+    }
+  }, [prompt, selectedProvider]);
   const customModelsByProvider = useMemo(() => getCustomModelsByProvider(settings), [settings]);
   const { modelOptions: composerModelOptions, selectedModel } = useEffectiveComposerModelState({
     threadId,
@@ -793,7 +834,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const nextCursor = collapseExpandedComposerCursor(nextCustomAnswer, nextCustomAnswer.length);
     setComposerCursor(nextCursor);
     setComposerTrigger(
-      detectComposerTrigger(
+      detectComposerTriggerForCurrentContext(
         nextCustomAnswer,
         expandCollapsedComposerCursor(nextCustomAnswer, nextCursor),
       ),
@@ -803,6 +844,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     activePendingProgress?.customAnswer,
     activePendingUserInput?.requestId,
     activePendingProgress?.activeQuestion?.id,
+    detectComposerTriggerForCurrentContext,
   ]);
   useEffect(() => {
     attachmentPreviewHandoffByMessageIdRef.current = attachmentPreviewHandoffByMessageId;
@@ -1054,35 +1096,63 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
 
     if (composerTrigger.kind === "slash-command") {
-      const slashCommandItems = [
+      const appSlashCommandItems = [
         {
-          id: "slash:model",
+          id: "slash:app:model",
           type: "slash-command",
-          command: "model",
+          source: "app",
+          command: "/model",
+          localCommand: "model",
+          groupLabel: "App",
           label: "/model",
           description: "Switch response model for this thread",
         },
         {
-          id: "slash:plan",
+          id: "slash:app:plan",
           type: "slash-command",
-          command: "plan",
+          source: "app",
+          command: "/plan",
+          localCommand: "plan",
+          groupLabel: "App",
           label: "/plan",
           description: "Switch this thread into plan mode",
         },
         {
-          id: "slash:default",
+          id: "slash:app:default",
           type: "slash-command",
-          command: "default",
+          source: "app",
+          command: "/default",
+          localCommand: "default",
+          groupLabel: "App",
           label: "/default",
           description: "Switch this thread back to normal chat mode",
         },
       ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
+      const providerSlashCommandItems =
+        selectedProvider === "claudeAgent"
+          ? (activeClaudeRuntimeInfo?.slashCommands ?? []).map(
+              (command): Extract<ComposerCommandItem, { type: "slash-command" }> => ({
+                id: `slash:provider:claude:${command}`,
+                type: "slash-command",
+                source: "provider",
+                command,
+                provider: "claudeAgent",
+                groupLabel: "Claude",
+                label: command,
+                description: "Run this Cloud Code slash command in Claude",
+              }),
+            )
+          : [];
       const query = composerTrigger.query.trim().toLowerCase();
+      const slashCommandItems = [...appSlashCommandItems, ...providerSlashCommandItems];
       if (!query) {
         return [...slashCommandItems];
       }
       return slashCommandItems.filter(
-        (item) => item.command.includes(query) || item.label.slice(1).includes(query),
+        (item) =>
+          item.command.toLowerCase().includes(`/${query}`) ||
+          item.command.toLowerCase().includes(query) ||
+          item.label.slice(1).toLowerCase().includes(query),
       );
     }
 
@@ -1102,7 +1172,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
         label: name,
         description: `${providerLabel} · ${slug}`,
       }));
-  }, [composerTrigger, searchableModelOptions, workspaceEntries]);
+  }, [
+    activeClaudeRuntimeInfo,
+    composerTrigger,
+    searchableModelOptions,
+    selectedProvider,
+    workspaceEntries,
+  ]);
   const composerMenuOpen = Boolean(composerTrigger);
   const activeComposerMenuItem = useMemo(
     () =>
@@ -1248,12 +1324,20 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
       promptRef.current = insertion.prompt;
       setComposerCursor(nextCollapsedCursor);
-      setComposerTrigger(detectComposerTrigger(insertion.prompt, insertion.cursor));
+      setComposerTrigger(
+        detectComposerTriggerForCurrentContext(insertion.prompt, insertion.cursor),
+      );
       window.requestAnimationFrame(() => {
         composerEditorRef.current?.focusAt(nextCollapsedCursor);
       });
     },
-    [activeThread, composerCursor, composerTerminalContexts, insertComposerDraftTerminalContext],
+    [
+      activeThread,
+      composerCursor,
+      composerTerminalContexts,
+      detectComposerTriggerForCurrentContext,
+      insertComposerDraftTerminalContext,
+    ],
   );
   const setTerminalOpen = useCallback(
     (open: boolean) => {
@@ -1943,11 +2027,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
     setSendStartedAt(null);
     setComposerHighlightedItemId(null);
     setComposerCursor(collapseExpandedComposerCursor(promptRef.current, promptRef.current.length));
-    setComposerTrigger(detectComposerTrigger(promptRef.current, promptRef.current.length));
+    setComposerTrigger(
+      detectComposerTriggerForCurrentContext(promptRef.current, promptRef.current.length),
+    );
     dragDepthRef.current = 0;
     setIsDragOverComposer(false);
     setExpandedImage(null);
-  }, [threadId]);
+  }, [detectComposerTriggerForCurrentContext, threadId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -2394,14 +2480,23 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setComposerHighlightedItemId(null);
       setComposerCursor(0);
       setComposerTrigger(null);
+      selectedProviderSlashCommandRef.current = null;
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
       });
       return;
     }
+    const providerSlashCommandBypassForRetry = resolveProviderSlashCommandBypassForRetry({
+      provider: selectedProvider,
+      selectedSlashCommand: selectedProviderSlashCommandRef.current,
+      trimmedPrompt: trimmed,
+    });
+    const shouldBypassStandaloneSlashCommand = providerSlashCommandBypassForRetry !== null;
     const standaloneSlashCommand =
-      composerImages.length === 0 && sendableComposerTerminalContexts.length === 0
+      !shouldBypassStandaloneSlashCommand &&
+      composerImages.length === 0 &&
+      sendableComposerTerminalContexts.length === 0
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
@@ -2411,6 +2506,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setComposerHighlightedItemId(null);
       setComposerCursor(0);
       setComposerTrigger(null);
+      selectedProviderSlashCommandRef.current = null;
       return;
     }
     if (!hasSendableContent) {
@@ -2429,6 +2525,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
     if (!activeProject) return;
     const threadIdForSend = activeThread.id;
+    selectedProviderSlashCommandRef.current = null;
     const isFirstMessage = !isServerThread || activeThread.messages.length === 0;
     const baseBranchForWorktree =
       isFirstMessage && envMode === "worktree" && !activeThread.worktreePath
@@ -2513,6 +2610,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     setComposerHighlightedItemId(null);
     setComposerCursor(0);
     setComposerTrigger(null);
+    selectedProviderSlashCommandRef.current = null;
 
     let createdServerThreadForLocalDraft = false;
     let turnStartSucceeded = false;
@@ -2682,7 +2780,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
         setComposerCursor(collapseExpandedComposerCursor(promptForSend, promptForSend.length));
         addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageForRetry));
         addComposerTerminalContextsToDraft(composerTerminalContextsSnapshot);
-        setComposerTrigger(detectComposerTrigger(promptForSend, promptForSend.length));
+        selectedProviderSlashCommandRef.current = providerSlashCommandBypassForRetry;
+        setComposerTrigger(
+          detectComposerTriggerForCurrentContext(promptForSend, promptForSend.length),
+        );
       }
       setThreadError(
         threadIdForSend,
@@ -2793,6 +2894,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       promptRef.current = "";
       setComposerCursor(0);
       setComposerTrigger(null);
+      selectedProviderSlashCommandRef.current = null;
     },
     [activePendingUserInput],
   );
@@ -2821,10 +2923,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }));
       setComposerCursor(nextCursor);
       setComposerTrigger(
-        cursorAdjacentToMention ? null : detectComposerTrigger(value, expandedCursor),
+        cursorAdjacentToMention
+          ? null
+          : detectComposerTriggerForCurrentContext(value, expandedCursor),
       );
     },
-    [activePendingUserInput],
+    [activePendingUserInput, detectComposerTriggerForCurrentContext],
   );
 
   const onAdvanceActivePendingUserInput = useCallback(() => {
@@ -3140,10 +3244,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
       setPrompt(nextPrompt);
       const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
       setComposerCursor(nextCursor);
-      setComposerTrigger(detectComposerTrigger(nextPrompt, nextPrompt.length));
+      setComposerTrigger(detectComposerTriggerForCurrentContext(nextPrompt, nextPrompt.length));
       scheduleComposerFocus();
     },
-    [scheduleComposerFocus, setPrompt],
+    [detectComposerTriggerForCurrentContext, scheduleComposerFocus, setPrompt],
   );
   const providerTraitsMenuContent = renderProviderTraitsMenuContent({
     provider: selectedProvider,
@@ -3207,14 +3311,22 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
       setComposerCursor(nextCursor);
       setComposerTrigger(
-        detectComposerTrigger(next.text, expandCollapsedComposerCursor(next.text, nextCursor)),
+        detectComposerTriggerForCurrentContext(
+          next.text,
+          expandCollapsedComposerCursor(next.text, nextCursor),
+        ),
       );
       window.requestAnimationFrame(() => {
         composerEditorRef.current?.focusAt(nextCursor);
       });
       return true;
     },
-    [activePendingProgress?.activeQuestion, activePendingUserInput, setPrompt],
+    [
+      activePendingProgress?.activeQuestion,
+      activePendingUserInput,
+      detectComposerTriggerForCurrentContext,
+      setPrompt,
+    ],
   );
 
   const readComposerSnapshot = useCallback((): {
@@ -3242,9 +3354,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
     const snapshot = readComposerSnapshot();
     return {
       snapshot,
-      trigger: detectComposerTrigger(snapshot.value, snapshot.expandedCursor),
+      trigger: detectComposerTriggerForCurrentContext(snapshot.value, snapshot.expandedCursor),
     };
-  }, [readComposerSnapshot]);
+  }, [detectComposerTriggerForCurrentContext, readComposerSnapshot]);
 
   const onSelectComposerItem = useCallback(
     (item: ComposerCommandItem) => {
@@ -3274,7 +3386,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         return;
       }
       if (item.type === "slash-command") {
-        if (item.command === "model") {
+        if (item.source === "app" && item.localCommand === "model") {
           const replacement = "/model ";
           const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
             snapshot.value,
@@ -3288,16 +3400,43 @@ export default function ChatView({ threadId }: ChatViewProps) {
             { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
           );
           if (applied) {
+            selectedProviderSlashCommandRef.current = null;
             setComposerHighlightedItemId(null);
           }
           return;
         }
-        void handleInteractionModeChange(item.command === "plan" ? "plan" : "default");
-        const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
-          expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
-        });
+        if (item.source === "app") {
+          void handleInteractionModeChange(item.localCommand === "plan" ? "plan" : "default");
+          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+            expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+          });
+          if (applied) {
+            selectedProviderSlashCommandRef.current = null;
+            setComposerHighlightedItemId(null);
+          }
+          return;
+        }
+
+        const replacement = `${item.command} `;
+        const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
+          snapshot.value,
+          trigger.rangeEnd,
+          replacement,
+        );
+        const previousProviderSlashCommand = selectedProviderSlashCommandRef.current;
+        selectedProviderSlashCommandRef.current = LOCAL_APP_SLASH_COMMANDS.has(item.command)
+          ? item.command
+          : null;
+        const applied = applyPromptReplacement(
+          trigger.rangeStart,
+          replacementRangeEnd,
+          replacement,
+          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+        );
         if (applied) {
           setComposerHighlightedItemId(null);
+        } else {
+          selectedProviderSlashCommandRef.current = previousProviderSlashCommand;
         }
         return;
       }
@@ -3306,6 +3445,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
       });
       if (applied) {
+        selectedProviderSlashCommandRef.current = null;
         setComposerHighlightedItemId(null);
       }
     },
@@ -3371,13 +3511,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
       setComposerCursor(nextCursor);
       setComposerTrigger(
-        cursorAdjacentToMention ? null : detectComposerTrigger(nextPrompt, expandedCursor),
+        cursorAdjacentToMention
+          ? null
+          : detectComposerTriggerForCurrentContext(nextPrompt, expandedCursor),
       );
     },
     [
       activePendingProgress?.activeQuestion,
       activePendingUserInput,
       composerTerminalContexts,
+      detectComposerTriggerForCurrentContext,
       onChangeActivePendingUserInputCustomAnswer,
       setPrompt,
       setComposerDraftTerminalContexts,
@@ -3521,6 +3664,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
 
       {/* Error banner */}
       <ProviderHealthBanner status={activeProviderStatus} />
+      {activeClaudeRuntimeInfo ? (
+        <div className="px-3 pt-2 text-muted-foreground text-xs sm:px-5">
+          {`Cloud Code: ${activeClaudeRuntimeInfo.slashCommands.length} commands · ${activeClaudeRuntimeInfo.skills.length} skills · sources: ${activeClaudeRuntimeInfo.settingSources.join(", ")}`}
+        </div>
+      ) : null}
       <ThreadErrorBanner
         error={activeThread.error}
         onDismiss={() => setThreadError(activeThread.id, null)}

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -19,7 +19,11 @@ export type ComposerCommandItem =
   | {
       id: string;
       type: "slash-command";
-      command: ComposerSlashCommand;
+      source: "app" | "provider";
+      command: string;
+      localCommand?: ComposerSlashCommand;
+      provider?: ProviderKind;
+      groupLabel: string;
       label: string;
       description: string;
     }
@@ -52,15 +56,29 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
     >
       <div className="relative overflow-hidden rounded-xl border border-border/80 bg-popover/96 shadow-lg/8 backdrop-blur-xs">
         <CommandList className="max-h-64">
-          {props.items.map((item) => (
-            <ComposerCommandMenuItem
-              key={item.id}
-              item={item}
-              resolvedTheme={props.resolvedTheme}
-              isActive={props.activeItemId === item.id}
-              onSelect={props.onSelect}
-            />
-          ))}
+          {props.items.map((item, index) => {
+            const previous = index > 0 ? props.items[index - 1] : null;
+            const previousSlashCommand = previous?.type === "slash-command" ? previous : null;
+            const showGroupLabel =
+              item.type === "slash-command" &&
+              (!previousSlashCommand || previousSlashCommand.groupLabel !== item.groupLabel);
+
+            return (
+              <div key={item.id}>
+                {showGroupLabel ? (
+                  <div className="px-3 pt-2 pb-1 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground/70">
+                    {item.groupLabel}
+                  </div>
+                ) : null}
+                <ComposerCommandMenuItem
+                  item={item}
+                  resolvedTheme={props.resolvedTheme}
+                  isActive={props.activeItemId === item.id}
+                  onSelect={props.onSelect}
+                />
+              </div>
+            );
+          })}
         </CommandList>
         {props.items.length === 0 && (
           <p className="px-3 py-2 text-muted-foreground/70 text-xs">
@@ -104,7 +122,13 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         />
       ) : null}
       {props.item.type === "slash-command" ? (
-        <BotIcon className="size-4 text-muted-foreground/80" />
+        props.item.source === "provider" ? (
+          <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+            Claude
+          </Badge>
+        ) : (
+          <BotIcon className="size-4 text-muted-foreground/80" />
+        )
       ) : null}
       {props.item.type === "model" ? (
         <Badge variant="outline" className="px-1.5 py-0 text-[10px]">

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -4,9 +4,12 @@ import {
   clampCollapsedComposerCursor,
   collapseExpandedComposerCursor,
   detectComposerTrigger,
+  detectComposerTriggerWithProviderSlashBypass,
   expandCollapsedComposerCursor,
   isCollapsedCursorAdjacentToInlineToken,
+  normalizeSlashCommandToken,
   parseStandaloneComposerSlashCommand,
+  promptStartsWithSlashCommand,
   replaceTextRange,
 } from "./composer-logic";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
@@ -36,6 +39,18 @@ describe("detectComposerTrigger", () => {
     });
   });
 
+  it("treats exact /model as a slash-command trigger until arguments begin", () => {
+    const text = "/model";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "model",
+      rangeStart: 0,
+      rangeEnd: text.length,
+    });
+  });
+
   it("detects slash model query after /model", () => {
     const text = "/model spark";
     const trigger = detectComposerTrigger(text, text.length);
@@ -55,6 +70,18 @@ describe("detectComposerTrigger", () => {
     expect(trigger).toEqual({
       kind: "slash-command",
       query: "pl",
+      rangeStart: 0,
+      rangeEnd: text.length,
+    });
+  });
+
+  it("detects arbitrary provider slash commands while typing", () => {
+    const text = "/rev";
+    const trigger = detectComposerTrigger(text, text.length);
+
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "rev",
       rangeStart: 0,
       rangeEnd: text.length,
     });
@@ -98,6 +125,50 @@ describe("detectComposerTrigger", () => {
     expect(trigger).not.toBeNull();
     expect(trigger?.kind).toBe("path");
     expect(trigger?.query).toBe("");
+  });
+});
+
+describe("detectComposerTriggerWithProviderSlashBypass", () => {
+  it("suppresses the local /model trigger when a Claude provider slash bypass is active", () => {
+    expect(
+      detectComposerTriggerWithProviderSlashBypass({
+        text: "/model ",
+        cursor: "/model ".length,
+        provider: "claudeAgent",
+        bypassSlashCommand: "/model",
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps regular provider slash commands visible when no collision bypass is active", () => {
+    expect(
+      detectComposerTriggerWithProviderSlashBypass({
+        text: "/review",
+        cursor: "/review".length,
+        provider: "claudeAgent",
+        bypassSlashCommand: null,
+      }),
+    ).toEqual({
+      kind: "slash-command",
+      query: "review",
+      rangeStart: 0,
+      rangeEnd: "/review".length,
+    });
+  });
+});
+
+describe("normalizeSlashCommandToken", () => {
+  it("returns the first normalized slash command token", () => {
+    expect(normalizeSlashCommandToken(" /Plan extra args ")).toBe("/plan");
+    expect(normalizeSlashCommandToken("plain text")).toBeNull();
+  });
+});
+
+describe("promptStartsWithSlashCommand", () => {
+  it("accepts prompts that start with the exact slash command token", () => {
+    expect(promptStartsWithSlashCommand("/plan review the patch", "/plan")).toBe(true);
+    expect(promptStartsWithSlashCommand("/plan\nreview the patch", "/plan")).toBe(true);
+    expect(promptStartsWithSlashCommand("please /plan", "/plan")).toBe(false);
   });
 });
 

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -1,5 +1,6 @@
 import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
+import { type ProviderKind } from "@t3tools/contracts";
 
 export type ComposerTriggerKind = "path" | "slash-command" | "slash-model";
 export type ComposerSlashCommand = "model" | "plan" | "default";
@@ -11,7 +12,8 @@ export interface ComposerTrigger {
   rangeEnd: number;
 }
 
-const SLASH_COMMANDS: readonly ComposerSlashCommand[] = ["model", "plan", "default"];
+export const LOCAL_APP_SLASH_COMMANDS = new Set(["/model", "/plan", "/default"]);
+
 const isInlineTokenSegment = (
   segment: { type: "text"; text: string } | { type: "mention" } | { type: "terminal-context" },
 ): boolean => segment.type !== "text";
@@ -192,24 +194,12 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
   if (linePrefix.startsWith("/")) {
     const commandMatch = /^\/(\S*)$/.exec(linePrefix);
     if (commandMatch) {
-      const commandQuery = commandMatch[1] ?? "";
-      if (commandQuery.toLowerCase() === "model") {
-        return {
-          kind: "slash-model",
-          query: "",
-          rangeStart: lineStart,
-          rangeEnd: cursor,
-        };
-      }
-      if (SLASH_COMMANDS.some((command) => command.startsWith(commandQuery.toLowerCase()))) {
-        return {
-          kind: "slash-command",
-          query: commandQuery,
-          rangeStart: lineStart,
-          rangeEnd: cursor,
-        };
-      }
-      return null;
+      return {
+        kind: "slash-command",
+        query: commandMatch[1] ?? "",
+        rangeStart: lineStart,
+        rangeEnd: cursor,
+      };
     }
 
     const modelMatch = /^\/model(?:\s+(.*))?$/.exec(linePrefix);
@@ -235,6 +225,68 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
     rangeStart: tokenStart,
     rangeEnd: cursor,
   };
+}
+
+export function normalizeSlashCommandToken(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const token = value.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? "";
+  if (!token.startsWith("/")) {
+    return null;
+  }
+  return token.length > 1 ? token : null;
+}
+
+export function promptStartsWithSlashCommand(text: string, command: string): boolean {
+  return (
+    text === command ||
+    text.startsWith(`${command} `) ||
+    text.startsWith(`${command}\n`) ||
+    text.startsWith(`${command}\t`)
+  );
+}
+
+export function detectComposerTriggerWithProviderSlashBypass(input: {
+  text: string;
+  cursor: number;
+  provider: ProviderKind;
+  bypassSlashCommand: string | null;
+}): ComposerTrigger | null {
+  const trigger = detectComposerTrigger(input.text, input.cursor);
+  if (input.provider !== "claudeAgent") {
+    return trigger;
+  }
+
+  const bypassSlashCommand = normalizeSlashCommandToken(input.bypassSlashCommand);
+  if (!bypassSlashCommand || !LOCAL_APP_SLASH_COMMANDS.has(bypassSlashCommand)) {
+    return trigger;
+  }
+
+  const lineStart = input.text.lastIndexOf("\n", Math.max(0, input.cursor - 1)) + 1;
+  const linePrefix = input.text.slice(lineStart, input.cursor).trimEnd();
+  if (!promptStartsWithSlashCommand(linePrefix, bypassSlashCommand)) {
+    return trigger;
+  }
+
+  if (bypassSlashCommand === "/model") {
+    if (
+      trigger?.kind === "slash-model" ||
+      (trigger?.kind === "slash-command" && trigger.query.trim().toLowerCase() === "model")
+    ) {
+      return null;
+    }
+    return trigger;
+  }
+
+  if (
+    trigger?.kind === "slash-command" &&
+    trigger.query.trim().toLowerCase() === bypassSlashCommand.slice(1)
+  ) {
+    return null;
+  }
+
+  return trigger;
 }
 
 export function parseStandaloneComposerSlashCommand(

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -2,13 +2,18 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDownIcon, PlusIcon, RotateCcwIcon, Undo2Icon, XIcon } from "lucide-react";
 import { type ReactNode, useCallback, useState } from "react";
-import { type ProviderKind, DEFAULT_GIT_TEXT_GENERATION_MODEL } from "@t3tools/contracts";
+import {
+  type ProviderKind,
+  DEFAULT_CLAUDE_SETTING_SOURCES,
+  DEFAULT_GIT_TEXT_GENERATION_MODEL,
+} from "@t3tools/contracts";
 import { getModelOptions, normalizeModelSlug } from "@t3tools/shared/model";
 import {
   getAppModelOptions,
   getCustomModelsForProvider,
   MAX_CUSTOM_MODEL_LENGTH,
   MODEL_PROVIDER_SETTINGS,
+  normalizeClaudeSettingSources,
   patchCustomModels,
   useAppSettings,
 } from "../appSettings";
@@ -188,12 +193,16 @@ function SettingResetButton({ label, onClick }: { label: string; onClick: () => 
 function SettingsRouteView() {
   const { theme, setTheme } = useTheme();
   const { settings, defaults, updateSettings, resetSettings } = useAppSettings();
+  const claudeSettingSources = normalizeClaudeSettingSources(settings.claudeSettingSources);
+  const defaultClaudeSettingSources = normalizeClaudeSettingSources(defaults.claudeSettingSources);
+  const claudeSettingSourcesDirty =
+    JSON.stringify(claudeSettingSources) !== JSON.stringify(defaultClaudeSettingSources);
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);
   const [openKeybindingsError, setOpenKeybindingsError] = useState<string | null>(null);
   const [openInstallProviders, setOpenInstallProviders] = useState<Record<ProviderKind, boolean>>({
     codex: Boolean(settings.codexBinaryPath || settings.codexHomePath),
-    claudeAgent: Boolean(settings.claudeBinaryPath),
+    claudeAgent: Boolean(settings.claudeBinaryPath || claudeSettingSourcesDirty),
   });
   const [selectedCustomModelProvider, setSelectedCustomModelProvider] =
     useState<ProviderKind>("codex");
@@ -247,6 +256,7 @@ function SettingsRouteView() {
     : savedCustomModelRows.slice(0, 5);
   const isInstallSettingsDirty =
     settings.claudeBinaryPath !== defaults.claudeBinaryPath ||
+    claudeSettingSourcesDirty ||
     settings.codexBinaryPath !== defaults.codexBinaryPath ||
     settings.codexHomePath !== defaults.codexHomePath;
   const changedSettingLabels = [
@@ -813,6 +823,7 @@ function SettingsRouteView() {
                       onClick={() => {
                         updateSettings({
                           claudeBinaryPath: defaults.claudeBinaryPath,
+                          claudeSettingSources: [...DEFAULT_CLAUDE_SETTING_SOURCES],
                           codexBinaryPath: defaults.codexBinaryPath,
                           codexHomePath: defaults.codexHomePath,
                         });
@@ -833,7 +844,8 @@ function SettingsRouteView() {
                         providerSettings.provider === "codex"
                           ? settings.codexBinaryPath !== defaults.codexBinaryPath ||
                             settings.codexHomePath !== defaults.codexHomePath
-                          : settings.claudeBinaryPath !== defaults.claudeBinaryPath;
+                          : settings.claudeBinaryPath !== defaults.claudeBinaryPath ||
+                            claudeSettingSourcesDirty;
                       const binaryPathValue =
                         providerSettings.binaryPathKey === "claudeBinaryPath"
                           ? claudeBinaryPath
@@ -930,6 +942,96 @@ function SettingsRouteView() {
                                         </span>
                                       ) : null}
                                     </label>
+                                  ) : null}
+
+                                  {providerSettings.provider === "claudeAgent" ? (
+                                    <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
+                                      <div className="flex items-center justify-between gap-3">
+                                        <div>
+                                          <p className="text-xs font-medium text-foreground">
+                                            Cloud Code setting sources
+                                          </p>
+                                          <p className="mt-1 text-xs text-muted-foreground">
+                                            Order is fixed as user, project, local. Loading user or
+                                            local settings can change Claude behavior between
+                                            machines.
+                                          </p>
+                                        </div>
+                                        {claudeSettingSourcesDirty ? (
+                                          <Button
+                                            size="xs"
+                                            variant="ghost"
+                                            onClick={() =>
+                                              updateSettings({
+                                                claudeSettingSources: [
+                                                  ...DEFAULT_CLAUDE_SETTING_SOURCES,
+                                                ],
+                                              })
+                                            }
+                                          >
+                                            Reset
+                                          </Button>
+                                        ) : null}
+                                      </div>
+                                      <div className="mt-3 space-y-2">
+                                        {(
+                                          [
+                                            {
+                                              value: "user",
+                                              label: "User",
+                                              description:
+                                                "~/.claude settings and skills for the current OS user.",
+                                            },
+                                            {
+                                              value: "project",
+                                              label: "Project",
+                                              description:
+                                                "Checked-in .claude settings and project skills in this workspace.",
+                                            },
+                                            {
+                                              value: "local",
+                                              label: "Local",
+                                              description:
+                                                "Machine-local project overrides such as .claude/settings.local.json.",
+                                            },
+                                          ] as const
+                                        ).map((source) => (
+                                          <div
+                                            key={source.value}
+                                            className="flex items-start justify-between gap-3 rounded-md border border-border/60 bg-background px-3 py-2"
+                                          >
+                                            <div className="min-w-0">
+                                              <p className="text-xs font-medium text-foreground">
+                                                {source.label}
+                                              </p>
+                                              <p className="mt-1 text-xs text-muted-foreground">
+                                                {source.description}
+                                              </p>
+                                            </div>
+                                            <Switch
+                                              checked={claudeSettingSources.includes(source.value)}
+                                              onCheckedChange={(checked) => {
+                                                const nextSources = checked
+                                                  ? normalizeClaudeSettingSources([
+                                                      ...claudeSettingSources,
+                                                      source.value,
+                                                    ])
+                                                  : claudeSettingSources.filter(
+                                                      (entry) => entry !== source.value,
+                                                    );
+                                                if (nextSources.length === 0) {
+                                                  return;
+                                                }
+                                                updateSettings({
+                                                  claudeSettingSources: nextSources,
+                                                });
+                                              }}
+                                              aria-label={`Enable Claude ${source.label.toLowerCase()} setting source`}
+                                            />
+                                          </div>
+                                        ))}
+                                      </div>
+                                    </div>
                                   ) : null}
                                 </div>
                               </div>

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -266,6 +266,9 @@ export function syncServerReadModel(state: AppState, readModel: OrchestrationRea
               createdAt: thread.session.updatedAt,
               updatedAt: thread.session.updatedAt,
               ...(thread.session.lastError ? { lastError: thread.session.lastError } : {}),
+              ...(thread.session.providerRuntimeInfo
+                ? { providerRuntimeInfo: thread.session.providerRuntimeInfo }
+                : {}),
             }
           : null,
         messages: thread.messages.map((message) => {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -4,6 +4,7 @@ import type {
   OrchestrationProposedPlanId,
   OrchestrationSessionStatus,
   OrchestrationThreadActivity,
+  ProviderRuntimeInfo,
   ProjectScript as ContractProjectScript,
   ThreadId,
   ProjectId,
@@ -118,4 +119,5 @@ export interface ThreadSession {
   updatedAt: string;
   lastError?: string;
   orchestrationStatus: OrchestrationSessionStatus;
+  providerRuntimeInfo?: ProviderRuntimeInfo;
 }

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -3,8 +3,10 @@ import { it } from "@effect/vitest";
 import { Effect, Schema } from "effect";
 
 import {
+  DEFAULT_CLAUDE_SETTING_SOURCES,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
+  OrchestrationEvent,
   OrchestrationGetTurnDiffInput,
   OrchestrationLatestTurn,
   ProjectCreatedPayload,
@@ -15,6 +17,7 @@ import {
   ThreadMetaUpdatedPayload,
   ThreadTurnStartCommand,
   ThreadCreatedPayload,
+  ThreadSubThreadCreatedPayload,
   ThreadTurnDiff,
   ThreadTurnStartRequestedPayload,
 } from "./orchestration";
@@ -31,8 +34,12 @@ const decodeThreadTurnStartRequestedPayload = Schema.decodeUnknownEffect(
 const decodeOrchestrationLatestTurn = Schema.decodeUnknownEffect(OrchestrationLatestTurn);
 const decodeOrchestrationProposedPlan = Schema.decodeUnknownEffect(OrchestrationProposedPlan);
 const decodeOrchestrationSession = Schema.decodeUnknownEffect(OrchestrationSession);
+const decodeOrchestrationEvent = Schema.decodeUnknownEffect(OrchestrationEvent);
 const decodeThreadCreatedPayload = Schema.decodeUnknownEffect(ThreadCreatedPayload);
 const decodeThreadMetaUpdatedPayload = Schema.decodeUnknownEffect(ThreadMetaUpdatedPayload);
+const decodeThreadSubThreadCreatedPayload = Schema.decodeUnknownEffect(
+  ThreadSubThreadCreatedPayload,
+);
 
 it.effect("parses turn diff input when fromTurnCount <= toTurnCount", () =>
   Effect.gen(function* () {
@@ -227,6 +234,51 @@ it.effect("decodes thread.meta-updated payloads with explicit provider", () =>
   }),
 );
 
+it.effect("decodes legacy thread.sub-thread-created payload defaults", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeThreadSubThreadCreatedPayload({
+      threadId: "thread-parent",
+      subThreadId: "thread-child",
+      title: "Child thread",
+      model: "gpt-5.4",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    assert.strictEqual(parsed.runtimeMode, DEFAULT_RUNTIME_MODE);
+    assert.strictEqual(parsed.interactionMode, DEFAULT_PROVIDER_INTERACTION_MODE);
+    assert.strictEqual(parsed.branch, null);
+    assert.strictEqual(parsed.worktreePath, null);
+  }),
+);
+
+it.effect("decodes legacy thread.provider-skills-set events", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeOrchestrationEvent({
+      sequence: 12,
+      eventId: "evt-provider-skills",
+      aggregateKind: "thread",
+      aggregateId: "thread-1",
+      type: "thread.provider-skills-set",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      commandId: null,
+      causationEventId: null,
+      correlationId: null,
+      metadata: {},
+      payload: {
+        threadId: "thread-1",
+        skills: [{ name: "review" }],
+      },
+    });
+
+    assert.strictEqual(parsed.type, "thread.provider-skills-set");
+    if (parsed.type === "thread.provider-skills-set") {
+      assert.strictEqual(parsed.payload.threadId, "thread-1");
+      assert.deepStrictEqual(parsed.payload.skills, [{ name: "review" }]);
+    }
+  }),
+);
+
 it.effect("accepts provider-scoped model options in thread.turn.start", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeThreadTurnStartCommand({
@@ -348,6 +400,43 @@ it.effect("decodes orchestration session runtime mode defaults", () =>
       updatedAt: "2026-01-01T00:00:00.000Z",
     });
     assert.strictEqual(parsed.runtimeMode, DEFAULT_RUNTIME_MODE);
+  }),
+);
+
+it.effect("decodes provider runtime info for claude sessions", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeOrchestrationSession({
+      threadId: "thread-1",
+      status: "ready",
+      providerName: "claudeAgent",
+      runtimeMode: "approval-required",
+      activeTurnId: null,
+      lastError: null,
+      providerRuntimeInfo: {
+        claudeAgent: {
+          slashCommands: ["/plan", "/review"],
+          skills: ["project-audit"],
+          tools: ["Skill", "Bash"],
+          plugins: ["filesystem"],
+          claudeCodeVersion: "1.2.3",
+          cwd: "/tmp/workspace",
+          settingSources: [...DEFAULT_CLAUDE_SETTING_SOURCES],
+        },
+      },
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    assert.deepStrictEqual(parsed.providerRuntimeInfo, {
+      claudeAgent: {
+        slashCommands: ["/plan", "/review"],
+        skills: ["project-audit"],
+        tools: ["Skill", "Bash"],
+        plugins: ["filesystem"],
+        claudeCodeVersion: "1.2.3",
+        cwd: "/tmp/workspace",
+        settingSources: [...DEFAULT_CLAUDE_SETTING_SOURCES],
+      },
+    });
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -43,6 +43,10 @@ export const ProviderSandboxMode = Schema.Literals([
 ]);
 export type ProviderSandboxMode = typeof ProviderSandboxMode.Type;
 export const DEFAULT_PROVIDER_KIND: ProviderKind = "codex";
+export const ClaudeSettingSource = Schema.Literals(["user", "project", "local"]);
+export type ClaudeSettingSource = typeof ClaudeSettingSource.Type;
+export const DEFAULT_CLAUDE_SETTING_SOURCES = ["user", "project", "local"] as const;
+export const ClaudeSettingSources = Schema.Array(ClaudeSettingSource);
 
 export const CodexModelSelection = Schema.Struct({
   provider: Schema.Literal("codex"),
@@ -70,6 +74,7 @@ export const ClaudeProviderStartOptions = Schema.Struct({
   binaryPath: Schema.optional(TrimmedNonEmptyString),
   permissionMode: Schema.optional(TrimmedNonEmptyString),
   maxThinkingTokens: Schema.optional(NonNegativeInt),
+  settingSources: Schema.optional(ClaudeSettingSources),
 });
 
 export const ProviderStartOptions = Schema.Struct({
@@ -214,6 +219,22 @@ export const OrchestrationSessionStatus = Schema.Literals([
 ]);
 export type OrchestrationSessionStatus = typeof OrchestrationSessionStatus.Type;
 
+export const ClaudeRuntimeCapabilities = Schema.Struct({
+  slashCommands: Schema.Array(TrimmedNonEmptyString),
+  skills: Schema.Array(TrimmedNonEmptyString),
+  tools: Schema.Array(TrimmedNonEmptyString),
+  plugins: Schema.Array(TrimmedNonEmptyString),
+  claudeCodeVersion: Schema.NullOr(TrimmedNonEmptyString),
+  cwd: Schema.NullOr(TrimmedNonEmptyString),
+  settingSources: ClaudeSettingSources,
+});
+export type ClaudeRuntimeCapabilities = typeof ClaudeRuntimeCapabilities.Type;
+
+export const ProviderRuntimeInfo = Schema.Struct({
+  claudeAgent: Schema.optional(ClaudeRuntimeCapabilities),
+});
+export type ProviderRuntimeInfo = typeof ProviderRuntimeInfo.Type;
+
 export const OrchestrationSession = Schema.Struct({
   threadId: ThreadId,
   status: OrchestrationSessionStatus,
@@ -221,6 +242,7 @@ export const OrchestrationSession = Schema.Struct({
   runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(() => DEFAULT_RUNTIME_MODE)),
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(TrimmedNonEmptyString),
+  providerRuntimeInfo: Schema.optional(ProviderRuntimeInfo),
   updatedAt: IsoDateTime,
 });
 export type OrchestrationSession = typeof OrchestrationSession.Type;
@@ -596,6 +618,8 @@ export const OrchestrationEventType = Schema.Literals([
   "project.meta-updated",
   "project.deleted",
   "thread.created",
+  "thread.sub-thread-created",
+  "thread.provider-skills-set",
   "thread.deleted",
   "thread.meta-updated",
   "thread.runtime-mode-set",
@@ -656,6 +680,30 @@ export const ThreadCreatedPayload = Schema.Struct({
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
+});
+
+// Legacy compatibility for historical event-store rows emitted before
+// subthreads were normalized into standalone thread.created events.
+export const ThreadSubThreadCreatedPayload = Schema.Struct({
+  threadId: ThreadId,
+  subThreadId: ThreadId,
+  title: TrimmedNonEmptyString,
+  model: TrimmedNonEmptyString,
+  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(() => DEFAULT_RUNTIME_MODE)),
+  interactionMode: ProviderInteractionMode.pipe(
+    Schema.withDecodingDefault(() => DEFAULT_PROVIDER_INTERACTION_MODE),
+  ),
+  branch: Schema.NullOr(TrimmedNonEmptyString).pipe(Schema.withDecodingDefault(() => null)),
+  worktreePath: Schema.NullOr(TrimmedNonEmptyString).pipe(Schema.withDecodingDefault(() => null)),
+  createdAt: IsoDateTime,
+  updatedAt: IsoDateTime,
+});
+
+// Legacy compatibility for historical event-store rows emitted before provider
+// capabilities were folded into thread.session-set snapshots.
+export const ThreadProviderSkillsSetPayload = Schema.Struct({
+  threadId: ThreadId,
+  skills: Schema.Array(Schema.Unknown).pipe(Schema.withDecodingDefault(() => [])),
 });
 
 export const ThreadDeletedPayload = Schema.Struct({
@@ -815,6 +863,16 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.created"),
     payload: ThreadCreatedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.sub-thread-created"),
+    payload: ThreadSubThreadCreatedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.provider-skills-set"),
+    payload: ThreadProviderSkillsSetPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,

--- a/packages/contracts/src/provider.test.ts
+++ b/packages/contracts/src/provider.test.ts
@@ -68,6 +68,7 @@ describe("ProviderSessionStartInput", () => {
           binaryPath: "/usr/local/bin/claude",
           permissionMode: "plan",
           maxThinkingTokens: 12_000,
+          settingSources: ["project", "user", "local"],
         },
       },
       runtimeMode: "full-access",
@@ -84,7 +85,27 @@ describe("ProviderSessionStartInput", () => {
     expect(parsed.providerOptions?.claudeAgent?.binaryPath).toBe("/usr/local/bin/claude");
     expect(parsed.providerOptions?.claudeAgent?.permissionMode).toBe("plan");
     expect(parsed.providerOptions?.claudeAgent?.maxThinkingTokens).toBe(12_000);
+    expect(parsed.providerOptions?.claudeAgent?.settingSources).toEqual([
+      "project",
+      "user",
+      "local",
+    ]);
     expect(parsed.runtimeMode).toBe("full-access");
+  });
+
+  it("rejects unsupported claude setting sources", () => {
+    expect(() =>
+      decodeProviderSessionStartInput({
+        threadId: "thread-1",
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+        providerOptions: {
+          claudeAgent: {
+            settingSources: ["global"],
+          },
+        },
+      }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./claude": {
+      "types": "./src/claude.ts",
+      "import": "./src/claude.ts"
+    },
     "./model": {
       "types": "./src/model.ts",
       "import": "./src/model.ts"

--- a/packages/shared/src/claude.test.ts
+++ b/packages/shared/src/claude.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { isClaudeSettingSource, normalizeClaudeSettingSources } from "./claude";
+
+describe("isClaudeSettingSource", () => {
+  it("accepts only supported Claude setting sources", () => {
+    expect(isClaudeSettingSource("user")).toBe(true);
+    expect(isClaudeSettingSource("project")).toBe(true);
+    expect(isClaudeSettingSource("local")).toBe(true);
+    expect(isClaudeSettingSource("workspace")).toBe(false);
+    expect(isClaudeSettingSource(null)).toBe(false);
+  });
+});
+
+describe("normalizeClaudeSettingSources", () => {
+  it("deduplicates entries and restores canonical order", () => {
+    expect(normalizeClaudeSettingSources(["local", "project", "local", "user"])).toEqual([
+      "user",
+      "project",
+      "local",
+    ]);
+  });
+
+  it("falls back to defaults for empty input", () => {
+    expect(normalizeClaudeSettingSources([])).toEqual(["user", "project", "local"]);
+  });
+
+  it("ignores invalid entries while keeping valid ones", () => {
+    expect(normalizeClaudeSettingSources(["project", "workspace", "local"])).toEqual([
+      "project",
+      "local",
+    ]);
+  });
+
+  it("falls back to defaults when every entry is invalid", () => {
+    expect(normalizeClaudeSettingSources(["workspace", "team"])).toEqual([
+      "user",
+      "project",
+      "local",
+    ]);
+  });
+});

--- a/packages/shared/src/claude.ts
+++ b/packages/shared/src/claude.ts
@@ -1,0 +1,22 @@
+import { DEFAULT_CLAUDE_SETTING_SOURCES, type ClaudeSettingSource } from "@t3tools/contracts";
+
+export function isClaudeSettingSource(value: unknown): value is ClaudeSettingSource {
+  return value === "user" || value === "project" || value === "local";
+}
+
+export function normalizeClaudeSettingSources(
+  sources: Iterable<string | null | undefined> | null | undefined,
+): ClaudeSettingSource[] {
+  const requested = new Set<ClaudeSettingSource>();
+
+  for (const source of sources ?? []) {
+    if (isClaudeSettingSource(source)) {
+      requested.add(source);
+    }
+  }
+
+  const normalized = DEFAULT_CLAUDE_SETTING_SOURCES.filter(
+    (source) => requested.size === 0 || requested.has(source),
+  );
+  return normalized.length > 0 ? [...normalized] : [...DEFAULT_CLAUDE_SETTING_SOURCES];
+}


### PR DESCRIPTION
> **Note:** We have read the [CONTRIBUTING.md](./CONTRIBUTING.md) and understand the project is not actively accepting contributions. We are submitting this PR to share work we found useful in our own usage of T3 Code. If the team decides this is not the right direction or scope for the project, we fully understand and will not take it personally. We simply want to collaborate and give back.

## What Changed

This PR surfaces **Claude Code capabilities** (slash commands, skills, tools, plugins) inside the T3 Code composer, so users can invoke them directly from the chat UI — the same way they work in the Claude Code CLI.

**Backend:**
- `ClaudeAdapter` now extracts and normalizes Claude's runtime capabilities from its init message (`buildClaudeRuntimeCapabilities()`)
- Capabilities are persisted in thread session metadata as `providerRuntimeInfo` (new DB migration)
- Environment variables passed to Claude are sanitized via an allowlist (~40 safe vars)
- Skill execution is gated: requires `approval-required` mode or explicit `T3CODE_CLAUDE_SKILLS_FULL_ACCESS=1`
- Legacy `thread.sub-thread-created` events are mapped for backward compatibility

**Frontend:**
- Composer autocomplete now shows provider slash commands alongside app commands
- Commands are visually distinguished with source badges ("App" vs "Claude")
- Claude setting sources (user/project/local) are configurable in provider settings

**Contracts & shared:**
- New schemas: `ClaudeRuntimeCapabilities`, `ProviderRuntimeInfo`, `ThreadSubThreadCreatedPayload`
- New shared utility: `normalizeClaudeSettingSources()`

## Why

T3 Code supports Claude as a provider, but none of Claude Code's extensibility features (skills, slash commands, tools, plugins) were exposed to the user. This meant users could not leverage the same workflows they use in the CLI — like `/test`, `/lint`, custom skills — through the T3 Code UI.

This change bridges that gap by extracting capabilities at session init and making them available in the composer, matching what users expect from a Claude Code integration.
> **Note:** The slash commands only work once you're in a Claude Code thread, not before. For that reason, the slash commands only show up after the first message is sent and responded. Maybe the team can work on it and make it work across providers, or before the first message is sent. 

## UI Changes

Composer autocomplete with Claude slash commands separated by source, with "Claude" badges:
<img width="767" height="263" alt="Captura de Tela 2026-03-25 às 16 08 15" src="https://github.com/user-attachments/assets/69a596f5-fed1-41e8-b71b-2ce0306ba0a7" />


## Checklist

- [x] This PR is small and focused (single feature, end-to-end)
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (**edit this PR to drag-drop the screenshot**)
- [x] N/A — no animation/interaction changes requiring video