### PR TITLE
fix(desktop): prevent git actions and terminal toggle from overlapping

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -753,7 +753,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
           {initMutation.isPending ? "Initializing..." : "Initialize Git"}
         </Button>
       ) : (
-        <Group aria-label="Git actions">
+        <Group aria-label="Git actions" className="shrink-0">
           {quickActionDisabledReason ? (
             <Popover>
               <PopoverTrigger


### PR DESCRIPTION
## What Changed

Prevented the Git actions control from shrinking in the desktop header by adding `shrink-0` to the action group container.

## Why

On narrower desktop widths, the Git actions control and terminal toggle could compete for space and visually overlap. Keeping the Git actions group at a fixed shrink behavior makes the layout more predictable and avoids that collision without changing the interaction model.

## UI Changes


https://github.com/user-attachments/assets/1290bcc3-4d52-4c4b-a6f8-56d8bcc7e101


https://github.com/user-attachments/assets/778ab0a2-5e82-4643-be8d-ba04cd76d718


## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent `GitActionsControl` from shrinking in flex layouts
> Adds `shrink-0` to the `GitActionsControl` Group element in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/1423/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) so the git actions bar no longer compresses when flex space is constrained, preventing overlap with the terminal toggle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d8e9c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->