### PR TITLE
feat(claude): Reflect Claude’s autonomous plan transitions to the UI

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -2320,4 +2320,65 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.status).toBe("error");
     expect(thread.session?.lastError).toBe("runtime still processed");
   });
+
+  it("dispatches thread.interaction-mode.set when interaction.mode.changed arrives with a different mode", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    // Thread starts with DEFAULT_PROVIDER_INTERACTION_MODE ("default").
+    // Emit interaction.mode.changed with "plan" — should update the thread.
+    harness.emit({
+      type: "interaction.mode.changed",
+      eventId: asEventId("evt-mode-changed-plan"),
+      provider: "claudeAgent",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      payload: {
+        interactionMode: "plan",
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) => entry.interactionMode === "plan");
+    expect(thread.interactionMode).toBe("plan");
+  });
+
+  it("does not dispatch when interaction.mode.changed arrives with the same mode", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    // First, change to plan mode.
+    harness.emit({
+      type: "interaction.mode.changed",
+      eventId: asEventId("evt-mode-changed-plan-1"),
+      provider: "claudeAgent",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      payload: {
+        interactionMode: "plan",
+      },
+    });
+
+    await waitForThread(harness.engine, (entry) => entry.interactionMode === "plan");
+
+    // Now emit the same mode again. The thread should still be in plan mode
+    // but no new command should be dispatched. We verify by emitting a
+    // subsequent event and confirming the thread state is unchanged.
+    harness.emit({
+      type: "interaction.mode.changed",
+      eventId: asEventId("evt-mode-changed-plan-2"),
+      provider: "claudeAgent",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      payload: {
+        interactionMode: "plan",
+      },
+    });
+
+    // Drain to ensure the duplicate event is processed.
+    await harness.drain();
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === asThreadId("thread-1"));
+    expect(thread?.interactionMode).toBe("plan");
+  });
 });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1210,6 +1210,19 @@ const make = Effect.gen(function* () {
         });
       }
 
+      if (
+        event.type === "interaction.mode.changed" &&
+        event.payload.interactionMode !== thread.interactionMode
+      ) {
+        yield* orchestrationEngine.dispatch({
+          type: "thread.interaction-mode.set",
+          commandId: providerCommandId(event, "interaction-mode-changed"),
+          threadId: thread.id,
+          interactionMode: event.payload.interactionMode,
+          createdAt: now,
+        });
+      }
+
       if (event.type === "turn.diff.updated") {
         const turnId = toTurnId(event.turnId);
         if (turnId && (yield* isGitRepoForThread(thread.id))) {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -2983,4 +2983,139 @@ describe("ClaudeAdapterLive", () => {
       Effect.provide(harness.layer),
     );
   });
+
+  it.effect(
+    "emits interaction.mode.changed with plan when EnterPlanMode tool starts in stream",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        // Collect enough events: session.started, session.configured, session.state.changed,
+        // turn.started, interaction.mode.changed, item.started, turn.completed = 7
+        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "please plan this",
+          attachments: [],
+        });
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-plan-enter",
+          uuid: "stream-enter-plan-0",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "tool-enter-plan-1",
+              name: "EnterPlanMode",
+              input: {},
+            },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-plan-enter",
+          uuid: "result-enter-plan",
+        } as unknown as SDKMessage);
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        const modeChanged = runtimeEvents.find(
+          (event) => event.type === "interaction.mode.changed",
+        );
+        assert.equal(modeChanged?.type, "interaction.mode.changed");
+        if (modeChanged?.type === "interaction.mode.changed") {
+          assert.equal(modeChanged.payload.interactionMode, "plan");
+        }
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
+  it.effect(
+    "emits interaction.mode.changed with default when ExitPlanMode tool starts in stream",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "exit plan mode",
+          interactionMode: "plan",
+          attachments: [],
+        });
+
+        harness.query.emit({
+          type: "stream_event",
+          session_id: "sdk-session-plan-exit",
+          uuid: "stream-exit-plan-0",
+          parent_tool_use_id: null,
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "tool-exit-plan-1",
+              name: "ExitPlanMode",
+              input: {
+                plan: "# My plan",
+              },
+            },
+          },
+        } as unknown as SDKMessage);
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          errors: [],
+          session_id: "sdk-session-plan-exit",
+          uuid: "result-exit-plan",
+        } as unknown as SDKMessage);
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        const modeChanged = runtimeEvents.find(
+          (event) => event.type === "interaction.mode.changed",
+        );
+        assert.equal(modeChanged?.type, "interaction.mode.changed");
+        if (modeChanged?.type === "interaction.mode.changed") {
+          assert.equal(modeChanged.payload.interactionMode, "default");
+        }
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
 });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -24,6 +24,7 @@ import {
   type CanonicalRequestType,
   EventId,
   type ProviderApprovalDecision,
+  type ProviderInteractionMode,
   ProviderItemId,
   type ProviderRuntimeEvent,
   type ProviderRuntimeTurnStatus,
@@ -447,6 +448,21 @@ function isReadOnlyToolName(toolName: string): boolean {
     normalized.includes("glob") ||
     normalized.includes("search")
   );
+}
+
+/**
+ * Maps a tool name to the interaction mode it implies.
+ * Returns undefined when the tool has no mode semantics.
+ */
+function interactionModeForTool(toolName: string): ProviderInteractionMode | undefined {
+  switch (toolName) {
+    case "EnterPlanMode":
+      return "plan";
+    case "ExitPlanMode":
+      return "default";
+    default:
+      return undefined;
+  }
 }
 
 function classifyRequestType(toolName: string): CanonicalRequestType {
@@ -1356,6 +1372,23 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
         });
       });
 
