### PR TITLE
feat(plan-sidebar): add drag-to-resize with localStorage persistence

### DIFF
--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -1,4 +1,11 @@
-import { memo, useState, useCallback, useRef, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  memo,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { Schema } from "effect";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 import { Badge } from "./ui/badge";
@@ -138,6 +145,17 @@ const PlanSidebar = memo(function PlanSidebar({
     if (didResizeDuringDragRef.current) {
       setLocalStorageItem(PLAN_SIDEBAR_WIDTH_STORAGE_KEY, sidebarWidthRef.current, Schema.Finite);
     }
+  }, []);
+
+  // Clean up body styles if the component unmounts mid-drag (e.g. sidebar closed
+  // while resizing). Without this, cursor and user-select overrides leak permanently.
+  // Mirrors the same cleanup pattern in SidebarRail.
+  useEffect(() => {
+    return () => {
+      resizeStateRef.current = null;
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+    };
   }, []);
 
   const planMarkdown = activeProposedPlan?.planMarkdown ?? null;


### PR DESCRIPTION
## What Changed

Adds drag-to-resize to the Plan sidebar and follows up with cleanup for drag styles if the sidebar unmounts mid-resize.

- Replaced the fixed `w-[340px]` layout with a dynamic width driven by React state
- Added a left-edge resize handle for `PlanSidebar`
- Clamp width between 240px and 560px and persist it to `localStorage`
- Clean up `document.body` cursor and `user-select` overrides if the sidebar unmounts during a drag

## Why

The Plan sidebar was fixed at 340px with no way to adjust it for different screen sizes or content widths.

This implementation keeps the resize handle fully inside the Plan sidebar bounds so it does not steal pointer interactions from the chat area. That is the same class of interaction problem described in #958, but this PR does not close #958 because that issue is specifically about the diff sidebar / `SidebarRail`.

## UI Changes

This is a drag-interaction change. The resize handle is invisible by default and shows a 2px border indicator on hover, consistent with the existing resize affordances.

Before:

https://github.com/user-attachments/assets/00f4280b-bfdf-41ef-b479-b79550ca2419

After:

https://github.com/user-attachments/assets/d7b5351c-0a9e-43dd-af52-fb070dda2c5a

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change confined to `PlanSidebar` that adds pointer-driven resizing and localStorage persistence; main risk is minor UX regressions (cursor/user-select leakage) during drag interactions.
> 
> **Overview**
> Makes the Plan sidebar width user-resizable by replacing the fixed `w-[340px]` layout with a state-driven inline width, clamped between 240–560px.
> 
> Adds a left-edge pointer-capture resize handle and persists the final width to `localStorage` (`Schema.Finite`) on drag end, with unmount cleanup to avoid leaked `cursor`/`user-select` body styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e60894f6cf8258f77ab9a5f94434806aee343cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-to-resize with localStorage persistence to `PlanSidebar`
> - Adds a left-edge drag handle to `PlanSidebar` that lets users resize the sidebar between 240px and 560px (default 340px).
> - Width is persisted to localStorage under `plan-sidebar-width` using `Schema.Finite` validation and restored on load.
> - Pointer capture handles drag tracking; body cursor and `user-select` are mutated during drag and cleaned up on release or unmount.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href=\"https://app.macroscope.com\">Macroscope</a> summarized 6e60894.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->