### PR TITLE
Add contextWindow to ClaudeModelOptionsPatch

### DIFF
--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -112,6 +112,7 @@ const ClaudeModelOptionsPatch = Schema.Struct({
   thinking: Schema.optionalKey(ClaudeModelOptions.fields.thinking),
   effort: Schema.optionalKey(ClaudeModelOptions.fields.effort),
   fastMode: Schema.optionalKey(ClaudeModelOptions.fields.fastMode),
+  contextWindow: Schema.optionalKey(ClaudeModelOptions.fields.contextWindow),
 });
 
 const ModelSelectionPatch = Schema.Union([


### PR DESCRIPTION
## What Changed

Added contextWindow to ClaudeModelOptionsPatch

## Why

The option to select Context Window is visible, but broken (selecting anything but default flickers and reverts back)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that expands the server settings patch contract for Claude model options; main risk is minor compatibility issues if consumers assume `contextWindow` cannot be patched.
> 
> **Overview**
> Updates the server settings patch schema so `textGenerationModelSelection.options` for the `claudeAgent` provider can include an optional `contextWindow` field (via `ClaudeModelOptionsPatch`). This unblocks persisting context window selection through patch updates instead of being dropped during validation/decoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4e34236e4a18168e1805c03900dcf9e463635f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `contextWindow` field to `ClaudeModelOptionsPatch` schema
> Adds an optional `contextWindow` property to the `ClaudeModelOptionsPatch` struct in [settings.ts](https://github.com/pingdotgg/t3code/pull/1536/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), reusing the field definition from `ClaudeModelOptions`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4e3423.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->