+    const emitInteractionModeChanged = (
+      context: ClaudeSessionContext,
+      mode: ProviderInteractionMode,
+    ): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const stamp = yield* makeEventStamp();
+        yield* offerRuntimeEvent({
+          type: "interaction.mode.changed",
+          eventId: stamp.eventId,
+          provider: PROVIDER,
+          createdAt: stamp.createdAt,
+          threadId: context.session.threadId,
+          ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+          payload: { interactionMode: mode },
+        });
+      });
+
     const completeTurn = (
       context: ClaudeSessionContext,
       status: ProviderRuntimeTurnStatus,
@@ -1677,6 +1710,11 @@ function makeClaudeAdapter(options?: ClaudeAdapterLiveOptions) {
 
           const toolName = block.name;
           const itemType = classifyToolItemType(toolName);
+
+          const resolvedInteractionMode = interactionModeForTool(toolName);
+          if (resolvedInteractionMode) {
+            yield* emitInteractionModeChanged(context, resolvedInteractionMode);
+          }
           const toolInput =
             typeof block.input === "object" && block.input !== null
               ? (block.input as Record<string, unknown>)

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -12,7 +12,7 @@ import {
   TrimmedNonEmptyString,
   TurnId,
 } from "./baseSchemas";
-import { ProviderKind } from "./orchestration";
+import { ProviderInteractionMode, ProviderKind } from "./orchestration";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const UnknownRecordSchema = Schema.Record(Schema.String, Schema.Unknown);
@@ -189,6 +189,7 @@ const ProviderRuntimeEventType = Schema.Literals([
   "files.persisted",
   "runtime.warning",
   "runtime.error",
+  "interaction.mode.changed",
 ]);
 export type ProviderRuntimeEventType = typeof ProviderRuntimeEventType.Type;
 
@@ -239,6 +240,7 @@ const DeprecationNoticeType = Schema.Literal("deprecation.notice");
 const FilesPersistedType = Schema.Literal("files.persisted");
 const RuntimeWarningType = Schema.Literal("runtime.warning");
 const RuntimeErrorType = Schema.Literal("runtime.error");
+const InteractionModeChangedType = Schema.Literal("interaction.mode.changed");
 
 const ProviderRuntimeEventBase = Schema.Struct({
   eventId: EventId,
@@ -940,6 +942,19 @@ const ProviderRuntimeErrorEvent = Schema.Struct({
 });
 export type ProviderRuntimeErrorEvent = typeof ProviderRuntimeErrorEvent.Type;
 
+const InteractionModeChangedPayload = Schema.Struct({
+  interactionMode: ProviderInteractionMode,
+});
+export type InteractionModeChangedPayload = typeof InteractionModeChangedPayload.Type;
+
+const ProviderRuntimeInteractionModeChangedEvent = Schema.Struct({
+  ...ProviderRuntimeEventBase.fields,
+  type: InteractionModeChangedType,
+  payload: InteractionModeChangedPayload,
+});
+export type ProviderRuntimeInteractionModeChangedEvent =
+  typeof ProviderRuntimeInteractionModeChangedEvent.Type;
+
 export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeSessionStartedEvent,
   ProviderRuntimeSessionConfiguredEvent,
@@ -988,6 +1003,7 @@ export const ProviderRuntimeEventV2 = Schema.Union([
   ProviderRuntimeFilesPersistedEvent,
   ProviderRuntimeWarningEvent,
   ProviderRuntimeErrorEvent,
+  ProviderRuntimeInteractionModeChangedEvent,
 ]);
 export type ProviderRuntimeEventV2 = typeof ProviderRuntimeEventV2.Type;
 


### PR DESCRIPTION
## What Changed

- Added `interaction.mode.changed` runtime event to the shared contracts layer (`ProviderRuntimeEvent`)
- Claude adapter now detects `EnterPlanMode` and `ExitPlanMode` tool calls in stream events (`content_block_start`) and emits `interaction.mode.changed` to propagate the mode transition
- Orchestration ingestion layer handles the new event and dispatches `thread.interaction-mode.set` to update the thread's read model, which the UI observes
- Added 4 tests: 2 in ClaudeAdapter (emit on enter/exit) and 2 in ProviderRuntimeIngestion (dispatch on change, dedup on same mode)

## Why

When the Claude agent autonomously decides to enter plan mode (i.e., the agent calls `EnterPlanMode` on its own without the user toggling it from the UI), the T3 Code UI didn't reflect the mode change. The user would remain in "default" mode visually while the agent was already operating in plan mode internally.

## Approach and Certain Trade-off's I faced

1- **Manual tool mapping required**. Due to the Claude SDK only exposing setPermissionMode() with no `getter`, we detect mode changes by intercepting tool names in stream events. If Claude adds new interaction modes in the future, the mapping in `interactionModeForTool()` must be updated manually.

2- **Codex does not support this behavior**. I realized that Codex has no mechanism for the agent to autonomously enter plan mode from a message, therefore, I intended to keep this PR as Claude-only for now.

## UI Changes

### Before

https://github.com/user-attachments/assets/6f7f153c-9e6e-4c0c-97c6-e1218664dadf

Notice "Chat" incorrectly persisted despite Claude entering plan mode.

### After


https://github.com/user-attachments/assets/12663d6e-ae55-413b-a514-b851cf4d4b46



Notice "Chat => Plan" transition upon Claude entering plan mode.
... and "Plan => Chat" transition upon Claude exiting plan mode.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new cross-layer runtime event and updates orchestration ingestion to mutate thread interaction mode, which could affect UI state for all providers if mis-emitted or mis-handled. Scope is contained and covered by new adapter/ingestion tests, lowering regression risk.
> 
> **Overview**
> Adds a new runtime event `interaction.mode.changed` to shared provider-runtime contracts, carrying the current `interactionMode`.
> 
> Updates the Claude provider adapter to detect `EnterPlanMode`/`ExitPlanMode` tool-use starts in the stream and emit `interaction.mode.changed` accordingly.
> 
> Extends `ProviderRuntimeIngestion` to translate `interaction.mode.changed` into a `thread.interaction-mode.set` command **only when the mode differs**, with tests covering both mode updates and deduping duplicate mode events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e21c2d7613b62c95ca59ebfff4ff86c214ab499c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reflect Claude's autonomous plan mode transitions to thread interaction mode
> - Adds `EnterPlanMode` and `ExitPlanMode` tool-use detection in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/1452/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), emitting `interaction.mode.changed` runtime events with the corresponding mode (`plan` or `default`).
> - Adds a new `interaction.mode.changed` handler in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/1452/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) that dispatches a `thread.interaction-mode.set` command when the incoming mode differs from the thread's current mode.
> - Extends the `ProviderRuntimeEventV2` union in [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/1452/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7) with the new `interaction.mode.changed` event type and its `interactionMode` payload.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e21c2d7.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->