### PR TITLE
fix(web): dismiss mobile sidebar sheet after navigation

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -101,6 +101,7 @@ import {
   SidebarMenuSubItem,
   SidebarSeparator,
   SidebarTrigger,
+  useSidebar,
 } from "./ui/sidebar";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
@@ -334,6 +335,11 @@ export default function Sidebar() {
     (store) => store.clearProjectDraftThreadId,
   );
   const navigate = useNavigate();
+  const { isMobile, setOpenMobile } = useSidebar();
+  /** Close the mobile sidebar sheet after any user-initiated navigation. */
+  const closeMobileSidebar = useCallback(() => {
+    if (isMobile) setOpenMobile(false);
+  }, [isMobile, setOpenMobile]);
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const isOnSettings = pathname.startsWith("/settings");
   const appSettings = useSettings();
@@ -835,9 +841,11 @@ export default function Sidebar() {
         to: "/$threadId",
         params: { threadId },
       });
+      closeMobileSidebar();
     },
     [
       clearSelection,
+      closeMobileSidebar,
       navigate,
       rangeSelectTo,
       selectedThreadIds.size,
@@ -856,8 +864,9 @@ export default function Sidebar() {
         to: "/$threadId",
         params: { threadId },
       });
+      closeMobileSidebar();
     },
-    [clearSelection, navigate, selectedThreadIds.size, setSelectionAnchor],
+    [clearSelection, closeMobileSidebar, navigate, selectedThreadIds.size, setSelectionAnchor],
   );
 
   const handleProjectContextMenu = useCallback(
@@ -1519,6 +1528,7 @@ export default function Sidebar() {
                         defaultEnvMode: appSettings.defaultThreadEnvMode,
                       }),
                     });
+                    closeMobileSidebar();
                   }}
                 >
                   <SquarePenIcon className="size-3.5" />
@@ -1976,7 +1986,10 @@ export default function Sidebar() {
                 <SidebarMenuButton
                   size="sm"
                   className="gap-2 px-2 py-1.5 text-muted-foreground/70 hover:bg-accent hover:text-foreground"
-                  onClick={() => void navigate({ to: "/settings" })}
+                  onClick={() => {
+                    void navigate({ to: "/settings" });
+                    closeMobileSidebar();
+                  }}
                 >
                   <SettingsIcon className="size-3.5" />
                   <span className="text-xs">Settings</span>


### PR DESCRIPTION
On mobile, the sidebar renders as a slide-over sheet. After tapping a thread, creating a new thread, or navigating to settings, the sheet stays open and must be manually dismissed.

Add a closeMobileSidebar() helper that calls setOpenMobile(false) when isMobile is true, and invoke it after:
- plain-click thread navigation (handleThreadClick)
- programmatic thread navigation (navigateToThread)
- new thread creation
- settings navigation

Fixes #1258

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to calling `setOpenMobile(false)` after user-initiated navigations; minimal impact outside mobile and no data/auth logic touched.
> 
> **Overview**
> Ensures the mobile sidebar (sheet) auto-dismisses after navigation actions.
> 
> `Sidebar` now uses `useSidebar()` to add a `closeMobileSidebar()` helper and calls it after thread navigation (click and keyboard/programmatic), after creating a new thread from a project, and after navigating to Settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be06b7b35087300e42875317a75044d3c6ced21a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Dismiss mobile sidebar sheet after navigation in `Sidebar`
> On mobile, the sidebar sheet previously stayed open after navigating to a thread, creating a new thread, or opening Settings. A `closeMobileSidebar` callback (via `useSidebar`) is now called after each navigation action in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1549/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), so the sheet closes automatically on mobile.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be06b7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->