### PR TITLE
fix: regenerate PR title and body when updating existing pull request

### DIFF
--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -272,6 +272,17 @@ const makeGitHubCli = Effect.sync(() => {
         cwd: input.cwd,
         args: ["pr", "checkout", input.reference, ...(input.force ? ["--force"] : [])],
       }).pipe(Effect.asVoid),
+    editPullRequest: (input) =>
+      execute({
+        cwd: input.cwd,
+        args: [
+          "pr",
+          "edit",
+          String(input.number),
+          ...(input.title ? ["--title", input.title] : []),
+          ...(input.bodyFile ? ["--body-file", input.bodyFile] : []),
+        ],
+      }).pipe(Effect.asVoid),
   } satisfies GitHubCliShape;
 
   return service;

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -889,19 +889,9 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
       upstreamRef: details.upstreamRef,
     });
 
-    const existing = yield* findOpenPr(cwd, headContext.headSelectors);
-    if (existing) {
-      return {
-        status: "opened_existing" as const,
-        url: existing.url,
-        number: existing.number,
-        baseBranch: existing.baseRefName,
-        headBranch: existing.headRefName,
-        title: existing.title,
-      };
-    }
-
     const baseBranch = yield* resolveBaseBranch(cwd, branch, details.upstreamRef, headContext);
+    const existing = yield* findOpenPr(cwd, headContext.headSelectors);
+
     const rangeContext = yield* gitCore.readRangeContext(cwd, baseBranch);
 
     const generated = yield* textGeneration.generatePrContent({
@@ -922,6 +912,27 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
           gitManagerError("runPrStep", "Failed to write pull request body temp file.", cause),
         ),
       );
+
+    if (existing) {
+      yield* gitHubCli
+        .editPullRequest({
+          cwd,
+          number: existing.number,
+          title: generated.title,
+          bodyFile,
+        })
+        .pipe(Effect.ensuring(fileSystem.remove(bodyFile).pipe(Effect.catch(() => Effect.void))));
+
+      return {
+        status: "opened_existing" as const,
+        url: existing.url,
+        number: existing.number,
+        baseBranch: existing.baseRefName,
+        headBranch: existing.headRefName,
+        title: generated.title,
+      };
+    }
+
     yield* gitHubCli
       .createPullRequest({
         cwd,

--- a/apps/server/src/git/Services/GitHubCli.ts
+++ b/apps/server/src/git/Services/GitHubCli.ts
@@ -93,6 +93,16 @@ export interface GitHubCliShape {
     readonly reference: string;
     readonly force?: boolean;
   }) => Effect.Effect<void, GitHubCliError>;
+
+  /**
+   * Edit an existing pull request's title and/or body.
+   */
+  readonly editPullRequest: (input: {
+    readonly cwd: string;
+    readonly number: number;
+    readonly title?: string;
+    readonly bodyFile?: string;
+  }) => Effect.Effect<void, GitHubCliError>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- When a branch already has an open PR, the `runPrStep` in `GitManager` now regenerates the PR title and body from the **current** diffs instead of returning the stale original title
- Added `editPullRequest` method to `GitHubCliShape` service (using `gh pr edit`) to update existing PRs
- The existing PR's title and body are updated via the new `editPullRequest` call before returning

### Root cause

In `runPrStep`, when `findOpenPr` found an existing open PR for the current branch, the code returned early with `status: "opened_existing"` and the **original** PR title — without regenerating content from the latest diffs. This meant subsequent pushes to the same branch never refreshed the PR metadata.

### Changes

- `apps/server/src/git/Services/GitHubCli.ts` — Added `editPullRequest` to the service interface
- `apps/server/src/git/Layers/GitHubCli.ts` — Implemented `editPullRequest` using `gh pr edit`
- `apps/server/src/git/Layers/GitManager.ts` — Restructured `runPrStep` to always generate fresh PR content from current diffs, and call `editPullRequest` when an open PR already exists

## Test plan

- [ ] Create a branch, make changes, commit+push+PR — verify PR is created with correct title/body
- [ ] Push additional commits to the same branch, run commit+push+PR again — verify the existing PR's title and body are **updated** to reflect the new diffs
- [ ] Verify that creating a PR on a fresh branch (no existing PR) still works as before

Fixes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR orchestration to edit existing GitHub PRs via `gh pr edit`, which affects a user-facing workflow and depends on external CLI behavior and temp-file handling.
> 
> **Overview**
> `runPrStep` now **always regenerates** pull request title/body from the current commit/diff range, even when an open PR already exists for the branch.
> 
> When an existing open PR is found, it updates that PR in-place via a new `GitHubCli.editPullRequest` (implemented with `gh pr edit --title/--body-file`) instead of returning the stale original title, while still cleaning up the generated temp body file in both edit and create paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c62c86209dd21ce4fd867714251c9c2b60f5396b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Regenerate and update PR title and body when an existing pull request is found
> Previously, `runPrStep` returned early with the existing PR's title and body unchanged when a matching open PR was found. Now it generates new PR content and calls `gh pr edit` to update the existing PR's title and body.
>
> - Adds `editPullRequest` to [`GitHubCliShape`](https://github.com/pingdotgg/t3code/pull/1520/files#diff-5806b1829927229623120641f572e1d4b351a0fd16937930d50cb0d1133d53ec) and implements it in [`makeGitHubCli`](https://github.com/pingdotgg/t3code/pull/1520/files#diff-97968eab7fdc99fda8af3ce3b46949beac5e717c360efb086a5a94d9c1829b85) using `gh pr edit <number> --title --body-file`.
> - Reorders [`makeGitManager.runPrStep`](https://github.com/pingdotgg/t3code/pull/1520/files#diff-3d2a98876a28b6b4d401b67afc09729806523bb0997970e508a7f4a9368b404e) to resolve the base branch before searching for an existing PR, so that path is no longer skipped.
> - Behavioral Change: existing PRs now have their title and body overwritten on every run of `runPrStep`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c62c862.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->