### PR TITLE
Skip a unit test that is using a bash script on Windows

### DIFF
--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -186,58 +186,60 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
         ),
       );
 
-      it.effect("inherits PATH when launching the codex probe with a CODEX_HOME override", () =>
-        Effect.gen(function* () {
-          const fileSystem = yield* FileSystem.FileSystem;
-          const path = yield* Path.Path;
-          const binDir = yield* fileSystem.makeTempDirectoryScoped({
-            prefix: "t3-test-codex-bin-",
-          });
-          const codexPath = path.join(binDir, "codex");
-          yield* fileSystem.writeFileString(
-            codexPath,
-            [
-              "#!/bin/sh",
-              'if [ "$1" = "--version" ]; then',
-              '  echo "codex-cli 1.0.0"',
-              "  exit 0",
-              "fi",
-              'if [ "$1" = "login" ] && [ "$2" = "status" ]; then',
-              '  echo "Logged in using ChatGPT"',
-              "  exit 0",
-              "fi",
-              'echo "unexpected args: $*" >&2',
-              "exit 1",
-              "",
-            ].join("\n"),
-          );
-          yield* fileSystem.chmod(codexPath, 0o755);
-          const customCodexHome = yield* fileSystem.makeTempDirectoryScoped({
-            prefix: "t3-test-codex-home-",
-          });
-          const previousPath = process.env.PATH;
-          process.env.PATH = binDir;
-
-          try {
-            const serverSettingsLayer = ServerSettingsService.layerTest({
-              providers: {
-                codex: {
-                  homePath: customCodexHome,
-                },
-              },
+      it.effect.skipIf(process.platform === "win32")(
+        "inherits PATH when launching the codex probe with a CODEX_HOME override",
+        () =>
+          Effect.gen(function* () {
+            const fileSystem = yield* FileSystem.FileSystem;
+            const path = yield* Path.Path;
+            const binDir = yield* fileSystem.makeTempDirectoryScoped({
+              prefix: "t3-test-codex-bin-",
             });
-
-            const status = yield* checkCodexProviderStatus().pipe(
-              Effect.provide(serverSettingsLayer),
+            const codexPath = path.join(binDir, "codex");
+            yield* fileSystem.writeFileString(
+              codexPath,
+              [
+                "#!/bin/sh",
+                'if [ "$1" = "--version" ]; then',
+                '  echo "codex-cli 1.0.0"',
+                "  exit 0",
+                "fi",
+                'if [ "$1" = "login" ] && [ "$2" = "status" ]; then',
+                '  echo "Logged in using ChatGPT"',
+                "  exit 0",
+                "fi",
+                'echo "unexpected args: $*" >&2',
+                "exit 1",
+                "",
+              ].join("\n"),
             );
-            assert.strictEqual(status.provider, "codex");
-            assert.strictEqual(status.installed, true);
-            assert.strictEqual(status.status, "ready");
-            assert.strictEqual(status.authStatus, "authenticated");
-          } finally {
-            process.env.PATH = previousPath;
-          }
-        }),
+            yield* fileSystem.chmod(codexPath, 0o755);
+            const customCodexHome = yield* fileSystem.makeTempDirectoryScoped({
+              prefix: "t3-test-codex-home-",
+            });
+            const previousPath = process.env.PATH;
+            process.env.PATH = binDir;
+
+            try {
+              const serverSettingsLayer = ServerSettingsService.layerTest({
+                providers: {
+                  codex: {
+                    homePath: customCodexHome,
+                  },
+                },
+              });
+
+              const status = yield* checkCodexProviderStatus().pipe(
+                Effect.provide(serverSettingsLayer),
+              );
+              assert.strictEqual(status.provider, "codex");
+              assert.strictEqual(status.installed, true);
+              assert.strictEqual(status.status, "ready");
+              assert.strictEqual(status.authStatus, "authenticated");
+            } finally {
+              process.env.PATH = previousPath;
+            }
+          }),
       );
 
       it.effect("returns unavailable when codex is missing", () =>


### PR DESCRIPTION
## What Changed

Skip PATH inheritance unit test on Windows

## Why

It's using a bash script and that won't work on win32

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes test execution by skipping a bash-script-based unit test on Windows, with no production code impact.
> 
> **Overview**
> Updates `ProviderRegistry.test.ts` to *skip on Windows* the `checkCodexProviderStatus` PATH-inheritance test that writes/executes a `#!/bin/sh` mock `codex` binary, preventing win32 CI failures while keeping the test behavior unchanged on non-Windows platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af5b0b0af46551685f00a9a9b28e9f882203bce7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Skip bash-dependent `checkCodexProviderStatus` test on Windows
> The test `"inherits PATH when launching the codex probe with a CODEX_HOME override"` in [ProviderRegistry.test.ts](https://github.com/pingdotgg/t3code/pull/1490/files#diff-28b6372c54d8310c6909678b338ea3a67f48ea13b57386544bfe5ffdfa742b6f) uses a bash script incompatible with Windows. Replaces `it.effect(...)` with `it.effect.skipIf(process.platform === "win32")(...)` to skip execution on Windows while leaving the test body unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af5b0b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->