### PR TITLE
Inline sqlite error classification

### DIFF
--- a/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.ts
@@ -29,9 +29,6 @@ export const TypeId: TypeId = "~local/sqlite-node/SqliteClient";
 
 export type TypeId = "~local/sqlite-node/SqliteClient";
 
-const classifyError = (cause: unknown, message: string, operation: string) =>
-  classifySqliteError(cause, { message, operation });
-
 /**
  * SqliteClient - Effect service tag for the sqlite SQL client.
  */
@@ -114,7 +111,10 @@ const makeWithDatabase = (
             try: () => db.prepare(sql),
             catch: (cause) =>
               new SqlError({
-                reason: classifyError(cause, "Failed to prepare statement", "prepare"),
+                reason: classifySqliteError(cause, {
+                  message: "Failed to prepare statement",
+                  operation: "prepare",
+                }),
               }),
           }),
       });
@@ -135,7 +135,10 @@ const makeWithDatabase = (
           } catch (cause) {
             return Effect.fail(
               new SqlError({
-                reason: classifyError(cause, "Failed to execute statement", "execute"),
+                reason: classifySqliteError(cause, {
+                  message: "Failed to execute statement",
+                  operation: "execute",
+                }),
               }),
             );
           }
@@ -162,7 +165,10 @@ const makeWithDatabase = (
               },
               catch: (cause) =>
                 new SqlError({
-                  reason: classifyError(cause, "Failed to execute statement", "execute"),
+                  reason: classifySqliteError(cause, {
+                    message: "Failed to execute statement",
+                    operation: "execute",
+                  }),
                 }),
             }),
           (statement) =>


### PR DESCRIPTION
- Remove the local wrapper helper
- Call `classifySqliteError` directly at each failure site

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to sqlite error construction; behavior should be unchanged aside from slightly different call sites for error classification.
> 
> **Overview**
> Removes the local `classifyError` helper in `NodeSqliteClient` and **inlines** `classifySqliteError` at each statement `prepare`/`execute` failure site.
> 
> This is a small refactor that keeps the same error messages/operations while making the error-classification calls explicit where `SqlError` is created.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 774bd628bf44d8477b15a1750699dabdcb4e5429. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Inline `classifySqliteError` calls in `NodeSqliteClient` by removing local helper
> Removes the local `classifyError` wrapper in [NodeSqliteClient.ts](https://github.com/pingdotgg/t3code/pull/1515/files#diff-cf61d9fd2d48cc7f6a5d0ebaaa66f8c39d982f536913a6fb92196591465087aa) and replaces its three call sites with direct calls to `classifySqliteError(cause, { message, operation })`. No logic or behavior changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 774bd62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->