### PR TITLE
fix(web): compact chat header actions into an overflow menu

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -54,6 +54,7 @@ import { readNativeApi } from "~/nativeApi";
 interface GitActionsControlProps {
   gitCwd: string | null;
   activeThreadId: ThreadId | null;
+  inMenu?: boolean;
 }
 
 interface PendingDefaultBranchAction {
@@ -203,7 +204,11 @@ function GitQuickActionIcon({ quickAction }: { quickAction: GitQuickAction }) {
   return <InfoIcon className={iconClassName} />;
 }
 
-export default function GitActionsControl({ gitCwd, activeThreadId }: GitActionsControlProps) {
+export default function GitActionsControl({
+  gitCwd,
+  activeThreadId,
+  inMenu,
+}: GitActionsControlProps) {
   const threadToastData = useMemo(
     () => (activeThreadId ? { threadId: activeThreadId } : undefined),
     [activeThreadId],
@@ -737,6 +742,53 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
   );
 
   if (!gitCwd) return null;
+
+  if (inMenu) {
+    return (
+      <>
+        {gitActionMenuItems.map((item) => {
+          const disabledReason = getMenuActionDisabledReason({
+            item,
+            gitStatus: gitStatusForActions,
+            isBusy: isGitActionRunning,
+            hasOriginRemote,
+          });
+          if (item.disabled && disabledReason) {
+            return (
+              <Popover key={`${item.id}-${item.label}`}>
+                <PopoverTrigger
+                  openOnHover
+                  nativeButton={false}
+                  render={<span className="block w-max cursor-not-allowed" />}
+                >
+                  <MenuItem className="w-full" disabled>
+                    <GitActionItemIcon icon={item.icon} />
+                    {item.label}
+                  </MenuItem>
+                </PopoverTrigger>
+                <PopoverPopup tooltipStyle side="left" align="center">
+                  {disabledReason}
+                </PopoverPopup>
+              </Popover>
+            );
+          }
+
+          return (
+            <MenuItem
+              key={`${item.id}-${item.label}`}
+              disabled={item.disabled}
+              onClick={() => {
+                openDialogForMenuItem(item);
+              }}
+            >
+              <GitActionItemIcon icon={item.icon} />
+              {item.label}
+            </MenuItem>
+          );
+        })}
+      </>
+    );
+  }
 
   return (
     <>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -4,15 +4,20 @@ import {
   type ResolvedKeybindingsConfig,
   type ThreadId,
 } from "@t3tools/contracts";
-import { memo } from "react";
+import { EllipsisIcon, DiffIcon, TerminalSquareIcon, PlayIcon, FolderOpenIcon } from "lucide-react";
+import { memo, useEffect, useRef, useState } from "react";
 import GitActionsControl from "../GitActionsControl";
-import { DiffIcon, TerminalSquareIcon } from "lucide-react";
 import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Menu, MenuItem, MenuPopup, MenuSeparator as MenuDivider, MenuTrigger } from "../ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
 import { Toggle } from "../ui/toggle";
 import { SidebarTrigger } from "../ui/sidebar";
 import { OpenInPicker } from "./OpenInPicker";
+import { readNativeApi } from "~/nativeApi";
+
+const HEADER_ACTIONS_COMPACT_BREAKPOINT_PX = 860;
 
 interface ChatHeaderProps {
   activeThreadId: ThreadId;
@@ -61,8 +66,35 @@ export const ChatHeader = memo(function ChatHeader({
   onToggleTerminal,
   onToggleDiff,
 }: ChatHeaderProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [useOverflowPopover, setUseOverflowPopover] = useState(false);
+  const hasOverflowActions = activeProjectScripts !== undefined || activeProjectName !== undefined;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const updateLayout = (width: number) => {
+      setUseOverflowPopover(width < HEADER_ACTIONS_COMPACT_BREAKPOINT_PX);
+    };
+
+    updateLayout(container.clientWidth);
+
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      updateLayout(entry.contentRect.width);
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2">
+    <div
+      ref={containerRef}
+      className="@container/header-actions flex min-w-0 flex-1 items-center gap-2"
+    >
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
         <SidebarTrigger className="size-7 shrink-0 md:hidden" />
         <h2
@@ -83,7 +115,53 @@ export const ChatHeader = memo(function ChatHeader({
         )}
       </div>
       <div className="flex shrink-0 items-center justify-end gap-2 @3xl/header-actions:gap-3">
-        {activeProjectScripts && (
+        {hasOverflowActions && useOverflowPopover ? (
+          <Menu>
+            <MenuTrigger
+              render={<Button size="icon-xs" variant="outline" aria-label="More actions" />}
+            >
+              <EllipsisIcon className="size-4" />
+            </MenuTrigger>
+            <MenuPopup align="end">
+              {activeProjectScripts && activeProjectScripts.length > 0 && (
+                <>
+                  <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">
+                    Run script
+                  </div>
+                  {activeProjectScripts.slice(0, 5).map((script) => (
+                    <MenuItem key={script.id} onClick={() => onRunProjectScript(script)}>
+                      <PlayIcon className="size-4 shrink-0" />
+                      {script.name}
+                    </MenuItem>
+                  ))}
+                  {activeProjectScripts.length > 5 && (
+                    <MenuItem disabled className="text-muted-foreground">
+                      +{activeProjectScripts.length - 5} more
+                    </MenuItem>
+                  )}
+                  <MenuDivider />
+                </>
+              )}
+              {activeProjectName && (
+                <>
+                  <MenuItem
+                    onClick={() => {
+                      const api = readNativeApi();
+                      if (!api || !openInCwd) return;
+                      void api.shell.openInEditor(openInCwd, "file-manager");
+                    }}
+                  >
+                    <FolderOpenIcon className="size-4 shrink-0" />
+                    Open folder
+                  </MenuItem>
+                  <MenuDivider />
+                  <GitActionsControl inMenu gitCwd={gitCwd} activeThreadId={activeThreadId} />
+                </>
+              )}
+            </MenuPopup>
+          </Menu>
+        ) : null}
+        {!useOverflowPopover && activeProjectScripts && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}
             keybindings={keybindings}
@@ -94,14 +172,16 @@ export const ChatHeader = memo(function ChatHeader({
             onDeleteScript={onDeleteProjectScript}
           />
         )}
-        {activeProjectName && (
+        {!useOverflowPopover && activeProjectName && (
           <OpenInPicker
             keybindings={keybindings}
             availableEditors={availableEditors}
             openInCwd={openInCwd}
           />
         )}
-        {activeProjectName && <GitActionsControl gitCwd={gitCwd} activeThreadId={activeThreadId} />}
+        {!useOverflowPopover && activeProjectName && (
+          <GitActionsControl gitCwd={gitCwd} activeThreadId={activeThreadId} />
+        )}
         <Tooltip>
           <TooltipTrigger
             render={


### PR DESCRIPTION
## Summary
- keep the terminal and diff controls pinned in the chat header while moving scripts, open-folder, and git actions into a compact overflow menu on narrower widths
- replace the oversized overflow popover with a polished menu treatment that matches the app's compact composer controls
- add a menu-only git action render path so the compact header can reuse the existing git workflows and disabled-state hints inline

## Verification
- bun fmt
- bun lint
- bun typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/layout refactoring in the chat header plus a new `GitActionsControl` menu-rendering mode; risk is limited to potential regressions in header action availability/disabled states at different widths.
> 
> **Overview**
> **Chat header actions are now responsive.** When the header is narrower than a fixed breakpoint, project scripts, “open folder”, and git actions move into an `…` overflow menu while the terminal/diff toggles remain pinned.
> 
> **`GitActionsControl` gains a menu-only render path.** A new `inMenu` prop lets the component emit `MenuItem`s (including disabled-state tooltips) so the same git workflows can be reused inside the new overflow menu.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 496fde5613fc8ba24962f5f2349c01e972481e93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse chat header actions into an overflow menu below 860px width
> - [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/1485/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c) uses a `ResizeObserver` to toggle a compact mode when the container is narrower than 860px, replacing inline controls with a 'More actions' menu.
> - The overflow menu includes up to 5 project scripts (with a disabled '+N more' item if there are more), an 'Open folder' action, and Git actions via a new `inMenu` prop on `GitActionsControl`.
> - [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/1485/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) gains an `inMenu` prop that renders Git actions as `MenuItem` entries with popover tooltips for disabled items instead of the previous inline UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 496fde5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->