### PR TITLE
fix(desktop): ensure all windows are destroyed before launching the NSIS installer during update process

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -810,7 +810,7 @@ async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed
   clearUpdatePollTimer();
   try {
     await stopBackendAndWaitForExit();
-    // Destroy all windows before launching the NSIS installer
+    // Destroy all windows before launching the NSIS installer to avoid the installer finding live windows it needs to close.
     for (const win of BrowserWindow.getAllWindows()) {
       win.destroy();
     }
@@ -1392,7 +1392,7 @@ app
   });
 
 app.on("window-all-closed", () => {
-  if (process.platform !== "darwin") {
+  if (process.platform !== "darwin" && !isQuitting) {
     app.quit();
   }
 });


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Fixes https://github.com/pingdotgg/t3code/issues/1460

## Why

Common pattern in Electron apps using electron-updater with NSIS on Windows.

Change can be done in one-liner but, is easier to understand this way.
`BrowserWindow.getAllWindows().forEach(w => w.close());`

## UI Changes

No UI Changes

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Destroy all windows before launching the NSIS installer during desktop app update
> - In `installDownloadedUpdate` in [main.ts](https://github.com/pingdotgg/t3code/pull/1461/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb), all `BrowserWindow` instances are now explicitly destroyed before invoking the updater, preventing stale windows from blocking the NSIS installer.
> - `autoUpdater.quitAndInstall` is now called with `(true, true)` instead of no arguments to force quit and silent install.
> - The `window-all-closed` handler is updated to skip `app.quit()` when `isQuitting` is already `true` on non-macOS platforms, avoiding a double-quit during the update flow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb20a2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->