### PR TITLE
fix(web): add safe-area-top padding to settings header on mobile

### DIFF
--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -32,7 +32,7 @@ function SettingsContentLayout() {
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground isolate">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background text-foreground">
         {!isElectron && (
-          <header className="border-b border-border px-3 py-2 sm:px-5">
+          <header className="border-b border-border px-3 py-2 pt-[calc(0.5rem+var(--safe-area-top))] sm:px-5">
             <div className="flex items-center gap-2">
               <SidebarTrigger className="size-7 shrink-0 md:hidden" />
               <span className="text-sm font-medium text-foreground">Settings</span>


### PR DESCRIPTION
On devices with a notch or Dynamic Island (iPhone X+), the settings page header renders underneath the system status bar because it lacks safe-area-inset padding.

The CSS custom property --safe-area-top is already defined in index.css and used by other headers (ChatView, sidebar sheet, index route). This adds the same padding to the settings header.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts layout spacing for mobile safe areas; no logic, data, or security behavior is modified.
> 
> **Overview**
> Fixes the Settings page header overlapping the iOS status bar/notch by adding top padding that incorporates `var(--safe-area-top)`.
> 
> The change applies to the non-Electron header only and keeps existing spacing by using `pt-[calc(0.5rem+var(--safe-area-top))]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbf262131448eda18d096b82478436f9328cacbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add safe-area-top padding to settings header on mobile web
> In [settings.tsx](https://github.com/pingdotgg/t3code/pull/1552/files#diff-6cc678720606306a67c0a682ce2147608273cd0d475243bf2938656a858ef7d6), the `SettingsContentLayout` header now applies `pt-[calc(0.5rem+var(--safe-area-top))]` on non-electron builds to avoid content being obscured by the device notch or status bar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dbf2621.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->