### PR TITLE
Scroll active item into view in composer menu

### DIFF
--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -103,7 +103,7 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
       value={props.item.id}
       data-composer-item-id={props.item.id}
       className={cn(
-        "cursor-pointer select-none gap-2 data-highlighted:bg-transparent data-highlighted:text-inherit",
+        "cursor-pointer select-none gap-2 hover:bg-transparent hover:text-inherit data-highlighted:bg-transparent data-highlighted:text-inherit",
         props.isActive && "bg-accent! text-accent-foreground!",
       )}
       onMouseMove={() => {


### PR DESCRIPTION
## What Changed

- Attach a ref to the list container and query the item by its data- attribute to call scrollIntoView.
- Add data-composer-item-id on items to support the lookup.

## Why

When navigating the @ file/command popover with arrow keys, the highlighted item's CSS class updated but the list never scrolled. Holding arrow down past 8+ items left the active item hidden behind the bottom edge of the max-h-64 container.


## UI Changes

Before: enter `@` then filename, if result is more than 8, hold down arrow down, the highlighted element is hidden 

https://github.com/user-attachments/assets/8f9472bb-86a2-49bb-8dc4-3aef8315b89a

After: the highlighted element is scrolled into view

https://github.com/user-attachments/assets/93c341a6-906a-4252-b14a-dcc5f5275f21




## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds `scrollIntoView` behavior when the active item changes. Main risk is minor scrolling/hover styling regressions in the command popover.
> 
> **Overview**
> Keeps the composer @/slash-command popover usable with long lists by automatically scrolling the currently active (keyboard-highlighted) item into view.
> 
> Adds a `useLayoutEffect` with a container ref that finds the active row via a new `data-composer-item-id` attribute and calls `scrollIntoView({ block: "nearest" })`, and tweaks `CommandItem` classes to preserve styling while hovering/highlighting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4db73ec1cf837a14c18e75fd3b8f3d29df1ce48d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scroll active item into view in the composer command menu
> - Adds a `useLayoutEffect` in [`ComposerCommandMenu`](https://github.com/pingdotgg/t3code/pull/1557/files#diff-ca7de5ada90d0c74157405378c7182002eab97a1ea23cd71e4376f8db6ba81a4) that calls `scrollIntoView({ block: "nearest" })` on the active item whenever `activeItemId` changes, using a `data-composer-item-id` attribute as the selector target.
> - Removes hover background and text color changes from `ComposerCommandMenuItem` to avoid visual conflicts with the existing `data-highlighted` styles.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4db73ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->