### PR TITLE
feat(web): upgrade project and thread deep linking

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -531,8 +531,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
         setProjectDraftThreadId(activeProject.id, storedDraftThread.threadId, input);
         if (storedDraftThread.threadId !== threadId) {
           await navigate({
-            to: "/$threadId",
-            params: { threadId: storedDraftThread.threadId },
+            to: "/projects/$projectId/threads/$threadId",
+            params: { projectId: activeProject.id, threadId: storedDraftThread.threadId },
           });
         }
         return storedDraftThread.threadId;
@@ -554,8 +554,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
         ...input,
       });
       await navigate({
-        to: "/$threadId",
-        params: { threadId: nextThreadId },
+        to: "/projects/$projectId/threads/$threadId",
+        params: { projectId: activeProject.id, threadId: nextThreadId },
       });
       return nextThreadId;
     },
@@ -1183,16 +1183,20 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [keybindings],
   );
   const onToggleDiff = useCallback(() => {
+    if (!activeThread) {
+      return;
+    }
+
     void navigate({
-      to: "/$threadId",
-      params: { threadId },
+      to: "/projects/$projectId/threads/$threadId",
+      params: { projectId: activeThread.projectId, threadId },
       replace: true,
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
         return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
       },
     });
-  }, [diffOpen, navigate, threadId]);
+  }, [activeThread, diffOpen, navigate, threadId]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -3117,8 +3121,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
         // Signal that the plan sidebar should open on the new thread.
         planSidebarOpenOnNextThreadRef.current = true;
         return navigate({
-          to: "/$threadId",
-          params: { threadId: nextThreadId },
+          to: "/projects/$projectId/threads/$threadId",
+          params: { projectId: activeThread.projectId, threadId: nextThreadId },
         });
       })
       .catch(async (err) => {
@@ -3501,9 +3505,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const expandedImageItem = expandedImage ? expandedImage.images[expandedImage.index] : null;
   const onOpenTurnDiff = useCallback(
     (turnId: TurnId, filePath?: string) => {
+      if (!activeThread) {
+        return;
+      }
+
       void navigate({
-        to: "/$threadId",
-        params: { threadId },
+        to: "/projects/$projectId/threads/$threadId",
+        params: { projectId: activeThread.projectId, threadId },
         search: (previous) => {
           const rest = stripDiffSearchParams(previous);
           return filePath
@@ -3512,7 +3520,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         },
       });
     },
-    [navigate, threadId],
+    [activeThread, navigate, threadId],
   );
   const onRevertUserMessage = (messageId: MessageId) => {
     const targetTurnCount = revertTurnCountByUserMessageId.get(messageId);

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -334,8 +334,8 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const selectTurn = (turnId: TurnId) => {
     if (!activeThread) return;
     void navigate({
-      to: "/$threadId",
-      params: { threadId: activeThread.id },
+      to: "/projects/$projectId/threads/$threadId",
+      params: { projectId: activeThread.projectId, threadId: activeThread.id },
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
         return { ...rest, diff: "1", diffTurnId: turnId };
@@ -345,8 +345,8 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const selectWholeConversation = () => {
     if (!activeThread) return;
     void navigate({
-      to: "/$threadId",
-      params: { threadId: activeThread.id },
+      to: "/projects/$projectId/threads/$threadId",
+      params: { projectId: activeThread.projectId, threadId: activeThread.id },
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
         return { ...rest, diff: "1" };

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -502,8 +502,8 @@ export default function Sidebar() {
       if (!latestThread) return;
 
       void navigate({
-        to: "/$threadId",
-        params: { threadId: latestThread.id },
+        to: "/projects/$projectId/threads/$threadId",
+        params: { projectId, threadId: latestThread.id },
       });
     },
     [appSettings.sidebarThreadSortOrder, navigate, threads],
@@ -733,9 +733,13 @@ export default function Sidebar() {
       clearTerminalState(threadId);
       if (shouldNavigateToFallback) {
         if (fallbackThreadId) {
+          const fallbackThread = threads.find((candidate) => candidate.id === fallbackThreadId);
           void navigate({
-            to: "/$threadId",
-            params: { threadId: fallbackThreadId },
+            to: "/projects/$projectId/threads/$threadId",
+            params: {
+              projectId: fallbackThread?.projectId ?? thread.projectId,
+              threadId: fallbackThreadId,
+            },
             replace: true,
           });
         } else {
@@ -959,9 +963,13 @@ export default function Sidebar() {
         clearSelection();
       }
       setSelectionAnchor(threadId);
+      const thread = threads.find((candidate) => candidate.id === threadId);
+      if (!thread) {
+        return;
+      }
       void navigate({
-        to: "/$threadId",
-        params: { threadId },
+        to: "/projects/$projectId/threads/$threadId",
+        params: { projectId: thread.projectId, threadId },
       });
     },
     [
@@ -970,6 +978,7 @@ export default function Sidebar() {
       rangeSelectTo,
       selectedThreadIds.size,
       setSelectionAnchor,
+      threads,
       toggleThreadSelection,
     ],
   );
@@ -1171,8 +1180,8 @@ export default function Sidebar() {
               }
               setSelectionAnchor(thread.id);
               void navigate({
-                to: "/$threadId",
-                params: { threadId: thread.id },
+                to: "/projects/$projectId/threads/$threadId",
+                params: { projectId: thread.projectId, threadId: thread.id },
               });
             }}
             onContextMenu={(event) => {

--- a/apps/web/src/components/ThreadRouteContent.tsx
+++ b/apps/web/src/components/ThreadRouteContent.tsx
@@ -1,0 +1,198 @@
+import { Suspense, lazy, type ReactNode, useCallback, useEffect, useState } from "react";
+import type { ThreadId } from "@t3tools/contracts";
+import { useMediaQuery } from "../hooks/useMediaQuery";
+import ChatView from "./ChatView";
+import { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
+import {
+  DiffPanelHeaderSkeleton,
+  DiffPanelLoadingState,
+  DiffPanelShell,
+  type DiffPanelMode,
+} from "./DiffPanelShell";
+import { Sheet, SheetPopup } from "./ui/sheet";
+import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "./ui/sidebar";
+
+const DiffPanel = lazy(() => import("./DiffPanel"));
+const DIFF_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 1180px)";
+const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
+const DIFF_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
+const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 26 * 16;
+const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
+
+const DiffPanelSheet = (props: {
+  children: ReactNode;
+  diffOpen: boolean;
+  onCloseDiff: () => void;
+}) => {
+  return (
+    <Sheet
+      open={props.diffOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          props.onCloseDiff();
+        }
+      }}
+    >
+      <SheetPopup
+        side="right"
+        showCloseButton={false}
+        keepMounted
+        className="w-[min(88vw,820px)] max-w-[820px] p-0"
+      >
+        {props.children}
+      </SheetPopup>
+    </Sheet>
+  );
+};
+
+const DiffLoadingFallback = (props: { mode: DiffPanelMode }) => {
+  return (
+    <DiffPanelShell mode={props.mode} header={<DiffPanelHeaderSkeleton />}>
+      <DiffPanelLoadingState label="Loading diff viewer..." />
+    </DiffPanelShell>
+  );
+};
+
+const LazyDiffPanel = (props: { mode: DiffPanelMode }) => {
+  return (
+    <DiffWorkerPoolProvider>
+      <Suspense fallback={<DiffLoadingFallback mode={props.mode} />}>
+        <DiffPanel mode={props.mode} />
+      </Suspense>
+    </DiffWorkerPoolProvider>
+  );
+};
+
+const DiffPanelInlineSidebar = (props: {
+  diffOpen: boolean;
+  onCloseDiff: () => void;
+  onOpenDiff: () => void;
+  renderDiffContent: boolean;
+}) => {
+  const { diffOpen, onCloseDiff, onOpenDiff, renderDiffContent } = props;
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        onOpenDiff();
+        return;
+      }
+      onCloseDiff();
+    },
+    [onCloseDiff, onOpenDiff],
+  );
+  const shouldAcceptInlineSidebarWidth = useCallback(
+    ({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }) => {
+      const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
+      if (!composerForm) return true;
+      const composerViewport = composerForm.parentElement;
+      if (!composerViewport) return true;
+      const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
+      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
+
+      const viewportStyle = window.getComputedStyle(composerViewport);
+      const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
+      const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
+      const viewportContentWidth = Math.max(
+        0,
+        composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
+      );
+      const formRect = composerForm.getBoundingClientRect();
+      const composerFooter = composerForm.querySelector<HTMLElement>(
+        "[data-chat-composer-footer='true']",
+      );
+      const composerRightActions = composerForm.querySelector<HTMLElement>(
+        "[data-chat-composer-actions='right']",
+      );
+      const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
+      const composerFooterGap = composerFooter
+        ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
+          Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
+          0
+        : 0;
+      const minimumComposerWidth =
+        COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
+      const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
+      const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
+      const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
+
+      if (previousSidebarWidth.length > 0) {
+        wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
+      } else {
+        wrapper.style.removeProperty("--sidebar-width");
+      }
+
+      return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
+    },
+    [],
+  );
+
+  return (
+    <SidebarProvider
+      defaultOpen={false}
+      open={diffOpen}
+      onOpenChange={onOpenChange}
+      className="w-auto min-h-0 flex-none bg-transparent"
+      style={{ "--sidebar-width": DIFF_INLINE_DEFAULT_WIDTH } as React.CSSProperties}
+    >
+      <Sidebar
+        side="right"
+        collapsible="offcanvas"
+        className="border-l border-border bg-card text-foreground"
+        resizable={{
+          minWidth: DIFF_INLINE_SIDEBAR_MIN_WIDTH,
+          shouldAcceptWidth: shouldAcceptInlineSidebarWidth,
+          storageKey: DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
+        }}
+      >
+        {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
+        <SidebarRail />
+      </Sidebar>
+    </SidebarProvider>
+  );
+};
+
+export function ThreadRouteContent(props: {
+  diffOpen: boolean;
+  onCloseDiff: () => void;
+  onOpenDiff: () => void;
+  threadId: ThreadId;
+}) {
+  const { diffOpen, onCloseDiff, onOpenDiff, threadId } = props;
+  const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
+  const [hasOpenedDiff, setHasOpenedDiff] = useState(diffOpen);
+
+  useEffect(() => {
+    if (diffOpen) {
+      setHasOpenedDiff(true);
+    }
+  }, [diffOpen]);
+
+  const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
+
+  if (!shouldUseDiffSheet) {
+    return (
+      <>
+        <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+          <ChatView key={threadId} threadId={threadId} />
+        </SidebarInset>
+        <DiffPanelInlineSidebar
+          diffOpen={diffOpen}
+          onCloseDiff={onCloseDiff}
+          onOpenDiff={onOpenDiff}
+          renderDiffContent={shouldRenderDiffContent}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+        <ChatView key={threadId} threadId={threadId} />
+      </SidebarInset>
+      <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={onCloseDiff}>
+        {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
+      </DiffPanelSheet>
+    </>
+  );
+}

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -63,8 +63,8 @@ export function useHandleNewThread() {
             return;
           }
           await navigate({
-            to: "/$threadId",
-            params: { threadId: storedDraftThread.threadId },
+            to: "/projects/$projectId/threads/$threadId",
+            params: { projectId, threadId: storedDraftThread.threadId },
           });
         })();
       }
@@ -100,8 +100,8 @@ export function useHandleNewThread() {
         applyStickyState(threadId);
 
         await navigate({
-          to: "/$threadId",
-          params: { threadId },
+          to: "/projects/$projectId/threads/$threadId",
+          params: { projectId, threadId },
         });
       })();
     },

--- a/apps/web/src/projectRoute.test.ts
+++ b/apps/web/src/projectRoute.test.ts
@@ -1,0 +1,99 @@
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+import { resolveProjectRouteTarget } from "./projectRoute";
+import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Project, type Thread } from "./types";
+
+function makeProject(overrides?: Partial<Project>): Project {
+  return {
+    id: ProjectId.makeUnsafe("project-1"),
+    name: "Repo",
+    cwd: "/repo",
+    defaultModelSelection: null,
+    expanded: false,
+    scripts: [],
+    ...overrides,
+  };
+}
+
+function makeThread(overrides?: Partial<Thread>): Thread {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread",
+    modelSelection: {
+      provider: "codex",
+      model: "gpt-5-codex",
+    },
+    runtimeMode: DEFAULT_RUNTIME_MODE,
+    interactionMode: DEFAULT_INTERACTION_MODE,
+    session: null,
+    messages: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-03-28T10:00:00.000Z",
+    updatedAt: "2026-03-28T10:00:00.000Z",
+    latestTurn: null,
+    branch: null,
+    worktreePath: null,
+    turnDiffSummaries: [],
+    activities: [],
+    ...overrides,
+  };
+}
+
+describe("resolveProjectRouteTarget", () => {
+  it("returns missing when the project does not exist", () => {
+    expect(
+      resolveProjectRouteTarget({
+        projectId: ProjectId.makeUnsafe("missing-project"),
+        projects: [],
+        threads: [],
+        threadSortOrder: "updated_at",
+      }),
+    ).toEqual({ kind: "missing" });
+  });
+
+  it("returns empty when the project has no threads", () => {
+    expect(
+      resolveProjectRouteTarget({
+        projectId: ProjectId.makeUnsafe("project-1"),
+        projects: [makeProject()],
+        threads: [],
+        threadSortOrder: "updated_at",
+      }),
+    ).toEqual({
+      kind: "empty",
+      project: makeProject(),
+    });
+  });
+
+  it("returns the latest thread for the project", () => {
+    expect(
+      resolveProjectRouteTarget({
+        projectId: ProjectId.makeUnsafe("project-1"),
+        projects: [makeProject()],
+        threads: [
+          makeThread({
+            id: ThreadId.makeUnsafe("thread-older"),
+            updatedAt: "2026-03-28T09:00:00.000Z",
+          }),
+          makeThread({
+            id: ThreadId.makeUnsafe("thread-newer"),
+            updatedAt: "2026-03-28T11:00:00.000Z",
+          }),
+          makeThread({
+            id: ThreadId.makeUnsafe("thread-other-project"),
+            projectId: ProjectId.makeUnsafe("project-2"),
+            updatedAt: "2026-03-28T12:00:00.000Z",
+          }),
+        ],
+        threadSortOrder: "updated_at",
+      }),
+    ).toEqual({
+      kind: "thread",
+      project: makeProject(),
+      threadId: ThreadId.makeUnsafe("thread-newer"),
+    });
+  });
+});

--- a/apps/web/src/projectRoute.thread.test.ts
+++ b/apps/web/src/projectRoute.thread.test.ts
@@ -1,0 +1,81 @@
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+import { resolveThreadRouteTarget } from "./projectRoute";
+import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "./types";
+
+function makeThread(overrides?: Partial<Thread>): Thread {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread",
+    modelSelection: {
+      provider: "codex",
+      model: "gpt-5-codex",
+    },
+    runtimeMode: DEFAULT_RUNTIME_MODE,
+    interactionMode: DEFAULT_INTERACTION_MODE,
+    session: null,
+    messages: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-03-28T10:00:00.000Z",
+    updatedAt: "2026-03-28T10:00:00.000Z",
+    latestTurn: null,
+    branch: null,
+    worktreePath: null,
+    turnDiffSummaries: [],
+    activities: [],
+    ...overrides,
+  };
+}
+
+describe("resolveThreadRouteTarget", () => {
+  it("returns a server thread project id", () => {
+    expect(
+      resolveThreadRouteTarget({
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        threads: [makeThread()],
+        draftThreadsByThreadId: {},
+      }),
+    ).toEqual({
+      kind: "thread",
+      projectId: ProjectId.makeUnsafe("project-1"),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+    });
+  });
+
+  it("returns a draft thread project id", () => {
+    expect(
+      resolveThreadRouteTarget({
+        threadId: ThreadId.makeUnsafe("draft-thread"),
+        threads: [],
+        draftThreadsByThreadId: {
+          [ThreadId.makeUnsafe("draft-thread")]: {
+            projectId: ProjectId.makeUnsafe("project-2"),
+            createdAt: "2026-03-28T10:00:00.000Z",
+            branch: null,
+            worktreePath: null,
+            envMode: "local",
+            runtimeMode: DEFAULT_RUNTIME_MODE,
+            interactionMode: DEFAULT_INTERACTION_MODE,
+          },
+        },
+      }),
+    ).toEqual({
+      kind: "thread",
+      projectId: ProjectId.makeUnsafe("project-2"),
+      threadId: ThreadId.makeUnsafe("draft-thread"),
+    });
+  });
+
+  it("returns missing when the thread cannot be resolved", () => {
+    expect(
+      resolveThreadRouteTarget({
+        threadId: ThreadId.makeUnsafe("missing-thread"),
+        threads: [],
+        draftThreadsByThreadId: {},
+      }),
+    ).toEqual({ kind: "missing" });
+  });
+});

--- a/apps/web/src/projectRoute.ts
+++ b/apps/web/src/projectRoute.ts
@@ -1,0 +1,85 @@
+import type { ProjectId, ThreadId } from "@t3tools/contracts";
+import type { SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import type { DraftThreadState } from "./composerDraftStore";
+import { sortThreadsForSidebar } from "./components/Sidebar.logic";
+import type { Project, Thread } from "./types";
+
+export type ProjectRouteTarget =
+  | {
+      kind: "missing";
+    }
+  | {
+      kind: "empty";
+      project: Project;
+    }
+  | {
+      kind: "thread";
+      project: Project;
+      threadId: ThreadId;
+    };
+
+export function resolveProjectRouteTarget(input: {
+  projectId: ProjectId;
+  projects: readonly Project[];
+  threads: readonly Thread[];
+  threadSortOrder: SidebarThreadSortOrder;
+}): ProjectRouteTarget {
+  const project = input.projects.find((candidate) => candidate.id === input.projectId);
+  if (!project) {
+    return { kind: "missing" };
+  }
+
+  const latestThread = sortThreadsForSidebar(
+    input.threads.filter((thread) => thread.projectId === input.projectId),
+    input.threadSortOrder,
+  )[0];
+
+  if (!latestThread) {
+    return {
+      kind: "empty",
+      project,
+    };
+  }
+
+  return {
+    kind: "thread",
+    project,
+    threadId: latestThread.id,
+  };
+}
+
+export type ThreadRouteTarget =
+  | {
+      kind: "missing";
+    }
+  | {
+      kind: "thread";
+      projectId: ProjectId;
+      threadId: ThreadId;
+    };
+
+export function resolveThreadRouteTarget(input: {
+  threadId: ThreadId;
+  threads: readonly Thread[];
+  draftThreadsByThreadId: Readonly<Record<ThreadId, DraftThreadState>>;
+}): ThreadRouteTarget {
+  const thread = input.threads.find((candidate) => candidate.id === input.threadId);
+  if (thread) {
+    return {
+      kind: "thread",
+      projectId: thread.projectId,
+      threadId: thread.id,
+    };
+  }
+
+  const draftThread = input.draftThreadsByThreadId[input.threadId];
+  if (draftThread) {
+    return {
+      kind: "thread",
+      projectId: draftThread.projectId,
+      threadId: input.threadId,
+    };
+  }
+
+  return { kind: "missing" };
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,8 @@ import { Route as ChatRouteImport } from './routes/_chat'
 import { Route as ChatIndexRouteImport } from './routes/_chat.index'
 import { Route as ChatSettingsRouteImport } from './routes/_chat.settings'
 import { Route as ChatThreadIdRouteImport } from './routes/_chat.$threadId'
+import { Route as ChatProjectsProjectIdRouteImport } from './routes/_chat.projects.$projectId'
+import { Route as ChatProjectsProjectIdThreadsThreadIdRouteImport } from './routes/_chat.projects.$projectId.threads.$threadId'
 
 const ChatRoute = ChatRouteImport.update({
   id: '/_chat',
@@ -33,16 +35,31 @@ const ChatThreadIdRoute = ChatThreadIdRouteImport.update({
   path: '/$threadId',
   getParentRoute: () => ChatRoute,
 } as any)
+const ChatProjectsProjectIdRoute = ChatProjectsProjectIdRouteImport.update({
+  id: '/projects/$projectId',
+  path: '/projects/$projectId',
+  getParentRoute: () => ChatRoute,
+} as any)
+const ChatProjectsProjectIdThreadsThreadIdRoute =
+  ChatProjectsProjectIdThreadsThreadIdRouteImport.update({
+    id: '/threads/$threadId',
+    path: '/threads/$threadId',
+    getParentRoute: () => ChatProjectsProjectIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof ChatIndexRoute
   '/$threadId': typeof ChatThreadIdRoute
   '/settings': typeof ChatSettingsRoute
+  '/projects/$projectId': typeof ChatProjectsProjectIdRouteWithChildren
+  '/projects/$projectId/threads/$threadId': typeof ChatProjectsProjectIdThreadsThreadIdRoute
 }
 export interface FileRoutesByTo {
   '/$threadId': typeof ChatThreadIdRoute
   '/settings': typeof ChatSettingsRoute
   '/': typeof ChatIndexRoute
+  '/projects/$projectId': typeof ChatProjectsProjectIdRouteWithChildren
+  '/projects/$projectId/threads/$threadId': typeof ChatProjectsProjectIdThreadsThreadIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -50,13 +67,32 @@ export interface FileRoutesById {
   '/_chat/$threadId': typeof ChatThreadIdRoute
   '/_chat/settings': typeof ChatSettingsRoute
   '/_chat/': typeof ChatIndexRoute
+  '/_chat/projects/$projectId': typeof ChatProjectsProjectIdRouteWithChildren
+  '/_chat/projects/$projectId/threads/$threadId': typeof ChatProjectsProjectIdThreadsThreadIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/$threadId' | '/settings'
+  fullPaths:
+    | '/'
+    | '/$threadId'
+    | '/settings'
+    | '/projects/$projectId'
+    | '/projects/$projectId/threads/$threadId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/$threadId' | '/settings' | '/'
-  id: '__root__' | '/_chat' | '/_chat/$threadId' | '/_chat/settings' | '/_chat/'
+  to:
+    | '/$threadId'
+    | '/settings'
+    | '/'
+    | '/projects/$projectId'
+    | '/projects/$projectId/threads/$threadId'
+  id:
+    | '__root__'
+    | '/_chat'
+    | '/_chat/$threadId'
+    | '/_chat/settings'
+    | '/_chat/'
+    | '/_chat/projects/$projectId'
+    | '/_chat/projects/$projectId/threads/$threadId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -93,19 +129,49 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChatThreadIdRouteImport
       parentRoute: typeof ChatRoute
     }
+    '/_chat/projects/$projectId': {
+      id: '/_chat/projects/$projectId'
+      path: '/projects/$projectId'
+      fullPath: '/projects/$projectId'
+      preLoaderRoute: typeof ChatProjectsProjectIdRouteImport
+      parentRoute: typeof ChatRoute
+    }
+    '/_chat/projects/$projectId/threads/$threadId': {
+      id: '/_chat/projects/$projectId/threads/$threadId'
+      path: '/threads/$threadId'
+      fullPath: '/projects/$projectId/threads/$threadId'
+      preLoaderRoute: typeof ChatProjectsProjectIdThreadsThreadIdRouteImport
+      parentRoute: typeof ChatProjectsProjectIdRoute
+    }
   }
 }
+
+interface ChatProjectsProjectIdRouteChildren {
+  ChatProjectsProjectIdThreadsThreadIdRoute: typeof ChatProjectsProjectIdThreadsThreadIdRoute
+}
+
+const ChatProjectsProjectIdRouteChildren: ChatProjectsProjectIdRouteChildren = {
+  ChatProjectsProjectIdThreadsThreadIdRoute:
+    ChatProjectsProjectIdThreadsThreadIdRoute,
+}
+
+const ChatProjectsProjectIdRouteWithChildren =
+  ChatProjectsProjectIdRoute._addFileChildren(
+    ChatProjectsProjectIdRouteChildren,
+  )
 
 interface ChatRouteChildren {
   ChatThreadIdRoute: typeof ChatThreadIdRoute
   ChatSettingsRoute: typeof ChatSettingsRoute
   ChatIndexRoute: typeof ChatIndexRoute
+  ChatProjectsProjectIdRoute: typeof ChatProjectsProjectIdRouteWithChildren
 }
 
 const ChatRouteChildren: ChatRouteChildren = {
   ChatThreadIdRoute: ChatThreadIdRoute,
   ChatSettingsRoute: ChatSettingsRoute,
   ChatIndexRoute: ChatIndexRoute,
+  ChatProjectsProjectIdRoute: ChatProjectsProjectIdRouteWithChildren,
 }
 
 const ChatRouteWithChildren = ChatRoute._addFileChildren(ChatRouteChildren)

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -251,8 +251,11 @@ function EventRouter() {
           return;
         }
         await navigate({
-          to: "/$threadId",
-          params: { threadId: payload.bootstrapThreadId },
+          to: "/projects/$projectId/threads/$threadId",
+          params: {
+            projectId: payload.bootstrapProjectId,
+            threadId: payload.bootstrapThreadId,
+          },
           replace: true,
         });
         handledBootstrapThreadIdRef.current = payload.bootstrapThreadId;

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,249 +1,39 @@
 import { ThreadId } from "@t3tools/contracts";
 import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
-import { Suspense, lazy, type ReactNode, useCallback, useEffect, useState } from "react";
-
-import ChatView from "../components/ChatView";
-import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
-import {
-  DiffPanelHeaderSkeleton,
-  DiffPanelLoadingState,
-  DiffPanelShell,
-  type DiffPanelMode,
-} from "../components/DiffPanelShell";
+import { useEffect } from "react";
 import { useComposerDraftStore } from "../composerDraftStore";
-import {
-  type DiffRouteSearch,
-  parseDiffRouteSearch,
-  stripDiffSearchParams,
-} from "../diffRouteSearch";
-import { useMediaQuery } from "../hooks/useMediaQuery";
+import { type DiffRouteSearch, parseDiffRouteSearch } from "../diffRouteSearch";
+import { resolveThreadRouteTarget } from "../projectRoute";
 import { useStore } from "../store";
-import { Sheet, SheetPopup } from "../components/ui/sheet";
-import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
 
-const DiffPanel = lazy(() => import("../components/DiffPanel"));
-const DIFF_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 1180px)";
-const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
-const DIFF_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
-const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 26 * 16;
-const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
-
-const DiffPanelSheet = (props: {
-  children: ReactNode;
-  diffOpen: boolean;
-  onCloseDiff: () => void;
-}) => {
-  return (
-    <Sheet
-      open={props.diffOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          props.onCloseDiff();
-        }
-      }}
-    >
-      <SheetPopup
-        side="right"
-        showCloseButton={false}
-        keepMounted
-        className="w-[min(88vw,820px)] max-w-[820px] p-0"
-      >
-        {props.children}
-      </SheetPopup>
-    </Sheet>
-  );
-};
-
-const DiffLoadingFallback = (props: { mode: DiffPanelMode }) => {
-  return (
-    <DiffPanelShell mode={props.mode} header={<DiffPanelHeaderSkeleton />}>
-      <DiffPanelLoadingState label="Loading diff viewer..." />
-    </DiffPanelShell>
-  );
-};
-
-const LazyDiffPanel = (props: { mode: DiffPanelMode }) => {
-  return (
-    <DiffWorkerPoolProvider>
-      <Suspense fallback={<DiffLoadingFallback mode={props.mode} />}>
-        <DiffPanel mode={props.mode} />
-      </Suspense>
-    </DiffWorkerPoolProvider>
-  );
-};
-
-const DiffPanelInlineSidebar = (props: {
-  diffOpen: boolean;
-  onCloseDiff: () => void;
-  onOpenDiff: () => void;
-  renderDiffContent: boolean;
-}) => {
-  const { diffOpen, onCloseDiff, onOpenDiff, renderDiffContent } = props;
-  const onOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        onOpenDiff();
-        return;
-      }
-      onCloseDiff();
-    },
-    [onCloseDiff, onOpenDiff],
-  );
-  const shouldAcceptInlineSidebarWidth = useCallback(
-    ({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }) => {
-      const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
-      if (!composerForm) return true;
-      const composerViewport = composerForm.parentElement;
-      if (!composerViewport) return true;
-      const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
-      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
-
-      const viewportStyle = window.getComputedStyle(composerViewport);
-      const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
-      const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
-      const viewportContentWidth = Math.max(
-        0,
-        composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
-      );
-      const formRect = composerForm.getBoundingClientRect();
-      const composerFooter = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-footer='true']",
-      );
-      const composerRightActions = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-actions='right']",
-      );
-      const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
-      const composerFooterGap = composerFooter
-        ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
-          Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
-          0
-        : 0;
-      const minimumComposerWidth =
-        COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
-      const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
-      const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
-      const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
-
-      if (previousSidebarWidth.length > 0) {
-        wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
-      } else {
-        wrapper.style.removeProperty("--sidebar-width");
-      }
-
-      return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
-    },
-    [],
-  );
-
-  return (
-    <SidebarProvider
-      defaultOpen={false}
-      open={diffOpen}
-      onOpenChange={onOpenChange}
-      className="w-auto min-h-0 flex-none bg-transparent"
-      style={{ "--sidebar-width": DIFF_INLINE_DEFAULT_WIDTH } as React.CSSProperties}
-    >
-      <Sidebar
-        side="right"
-        collapsible="offcanvas"
-        className="border-l border-border bg-card text-foreground"
-        resizable={{
-          minWidth: DIFF_INLINE_SIDEBAR_MIN_WIDTH,
-          shouldAcceptWidth: shouldAcceptInlineSidebarWidth,
-          storageKey: DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
-        }}
-      >
-        {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
-        <SidebarRail />
-      </Sidebar>
-    </SidebarProvider>
-  );
-};
-
-function ChatThreadRouteView() {
-  const threadsHydrated = useStore((store) => store.threadsHydrated);
+function LegacyChatThreadRedirectView() {
   const navigate = useNavigate();
+  const threadsHydrated = useStore((store) => store.threadsHydrated);
+  const threads = useStore((store) => store.threads);
+  const draftThreadsByThreadId = useComposerDraftStore((store) => store.draftThreadsByThreadId);
   const threadId = Route.useParams({
     select: (params) => ThreadId.makeUnsafe(params.threadId),
   });
   const search = Route.useSearch();
-  const threadExists = useStore((store) => store.threads.some((thread) => thread.id === threadId));
-  const draftThreadExists = useComposerDraftStore((store) =>
-    Object.hasOwn(store.draftThreadsByThreadId, threadId),
-  );
-  const routeThreadExists = threadExists || draftThreadExists;
-  const diffOpen = search.diff === "1";
-  const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
-  // TanStack Router keeps active route components mounted across param-only navigations
-  // unless remountDeps are configured, so this stays warm across thread switches.
-  const [hasOpenedDiff, setHasOpenedDiff] = useState(diffOpen);
-  const closeDiff = useCallback(() => {
-    void navigate({
-      to: "/$threadId",
-      params: { threadId },
-      search: { diff: undefined },
-    });
-  }, [navigate, threadId]);
-  const openDiff = useCallback(() => {
-    void navigate({
-      to: "/$threadId",
-      params: { threadId },
-      search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
-      },
-    });
-  }, [navigate, threadId]);
+  const target = resolveThreadRouteTarget({ threadId, threads, draftThreadsByThreadId });
 
   useEffect(() => {
-    if (diffOpen) {
-      setHasOpenedDiff(true);
-    }
-  }, [diffOpen]);
-
-  useEffect(() => {
-    if (!threadsHydrated) {
+    if (target.kind === "missing") {
+      if (threadsHydrated) {
+        void navigate({ to: "/", replace: true });
+      }
       return;
     }
 
-    if (!routeThreadExists) {
-      void navigate({ to: "/", replace: true });
-      return;
-    }
-  }, [navigate, routeThreadExists, threadsHydrated, threadId]);
+    void navigate({
+      to: "/projects/$projectId/threads/$threadId",
+      params: { projectId: target.projectId, threadId },
+      search,
+      replace: true,
+    });
+  }, [navigate, search, target, threadId, threadsHydrated]);
 
