### PR TITLE
fix: prevent iOS composer focus zoom

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -59,6 +59,8 @@ import {
   isCollapsedCursorAdjacentToInlineToken,
 } from "~/composer-logic";
 import { splitPromptIntoComposerSegments } from "~/composer-editor-mentions";
+import { useMediaQuery } from "~/hooks/useMediaQuery";
+import { usePreventIosInputZoom } from "~/hooks/usePreventIosInputZoom";
 import {
   INLINE_TERMINAL_CONTEXT_PLACEHOLDER,
   type TerminalContextDraft,
@@ -893,6 +895,13 @@ function ComposerPromptEditorInner({
 }: ComposerPromptEditorInnerProps) {
   const [editor] = useLexicalComposerContext();
   const onChangeRef = useRef(onChange);
+  const isCoarsePointer = useMediaQuery({ pointer: "coarse" });
+  const composerFontSizePx = isCoarsePointer ? 16 : 14;
+  const {
+    onBlur: handleEditorBlur,
+    onFocus: handleEditorFocus,
+    onTouchStartCapture: handleEditorTouchStartCapture,
+  } = usePreventIosInputZoom();
   const initialCursor = clampCollapsedComposerCursor(value, cursor);
   const terminalContextsSignature = terminalContextSignature(terminalContexts);
   const terminalContextsSignatureRef = useRef(terminalContextsSignature);
@@ -1093,18 +1102,25 @@ function ComposerPromptEditorInner({
           contentEditable={
             <ContentEditable
               className={cn(
-                "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-[14px] leading-relaxed text-foreground focus:outline-none",
+                "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent leading-relaxed text-foreground focus:outline-none",
                 className,
               )}
               data-testid="composer-editor"
               aria-placeholder={placeholder}
               placeholder={<span />}
+              style={{ fontSize: composerFontSizePx }}
+              onBlur={handleEditorBlur}
+              onFocus={handleEditorFocus}
               onPaste={onPaste}
+              onTouchStartCapture={handleEditorTouchStartCapture}
             />
           }
           placeholder={
             terminalContexts.length > 0 ? null : (
-              <div className="pointer-events-none absolute inset-0 text-[14px] leading-relaxed text-muted-foreground/35">
+              <div
+                className="pointer-events-none absolute inset-0 leading-relaxed text-muted-foreground/35"
+                style={{ fontSize: composerFontSizePx }}
+              >
                 {placeholder}
               </div>
             )

--- a/apps/web/src/hooks/usePreventIosInputZoom.test.ts
+++ b/apps/web/src/hooks/usePreventIosInputZoom.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildInputZoomLockedViewportContent,
+  isIosInputZoomPlatform,
+} from "./usePreventIosInputZoom";
+
+describe("isIosInputZoomPlatform", () => {
+  it("detects iPhone user agents", () => {
+    expect(
+      isIosInputZoomPlatform({
+        maxTouchPoints: 5,
+        platform: "iPhone",
+        userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_3 like Mac OS X) AppleWebKit/605.1.15",
+      }),
+    ).toBe(true);
+  });
+
+  it("detects iPadOS devices that report as MacIntel", () => {
+    expect(
+      isIosInputZoomPlatform({
+        maxTouchPoints: 5,
+        platform: "MacIntel",
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores desktop macOS", () => {
+    expect(
+      isIosInputZoomPlatform({
+        maxTouchPoints: 0,
+        platform: "MacIntel",
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildInputZoomLockedViewportContent", () => {
+  it("adds the focus zoom lock directives", () => {
+    expect(buildInputZoomLockedViewportContent("width=device-width, initial-scale=1.0")).toBe(
+      "width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no",
+    );
+  });
+
+  it("replaces existing maximum scale directives", () => {
+    expect(
+      buildInputZoomLockedViewportContent(
+        "width=device-width, initial-scale=1.0, maximum-scale=5, user-scalable=yes",
+      ),
+    ).toBe("width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no");
+  });
+});

--- a/apps/web/src/hooks/usePreventIosInputZoom.ts
+++ b/apps/web/src/hooks/usePreventIosInputZoom.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+const DEFAULT_VIEWPORT_CONTENT = "width=device-width, initial-scale=1.0";
+const IOS_USER_AGENT_PATTERN = /\b(iPad|iPhone|iPod)\b/i;
+const VIEWPORT_META_SELECTOR = 'meta[name="viewport"]';
+
+export function isIosInputZoomPlatform(input: {
+  maxTouchPoints: number;
+  platform: string;
+  userAgent: string;
+}): boolean {
+  return (
+    IOS_USER_AGENT_PATTERN.test(input.userAgent) ||
+    (input.platform === "MacIntel" && input.maxTouchPoints > 1)
+  );
+}
+
+export function buildInputZoomLockedViewportContent(content: string): string {
+  const baseContent = content.trim() || DEFAULT_VIEWPORT_CONTENT;
+  const segments = baseContent
+    .split(",")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+  const filteredSegments = segments.filter((segment) => {
+    const [key] = segment.split("=", 1);
+    const normalizedKey = key?.trim().toLowerCase();
+    return normalizedKey !== "maximum-scale" && normalizedKey !== "user-scalable";
+  });
+
+  filteredSegments.push("maximum-scale=1", "user-scalable=no");
+  return filteredSegments.join(", ");
+}
+
+export function usePreventIosInputZoom(): {
+  onBlur: () => void;
+  onFocus: () => void;
+  onTouchStartCapture: () => void;
+} {
+  const isEnabled = useMemo(() => {
+    if (typeof navigator === "undefined") {
+      return false;
+    }
+
+    return isIosInputZoomPlatform({
+      maxTouchPoints: navigator.maxTouchPoints,
+      platform: navigator.platform,
+      userAgent: navigator.userAgent,
+    });
+  }, []);
+  const focusedRef = useRef(false);
+  const lockStateRef = useRef<{
+    isLocked: boolean;
+    originalContent: string | null;
+    viewportMeta: HTMLMetaElement | null;
+  }>({
+    isLocked: false,
+    originalContent: null,
+    viewportMeta: null,
+  });
+
+  const restoreViewport = useCallback(() => {
+    const lockState = lockStateRef.current;
+    if (!lockState.isLocked) {
+      return;
+    }
+
+    if (lockState.viewportMeta && lockState.originalContent != null) {
+      lockState.viewportMeta.setAttribute("content", lockState.originalContent);
+    }
+
+    lockState.isLocked = false;
+    lockState.originalContent = null;
+    lockState.viewportMeta = null;
+  }, []);
+
+  const lockViewport = useCallback(() => {
+    if (!isEnabled || typeof document === "undefined") {
+      return;
+    }
+
+    const lockState = lockStateRef.current;
+    if (lockState.isLocked) {
+      return;
+    }
+
+    const viewportMeta = document.querySelector<HTMLMetaElement>(VIEWPORT_META_SELECTOR);
+    if (!viewportMeta) {
+      return;
+    }
+
+    lockState.isLocked = true;
+    lockState.originalContent = viewportMeta.getAttribute("content") ?? DEFAULT_VIEWPORT_CONTENT;
+    lockState.viewportMeta = viewportMeta;
+    viewportMeta.setAttribute(
+      "content",
+      buildInputZoomLockedViewportContent(lockState.originalContent),
+    );
+  }, [isEnabled]);
+
+  const handleTouchStartCapture = useCallback(() => {
+    lockViewport();
+    requestAnimationFrame(() => {
+      if (!focusedRef.current) {
+        restoreViewport();
+      }
+    });
+  }, [lockViewport, restoreViewport]);
+
+  const handleFocus = useCallback(() => {
+    focusedRef.current = true;
+    lockViewport();
+  }, [lockViewport]);
+
+  const handleBlur = useCallback(() => {
+    focusedRef.current = false;
+    restoreViewport();
+  }, [restoreViewport]);
+
+  useEffect(() => restoreViewport, [restoreViewport]);
+
+  return {
+    onBlur: handleBlur,
+    onFocus: handleFocus,
+    onTouchStartCapture: handleTouchStartCapture,
+  };
+}


### PR DESCRIPTION
## What Changed
  Prevents the chat composer from triggering iOS Safari's automatic page zoom when the editor is focused on mobile.
  The fix does two things:
  - Sets the composer editor text size to 16px on coarse-pointer devices, which avoids the common iOS auto-zoom trigger.
  - Adds a small iOS-specific focus guard that temporarily locks the viewport while the composer is focused, then restores the original viewport
    settings on blur.
  This is scoped only to the composer and includes a small unit test for the viewport helper.
  ## Why
  On iPhone, tapping into the composer caused the page to zoom in slightly when the keyboard opened, which left the UI at the wrong zoom level
  afterward and made the mobile experience feel broken.
  This approach keeps the fix narrow:
  - It only affects the composer, not the whole app.
  - It preserves the normal viewport configuration outside of composer focus.
  - It handles iOS/iPadOS specifically instead of applying a global zoom restriction.
  ## UI Changes
  Behavior change only. The composer no longer causes the page to zoom when focused on iPhone.
  ## Checklist
  - [x] This PR is small and focused
  - [x] I explained what changed and why
  - [ ] I included before/after screenshots for any UI changes
  - [x] I included a video for animation/interaction changes
  
https://github.com/user-attachments/assets/90d9e5ce-a134-4734-a575-9dfa8391dbd9


https://github.com/user-attachments/assets/bca309df-ba21-48f3-b28e-4d68aeef35ea


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds iOS-specific viewport meta manipulation on focus/blur and adjusts editor font sizing; mistakes could impact mobile zoom/scroll behavior if the viewport content isn’t restored correctly.
> 
> **Overview**
> Prevents iOS Safari from auto-zooming when the chat composer is focused by **raising the composer font size to 16px on coarse-pointer devices** and wiring new focus/blur/touch handlers into `ComposerPromptEditor`.
> 
> Introduces a new `usePreventIosInputZoom` hook that, on iOS/iPadOS, temporarily locks the page viewport (`maximum-scale=1`, `user-scalable=no`) while the editor is focused and restores the original viewport on blur/unmount, with unit tests covering platform detection and viewport content rewriting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5df22831f5e7c768974b1bbf6f063d321f6181e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent iOS composer input zoom by locking viewport on focus
> - Adds a `usePreventIosInputZoom` hook that mutates the viewport meta tag (`maximum-scale=1`, `user-scalable=no`) when a focusable element is focused on iOS/iPadOS, restoring the original viewport on blur.
> - Detects iOS/iPadOS via user agent or `MacIntel` platform with multiple touch points.
> - Sets the composer font size to 16px on coarse-pointer devices (preventing iOS auto-zoom) and 14px otherwise, replacing the hardcoded `text-[14px]` Tailwind class.
> - Risk: Setting `user-scalable=no` temporarily disables pinch-to-zoom globally while the composer is focused, which may affect accessibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5df2283.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->