### PR TITLE
Make DrainableWorker drain off outstanding count

### DIFF
--- a/packages/shared/src/DrainableWorker.ts
+++ b/packages/shared/src/DrainableWorker.ts
@@ -1,13 +1,15 @@
 /**
- * DrainableWorker - A queue-based worker with deterministic `drain()`.
+ * DrainableWorker - A queue-based worker that exposes a `drain()` effect.
  *
- * Tracks outstanding work in STM so `drain()` resolves only when no items
- * are queued or in flight. Useful in tests instead of timing-based waits.
+ * Wraps the common `Queue.unbounded` + `Effect.forever` pattern and adds
+ * a signal that resolves when the queue is empty **and** the current item
+ * has finished processing. This lets tests replace timing-sensitive
+ * `Effect.sleep` calls with deterministic `drain()`.
  *
  * @module DrainableWorker
  */
-import { Effect, TxQueue, TxRef } from "effect";
 import type { Scope } from "effect";
+import { Effect, TxQueue, TxRef } from "effect";
 
 export interface DrainableWorker<A> {
   /**
@@ -37,40 +39,30 @@ export const makeDrainableWorker = <A, E, R>(
   process: (item: A) => Effect.Effect<void, E, R>,
 ): Effect.Effect<DrainableWorker<A>, never, Scope.Scope | R> =>
   Effect.gen(function* () {
-    const ref = yield* TxRef.make(0);
+    const queue = yield* Effect.acquireRelease(TxQueue.unbounded<A>(), TxQueue.shutdown);
+    const outstanding = yield* TxRef.make(0);
 
-    const queue = yield* Effect.acquireRelease(TxQueue.unbounded<A>(), (queue) =>
-      TxQueue.shutdown(queue),
-    );
-
-    const takeItem = Effect.tx(
-      Effect.gen(function* () {
-        const item = yield* TxQueue.take(queue);
-        yield* TxRef.update(ref, (n) => n + 1);
-        return item;
-      }),
-    );
-
-    yield* takeItem.pipe(
-      Effect.flatMap((item) =>
-        process(item).pipe(Effect.ensuring(TxRef.update(ref, (n) => n - 1))),
+    yield* TxQueue.take(queue).pipe(
+      Effect.tap((a) =>
+        Effect.ensuring(
+          process(a),
+          TxRef.update(outstanding, (n) => n - 1),
+        ),
       ),
       Effect.forever,
       Effect.forkScoped,
     );
 
-    const drain: DrainableWorker<A>["drain"] = Effect.tx(
-      Effect.gen(function* () {
-        const inFlight = yield* TxRef.get(ref);
-        const isEmpty = yield* TxQueue.isEmpty(queue);
-        if (inFlight > 0 || !isEmpty) {
-          return yield* Effect.txRetry;
-        }
-      }),
+    const drain: DrainableWorker<A>["drain"] = TxRef.get(outstanding).pipe(
+      Effect.tap((n) => (n > 0 ? Effect.txRetry : Effect.void)),
+      Effect.tx,
     );
 
-    return {
-      enqueue: (item) => TxQueue.offer(queue, item),
-      drain,
-    } satisfies DrainableWorker<A>;
+    const enqueue = (element: A): Effect.Effect<boolean, never, never> =>
+      TxQueue.offer(queue, element).pipe(
+        Effect.tap(() => TxRef.update(outstanding, (n) => n + 1)),
+        Effect.tx,
+      );
+
+    return { enqueue, drain } satisfies DrainableWorker<A>;
   });


### PR DESCRIPTION
- Track queued and in-flight items with a single STM counter
- Simplify drain and enqueue around the shared outstanding signal

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes STM concurrency semantics for `drain()` by relying on a single counter updated on enqueue/complete, which could regress drain behavior under edge cases (failed offers, interruptions). Minor API/typing risk if callers relied on `enqueue`’s previous return type/behavior.
> 
> **Overview**
> `DrainableWorker` now tracks *both queued and in-flight* work via a single STM `outstanding` counter that is incremented atomically in `enqueue` and decremented when `process` finishes.
> 
> `drain()` is simplified to retry solely based on `outstanding > 0`, removing the previous logic that also checked `TxQueue.isEmpty` and incremented the counter on `take()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15905ec2f2e4e22a0b0a455a5142b8333a980a2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make `DrainableWorker` drain off outstanding count atomically
> - `enqueue` now atomically increments an outstanding counter alongside queuing the item in a single transaction, replacing the previous approach of incrementing on `take`.
> - `drain()` waits until the outstanding counter reaches zero, which means it resolves only after all enqueued items have finished processing, not just when the queue is empty.
> - The explicit `TxQueue.isEmpty` check in `drain` is removed, as the counter already subsumes it.
> - Behavioral Change: `drain()` now accounts for items currently being processed, making it safe to use as a deterministic completion signal in tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15905ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->