### PR TITLE
fix: disable command menu auto highlight

### DIFF
--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -43,6 +43,8 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
 }) {
   return (
     <Command
+      autoHighlight={false}
+      keepHighlight={false}
       mode="none"
       onItemHighlighted={(highlightedValue) => {
         props.onHighlightedItemChange(

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -47,9 +47,9 @@ export const ComposerCommandMenu = memo(function ComposerCommandMenu(props: {
       keepHighlight={false}
       mode="none"
       onItemHighlighted={(highlightedValue) => {
-        props.onHighlightedItemChange(
-          typeof highlightedValue === "string" ? highlightedValue : null,
-        );
+        if (typeof highlightedValue === "string") {
+          props.onHighlightedItemChange(highlightedValue);
+        }
       }}
     >
       <div className="relative overflow-hidden rounded-xl border border-border/80 bg-popover/96 shadow-lg/8 backdrop-blur-xs">


### PR DESCRIPTION
## What Changed

Disabled the composer slash-command menu's built-in auto-highlight behavior in `ComposerCommandMenu.tsx`. The menu now relies only on the app-managed active item state instead of also keeping Base UI's initial highlighted row.

## Why

When using `/model`, arrow-key navigation is handled in the chat composer, not by the menu primitive. That meant Base UI kept the first item highlighted from mount while the app separately highlighted the keyboard-active item, so gpt-5.4 appeared selected even when navigating to another model. Disabling the menu primitive's auto-highlight is the narrow fix because it removes the stale visual state without changing selection behavior.

## UI Changes

Before : 

https://github.com/user-attachments/assets/591c0cc0-b7c9-41a6-ada2-20c1cfa01ecc

After : 

https://github.com/user-attachments/assets/e392351b-cd2d-4ba8-84cc-6430c526d7b0

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to command-menu highlighting; it may slightly alter keyboard/mouse highlight feedback but does not affect selection or data handling.
> 
> **Overview**
> Disables the command menu primitive’s built-in auto-highlighting in `ComposerCommandMenu` by setting `autoHighlight={false}` and `keepHighlight={false}`, so the UI highlight is driven solely by the app-managed `activeItemId`.
> 
> Tightens the `onItemHighlighted` handler to only forward string item IDs (no longer emitting `null`), avoiding stale/competing highlight state in the slash-command menu.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4333e5692b1ee47f0995ee8703d7a2b29d3206ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable auto-highlight in `ComposerCommandMenu`
> Sets `autoHighlight={false}` and `keepHighlight={false}` on the `Command` element in [ComposerCommandMenu.tsx](https://github.com/pingdotgg/t3code/pull/1548/files#diff-ca7de5ada90d0c74157405378c7182002eab97a1ea23cd71e4376f8db6ba81a4). The `onHighlightedItemChange` callback is now only invoked with string item IDs; it is no longer called with `null` when no string value is highlighted.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4333e56. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->