-  if (!threadsHydrated || !routeThreadExists) {
-    return null;
-  }
-
-  const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
-
-  if (!shouldUseDiffSheet) {
-    return (
-      <>
-        <SidebarInset className="h-dvh  min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
-          <ChatView key={threadId} threadId={threadId} />
-        </SidebarInset>
-        <DiffPanelInlineSidebar
-          diffOpen={diffOpen}
-          onCloseDiff={closeDiff}
-          onOpenDiff={openDiff}
-          renderDiffContent={shouldRenderDiffContent}
-        />
-      </>
-    );
-  }
-
-  return (
-    <>
-      <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
-        <ChatView key={threadId} threadId={threadId} />
-      </SidebarInset>
-      <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={closeDiff}>
-        {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
-      </DiffPanelSheet>
-    </>
-  );
+  return null;
 }
 
 export const Route = createFileRoute("/_chat/$threadId")({
@@ -251,5 +41,5 @@ export const Route = createFileRoute("/_chat/$threadId")({
   search: {
     middlewares: [retainSearchParams<DiffRouteSearch>(["diff"])],
   },
-  component: ChatThreadRouteView,
+  component: LegacyChatThreadRedirectView,
 });

--- a/apps/web/src/routes/_chat.projects.$projectId.threads.$threadId.tsx
+++ b/apps/web/src/routes/_chat.projects.$projectId.threads.$threadId.tsx
@@ -1,0 +1,83 @@
+import { ProjectId, ThreadId } from "@t3tools/contracts";
+import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect } from "react";
+import { useComposerDraftStore } from "../composerDraftStore";
+import { ThreadRouteContent } from "../components/ThreadRouteContent";
+import {
+  type DiffRouteSearch,
+  parseDiffRouteSearch,
+  stripDiffSearchParams,
+} from "../diffRouteSearch";
+import { resolveThreadRouteTarget } from "../projectRoute";
+import { useStore } from "../store";
+
+function CanonicalThreadRouteView() {
+  const navigate = useNavigate();
+  const threadsHydrated = useStore((store) => store.threadsHydrated);
+  const threads = useStore((store) => store.threads);
+  const draftThreadsByThreadId = useComposerDraftStore((store) => store.draftThreadsByThreadId);
+  const projectId = Route.useParams({
+    select: (params) => ProjectId.makeUnsafe(params.projectId),
+  });
+  const threadId = Route.useParams({
+    select: (params) => ThreadId.makeUnsafe(params.threadId),
+  });
+  const search = Route.useSearch();
+  const target = resolveThreadRouteTarget({ threadId, threads, draftThreadsByThreadId });
+  const closeDiff = useCallback(() => {
+    void navigate({
+      to: "/projects/$projectId/threads/$threadId",
+      params: { projectId, threadId },
+      search: { diff: undefined },
+    });
+  }, [navigate, projectId, threadId]);
+  const openDiff = useCallback(() => {
+    void navigate({
+      to: "/projects/$projectId/threads/$threadId",
+      params: { projectId, threadId },
+      search: (previous) => {
+        const rest = stripDiffSearchParams(previous);
+        return { ...rest, diff: "1" };
+      },
+    });
+  }, [navigate, projectId, threadId]);
+
+  useEffect(() => {
+    if (target.kind === "missing") {
+      if (threadsHydrated) {
+        void navigate({ to: "/", replace: true });
+      }
+      return;
+    }
+
+    if (target.projectId !== projectId) {
+      void navigate({
+        to: "/projects/$projectId/threads/$threadId",
+        params: { projectId: target.projectId, threadId },
+        search,
+        replace: true,
+      });
+    }
+  }, [navigate, projectId, search, target, threadId, threadsHydrated]);
+
+  if (target.kind === "missing" || target.projectId !== projectId) {
+    return null;
+  }
+
+  return (
+    <ThreadRouteContent
+      diffOpen={search.diff === "1"}
+      onCloseDiff={closeDiff}
+      onOpenDiff={openDiff}
+      threadId={threadId}
+    />
+  );
+}
+
+export const Route = createFileRoute("/_chat/projects/$projectId/threads/$threadId")({
+  validateSearch: (search) => parseDiffRouteSearch(search),
+  search: {
+    middlewares: [retainSearchParams<DiffRouteSearch>(["diff"])],
+  },
+  component: CanonicalThreadRouteView,
+});

--- a/apps/web/src/routes/_chat.projects.$projectId.tsx
+++ b/apps/web/src/routes/_chat.projects.$projectId.tsx
@@ -1,0 +1,102 @@
+import { ProjectId } from "@t3tools/contracts";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect, useMemo } from "react";
+import { Button } from "../components/ui/button";
+import { SidebarTrigger } from "../components/ui/sidebar";
+import { isElectron } from "../env";
+import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useSettings } from "../hooks/useSettings";
+import { resolveProjectRouteTarget } from "../projectRoute";
+import { useStore } from "../store";
+
+function ProjectRouteView() {
+  const navigate = useNavigate();
+  const projectId = Route.useParams({
+    select: (params) => ProjectId.makeUnsafe(params.projectId),
+  });
+  const projects = useStore((store) => store.projects);
+  const threads = useStore((store) => store.threads);
+  const threadsHydrated = useStore((store) => store.threadsHydrated);
+  const setProjectExpanded = useStore((store) => store.setProjectExpanded);
+  const appSettings = useSettings();
+  const { handleNewThread } = useHandleNewThread();
+  const target = useMemo(
+    () =>
+      resolveProjectRouteTarget({
+        projectId,
+        projects,
+        threads,
+        threadSortOrder: appSettings.sidebarThreadSortOrder,
+      }),
+    [appSettings.sidebarThreadSortOrder, projectId, projects, threads],
+  );
+
+  useEffect(() => {
+    if (!threadsHydrated) {
+      return;
+    }
+
+    if (target.kind === "missing") {
+      void navigate({ to: "/", replace: true });
+      return;
+    }
+
+    setProjectExpanded(projectId, true);
+
+    if (target.kind === "thread") {
+      void navigate({
+        to: "/projects/$projectId/threads/$threadId",
+        params: { projectId, threadId: target.threadId },
+        replace: true,
+      });
+    }
+  }, [navigate, projectId, setProjectExpanded, target, threadsHydrated]);
+
+  if (!threadsHydrated || target.kind !== "empty") {
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-muted-foreground/40">
+      {!isElectron && (
+        <header className="border-b border-border px-3 py-2 md:hidden">
+          <div className="flex items-center gap-2">
+            <SidebarTrigger className="size-7 shrink-0" />
+            <span className="text-sm font-medium text-foreground">{target.project.name}</span>
+          </div>
+        </header>
+      )}
+
+      {isElectron && (
+        <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
+          <span className="truncate text-xs text-muted-foreground/50">{target.project.name}</span>
+        </div>
+      )}
+
+      <div className="flex flex-1 items-center justify-center px-6">
+        <div className="max-w-md text-center">
+          <p className="text-sm text-foreground">This project does not have any threads yet.</p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Create a thread to start working in {target.project.name}.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-4"
+            onClick={() =>
+              void handleNewThread(projectId, {
+                envMode: appSettings.defaultThreadEnvMode,
+              })
+            }
+          >
+            New thread
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Route = createFileRoute("/_chat/projects/$projectId")({
+  component: ProjectRouteView,
+});


### PR DESCRIPTION
## What Changed

- added canonical deep-link routes for projects and threads at `/projects/$projectId` and `/projects/$projectId/threads/$threadId`
- turned legacy `/$threadId` links into compatibility redirects so existing deep links still resolve while the app moves to project-scoped URLs
- updated in-app navigation to emit the new project-aware thread URLs, including sidebar navigation, new-thread flows, bootstrap navigation, and diff-panel transitions
- extracted shared route resolution and thread-route rendering helpers so the upgraded deep-link behavior stays testable and easier to extend
- added focused unit coverage for resolving project and thread deep-link targets

## Why

The app already had deep links for individual threads and settings, but thread URLs did not include project context and projects themselves were not first-class deep-link targets. That made links less descriptive and made it harder to build more predictable navigation on top of the current routing model.

This change upgrades deep linking with a canonical project-first URL shape while preserving backward compatibility for old thread links. It improves shareability and routing clarity without broad UI churn or server-side behavior changes.

## UI Changes

- Visiting a project deep link with no threads now shows a small empty state with a `New thread` action.
- Existing thread and diff views keep the same UI; the main visible change is the upgraded URL structure and redirect behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors client-side routing/deep-link behavior across thread creation, sidebar navigation, and diff toggling; mistakes could break navigation or redirects but no auth/data-path changes are involved.
> 
> **Overview**
> **Upgrades deep linking to project-scoped URLs.** Adds canonical routes for `/projects/$projectId` and `/projects/$projectId/threads/$threadId`, with `/$threadId` converted into a compatibility redirect that preserves diff-related search params.
> 
> **Updates in-app navigation to emit the new URLs.** Thread/diff navigation from `ChatView`, `DiffPanel`, `Sidebar`, app bootstrap, and new-thread flows now include `projectId`, with guards for missing `activeThread` and better fallback behavior after deletes.
> 
> **Extracts and tests route resolution/rendering.** Introduces `ThreadRouteContent` for shared thread UI and `projectRoute` helpers (`resolveProjectRouteTarget`, `resolveThreadRouteTarget`) with unit coverage for missing/empty/latest-thread and draft/server thread resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06c6a3742faeeb54689ee96729513467dc7e095f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade thread routing to project-scoped deep links at `/projects/$projectId/threads/$threadId`
> - All thread navigations across [ChatView](https://github.com/pingdotgg/t3code/pull/1493/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), [DiffPanel](https://github.com/pingdotgg/t3code/pull/1493/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3), [Sidebar](https://github.com/pingdotgg/t3code/pull/1493/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), and [useHandleNewThread](https://github.com/pingdotgg/t3code/pull/1493/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef) now route to `/projects/$projectId/threads/$threadId` instead of `/$threadId`.
> - Adds a new canonical thread route in [_chat.projects.$projectId.threads.$threadId.tsx](https://github.com/pingdotgg/t3code/pull/1493/files#diff-1a3e5bb6ef8bc9382f8346c3eab569f0a8dbbde4d48b39b41e66e32f59cf5d5a) that renders the chat view with a responsive diff panel (inline sidebar on wide screens, sheet on narrow screens) and self-corrects a mismatched `projectId` in the URL.
> - Adds a project-level route in [_chat.projects.$projectId.tsx](https://github.com/pingdotgg/t3code/pull/1493/files#diff-b2cf67602a2060c6ab4552729e6afc6098cc701930d7b78d397bc29529115627) that redirects to the latest thread or shows an empty-state with a "New thread" button.
> - The legacy `/$threadId` route in [_chat.$threadId.tsx](https://github.com/pingdotgg/t3code/pull/1493/files#diff-4ee19a4a6919608c555bdc4562ccba6ebb331bc0eec4d4d8c3be8543913c336e) now only redirects to the canonical project-scoped path rather than rendering the chat UI.
> - Introduces `resolveProjectRouteTarget` and `resolveThreadRouteTarget` helpers in [projectRoute.ts](https://github.com/pingdotgg/t3code/pull/1493/files#diff-94a347417dac1bc3b08eaf063b80ef7eac982ef1ddb16f64ec40bc9465adf1bf) for resolving project/thread ownership during route transitions.
> - Behavioral Change: existing bookmarks or links to `/$threadId` will redirect to the canonical route; any navigation without a resolvable `projectId` will redirect to `/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06c6a37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->