### PR TITLE
Improve desktop update button with status-based visuals

### DIFF
--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -309,3 +309,64 @@ export const OpenCodeIcon: Icon = (props) => (
     </defs>
   </svg>
 );
+
+const ROCKET_BODY =
+  "M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09zM12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z";
+const ROCKET_FINS = "M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5";
+
+/** Rocket icon with optional bottom-to-top fill overlay for download progress (0–100). */
+export function RocketUpdateIcon({
+  fillPercent,
+  ...props
+}: SVGProps<SVGSVGElement> & { fillPercent?: number | null }) {
+  const clipId = useId();
+  const showFill = typeof fillPercent === "number";
+
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none">
+      {showFill && (
+        <defs>
+          <clipPath id={clipId}>
+            <rect x="0" y={24 - (24 * fillPercent) / 100} width="24" height="24" />
+          </clipPath>
+        </defs>
+      )}
+      <path
+        d={ROCKET_BODY}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={showFill ? "opacity-30" : undefined}
+      />
+      <path
+        d={ROCKET_FINS}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={showFill ? "opacity-30" : undefined}
+      />
+      {showFill && (
+        <g clipPath={`url(#${clipId})`}>
+          <path
+            d={ROCKET_BODY}
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="currentColor"
+            fillOpacity="0.3"
+          />
+          <path
+            d={ROCKET_FINS}
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,7 +5,6 @@ import {
   FolderIcon,
   GitPullRequestIcon,
   PlusIcon,
-  RocketIcon,
   SettingsIcon,
   SquarePenIcon,
   TerminalIcon,
@@ -45,7 +44,13 @@ import {
 } from "../appSettings";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
-import { isLinuxPlatform, isMacPlatform, newCommandId, newProjectId } from "../lib/utils";
+import {
+  formatRelativeTime,
+  isLinuxPlatform,
+  isMacPlatform,
+  newCommandId,
+  newProjectId,
+} from "../lib/utils";
 import { useStore } from "../store";
 import { shortcutLabelForCommand } from "../keybindings";
 import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
@@ -55,6 +60,7 @@ import { readNativeApi } from "../nativeApi";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+import { RocketUpdateIcon } from "./Icons";
 import { toastManager } from "./ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
@@ -62,8 +68,8 @@ import {
   getDesktopUpdateButtonTooltip,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
+  resolveDesktopUpdateButtonVisualState,
   shouldShowArm64IntelBuildWarning,
-  shouldHighlightDesktopUpdateError,
   shouldShowDesktopUpdateButton,
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
@@ -119,16 +125,6 @@ const SIDEBAR_LIST_ANIMATION_OPTIONS = {
   easing: "ease-out",
 } as const;
 const loadedProjectFaviconSrcs = new Set<string>();
-
-function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
-}
 
 interface TerminalStatusIndicator {
   label: "Terminal process running";
@@ -1497,7 +1493,7 @@ export default function Sidebar() {
 
   const desktopUpdateTooltip = desktopUpdateState
     ? getDesktopUpdateButtonTooltip(desktopUpdateState)
-    : "Update available";
+    : "";
 
   const desktopUpdateButtonDisabled = isDesktopUpdateButtonDisabled(desktopUpdateState);
   const desktopUpdateButtonAction = desktopUpdateState
@@ -1509,17 +1505,12 @@ export default function Sidebar() {
     desktopUpdateState && showArm64IntelBuildWarning
       ? getArm64IntelBuildWarningDescription(desktopUpdateState)
       : null;
+  const desktopUpdateVisual = desktopUpdateState
+    ? resolveDesktopUpdateButtonVisualState(desktopUpdateState)
+    : null;
   const desktopUpdateButtonInteractivityClasses = desktopUpdateButtonDisabled
     ? "cursor-not-allowed opacity-60"
-    : "hover:bg-accent hover:text-foreground";
-  const desktopUpdateButtonClasses =
-    desktopUpdateState?.status === "downloaded"
-      ? "text-emerald-500"
-      : desktopUpdateState?.status === "downloading"
-        ? "text-sky-400"
-        : shouldHighlightDesktopUpdateError(desktopUpdateState)
-          ? "text-rose-500 animate-pulse"
-          : "text-amber-500 animate-pulse";
+    : "";
   const newThreadShortcutLabel =
     shortcutLabelForCommand(keybindings, "chat.newLocal") ??
     shortcutLabelForCommand(keybindings, "chat.new");
@@ -1624,36 +1615,49 @@ export default function Sidebar() {
     </div>
   );
 
+  const downloadPercent =
+    desktopUpdateState?.status === "downloading" &&
+    typeof desktopUpdateState.downloadPercent === "number"
+      ? desktopUpdateState.downloadPercent
+      : null;
+
+  const updateButton =
+    showDesktopUpdateButton && desktopUpdateVisual ? (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              aria-label={desktopUpdateTooltip}
+              aria-disabled={desktopUpdateButtonDisabled || undefined}
+              disabled={desktopUpdateButtonDisabled}
+              className={`group/update relative inline-flex size-7 ml-auto items-center justify-center rounded-md transition-all duration-150 ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateVisual.colorClass} ${desktopUpdateVisual.hoverClass}`}
+              onClick={handleDesktopUpdateButtonClick}
+            >
+              <RocketUpdateIcon
+                className={`size-3.5 ${desktopUpdateVisual.pulse ? "animate-pulse-soft group-hover/update:animate-none" : ""}`}
+                fillPercent={downloadPercent}
+              />
+            </button>
+          }
+        />
+        <TooltipPopup side="bottom">{desktopUpdateTooltip}</TooltipPopup>
+      </Tooltip>
+    ) : null;
+
   return (
     <>
       {isElectron ? (
         <>
           <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}
-            {showDesktopUpdateButton && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <button
-                      type="button"
-                      aria-label={desktopUpdateTooltip}
-                      aria-disabled={desktopUpdateButtonDisabled || undefined}
-                      disabled={desktopUpdateButtonDisabled}
-                      className={`inline-flex size-7 ml-auto mt-1.5 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
-                      onClick={handleDesktopUpdateButtonClick}
-                    >
-                      <RocketIcon className="size-3.5" />
-                    </button>
-                  }
-                />
-                <TooltipPopup side="bottom">{desktopUpdateTooltip}</TooltipPopup>
-              </Tooltip>
-            )}
+            <div className="mt-1.5">{updateButton}</div>
           </SidebarHeader>
         </>
       ) : (
-        <SidebarHeader className="gap-3 px-3 py-2 sm:gap-2.5 sm:px-4 sm:py-3">
+        <SidebarHeader className="flex-row items-center gap-2 px-3 py-2 sm:gap-2.5 sm:px-4 sm:py-3">
           {wordmark}
+          {updateButton}
         </SidebarHeader>
       )}
 
@@ -1664,7 +1668,8 @@ export default function Sidebar() {
               <TriangleAlertIcon />
               <AlertTitle>Intel build on Apple Silicon</AlertTitle>
               <AlertDescription>{arm64IntelBuildWarningDescription}</AlertDescription>
-              {desktopUpdateButtonAction !== "none" ? (
+              {desktopUpdateButtonAction === "download" ||
+              desktopUpdateButtonAction === "install" ? (
                 <AlertAction>
                   <Button
                     size="xs"

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1631,7 +1631,7 @@ export default function Sidebar() {
               aria-label={desktopUpdateTooltip}
               aria-disabled={desktopUpdateButtonDisabled || undefined}
               disabled={desktopUpdateButtonDisabled}
-              className={`group/update relative inline-flex size-7 ml-auto items-center justify-center rounded-md transition-all duration-150 ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateVisual.colorClass} ${desktopUpdateVisual.hoverClass}`}
+              className={`group/update relative inline-flex size-7 ml-auto items-center justify-center rounded-md transition-all duration-150 ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateVisual.colorClass} ${desktopUpdateButtonDisabled ? "" : desktopUpdateVisual.hoverClass}`}
               onClick={handleDesktopUpdateButtonClick}
             >
               <RocketUpdateIcon
@@ -1651,7 +1651,7 @@ export default function Sidebar() {
         <>
           <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}
-            <div className="mt-1.5">{updateButton}</div>
+            <div className="mt-1.5 ml-auto">{updateButton}</div>
           </SidebarHeader>
         </>
       ) : (

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -9,7 +9,6 @@ import {
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   resolveDesktopUpdateButtonVisualState,
-  shouldHighlightDesktopUpdateError,
   shouldShowArm64IntelBuildWarning,
   shouldShowDesktopUpdateButton,
   shouldToastDesktopUpdateActionResult,
@@ -164,25 +163,6 @@ describe("desktop update UI helpers", () => {
         accepted: true,
         completed: true,
         state: baseState,
-      }),
-    ).toBe(false);
-  });
-
-  it("highlights only actionable updater errors", () => {
-    expect(
-      shouldHighlightDesktopUpdateError({
-        ...baseState,
-        status: "error",
-        errorContext: "download",
-        canRetry: true,
-      }),
-    ).toBe(true);
-    expect(
-      shouldHighlightDesktopUpdateError({
-        ...baseState,
-        status: "error",
-        errorContext: "check",
-        canRetry: true,
       }),
     ).toBe(false);
   });

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
 
 import {
+  DEFAULT_VISUAL,
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
+  resolveDesktopUpdateButtonVisualState,
   shouldHighlightDesktopUpdateError,
   shouldShowArm64IntelBuildWarning,
   shouldShowDesktopUpdateButton,
@@ -79,6 +81,10 @@ describe("desktop update button state", () => {
     };
     expect(shouldShowDesktopUpdateButton(state)).toBe(false);
     expect(resolveDesktopUpdateButtonAction(state)).toBe("none");
+  });
+
+  it("returns none when idle", () => {
+    expect(resolveDesktopUpdateButtonAction(baseState)).toBe("none");
   });
 
   it("disables the button while downloading", () => {
@@ -205,5 +211,53 @@ describe("desktop update UI helpers", () => {
     };
 
     expect(getArm64IntelBuildWarningDescription(state)).toContain("Download the available update");
+  });
+});
+
+describe("resolveDesktopUpdateButtonVisualState", () => {
+  it("returns pulse and amber for available state", () => {
+    const visual = resolveDesktopUpdateButtonVisualState({
+      ...baseState,
+      status: "available",
+      availableVersion: "2.0.0",
+    });
+    expect(visual.pulse).toBe(true);
+    expect(visual.colorClass).toContain("amber");
+  });
+
+  it("returns no pulse for downloading state", () => {
+    const visual = resolveDesktopUpdateButtonVisualState({
+      ...baseState,
+      status: "downloading",
+      downloadPercent: 50,
+    });
+    expect(visual.pulse).toBe(false);
+    expect(visual.colorClass).toContain("sky");
+  });
+
+  it("returns pulse and emerald for downloaded state", () => {
+    const visual = resolveDesktopUpdateButtonVisualState({
+      ...baseState,
+      status: "downloaded",
+      downloadedVersion: "2.0.0",
+    });
+    expect(visual.pulse).toBe(true);
+    expect(visual.colorClass).toContain("emerald");
+  });
+
+  it("returns pulse and rose for error state", () => {
+    const visual = resolveDesktopUpdateButtonVisualState({
+      ...baseState,
+      status: "error",
+      errorContext: "download",
+      canRetry: true,
+    });
+    expect(visual.pulse).toBe(true);
+    expect(visual.colorClass).toContain("rose");
+  });
+
+  it("falls back to DEFAULT_VISUAL for unmapped statuses like idle", () => {
+    const visual = resolveDesktopUpdateButtonVisualState(baseState);
+    expect(visual).toBe(DEFAULT_VISUAL);
   });
 });

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -1,25 +1,59 @@
-import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
+import type {
+  DesktopUpdateActionResult,
+  DesktopUpdateState,
+  DesktopUpdateStatus,
+} from "@t3tools/contracts";
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
+
+export interface DesktopUpdateButtonVisualState {
+  pulse: boolean;
+  colorClass: string;
+  hoverClass: string;
+}
+
+/** Fallback visual used for statuses without an explicit mapping (e.g. idle, checking). */
+export const DEFAULT_VISUAL: DesktopUpdateButtonVisualState = {
+  pulse: true,
+  colorClass: "text-amber-500",
+  hoverClass: "hover:text-amber-400 hover:bg-amber-500/10",
+};
+
+const VISUAL_BY_STATUS: Partial<Record<DesktopUpdateStatus, DesktopUpdateButtonVisualState>> = {
+  available: DEFAULT_VISUAL,
+  downloading: {
+    pulse: false,
+    colorClass: "text-sky-400",
+    hoverClass: "hover:text-sky-300 hover:bg-sky-400/10",
+  },
+  downloaded: {
+    pulse: true,
+    colorClass: "text-emerald-500",
+    hoverClass: "hover:text-emerald-400 hover:bg-emerald-500/10",
+  },
+  error: {
+    pulse: true,
+    colorClass: "text-rose-500",
+    hoverClass: "hover:text-rose-400 hover:bg-rose-500/10",
+  },
+};
 
 export function resolveDesktopUpdateButtonAction(
   state: DesktopUpdateState,
 ): DesktopUpdateButtonAction {
-  if (state.status === "available") {
-    return "download";
-  }
-  if (state.status === "downloaded") {
-    return "install";
-  }
+  if (state.status === "available") return "download";
+  if (state.status === "downloaded") return "install";
   if (state.status === "error") {
-    if (state.errorContext === "install" && state.downloadedVersion) {
-      return "install";
-    }
-    if (state.errorContext === "download" && state.availableVersion) {
-      return "download";
-    }
+    if (state.errorContext === "install" && state.downloadedVersion) return "install";
+    if (state.errorContext === "download" && state.availableVersion) return "download";
   }
   return "none";
+}
+
+export function resolveDesktopUpdateButtonVisualState(
+  state: DesktopUpdateState,
+): DesktopUpdateButtonVisualState {
+  return VISUAL_BY_STATUS[state.status] ?? DEFAULT_VISUAL;
 }
 
 export function shouldShowDesktopUpdateButton(state: DesktopUpdateState | null): boolean {

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -123,8 +123,3 @@ export function getDesktopUpdateActionError(result: DesktopUpdateActionResult): 
 export function shouldToastDesktopUpdateActionResult(result: DesktopUpdateActionResult): boolean {
   return result.accepted && !result.completed;
 }
-
-export function shouldHighlightDesktopUpdateError(state: DesktopUpdateState | null): boolean {
-  if (!state || state.status !== "error") return false;
-  return state.errorContext === "download" || state.errorContext === "install";
-}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,6 +4,7 @@
 
 @theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;
+  --animate-pulse-soft: pulse-soft 2s ease-in-out infinite;
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);
   --color-success-foreground: var(--success-foreground);
@@ -39,6 +40,15 @@
   @keyframes skeleton {
     to {
       background-position: -200% 0;
+    }
+  }
+  @keyframes pulse-soft {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
     }
   }
 }

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -34,3 +34,20 @@ export const newProjectId = (): ProjectId => ProjectId.makeUnsafe(randomUUID());
 export const newThreadId = (): ThreadId => ThreadId.makeUnsafe(randomUUID());
 
 export const newMessageId = (): MessageId => MessageId.makeUnsafe(randomUUID());
+
+/** Format an ISO timestamp as a human-readable relative time string. */
+export function formatRelativeTime(iso: string | null): string {
+  if (!iso) return "";
+  const diff = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(diff)) return "";
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}


### PR DESCRIPTION
## What Changed

Replace the generic dot indicator on the desktop update button with a color-coded rocket icon that reflects update state:

- **Available** — amber pulsing rocket, prompts download
- **Downloading** — sky-blue rocket with real-time SVG fill showing download progress
- **Downloaded** — emerald pulsing rocket, prompts install  
- **Error** — rose pulsing rocket, retries the failed action

Extract all visual-state logic into a data-driven lookup table (`VISUAL_BY_STATUS`) in `desktopUpdate.logic.ts` — removes the inline ternary chain that was in Sidebar. Add `RocketUpdateIcon` to `Icons.tsx` with a `fillPercent` prop for the download progress overlay. Move the local `formatRelativeTime` out of Sidebar into the shared `utils.ts` with full range support (m → h → d → mo → y).

6 files changed, +238 / −57.

## Why

The previous update indicator was a plain dot with `animate-pulse` that gave no visual feedback during download and used a hard-to-follow ternary chain for color selection. The rocket icon communicates action more clearly, the progress fill gives real-time download feedback, and the lookup table makes adding future states trivial.

## UI Changes

![webappgif8](https://github.com/user-attachments/assets/7217e873-3402-4fff-9208-8d43d8e84386)


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/UX change in the sidebar update flow plus a shared `formatRelativeTime` behavior change, which could affect multiple screens’ timestamps and updater button interactions but not security-critical logic.
> 
> **Overview**
> Replaces the sidebar desktop update indicator with a new `RocketUpdateIcon` that reflects updater status via color/pulse and shows download progress via an SVG fill overlay.
> 
> Moves update-button visual styling into `desktopUpdate.logic.ts` via `resolveDesktopUpdateButtonVisualState` (data-driven status→classes mapping) and updates tests accordingly, removing the old inline styling/error-highlight helper.
> 
> Adds a new `pulse-soft` animation in `index.css` and centralizes `formatRelativeTime` into `utils.ts` with broader/safer formatting (including `yesterday`, months, years).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dca7c67213aa3c8c97b3f0b7d6dca684aedbfd2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve desktop update button with status-based visuals and download progress
> - Adds a new `RocketUpdateIcon` SVG component in [Icons.tsx](https://github.com/pingdotgg/t3code/pull/1427/files#diff-d19962a9c1cb0bc3363e0d837062d1bd60923e4ea67f675a9f9fc3ec7f7e3442) that renders a rocket with an optional bottom-to-top fill overlay driven by `fillPercent` (0–100) to visualize download progress.
> - Adds `resolveDesktopUpdateButtonVisualState` in [desktopUpdate.logic.ts](https://github.com/pingdotgg/t3code/pull/1427/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af) that maps updater status (`available`, `downloading`, `downloaded`, `error`) to pulse, color, and hover classes; replaces the removed `shouldHighlightDesktopUpdateError`.
> - Updates the update button in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1427/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to use `RocketUpdateIcon` with download progress fill and status-derived visual classes.
> - Adds a `pulse-soft` CSS animation in [index.css](https://github.com/pingdotgg/t3code/pull/1427/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) and moves relative time formatting to a shared `formatRelativeTime` utility in [utils.ts](https://github.com/pingdotgg/t3code/pull/1427/files#diff-a77b1983abf81ad3ac9e3d762f4ea683e77399fc446a1f34a6c0d57cde0ab767).
> - Behavioral Change: tooltip text is now empty (instead of 'Update available') when `desktopUpdateState` is null; alert action button renders only for `download` or `install` actions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dca7c67.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->