### PR TITLE
fix: filter already-merged commits from PR range context

### DIFF
--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1374,7 +1374,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
           runGitStdoutWithOptions(
             "GitCore.readRangeContext.log",
             cwd,
-            ["log", "--oneline", range],
+            ["log", "--oneline", "--cherry-pick", "--right-only", range],
             {
               maxOutputBytes: RANGE_COMMIT_SUMMARY_MAX_OUTPUT_BYTES,
               truncateOutputAtMaxBytes: true,


### PR DESCRIPTION
## Summary
Fixes #1487

When generating PR title and body, `readRangeContext` uses `git log --oneline baseBranch..HEAD` to collect the commit summary that feeds into the LLM prompt. On long-lived branches where previous PRs were squash-merged (or merge-committed) into the base branch, this range includes **all** old commits whose SHAs differ from what landed on the base — even though their patch content is already upstream. The LLM then generates a title dominated by stale commit messages from previously merged PRs.

**Root cause**: `git log main..HEAD` lists commits reachable from HEAD but not from `main` by commit identity (SHA). After a squash-merge, the original commits on the feature branch have different SHAs than the squash commit on `main`, so they all appear in the log — even though the actual code changes are already in `main`.

**Fix**: Add `--cherry-pick --right-only` flags to the `git log` command in `readRangeContext`. These flags tell git to compare patch-ids (content hashes of each commit's diff) and skip any commit on the right side (HEAD) whose patch already exists on the left side (base branch). This filters out commits from previously merged PRs, ensuring only genuinely new commits feed into PR content generation.

This is a single-line change with no network overhead (unlike fetching the base branch), works entirely locally, and gracefully handles all merge strategies (squash, merge commit, rebase).

**Changed file**: `apps/server/src/git/Layers/GitCore.ts` — `readRangeContext` method

## Test plan
- [ ] On a long-lived branch with previously squash-merged PRs, run commit+push+PR — verify the generated PR title only reflects new changes
- [ ] On a fresh feature branch with no prior PRs, verify PR generation works normally
- [ ] Verify the existing `readRangeContext` test still passes (it creates fresh commits not present on the base, so `--cherry-pick` won't filter them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to the `git log` invocation used for PR context generation; it only affects which commits appear in the summary, not repository state or data writes.
> 
> **Overview**
> Updates `GitCore.readRangeContext` to call `git log` with `--cherry-pick --right-only` for the `base..HEAD` range, filtering out commits whose patch content already exists on the base branch.
> 
> This reduces stale/previously-merged commit messages from being included in the commit summary used to generate PR titles/bodies, while leaving diff stat/patch collection unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f2aaf0a7316d3bc5a17efc325d82d296f24df7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter already-merged commits from `readRangeContext` PR range summary
> Adds `--cherry-pick` and `--right-only` flags to the `git log` call in `readRangeContext` ([GitCore.ts](https://github.com/pingdotgg/t3code/pull/1521/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865)). This limits the commit summary to the right side of the range and excludes commits whose patches already exist on the other side (e.g. cherry-picks). Behavioral Change: the set of commits appearing in the PR range summary may change for branches that share cherry-picked commits with their base.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f2aaf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->