### PR TITLE
Add desktop window decoration modes

### DIFF
--- a/apps/desktop/src/desktopSettings.test.ts
+++ b/apps/desktop/src/desktopSettings.test.ts
@@ -1,0 +1,63 @@
+import * as FS from "node:fs";
+import * as OS from "node:os";
+import * as Path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { applyDesktopTitleBarModeSetting, readDesktopSettingsFromDisk } from "./desktopSettings";
+
+function makeTempSettingsPath(): string {
+  return Path.join(
+    FS.mkdtempSync(Path.join(OS.tmpdir(), "t3code-desktop-settings-")),
+    "settings.json",
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("readDesktopSettingsFromDisk", () => {
+  it("returns an empty object when settings.json is invalid", () => {
+    const settingsPath = makeTempSettingsPath();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    FS.writeFileSync(settingsPath, "{invalid", "utf8");
+
+    expect(readDesktopSettingsFromDisk(settingsPath)).toEqual({});
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+
+    FS.rmSync(Path.dirname(settingsPath), { recursive: true, force: true });
+  });
+
+  it("returns an empty object when settings.json is not a JSON object", () => {
+    const settingsPath = makeTempSettingsPath();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    FS.writeFileSync(settingsPath, "[]", "utf8");
+
+    expect(readDesktopSettingsFromDisk(settingsPath)).toEqual({});
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+
+    FS.rmSync(Path.dirname(settingsPath), { recursive: true, force: true });
+  });
+});
+
+describe("applyDesktopTitleBarModeSetting", () => {
+  it("removes desktopTitleBarMode when the default mode is persisted", () => {
+    expect(
+      applyDesktopTitleBarModeSetting(
+        { desktopTitleBarMode: "system", other: true },
+        "t3code",
+        "t3code",
+      ),
+    ).toEqual({ other: true });
+  });
+
+  it("writes desktopTitleBarMode when a non-default mode is persisted", () => {
+    expect(applyDesktopTitleBarModeSetting({ other: true }, "system", "t3code")).toEqual({
+      desktopTitleBarMode: "system",
+      other: true,
+    });
+  });
+});

--- a/apps/desktop/src/desktopSettings.ts
+++ b/apps/desktop/src/desktopSettings.ts
@@ -1,4 +1,5 @@
 import * as FS from "node:fs";
+import * as Path from "node:path";
 
 import type { DesktopTitleBarMode } from "@t3tools/contracts";
 
@@ -32,4 +33,19 @@ export function applyDesktopTitleBarModeSetting(
     nextSettings.desktopTitleBarMode = mode;
   }
   return nextSettings;
+}
+
+export function writeDesktopSettingsToDisk(
+  settingsFilePath: string,
+  settings: Record<string, unknown>,
+): void {
+  FS.mkdirSync(Path.dirname(settingsFilePath), { recursive: true });
+
+  const tempPath = `${settingsFilePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    FS.writeFileSync(tempPath, `${JSON.stringify(settings, null, 2)}\n`, "utf8");
+    FS.renameSync(tempPath, settingsFilePath);
+  } finally {
+    FS.rmSync(tempPath, { force: true });
+  }
 }

--- a/apps/desktop/src/desktopSettings.ts
+++ b/apps/desktop/src/desktopSettings.ts
@@ -1,0 +1,35 @@
+import * as FS from "node:fs";
+
+import type { DesktopTitleBarMode } from "@t3tools/contracts";
+
+export function readDesktopSettingsFromDisk(settingsFilePath: string): Record<string, unknown> {
+  if (!FS.existsSync(settingsFilePath)) {
+    return {};
+  }
+
+  try {
+    const raw = FS.readFileSync(settingsFilePath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
+      throw new Error("settings.json must contain a JSON object");
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    console.error("[desktop] failed to parse settings.json", error);
+    return {};
+  }
+}
+
+export function applyDesktopTitleBarModeSetting(
+  settings: Record<string, unknown>,
+  mode: DesktopTitleBarMode,
+  defaultMode: DesktopTitleBarMode,
+): Record<string, unknown> {
+  const nextSettings = { ...settings };
+  if (mode === defaultMode) {
+    delete nextSettings.desktopTitleBarMode;
+  } else {
+    nextSettings.desktopTitleBarMode = mode;
+  }
+  return nextSettings;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -178,6 +178,11 @@ async function applyDesktopTitleBarMode(mode: DesktopTitleBarMode): Promise<Desk
   const previousMode = currentDesktopTitleBarMode;
   persistDesktopTitleBarModeToDisk(mode);
 
+  if (isRebuildingMainWindow) {
+    pendingDesktopTitleBarMode = mode;
+    return resolveDesktopWindowState(mainWindow);
+  }
+
   if (mode !== currentDesktopTitleBarMode) {
     const nextState = await rebuildMainWindow(mode);
     if (nextState.titleBarMode !== mode) {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1631,14 +1631,23 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
   isRebuildingMainWindow = true;
   pendingDesktopTitleBarMode = null;
 
-  const snapshot = snapshotWindow(previousWindow);
-  const replacementWindow = createWindow({
-    bounds: snapshot.bounds,
-    loadUrl: snapshot.url,
-    showOnReady: false,
-    titleBarMode: nextTitleBarMode,
-  });
-  mainWindow = replacementWindow;
+  let snapshot: WindowSnapshot;
+  let replacementWindow: BrowserWindow;
+
+  try {
+    snapshot = snapshotWindow(previousWindow);
+    replacementWindow = createWindow({
+      bounds: snapshot.bounds,
+      loadUrl: snapshot.url,
+      showOnReady: false,
+      titleBarMode: nextTitleBarMode,
+    });
+    mainWindow = replacementWindow;
+  } catch (error) {
+    isRebuildingMainWindow = false;
+    pendingDesktopTitleBarMode = null;
+    throw error;
+  }
 
   return new Promise<DesktopWindowState>((resolve) => {
     let settled = false;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -174,6 +174,23 @@ function persistDesktopTitleBarModeToDisk(mode: DesktopTitleBarMode): void {
   writeDesktopSettingsToDisk(DESKTOP_SETTINGS_FILE_PATH, nextSettings);
 }
 
+async function applyDesktopTitleBarMode(mode: DesktopTitleBarMode): Promise<DesktopWindowState> {
+  const previousMode = currentDesktopTitleBarMode;
+  persistDesktopTitleBarModeToDisk(mode);
+
+  if (mode !== currentDesktopTitleBarMode) {
+    const nextState = await rebuildMainWindow(mode);
+    if (nextState.titleBarMode !== mode) {
+      persistDesktopTitleBarModeToDisk(previousMode);
+    }
+    return nextState;
+  }
+
+  currentDesktopTitleBarMode = mode;
+  emitDesktopWindowState(mainWindow);
+  return resolveDesktopWindowState(mainWindow);
+}
+
 function resolveDesktopWindowState(window: BrowserWindow | null): DesktopWindowState {
   const activeWindow = window && !window.isDestroyed() ? window : null;
 
@@ -1290,20 +1307,7 @@ function registerIpcHandlers(): void {
       return resolveDesktopWindowState(mainWindow);
     }
 
-    const previousMode = currentDesktopTitleBarMode;
-    persistDesktopTitleBarModeToDisk(mode);
-
-    if (mode !== currentDesktopTitleBarMode) {
-      const nextState = await rebuildMainWindow(mode);
-      if (nextState.titleBarMode !== mode) {
-        persistDesktopTitleBarModeToDisk(previousMode);
-      }
-      return nextState;
-    }
-
-    currentDesktopTitleBarMode = mode;
-    emitDesktopWindowState(mainWindow);
-    return resolveDesktopWindowState(mainWindow);
+    return applyDesktopTitleBarMode(mode);
   });
 
   ipcMain.removeHandler(CONTEXT_MENU_CHANNEL);
@@ -1657,7 +1661,9 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
       pendingDesktopTitleBarMode = null;
 
       if (pendingMode && pendingMode !== currentDesktopTitleBarMode) {
-        void rebuildMainWindow(pendingMode);
+        void applyDesktopTitleBarMode(pendingMode).catch((error) => {
+          console.error("[desktop] failed to apply pending title bar mode", error);
+        });
       }
 
       resolve(state);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -17,10 +17,14 @@ import {
 } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
 import * as Effect from "effect/Effect";
+import { DEFAULT_DESKTOP_TITLE_BAR_MODE, type DesktopTitleBarMode } from "@t3tools/contracts";
 import type {
   DesktopTheme,
   DesktopUpdateActionResult,
   DesktopUpdateState,
+  DesktopWindowAction,
+  DesktopWindowPlatform,
+  DesktopWindowState,
 } from "@t3tools/contracts";
 import { autoUpdater } from "electron-updater";
 
@@ -49,9 +53,13 @@ syncShellEnvironment();
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
+const SET_TITLE_BAR_MODE_CHANNEL = "desktop:set-title-bar-mode";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 const MENU_ACTION_CHANNEL = "desktop:menu-action";
+const WINDOW_STATE_CHANNEL = "desktop:window-state";
+const WINDOW_GET_STATE_CHANNEL = "desktop:window-get-state";
+const WINDOW_ACTION_CHANNEL = "desktop:window-action";
 const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
@@ -62,6 +70,8 @@ const STATE_DIR = Path.join(BASE_DIR, "userdata");
 const DESKTOP_SCHEME = "t3";
 const ROOT_DIR = Path.resolve(__dirname, "../../..");
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
+const SETTINGS_STATE_DIR = Path.join(BASE_DIR, isDevelopment ? "dev" : "userdata");
+const SETTINGS_FILE_PATH = Path.join(SETTINGS_STATE_DIR, "settings.json");
 const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
 const APP_USER_MODEL_ID = "com.t3tools.t3code";
 const USER_DATA_DIR_NAME = isDevelopment ? "t3code-dev" : "t3code";
@@ -76,6 +86,9 @@ const AUTO_UPDATE_STARTUP_DELAY_MS = 15_000;
 const AUTO_UPDATE_POLL_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const DESKTOP_UPDATE_CHANNEL = "latest";
 const DESKTOP_UPDATE_ALLOW_PRERELEASE = false;
+const DESKTOP_ZOOM_LEVEL_STEP = 0.5;
+const DESKTOP_ZOOM_LEVEL_MIN = -8;
+const DESKTOP_ZOOM_LEVEL_MAX = 9;
 
 type DesktopUpdateErrorContext = DesktopUpdateState["errorContext"];
 
@@ -92,6 +105,12 @@ let aboutCommitHashCache: string | null | undefined;
 let desktopLogSink: RotatingFileSink | null = null;
 let backendLogSink: RotatingFileSink | null = null;
 let restoreStdIoCapture: (() => void) | null = null;
+let desktopSettingsWatcher: FS.FSWatcher | null = null;
+let desktopSettingsSyncTimer: ReturnType<typeof setTimeout> | null = null;
+let currentDesktopTitleBarMode: DesktopTitleBarMode = DEFAULT_DESKTOP_TITLE_BAR_MODE;
+let pendingDesktopTitleBarMode: DesktopTitleBarMode | null = null;
+let isRebuildingMainWindow = false;
+const desktopTitleBarModeByWindow = new WeakMap<BrowserWindow, DesktopTitleBarMode>();
 
 let destructiveMenuIconCache: Electron.NativeImage | null | undefined;
 const desktopRuntimeInfo = resolveDesktopRuntimeInfo({
@@ -112,6 +131,90 @@ function logScope(scope: string): string {
 
 function sanitizeLogValue(value: string): string {
   return value.replace(/\s+/g, " ").trim();
+}
+
+function resolveDesktopWindowPlatform(platform: NodeJS.Platform): DesktopWindowPlatform {
+  if (platform === "darwin" || platform === "linux" || platform === "win32") {
+    return platform;
+  }
+
+  return "other";
+}
+
+function getDesktopTitleBarMode(rawMode: unknown): DesktopTitleBarMode {
+  return rawMode === "system" ? "system" : "t3code";
+}
+
+function parseDesktopTitleBarMode(rawMode: unknown): DesktopTitleBarMode | null {
+  return rawMode === "t3code" || rawMode === "system" ? rawMode : null;
+}
+
+function readDesktopTitleBarModeFromDisk(): DesktopTitleBarMode {
+  if (!FS.existsSync(SETTINGS_FILE_PATH)) {
+    return DEFAULT_DESKTOP_TITLE_BAR_MODE;
+  }
+
+  try {
+    const raw = FS.readFileSync(SETTINGS_FILE_PATH, "utf8");
+    const parsed = JSON.parse(raw) as { desktopTitleBarMode?: unknown };
+    return getDesktopTitleBarMode(parsed.desktopTitleBarMode);
+  } catch (error) {
+    console.error("[desktop] failed to read desktop title bar mode", error);
+    return DEFAULT_DESKTOP_TITLE_BAR_MODE;
+  }
+}
+
+function shouldUseT3CodeTitleBar(mode: DesktopTitleBarMode): boolean {
+  return resolveDesktopWindowPlatform(process.platform) !== "other" && mode === "t3code";
+}
+
+function persistDesktopTitleBarModeToDisk(mode: DesktopTitleBarMode): void {
+  FS.mkdirSync(SETTINGS_STATE_DIR, { recursive: true });
+
+  const currentSettings = FS.existsSync(SETTINGS_FILE_PATH)
+    ? JSON.parse(FS.readFileSync(SETTINGS_FILE_PATH, "utf8"))
+    : {};
+
+  if (
+    currentSettings === null ||
+    Array.isArray(currentSettings) ||
+    typeof currentSettings !== "object"
+  ) {
+    throw new Error("settings.json must contain a JSON object");
+  }
+
+  const nextSettings = { ...currentSettings } as Record<string, unknown>;
+  if (mode === DEFAULT_DESKTOP_TITLE_BAR_MODE) {
+    delete nextSettings.desktopTitleBarMode;
+  } else {
+    nextSettings.desktopTitleBarMode = mode;
+  }
+
+  FS.writeFileSync(SETTINGS_FILE_PATH, `${JSON.stringify(nextSettings, null, 2)}\n`, "utf8");
+}
+
+function resolveDesktopWindowState(window: BrowserWindow | null): DesktopWindowState {
+  return {
+    isFullScreen: window?.isFullScreen() ?? false,
+    isMaximized: window?.isMaximized() ?? false,
+    platform: resolveDesktopWindowPlatform(process.platform),
+    titleBarMode:
+      (window ? desktopTitleBarModeByWindow.get(window) : undefined) ?? currentDesktopTitleBarMode,
+    zoomFactor: window?.webContents.getZoomFactor() ?? 1,
+  };
+}
+
+function getDesktopWindowAction(rawAction: unknown): DesktopWindowAction | null {
+  if (
+    rawAction === "minimize" ||
+    rawAction === "toggle-maximize" ||
+    rawAction === "exit-full-screen" ||
+    rawAction === "close"
+  ) {
+    return rawAction;
+  }
+
+  return null;
 }
 
 function backendChildEnv(): NodeJS.ProcessEnv {
@@ -524,6 +627,42 @@ function dispatchMenuAction(action: string): void {
   send();
 }
 
+function resolveActiveDesktopWindow(): BrowserWindow | null {
+  return BrowserWindow.getFocusedWindow() ?? mainWindow ?? BrowserWindow.getAllWindows()[0] ?? null;
+}
+
+function setDesktopZoomLevel(nextZoomLevel: number): void {
+  const targetWindow = resolveActiveDesktopWindow();
+  if (!targetWindow || targetWindow.isDestroyed()) {
+    return;
+  }
+
+  const clampedZoomLevel = Math.min(
+    DESKTOP_ZOOM_LEVEL_MAX,
+    Math.max(DESKTOP_ZOOM_LEVEL_MIN, nextZoomLevel),
+  );
+  targetWindow.webContents.setZoomLevel(clampedZoomLevel);
+  emitDesktopWindowState(targetWindow);
+}
+
+function resetDesktopZoom(): void {
+  setDesktopZoomLevel(0);
+}
+
+function stepDesktopZoom(direction: "in" | "out"): void {
+  const targetWindow = resolveActiveDesktopWindow();
+  if (!targetWindow || targetWindow.isDestroyed()) {
+    return;
+  }
+
+  const currentZoomLevel = targetWindow.webContents.getZoomLevel();
+  const nextZoomLevel =
+    direction === "in"
+      ? currentZoomLevel + DESKTOP_ZOOM_LEVEL_STEP
+      : currentZoomLevel - DESKTOP_ZOOM_LEVEL_STEP;
+  setDesktopZoomLevel(nextZoomLevel);
+}
+
 function handleCheckForUpdatesMenuClick(): void {
   const disabledReason = getAutoUpdateDisabledReason({
     isDevelopment,
@@ -626,10 +765,27 @@ function configureApplicationMenu(): void {
         { role: "forceReload" },
         { role: "toggleDevTools" },
         { type: "separator" },
-        { role: "resetZoom" },
-        { role: "zoomIn", accelerator: "CmdOrCtrl+=" },
-        { role: "zoomIn", accelerator: "CmdOrCtrl+Plus", visible: false },
-        { role: "zoomOut" },
+        {
+          label: "Actual Size",
+          accelerator: "CmdOrCtrl+0",
+          click: () => resetDesktopZoom(),
+        },
+        {
+          label: "Zoom In",
+          accelerator: "CmdOrCtrl+=",
+          click: () => stepDesktopZoom("in"),
+        },
+        {
+          label: "Zoom In",
+          accelerator: "CmdOrCtrl+Plus",
+          visible: false,
+          click: () => stepDesktopZoom("in"),
+        },
+        {
+          label: "Zoom Out",
+          accelerator: "CmdOrCtrl+-",
+          click: () => stepDesktopZoom("out"),
+        },
         { type: "separator" },
         { role: "togglefullscreen" },
       ],
@@ -734,6 +890,15 @@ function emitUpdateState(): void {
   for (const window of BrowserWindow.getAllWindows()) {
     if (window.isDestroyed()) continue;
     window.webContents.send(UPDATE_STATE_CHANNEL, updateState);
+  }
+}
+
+function emitDesktopWindowState(targetWindow?: BrowserWindow | null): void {
+  const windows = targetWindow ? [targetWindow] : BrowserWindow.getAllWindows();
+
+  for (const window of windows) {
+    if (!window || window.isDestroyed()) continue;
+    window.webContents.send(WINDOW_STATE_CHANNEL, resolveDesktopWindowState(window));
   }
 }
 
@@ -1131,6 +1296,29 @@ function registerIpcHandlers(): void {
     nativeTheme.themeSource = theme;
   });
 
+  ipcMain.removeHandler(SET_TITLE_BAR_MODE_CHANNEL);
+  ipcMain.handle(SET_TITLE_BAR_MODE_CHANNEL, async (_event, rawMode: unknown) => {
+    const mode = parseDesktopTitleBarMode(rawMode);
+    if (!mode) {
+      return resolveDesktopWindowState(mainWindow);
+    }
+
+    const previousMode = currentDesktopTitleBarMode;
+    persistDesktopTitleBarModeToDisk(mode);
+
+    if (mode !== currentDesktopTitleBarMode) {
+      const nextState = await rebuildMainWindow(mode);
+      if (nextState.titleBarMode !== mode) {
+        persistDesktopTitleBarModeToDisk(previousMode);
+      }
+      return nextState;
+    }
+
+    currentDesktopTitleBarMode = mode;
+    emitDesktopWindowState(mainWindow);
+    return resolveDesktopWindowState(mainWindow);
+  });
+
   ipcMain.removeHandler(CONTEXT_MENU_CHANNEL);
   ipcMain.handle(
     CONTEXT_MENU_CHANNEL,
@@ -1207,6 +1395,40 @@ function registerIpcHandlers(): void {
     }
   });
 
+  ipcMain.removeHandler(WINDOW_GET_STATE_CHANNEL);
+  ipcMain.handle(WINDOW_GET_STATE_CHANNEL, async (event) => {
+    const owner = BrowserWindow.fromWebContents(event.sender) ?? mainWindow;
+    return resolveDesktopWindowState(owner);
+  });
+
+  ipcMain.removeHandler(WINDOW_ACTION_CHANNEL);
+  ipcMain.handle(WINDOW_ACTION_CHANNEL, async (event, rawAction: unknown) => {
+    const action = getDesktopWindowAction(rawAction);
+    const owner =
+      BrowserWindow.fromWebContents(event.sender) ?? BrowserWindow.getFocusedWindow() ?? mainWindow;
+
+    if (!action || !owner) {
+      return resolveDesktopWindowState(owner ?? null);
+    }
+
+    if (action === "minimize") {
+      owner.minimize();
+    } else if (action === "toggle-maximize") {
+      if (owner.isMaximized()) {
+        owner.unmaximize();
+      } else {
+        owner.maximize();
+      }
+    } else if (action === "exit-full-screen") {
+      owner.setFullScreen(false);
+    } else if (action === "close") {
+      owner.close();
+    }
+
+    emitDesktopWindowState(owner);
+    return resolveDesktopWindowState(owner);
+  });
+
   ipcMain.removeHandler(UPDATE_GET_STATE_CHANNEL);
   ipcMain.handle(UPDATE_GET_STATE_CHANNEL, async () => updateState);
 
@@ -1245,18 +1467,75 @@ function getIconOption(): { icon: string } | Record<string, never> {
   return iconPath ? { icon: iconPath } : {};
 }
 
-function createWindow(): BrowserWindow {
+type CreateWindowOptions = {
+  bounds?: Electron.Rectangle;
+  loadUrl?: string | null;
+  showOnReady?: boolean;
+  titleBarMode?: DesktopTitleBarMode;
+};
+
+type WindowSnapshot = {
+  bounds: Electron.Rectangle;
+  isFullScreen: boolean;
+  isMaximized: boolean;
+  url: string | null;
+};
+
+function snapshotWindow(window: BrowserWindow): WindowSnapshot {
+  return {
+    bounds: window.getBounds(),
+    isFullScreen: window.isFullScreen(),
+    isMaximized: window.isMaximized(),
+    url: window.webContents.getURL() || null,
+  };
+}
+
+function resolveWindowLoadUrl(loadUrl: string | null | undefined): string {
+  if (loadUrl) {
+    return loadUrl;
+  }
+
+  if (isDevelopment) {
+    return process.env.VITE_DEV_SERVER_URL as string;
+  }
+
+  return `${DESKTOP_SCHEME}://app/index.html`;
+}
+
+function clearDesktopSettingsSyncTimer(): void {
+  if (!desktopSettingsSyncTimer) {
+    return;
+  }
+
+  clearTimeout(desktopSettingsSyncTimer);
+  desktopSettingsSyncTimer = null;
+}
+
+function createWindow(options: CreateWindowOptions = {}): BrowserWindow {
+  const titleBarMode = options.titleBarMode ?? currentDesktopTitleBarMode;
+  const useT3CodeTitleBar = shouldUseT3CodeTitleBar(titleBarMode);
   const window = new BrowserWindow({
-    width: 1100,
-    height: 780,
+    width: options.bounds?.width ?? 1100,
+    height: options.bounds?.height ?? 780,
     minWidth: 840,
     minHeight: 620,
+    ...(options.bounds
+      ? {
+          x: options.bounds.x,
+          y: options.bounds.y,
+        }
+      : {}),
     show: false,
     autoHideMenuBar: true,
     ...getIconOption(),
+    ...(useT3CodeTitleBar ? { frame: false } : {}),
     title: APP_DISPLAY_NAME,
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 18 },
+    ...(process.platform === "darwin" && !useT3CodeTitleBar
+      ? {
+          titleBarStyle: "hiddenInset" as const,
+          trafficLightPosition: { x: 16, y: 18 },
+        }
+      : {}),
     webPreferences: {
       preload: Path.join(__dirname, "preload.js"),
       contextIsolation: true,
@@ -1264,6 +1543,7 @@ function createWindow(): BrowserWindow {
       sandbox: true,
     },
   });
+  desktopTitleBarModeByWindow.set(window, titleBarMode);
 
   window.webContents.on("context-menu", (event, params) => {
     event.preventDefault();
@@ -1308,16 +1588,33 @@ function createWindow(): BrowserWindow {
   window.webContents.on("did-finish-load", () => {
     window.setTitle(APP_DISPLAY_NAME);
     emitUpdateState();
+    emitDesktopWindowState(window);
   });
-  window.once("ready-to-show", () => {
-    window.show();
+  if (options.showOnReady !== false) {
+    window.once("ready-to-show", () => {
+      window.show();
+    });
+  }
+  window.on("enter-full-screen", () => {
+    emitDesktopWindowState(window);
+  });
+  window.on("leave-full-screen", () => {
+    emitDesktopWindowState(window);
+  });
+  window.on("maximize", () => {
+    emitDesktopWindowState(window);
+  });
+  window.on("unmaximize", () => {
+    emitDesktopWindowState(window);
+  });
+  window.webContents.on("zoom-changed", () => {
+    emitDesktopWindowState(window);
   });
 
+  void window.loadURL(resolveWindowLoadUrl(options.loadUrl));
+
   if (isDevelopment) {
-    void window.loadURL(process.env.VITE_DEV_SERVER_URL as string);
     window.webContents.openDevTools({ mode: "detach" });
-  } else {
-    void window.loadURL(`${DESKTOP_SCHEME}://app/index.html`);
   }
 
   window.on("closed", () => {
@@ -1329,6 +1626,144 @@ function createWindow(): BrowserWindow {
   return window;
 }
 
+function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<DesktopWindowState> {
+  if (isRebuildingMainWindow) {
+    pendingDesktopTitleBarMode = nextTitleBarMode;
+    return Promise.resolve(resolveDesktopWindowState(mainWindow));
+  }
+
+  const previousWindow = mainWindow;
+  if (!previousWindow || previousWindow.isDestroyed()) {
+    currentDesktopTitleBarMode = nextTitleBarMode;
+    mainWindow = createWindow({ titleBarMode: nextTitleBarMode });
+    return Promise.resolve(resolveDesktopWindowState(mainWindow));
+  }
+
+  if (desktopTitleBarModeByWindow.get(previousWindow) === nextTitleBarMode) {
+    currentDesktopTitleBarMode = nextTitleBarMode;
+    emitDesktopWindowState(previousWindow);
+    return Promise.resolve(resolveDesktopWindowState(previousWindow));
+  }
+
+  isRebuildingMainWindow = true;
+  pendingDesktopTitleBarMode = null;
+
+  const snapshot = snapshotWindow(previousWindow);
+  const replacementWindow = createWindow({
+    bounds: snapshot.bounds,
+    loadUrl: snapshot.url,
+    showOnReady: false,
+    titleBarMode: nextTitleBarMode,
+  });
+  mainWindow = replacementWindow;
+
+  return new Promise<DesktopWindowState>((resolve) => {
+    let settled = false;
+
+    const settle = (applied: boolean, state: DesktopWindowState) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      isRebuildingMainWindow = false;
+
+      if (!applied && mainWindow === replacementWindow) {
+        mainWindow = previousWindow.isDestroyed() ? null : previousWindow;
+      }
+
+      const pendingMode = pendingDesktopTitleBarMode;
+      pendingDesktopTitleBarMode = null;
+
+      if (pendingMode && pendingMode !== currentDesktopTitleBarMode) {
+        void rebuildMainWindow(pendingMode);
+      }
+
+      resolve(state);
+    };
+
+    replacementWindow.webContents.once("did-finish-load", () => {
+      currentDesktopTitleBarMode = nextTitleBarMode;
+
+      if (snapshot.isMaximized) {
+        replacementWindow.maximize();
+      }
+      if (snapshot.isFullScreen) {
+        replacementWindow.setFullScreen(true);
+      }
+      if (!replacementWindow.isVisible()) {
+        replacementWindow.show();
+      }
+
+      if (!previousWindow.isDestroyed()) {
+        previousWindow.close();
+      }
+
+      const nextState = resolveDesktopWindowState(replacementWindow);
+      emitDesktopWindowState(replacementWindow);
+      settle(true, nextState);
+    });
+
+    replacementWindow.webContents.once("did-fail-load", () => {
+      if (!replacementWindow.isDestroyed()) {
+        replacementWindow.destroy();
+      }
+      const fallbackState = resolveDesktopWindowState(
+        previousWindow.isDestroyed() ? null : previousWindow,
+      );
+      emitDesktopWindowState(previousWindow.isDestroyed() ? null : previousWindow);
+      settle(false, fallbackState);
+    });
+  });
+}
+
+function syncDesktopTitleBarModeFromDisk(): void {
+  const nextTitleBarMode = readDesktopTitleBarModeFromDisk();
+  if (nextTitleBarMode === currentDesktopTitleBarMode) {
+    return;
+  }
+
+  void rebuildMainWindow(nextTitleBarMode);
+}
+
+function scheduleDesktopTitleBarModeSync(): void {
+  clearDesktopSettingsSyncTimer();
+  desktopSettingsSyncTimer = setTimeout(() => {
+    desktopSettingsSyncTimer = null;
+    syncDesktopTitleBarModeFromDisk();
+  }, 100);
+}
+
+function stopDesktopSettingsWatcher(): void {
+  clearDesktopSettingsSyncTimer();
+
+  if (!desktopSettingsWatcher) {
+    return;
+  }
+
+  desktopSettingsWatcher.close();
+  desktopSettingsWatcher = null;
+}
+
+function startDesktopSettingsWatcher(): void {
+  stopDesktopSettingsWatcher();
+
+  FS.mkdirSync(SETTINGS_STATE_DIR, { recursive: true });
+
+  desktopSettingsWatcher = FS.watch(SETTINGS_STATE_DIR, (_eventType, fileName) => {
+    const normalizedFileName = typeof fileName === "string" ? fileName : null;
+
+    if (normalizedFileName !== null && normalizedFileName !== "settings.json") {
+      return;
+    }
+
+    scheduleDesktopTitleBarModeSync();
+  });
+  desktopSettingsWatcher.on("error", (error) => {
+    console.error("[desktop] settings watcher failed", error);
+  });
+}
+
 // Override Electron's userData path before the `ready` event so that
 // Chromium session data uses a filesystem-friendly directory name.
 // Must be called synchronously at the top level — before `app.whenReady()`.
@@ -1338,6 +1773,7 @@ configureAppIdentity();
 
 async function bootstrap(): Promise<void> {
   writeDesktopLogHeader("bootstrap start");
+  currentDesktopTitleBarMode = readDesktopTitleBarModeFromDisk();
   backendPort = await Effect.service(NetService).pipe(
     Effect.flatMap((net) => net.reserveLoopbackPort()),
     Effect.provide(NetService.layer),
@@ -1351,6 +1787,8 @@ async function bootstrap(): Promise<void> {
 
   registerIpcHandlers();
   writeDesktopLogHeader("bootstrap ipc handlers registered");
+  startDesktopSettingsWatcher();
+  writeDesktopLogHeader("bootstrap desktop settings watcher started");
   startBackend();
   writeDesktopLogHeader("bootstrap backend start requested");
   mainWindow = createWindow();
@@ -1361,6 +1799,7 @@ app.on("before-quit", () => {
   isQuitting = true;
   writeDesktopLogHeader("before-quit received");
   clearUpdatePollTimer();
+  stopDesktopSettingsWatcher();
   stopBackend();
   restoreStdIoCapture?.();
 });
@@ -1379,7 +1818,7 @@ app
 
     app.on("activate", () => {
       if (BrowserWindow.getAllWindows().length === 0) {
-        mainWindow = createWindow();
+        mainWindow = createWindow({ titleBarMode: currentDesktopTitleBarMode });
       }
     });
   })
@@ -1399,6 +1838,7 @@ if (process.platform !== "win32") {
     isQuitting = true;
     writeDesktopLogHeader("SIGINT received");
     clearUpdatePollTimer();
+    stopDesktopSettingsWatcher();
     stopBackend();
     restoreStdIoCapture?.();
     app.quit();
@@ -1409,6 +1849,7 @@ if (process.platform !== "win32") {
     isQuitting = true;
     writeDesktopLogHeader("SIGTERM received");
     clearUpdatePollTimer();
+    stopDesktopSettingsWatcher();
     stopBackend();
     restoreStdIoCapture?.();
     app.quit();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -111,6 +111,7 @@ let desktopSettingsSyncTimer: ReturnType<typeof setTimeout> | null = null;
 let currentDesktopTitleBarMode: DesktopTitleBarMode = DEFAULT_DESKTOP_TITLE_BAR_MODE;
 let pendingDesktopTitleBarMode: DesktopTitleBarMode | null = null;
 let isRebuildingMainWindow = false;
+let isApplyingDesktopTitleBarModeFromIpc = false;
 const desktopTitleBarModeByWindow = new WeakMap<BrowserWindow, DesktopTitleBarMode>();
 
 let destructiveMenuIconCache: Electron.NativeImage | null | undefined;
@@ -175,13 +176,19 @@ function persistDesktopTitleBarModeToDisk(mode: DesktopTitleBarMode): void {
 }
 
 function resolveDesktopWindowState(window: BrowserWindow | null): DesktopWindowState {
+  const activeWindow = window && !window.isDestroyed() ? window : null;
+
   return {
-    isFullScreen: window?.isFullScreen() ?? false,
-    isMaximized: window?.isMaximized() ?? false,
+    isFullScreen: activeWindow?.isFullScreen() ?? false,
+    isMaximized: activeWindow?.isMaximized() ?? false,
     platform: resolveDesktopWindowPlatform(process.platform),
     titleBarMode:
-      (window ? desktopTitleBarModeByWindow.get(window) : undefined) ?? currentDesktopTitleBarMode,
-    zoomFactor: window?.webContents.getZoomFactor() ?? 1,
+      (activeWindow ? desktopTitleBarModeByWindow.get(activeWindow) : undefined) ??
+      currentDesktopTitleBarMode,
+    zoomFactor:
+      activeWindow && !activeWindow.webContents.isDestroyed()
+        ? activeWindow.webContents.getZoomFactor()
+        : 1,
   };
 }
 
@@ -1284,20 +1291,26 @@ function registerIpcHandlers(): void {
       return resolveDesktopWindowState(mainWindow);
     }
 
-    const previousMode = currentDesktopTitleBarMode;
-    persistDesktopTitleBarModeToDisk(mode);
+    isApplyingDesktopTitleBarModeFromIpc = true;
 
-    if (mode !== currentDesktopTitleBarMode) {
-      const nextState = await rebuildMainWindow(mode);
-      if (nextState.titleBarMode !== mode) {
-        persistDesktopTitleBarModeToDisk(previousMode);
+    try {
+      const previousMode = currentDesktopTitleBarMode;
+      persistDesktopTitleBarModeToDisk(mode);
+
+      if (mode !== currentDesktopTitleBarMode) {
+        const nextState = await rebuildMainWindow(mode);
+        if (nextState.titleBarMode !== mode) {
+          persistDesktopTitleBarModeToDisk(previousMode);
+        }
+        return nextState;
       }
-      return nextState;
-    }
 
-    currentDesktopTitleBarMode = mode;
-    emitDesktopWindowState(mainWindow);
-    return resolveDesktopWindowState(mainWindow);
+      currentDesktopTitleBarMode = mode;
+      emitDesktopWindowState(mainWindow);
+      return resolveDesktopWindowState(mainWindow);
+    } finally {
+      isApplyingDesktopTitleBarModeFromIpc = false;
+    }
   });
 
   ipcMain.removeHandler(CONTEXT_MENU_CHANNEL);
@@ -1406,8 +1419,9 @@ function registerIpcHandlers(): void {
       owner.close();
     }
 
-    emitDesktopWindowState(owner);
-    return resolveDesktopWindowState(owner);
+    const nextOwner = owner.isDestroyed() ? null : owner;
+    emitDesktopWindowState(nextOwner);
+    return resolveDesktopWindowState(nextOwner);
   });
 
   ipcMain.removeHandler(UPDATE_GET_STATE_CHANNEL);
@@ -1709,6 +1723,11 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
 }
 
 function syncDesktopTitleBarModeFromDisk(): void {
+  if (isApplyingDesktopTitleBarModeFromIpc) {
+    scheduleDesktopTitleBarModeSync();
+    return;
+  }
+
   const nextTitleBarMode = readDesktopTitleBarModeFromDisk();
   if (nextTitleBarMode === currentDesktopTitleBarMode) {
     return;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -32,6 +32,7 @@ import type { ContextMenuItem } from "@t3tools/contracts";
 import { NetService } from "@t3tools/shared/Net";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
+import { applyDesktopTitleBarModeSetting, readDesktopSettingsFromDisk } from "./desktopSettings";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
 import {
@@ -149,27 +150,11 @@ function parseDesktopTitleBarMode(rawMode: unknown): DesktopTitleBarMode | null 
   return rawMode === "t3code" || rawMode === "system" ? rawMode : null;
 }
 
-function readDesktopSettingsFromDisk(): Record<string, unknown> {
-  if (!FS.existsSync(SETTINGS_FILE_PATH)) {
-    return {};
-  }
-
-  try {
-    const raw = FS.readFileSync(SETTINGS_FILE_PATH, "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-
-    if (parsed !== null && !Array.isArray(parsed) && typeof parsed === "object") {
-      return parsed as Record<string, unknown>;
-    }
-  } catch (error) {
-    console.error("[desktop] failed to read desktop settings", error);
-  }
-
-  return {};
-}
-
 function readDesktopTitleBarModeFromDisk(): DesktopTitleBarMode {
-  return getDesktopTitleBarMode(readDesktopSettingsFromDisk().desktopTitleBarMode);
+  const parsed = readDesktopSettingsFromDisk(SETTINGS_FILE_PATH) as {
+    desktopTitleBarMode?: unknown;
+  };
+  return getDesktopTitleBarMode(parsed.desktopTitleBarMode);
 }
 
 function shouldUseT3CodeTitleBar(mode: DesktopTitleBarMode): boolean {
@@ -179,12 +164,12 @@ function shouldUseT3CodeTitleBar(mode: DesktopTitleBarMode): boolean {
 function persistDesktopTitleBarModeToDisk(mode: DesktopTitleBarMode): void {
   FS.mkdirSync(SETTINGS_STATE_DIR, { recursive: true });
 
-  const nextSettings = readDesktopSettingsFromDisk();
-  if (mode === DEFAULT_DESKTOP_TITLE_BAR_MODE) {
-    delete nextSettings.desktopTitleBarMode;
-  } else {
-    nextSettings.desktopTitleBarMode = mode;
-  }
+  const currentSettings = readDesktopSettingsFromDisk(SETTINGS_FILE_PATH);
+  const nextSettings = applyDesktopTitleBarModeSetting(
+    currentSettings,
+    mode,
+    DEFAULT_DESKTOP_TITLE_BAR_MODE,
+  );
 
   FS.writeFileSync(SETTINGS_FILE_PATH, `${JSON.stringify(nextSettings, null, 2)}\n`, "utf8");
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1693,12 +1693,18 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
       }
 
       if (!previousWindow.isDestroyed()) {
-        previousWindow.close();
+        previousWindow.hide();
       }
 
       const nextState = resolveDesktopWindowState(replacementWindow);
       emitDesktopWindowState(replacementWindow);
       settle(true, nextState);
+
+      setTimeout(() => {
+        if (!previousWindow.isDestroyed()) {
+          previousWindow.close();
+        }
+      }, 0);
     });
 
     replacementWindow.webContents.once("did-fail-load", () => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -149,19 +149,27 @@ function parseDesktopTitleBarMode(rawMode: unknown): DesktopTitleBarMode | null 
   return rawMode === "t3code" || rawMode === "system" ? rawMode : null;
 }
 
-function readDesktopTitleBarModeFromDisk(): DesktopTitleBarMode {
+function readDesktopSettingsFromDisk(): Record<string, unknown> {
   if (!FS.existsSync(SETTINGS_FILE_PATH)) {
-    return DEFAULT_DESKTOP_TITLE_BAR_MODE;
+    return {};
   }
 
   try {
     const raw = FS.readFileSync(SETTINGS_FILE_PATH, "utf8");
-    const parsed = JSON.parse(raw) as { desktopTitleBarMode?: unknown };
-    return getDesktopTitleBarMode(parsed.desktopTitleBarMode);
+    const parsed = JSON.parse(raw) as unknown;
+
+    if (parsed !== null && !Array.isArray(parsed) && typeof parsed === "object") {
+      return parsed as Record<string, unknown>;
+    }
   } catch (error) {
-    console.error("[desktop] failed to read desktop title bar mode", error);
-    return DEFAULT_DESKTOP_TITLE_BAR_MODE;
+    console.error("[desktop] failed to read desktop settings", error);
   }
+
+  return {};
+}
+
+function readDesktopTitleBarModeFromDisk(): DesktopTitleBarMode {
+  return getDesktopTitleBarMode(readDesktopSettingsFromDisk().desktopTitleBarMode);
 }
 
 function shouldUseT3CodeTitleBar(mode: DesktopTitleBarMode): boolean {
@@ -171,19 +179,7 @@ function shouldUseT3CodeTitleBar(mode: DesktopTitleBarMode): boolean {
 function persistDesktopTitleBarModeToDisk(mode: DesktopTitleBarMode): void {
   FS.mkdirSync(SETTINGS_STATE_DIR, { recursive: true });
 
-  const currentSettings = FS.existsSync(SETTINGS_FILE_PATH)
-    ? JSON.parse(FS.readFileSync(SETTINGS_FILE_PATH, "utf8"))
-    : {};
-
-  if (
-    currentSettings === null ||
-    Array.isArray(currentSettings) ||
-    typeof currentSettings !== "object"
-  ) {
-    throw new Error("settings.json must contain a JSON object");
-  }
-
-  const nextSettings = { ...currentSettings } as Record<string, unknown>;
+  const nextSettings = readDesktopSettingsFromDisk();
   if (mode === DEFAULT_DESKTOP_TITLE_BAR_MODE) {
     delete nextSettings.desktopTitleBarMode;
   } else {
@@ -1659,6 +1655,8 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
 
   return new Promise<DesktopWindowState>((resolve) => {
     let settled = false;
+    const resolveFallbackState = () =>
+      resolveDesktopWindowState(previousWindow.isDestroyed() ? null : previousWindow);
 
     const settle = (applied: boolean, state: DesktopWindowState) => {
       if (settled) {
@@ -1681,6 +1679,16 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
 
       resolve(state);
     };
+
+    replacementWindow.once("closed", () => {
+      if (settled) {
+        return;
+      }
+
+      const fallbackState = resolveFallbackState();
+      emitDesktopWindowState(previousWindow.isDestroyed() ? null : previousWindow);
+      settle(false, fallbackState);
+    });
 
     replacementWindow.webContents.once("did-finish-load", () => {
       currentDesktopTitleBarMode = nextTitleBarMode;
@@ -1708,9 +1716,7 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
       if (!replacementWindow.isDestroyed()) {
         replacementWindow.destroy();
       }
-      const fallbackState = resolveDesktopWindowState(
-        previousWindow.isDestroyed() ? null : previousWindow,
-      );
+      const fallbackState = resolveFallbackState();
       emitDesktopWindowState(previousWindow.isDestroyed() ? null : previousWindow);
       settle(false, fallbackState);
     });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -32,7 +32,11 @@ import type { ContextMenuItem } from "@t3tools/contracts";
 import { NetService } from "@t3tools/shared/Net";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
-import { applyDesktopTitleBarModeSetting, readDesktopSettingsFromDisk } from "./desktopSettings";
+import {
+  applyDesktopTitleBarModeSetting,
+  readDesktopSettingsFromDisk,
+  writeDesktopSettingsToDisk,
+} from "./desktopSettings";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
 import {
@@ -71,8 +75,8 @@ const STATE_DIR = Path.join(BASE_DIR, "userdata");
 const DESKTOP_SCHEME = "t3";
 const ROOT_DIR = Path.resolve(__dirname, "../../..");
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
-const SETTINGS_STATE_DIR = Path.join(BASE_DIR, isDevelopment ? "dev" : "userdata");
-const SETTINGS_FILE_PATH = Path.join(SETTINGS_STATE_DIR, "settings.json");
+const DESKTOP_SETTINGS_DIR = Path.join(BASE_DIR, isDevelopment ? "dev" : "userdata");
+const DESKTOP_SETTINGS_FILE_PATH = Path.join(DESKTOP_SETTINGS_DIR, "desktop-settings.json");
 const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
 const APP_USER_MODEL_ID = "com.t3tools.t3code";
 const USER_DATA_DIR_NAME = isDevelopment ? "t3code-dev" : "t3code";
@@ -106,12 +110,9 @@ let aboutCommitHashCache: string | null | undefined;
 let desktopLogSink: RotatingFileSink | null = null;
 let backendLogSink: RotatingFileSink | null = null;
 let restoreStdIoCapture: (() => void) | null = null;
-let desktopSettingsWatcher: FS.FSWatcher | null = null;
-let desktopSettingsSyncTimer: ReturnType<typeof setTimeout> | null = null;
 let currentDesktopTitleBarMode: DesktopTitleBarMode = DEFAULT_DESKTOP_TITLE_BAR_MODE;
 let pendingDesktopTitleBarMode: DesktopTitleBarMode | null = null;
 let isRebuildingMainWindow = false;
-let isApplyingDesktopTitleBarModeFromIpc = false;
 const desktopTitleBarModeByWindow = new WeakMap<BrowserWindow, DesktopTitleBarMode>();
 
 let destructiveMenuIconCache: Electron.NativeImage | null | undefined;
@@ -152,7 +153,7 @@ function parseDesktopTitleBarMode(rawMode: unknown): DesktopTitleBarMode | null 
 }
 
 function readDesktopTitleBarModeFromDisk(): DesktopTitleBarMode {
-  const parsed = readDesktopSettingsFromDisk(SETTINGS_FILE_PATH) as {
+  const parsed = readDesktopSettingsFromDisk(DESKTOP_SETTINGS_FILE_PATH) as {
     desktopTitleBarMode?: unknown;
   };
   return getDesktopTitleBarMode(parsed.desktopTitleBarMode);
@@ -163,16 +164,14 @@ function shouldUseT3CodeTitleBar(mode: DesktopTitleBarMode): boolean {
 }
 
 function persistDesktopTitleBarModeToDisk(mode: DesktopTitleBarMode): void {
-  FS.mkdirSync(SETTINGS_STATE_DIR, { recursive: true });
-
-  const currentSettings = readDesktopSettingsFromDisk(SETTINGS_FILE_PATH);
+  const currentSettings = readDesktopSettingsFromDisk(DESKTOP_SETTINGS_FILE_PATH);
   const nextSettings = applyDesktopTitleBarModeSetting(
     currentSettings,
     mode,
     DEFAULT_DESKTOP_TITLE_BAR_MODE,
   );
 
-  FS.writeFileSync(SETTINGS_FILE_PATH, `${JSON.stringify(nextSettings, null, 2)}\n`, "utf8");
+  writeDesktopSettingsToDisk(DESKTOP_SETTINGS_FILE_PATH, nextSettings);
 }
 
 function resolveDesktopWindowState(window: BrowserWindow | null): DesktopWindowState {
@@ -1291,26 +1290,20 @@ function registerIpcHandlers(): void {
       return resolveDesktopWindowState(mainWindow);
     }
 
-    isApplyingDesktopTitleBarModeFromIpc = true;
+    const previousMode = currentDesktopTitleBarMode;
+    persistDesktopTitleBarModeToDisk(mode);
 
-    try {
-      const previousMode = currentDesktopTitleBarMode;
-      persistDesktopTitleBarModeToDisk(mode);
-
-      if (mode !== currentDesktopTitleBarMode) {
-        const nextState = await rebuildMainWindow(mode);
-        if (nextState.titleBarMode !== mode) {
-          persistDesktopTitleBarModeToDisk(previousMode);
-        }
-        return nextState;
+    if (mode !== currentDesktopTitleBarMode) {
+      const nextState = await rebuildMainWindow(mode);
+      if (nextState.titleBarMode !== mode) {
+        persistDesktopTitleBarModeToDisk(previousMode);
       }
-
-      currentDesktopTitleBarMode = mode;
-      emitDesktopWindowState(mainWindow);
-      return resolveDesktopWindowState(mainWindow);
-    } finally {
-      isApplyingDesktopTitleBarModeFromIpc = false;
+      return nextState;
     }
+
+    currentDesktopTitleBarMode = mode;
+    emitDesktopWindowState(mainWindow);
+    return resolveDesktopWindowState(mainWindow);
   });
 
   ipcMain.removeHandler(CONTEXT_MENU_CHANNEL);
@@ -1495,15 +1488,6 @@ function resolveWindowLoadUrl(loadUrl: string | null | undefined): string {
   }
 
   return `${DESKTOP_SCHEME}://app/index.html`;
-}
-
-function clearDesktopSettingsSyncTimer(): void {
-  if (!desktopSettingsSyncTimer) {
-    return;
-  }
-
-  clearTimeout(desktopSettingsSyncTimer);
-  desktopSettingsSyncTimer = null;
 }
 
 function createWindow(options: CreateWindowOptions = {}): BrowserWindow {
@@ -1722,58 +1706,6 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
   });
 }
 
-function syncDesktopTitleBarModeFromDisk(): void {
-  if (isApplyingDesktopTitleBarModeFromIpc) {
-    scheduleDesktopTitleBarModeSync();
-    return;
-  }
-
-  const nextTitleBarMode = readDesktopTitleBarModeFromDisk();
-  if (nextTitleBarMode === currentDesktopTitleBarMode) {
-    return;
-  }
-
-  void rebuildMainWindow(nextTitleBarMode);
-}
-
-function scheduleDesktopTitleBarModeSync(): void {
-  clearDesktopSettingsSyncTimer();
-  desktopSettingsSyncTimer = setTimeout(() => {
-    desktopSettingsSyncTimer = null;
-    syncDesktopTitleBarModeFromDisk();
-  }, 100);
-}
-
-function stopDesktopSettingsWatcher(): void {
-  clearDesktopSettingsSyncTimer();
-
-  if (!desktopSettingsWatcher) {
-    return;
-  }
-
-  desktopSettingsWatcher.close();
-  desktopSettingsWatcher = null;
-}
-
-function startDesktopSettingsWatcher(): void {
-  stopDesktopSettingsWatcher();
-
-  FS.mkdirSync(SETTINGS_STATE_DIR, { recursive: true });
-
-  desktopSettingsWatcher = FS.watch(SETTINGS_STATE_DIR, (_eventType, fileName) => {
-    const normalizedFileName = typeof fileName === "string" ? fileName : null;
-
-    if (normalizedFileName !== null && normalizedFileName !== "settings.json") {
-      return;
-    }
-
-    scheduleDesktopTitleBarModeSync();
-  });
-  desktopSettingsWatcher.on("error", (error) => {
-    console.error("[desktop] settings watcher failed", error);
-  });
-}
-
 // Override Electron's userData path before the `ready` event so that
 // Chromium session data uses a filesystem-friendly directory name.
 // Must be called synchronously at the top level — before `app.whenReady()`.
@@ -1797,8 +1729,6 @@ async function bootstrap(): Promise<void> {
 
   registerIpcHandlers();
   writeDesktopLogHeader("bootstrap ipc handlers registered");
-  startDesktopSettingsWatcher();
-  writeDesktopLogHeader("bootstrap desktop settings watcher started");
   startBackend();
   writeDesktopLogHeader("bootstrap backend start requested");
   mainWindow = createWindow();
@@ -1809,7 +1739,6 @@ app.on("before-quit", () => {
   isQuitting = true;
   writeDesktopLogHeader("before-quit received");
   clearUpdatePollTimer();
-  stopDesktopSettingsWatcher();
   stopBackend();
   restoreStdIoCapture?.();
 });
@@ -1848,7 +1777,6 @@ if (process.platform !== "win32") {
     isQuitting = true;
     writeDesktopLogHeader("SIGINT received");
     clearUpdatePollTimer();
-    stopDesktopSettingsWatcher();
     stopBackend();
     restoreStdIoCapture?.();
     app.quit();
@@ -1859,7 +1787,6 @@ if (process.platform !== "win32") {
     isQuitting = true;
     writeDesktopLogHeader("SIGTERM received");
     clearUpdatePollTimer();
-    stopDesktopSettingsWatcher();
     stopBackend();
     restoreStdIoCapture?.();
     app.quit();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1649,7 +1649,7 @@ function rebuildMainWindow(nextTitleBarMode: DesktopTitleBarMode): Promise<Deskt
       settled = true;
       isRebuildingMainWindow = false;
 
-      if (!applied && mainWindow === replacementWindow) {
+      if (!applied && (!mainWindow || mainWindow === replacementWindow)) {
         mainWindow = previousWindow.isDestroyed() ? null : previousWindow;
       }
 

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -4,9 +4,13 @@ import type { DesktopBridge } from "@t3tools/contracts";
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
 const SET_THEME_CHANNEL = "desktop:set-theme";
+const SET_TITLE_BAR_MODE_CHANNEL = "desktop:set-title-bar-mode";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 const MENU_ACTION_CHANNEL = "desktop:menu-action";
+const WINDOW_STATE_CHANNEL = "desktop:window-state";
+const WINDOW_GET_STATE_CHANNEL = "desktop:window-get-state";
+const WINDOW_ACTION_CHANNEL = "desktop:window-action";
 const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_DOWNLOAD_CHANNEL = "desktop:update-download";
@@ -21,6 +25,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   pickFolder: () => ipcRenderer.invoke(PICK_FOLDER_CHANNEL),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),
+  setTitleBarMode: (mode) => ipcRenderer.invoke(SET_TITLE_BAR_MODE_CHANNEL, mode),
   showContextMenu: (items, position) => ipcRenderer.invoke(CONTEXT_MENU_CHANNEL, items, position),
   openExternal: (url: string) => ipcRenderer.invoke(OPEN_EXTERNAL_CHANNEL, url),
   onMenuAction: (listener) => {
@@ -32,6 +37,19 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     ipcRenderer.on(MENU_ACTION_CHANNEL, wrappedListener);
     return () => {
       ipcRenderer.removeListener(MENU_ACTION_CHANNEL, wrappedListener);
+    };
+  },
+  getWindowState: () => ipcRenderer.invoke(WINDOW_GET_STATE_CHANNEL),
+  performWindowAction: (action) => ipcRenderer.invoke(WINDOW_ACTION_CHANNEL, action),
+  onWindowState: (listener) => {
+    const wrappedListener = (_event: Electron.IpcRendererEvent, state: unknown) => {
+      if (typeof state !== "object" || state === null) return;
+      listener(state as Parameters<typeof listener>[0]);
+    };
+
+    ipcRenderer.on(WINDOW_STATE_CHANNEL, wrappedListener);
+    return () => {
+      ipcRenderer.removeListener(WINDOW_STATE_CHANNEL, wrappedListener);
     };
   },
   getUpdateState: () => ipcRenderer.invoke(UPDATE_GET_STATE_CHANNEL),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -30,6 +30,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { gitBranchesQueryOptions, gitCreateWorktreeMutationOptions } from "~/lib/gitReactQuery";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
+import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
 import { isElectron } from "../env";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import {
@@ -241,6 +242,7 @@ interface ChatViewProps {
 }
 
 export default function ChatView({ threadId }: ChatViewProps) {
+  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
   const threads = useStore((store) => store.threads);
   const projects = useStore((store) => store.projects);
   const markThreadVisited = useStore((store) => store.markThreadVisited);
@@ -3476,7 +3478,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
             </div>
           </header>
         )}
-        {isElectron && (
+        {shouldUseT3CodeWindowDecoration && (
           <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
             <span className="text-xs text-muted-foreground/50">No active thread</span>
           </div>
@@ -3496,7 +3498,9 @@ export default function ChatView({ threadId }: ChatViewProps) {
       <header
         className={cn(
           "border-b border-border px-3 sm:px-5",
-          isElectron ? "drag-region flex h-[52px] items-center" : "py-2 sm:py-3",
+          shouldUseT3CodeWindowDecoration
+            ? "drag-region flex h-[52px] items-center"
+            : "py-2 sm:py-3",
         )}
       >
         <ChatHeader

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -30,7 +30,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { gitBranchesQueryOptions, gitCreateWorktreeMutationOptions } from "~/lib/gitReactQuery";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { serverConfigQueryOptions, serverQueryKeys } from "~/lib/serverReactQuery";
-import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
+import { useShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
 import { isElectron } from "../env";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import {
@@ -242,7 +242,7 @@ interface ChatViewProps {
 }
 
 export default function ChatView({ threadId }: ChatViewProps) {
-  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
+  const shouldUseDesktopHeaderDragRegion = useShouldUseDesktopHeaderDragRegion();
   const threads = useStore((store) => store.threads);
   const projects = useStore((store) => store.projects);
   const markThreadVisited = useStore((store) => store.markThreadVisited);
@@ -3478,7 +3478,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
             </div>
           </header>
         )}
-        {shouldUseT3CodeWindowDecoration && (
+        {shouldUseDesktopHeaderDragRegion && (
           <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
             <span className="text-xs text-muted-foreground/50">No active thread</span>
           </div>
@@ -3498,7 +3498,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       <header
         className={cn(
           "border-b border-border px-3 sm:px-5",
-          shouldUseT3CodeWindowDecoration
+          shouldUseDesktopHeaderDragRegion
             ? "drag-region flex h-[52px] items-center"
             : "py-2 sm:py-3",
         )}

--- a/apps/web/src/components/DesktopWindowTopBar.logic.ts
+++ b/apps/web/src/components/DesktopWindowTopBar.logic.ts
@@ -1,0 +1,55 @@
+import type { DesktopWindowState } from "@t3tools/contracts";
+
+export const DESKTOP_WINDOW_TOP_BAR_HEIGHT_PX = 44;
+export const DESKTOP_WINDOW_TOP_BAR_REVEAL_ZONE_PX = 4;
+export const DESKTOP_WINDOW_TOP_BAR_MARGIN_X_PX = 8;
+export const DESKTOP_WINDOW_TOP_BAR_MARGIN_TOP_PX = 8;
+
+export function resolveDesktopWindowTopBarZoomFactor(
+  windowState: DesktopWindowState | null,
+): number {
+  const zoomFactor = windowState?.zoomFactor ?? 1;
+  return Number.isFinite(zoomFactor) && zoomFactor > 0 ? zoomFactor : 1;
+}
+
+export function shouldUseDesktopWindowTopBar(windowState: DesktopWindowState | null): boolean {
+  return (
+    windowState !== null &&
+    windowState.platform !== "other" &&
+    windowState.titleBarMode === "t3code"
+  );
+}
+
+export function shouldOverlayDesktopWindowTopBar(windowState: DesktopWindowState | null): boolean {
+  return shouldUseDesktopWindowTopBar(windowState) && windowState?.isFullScreen === true;
+}
+
+export function nextDesktopWindowTopBarVisibility(input: {
+  windowState: DesktopWindowState | null;
+  pointerY: number | null;
+  isHovered: boolean;
+  wasVisible: boolean;
+}): boolean {
+  if (!shouldUseDesktopWindowTopBar(input.windowState)) {
+    return false;
+  }
+
+  if (input.windowState?.isFullScreen !== true) {
+    return true;
+  }
+
+  if (input.isHovered) {
+    return true;
+  }
+
+  if (input.pointerY === null) {
+    return false;
+  }
+
+  const zoomFactor = resolveDesktopWindowTopBarZoomFactor(input.windowState);
+  const revealThreshold = input.wasVisible
+    ? DESKTOP_WINDOW_TOP_BAR_HEIGHT_PX / zoomFactor
+    : DESKTOP_WINDOW_TOP_BAR_REVEAL_ZONE_PX / zoomFactor;
+
+  return input.pointerY <= revealThreshold;
+}

--- a/apps/web/src/components/DesktopWindowTopBar.tsx
+++ b/apps/web/src/components/DesktopWindowTopBar.tsx
@@ -28,10 +28,8 @@ function DesktopWindowTopBar() {
       return;
     }
 
-    if (nextState?.isFullScreen !== true) {
-      setIsHovered(false);
-      setIsVisible(true);
-    }
+    setIsHovered(false);
+    setIsVisible(nextState?.isFullScreen !== true);
   });
 
   const updateVisibility = useEffectEvent((pointerY: number | null) => {

--- a/apps/web/src/components/DesktopWindowTopBar.tsx
+++ b/apps/web/src/components/DesktopWindowTopBar.tsx
@@ -1,0 +1,258 @@
+import type { DesktopWindowAction, DesktopWindowState } from "@t3tools/contracts";
+import { Maximize2Icon, Minimize2Icon, MinusIcon, XIcon } from "lucide-react";
+import { useEffect, useEffectEvent, useState } from "react";
+
+import { APP_DISPLAY_NAME } from "~/branding";
+import {
+  DESKTOP_WINDOW_TOP_BAR_HEIGHT_PX,
+  DESKTOP_WINDOW_TOP_BAR_MARGIN_TOP_PX,
+  DESKTOP_WINDOW_TOP_BAR_MARGIN_X_PX,
+  nextDesktopWindowTopBarVisibility,
+  resolveDesktopWindowTopBarZoomFactor,
+  shouldOverlayDesktopWindowTopBar,
+  shouldUseDesktopWindowTopBar,
+} from "~/components/DesktopWindowTopBar.logic";
+import { Button } from "~/components/ui/button";
+import { useDesktopWindowState } from "~/hooks/useDesktopWindowState";
+import { cn } from "~/lib/utils";
+
+function DesktopWindowTopBar() {
+  const windowState = useDesktopWindowState();
+  const [isHovered, setIsHovered] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  const syncVisibility = useEffectEvent((nextState: DesktopWindowState | null) => {
+    if (!shouldUseDesktopWindowTopBar(nextState)) {
+      setIsHovered(false);
+      setIsVisible(false);
+      return;
+    }
+
+    if (nextState?.isFullScreen !== true) {
+      setIsHovered(false);
+      setIsVisible(true);
+    }
+  });
+
+  const updateVisibility = useEffectEvent((pointerY: number | null) => {
+    setIsVisible((wasVisible) =>
+      nextDesktopWindowTopBarVisibility({
+        windowState,
+        pointerY,
+        isHovered,
+        wasVisible,
+      }),
+    );
+  });
+
+  const performWindowAction = useEffectEvent(async (action: DesktopWindowAction) => {
+    const bridge = window.desktopBridge;
+    if (!bridge) {
+      return;
+    }
+
+    await bridge.performWindowAction(action);
+    if (action === "minimize" || action === "close" || action === "exit-full-screen") {
+      setIsHovered(false);
+      setIsVisible(false);
+    }
+  });
+
+  useEffect(() => {
+    syncVisibility(windowState);
+  }, [windowState]);
+
+  useEffect(() => {
+    if (!shouldOverlayDesktopWindowTopBar(windowState)) {
+      return;
+    }
+
+    const handlePointerMove = (event: MouseEvent) => {
+      updateVisibility(event.clientY);
+    };
+    const handlePointerLeave = () => {
+      setIsHovered(false);
+      setIsVisible(false);
+    };
+
+    window.addEventListener("mousemove", handlePointerMove);
+    window.addEventListener("mouseleave", handlePointerLeave);
+
+    return () => {
+      window.removeEventListener("mousemove", handlePointerMove);
+      window.removeEventListener("mouseleave", handlePointerLeave);
+    };
+  }, [windowState]);
+
+  if (!windowState || !shouldUseDesktopWindowTopBar(windowState)) {
+    return null;
+  }
+
+  const activeWindowState = windowState;
+  const isMacWindow = activeWindowState.platform === "darwin";
+  const isOverlay = shouldOverlayDesktopWindowTopBar(activeWindowState);
+  const zoomFactor = resolveDesktopWindowTopBarZoomFactor(activeWindowState);
+  const inverseZoomFactor = 1 / zoomFactor;
+  const frameHeightPx =
+    (DESKTOP_WINDOW_TOP_BAR_HEIGHT_PX + (isOverlay ? DESKTOP_WINDOW_TOP_BAR_MARGIN_TOP_PX : 0)) /
+    zoomFactor;
+  const frameWidth = isOverlay
+    ? `calc(${100 * zoomFactor}% - ${2 * DESKTOP_WINDOW_TOP_BAR_MARGIN_X_PX}px)`
+    : `${100 * zoomFactor}%`;
+  const secondaryAction: {
+    action: DesktopWindowAction;
+    label: string;
+    icon: typeof Maximize2Icon;
+  } = activeWindowState.isFullScreen
+    ? {
+        action: "exit-full-screen",
+        label: "Exit full screen",
+        icon: Minimize2Icon,
+      }
+    : activeWindowState.isMaximized
+      ? {
+          action: "toggle-maximize",
+          label: "Restore window",
+          icon: Minimize2Icon,
+        }
+      : {
+          action: "toggle-maximize",
+          label: "Maximize window",
+          icon: Maximize2Icon,
+        };
+
+  const SecondaryActionIcon = secondaryAction.icon;
+  const windowActions: ReadonlyArray<{
+    action: DesktopWindowAction;
+    icon: typeof Maximize2Icon;
+    label: string;
+  }> = isMacWindow
+    ? [
+        {
+          action: "close",
+          icon: XIcon,
+          label: "Close window",
+        },
+        {
+          action: "minimize",
+          icon: MinusIcon,
+          label: "Minimize window",
+        },
+        {
+          action: secondaryAction.action,
+          icon: SecondaryActionIcon,
+          label: secondaryAction.label,
+        },
+      ]
+    : [
+        {
+          action: "minimize",
+          icon: MinusIcon,
+          label: "Minimize window",
+        },
+        {
+          action: secondaryAction.action,
+          icon: SecondaryActionIcon,
+          label: secondaryAction.label,
+        },
+        {
+          action: "close",
+          icon: XIcon,
+          label: "Close window",
+        },
+      ];
+
+  const content = (
+    <div className="relative w-full shrink-0" style={{ height: `${frameHeightPx}px` }}>
+      <div
+        className={cn(
+          "drag-region absolute left-0 top-0 flex items-center border-border/80 bg-background/92 backdrop-blur-md",
+          isMacWindow ? "justify-start" : "justify-end",
+          isOverlay
+            ? "pointer-events-auto mx-2 mt-2 rounded-xl border px-2 shadow-lg"
+            : "border-b px-3 shadow-[0_1px_0_rgba(255,255,255,0.04)]",
+        )}
+        onDoubleClick={() => {
+          if (!activeWindowState.isFullScreen) {
+            void performWindowAction("toggle-maximize");
+          }
+        }}
+        onMouseEnter={() => {
+          if (isOverlay) {
+            setIsHovered(true);
+            setIsVisible(true);
+          }
+        }}
+        onMouseLeave={() => {
+          if (isOverlay) {
+            setIsHovered(false);
+            setIsVisible(false);
+          }
+        }}
+        onFocusCapture={() => {
+          if (isOverlay) {
+            setIsHovered(true);
+            setIsVisible(true);
+          }
+        }}
+        onBlurCapture={(event) => {
+          if (!isOverlay) {
+            return;
+          }
+
+          const relatedTarget = event.relatedTarget;
+          if (!(relatedTarget instanceof Node) || !event.currentTarget.contains(relatedTarget)) {
+            setIsHovered(false);
+            setIsVisible(false);
+          }
+        }}
+        style={{
+          height: `${DESKTOP_WINDOW_TOP_BAR_HEIGHT_PX}px`,
+          transform: `scale(${inverseZoomFactor})`,
+          transformOrigin: "top left",
+          width: frameWidth,
+        }}
+      >
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center px-24 text-sm font-medium text-foreground/80">
+          <span className="truncate">{APP_DISPLAY_NAME}</span>
+        </div>
+
+        <div className="relative z-10 flex items-center gap-1">
+          {windowActions.map((windowAction) => {
+            const ActionIcon = windowAction.icon;
+            return (
+              <Button
+                key={`${windowAction.action}-${windowAction.label}`}
+                aria-label={windowAction.label}
+                size="icon-xs"
+                variant="ghost"
+                onClick={() => {
+                  void performWindowAction(windowAction.action);
+                }}
+              >
+                <ActionIcon />
+              </Button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (!isOverlay) {
+    return content;
+  }
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none fixed inset-x-0 top-0 z-[90] transition-all duration-150",
+        isVisible ? "translate-y-0 opacity-100" : "-translate-y-full opacity-0",
+      )}
+    >
+      {content}
+    </div>
+  );
+}
+
+export { DesktopWindowTopBar };

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -1,14 +1,17 @@
 import type { ReactNode } from "react";
 
-import { isElectron } from "~/env";
+import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
 import { cn } from "~/lib/utils";
 
 import { Skeleton } from "./ui/skeleton";
 
 export type DiffPanelMode = "inline" | "sheet" | "sidebar";
 
-function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
-  const shouldUseDragRegion = isElectron && mode !== "sheet";
+function getDiffPanelHeaderRowClassName(
+  mode: DiffPanelMode,
+  shouldUseT3CodeWindowDecoration: boolean,
+) {
+  const shouldUseDragRegion = shouldUseT3CodeWindowDecoration && mode !== "sheet";
   return cn(
     "flex items-center justify-between gap-2 px-4",
     shouldUseDragRegion ? "drag-region h-[52px] border-b border-border" : "h-12",
@@ -20,7 +23,8 @@ export function DiffPanelShell(props: {
   header: ReactNode;
   children: ReactNode;
 }) {
-  const shouldUseDragRegion = isElectron && props.mode !== "sheet";
+  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
+  const shouldUseDragRegion = shouldUseT3CodeWindowDecoration && props.mode !== "sheet";
 
   return (
     <div
@@ -32,10 +36,18 @@ export function DiffPanelShell(props: {
       )}
     >
       {shouldUseDragRegion ? (
-        <div className={getDiffPanelHeaderRowClassName(props.mode)}>{props.header}</div>
+        <div
+          className={getDiffPanelHeaderRowClassName(props.mode, shouldUseT3CodeWindowDecoration)}
+        >
+          {props.header}
+        </div>
       ) : (
         <div className="border-b border-border">
-          <div className={getDiffPanelHeaderRowClassName(props.mode)}>{props.header}</div>
+          <div
+            className={getDiffPanelHeaderRowClassName(props.mode, shouldUseT3CodeWindowDecoration)}
+          >
+            {props.header}
+          </div>
         </div>
       )}
       {props.children}

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
+import { useShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
 import { cn } from "~/lib/utils";
 
 import { Skeleton } from "./ui/skeleton";
@@ -9,9 +9,9 @@ export type DiffPanelMode = "inline" | "sheet" | "sidebar";
 
 function getDiffPanelHeaderRowClassName(
   mode: DiffPanelMode,
-  shouldUseT3CodeWindowDecoration: boolean,
+  shouldUseDesktopHeaderDragRegion: boolean,
 ) {
-  const shouldUseDragRegion = shouldUseT3CodeWindowDecoration && mode !== "sheet";
+  const shouldUseDragRegion = shouldUseDesktopHeaderDragRegion && mode !== "sheet";
   return cn(
     "flex items-center justify-between gap-2 px-4",
     shouldUseDragRegion ? "drag-region h-[52px] border-b border-border" : "h-12",
@@ -23,8 +23,8 @@ export function DiffPanelShell(props: {
   header: ReactNode;
   children: ReactNode;
 }) {
-  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
-  const shouldUseDragRegion = shouldUseT3CodeWindowDecoration && props.mode !== "sheet";
+  const shouldUseDesktopHeaderDragRegion = useShouldUseDesktopHeaderDragRegion();
+  const shouldUseDragRegion = shouldUseDesktopHeaderDragRegion && props.mode !== "sheet";
 
   return (
     <div
@@ -37,14 +37,14 @@ export function DiffPanelShell(props: {
     >
       {shouldUseDragRegion ? (
         <div
-          className={getDiffPanelHeaderRowClassName(props.mode, shouldUseT3CodeWindowDecoration)}
+          className={getDiffPanelHeaderRowClassName(props.mode, shouldUseDesktopHeaderDragRegion)}
         >
           {props.header}
         </div>
       ) : (
         <div className="border-b border-border">
           <div
-            className={getDiffPanelHeaderRowClassName(props.mode, shouldUseT3CodeWindowDecoration)}
+            className={getDiffPanelHeaderRowClassName(props.mode, shouldUseDesktopHeaderDragRegion)}
           >
             {props.header}
           </div>

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -57,6 +57,7 @@ function createBaseServerConfig(): ServerConfig {
     ],
     availableEditors: [],
     settings: {
+      desktopTitleBarMode: "t3code",
       enableAssistantStreaming: false,
       defaultThreadEnvMode: "local" as const,
       textGenerationModelSelection: { provider: "codex" as const, model: "gpt-5.4-mini" },

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -55,7 +55,7 @@ import { useComposerDraftStore } from "../composerDraftStore";
 import { useDesktopWindowState } from "../hooks/useDesktopWindowState";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
-import { useShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
+import { resolveShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
 import { toastManager } from "./ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
@@ -420,7 +420,10 @@ export default function Sidebar() {
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const desktopWindowState = useDesktopWindowState();
   const isLinuxDesktop = isElectron && isLinuxPlatform(navigator.platform);
-  const shouldUseDesktopHeaderDragRegion = useShouldUseDesktopHeaderDragRegion();
+  const shouldUseDesktopHeaderDragRegion = resolveShouldUseDesktopHeaderDragRegion({
+    windowState: desktopWindowState,
+    desktopTitleBarMode: appSettings.desktopTitleBarMode,
+  });
   const shouldUseMacSystemTrafficLightInset =
     isElectron &&
     (desktopWindowState

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -54,7 +54,7 @@ import { readNativeApi } from "../nativeApi";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
-import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
+import { useShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
 import { toastManager } from "./ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
@@ -418,7 +418,7 @@ export default function Sidebar() {
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const isLinuxDesktop = isElectron && isLinuxPlatform(navigator.platform);
-  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
+  const shouldUseDesktopHeaderDragRegion = useShouldUseDesktopHeaderDragRegion();
   const shouldBrowseForProjectImmediately = isElectron && !isLinuxDesktop;
   const shouldShowProjectPathEntry = addingProject && !shouldBrowseForProjectImmediately;
   const projectCwdById = useMemo(
@@ -1636,7 +1636,7 @@ export default function Sidebar() {
             aria-label={desktopUpdateTooltip}
             aria-disabled={desktopUpdateButtonDisabled || undefined}
             disabled={desktopUpdateButtonDisabled}
-            className={`inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses} ${shouldUseT3CodeWindowDecoration ? "ml-auto mt-1.5" : "ms-auto"}`}
+            className={`inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses} ${shouldUseDesktopHeaderDragRegion ? "ml-auto mt-1.5" : "ms-auto"}`}
             onClick={handleDesktopUpdateButtonClick}
           >
             <RocketIcon className="size-3.5" />
@@ -1649,7 +1649,7 @@ export default function Sidebar() {
 
   return (
     <>
-      {shouldUseT3CodeWindowDecoration ? (
+      {shouldUseDesktopHeaderDragRegion ? (
         <>
           <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -52,6 +52,7 @@ import { gitRemoveWorktreeMutationOptions, gitStatusQueryOptions } from "../lib/
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { useComposerDraftStore } from "../composerDraftStore";
+import { useDesktopWindowState } from "../hooks/useDesktopWindowState";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { useShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
@@ -417,8 +418,14 @@ export default function Sidebar() {
   const clearSelection = useThreadSelectionStore((s) => s.clearSelection);
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
+  const desktopWindowState = useDesktopWindowState();
   const isLinuxDesktop = isElectron && isLinuxPlatform(navigator.platform);
   const shouldUseDesktopHeaderDragRegion = useShouldUseDesktopHeaderDragRegion();
+  const shouldUseMacSystemTrafficLightInset =
+    isElectron &&
+    (desktopWindowState
+      ? desktopWindowState.platform === "darwin" && desktopWindowState.titleBarMode === "system"
+      : isMacPlatform(navigator.platform) && appSettings.desktopTitleBarMode === "system");
   const shouldBrowseForProjectImmediately = isElectron && !isLinuxDesktop;
   const shouldShowProjectPathEntry = addingProject && !shouldBrowseForProjectImmediately;
   const projectCwdById = useMemo(
@@ -1651,7 +1658,13 @@ export default function Sidebar() {
     <>
       {shouldUseDesktopHeaderDragRegion ? (
         <>
-          <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
+          <SidebarHeader
+            className={
+              shouldUseMacSystemTrafficLightInset
+                ? "drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]"
+                : "drag-region h-[52px] flex-row items-center gap-2 px-4 py-0"
+            }
+          >
             {wordmark}
             {desktopUpdateButton}
           </SidebarHeader>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -54,6 +54,7 @@ import { readNativeApi } from "../nativeApi";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
 import { toastManager } from "./ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
@@ -417,6 +418,7 @@ export default function Sidebar() {
   const removeFromSelection = useThreadSelectionStore((s) => s.removeFromSelection);
   const setSelectionAnchor = useThreadSelectionStore((s) => s.setAnchor);
   const isLinuxDesktop = isElectron && isLinuxPlatform(navigator.platform);
+  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
   const shouldBrowseForProjectImmediately = isElectron && !isLinuxDesktop;
   const shouldShowProjectPathEntry = addingProject && !shouldBrowseForProjectImmediately;
   const projectCwdById = useMemo(
@@ -1625,36 +1627,39 @@ export default function Sidebar() {
     </div>
   );
 
+  const desktopUpdateButton = showDesktopUpdateButton ? (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            aria-label={desktopUpdateTooltip}
+            aria-disabled={desktopUpdateButtonDisabled || undefined}
+            disabled={desktopUpdateButtonDisabled}
+            className={`inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses} ${shouldUseT3CodeWindowDecoration ? "ml-auto mt-1.5" : "ms-auto"}`}
+            onClick={handleDesktopUpdateButtonClick}
+          >
+            <RocketIcon className="size-3.5" />
+          </button>
+        }
+      />
+      <TooltipPopup side="bottom">{desktopUpdateTooltip}</TooltipPopup>
+    </Tooltip>
+  ) : null;
+
   return (
     <>
-      {isElectron ? (
+      {shouldUseT3CodeWindowDecoration ? (
         <>
           <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
             {wordmark}
-            {showDesktopUpdateButton && (
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <button
-                      type="button"
-                      aria-label={desktopUpdateTooltip}
-                      aria-disabled={desktopUpdateButtonDisabled || undefined}
-                      disabled={desktopUpdateButtonDisabled}
-                      className={`inline-flex size-7 ml-auto mt-1.5 items-center justify-center rounded-md text-muted-foreground transition-colors ${desktopUpdateButtonInteractivityClasses} ${desktopUpdateButtonClasses}`}
-                      onClick={handleDesktopUpdateButtonClick}
-                    >
-                      <RocketIcon className="size-3.5" />
-                    </button>
-                  }
-                />
-                <TooltipPopup side="bottom">{desktopUpdateTooltip}</TooltipPopup>
-              </Tooltip>
-            )}
+            {desktopUpdateButton}
           </SidebarHeader>
         </>
       ) : (
         <SidebarHeader className="gap-3 px-3 py-2 sm:gap-2.5 sm:px-4 sm:py-3">
           {wordmark}
+          {desktopUpdateButton}
         </SidebarHeader>
       )}
 

--- a/apps/web/src/hooks/useDesktopWindowState.ts
+++ b/apps/web/src/hooks/useDesktopWindowState.ts
@@ -12,15 +12,17 @@ export function useDesktopWindowState(): DesktopWindowState | null {
     }
 
     let cancelled = false;
+    let receivedSubscriptionState = false;
 
-    void bridge.getWindowState().then((nextState) => {
+    const unsubscribe = bridge.onWindowState((nextState) => {
       if (!cancelled) {
+        receivedSubscriptionState = true;
         setWindowState(nextState);
       }
     });
 
-    const unsubscribe = bridge.onWindowState((nextState) => {
-      if (!cancelled) {
+    void bridge.getWindowState().then((nextState) => {
+      if (!cancelled && !receivedSubscriptionState) {
         setWindowState(nextState);
       }
     });

--- a/apps/web/src/hooks/useDesktopWindowState.ts
+++ b/apps/web/src/hooks/useDesktopWindowState.ts
@@ -1,0 +1,35 @@
+import type { DesktopWindowState } from "@t3tools/contracts";
+import { useEffect, useState } from "react";
+
+export function useDesktopWindowState(): DesktopWindowState | null {
+  const [windowState, setWindowState] = useState<DesktopWindowState | null>(null);
+
+  useEffect(() => {
+    const bridge = window.desktopBridge;
+    if (!bridge) {
+      setWindowState(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    void bridge.getWindowState().then((nextState) => {
+      if (!cancelled) {
+        setWindowState(nextState);
+      }
+    });
+
+    const unsubscribe = bridge.onWindowState((nextState) => {
+      if (!cancelled) {
+        setWindowState(nextState);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  return windowState;
+}

--- a/apps/web/src/hooks/useWindowDecorationMode.ts
+++ b/apps/web/src/hooks/useWindowDecorationMode.ts
@@ -1,15 +1,19 @@
+import type { DesktopTitleBarMode, DesktopWindowState } from "@t3tools/contracts";
+
 import { isElectron } from "~/env";
 import { useDesktopWindowState } from "~/hooks/useDesktopWindowState";
 import { useSettings } from "~/hooks/useSettings";
 import { isMacPlatform } from "~/lib/utils";
 
-function shouldUseDesktopHeaderDragRegion(
-  windowState: ReturnType<typeof useDesktopWindowState>,
-  desktopTitleBarMode: ReturnType<typeof useSettings>["desktopTitleBarMode"],
-): boolean {
+export function resolveShouldUseDesktopHeaderDragRegion(input: {
+  windowState: DesktopWindowState | null;
+  desktopTitleBarMode: DesktopTitleBarMode;
+}): boolean {
   if (!isElectron) {
     return false;
   }
+
+  const { windowState, desktopTitleBarMode } = input;
 
   if (!windowState) {
     return desktopTitleBarMode === "t3code" || isMacPlatform(navigator.platform);
@@ -26,5 +30,8 @@ export function useShouldUseDesktopHeaderDragRegion(): boolean {
   const windowState = useDesktopWindowState();
   const desktopTitleBarMode = useSettings().desktopTitleBarMode;
 
-  return shouldUseDesktopHeaderDragRegion(windowState, desktopTitleBarMode);
+  return resolveShouldUseDesktopHeaderDragRegion({
+    windowState,
+    desktopTitleBarMode,
+  });
 }

--- a/apps/web/src/hooks/useWindowDecorationMode.ts
+++ b/apps/web/src/hooks/useWindowDecorationMode.ts
@@ -1,0 +1,22 @@
+import { isElectron } from "~/env";
+import { useDesktopWindowState } from "~/hooks/useDesktopWindowState";
+import { useSettings } from "~/hooks/useSettings";
+
+export function useShouldUseT3CodeWindowDecoration(): boolean {
+  const windowState = useDesktopWindowState();
+  const desktopTitleBarMode = useSettings().desktopTitleBarMode;
+
+  if (!isElectron) {
+    return false;
+  }
+
+  if (!windowState) {
+    return desktopTitleBarMode === "t3code";
+  }
+
+  if (windowState.platform === "other") {
+    return false;
+  }
+
+  return windowState.titleBarMode === "t3code";
+}

--- a/apps/web/src/hooks/useWindowDecorationMode.ts
+++ b/apps/web/src/hooks/useWindowDecorationMode.ts
@@ -1,22 +1,30 @@
 import { isElectron } from "~/env";
 import { useDesktopWindowState } from "~/hooks/useDesktopWindowState";
 import { useSettings } from "~/hooks/useSettings";
+import { isMacPlatform } from "~/lib/utils";
 
-export function useShouldUseT3CodeWindowDecoration(): boolean {
-  const windowState = useDesktopWindowState();
-  const desktopTitleBarMode = useSettings().desktopTitleBarMode;
-
+function shouldUseDesktopHeaderDragRegion(
+  windowState: ReturnType<typeof useDesktopWindowState>,
+  desktopTitleBarMode: ReturnType<typeof useSettings>["desktopTitleBarMode"],
+): boolean {
   if (!isElectron) {
     return false;
   }
 
   if (!windowState) {
-    return desktopTitleBarMode === "t3code";
+    return desktopTitleBarMode === "t3code" || isMacPlatform(navigator.platform);
   }
 
   if (windowState.platform === "other") {
     return false;
   }
 
-  return windowState.titleBarMode === "t3code";
+  return windowState.titleBarMode === "t3code" || windowState.platform === "darwin";
+}
+
+export function useShouldUseDesktopHeaderDragRegion(): boolean {
+  const windowState = useDesktopWindowState();
+  const desktopTitleBarMode = useSettings().desktopTitleBarMode;
+
+  return shouldUseDesktopHeaderDragRegion(windowState, desktopTitleBarMode);
 }

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -221,7 +221,7 @@ function ChatThreadRouteView() {
   if (!shouldUseDiffSheet) {
     return (
       <>
-        <SidebarInset className="h-dvh  min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+        <SidebarInset className="h-full min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
           <ChatView key={threadId} threadId={threadId} />
         </SidebarInset>
         <DiffPanelInlineSidebar
@@ -236,7 +236,7 @@ function ChatThreadRouteView() {
 
   return (
     <>
-      <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+      <SidebarInset className="h-full min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
         <ChatView key={threadId} threadId={threadId} />
       </SidebarInset>
       <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={closeDiff}>

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -2,10 +2,10 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
 import { SidebarTrigger } from "../components/ui/sidebar";
-import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
+import { useShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
 
 function ChatIndexRouteView() {
-  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
+  const shouldUseDesktopHeaderDragRegion = useShouldUseDesktopHeaderDragRegion();
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-muted-foreground/40">
@@ -18,7 +18,7 @@ function ChatIndexRouteView() {
         </header>
       )}
 
-      {shouldUseT3CodeWindowDecoration && (
+      {shouldUseDesktopHeaderDragRegion && (
         <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
           <span className="text-xs text-muted-foreground/50">No active thread</span>
         </div>

--- a/apps/web/src/routes/_chat.index.tsx
+++ b/apps/web/src/routes/_chat.index.tsx
@@ -2,8 +2,11 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
 import { SidebarTrigger } from "../components/ui/sidebar";
+import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
 
 function ChatIndexRouteView() {
+  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
+
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-muted-foreground/40">
       {!isElectron && (
@@ -15,7 +18,7 @@ function ChatIndexRouteView() {
         </header>
       )}
 
-      {isElectron && (
+      {shouldUseT3CodeWindowDecoration && (
         <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
           <span className="text-xs text-muted-foreground/50">No active thread</span>
         </div>

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import {
+  type DesktopTitleBarMode,
   PROVIDER_DISPLAY_NAMES,
   type ProviderKind,
   type ServerProvider,
@@ -50,6 +51,8 @@ import { formatRelativeTime } from "../timestampFormat";
 import { ensureNativeApi, readNativeApi } from "../nativeApi";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { Equal } from "effect";
+import { useDesktopWindowState } from "~/hooks/useDesktopWindowState";
+import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
 
 const THEME_OPTIONS = [
   {
@@ -74,6 +77,11 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const DESKTOP_TITLE_BAR_MODE_LABELS: Record<DesktopTitleBarMode, string> = {
+  t3code: "T3 Code",
+  system: "System",
+};
 
 const EMPTY_SERVER_PROVIDERS: ReadonlyArray<ServerProvider> = [];
 
@@ -286,10 +294,14 @@ function SettingResetButton({ label, onClick }: { label: string; onClick: () => 
 function SettingsRouteView() {
   const { theme, setTheme } = useTheme();
   const settings = useSettings();
+  const desktopWindowState = useDesktopWindowState();
+  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
   const { updateSettings, resetSettings } = useUpdateSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);
   const [openKeybindingsError, setOpenKeybindingsError] = useState<string | null>(null);
+  const [desktopTitleBarModeSelection, setDesktopTitleBarModeSelection] =
+    useState<DesktopTitleBarMode>(settings.desktopTitleBarMode);
   const [openProviderDetails, setOpenProviderDetails] = useState<Record<ProviderKind, boolean>>({
     codex: Boolean(
       settings.providers.codex.binaryPath !== DEFAULT_UNIFIED_SETTINGS.providers.codex.binaryPath ||
@@ -315,6 +327,17 @@ function SettingsRouteView() {
   const refreshingRef = useRef(false);
   const queryClient = useQueryClient();
   useRelativeTimeTick();
+  const effectiveDesktopTitleBarMode =
+    desktopWindowState?.titleBarMode ?? desktopTitleBarModeSelection;
+
+  const setDesktopTitleBarMode = useCallback(async (mode: DesktopTitleBarMode) => {
+    const bridge = window.desktopBridge;
+    if (!bridge) {
+      throw new Error("Desktop bridge unavailable");
+    }
+
+    return bridge.setTitleBarMode(mode);
+  }, []);
 
   const refreshProviders = useCallback(() => {
     if (refreshingRef.current) return;
@@ -332,6 +355,33 @@ function SettingsRouteView() {
         setIsRefreshingProviders(false);
       });
   }, [queryClient]);
+
+  useEffect(() => {
+    if (desktopWindowState !== null) {
+      setDesktopTitleBarModeSelection(desktopWindowState.titleBarMode);
+      return;
+    }
+
+    setDesktopTitleBarModeSelection(settings.desktopTitleBarMode);
+  }, [desktopWindowState, settings.desktopTitleBarMode]);
+
+  const updateDesktopTitleBarMode = useCallback(
+    async (mode: DesktopTitleBarMode) => {
+      setDesktopTitleBarModeSelection(mode);
+
+      try {
+        const nextWindowState = await setDesktopTitleBarMode(mode);
+        setDesktopTitleBarModeSelection(nextWindowState.titleBarMode);
+      } catch (error) {
+        setDesktopTitleBarModeSelection(effectiveDesktopTitleBarMode);
+        queryClient.invalidateQueries({ queryKey: serverQueryKeys.config() }).catch((reason) => {
+          console.error("Failed to refresh settings after window decoration update", reason);
+        });
+        console.error("Failed to update window decoration", error);
+      }
+    },
+    [effectiveDesktopTitleBarMode, queryClient, setDesktopTitleBarMode],
+  );
 
   const modelListRefs = useRef<Partial<Record<ProviderKind, HTMLDivElement | null>>>({});
 
@@ -359,8 +409,13 @@ function SettingsRouteView() {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
+  const shouldShowDesktopTitleBarModeSetting =
+    isElectron && desktopWindowState !== null && desktopWindowState.platform !== "other";
   const changedSettingLabels = [
     ...(theme !== "system" ? ["Theme"] : []),
+    ...(effectiveDesktopTitleBarMode !== DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode
+      ? ["Window decoration"]
+      : []),
     ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
       ? ["Time format"]
       : []),
@@ -550,6 +605,10 @@ function SettingsRouteView() {
 
     setTheme("system");
     resetSettings();
+    if (effectiveDesktopTitleBarMode !== DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode) {
+      setDesktopTitleBarModeSelection(DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode);
+      await setDesktopTitleBarMode(DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode);
+    }
     setOpenProviderDetails({
       codex: false,
       claudeAgent: false,
@@ -562,9 +621,9 @@ function SettingsRouteView() {
   }
 
   return (
-    <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
+    <SidebarInset className="h-full min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
-        {!isElectron && (
+        {!shouldUseT3CodeWindowDecoration && (
           <header className="border-b border-border px-3 py-2 sm:px-5">
             <div className="flex items-center gap-2">
               <SidebarTrigger className="size-7 shrink-0 md:hidden" />
@@ -584,7 +643,7 @@ function SettingsRouteView() {
           </header>
         )}
 
-        {isElectron && (
+        {shouldUseT3CodeWindowDecoration && (
           <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
@@ -637,6 +696,52 @@ function SettingsRouteView() {
                   </Select>
                 }
               />
+
+              {shouldShowDesktopTitleBarModeSetting ? (
+                <SettingsRow
+                  title="Window decoration"
+                  description="Choose whether T3 Code or your system draws the window decoration. Active chats keep running while the window is rebuilt."
+                  resetAction={
+                    effectiveDesktopTitleBarMode !==
+                    DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode ? (
+                      <SettingResetButton
+                        label="window decoration"
+                        onClick={() => {
+                          void updateDesktopTitleBarMode(
+                            DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode,
+                          );
+                        }}
+                      />
+                    ) : null
+                  }
+                  control={
+                    <Select
+                      value={desktopTitleBarModeSelection}
+                      onValueChange={(value) => {
+                        if (value !== "t3code" && value !== "system") {
+                          return;
+                        }
+
+                        void updateDesktopTitleBarMode(value);
+                      }}
+                    >
+                      <SelectTrigger className="w-full sm:w-56" aria-label="Window decoration">
+                        <SelectValue>
+                          {DESKTOP_TITLE_BAR_MODE_LABELS[desktopTitleBarModeSelection]}
+                        </SelectValue>
+                      </SelectTrigger>
+                      <SelectPopup align="end" alignItemWithTrigger={false}>
+                        <SelectItem hideIndicator value="t3code">
+                          {DESKTOP_TITLE_BAR_MODE_LABELS.t3code}
+                        </SelectItem>
+                        <SelectItem hideIndicator value="system">
+                          {DESKTOP_TITLE_BAR_MODE_LABELS.system}
+                        </SelectItem>
+                      </SelectPopup>
+                    </Select>
+                  }
+                />
+              ) : null}
 
               <SettingsRow
                 title="Time format"

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -605,12 +605,8 @@ function SettingsRouteView() {
 
     setTheme("system");
     resetSettings();
-    if (
-      window.desktopBridge &&
-      effectiveDesktopTitleBarMode !== DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode
-    ) {
-      setDesktopTitleBarModeSelection(DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode);
-      await setDesktopTitleBarMode(DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode);
+    if (effectiveDesktopTitleBarMode !== DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode) {
+      await updateDesktopTitleBarMode(DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode);
     }
     setOpenProviderDetails({
       codex: false,

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -375,6 +375,9 @@ function SettingsRouteView() {
       try {
         const nextWindowState = await setDesktopTitleBarMode(mode);
         setDesktopTitleBarModeSelection(nextWindowState.titleBarMode);
+        updateSettings({
+          desktopTitleBarMode: nextWindowState.titleBarMode,
+        });
       } catch (error) {
         setDesktopTitleBarModeSelection(effectiveDesktopTitleBarMode);
         queryClient.invalidateQueries({ queryKey: serverQueryKeys.config() }).catch((reason) => {
@@ -383,7 +386,7 @@ function SettingsRouteView() {
         console.error("Failed to update window decoration", error);
       }
     },
-    [effectiveDesktopTitleBarMode, queryClient, setDesktopTitleBarMode],
+    [effectiveDesktopTitleBarMode, queryClient, setDesktopTitleBarMode, updateSettings],
   );
 
   const modelListRefs = useRef<Partial<Record<ProviderKind, HTMLDivElement | null>>>({});

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -52,7 +52,7 @@ import { ensureNativeApi, readNativeApi } from "../nativeApi";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { Equal } from "effect";
 import { useDesktopWindowState } from "~/hooks/useDesktopWindowState";
-import { useShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
+import { resolveShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
 
 const THEME_OPTIONS = [
   {
@@ -295,7 +295,10 @@ function SettingsRouteView() {
   const { theme, setTheme } = useTheme();
   const settings = useSettings();
   const desktopWindowState = useDesktopWindowState();
-  const shouldUseDesktopHeaderDragRegion = useShouldUseDesktopHeaderDragRegion();
+  const shouldUseDesktopHeaderDragRegion = resolveShouldUseDesktopHeaderDragRegion({
+    windowState: desktopWindowState,
+    desktopTitleBarMode: settings.desktopTitleBarMode,
+  });
   const { updateSettings, resetSettings } = useUpdateSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);

--- a/apps/web/src/routes/_chat.settings.tsx
+++ b/apps/web/src/routes/_chat.settings.tsx
@@ -52,7 +52,7 @@ import { ensureNativeApi, readNativeApi } from "../nativeApi";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { Equal } from "effect";
 import { useDesktopWindowState } from "~/hooks/useDesktopWindowState";
-import { useShouldUseT3CodeWindowDecoration } from "~/hooks/useWindowDecorationMode";
+import { useShouldUseDesktopHeaderDragRegion } from "~/hooks/useWindowDecorationMode";
 
 const THEME_OPTIONS = [
   {
@@ -295,7 +295,7 @@ function SettingsRouteView() {
   const { theme, setTheme } = useTheme();
   const settings = useSettings();
   const desktopWindowState = useDesktopWindowState();
-  const shouldUseT3CodeWindowDecoration = useShouldUseT3CodeWindowDecoration();
+  const shouldUseDesktopHeaderDragRegion = useShouldUseDesktopHeaderDragRegion();
   const { updateSettings, resetSettings } = useUpdateSettings();
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);
@@ -605,7 +605,10 @@ function SettingsRouteView() {
 
     setTheme("system");
     resetSettings();
-    if (effectiveDesktopTitleBarMode !== DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode) {
+    if (
+      window.desktopBridge &&
+      effectiveDesktopTitleBarMode !== DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode
+    ) {
       setDesktopTitleBarModeSelection(DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode);
       await setDesktopTitleBarMode(DEFAULT_UNIFIED_SETTINGS.desktopTitleBarMode);
     }
@@ -623,7 +626,7 @@ function SettingsRouteView() {
   return (
     <SidebarInset className="h-full min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
-        {!shouldUseT3CodeWindowDecoration && (
+        {!shouldUseDesktopHeaderDragRegion && (
           <header className="border-b border-border px-3 py-2 sm:px-5">
             <div className="flex items-center gap-2">
               <SidebarTrigger className="size-7 shrink-0 md:hidden" />
@@ -643,7 +646,7 @@ function SettingsRouteView() {
           </header>
         )}
 
-        {shouldUseT3CodeWindowDecoration && (
+        {shouldUseDesktopHeaderDragRegion && (
           <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -4,6 +4,7 @@ import { Outlet, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import ThreadSidebar from "../components/Sidebar";
+import { DesktopWindowTopBar } from "~/components/DesktopWindowTopBar";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { serverConfigQueryOptions } from "../lib/serverReactQuery";
@@ -113,24 +114,27 @@ function ChatRouteLayout() {
   }, [navigate]);
 
   return (
-    <SidebarProvider defaultOpen>
-      <ChatRouteGlobalShortcuts />
-      <Sidebar
-        side="left"
-        collapsible="offcanvas"
-        className="border-r border-border bg-card text-foreground"
-        resizable={{
-          minWidth: THREAD_SIDEBAR_MIN_WIDTH,
-          shouldAcceptWidth: ({ nextWidth, wrapper }) =>
-            wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
-          storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
-        }}
-      >
-        <ThreadSidebar />
-        <SidebarRail />
-      </Sidebar>
-      <Outlet />
-    </SidebarProvider>
+    <div className="flex h-dvh min-h-0 flex-col bg-background text-foreground">
+      <DesktopWindowTopBar />
+      <SidebarProvider defaultOpen className="min-h-0 flex-1">
+        <ChatRouteGlobalShortcuts />
+        <Sidebar
+          side="left"
+          collapsible="offcanvas"
+          className="border-r border-border bg-card text-foreground"
+          resizable={{
+            minWidth: THREAD_SIDEBAR_MIN_WIDTH,
+            shouldAcceptWidth: ({ nextWidth, wrapper }) =>
+              wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
+            storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
+          }}
+        >
+          <ThreadSidebar />
+          <SidebarRail />
+        </Sidebar>
+        <Outlet />
+      </SidebarProvider>
+    </div>
   );
 }
 

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -51,7 +51,7 @@ import type {
   OrchestrationReadModel,
 } from "./orchestration";
 import { EditorId } from "./editor";
-import { ServerSettings, ServerSettingsPatch } from "./settings";
+import { type DesktopTitleBarMode, ServerSettings, ServerSettingsPatch } from "./settings";
 
 export interface ContextMenuItem<T extends string = string> {
   id: T;
@@ -71,11 +71,21 @@ export type DesktopUpdateStatus =
 
 export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
+export type DesktopWindowPlatform = "darwin" | "linux" | "win32" | "other";
+export type DesktopWindowAction = "minimize" | "toggle-maximize" | "exit-full-screen" | "close";
 
 export interface DesktopRuntimeInfo {
   hostArch: DesktopRuntimeArch;
   appArch: DesktopRuntimeArch;
   runningUnderArm64Translation: boolean;
+}
+
+export interface DesktopWindowState {
+  isFullScreen: boolean;
+  isMaximized: boolean;
+  platform: DesktopWindowPlatform;
+  titleBarMode: DesktopTitleBarMode;
+  zoomFactor: number;
 }
 
 export interface DesktopUpdateState {
@@ -105,12 +115,16 @@ export interface DesktopBridge {
   pickFolder: () => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;
+  setTitleBarMode: (mode: DesktopTitleBarMode) => Promise<DesktopWindowState>;
   showContextMenu: <T extends string>(
     items: readonly ContextMenuItem<T>[],
     position?: { x: number; y: number },
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
   onMenuAction: (listener: (action: string) => void) => () => void;
+  getWindowState: () => Promise<DesktopWindowState>;
+  performWindowAction: (action: DesktopWindowAction) => Promise<DesktopWindowState>;
+  onWindowState: (listener: (state: DesktopWindowState) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   downloadUpdate: () => Promise<DesktopUpdateActionResult>;
   installUpdate: () => Promise<DesktopUpdateActionResult>;

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -42,6 +42,9 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 
 export const ThreadEnvMode = Schema.Literals(["local", "worktree"]);
 export type ThreadEnvMode = typeof ThreadEnvMode.Type;
+export const DesktopTitleBarMode = Schema.Literals(["t3code", "system"]);
+export type DesktopTitleBarMode = typeof DesktopTitleBarMode.Type;
+export const DEFAULT_DESKTOP_TITLE_BAR_MODE: DesktopTitleBarMode = "t3code";
 
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
@@ -71,6 +74,9 @@ export const ClaudeSettings = Schema.Struct({
 export type ClaudeSettings = typeof ClaudeSettings.Type;
 
 export const ServerSettings = Schema.Struct({
+  desktopTitleBarMode: DesktopTitleBarMode.pipe(
+    Schema.withDecodingDefault(() => DEFAULT_DESKTOP_TITLE_BAR_MODE),
+  ),
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   defaultThreadEnvMode: ThreadEnvMode.pipe(
     Schema.withDecodingDefault(() => "local" as const satisfies ThreadEnvMode),
@@ -140,6 +146,7 @@ const ClaudeSettingsPatch = Schema.Struct({
 });
 
 export const ServerSettingsPatch = Schema.Struct({
+  desktopTitleBarMode: Schema.optionalKey(DesktopTitleBarMode),
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),


### PR DESCRIPTION
## Summary
- add a desktop window decoration mode switch between T3 Code and the system decoration
- add the shared T3 Code top bar, including fullscreen reveal behavior
- rebuild only the window when switching decoration modes so active chats can keep running
- route drag regions and headers through the active decoration mode across desktop platforms

## Validation
- bun run fmt
- bun run lint
- bun run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Electron window creation and introduces window rebuild + new IPC/state syncing paths; failures could impact window lifecycle/state or user settings persistence.
> 
> **Overview**
> Adds a new desktop “window decoration” setting (`DesktopTitleBarMode`: `t3code` vs `system`) that is persisted to disk and exposed via IPC, with the Electron main process rebuilding the `BrowserWindow` when the mode changes (preserving bounds/URL and reverting persistence on failure).
> 
> Introduces `DesktopWindowState` + window actions/zoom handling across the bridge, and updates the web UI to render a custom `DesktopWindowTopBar` (with fullscreen reveal behavior) and to drive drag-region/header behavior via a new `useDesktopWindowState`/`useWindowDecorationMode` hook instead of `isElectron` checks.
> 
> Updates Settings to let desktop users switch decoration modes at runtime, and adjusts desktop menu zoom controls to emit window-state updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 257467c864530ad0a48da376af4f2345e66f6c0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add switchable desktop window decoration modes with a custom frameless title bar
> - Adds a `DesktopTitleBarMode` setting (`'t3code'` | `'system'`) that controls whether the app uses a custom frameless window or the native OS frame; defaults to `'t3code'`.
> - Implements a custom `DesktopWindowTopBar` React component with minimize, maximize/restore, and close controls, including fullscreen reveal animation and zoom-aware scaling.
> - Switching modes rebuilds the main `BrowserWindow` at runtime via `rebuildMainWindow`, preserving window geometry and the active page URL.
> - Exposes `setTitleBarMode`, `getWindowState`, `performWindowAction`, and `onWindowState` over the Electron IPC bridge so the renderer can control and observe window state.
> - Adds a Window Decoration selector in Settings, with the selection persisted to disk via an atomic write and restored on next launch.
> - Drag regions in `ChatView`, `Sidebar`, `DiffPanelShell`, and route layouts are now conditioned on the active mode and platform instead of a plain `isElectron` check.
> - Risk: mode changes trigger a full window rebuild; if the rebuild fails, the previous mode is restored but a transient blank window may be visible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 257467c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->