### PR TITLE
fix(ci): use whitespace-insensitive PR size diff

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -139,8 +139,6 @@ jobs:
             const issueNumber = context.payload.pull_request.number;
             const baseSha = context.payload.pull_request.base.sha;
             const headSha = context.payload.pull_request.head.sha;
-            const headCloneUrl = context.payload.pull_request.head.repo.clone_url;
-            const headRef = context.payload.pull_request.head.ref;
             const headTrackingRef = `refs/remotes/pr-size/${issueNumber}`;
             const managedLabels = JSON.parse(process.env.PR_SIZE_LABELS_JSON ?? "[]");
             const managedLabelNames = new Set(managedLabels.map((label) => label.name));
@@ -200,7 +198,7 @@ jobs:
 
             execFileSync(
               "git",
-              ["fetch", "--no-tags", headCloneUrl, `+refs/heads/${headRef}:${headTrackingRef}`],
+              ["fetch", "--no-tags", "origin", `+refs/pull/${issueNumber}/head:${headTrackingRef}`],
               {
                 stdio: "inherit",
               },


### PR DESCRIPTION
## What Changed

Use a whitespace-insensitive diff for PR size labels.

## Why

GitHub's raw diff counts can overcount whitespace-only changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

> [!WARNING]
> this might be a hallucination from codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR size labeling logic in CI to compute diff stats locally with `git diff`, which could shift size labels and depends on correct ref fetching in `pull_request_target` runs.
> 
> **Overview**
> Updates the `PR Size` GitHub Action to compute effective changed lines using a local `git diff --numstat` that ignores whitespace and blank-line-only changes, instead of relying on the GitHub `pulls.listFiles` API.
> 
> The workflow now checks out and fetches base/head refs for the PR (avoiding the 3,000-file API truncation risk), excludes test files via git pathspec excludes, and logs a warning if the fetched head SHA differs from the PR’s reported head SHA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dbdc0ed7ff7301d69253aaf4cbd4fb7d30a8833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PR size labeling to use whitespace-insensitive `git diff --numstat`
> - Replaces the GitHub Pulls REST API file listing with local `git diff --numstat --ignore-all-space --ignore-blank-lines` to compute line change counts in [pr-size.yml](.github/workflows/pr-size.yml).
> - Adds a repo checkout step and fetches both the base SHA and PR head ref (`refs/pull/<number>/head`) so the diff runs locally.
> - Switches test file exclusion from regex matching to git pathspec `:(glob,exclude)` patterns passed directly to the diff command.
> - Removes the prior 3000-file truncation warning that came with the paginated API approach.
> - Behavioral Change: whitespace-only and blank-line changes no longer contribute to PR size counts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0dbdc0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->