### PR TITLE
fix(web): linkify Windows C:/ paths in terminal output

### DIFF
--- a/apps/web/src/terminal-links.test.ts
+++ b/apps/web/src/terminal-links.test.ts
@@ -43,6 +43,32 @@ describe("extractTerminalLinks", () => {
       },
     ]);
   });
+
+  it("finds Windows absolute paths with forward slashes", () => {
+    const line = "see C:/Users/someone/project/src/file.ts:42 for details";
+    const path = "C:/Users/someone/project/src/file.ts:42";
+    const start = line.indexOf(path);
+    expect(extractTerminalLinks(line)).toEqual([
+      {
+        kind: "path",
+        text: path,
+        start,
+        end: start + path.length,
+      },
+    ]);
+  });
+
+  it("trims trailing punctuation from Windows forward-slash paths", () => {
+    const line = "(C:/tmp/x.ts).";
+    expect(extractTerminalLinks(line)).toEqual([
+      {
+        kind: "path",
+        text: "C:/tmp/x.ts",
+        start: 1,
+        end: 12,
+      },
+    ]);
+  });
 });
 
 describe("resolvePathLinkTarget", () => {
@@ -59,6 +85,12 @@ describe("resolvePathLinkTarget", () => {
     expect(
       resolvePathLinkTarget("/Users/julius/project/src/main.ts:12", "/Users/julius/project"),
     ).toBe("/Users/julius/project/src/main.ts:12");
+  });
+
+  it("keeps Windows absolute paths with forward slashes unchanged", () => {
+    expect(
+      resolvePathLinkTarget("C:/Users/julius/project/src/main.ts:12", "C:\\Users\\julius\\project"),
+    ).toBe("C:/Users/julius/project/src/main.ts:12");
   });
 });
 

--- a/apps/web/src/terminal-links.ts
+++ b/apps/web/src/terminal-links.ts
@@ -11,7 +11,7 @@ export interface TerminalLinkMatch {
 
 const URL_PATTERN = /https?:\/\/[^\s"'`<>]+/g;
 const FILE_PATH_PATTERN =
-  /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:\\|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}/g;
+  /(?:~\/|\.{1,2}\/|\/|[A-Za-z]:[\\/]|\\\\)[^\s"'`<>]+|[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}/g;
 const TRAILING_PUNCTUATION_PATTERN = /[.,;!?]+$/;
 
 function trimClosingDelimiters(value: string): string {

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -175,7 +175,7 @@ describe("WsTransport", () => {
     expect(warnSpy).toHaveBeenNthCalledWith(
       1,
       "Dropped inbound WebSocket envelope",
-      "SyntaxError: Expected property name or '}' in JSON at position 2 (line 1 column 3)",
+      expect.stringMatching(/^SyntaxError:/),
     );
     expect(warnSpy).toHaveBeenNthCalledWith(
       2,


### PR DESCRIPTION
## What changed

- `FILE_PATH_PATTERN` now treats `X:/` like `X:\` so paths such as `C:/Users/.../file.ts:42` get linkified (resolution already accepted both separators).
- Tests for extraction, trailing punctuation, and `resolvePathLinkTarget` for `C:/...`.
- `wsTransport` malformed-envelope test: match any `SyntaxError:` prefix — Bun's `JSON.parse` message differs from the old hard-coded V8 string.

## Why

Some tools print Windows paths with forward slashes. Those lines weren't linkified while backslash paths were.

## UI

No layout change; only paths that were plain text before can become links. No screenshots.

## Testing

- `bun run lint`, `bun typecheck`
- `bun run test --filter=@t3tools/web`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small regex tweak to terminal link detection plus test-only adjustments; main behavior change is additional paths becoming clickable.
> 
> **Overview**
> Terminal output linkification now recognizes Windows absolute paths that use forward slashes (e.g. `C:/...`) by broadening `FILE_PATH_PATTERN`, and adds coverage for extraction, punctuation trimming, and `resolvePathLinkTarget` behavior for these paths.
> 
> The `WsTransport` malformed-envelope test assertion is loosened to accept any `SyntaxError:` prefix so it’s resilient across JS runtimes with different `JSON.parse` error strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d32754364a293ed46968ca3ae53af20782aa5d9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `FILE_PATH_PATTERN` to linkify Windows `C:/` paths in terminal output
> Updates the Windows path regex in [terminal-links.ts](https://github.com/pingdotgg/t3code/pull/1483/files#diff-5f57eb38e8e99e705308a736729815ef1ec005cf2f20cca912a9f7abcf28c110) to accept either a backslash or forward slash after the drive letter (`[A-Za-z]:[\\/ ]`), so paths like `C:/Users/...` are now detected and linkified alongside the existing `C:\...` support.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d327543.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->