### PR TITLE
Fix Claude [ede_diagnostic] red popups

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -626,6 +626,11 @@ function turnStatusFromResult(result: SDKResultMessage): ProviderRuntimeTurnStat
   if (errors.includes("cancel")) {
     return "cancelled";
   }
+
+  if (result.is_error === false) {
+    return "completed";
+  }
+
   return "failed";
 }
 
@@ -1907,7 +1912,11 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     const status = turnStatusFromResult(message);
-    const errorMessage = message.subtype === "success" ? undefined : message.errors[0];
+    // Skip [ede_diagnostic] entries (SDK-internal diagnostics, not user-facing errors).
+    const errorMessage =
+      message.subtype === "success"
+        ? undefined
+        : message.errors.find((e: string) => !e.startsWith("[ede_diagnostic]"));
 
     if (status === "failed") {
       yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");


### PR DESCRIPTION
## What Changed

Claude: Mark results that have 'is_error === false' as completed, plus specifically filter for [ede_diagnostic]

## Why

Claude SDK sometimes does give "diagnostics" which aren't actually errors, so shouldn't trigger a red pop up in UI

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to Claude result classification and error-message selection that mainly affects UI error surfacing and turn status reporting.
> 
> **Overview**
> Prevents Claude SDK diagnostic messages from surfacing as user-facing failures.
> 
> `turnStatusFromResult` now treats result messages with `is_error === false` as `completed` (after existing interrupted/cancelled checks), and `handleResultMessage` now filters out `[ede_diagnostic]` entries when choosing an error message to emit/record, reducing spurious red error popups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9464460b7daed51b1bdf54604aa04135ee8efeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `[ede_diagnostic]` errors appearing as red popups in Claude turns
> - Filters out SDK-internal `[ede_diagnostic]` error entries when selecting the error message for failed Claude turns in `handleResultMessage`; if only diagnostics are present, the error message is `undefined` and falls back to "Claude turn failed."
> - Fixes `turnStatusFromResult` to return `"completed"` when `result.is_error === false`, preventing non-error results from falling through to `"failed"`.
> - Behavioral Change: non-success results containing only `[ede_diagnostic]` errors no longer surface a specific error message to the user.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e946446.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->