### PR TITLE
Add eol=lf to .gitattributes for Windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# git autocrlf=true converts LF to CRLF on Windows, causing issues with oxfmt
+* text=auto eol=lf


### PR DESCRIPTION
## What Changed

Added eol=lf to .gitattributes

## Why

On Windows, the default is autocrlf=true which checks out files with eof=crlf which then creates problems for oxfmt which expects eof=lf

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: repository metadata-only change that affects how files are checked out, not runtime behavior. Main risk is unexpected line-ending normalization in existing working trees.
> 
> **Overview**
> Adds a new `.gitattributes` to **force LF line endings** (`* text=auto eol=lf`) to prevent Windows `autocrlf` from checking out CRLF and breaking `oxfmt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31a4258672d50ab67f5b89c38867e1ef1c794196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `eol=lf` to `.gitattributes` to enforce LF line endings for Windows users
> Adds a [`.gitattributes`](https://github.com/pingdotgg/t3code/pull/1491/files#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393e) file with `text=auto eol=lf` to ensure all text files use LF line endings regardless of the OS. This prevents CRLF line endings from being committed by Windows users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 31a4258.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->