### PR TITLE
Regenerate PR title and body when updating an existing PR

### DIFF
--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -352,6 +352,16 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
       });
     }
 
+    if (args[0] === "pr" && args[1] === "edit") {
+      return Effect.succeed({
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+    }
+
     if (args[0] === "repo" && args[1] === "view") {
       const repository = args[2];
       if (typeof repository === "string" && args.includes("nameWithOwner,url,sshUrl")) {
@@ -463,6 +473,17 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
         execute({
           cwd: input.cwd,
           args: ["pr", "checkout", input.reference, ...(input.force ? ["--force"] : [])],
+        }).pipe(Effect.asVoid),
+      editPullRequest: (input) =>
+        execute({
+          cwd: input.cwd,
+          args: [
+            "pr",
+            "edit",
+            String(input.number),
+            ...(input.title ? ["--title", input.title] : []),
+            ...(input.bodyFile ? ["--body-file", input.bodyFile] : []),
+          ],
         }).pipe(Effect.asVoid),
     },
     ghCalls,

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -889,19 +889,9 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
       upstreamRef: details.upstreamRef,
     });
 
-    const existing = yield* findOpenPr(cwd, headContext.headSelectors);
-    if (existing) {
-      return {
-        status: "opened_existing" as const,
-        url: existing.url,
-        number: existing.number,
-        baseBranch: existing.baseRefName,
-        headBranch: existing.headRefName,
-        title: existing.title,
-      };
-    }
-
     const baseBranch = yield* resolveBaseBranch(cwd, branch, details.upstreamRef, headContext);
+    const existing = yield* findOpenPr(cwd, headContext.headSelectors);
+
     const rangeContext = yield* gitCore.readRangeContext(cwd, baseBranch);
 
     const generated = yield* textGeneration.generatePrContent({
@@ -922,6 +912,27 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
           gitManagerError("runPrStep", "Failed to write pull request body temp file.", cause),
         ),
       );
+
+    if (existing) {
+      yield* gitHubCli
+        .editPullRequest({
+          cwd,
+          number: existing.number,
+          title: generated.title,
+          bodyFile,
+        })
+        .pipe(Effect.ensuring(fileSystem.remove(bodyFile).pipe(Effect.catch(() => Effect.void))));
+
+      return {
+        status: "opened_existing" as const,
+        url: existing.url,
+        number: existing.number,
+        baseBranch: existing.baseRefName,
+        headBranch: existing.headRefName,
+        title: generated.title,
+      };
+    }
+
     yield* gitHubCli
       .createPullRequest({
         cwd,


### PR DESCRIPTION
## Summary
Fixes #1487

When an open PR already exists for the current branch, `runPrStep` previously short-circuited and returned the stale PR metadata (title, body) from GitHub without regenerating it. This caused the original PR title to persist across subsequent pushes — only the commits changed, not the description.

The fix removes the early-return path and instead always:
1. Resolves the base branch and computes fresh range context (`baseBranch..HEAD`)
2. Generates new PR title and body from the current diffs via `generatePrContent`
3. If an existing open PR is found, calls `editPullRequest` to update its title and body on GitHub
4. If no existing PR exists, creates a new one as before

This ensures each push produces an accurate, up-to-date PR description reflecting the current state of the branch.

## Test plan
- [x] Updated test fake to handle `pr edit` commands
- [x] Added `editPullRequest` to the fake `GitHubCliShape` in tests
- [ ] Existing `opened_existing` tests should pass (they verify status and PR number, not title text)
- [ ] Create a PR, push more commits, trigger PR step again — verify title/body are updated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the PR creation flow to mutate existing GitHub PRs via `gh pr edit`, which can overwrite titles/bodies and relies on new CLI interactions/temp-file handling.
> 
> **Overview**
> `runPrStep` no longer short-circuits when an open PR already exists for the current branch. It now always recomputes the base branch and range context, regenerates PR title/body via `generatePrContent`, and **updates the existing PR** by calling `gh pr edit` with a temp body file; otherwise it creates a PR as before.
> 
> Tests update the fake `gh` executor to accept `pr edit` and add an `editPullRequest` helper so existing-PR scenarios can exercise the new update path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c5b0ea1417f97b2e36c9a3e4709e59f03dd8ca5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Regenerate and update PR title/body when an existing open PR is found
> - Previously, `runPrStep` returned early without changes when an open PR already existed for the current branch.
> - Now, PR content (title and body) is always generated, and if an existing PR is found, it is updated via `gh pr edit` before returning `opened_existing` with the new title.
> - Behavioral Change: Existing PRs will have their title and body overwritten on each run of `runPrStep`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c5b0ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->