### PR TITLE
Fix turn checkpoint diffs being captured too early

### DIFF
--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -415,6 +415,190 @@ describe("CheckpointReactor", () => {
     ).toBe("v2\n");
   });
 
+  it("refreshes an existing real checkpoint on completed turn completion without duplicating activity", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const createdAt = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-refresh-existing-checkpoint"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.makeUnsafe("evt-turn-started-refresh-existing-checkpoint"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-refresh"),
+    });
+    await waitForGitRefExists(
+      harness.cwd,
+      checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 0),
+    );
+
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "v2\n", "utf8");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.makeUnsafe("cmd-placeholder-diff-refresh-existing-checkpoint"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        turnId: asTurnId("turn-refresh"),
+        completedAt: new Date().toISOString(),
+        checkpointRef: checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1),
+        status: "missing",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await waitForGitRefExists(
+      harness.cwd,
+      checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1),
+    );
+    expect(
+      gitShowFileAtRef(
+        harness.cwd,
+        checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1),
+        "README.md",
+      ),
+    ).toBe("v2\n");
+
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "v3\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.makeUnsafe("evt-turn-completed-refresh-existing-checkpoint"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-refresh"),
+      payload: { state: "completed" },
+    });
+
+    await harness.drain();
+    expect(
+      gitShowFileAtRef(
+        harness.cwd,
+        checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1),
+        "README.md",
+      ),
+    ).toBe("v3\n");
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+    expect(thread?.checkpoints).toHaveLength(1);
+    expect(thread?.checkpoints[0]?.checkpointTurnCount).toBe(1);
+    expect(
+      thread?.activities.filter((activity) => activity.kind === "checkpoint.captured"),
+    ).toHaveLength(1);
+  });
+
+  it("does not refresh an existing real checkpoint for non-completed turn completion", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const createdAt = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-skip-refresh-interrupted"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.makeUnsafe("evt-turn-started-skip-refresh-interrupted"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-interrupted-refresh"),
+    });
+    await waitForGitRefExists(
+      harness.cwd,
+      checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 0),
+    );
+
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "v2\n", "utf8");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.diff.complete",
+        commandId: CommandId.makeUnsafe("cmd-placeholder-diff-skip-refresh-interrupted"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        turnId: asTurnId("turn-interrupted-refresh"),
+        completedAt: new Date().toISOString(),
+        checkpointRef: checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1),
+        status: "missing",
+        files: [],
+        checkpointTurnCount: 1,
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    await waitForGitRefExists(
+      harness.cwd,
+      checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1),
+    );
+    expect(
+      gitShowFileAtRef(
+        harness.cwd,
+        checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1),
+        "README.md",
+      ),
+    ).toBe("v2\n");
+
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "v3\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.makeUnsafe("evt-turn-completed-skip-refresh-interrupted"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-interrupted-refresh"),
+      payload: { state: "interrupted" },
+    });
+
+    await harness.drain();
+    expect(
+      gitShowFileAtRef(
+        harness.cwd,
+        checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1),
+        "README.md",
+      ),
+    ).toBe("v2\n");
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.makeUnsafe("thread-1"));
+    expect(thread?.checkpoints).toHaveLength(1);
+    expect(thread?.checkpoints[0]?.checkpointTurnCount).toBe(1);
+    expect(
+      thread?.activities.filter((activity) => activity.kind === "checkpoint.captured"),
+    ).toHaveLength(1);
+  });
+
   it("ignores auxiliary thread turn completion while primary turn is active", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });
     const createdAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.ts
@@ -202,6 +202,7 @@ const make = Effect.gen(function* () {
     readonly status: "ready" | "missing" | "error";
     readonly assistantMessageId: MessageId | undefined;
     readonly createdAt: string;
+    readonly emitCapturedActivity?: boolean | undefined;
   }) {
     const fromTurnCount = Math.max(0, input.turnCount - 1);
     const fromCheckpointRef = checkpointRefForThreadTurn(input.threadId, fromTurnCount);
@@ -299,24 +300,26 @@ const make = Effect.gen(function* () {
       createdAt: input.createdAt,
     });
 
-    yield* orchestrationEngine.dispatch({
-      type: "thread.activity.append",
-      commandId: serverCommandId("checkpoint-captured-activity"),
-      threadId: input.threadId,
-      activity: {
-        id: EventId.makeUnsafe(crypto.randomUUID()),
-        tone: "info",
-        kind: "checkpoint.captured",
-        summary: "Checkpoint captured",
-        payload: {
-          turnCount: input.turnCount,
-          status: input.status,
+    if (input.emitCapturedActivity ?? true) {
+      yield* orchestrationEngine.dispatch({
+        type: "thread.activity.append",
+        commandId: serverCommandId("checkpoint-captured-activity"),
+        threadId: input.threadId,
+        activity: {
+          id: EventId.makeUnsafe(crypto.randomUUID()),
+          tone: "info",
+          kind: "checkpoint.captured",
+          summary: "Checkpoint captured",
+          payload: {
+            turnCount: input.turnCount,
+            status: input.status,
+          },
+          turnId: input.turnId,
+          createdAt: input.createdAt,
         },
-        turnId: input.turnId,
         createdAt: input.createdAt,
-      },
-      createdAt: input.createdAt,
-    });
+      });
+    }
   });
 
   // Captures a real git checkpoint when a turn completes via a runtime event.
