### PR TITLE
feat(plan-sidebar): add drag-to-resize with localStorage persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ apps/web/src/components/__screenshots__
 .vitest-*
 __screenshots__/
 .tanstack
+.worktrees/

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -47,8 +47,13 @@ function clampSidebarWidth(width: number): number {
 }
 
 function readStoredWidth(): number {
-  const stored = getLocalStorageItem(PLAN_SIDEBAR_WIDTH_STORAGE_KEY, Schema.Finite);
-  return stored !== null ? clampSidebarWidth(stored) : PLAN_SIDEBAR_DEFAULT_WIDTH;
+  try {
+    const stored = getLocalStorageItem(PLAN_SIDEBAR_WIDTH_STORAGE_KEY, Schema.Finite);
+    return stored !== null ? clampSidebarWidth(stored) : PLAN_SIDEBAR_DEFAULT_WIDTH;
+  } catch (error) {
+    console.error("[LOCALSTORAGE] Error:", error);
+    return PLAN_SIDEBAR_DEFAULT_WIDTH;
+  }
 }
 
 function stepStatusIcon(status: string): React.ReactNode {

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -1,4 +1,11 @@
-import { memo, useState, useCallback, useRef, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  memo,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { Schema } from "effect";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 import { Badge } from "./ui/badge";
@@ -138,6 +145,17 @@ const PlanSidebar = memo(function PlanSidebar({
     if (didResizeDuringDragRef.current) {
       setLocalStorageItem(PLAN_SIDEBAR_WIDTH_STORAGE_KEY, sidebarWidthRef.current, Schema.Finite);
     }
+  }, []);
+
+  // Clean up body styles if the component unmounts mid-drag (e.g. sidebar closed
+  // while resizing). Without this, cursor and user-select overrides leak permanently.
+  // Mirrors the same cleanup pattern in SidebarRail.
+  useEffect(() => {
+    return () => {
+      resizeStateRef.current = null;
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+    };
   }, []);
 
   const planMarkdown = activeProposedPlan?.planMarkdown ?? null;

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -1,4 +1,5 @@
-import { memo, useState, useCallback } from "react";
+import { memo, useState, useCallback, useRef, type PointerEvent as ReactPointerEvent } from "react";
+import { Schema } from "effect";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
@@ -27,6 +28,21 @@ import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
 import { readNativeApi } from "~/nativeApi";
 import { toastManager } from "./ui/toast";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { getLocalStorageItem, setLocalStorageItem } from "~/hooks/useLocalStorage";
+
+const PLAN_SIDEBAR_DEFAULT_WIDTH = 340;
+const PLAN_SIDEBAR_MIN_WIDTH = 240;
+const PLAN_SIDEBAR_MAX_WIDTH = 560;
+const PLAN_SIDEBAR_WIDTH_STORAGE_KEY = "plan-sidebar-width";
+
+function clampSidebarWidth(width: number): number {
+  return Math.max(PLAN_SIDEBAR_MIN_WIDTH, Math.min(PLAN_SIDEBAR_MAX_WIDTH, width));
+}
+
+function readStoredWidth(): number {
+  const stored = getLocalStorageItem(PLAN_SIDEBAR_WIDTH_STORAGE_KEY, Schema.Finite);
+  return stored !== null ? clampSidebarWidth(stored) : PLAN_SIDEBAR_DEFAULT_WIDTH;
+}
 
 function stepStatusIcon(status: string): React.ReactNode {
   if (status === "completed") {
@@ -70,6 +86,59 @@ const PlanSidebar = memo(function PlanSidebar({
   const [proposedPlanExpanded, setProposedPlanExpanded] = useState(false);
   const [isSavingToWorkspace, setIsSavingToWorkspace] = useState(false);
   const { copyToClipboard, isCopied } = useCopyToClipboard();
+
+  // --- Resize logic (follows ThreadTerminalDrawer pointer-capture pattern) ---
+  const [sidebarWidth, setSidebarWidth] = useState(readStoredWidth);
+  const sidebarWidthRef = useRef(sidebarWidth);
+  sidebarWidthRef.current = sidebarWidth;
+  const resizeStateRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startWidth: number;
+  } | null>(null);
+  const didResizeDuringDragRef = useRef(false);
+
+  const handleResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    didResizeDuringDragRef.current = false;
+    resizeStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: sidebarWidthRef.current,
+    };
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const handleResizePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const resizeState = resizeStateRef.current;
+    if (!resizeState || resizeState.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    // Dragging left (negative clientX delta) should widen the sidebar.
+    const nextWidth = clampSidebarWidth(
+      resizeState.startWidth + (resizeState.startX - event.clientX),
+    );
+    if (nextWidth === sidebarWidthRef.current) return;
+    didResizeDuringDragRef.current = true;
+    sidebarWidthRef.current = nextWidth;
+    setSidebarWidth(nextWidth);
+  }, []);
+
+  const handleResizePointerEnd = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    const resizeState = resizeStateRef.current;
+    if (!resizeState || resizeState.pointerId !== event.pointerId) return;
+    resizeStateRef.current = null;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    document.body.style.removeProperty("cursor");
+    document.body.style.removeProperty("user-select");
+    if (didResizeDuringDragRef.current) {
+      setLocalStorageItem(PLAN_SIDEBAR_WIDTH_STORAGE_KEY, sidebarWidthRef.current, Schema.Finite);
+    }
+  }, []);
 
   const planMarkdown = activeProposedPlan?.planMarkdown ?? null;
   const displayedPlanMarkdown = planMarkdown ? stripDisplayedPlanMarkdown(planMarkdown) : null;
@@ -118,7 +187,18 @@ const PlanSidebar = memo(function PlanSidebar({
   }, [planMarkdown, workspaceRoot]);
 
   return (
-    <div className="flex h-full w-[340px] shrink-0 flex-col border-l border-border/70 bg-card/50">
+    <div
+      className="relative flex h-full shrink-0 flex-col border-l border-border/70 bg-card/50"
+      style={{ width: `${sidebarWidth}px` }}
+    >
+      {/* Resize handle — fully inside sidebar bounds to avoid stealing chat scroll (see #958) */}
+      <div
+        className="absolute inset-y-0 left-0 z-10 w-2 cursor-col-resize after:absolute after:inset-y-0 after:left-0 after:w-[2px] hover:after:bg-border"
+        onPointerDown={handleResizePointerDown}
+        onPointerMove={handleResizePointerMove}
+        onPointerUp={handleResizePointerEnd}
+        onPointerCancel={handleResizePointerEnd}
+      />
       {/* Header */}
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-3">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## What Changed

Adds drag-to-resize to the Plan sidebar and follows up with cleanup for drag styles if the sidebar unmounts mid-resize.

- Replaced the fixed `w-[340px]` layout with a dynamic width driven by React state
- Added a left-edge resize handle for `PlanSidebar`
- Clamp width between 240px and 560px and persist it to `localStorage`
- Clean up `document.body` cursor and `user-select` overrides if the sidebar unmounts during a drag

## Why

The Plan sidebar was fixed at 340px with no way to adjust it for different screen sizes or content widths.

This implementation keeps the resize handle fully inside the Plan sidebar bounds so it does not steal pointer interactions from the chat area. That is the same class of interaction problem described in #958, but this PR does not close #958 because that issue is specifically about the diff sidebar / `SidebarRail`.

Supersedes #1438 to correct the commit history and remove the incorrect `Closes #958` reference from the original branch.

## UI Changes

This is a drag-interaction change. The resize handle is invisible by default and shows a 2px border indicator on hover, consistent with the existing resize affordances.

Before:

https://github.com/user-attachments/assets/00f4280b-bfdf-41ef-b479-b79550ca2419

After:

https://github.com/user-attachments/assets/d7b5351c-0a9e-43dd-af52-fb070dda2c5a

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds pointer-based resizing and localStorage persistence; main risk is minor UX regressions (drag/scroll interactions or leaked cursor styles) mitigated by pointer capture and unmount cleanup.
> 
> **Overview**
> Adds drag-to-resize support to `PlanSidebar` by replacing the fixed `w-[340px]` width with a state-driven inline width and a left-edge pointer resize handle.
> 
> Sidebar width is clamped (240–560px), restored from `localStorage` on mount, and persisted back to `localStorage` on drag end; body `cursor`/`user-select` overrides are applied during drag and cleaned up on release or unmount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27f82f703b8fed99c104ec4663d8c2f067d0eb6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-to-resize with localStorage persistence to `PlanSidebar`
> - Adds a left-edge resize handle to [PlanSidebar.tsx](https://github.com/pingdotgg/t3code/pull/1439/files#diff-a69033fa91de15c2474ca629c0dd2d24282e3389b3378f709f592f3119923d17) using pointer-capture events; width is clamped between 240–560px via a `clampSidebarWidth` helper.
> - Persists the chosen width to localStorage on drag end and restores it on mount via `readStoredWidth`, defaulting to 340px if no valid value is stored.
> - During resize, `document.body` cursor is set to `col-resize` and text selection is disabled, with cleanup on unmount.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9629d17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->