### PR TITLE
Detect command not found when checking codex/claude CLI on Windows

### DIFF
--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -37,7 +37,7 @@ function normalizeSpawnError(command: string, args: readonly string[], error: un
   return new Error(`Failed to run ${commandLabel(command, args)}: ${error.message}`);
 }
 
-function isWindowsCommandNotFound(code: number | null, stderr: string): boolean {
+export function isWindowsCommandNotFound(code: number | null, stderr: string): boolean {
   if (process.platform !== "win32") return false;
   if (code === 9009) return true;
   return /is not recognized as an internal or external command/i.test(stderr);

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -13,13 +13,13 @@ import { resolveContextWindow, resolveEffort } from "@t3tools/shared/model";
 
 import {
   buildServerProvider,
-  collectStreamAsString,
   DEFAULT_TIMEOUT_MS,
   detailFromResult,
   extractAuthBoolean,
   isCommandMissingCause,
   parseGenericCliVersion,
   providerModelsFromSettings,
+  spawnAndCollect,
   type CommandResult,
 } from "../providerSnapshot";
 import { makeManagedServerProvider } from "../makeManagedServerProvider";
@@ -198,7 +198,6 @@ export function parseClaudeAuthStatusFromOutput(result: CommandResult): {
 
 const runClaudeCommand = (args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
-    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const claudeSettings = yield* Effect.service(ServerSettingsService).pipe(
       Effect.flatMap((service) => service.getSettings),
       Effect.map((settings) => settings.providers.claudeAgent),
@@ -206,19 +205,8 @@ const runClaudeCommand = (args: ReadonlyArray<string>) =>
     const command = ChildProcess.make(claudeSettings.binaryPath, [...args], {
       shell: process.platform === "win32",
     });
-
-    const child = yield* spawner.spawn(command);
-    const [stdout, stderr, exitCode] = yield* Effect.all(
-      [
-        collectStreamAsString(child.stdout),
-        collectStreamAsString(child.stderr),
-        child.exitCode.pipe(Effect.map(Number)),
-      ],
-      { concurrency: "unbounded" },
-    );
-
-    return { stdout, stderr, code: exitCode } satisfies CommandResult;
-  }).pipe(Effect.scoped);
+    return yield* spawnAndCollect(claudeSettings.binaryPath, command);
+  });
 
 export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   function* (): Effect.fn.Return<

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -14,13 +14,13 @@ import { resolveEffort } from "@t3tools/shared/model";
 
 import {
   buildServerProvider,
-  collectStreamAsString,
   DEFAULT_TIMEOUT_MS,
   detailFromResult,
   extractAuthBoolean,
   isCommandMissingCause,
   parseGenericCliVersion,
   providerModelsFromSettings,
+  spawnAndCollect,
   type CommandResult,
 } from "../providerSnapshot";
 import { makeManagedServerProvider } from "../makeManagedServerProvider";
@@ -292,7 +292,6 @@ export const hasCustomModelProvider = readCodexConfigModelProvider().pipe(
 
 const runCodexCommand = (args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
-    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const settingsService = yield* ServerSettingsService;
     const codexSettings = yield* settingsService.getSettings.pipe(
       Effect.map((settings) => settings.providers.codex),
@@ -304,19 +303,8 @@ const runCodexCommand = (args: ReadonlyArray<string>) =>
         ...(codexSettings.homePath ? { CODEX_HOME: codexSettings.homePath } : {}),
       },
     });
-
-    const child = yield* spawner.spawn(command);
-    const [stdout, stderr, exitCode] = yield* Effect.all(
-      [
-        collectStreamAsString(child.stdout),
-        collectStreamAsString(child.stderr),
-        child.exitCode.pipe(Effect.map(Number)),
-      ],
-      { concurrency: "unbounded" },
-    );
-
-    return { stdout, stderr, code: exitCode } satisfies CommandResult;
-  }).pipe(Effect.scoped);
+    return yield* spawnAndCollect(codexSettings.binaryPath, command);
+  });
 
 export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(
   function* (): Effect.fn.Return<

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -5,7 +5,9 @@ import type {
   ServerProviderState,
 } from "@t3tools/contracts";
 import { Effect, Stream } from "effect";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { normalizeModelSlug } from "@t3tools/shared/model";
+import { isWindowsCommandNotFound } from "../processRunner";
 
 export const DEFAULT_TIMEOUT_MS = 4_000;
 
@@ -34,6 +36,26 @@ export function isCommandMissingCause(error: unknown): boolean {
   const lower = error.message.toLowerCase();
   return lower.includes("enoent") || lower.includes("notfound");
 }
+
+export const spawnAndCollect = (binaryPath: string, command: ChildProcess.Command) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const child = yield* spawner.spawn(command);
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [
+        collectStreamAsString(child.stdout),
+        collectStreamAsString(child.stderr),
+        child.exitCode.pipe(Effect.map(Number)),
+      ],
+      { concurrency: "unbounded" },
+    );
+
+    const result: CommandResult = { stdout, stderr, code: exitCode };
+    if (isWindowsCommandNotFound(exitCode, stderr)) {
+      return yield* Effect.fail(new Error(`spawn ${binaryPath} ENOENT`));
+    }
+    return result;
+  }).pipe(Effect.scoped);
 
 export function detailFromResult(
   result: CommandResult & { readonly timedOut?: boolean },


### PR DESCRIPTION
## What Changed

Use ```isWindowsCommandNotFound``` to check if codex/claude CLI is missing.
Extracted ```spawnAndCollect``` method to avoid copypasting the check.

## Why

On Windows, missing Codex CLI gives misleading message:
"Codex CLI is installed but failed to run. 'codex' is not recognized as an internal or external command, operable program or batch file."

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors provider health-check command execution and improves Windows-only error detection for missing CLIs, which mainly affects status reporting and messaging.
> 
> **Overview**
> Improves Windows handling for provider health checks by treating `cmd.exe` "command not recognized" failures as a missing CLI, so Codex/Claude report *not installed/on PATH* instead of a generic execution failure.
> 
> Extracts a shared `spawnAndCollect` helper in `providerSnapshot.ts` (used by `CodexProvider` and `ClaudeProvider`) and exports `isWindowsCommandNotFound` from `processRunner.ts` to centralize this detection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a2f12ccb6ed620f1839ca37e8b91573546ed525. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect command-not-found errors for Codex and Claude CLI on Windows
> - Adds a `spawnAndCollect` helper in [`providerSnapshot.ts`](https://github.com/pingdotgg/t3code/pull/1492/files#diff-62373f674410fb63637739f0efeb07b9ef79b579393ae2adf51567de0b812b26) that centralizes process spawning, stream collection, and Windows command-not-found detection.
> - Both [`ClaudeProvider`](https://github.com/pingdotgg/t3code/pull/1492/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) and [`CodexProvider`](https://github.com/pingdotgg/t3code/pull/1492/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) now delegate to `spawnAndCollect` instead of handling spawn logic inline.
> - Behavioral Change: when the CLI binary is missing on Windows, the effect now fails with an `ENOENT`-style error instead of returning a successful `CommandResult` with exit code 9009.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a2f12c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->