### PR TITLE
Fix Linux desktop bootstrap fd handling

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -3,6 +3,7 @@ import * as Crypto from "node:crypto";
 import * as FS from "node:fs";
 import * as OS from "node:os";
 import * as Path from "node:path";
+import type { Writable } from "node:stream";
 
 import {
   app,
@@ -943,6 +944,40 @@ function scheduleBackendRestart(reason: string): void {
   }, delayMs);
 }
 
+function isWritableBootstrapStream(stream: unknown): stream is Writable {
+  return (
+    stream !== null &&
+    typeof stream === "object" &&
+    "write" in stream &&
+    typeof stream.write === "function" &&
+    "end" in stream &&
+    typeof stream.end === "function" &&
+    "once" in stream &&
+    typeof stream.once === "function"
+  );
+}
+
+function writeBackendBootstrapEnvelope(stream: unknown): boolean {
+  if (!isWritableBootstrapStream(stream)) {
+    return false;
+  }
+
+  stream.once("error", (error: Error) => {
+    console.error("[desktop] backend bootstrap pipe error", error);
+  });
+  stream.write(
+    `${JSON.stringify({
+      mode: "desktop",
+      noBrowser: true,
+      port: backendPort,
+      t3Home: BASE_DIR,
+      authToken: backendAuthToken,
+    })}\n`,
+  );
+  stream.end();
+  return true;
+}
+
 function startBackend(): void {
   if (isQuitting || backendProcess) return;
 
@@ -966,18 +1001,7 @@ function startBackend(): void {
       : ["ignore", "inherit", "inherit", "pipe"],
   });
   const bootstrapStream = child.stdio[3];
