### PR TITLE
fix: fetch remote base branch before PR range context to prevent stale diffs

### DIFF
--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -912,29 +912,34 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
       if (baseBranch.includes("/")) {
         return baseBranch;
       }
-      // Try to fetch the base branch from the primary remote (usually "origin")
-      // and use the remote tracking ref for range computation.
-      const remoteName = "origin";
+      // Try to fetch the base branch from the remote and use the remote
+      // tracking ref for range computation.  Prefer the head context's
+      // remote when available (e.g. fork remotes) and fall back to "origin".
+      const remoteName = headContext.remoteName ?? "origin";
       const remoteRef = `${remoteName}/${baseBranch}`;
-      const fetched = yield* gitCore
-        .execute({
-          operation: "runPrStep.fetchBaseBranch",
-          cwd,
-          args: [
-            "fetch",
-            "--quiet",
-            "--no-tags",
-            remoteName,
-            `+refs/heads/${baseBranch}:refs/remotes/${remoteRef}`,
-          ],
-          timeoutMs: 30_000,
-        })
-        .pipe(
-          Effect.map(() => true),
-          Effect.catch(() => Effect.succeed(false)),
-        );
-      return fetched ? remoteRef : baseBranch;
-    });
+      yield* gitCore.execute({
+        operation: "runPrStep.fetchBaseBranch",
+        cwd,
+        args: [
+          "fetch",
+          "--quiet",
+          "--no-tags",
+          remoteName,
+          `+refs/heads/${baseBranch}:refs/remotes/${remoteRef}`,
+        ],
+        allowNonZeroExit: true,
+        timeoutMs: 30_000,
+      });
+      // Verify the remote ref exists after fetch; if it does, prefer it.
+      const verifyResult = yield* gitCore.execute({
+        operation: "runPrStep.verifyRemoteRef",
+        cwd,
+        args: ["rev-parse", "--verify", remoteRef],
+        allowNonZeroExit: true,
+      });
+      return verifyResult.code === 0 ? remoteRef : baseBranch;
+    }).pipe(Effect.catch(() => Effect.succeed(baseBranch)));
+
     const rangeContext = yield* gitCore.readRangeContext(cwd, rangeRef);
 
     const generated = yield* textGeneration.generatePrContent({

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -902,7 +902,40 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     }
 
     const baseBranch = yield* resolveBaseBranch(cwd, branch, details.upstreamRef, headContext);
-    const rangeContext = yield* gitCore.readRangeContext(cwd, baseBranch);
+
+    // Fetch the remote tracking ref for the base branch so that the range
+    // context reflects any upstream changes (e.g. previously merged PRs).
+    // Without this fetch the local ref can be stale, causing readRangeContext
+    // to include commits/diffs that were already merged upstream (#1487).
+    const rangeRef = yield* Effect.gen(function* () {
+      // If baseBranch already contains a remote prefix, use it as-is.
+      if (baseBranch.includes("/")) {
+        return baseBranch;
+      }
+      // Try to fetch the base branch from the primary remote (usually "origin")
+      // and use the remote tracking ref for range computation.
+      const remoteName = "origin";
+      const remoteRef = `${remoteName}/${baseBranch}`;
+      const fetched = yield* gitCore
+        .execute({
+          operation: "runPrStep.fetchBaseBranch",
+          cwd,
+          args: [
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            remoteName,
+            `+refs/heads/${baseBranch}:refs/remotes/${remoteRef}`,
+          ],
+          timeoutMs: 30_000,
+        })
+        .pipe(
+          Effect.map(() => true),
+          Effect.catch(() => Effect.succeed(false)),
+        );
+      return fetched ? remoteRef : baseBranch;
+    });
+    const rangeContext = yield* gitCore.readRangeContext(cwd, rangeRef);
 
     const generated = yield* textGeneration.generatePrContent({
       cwd,


### PR DESCRIPTION
## Summary
Fixes #1487

When creating a pull request via the git button, the range context (commit log and diff used to generate the PR title/body) was computed using `baseBranch..HEAD` where `baseBranch` referred to the **local** branch ref (e.g. `main`). If the local ref hadn't been fetched since previous PRs were merged upstream, the range would include all old commits from previously merged PRs, causing:

- PR titles to reflect the **first** PR's content rather than the current changes
- PR bodies to accumulate descriptions from all past changes

**Root cause**: `runPrStep` in `GitManager.ts` called `readRangeContext(cwd, baseBranch)` with a potentially stale local branch ref. Since the `push` step only pushes the current feature branch (not fetching the base), the local `main` could be many commits behind `origin/main`.

**Fix**: Before computing the range context, fetch the remote tracking ref for the base branch (e.g. `origin/main`) and use it for the range computation. This ensures the diff only contains commits not yet present upstream, so each PR gets a fresh title and body based solely on its own changes.

The fix is conservative:
- If `baseBranch` already contains a remote prefix (e.g. `origin/main`), it's used as-is
- If the fetch fails (e.g. offline, no remote), it falls back to the local ref (preserving current behavior)
- The `baseBranch` variable is still used for PR targeting — only the range computation uses the refreshed remote ref

## Test plan
- [ ] Create commits on a feature branch, commit+push+PR via git button — verify title/body match the changes
- [ ] Merge that PR upstream, then create new commits on the same branch
- [ ] Commit+push+PR again — verify the new PR title/body only reflect the **new** changes, not the previously merged ones
- [ ] Test offline/disconnected scenario — verify graceful fallback to local ref
- [ ] Verify cross-repository fork PRs still work correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a network `git fetch` (30s timeout) during PR creation and changes which commits/diffs are used to generate PR title/body; failures fall back to prior local-ref behavior.
> 
> **Overview**
> Ensures PR title/body generation uses an up-to-date base by **fetching the base branch’s remote tracking ref** before computing the range context in `runPrStep`.
> 
> If the base branch already includes a remote prefix it’s used directly; otherwise it fetches `headContext.remoteName` (or `origin`) and prefers `remote/<baseBranch>` for `readRangeContext`, falling back to the local `baseBranch` on fetch/verify failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a00a0dc23ed6fbf742ff32bd7bbade66635a0ddf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fetch remote base branch before computing PR diff range to prevent stale diffs
> In `configurePullRequestHeadUpstream`, the base branch ref used for `readRangeContext` is now resolved to its remote-tracking counterpart before computing PR content. The code fetches the base branch from the appropriate remote (using `headContext.remoteName` or falling back to `origin`), verifies the ref exists via `git rev-parse --verify`, and uses it if successful. On any error, it falls back to the local base branch name.
>
> - Behavioral Change: PR commit and diff summaries may differ from before when the local base branch was behind the remote.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a00a0dc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->