@@ -339,14 +342,36 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    // Only skip if a real (non-placeholder) checkpoint already exists for this turn.
-    // ProviderRuntimeIngestion may insert placeholder entries with status "missing"
-    // before this reactor runs; those must not prevent real git capture.
-    if (
-      thread.checkpoints.some(
-        (checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing",
-      )
-    ) {
+    const existingNonMissing = thread.checkpoints.find(
+      (checkpoint) => checkpoint.turnId === turnId && checkpoint.status !== "missing",
+    );
+    // If a real checkpoint was already captured mid-turn (first turn.diff.updated),
+    // re-capture at turn completion only for successful turns so the diff
+    // includes all edits from that turn without changing non-success semantics.
+    if (existingNonMissing && event.payload.state === "completed") {
+      const checkpointCwdForRefresh = yield* resolveCheckpointCwd({
+        threadId: thread.id,
+        thread,
+        projects: readModel.projects,
+        preferSessionRuntime: true,
+      });
+      if (!checkpointCwdForRefresh) {
+        return;
+      }
+      yield* captureAndDispatchCheckpoint({
+        threadId: thread.id,
+        turnId,
+        thread,
+        cwd: checkpointCwdForRefresh,
+        turnCount: existingNonMissing.checkpointTurnCount,
+        status: checkpointStatusFromRuntime(event.payload.state),
+        assistantMessageId: existingNonMissing.assistantMessageId ?? undefined,
+        createdAt: event.createdAt,
+        emitCapturedActivity: false,
+      });
+      return;
+    }
+    if (existingNonMissing) {
       return;
     }
 


### PR DESCRIPTION
## What Changed

Refresh an existing real checkpoint when a turn finishes successfully, instead of skipping capture once an earlier checkpoint already exists for that turn.

This keeps the same checkpoint turn count and ref, but updates it with the final filesystem state from that turn. The refresh path also avoids emitting a duplicate `checkpoint.captured` activity.

## Why

The bug was caused by checkpoints sometimes being captured too early during a turn. When the turn later completed, the reactor saw that a real checkpoint already existed and returned early, so the checkpoint only reflected the partial state from mid-turn.

That caused later edits from the same turn to appear as if they belonged to the next turn, which made diffs look shifted or split incorrectly.

## UI Changes
Changed:
<img width="941" height="903" alt="Screenshot 2026-03-26 at 16 32 14" src="https://github.com/user-attachments/assets/74787d6f-8994-4b22-a43c-ccc3ce0587b7" />

Before, from issue #1434:
<img width="943" height="1225" alt="image" src="https://github.com/user-attachments/assets/13c57594-bad7-4af1-9f1e-1bcd0001d02e" />


## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] No UI changes
- [X] N/A no animation changed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix turn checkpoint diffs being captured too early by refreshing checkpoints on completed turns
> - Previously, `captureCheckpointFromTurnCompletion` returned early if a non-missing checkpoint already existed for the turn, meaning any final edits made after the mid-turn checkpoint were lost.
> - Now, when a `turn.completed` event fires with `state: 'completed'`, the reactor re-resolves the working directory and refreshes the existing checkpoint to include final changes.
> - For non-completed states (e.g. `interrupted`), the existing checkpoint is kept as-is and the handler returns early.
> - `captureAndDispatchCheckpoint` gains an optional `emitCapturedActivity` flag so the refresh path can suppress the duplicate `checkpoint.captured` activity.
> - Behavioral Change: a refresh now also publishes an additional `turn.processing.quiesced` receipt where previously none would be emitted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a204547.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->