### PR TITLE
fix(web): Differentiate duplicate "Plan" button labels

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3916,7 +3916,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
                                   }
                                 >
                                   <ListTodoIcon />
-                                  <span className="sr-only sm:not-sr-only">Plan</span>
+                                  <span className="sr-only sm:not-sr-only">
+                                    {planSidebarOpen ? "Hide Plan" : "Show Plan"}
+                                  </span>
                                 </Button>
                               </>
                             ) : null}


### PR DESCRIPTION
## What Changed

Renamed the plan sidebar toggle button label from a static "Plan" to dynamic "Show Plan" / "Hide Plan" in `ChatView.tsx`. I realize this is a subjective change, feel free to suggest better solutions / close it if there is a better design planned (pun intended) in the future.

## Why

The composer toolbar had two buttons both labeled "Plan", the mode toggle (Chat/Plan) and the sidebar toggle (Plan). This may cause ambiguity as to which button is which. The new "Show Plan" / "Hide Plan" labels clearly communicate that the button opens/closes the plan sidebar.

I paid attention to make it consistent with labels in `CompactComposerControlsMenu` which displays "Show plan sidebar" / "Hide plan sidebar".

## UI Changes

### Before

<img width="821" height="198" alt="Before" src="https://github.com/user-attachments/assets/df17c6bd-e606-4ef5-b4b0-645333366e39" />

### After

![After](https://github.com/user-attachments/assets/fb0268f3-83cc-4af4-9538-cb11d647985c)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only text change to a button label; no logic or data flow changes.
> 
> **Overview**
> Updates the plan sidebar toggle button in `ChatView.tsx` to use dynamic text (`Show Plan` / `Hide Plan`) instead of a static `Plan`, reducing ambiguity with the separate Plan/Chat mode toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adff5bf822786fb43f405290faec1ca6169cdd61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change plan sidebar toggle label to 'Show Plan' / 'Hide Plan' based on state
> Updates the toggle button label in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1448/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to reflect the current sidebar state, showing 'Hide Plan' when open and 'Show Plan' when closed. This fixes duplicate 'Plan' labels that could confuse screen readers and sighted users alike.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adff5bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->