### PR TITLE
Fix for broken Codex model selection for 'Text Generation Model'

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -104,6 +104,43 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("preserves model when switching providers via textGenerationModelSelection", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsService;
+
+      // Start with Claude text generation selection
+      yield* serverSettings.updateSettings({
+        textGenerationModelSelection: {
+          provider: "claudeAgent",
+          model: "claude-sonnet-4-6",
+          options: {
+            effort: "high",
+          },
+        },
+      });
+
+      // Switch to Codex — the stale Claude "effort" in options must not
+      // cause the update to lose the selected model.
+      const next = yield* serverSettings.updateSettings({
+        textGenerationModelSelection: {
+          provider: "codex",
+          model: "gpt-5.4",
+          options: {
+            reasoningEffort: "high",
+          },
+        },
+      });
+
+      assert.deepEqual(next.textGenerationModelSelection, {
+        provider: "codex",
+        model: "gpt-5.4",
+        options: {
+          reasoningEffort: "high",
+        },
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("trims provider path settings when updates are applied", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsService;

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -27,6 +27,7 @@ import {
   FileSystem,
   Layer,
   Path,
+  Equal,
   PubSub,
   Ref,
   Schema,
@@ -130,6 +131,9 @@ function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings
   };
 }
 
+// Values under these keys are compared as a whole — never stripped field-by-field.
+const ATOMIC_SETTINGS_KEYS: ReadonlySet<string> = new Set(["textGenerationModelSelection"]);
+
 function stripDefaultServerSettings(current: unknown, defaults: unknown): unknown | undefined {
   if (Array.isArray(current) || Array.isArray(defaults)) {
     return JSON.stringify(current) === JSON.stringify(defaults) ? undefined : current;
@@ -146,9 +150,15 @@ function stripDefaultServerSettings(current: unknown, defaults: unknown): unknow
     const next: Record<string, unknown> = {};
 
     for (const key of Object.keys(currentRecord)) {
-      const stripped = stripDefaultServerSettings(currentRecord[key], defaultsRecord[key]);
-      if (stripped !== undefined) {
-        next[key] = stripped;
+      if (ATOMIC_SETTINGS_KEYS.has(key)) {
+        if (!Equal.equals(currentRecord[key], defaultsRecord[key])) {
+          next[key] = currentRecord[key];
+        }
+      } else {
+        const stripped = stripDefaultServerSettings(currentRecord[key], defaultsRecord[key]);
+        if (stripped !== undefined) {
+          next[key] = stripped;
+        }
       }
     }
 


### PR DESCRIPTION
## What Changed

Treat textGenerationModelSelection as a atomic block

## Why

Broken switching between Codex models, only 'GPT 5.4 Mini' was selectable 

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches settings persistence logic used for writing `settings.json`; a mistake could cause incorrect config serialization or unexpected resets of user selections. Change is small and covered by a new regression test around provider/model switching.
> 
> **Overview**
> Fixes a persistence bug where `stripDefaultServerSettings` could partially strip nested fields inside `textGenerationModelSelection`, causing the chosen Codex model to be dropped when switching providers.
> 
> Adds `ATOMIC_SETTINGS_KEYS` (currently just `textGenerationModelSelection`) so those settings are compared and retained as a whole using `Equal.equals`, and adds a regression test ensuring provider/model switching preserves the selected model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 943d1215225b79ef5a23a272ce4b619febd98542. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `textGenerationModelSelection` being partially stripped when switching to Codex provider
> When switching providers, `stripDefaultServerSettings` in [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/1543/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e) was recursively stripping nested fields from `textGenerationModelSelection`, causing the model to be dropped.
>
> - Introduces `ATOMIC_SETTINGS_KEYS`, a set of keys that must be preserved or omitted as a whole rather than recursively stripped field-by-field.
> - `textGenerationModelSelection` is added to this set; its value is now compared against defaults using full-object equality, and the entire value is kept or dropped based on that comparison.
> - Behavioral Change: nested fields under atomic keys are no longer individually compared to defaults — the entire object is preserved if any part differs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 943d121.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->