### PR TITLE
Add changelog dialog with GitHub releases in settings

### DIFF
--- a/apps/web/src/branding.ts
+++ b/apps/web/src/branding.ts
@@ -2,3 +2,5 @@ export const APP_BASE_NAME = "T3 Code";
 export const APP_STAGE_LABEL = import.meta.env.DEV ? "Dev" : "Alpha";
 export const APP_DISPLAY_NAME = `${APP_BASE_NAME} (${APP_STAGE_LABEL})`;
 export const APP_VERSION = import.meta.env.APP_VERSION || "0.0.0";
+export const GITHUB_REPO_URL = "https://github.com/pingdotgg/t3code";
+export const GITHUB_REPO_SLUG = "pingdotgg/t3code";

--- a/apps/web/src/components/ChangelogDialog.tsx
+++ b/apps/web/src/components/ChangelogDialog.tsx
@@ -254,7 +254,7 @@ export function ChangelogDialog({ open, onOpenChange, highlightVersion }: Change
 
         {error && (
           <div className="py-12 text-center text-sm text-muted-foreground">
-            Failed to load releases. Check your internet connection.
+            {error.message || "Failed to load releases. Check your internet connection."}
           </div>
         )}
 

--- a/apps/web/src/components/ChangelogDialog.tsx
+++ b/apps/web/src/components/ChangelogDialog.tsx
@@ -1,0 +1,334 @@
+import { useQuery } from "@tanstack/react-query";
+import { ExternalLinkIcon, LoaderCircleIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { APP_VERSION, GITHUB_REPO_URL } from "~/branding";
+import { changelogQueryOptions } from "~/lib/changelogReactQuery";
+import { cn, formatRelativeTime } from "~/lib/utils";
+import { openExternalUrl } from "~/nativeApi";
+import { GitHubIcon } from "./Icons";
+import {
+  Dialog,
+  DialogDescription,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+
+interface ChangelogDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  highlightVersion?: string | null | undefined;
+}
+
+/**
+ * Parse a single changelog line like:
+ *   "fix(web): add pointer cursor by @binbandit in https://github.com/.../pull/1220"
+ * into structured parts for rich rendering.
+ */
+interface ChangelogEntry {
+  description: string;
+  author: string | null;
+  prNumber: string | null;
+  prUrl: string | null;
+}
+
+function parseChangelogLine(line: string): ChangelogEntry {
+  const cleaned = line.replace(/^\*\s*/, "").trim();
+
+  const authorMatch = cleaned.match(/ by @([\w-]+)/);
+  const prMatch = cleaned.match(/ in (https:\/\/github\.com\/[\w-]+\/[\w-]+\/pull\/(\d+))$/);
+
+  let description = cleaned;
+  if (authorMatch) {
+    description = description.slice(0, authorMatch.index).trim();
+  }
+  if (!authorMatch && prMatch) {
+    description = description.slice(0, prMatch.index).trim();
+  }
+
+  return {
+    description,
+    author: authorMatch ? authorMatch[1]! : null,
+    prNumber: prMatch ? prMatch[2]! : null,
+    prUrl: prMatch ? prMatch[1]! : null,
+  };
+}
+
+interface ParsedSection {
+  title: string;
+  entries: ChangelogEntry[];
+}
+
+function parseReleaseBody(body: string): {
+  sections: ParsedSection[];
+  fullChangelogUrl: string | null;
+} {
+  const lines = body.split("\n");
+  const sections: ParsedSection[] = [];
+  let currentSection: ParsedSection | null = null;
+  let fullChangelogUrl: string | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("**Full Changelog**:")) {
+      const urlMatch = trimmed.match(/https:\/\/[^\s]+/);
+      if (urlMatch) fullChangelogUrl = urlMatch[0]!;
+      continue;
+    }
+
+    if (trimmed.startsWith("## ")) {
+      currentSection = { title: trimmed.replace(/^##\s*/, ""), entries: [] };
+      sections.push(currentSection);
+      continue;
+    }
+
+    if (trimmed.startsWith("* ") && currentSection) {
+      currentSection.entries.push(parseChangelogLine(trimmed));
+    }
+  }
+
+  return { sections, fullChangelogUrl };
+}
+
+function ChangelogEntryItem({ entry }: { entry: ChangelogEntry }) {
+  return (
+    <li className="group flex items-start gap-2 py-1">
+      <span className="mt-1.5 size-1 shrink-0 rounded-full bg-muted-foreground/30" />
+      <div className="min-w-0 text-xs leading-relaxed">
+        <span className="text-muted-foreground">{entry.description}</span>
+        {entry.author && (
+          <button
+            type="button"
+            className="ml-1 inline-flex items-center rounded-md bg-accent/50 px-1 py-0.5 text-[10px] font-medium text-foreground/70 transition-colors hover:bg-accent hover:text-foreground"
+            onClick={() => openExternalUrl(`https://github.com/${entry.author}`)}
+          >
+            @{entry.author}
+          </button>
+        )}
+        {entry.prNumber && entry.prUrl && (
+          <button
+            type="button"
+            className="ml-1 inline-flex items-center text-[10px] font-medium text-primary/70 transition-colors hover:text-primary hover:underline"
+            onClick={() => openExternalUrl(entry.prUrl!)}
+          >
+            #{entry.prNumber}
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function ReleaseCard({
+  tagName,
+  publishedAt,
+  body,
+  htmlUrl,
+  isCurrent,
+  isHighlighted,
+  innerRef,
+}: {
+  tagName: string;
+  publishedAt: string | null;
+  body: string | null;
+  htmlUrl: string;
+  isCurrent: boolean;
+  isHighlighted: boolean;
+  innerRef?: ((el: HTMLDivElement | null) => void) | undefined;
+}) {
+  const parsed = body ? parseReleaseBody(body) : null;
+  const hasParsedContent = parsed && parsed.sections.some((s) => s.entries.length > 0);
+
+  return (
+    <div
+      ref={innerRef}
+      className={cn(
+        "rounded-lg border border-border/40 bg-card/30 p-4 transition-colors",
+        isHighlighted && "border-primary/40 bg-primary/5",
+      )}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <span className="text-sm font-semibold text-foreground">{tagName}</span>
+        {isCurrent && (
+          <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-500">
+            current
+          </span>
+        )}
+        <span className="text-[11px] text-muted-foreground/50">
+          {formatRelativeTime(publishedAt)}
+        </span>
+        <button
+          type="button"
+          aria-label="View release on GitHub"
+          className="ml-auto inline-flex size-5 items-center justify-center rounded text-muted-foreground/40 transition-colors hover:text-foreground"
+          onClick={() => openExternalUrl(htmlUrl)}
+        >
+          <ExternalLinkIcon className="size-3" />
+        </button>
+      </div>
+
+      {hasParsedContent
+        ? parsed.sections.map((section) => (
+            <div key={section.title} className="mb-2 last:mb-0">
+              <h4 className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-foreground/50">
+                {section.title}
+              </h4>
+              <ul className="space-y-0">
+                {section.entries.map((entry) => (
+                  <ChangelogEntryItem
+                    key={`${entry.description}-${entry.prNumber ?? ""}`}
+                    entry={entry}
+                  />
+                ))}
+              </ul>
+            </div>
+          ))
+        : body && (
+            <p className="text-xs leading-relaxed text-muted-foreground/60">
+              {body.slice(0, 200)}
+              {body.length > 200 ? "…" : ""}
+            </p>
+          )}
+
+      {!body && <p className="text-xs italic text-muted-foreground/40">No release notes.</p>}
+
+      {parsed?.fullChangelogUrl && (
+        <button
+          type="button"
+          className="mt-2 text-[10px] text-muted-foreground/40 transition-colors hover:text-primary"
+          onClick={() => openExternalUrl(parsed.fullChangelogUrl!)}
+        >
+          Full changelog &rarr;
+        </button>
+      )}
+    </div>
+  );
+}
+
+function isVersionMatch(tagName: string, target: string): boolean {
+  const version = tagName.replace(/^v/, "");
+  return tagName === target || version === target.replace(/^v/, "");
+}
+
+export function ChangelogDialog({ open, onOpenChange, highlightVersion }: ChangelogDialogProps) {
+  const {
+    data: releases,
+    isLoading,
+    error,
+  } = useQuery({ ...changelogQueryOptions(), enabled: open });
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  const scrollToVersion = useCallback((tag: string) => {
+    setActiveTag(tag);
+    const el = cardRefs.current.get(tag);
+    el?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
+  // Scroll to highlighted version on open
+  useEffect(() => {
+    if (!open || !releases?.length || !highlightVersion) return;
+    const match = releases.find((r) => isVersionMatch(r.tag_name, highlightVersion));
+    if (match) {
+      // Defer to next frame so dialog has rendered
+      requestAnimationFrame(() => scrollToVersion(match.tag_name));
+    }
+  }, [open, releases, highlightVersion, scrollToVersion]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Changelog</DialogTitle>
+          <DialogDescription>Release history for T3 Code</DialogDescription>
+        </DialogHeader>
+
+        {isLoading && (
+          <div className="flex justify-center py-12">
+            <LoaderCircleIcon className="size-5 animate-spin text-muted-foreground" />
+          </div>
+        )}
+
+        {error && (
+          <div className="py-12 text-center text-sm text-muted-foreground">
+            Failed to load releases. Check your internet connection.
+          </div>
+        )}
+
+        {releases && releases.length > 0 && (
+          <div className="flex max-h-[60vh] min-h-0">
+            {/* Version sidebar */}
+            <nav className="flex w-28 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border/30 py-2 pr-2 pl-4">
+              {releases.map((release) => {
+                const version = release.tag_name.replace(/^v/, "");
+                const isCurrent = version === APP_VERSION || release.tag_name === APP_VERSION;
+                const isActive = activeTag === release.tag_name;
+
+                return (
+                  <button
+                    key={release.tag_name}
+                    type="button"
+                    className={cn(
+                      "rounded-md px-2 py-1 text-left text-[11px] transition-colors",
+                      isActive
+                        ? "bg-accent text-foreground font-medium"
+                        : "text-muted-foreground/60 hover:bg-accent/50 hover:text-muted-foreground",
+                    )}
+                    onClick={() => scrollToVersion(release.tag_name)}
+                  >
+                    <span className="flex items-center justify-between gap-1">
+                      <span>{release.tag_name}</span>
+                      {isCurrent && (
+                        <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" />
+                      )}
+                    </span>
+                  </button>
+                );
+              })}
+            </nav>
+
+            {/* Release cards */}
+            <DialogPanel className="flex-1 space-y-3 overflow-y-auto">
+              {releases.map((release) => {
+                const version = release.tag_name.replace(/^v/, "");
+                const isCurrent = version === APP_VERSION || release.tag_name === APP_VERSION;
+                const isHighlighted =
+                  !!highlightVersion && isVersionMatch(release.tag_name, highlightVersion);
+
+                return (
+                  <ReleaseCard
+                    key={release.tag_name}
+                    tagName={release.tag_name}
+                    publishedAt={release.published_at}
+                    body={release.body}
+                    htmlUrl={release.html_url}
+                    isCurrent={isCurrent}
+                    isHighlighted={isHighlighted}
+                    innerRef={(el) => {
+                      if (el) cardRefs.current.set(release.tag_name, el);
+                      else cardRefs.current.delete(release.tag_name);
+                    }}
+                  />
+                );
+              })}
+            </DialogPanel>
+          </div>
+        )}
+
+        <div className="flex items-center justify-end border-t border-border/30 px-6 py-2.5">
+          <button
+            type="button"
+            className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+            onClick={() => openExternalUrl(GITHUB_REPO_URL)}
+          >
+            <GitHubIcon className="size-3.5" />
+            View on GitHub
+          </button>
+        </div>
+      </DialogPopup>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -309,3 +309,64 @@ export const OpenCodeIcon: Icon = (props) => (
     </defs>
   </svg>
 );
+
+const ROCKET_BODY =
+  "M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09zM12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z";
+const ROCKET_FINS = "M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5";
+
+/** Rocket icon with optional bottom-to-top fill overlay for download progress (0–100). */
+export function RocketUpdateIcon({
+  fillPercent,
+  ...props
+}: SVGProps<SVGSVGElement> & { fillPercent?: number | null }) {
+  const clipId = useId();
+  const showFill = typeof fillPercent === "number";
+
+  return (
+    <svg {...props} viewBox="0 0 24 24" fill="none">
+      {showFill && (
+        <defs>
+          <clipPath id={clipId}>
+            <rect x="0" y={24 - (24 * fillPercent) / 100} width="24" height="24" />
+          </clipPath>
+        </defs>
+      )}
+      <path
+        d={ROCKET_BODY}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={showFill ? "opacity-30" : undefined}
+      />
+      <path
+        d={ROCKET_FINS}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={showFill ? "opacity-30" : undefined}
+      />
+      {showFill && (
+        <g clipPath={`url(#${clipId})`}>
+          <path
+            d={ROCKET_BODY}
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="currentColor"
+            fillOpacity="0.3"
+          />
+          <path
+            d={ROCKET_FINS}
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -5,7 +5,6 @@ import {
   FolderIcon,
   GitPullRequestIcon,
   PlusIcon,
-  RocketIcon,
   SettingsIcon,
   SquarePenIcon,
   TerminalIcon,
@@ -45,7 +44,13 @@ import {
 } from "../appSettings";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
-import { isLinuxPlatform, isMacPlatform, newCommandId, newProjectId } from "../lib/utils";
+import {
+  formatRelativeTime,
+  isLinuxPlatform,
+  isMacPlatform,
+  newCommandId,
+  newProjectId,
+} from "../lib/utils";
 import { useStore } from "../store";
 import { shortcutLabelForCommand } from "../keybindings";
 import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
@@ -55,6 +60,7 @@ import { readNativeApi } from "../nativeApi";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+import { RocketUpdateIcon } from "./Icons";
 import { toastManager } from "./ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
@@ -62,8 +68,8 @@ import {
   getDesktopUpdateButtonTooltip,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
+  resolveDesktopUpdateButtonVisualState,
   shouldShowArm64IntelBuildWarning,
-  shouldHighlightDesktopUpdateError,
   shouldShowDesktopUpdateButton,
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
@@ -119,16 +125,6 @@ const SIDEBAR_LIST_ANIMATION_OPTIONS = {
   easing: "ease-out",
 } as const;
 const loadedProjectFaviconSrcs = new Set<string>();
-
-function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
-}
 
 interface TerminalStatusIndicator {
   label: "Terminal process running";
@@ -1497,7 +1493,7 @@ export default function Sidebar() {
 
   const desktopUpdateTooltip = desktopUpdateState
     ? getDesktopUpdateButtonTooltip(desktopUpdateState)
-    : "Update available";
+    : "";
 
   const desktopUpdateButtonDisabled = isDesktopUpdateButtonDisabled(desktopUpdateState);
   const desktopUpdateButtonAction = desktopUpdateState
@@ -1509,17 +1505,12 @@ export default function Sidebar() {
     desktopUpdateState && showArm64IntelBuildWarning
       ? getArm64IntelBuildWarningDescription(desktopUpdateState)
       : null;
+  const desktopUpdateVisual = desktopUpdateState
+    ? resolveDesktopUpdateButtonVisualState(desktopUpdateState)
+    : null;
   const desktopUpdateButtonInteractivityClasses = desktopUpdateButtonDisabled
     ? "cursor-not-allowed opacity-60"
-    : "hover:bg-accent hover:text-foreground";
-  const desktopUpdateButtonClasses =
-    desktopUpdateState?.status === "downloaded"
-      ? "text-emerald-500"
-      : desktopUpdateState?.status === "downloading"
-        ? "text-sky-400"
-        : shouldHighlightDesktopUpdateError(desktopUpdateState)
-          ? "text-rose-500 animate-pulse"
-          : "text-amber-500 animate-pulse";
+    : "";
   const newThreadShortcutLabel =
     shortcutLabelForCommand(keybindings, "chat.newLocal") ??
     shortcutLabelForCommand(keybindings, "chat.new");
@@ -1624,36 +1615,49 @@ export default function Sidebar() {
     </div>
   );
 
+  const downloadPercent =
+    desktopUpdateState?.status === "downloading" &&
+    typeof desktopUpdateState.downloadPercent === "number"
+      ? desktopUpdateState.downloadPercent
+      : null;
+
+  const updateButton =
+    showDesktopUpdateButton && desktopUpdateVisual ? (
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              aria-label={desktopUpdateTooltip}
+              aria-disabled={desktopUpdateButtonDisabled || undefined}
+              disabled={desktopUpdateButtonDisabled}
+              className={`group/update relative inline-flex size-7 ml-auto items-center justify-center rounded-md transition-all duration-150 ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateVisual.colorClass} ${desktopUpdateVisual.hoverClass}`}
+              onClick={handleDesktopUpdateButtonClick}
+            >
+              <RocketUpdateIcon
+                className={`size-3.5 ${desktopUpdateVisual.pulse ? "animate-pulse-soft group-hover/update:animate-none" : ""}`}
+                fillPercent={downloadPercent}
+              />
+            </button>
+          }
+        />
+        <TooltipPopup side="bottom">{desktopUpdateTooltip}</TooltipPopup>
+      </Tooltip>
+    ) : null;
+
   return (
     <>
       {isElectron ? (
         <>
           <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}
-            {showDesktopUpdateButton && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <button
-                      type="button"
-                      aria-label={desktopUpdateTooltip}
-                      aria-disabled={desktopUpdateButtonDisabled || undefined}
-                      disabled={desktopUpdateButtonDisabled}
-                      className={`inline-flex size-7 ml-auto mt-1.5 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
-                      onClick={handleDesktopUpdateButtonClick}
-                    >
-                      <RocketIcon className="size-3.5" />
-                    </button>
-                  }
-                />
-                <TooltipPopup side="bottom">{desktopUpdateTooltip}</TooltipPopup>
-              </Tooltip>
-            )}
+            <div className="mt-1.5">{updateButton}</div>
           </SidebarHeader>
         </>
       ) : (
-        <SidebarHeader className="gap-3 px-3 py-2 sm:gap-2.5 sm:px-4 sm:py-3">
+        <SidebarHeader className="flex-row items-center gap-2 px-3 py-2 sm:gap-2.5 sm:px-4 sm:py-3">
           {wordmark}
+          {updateButton}
         </SidebarHeader>
       )}
 
@@ -1664,7 +1668,8 @@ export default function Sidebar() {
               <TriangleAlertIcon />
               <AlertTitle>Intel build on Apple Silicon</AlertTitle>
               <AlertDescription>{arm64IntelBuildWarningDescription}</AlertDescription>
-              {desktopUpdateButtonAction !== "none" ? (
+              {desktopUpdateButtonAction === "download" ||
+              desktopUpdateButtonAction === "install" ? (
                 <AlertAction>
                   <Button
                     size="xs"

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1631,7 +1631,7 @@ export default function Sidebar() {
               aria-label={desktopUpdateTooltip}
               aria-disabled={desktopUpdateButtonDisabled || undefined}
               disabled={desktopUpdateButtonDisabled}
-              className={`group/update relative inline-flex size-7 ml-auto items-center justify-center rounded-md transition-all duration-150 ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateVisual.colorClass} ${desktopUpdateVisual.hoverClass}`}
+              className={`group/update relative inline-flex size-7 ml-auto items-center justify-center rounded-md transition-all duration-150 ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateVisual.colorClass} ${desktopUpdateButtonDisabled ? "" : desktopUpdateVisual.hoverClass}`}
               onClick={handleDesktopUpdateButtonClick}
             >
               <RocketUpdateIcon
@@ -1651,7 +1651,7 @@ export default function Sidebar() {
         <>
           <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}
-            <div className="mt-1.5">{updateButton}</div>
+            <div className="mt-1.5 ml-auto">{updateButton}</div>
           </SidebarHeader>
         </>
       ) : (

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -9,7 +9,6 @@ import {
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   resolveDesktopUpdateButtonVisualState,
-  shouldHighlightDesktopUpdateError,
   shouldShowArm64IntelBuildWarning,
   shouldShowDesktopUpdateButton,
   shouldToastDesktopUpdateActionResult,
@@ -164,25 +163,6 @@ describe("desktop update UI helpers", () => {
         accepted: true,
         completed: true,
         state: baseState,
-      }),
-    ).toBe(false);
-  });
-
-  it("highlights only actionable updater errors", () => {
-    expect(
-      shouldHighlightDesktopUpdateError({
-        ...baseState,
-        status: "error",
-        errorContext: "download",
-        canRetry: true,
-      }),
-    ).toBe(true);
-    expect(
-      shouldHighlightDesktopUpdateError({
-        ...baseState,
-        status: "error",
-        errorContext: "check",
-        canRetry: true,
       }),
     ).toBe(false);
   });

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
 
 import {
+  DEFAULT_VISUAL,
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
+  resolveDesktopUpdateButtonVisualState,
   shouldHighlightDesktopUpdateError,
   shouldShowArm64IntelBuildWarning,
   shouldShowDesktopUpdateButton,
@@ -79,6 +81,10 @@ describe("desktop update button state", () => {
     };
     expect(shouldShowDesktopUpdateButton(state)).toBe(false);
     expect(resolveDesktopUpdateButtonAction(state)).toBe("none");
+  });
+
+  it("returns none when idle", () => {
+    expect(resolveDesktopUpdateButtonAction(baseState)).toBe("none");
   });
 
   it("disables the button while downloading", () => {
@@ -205,5 +211,53 @@ describe("desktop update UI helpers", () => {
     };
 
     expect(getArm64IntelBuildWarningDescription(state)).toContain("Download the available update");
+  });
+});
+
+describe("resolveDesktopUpdateButtonVisualState", () => {
+  it("returns pulse and amber for available state", () => {
+    const visual = resolveDesktopUpdateButtonVisualState({
+      ...baseState,
+      status: "available",
+      availableVersion: "2.0.0",
+    });
+    expect(visual.pulse).toBe(true);
+    expect(visual.colorClass).toContain("amber");
+  });
+
+  it("returns no pulse for downloading state", () => {
+    const visual = resolveDesktopUpdateButtonVisualState({
+      ...baseState,
+      status: "downloading",
+      downloadPercent: 50,
+    });
+    expect(visual.pulse).toBe(false);
+    expect(visual.colorClass).toContain("sky");
+  });
+
+  it("returns pulse and emerald for downloaded state", () => {
+    const visual = resolveDesktopUpdateButtonVisualState({
+      ...baseState,
+      status: "downloaded",
+      downloadedVersion: "2.0.0",
+    });
+    expect(visual.pulse).toBe(true);
+    expect(visual.colorClass).toContain("emerald");
+  });
+
+  it("returns pulse and rose for error state", () => {
+    const visual = resolveDesktopUpdateButtonVisualState({
+      ...baseState,
+      status: "error",
+      errorContext: "download",
+      canRetry: true,
+    });
+    expect(visual.pulse).toBe(true);
+    expect(visual.colorClass).toContain("rose");
+  });
+
+  it("falls back to DEFAULT_VISUAL for unmapped statuses like idle", () => {
+    const visual = resolveDesktopUpdateButtonVisualState(baseState);
+    expect(visual).toBe(DEFAULT_VISUAL);
   });
 });

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -1,25 +1,59 @@
-import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
+import type {
+  DesktopUpdateActionResult,
+  DesktopUpdateState,
+  DesktopUpdateStatus,
+} from "@t3tools/contracts";
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
+
+export interface DesktopUpdateButtonVisualState {
+  pulse: boolean;
+  colorClass: string;
+  hoverClass: string;
+}
+
+/** Fallback visual used for statuses without an explicit mapping (e.g. idle, checking). */
+export const DEFAULT_VISUAL: DesktopUpdateButtonVisualState = {
+  pulse: true,
+  colorClass: "text-amber-500",
+  hoverClass: "hover:text-amber-400 hover:bg-amber-500/10",
+};
+
+const VISUAL_BY_STATUS: Partial<Record<DesktopUpdateStatus, DesktopUpdateButtonVisualState>> = {
+  available: DEFAULT_VISUAL,
+  downloading: {
+    pulse: false,
+    colorClass: "text-sky-400",
+    hoverClass: "hover:text-sky-300 hover:bg-sky-400/10",
+  },
+  downloaded: {
+    pulse: true,
+    colorClass: "text-emerald-500",
+    hoverClass: "hover:text-emerald-400 hover:bg-emerald-500/10",
+  },
+  error: {
+    pulse: true,
+    colorClass: "text-rose-500",
+    hoverClass: "hover:text-rose-400 hover:bg-rose-500/10",
+  },
+};
 
 export function resolveDesktopUpdateButtonAction(
   state: DesktopUpdateState,
 ): DesktopUpdateButtonAction {
-  if (state.status === "available") {
-    return "download";
-  }
-  if (state.status === "downloaded") {
-    return "install";
-  }
+  if (state.status === "available") return "download";
+  if (state.status === "downloaded") return "install";
   if (state.status === "error") {
-    if (state.errorContext === "install" && state.downloadedVersion) {
-      return "install";
-    }
-    if (state.errorContext === "download" && state.availableVersion) {
-      return "download";
-    }
+    if (state.errorContext === "install" && state.downloadedVersion) return "install";
+    if (state.errorContext === "download" && state.availableVersion) return "download";
   }
   return "none";
+}
+
+export function resolveDesktopUpdateButtonVisualState(
+  state: DesktopUpdateState,
+): DesktopUpdateButtonVisualState {
+  return VISUAL_BY_STATUS[state.status] ?? DEFAULT_VISUAL;
 }
 
 export function shouldShowDesktopUpdateButton(state: DesktopUpdateState | null): boolean {

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -123,8 +123,3 @@ export function getDesktopUpdateActionError(result: DesktopUpdateActionResult): 
 export function shouldToastDesktopUpdateActionResult(result: DesktopUpdateActionResult): boolean {
   return result.accepted && !result.completed;
 }
-
-export function shouldHighlightDesktopUpdateError(state: DesktopUpdateState | null): boolean {
-  if (!state || state.status !== "error") return false;
-  return state.errorContext === "download" || state.errorContext === "install";
-}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,6 +4,7 @@
 
 @theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;
+  --animate-pulse-soft: pulse-soft 2s ease-in-out infinite;
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);
   --color-success-foreground: var(--success-foreground);
@@ -39,6 +40,15 @@
   @keyframes skeleton {
     to {
       background-position: -200% 0;
+    }
+  }
+  @keyframes pulse-soft {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
     }
   }
 }

--- a/apps/web/src/lib/changelogReactQuery.ts
+++ b/apps/web/src/lib/changelogReactQuery.ts
@@ -1,0 +1,37 @@
+import { queryOptions } from "@tanstack/react-query";
+import { GITHUB_REPO_SLUG } from "~/branding";
+
+export interface GitHubRelease {
+  tag_name: string;
+  name: string | null;
+  body: string | null;
+  /** `null` for draft releases (not returned by the public endpoint, but defensive). */
+  published_at: string | null;
+  html_url: string;
+}
+
+export const changelogQueryKeys = {
+  releases: () => ["changelog", "releases"] as const,
+};
+
+export function changelogQueryOptions() {
+  return queryOptions({
+    queryKey: changelogQueryKeys.releases(),
+    queryFn: async (): Promise<GitHubRelease[]> => {
+      const response = await fetch(
+        `https://api.github.com/repos/${GITHUB_REPO_SLUG}/releases?per_page=20`,
+        { headers: { Accept: "application/vnd.github+json" } },
+      );
+      if (!response.ok) {
+        const message =
+          response.status === 403
+            ? "GitHub API rate limit exceeded. Try again later."
+            : `Failed to fetch releases (${response.status})`;
+        throw new Error(message);
+      }
+      return response.json() as Promise<GitHubRelease[]>;
+    },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+}

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -34,3 +34,20 @@ export const newProjectId = (): ProjectId => ProjectId.makeUnsafe(randomUUID());
 export const newThreadId = (): ThreadId => ThreadId.makeUnsafe(randomUUID());
 
 export const newMessageId = (): MessageId => MessageId.makeUnsafe(randomUUID());
+
+/** Format an ISO timestamp as a human-readable relative time string. */
+export function formatRelativeTime(iso: string | null): string {
+  if (!iso) return "";
+  const diff = Date.now() - new Date(iso).getTime();
+  if (Number.isNaN(diff)) return "";
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "yesterday";
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}

--- a/apps/web/src/nativeApi.ts
+++ b/apps/web/src/nativeApi.ts
@@ -24,3 +24,13 @@ export function ensureNativeApi(): NativeApi {
   }
   return api;
 }
+
+/** Open a URL in the system browser, using the native API when available. */
+export function openExternalUrl(url: string): void {
+  const api = readNativeApi();
+  if (api) {
+    void api.shell.openExternal(url);
+  } else {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -13,7 +13,9 @@ import {
   patchCustomModels,
   resolveAppModelSelectionState,
 } from "../modelSelection";
-import { APP_VERSION } from "../branding";
+import { APP_VERSION, GITHUB_REPO_URL } from "../branding";
+import { ChangelogDialog } from "../components/ChangelogDialog";
+import { GitHubIcon } from "../components/Icons";
 import { Button } from "../components/ui/button";
 import { Collapsible, CollapsibleContent } from "../components/ui/collapsible";
 import { Input } from "../components/ui/input";
@@ -35,7 +37,7 @@ import { isElectron } from "../env";
 import { useTheme } from "../hooks/useTheme";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { cn } from "../lib/utils";
-import { ensureNativeApi, readNativeApi } from "../nativeApi";
+import { ensureNativeApi, openExternalUrl, readNativeApi } from "../nativeApi";
 
 const THEME_OPTIONS = [
   {
@@ -192,6 +194,7 @@ function SettingsRouteView() {
   const { theme, setTheme } = useTheme();
   const { settings, defaults, updateSettings, resetSettings } = useAppSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
+  const [settingsChangelogOpen, setSettingsChangelogOpen] = useState(false);
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);
   const [openKeybindingsError, setOpenKeybindingsError] = useState<string | null>(null);
   const [openInstallProviders, setOpenInstallProviders] = useState<Record<ProviderKind, boolean>>({
@@ -992,10 +995,38 @@ function SettingsRouteView() {
                 title="Version"
                 description="Current application version."
                 control={
-                  <code className="text-xs font-medium text-muted-foreground">{APP_VERSION}</code>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className="text-xs font-medium text-muted-foreground underline decoration-muted-foreground/30 underline-offset-2 transition-colors hover:text-foreground"
+                      onClick={() => setSettingsChangelogOpen(true)}
+                    >
+                      {APP_VERSION}
+                    </button>
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+                            onClick={() => openExternalUrl(GITHUB_REPO_URL)}
+                          >
+                            <GitHubIcon className="size-3.5" />
+                          </button>
+                        }
+                      />
+                      <TooltipPopup side="top">Open GitHub repository</TooltipPopup>
+                    </Tooltip>
+                  </div>
                 }
               />
             </SettingsSection>
+
+            <ChangelogDialog
+              open={settingsChangelogOpen}
+              onOpenChange={setSettingsChangelogOpen}
+              highlightVersion={APP_VERSION}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What Changed

Add a changelog dialog to the settings page. Clicking the version label opens a dialog that shows the full release history fetched from the GitHub API.

- **Version sidebar** — lists every release tag; the current version is highlighted, click to scroll
- **Parsed release notes** — each release body is split into sections (New Features, Bug Fixes, etc.) with linked PR numbers and `@author` mentions
- **Lazy loading** — data is fetched only when the dialog opens, via React Query (`staleTime: 5min`, `gcTime: 30min`); rate-limit 403 shows a specific message
- **GitHub link** — small GitHub icon next to the version opens the repo in the system browser

Also extracts:
- `openExternalUrl()` → `nativeApi.ts` (was duplicated in 3 places)
- `GITHUB_REPO_URL` / `GITHUB_REPO_SLUG` → `branding.ts`

5 files changed, +417 / −3.

## Why

There was no way to see what changed between versions without leaving the app. This gives users a quick overview of release history right in settings — especially useful on desktop where checking GitHub is an extra step.

## UI Changes


![cl5](https://github.com/user-attachments/assets/b791b1a1-da9d-4cbf-a9a3-c3acdc51932c)


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: introduces a new client-side GitHub API fetch path and refactors desktop updater button visuals/behavior, which could affect settings UX and update interactions if state mapping or rate-limits are mishandled.
> 
> **Overview**
> Adds an in-app **Changelog** dialog accessible from the Settings "Version" row, lazily fetching and rendering recent GitHub releases (with parsed sections, linked authors/PRs, and a repo link).
> 
> Refactors desktop updater UI: introduces `resolveDesktopUpdateButtonVisualState` plus a new `RocketUpdateIcon` with download-progress fill and soft pulse animation, and centralizes external link handling via `openExternalUrl()` and new `GITHUB_REPO_URL`/`GITHUB_REPO_SLUG` branding constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 683e5233e9c580220e756349ecbd7ac1b010660f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add changelog dialog with GitHub releases to settings version row
> - Adds a `ChangelogDialog` component in [ChangelogDialog.tsx](https://github.com/pingdotgg/t3code/pull/1428/files#diff-8ff4545d464fa9df0e33cff871a8bb0f6360cb4e2db00cd16408a9e8bca86ff5) that fetches up to 20 releases from GitHub, parses release notes into sections, and supports scrolling to a specific version.
> - Clicking the version string in the settings page opens the dialog highlighted to the current app version; a new GitHub button opens the repository in the system browser.
> - Adds `RocketUpdateIcon` to the sidebar update button with state-driven color, pulse animation, and download progress fill via a new `resolveDesktopUpdateButtonVisualState` helper.
> - Adds `openExternalUrl` in [nativeApi.ts](https://github.com/pingdotgg/t3code/pull/1428/files#diff-60ade71805ff4536a71369e51b0ab25d0375dfe67c18b1aef5e6b37433d001b8) to route external links through the native API in Electron or fall back to `window.open`.
> - Removes `shouldHighlightDesktopUpdateError`; callers must use `resolveDesktopUpdateButtonVisualState` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 683e523.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->