### PR TITLE
Refactor Codex adapter lifecycle helpers

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -20,6 +20,7 @@ import {
   ProviderItemId,
   ThreadId,
   TurnId,
+  ProviderSendTurnInput,
 } from "@t3tools/contracts";
 import { Effect, FileSystem, Layer, Queue, Schema, ServiceMap, Stream } from "effect";
 
@@ -1413,8 +1414,8 @@ const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   );
 
   const resolveAttachment = Effect.fn("resolveAttachment")(function* (
-    input: Parameters<CodexAdapterShape["sendTurn"]>[0],
-    attachment: NonNullable<Parameters<CodexAdapterShape["sendTurn"]>[0]["attachments"]>[number],
+    input: ProviderSendTurnInput,
+    attachment: NonNullable<ProviderSendTurnInput["attachments"]>[number],
   ) {
     const attachmentPath = resolveAttachmentPath({
       attachmentsDir: serverConfig.attachmentsDir,


### PR DESCRIPTION
- Split adapter setup into named Effect.fn helpers
- Keep listener registration and cleanup explicit

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change in the Codex provider adapter; primary risk is subtle lifecycle/cleanup differences around manager acquisition and event listener registration/shutdown.
> 
> **Overview**
> Refactors `apps/server/src/provider/Layers/CodexAdapter.ts` to break `makeCodexAdapter` into named `Effect.fn` helpers, improving stack traces and making the lifecycle steps more explicit.
> 
> This extracts helpers for manager acquisition (`acquireManager`), attachment loading/encoding (`resolveAttachment` used by `sendTurn`), and event listener registration/cleanup (`registerListener`/`unregisterListener` plus `writeNativeEvent`), while keeping the adapter’s public operations and error mapping behavior the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b9c9b3b12aec6cd7a5f37764063e5720487ffa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor `CodexAdapter` lifecycle helpers into named `Effect.fn` generators
> Restructures [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/1478/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) to use named `Effect.fn` generators throughout, improving traceability in Effect traces.
>
> - Extracts `acquireManager` as a standalone helper that resolves an existing manager from options or constructs one via `CodexAppServerManager`
> - Adds `resolveAttachment` helper to consolidate inline file-reading logic from `sendTurn`, using `Effect.forEach` with concurrency 1
> - Extracts `registerListener` and `unregisterListener` as named helpers wired via `Effect.acquireRelease`, and adds `writeNativeEvent` to isolate native event logging
> - No behavioral changes; all handler logic (session management, turn sending, thread operations) is preserved as-is
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b9c9b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->