-  if (bootstrapStream && "write" in bootstrapStream) {
-    bootstrapStream.write(
-      `${JSON.stringify({
-        mode: "desktop",
-        noBrowser: true,
-        port: backendPort,
-        t3Home: BASE_DIR,
-        authToken: backendAuthToken,
-      })}\n`,
-    );
-    bootstrapStream.end();
-  } else {
+  if (!writeBackendBootstrapEnvelope(bootstrapStream)) {
     child.kill("SIGTERM");
     scheduleBackendRestart("missing desktop bootstrap pipe");
     return;

--- a/apps/server/src/bootstrap.test.ts
+++ b/apps/server/src/bootstrap.test.ts
@@ -9,7 +9,7 @@ import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import { TestClock } from "effect/testing";
 
-import { readBootstrapEnvelope, resolveFdPath } from "./bootstrap";
+import { openBootstrapInputStream, readBootstrapEnvelope, resolveFdPath } from "./bootstrap";
 import { assertNone, assertSome } from "@effect/vitest/utils";
 
 const TestEnvelopeSchema = Schema.Struct({ mode: Schema.String });
@@ -55,6 +55,53 @@ it.layer(NodeServices.layer)("readBootstrapEnvelope", (it) => {
       const payload = yield* readBootstrapEnvelope(TestEnvelopeSchema, fd, { timeoutMs: 100 });
       assertNone(payload);
     }),
+  );
+
+  it.effect(
+    "falls back to directly reading the inherited fd when fd duplication is unavailable",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const filePath = yield* fs.makeTempFileScoped({
+          prefix: "t3-bootstrap-",
+          suffix: ".ndjson",
+        });
+        yield* fs.writeFileString(filePath, '{"mode":"desktop"}\n');
+
+        const fd = yield* Effect.acquireRelease(
+          Effect.sync(() => NFS.openSync(filePath, "r")),
+          (openedFd) => Effect.sync(() => NFS.closeSync(openedFd)),
+        );
+        const fdPath = resolveFdPath(fd);
+        assert.isDefined(fdPath);
+
+        const stream = openBootstrapInputStream(fd, {
+          platform: process.platform,
+          duplicateFd: (path) => {
+            if (path === fdPath) {
+              const error = new Error(
+                `ENXIO: no such device or address, open '${fdPath}'`,
+              ) as NodeJS.ErrnoException;
+              error.code = "ENXIO";
+              throw error;
+            }
+
+            return NFS.openSync(path, "r");
+          },
+        });
+
+        const content = yield* Effect.promise<string>(
+          () =>
+            new Promise((resolve, reject) => {
+              stream.once("data", (chunk) => resolve(String(chunk)));
+              stream.once("error", reject);
+              stream.once("close", () => reject(new Error("bootstrap stream closed before data")));
+            }),
+        );
+        stream.destroy();
+
+        assert.equal(content, '{"mode":"desktop"}\n');
+      }),
   );
 
   it.effect("returns none when the bootstrap read times out before any value arrives", () =>

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -11,6 +11,11 @@ class BootstrapError extends Data.TaggedError("BootstrapError")<{
   readonly cause?: unknown;
 }> {}
 
+interface OpenBootstrapInputStreamOptions {
+  readonly platform?: NodeJS.Platform;
+  readonly duplicateFd?: (fdPath: string) => number;
+}
+
 export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function* <A, I>(
   schema: Schema.Codec<A, I>,
   fd: number,
@@ -87,6 +92,11 @@ const isUnavailableBootstrapFdError = Predicate.compose(
   (_) => _.code === "EBADF" || _.code === "ENOENT",
 );
 
+const isUnduplicatableBootstrapFdError = Predicate.compose(
+  Predicate.hasProperty("code"),
+  (_) => _.code === "ENXIO",
+);
+
 const isFdReady = (fd: number) =>
   Effect.try({
     try: () => NFS.fstatSync(fd),
@@ -105,31 +115,50 @@ const isFdReady = (fd: number) =>
 
 const makeBootstrapInputStream = (fd: number) =>
   Effect.try<Readable, BootstrapError>({
-    try: () => {
-      const fdPath = resolveFdPath(fd);
-      if (fdPath === undefined) {
-        const stream = new Net.Socket({
-          fd,
-          readable: true,
-          writable: false,
-        });
-        stream.setEncoding("utf8");
-        return stream;
-      }
-
-      const streamFd = NFS.openSync(fdPath, "r");
-      return NFS.createReadStream("", {
-        fd: streamFd,
-        encoding: "utf8",
-        autoClose: true,
-      });
-    },
+    try: () => openBootstrapInputStream(fd),
     catch: (error) =>
       new BootstrapError({
         message: "Failed to duplicate bootstrap fd.",
         cause: error,
       }),
   });
+
+export function openBootstrapInputStream(
+  fd: number,
+  options?: OpenBootstrapInputStreamOptions,
+): Readable {
+  const fdPath = resolveFdPath(fd, options?.platform);
+  if (fdPath === undefined) {
+    const stream = new Net.Socket({
+      fd,
+      readable: true,
+      writable: false,
+    });
+    stream.setEncoding("utf8");
+    return stream;
+  }
+
+  const duplicateFd = options?.duplicateFd ?? ((path: string) => NFS.openSync(path, "r"));
+
+  try {
+    const streamFd = duplicateFd(fdPath);
+    return NFS.createReadStream("", {
+      fd: streamFd,
+      encoding: "utf8",
+      autoClose: true,
+    });
+  } catch (error) {
+    if (!isUnduplicatableBootstrapFdError(error)) {
+      throw error;
+    }
+
+    return NFS.createReadStream("", {
+      fd,
+      encoding: "utf8",
+      autoClose: true,
+    });
+  }
+}
 
 export function resolveFdPath(
   fd: number,


### PR DESCRIPTION
## Summary
- fall back to directly reading inherited bootstrap fds when Linux cannot duplicate `/proc/self/fd/*`
- guard the Electron desktop bootstrap pipe against unhandled `ECONNRESET` errors
- add a regression test for the Linux fallback path

## Verification
- bun run fmt
- bun run lint
- bun run typecheck
- bun run --cwd apps/server test -- src/bootstrap.test.ts
- bun run --cwd apps/desktop test

## Notes
- `apps/server/src/main.test.ts` is still blocked locally by a missing `node-pty` native binary in this environment, separate from this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop↔server bootstrap IPC and file descriptor handling; regressions could prevent the desktop backend from starting on Linux or cause silent startup failures.
> 
> **Overview**
> Improves robustness of the desktop backend bootstrap handshake.
> 
> On the **desktop app**, bootstrap envelope writing to the backend pipe is wrapped in a type guard and now attaches an `error` listener before writing, avoiding unhandled stream errors and failing fast when the bootstrap pipe isn’t writable.
> 
> On the **server**, bootstrap fd reading is refactored into `openBootstrapInputStream` and now **falls back to reading directly from the inherited fd** when duplicating `/proc/self/fd/*` fails with `ENXIO` (Linux), with a new regression test covering this fallback path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e632a57a3b25b650720ca52ae4efee3300cfe0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux desktop bootstrap fd handling for writable stream validation and ENXIO fallback
> - Adds `isWritableBootstrapStream` type guard in [main.ts](https://github.com/pingdotgg/t3code/pull/1446/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb) to validate write, end, and once methods before writing; `startBackend` now kills the child with SIGTERM and schedules a restart if the check fails.
> - Extracts `writeBackendBootstrapEnvelope` helper that attaches a one-time error listener and writes the JSON envelope, replacing inline logic in `startBackend`.
> - Adds `openBootstrapInputStream` in [bootstrap.ts](https://github.com/pingdotgg/t3code/pull/1446/files#diff-134419e5ebf3f75491ebaa844716de9728271ae9e3b8ceb6f33964851d52a147) that falls back to reading from the inherited fd directly when fd duplication fails with ENXIO, instead of throwing a `BootstrapError`.
> - Adds a test in [bootstrap.test.ts](https://github.com/pingdotgg/t3code/pull/1446/files#diff-0ce606ba1b9ab11f436ea374b47d8760acc9ca02c427343b8690bdc8c52a2175) verifying the ENXIO fallback path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e632a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->