### PR TITLE
Tolerate unsupported persisted provider kinds

### DIFF
--- a/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
+++ b/apps/server/src/persistence/Layers/OrchestrationEventStore.ts
@@ -1,5 +1,6 @@
 import {
   CommandId,
+  DEFAULT_PROVIDER_KIND,
   EventId,
   IsoDateTime,
   NonNegativeInt,
@@ -10,6 +11,7 @@ import {
   OrchestrationEventType,
   ProjectId,
   ThreadId,
+  isSupportedProvider,
 } from "@t3tools/contracts";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
@@ -26,6 +28,29 @@ import {
 } from "../Services/OrchestrationEventStore.ts";
 
 const decodeEvent = Schema.decodeUnknownEffect(OrchestrationEvent);
+
+/**
+ * Coerce unsupported provider names in `modelSelection` /
+ * `defaultModelSelection` payloads to the default provider so the strict
+ * `OrchestrationEvent` schema can always decode persisted events.  This
+ * keeps the read path tolerant of legacy or future provider data without
+ * widening the canonical types.
+ */
+function coerceUnsupportedProviders<T>(row: T): T {
+  const r = row as Record<string, unknown>;
+  const payload = r.payload;
+  if (typeof payload !== "object" || payload === null) return row;
+  const p = payload as Record<string, unknown>;
+  let patched: Record<string, unknown> | null = null;
+  for (const key of ["modelSelection", "defaultModelSelection"] as const) {
+    const ms = p[key] as Record<string, unknown> | null | undefined;
+    if (ms && typeof ms.provider === "string" && !isSupportedProvider(ms.provider)) {
+      patched ??= { ...p };
+      patched[key] = { provider: DEFAULT_PROVIDER_KIND, model: ms.model };
+    }
+  }
+  return patched ? ({ ...r, payload: patched } as T) : row;
+}
 const UnknownFromJsonString = Schema.fromJsonString(Schema.Unknown);
 const EventMetadataFromJsonString = Schema.fromJsonString(OrchestrationEventMetadata);
 
@@ -230,7 +255,7 @@ const makeEventStore = Effect.gen(function* () {
           ),
           Effect.flatMap((rows) =>
             Effect.forEach(rows, (row) =>
-              decodeEvent(row).pipe(
+              decodeEvent(coerceUnsupportedProviders(row)).pipe(
                 Effect.mapError(
                   toPersistenceDecodeError("OrchestrationEventStore.readFromSequence:rowToEvent"),
                 ),

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -18,19 +18,25 @@ function toPersistenceError(operation: string) {
     });
 }
 
+/**
+ * Accept any non-empty provider string.
+ * Legacy or future providers are passed through so the read path never fails;
+ * unsupported providers are simply cast — the caller is responsible for
+ * checking `isSupportedProvider` before dispatching adapter operations.
+ */
 function decodeProviderKind(
   providerName: string,
-  operation: string,
+  _operation: string,
 ): Effect.Effect<ProviderKind, ProviderSessionDirectoryPersistenceError> {
-  if (providerName === "codex" || providerName === "claudeAgent") {
-    return Effect.succeed(providerName);
+  if (providerName.trim().length === 0) {
+    return Effect.fail(
+      new ProviderSessionDirectoryPersistenceError({
+        operation: _operation,
+        detail: `Provider name must be a non-empty string.`,
+      }),
+    );
   }
-  return Effect.fail(
-    new ProviderSessionDirectoryPersistenceError({
-      operation,
-      detail: `Unknown persisted provider '${providerName}'.`,
-    }),
-  );
+  return Effect.succeed(providerName as ProviderKind);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -29,6 +29,10 @@ export const ORCHESTRATION_WS_CHANNELS = {
 
 export const ProviderKind = Schema.Literals(["codex", "claudeAgent"]);
 export type ProviderKind = typeof ProviderKind.Type;
+
+export function isSupportedProvider(provider: string): provider is ProviderKind {
+  return provider === "codex" || provider === "claudeAgent";
+}
 export const ProviderApprovalPolicy = Schema.Literals([
   "untrusted",
   "on-failure",


### PR DESCRIPTION
- Coerce legacy or future provider values during orchestration event reads
- Accept non-empty persisted provider names in session directories
- Add a shared provider support guard in contracts

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event/session decoding to no longer fail on unknown provider strings, which could mask bad data and affect downstream provider dispatch if callers don’t re-validate.
> 
> **Overview**
> Makes persisted reads tolerant of legacy/future provider values instead of failing strict schema decoding.
> 
> On orchestration event replay (`OrchestrationEventStore.readFromSequence`), the payload’s `modelSelection`/`defaultModelSelection` provider is coerced to `DEFAULT_PROVIDER_KIND` when `isSupportedProvider` rejects it, ensuring `OrchestrationEvent` decoding succeeds.
> 
> For provider session directory bindings, persisted provider names now accept any non-empty string (cast to `ProviderKind`) rather than rejecting unknown providers, and contracts add a shared `isSupportedProvider` guard for callers to explicitly check support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 415a840fdc5e88fe9dbc259d9bc8ca700d43e062. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tolerate unsupported persisted provider kinds when reading orchestration events
> - Adds `coerceUnsupportedProviders` in [`OrchestrationEventStore`](https://github.com/pingdotgg/t3code/pull/1507/files#diff-6bb6ea3b72cbe6e78aa809efd497a676913960aaf3e73fd0d10a07ffd20ddd6d) to patch `modelSelection`/`defaultModelSelection` payloads that contain unknown provider names, replacing them with `DEFAULT_PROVIDER_KIND` before schema decoding.
> - Adds `isSupportedProvider` type guard in [`orchestration.ts`](https://github.com/pingdotgg/t3code/pull/1507/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af) to test whether a provider string is `'codex'` or `'claudeAgent'`.
> - Relaxes `decodeProviderKind` in [`ProviderSessionDirectory`](https://github.com/pingdotgg/t3code/pull/1507/files#diff-0ca581a6030196f89d4a3b84a4699e4eb24dd0d70432ebcd642b6b1ca88851ab) to accept any non-empty provider string instead of only known kinds.
> - Behavioral Change: rows with unrecognized provider names that previously caused decode failures now succeed, yielding events with the default provider.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 415a840.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->