### PR TITLE
fix(web): Fix duplicate highlight in composer slash command menu

### DIFF
--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -43,6 +43,7 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
 }) {
   return (
     <Command
+      autoHighlight={false}
       mode="none"
       onItemHighlighted={(highlightedValue) => {
         props.onHighlightedItemChange(
@@ -58,6 +59,7 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
               item={item}
               resolvedTheme={props.resolvedTheme}
               isActive={props.activeItemId === item.id}
+              onHighlight={props.onHighlightedItemChange}
               onSelect={props.onSelect}
             />
           ))}
@@ -80,15 +82,19 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
   item: ComposerCommandItem;
   resolvedTheme: "light" | "dark";
   isActive: boolean;
+  onHighlight: (itemId: string | null) => void;
   onSelect: (item: ComposerCommandItem) => void;
 }) {
   return (
     <CommandItem
       value={props.item.id}
       className={cn(
-        "cursor-pointer select-none gap-2",
-        props.isActive && "bg-accent text-accent-foreground",
+        "cursor-pointer select-none gap-2 data-highlighted:bg-transparent data-highlighted:text-inherit",
+        props.isActive && "bg-accent! text-accent-foreground!",
       )}
+      onMouseMove={() => {
+        if (!props.isActive) props.onHighlight(props.item.id);
+      }}
       onMouseDown={(event) => {
         event.preventDefault();
       }}


### PR DESCRIPTION
## What Changed

Four CSS-level changes in `ComposerCommandMenu.tsx` to make the `isActive` state the authoritative source of truth for item highlighting:

- Set `autoHighlight={false}` on the `Command` component
- Added `data-highlighted:bg-transparent data-highlighted:text-inherit` to suppress Base UI's built-in highlight styling
- Used `bg-accent!` / `text-accent-foreground!` so `isActive` always wins over `data-highlighted` when both are present
- Added `onMouseMove` with an `!isActive` guard so that moving the mouse after keyboard navigation re-syncs the highlight to the hovered item

## Why

When navigating the slash command menu (`/`, `/model`, etc..) with arrow keys, two items appear highlighted at the same time.

This happens because Base UI's `Autocomplete` internally sets a `data-highlighted` attribute on items, while the custom keyboard navigation (which exists because Lexical intercepts key events before Base UI sees them) manages its own `isActive` highlight. The two systems can point at different items, producing a double selection.

Mouse interaction is unaffected because `onItemHighlighted` already syncs hover events into `isActive`.

## UI Changes

### Before

https://github.com/user-attachments/assets/1f5540b0-e898-4add-9eb0-8bca0b318c81

### After

https://github.com/user-attachments/assets/25cf083b-f7c5-4789-b58f-8c8005ba473c

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts how command items are highlighted; main risk is minor regressions in keyboard/mouse highlight behavior.
> 
> **Overview**
> Fixes double-highlight in the chat composer slash-command menu by making the app-controlled `activeItemId` the single source of truth for item styling.
> 
> Disables Base UI auto-highlighting (`autoHighlight={false}`), suppresses `data-highlighted` styles, forces `isActive` classes to win, and adds `onMouseMove` syncing so hover re-aligns the active item after keyboard navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 489a23033ff2576ae7f223e025669aa0c83b4935. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate highlight in composer slash command menu
> - Disables the `Command` component's built-in auto-highlighting (`autoHighlight=false`) in [`ComposerCommandMenu`](https://github.com/pingdotgg/t3code/pull/1445/files#diff-ca7de5ada90d0c74157405378c7182002eab97a1ea23cd71e4376f8db6ba81a4) to remove the duplicate highlight.
> - Adds an `onHighlight` prop to `ComposerCommandMenuItem` that fires on `mousemove` when the item is not already active, delegating highlight control to the parent via `onHighlightedItemChange`.
> - Suppresses default `data-highlighted` styles on menu items in favor of the component's own active state styling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 489a230.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->