### PR TITLE
fix(web): add pointer cursor to composer send button

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4024,7 +4024,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                           ) : (
                             <button
                               type="submit"
-                              className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/90 text-primary-foreground transition-all duration-150 hover:bg-primary hover:scale-105 disabled:opacity-30 disabled:hover:scale-100 sm:h-8 sm:w-8"
+                              className="flex h-9 w-9 enabled:cursor-pointer items-center justify-center rounded-full bg-primary/90 text-primary-foreground transition-all duration-150 hover:bg-primary hover:scale-105 disabled:pointer-events-none disabled:opacity-30 disabled:hover:scale-100 sm:h-8 sm:w-8"
                               disabled={
                                 isSendBusy || isConnecting || !composerSendState.hasSendableContent
                               }


### PR DESCRIPTION
## What Changed

Updated the composer send button in `ChatView` to use a pointer cursor only when the control is enabled.

## Why

The composer send button did not show a pointer cursor when it was clickable, making it inconsistent with other interactive controls.

## UI Changes

This is a cursor-affordance-only change.

I used a short recording instead of screenshots because the mouse pointer doesn't show up in screenshots.

https://github.com/user-attachments/assets/b8f7c6a7-f28a-448a-8185-0b5dbb3bf21a

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included a video for animation/interaction changes


Related to #416. Only affects the composer send button.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pointer cursor to composer send button in ChatView
> Adds `enabled:cursor-pointer` and `disabled:pointer-events-none` Tailwind classes to the submit button in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1415/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to match standard button cursor behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c22dde5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c22dde5f885d524785ff1f8cfc0294cddd57fdfe. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->