### PR TITLE
Fix setup action doesn't run automatically

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2623,14 +2623,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
           // Keep local thread state in sync immediately so terminal drawer opens
           // with the worktree cwd/env instead of briefly using the project root.
           setStoreThreadBranch(threadIdForSend, result.worktree.branch, result.worktree.path);
-        } else {
-          // Keep the draft thread in sync immediately so the terminal drawer
-          // does not reopen the setup terminal at the project root.
-          setDraftThreadContext(threadIdForSend, {
-            branch: result.worktree.branch,
-            worktreePath: result.worktree.path,
-            envMode: "worktree",
-          });
         }
       }
 
@@ -2675,6 +2667,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
           worktreePath: nextThreadWorktreePath,
           createdAt: activeThread.createdAt,
         });
+        if (baseBranchForWorktree && nextThreadWorktreePath) {
+          // Sync the draft thread before opening the setup terminal so the
+          // terminal drawer resolves the same worktree cwd and env.
+          setDraftThreadContext(threadIdForSend, {
+            branch: nextThreadBranch,
+            worktreePath: nextThreadWorktreePath,
+            envMode: "worktree",
+          });
+        }
         createdServerThreadForLocalDraft = true;
       }
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Fixes #1527 where the worktree setup action wouldn't actually run automatically.

Now the local draft-thread worktree state is synced only after `thread.create` succeeds and before launching `runOnWorktreeCreate` actions. This keeps `ThreadTerminalDrawer` and the setup launcher on the same worktree cwd/env without marking the draft as already worktree-backed too early, so retries still go through the full setup path.

## Why

T3 code is awesome, but a big part of that is worktrees, which are much less useful without automatic setup *before* the agent goes to work.

## UI Changes

No

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-message thread/worktree creation and terminal setup sequencing; behavior changes are localized but could affect automatic setup script execution and terminal cwd/env in new worktree threads.
> 
> **Overview**
> Fixes a race in the first-send worktree flow where a newly-created local draft thread could launch `runOnWorktreeCreate` setup actions with stale cwd/env.
> 
> When creating the server thread from a local draft and a worktree was just created, `ChatView` now immediately calls `setDraftThreadContext` with the new `branch`, `worktreePath`, and `envMode="worktree"` so `ThreadTerminalDrawer` resolves the correct worktree environment before opening the setup terminal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4c9dcb35454bd8f12a08032b2186dab5de71833. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix setup action not running automatically in worktree draft threads
> In [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1568/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), after a server-side thread is created for a local draft, the component now calls `setDraftThreadContext` with `branch`, `worktreePath`, and `envMode="worktree"` when both `baseBranchForWorktree` and `nextThreadWorktreePath` are present. Previously this context was never set, causing the setup action to not trigger automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4c9dcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->