### PR TITLE
Add background attention notifications

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -2,6 +2,7 @@ import { useEffect, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import ThreadSidebar from "./Sidebar";
+import { useLifecycleNotifications } from "../hooks/useLifecycleNotifications";
 import { Sidebar, SidebarProvider, SidebarRail } from "./ui/sidebar";
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
@@ -10,6 +11,7 @@ const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  useLifecycleNotifications();
 
   useEffect(() => {
     const onMenuAction = window.desktopBridge?.onMenuAction;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -47,6 +47,7 @@ import {
   resolveAppModelSelectionState,
 } from "../../modelSelection";
 import { ensureNativeApi, readNativeApi } from "../../nativeApi";
+import { requestLocalNotificationPermission } from "../../lib/localNotifications";
 import { useStore } from "../../store";
 import { formatRelativeTime, formatRelativeTimeLabel } from "../../timestampFormat";
 import { cn } from "../../lib/utils";
@@ -463,6 +464,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.diffWordWrap !== DEFAULT_UNIFIED_SETTINGS.diffWordWrap
         ? ["Diff line wrapping"]
         : []),
+      ...(settings.attentionNotifications !== DEFAULT_UNIFIED_SETTINGS.attentionNotifications
+        ? ["Attention notifications"]
+        : []),
       ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
@@ -483,6 +487,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       isGitWritingModelDirty,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
+      settings.attentionNotifications,
       settings.defaultThreadEnvMode,
       settings.diffWordWrap,
       settings.enableAssistantStreaming,
@@ -861,6 +866,54 @@ export function GeneralSettingsPanel() {
                 updateSettings({ enableAssistantStreaming: Boolean(checked) })
               }
               aria-label="Stream assistant messages"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Attention notifications"
+          description="Show a local notification when a turn finishes or the agent needs input while T3 Code is in the background."
+          resetAction={
+            settings.attentionNotifications !== DEFAULT_UNIFIED_SETTINGS.attentionNotifications ? (
+              <SettingResetButton
+                label="attention notifications"
+                onClick={() =>
+                  updateSettings({
+                    attentionNotifications: DEFAULT_UNIFIED_SETTINGS.attentionNotifications,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.attentionNotifications}
+              onCheckedChange={async (checked) => {
+                const enabled = Boolean(checked);
+                if (!enabled) {
+                  updateSettings({ attentionNotifications: false });
+                  return;
+                }
+
+                const permission = await requestLocalNotificationPermission();
+                if (permission === "granted") {
+                  updateSettings({ attentionNotifications: true });
+                  return;
+                }
+
+                toastManager.add({
+                  type: "warning",
+                  title:
+                    permission === "unsupported"
+                      ? "Notifications unavailable"
+                      : "Notifications blocked",
+                  description:
+                    permission === "unsupported"
+                      ? "This environment does not support local notifications."
+                      : "Allow notifications for T3 Code in your browser or OS settings to enable this feature.",
+                });
+              }}
+              aria-label="Enable local attention notifications"
             />
           }
         />

--- a/apps/web/src/hooks/useLifecycleNotifications.test.ts
+++ b/apps/web/src/hooks/useLifecycleNotifications.test.ts
@@ -1,0 +1,271 @@
+import {
+  EventId,
+  ProjectId,
+  ThreadId,
+  TurnId,
+  type OrchestrationThreadActivity,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+import { collectLifecycleNotifications } from "../lifecycleNotifications";
+
+function makeActivity(overrides: {
+  id?: string;
+  createdAt?: string;
+  kind?: string;
+  summary?: string;
+  tone?: OrchestrationThreadActivity["tone"];
+  payload?: Record<string, unknown>;
+  turnId?: string;
+}): OrchestrationThreadActivity {
+  return {
+    id: EventId.makeUnsafe(overrides.id ?? crypto.randomUUID()),
+    createdAt: overrides.createdAt ?? "2026-03-30T10:00:00.000Z",
+    kind: overrides.kind ?? "tool.started",
+    summary: overrides.summary ?? "Tool call",
+    tone: overrides.tone ?? "tool",
+    payload: overrides.payload ?? {},
+    turnId: overrides.turnId ? TurnId.makeUnsafe(overrides.turnId) : null,
+  };
+}
+
+function makeThread(
+  overrides: Partial<
+    Parameters<typeof collectLifecycleNotifications>[0]["nextThreads"][number]
+  > = {},
+) {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Review auth flow",
+    activities: [],
+    latestTurn: null,
+    session: null,
+    ...overrides,
+  };
+}
+
+const projects = [{ id: ProjectId.makeUnsafe("project-1"), name: "t3code" }];
+
+describe("collectLifecycleNotifications", () => {
+  it("emits a completion notification when a turn newly settles", () => {
+    const notifications = collectLifecycleNotifications({
+      previousThreads: [
+        makeThread({
+          latestTurn: {
+            turnId: TurnId.makeUnsafe("turn-1"),
+            state: "running",
+            requestedAt: "2026-03-30T10:00:00.000Z",
+            startedAt: "2026-03-30T10:00:01.000Z",
+            completedAt: null,
+            assistantMessageId: null,
+          },
+          session: {
+            provider: "codex",
+            status: "running",
+            createdAt: "2026-03-30T10:00:00.000Z",
+            updatedAt: "2026-03-30T10:00:02.000Z",
+            orchestrationStatus: "running",
+            activeTurnId: TurnId.makeUnsafe("turn-1"),
+          },
+        }),
+      ],
+      nextThreads: [
+        makeThread({
+          latestTurn: {
+            turnId: TurnId.makeUnsafe("turn-1"),
+            state: "completed",
+            requestedAt: "2026-03-30T10:00:00.000Z",
+            startedAt: "2026-03-30T10:00:01.000Z",
+            completedAt: "2026-03-30T10:00:05.000Z",
+            assistantMessageId: null,
+          },
+          session: {
+            provider: "codex",
+            status: "ready",
+            createdAt: "2026-03-30T10:00:00.000Z",
+            updatedAt: "2026-03-30T10:00:05.000Z",
+            orchestrationStatus: "ready",
+            activeTurnId: undefined,
+          },
+        }),
+      ],
+      projects,
+    });
+
+    expect(notifications).toEqual([
+      {
+        id: "turn-completed:thread-1:turn-1:2026-03-30T10:00:05.000Z",
+        kind: "turn-completed",
+        title: "Turn completed",
+        body: "Agent finished work in t3code · Review auth flow.",
+        threadId: ThreadId.makeUnsafe("thread-1"),
+      },
+    ]);
+  });
+
+  it("emits an attention notification for a newly requested user input", () => {
+    const notifications = collectLifecycleNotifications({
+      previousThreads: [makeThread()],
+      nextThreads: [
+        makeThread({
+          activities: [
+            makeActivity({
+              id: "evt-user-input",
+              kind: "user-input.requested",
+              summary: "Need clarification",
+              tone: "approval",
+              payload: {
+                requestId: "req-user-1",
+                questions: [
+                  {
+                    id: "q-1",
+                    header: "Clarify",
+                    question: "Which branch should I use?",
+                    options: [{ label: "main", description: "Use main" }],
+                  },
+                ],
+              },
+            }),
+          ],
+        }),
+      ],
+      projects,
+    });
+
+    expect(notifications[0]).toMatchObject({
+      id: "user-input:thread-1:req-user-1",
+      kind: "user-input-requested",
+      title: "Input needed",
+      body: "Agent is waiting for your input in t3code · Review auth flow.",
+    });
+  });
+
+  it("emits an attention notification for a newly requested approval", () => {
+    const notifications = collectLifecycleNotifications({
+      previousThreads: [makeThread()],
+      nextThreads: [
+        makeThread({
+          activities: [
+            makeActivity({
+              id: "evt-approval",
+              kind: "approval.requested",
+              summary: "Command approval requested",
+              tone: "approval",
+              payload: {
+                requestId: "req-approval-1",
+                requestKind: "command",
+                detail: "bun run lint",
+              },
+            }),
+          ],
+        }),
+      ],
+      projects,
+    });
+
+    expect(notifications[0]).toMatchObject({
+      id: "approval:thread-1:req-approval-1",
+      kind: "approval-requested",
+      title: "Approval needed",
+      body: "Agent needs approval in t3code · Review auth flow.",
+    });
+  });
+
+  it("does not duplicate a completion that was already observed", () => {
+    const completedThread = makeThread({
+      latestTurn: {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        state: "completed",
+        requestedAt: "2026-03-30T10:00:00.000Z",
+        startedAt: "2026-03-30T10:00:01.000Z",
+        completedAt: "2026-03-30T10:00:05.000Z",
+        assistantMessageId: null,
+      },
+      session: {
+        provider: "codex",
+        status: "ready",
+        createdAt: "2026-03-30T10:00:00.000Z",
+        updatedAt: "2026-03-30T10:00:05.000Z",
+        orchestrationStatus: "ready",
+        activeTurnId: undefined,
+      },
+    });
+
+    const notifications = collectLifecycleNotifications({
+      previousThreads: [completedThread],
+      nextThreads: [completedThread],
+      projects,
+    });
+
+    expect(notifications).toEqual([]);
+  });
+
+  it("prioritizes pending attention requests over completion notifications", () => {
+    const notifications = collectLifecycleNotifications({
+      previousThreads: [
+        makeThread({
+          latestTurn: {
+            turnId: TurnId.makeUnsafe("turn-1"),
+            state: "running",
+            requestedAt: "2026-03-30T10:00:00.000Z",
+            startedAt: "2026-03-30T10:00:01.000Z",
+            completedAt: null,
+            assistantMessageId: null,
+          },
+          session: {
+            provider: "codex",
+            status: "running",
+            createdAt: "2026-03-30T10:00:00.000Z",
+            updatedAt: "2026-03-30T10:00:02.000Z",
+            orchestrationStatus: "running",
+            activeTurnId: TurnId.makeUnsafe("turn-1"),
+          },
+        }),
+      ],
+      nextThreads: [
+        makeThread({
+          activities: [
+            makeActivity({
+              id: "evt-approval",
+              kind: "approval.requested",
+              summary: "Command approval requested",
+              tone: "approval",
+              payload: {
+                requestId: "req-approval-1",
+                requestKind: "command",
+                detail: "bun run lint",
+              },
+            }),
+          ],
+          latestTurn: {
+            turnId: TurnId.makeUnsafe("turn-1"),
+            state: "completed",
+            requestedAt: "2026-03-30T10:00:00.000Z",
+            startedAt: "2026-03-30T10:00:01.000Z",
+            completedAt: "2026-03-30T10:00:05.000Z",
+            assistantMessageId: null,
+          },
+          session: {
+            provider: "codex",
+            status: "ready",
+            createdAt: "2026-03-30T10:00:00.000Z",
+            updatedAt: "2026-03-30T10:00:05.000Z",
+            orchestrationStatus: "ready",
+            activeTurnId: undefined,
+          },
+        }),
+      ],
+      projects,
+    });
+
+    expect(notifications).toEqual([
+      {
+        id: "approval:thread-1:req-approval-1",
+        kind: "approval-requested",
+        title: "Approval needed",
+        body: "Agent needs approval in t3code · Review auth flow.",
+        threadId: ThreadId.makeUnsafe("thread-1"),
+      },
+    ]);
+  });
+});

--- a/apps/web/src/hooks/useLifecycleNotifications.ts
+++ b/apps/web/src/hooks/useLifecycleNotifications.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react";
+import { useStore } from "../store";
+import { useSettings } from "./useSettings";
+import { sendLocalNotification } from "../lib/localNotifications";
+import {
+  cloneThreadSnapshot,
+  collectLifecycleNotifications,
+  type NotificationThreadSnapshot,
+} from "../lifecycleNotifications";
+
+function isAppInForeground(): boolean {
+  if (typeof document === "undefined") {
+    return true;
+  }
+  return document.visibilityState === "visible" && document.hasFocus();
+}
+
+export function useLifecycleNotifications(): void {
+  const threads = useStore((store) => store.threads);
+  const projects = useStore((store) => store.projects);
+  const settings = useSettings();
+  const attentionNotifications = settings.attentionNotifications;
+  const previousThreadsRef = useRef<NotificationThreadSnapshot[]>([]);
+  const initializedRef = useRef(false);
+
+  useEffect(() => {
+    const nextThreadSnapshot = threads.map((thread) => cloneThreadSnapshot(thread));
+
+    if (!initializedRef.current) {
+      previousThreadsRef.current = nextThreadSnapshot;
+      initializedRef.current = true;
+      return;
+    }
+
+    if (!attentionNotifications) {
+      previousThreadsRef.current = nextThreadSnapshot;
+      return;
+    }
+
+    const notifications = collectLifecycleNotifications({
+      previousThreads: previousThreadsRef.current,
+      nextThreads: nextThreadSnapshot,
+      projects,
+    });
+    previousThreadsRef.current = nextThreadSnapshot;
+
+    if (notifications.length === 0 || isAppInForeground()) {
+      return;
+    }
+
+    for (const notification of notifications) {
+      sendLocalNotification({
+        title: notification.title,
+        body: notification.body,
+        tag: notification.id,
+      });
+    }
+  }, [attentionNotifications, projects, threads]);
+}

--- a/apps/web/src/lib/localNotifications.ts
+++ b/apps/web/src/lib/localNotifications.ts
@@ -1,0 +1,44 @@
+export interface LocalNotificationInput {
+  title: string;
+  body: string;
+  tag?: string;
+}
+
+export type LocalNotificationPermissionState = NotificationPermission | "unsupported";
+
+export function isLocalNotificationSupported(): boolean {
+  return typeof Notification !== "undefined";
+}
+
+export async function requestLocalNotificationPermission(): Promise<LocalNotificationPermissionState> {
+  if (!isLocalNotificationSupported()) {
+    return "unsupported";
+  }
+  if (Notification.permission === "granted" || Notification.permission === "denied") {
+    return Notification.permission;
+  }
+  try {
+    return await Notification.requestPermission();
+  } catch {
+    return "denied";
+  }
+}
+
+export function sendLocalNotification(input: LocalNotificationInput): boolean {
+  if (!isLocalNotificationSupported() || Notification.permission !== "granted") {
+    return false;
+  }
+
+  try {
+    const notification = new Notification(input.title, {
+      body: input.body,
+      ...(input.tag ? { tag: input.tag } : {}),
+    });
+    globalThis.setTimeout(() => {
+      notification.close();
+    }, 10_000);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/lifecycleNotifications.ts
+++ b/apps/web/src/lifecycleNotifications.ts
@@ -1,0 +1,126 @@
+import { type Project, type Thread } from "./types";
+import {
+  derivePendingApprovals,
+  derivePendingUserInputs,
+  isLatestTurnSettled,
+} from "./session-logic";
+
+export type NotificationThreadSnapshot = Pick<
+  Thread,
+  "id" | "projectId" | "title" | "activities" | "latestTurn" | "session"
+>;
+export type NotificationProjectSnapshot = Pick<Project, "id" | "name">;
+
+export interface LifecycleNotificationEvent {
+  id: string;
+  kind: "approval-requested" | "turn-completed" | "user-input-requested";
+  title: string;
+  body: string;
+  threadId: Thread["id"];
+}
+
+function formatThreadTarget(
+  thread: NotificationThreadSnapshot,
+  projectName: string | undefined,
+): string {
+  return projectName ? `${projectName} · ${thread.title}` : thread.title;
+}
+
+export function cloneThreadSnapshot(
+  thread: NotificationThreadSnapshot,
+): NotificationThreadSnapshot {
+  return {
+    ...thread,
+    activities: thread.activities.map((activity) => ({ ...activity })),
+    latestTurn: thread.latestTurn ? { ...thread.latestTurn } : null,
+    session: thread.session ? { ...thread.session } : null,
+  };
+}
+
+export function collectLifecycleNotifications(input: {
+  previousThreads: ReadonlyArray<NotificationThreadSnapshot>;
+  nextThreads: ReadonlyArray<NotificationThreadSnapshot>;
+  projects: ReadonlyArray<NotificationProjectSnapshot>;
+}): LifecycleNotificationEvent[] {
+  const previousByThreadId = new Map(
+    input.previousThreads.map((thread) => [thread.id, thread] as const),
+  );
+  const projectNameById = new Map(
+    input.projects.map((project) => [project.id, project.name] as const),
+  );
+  const notifications: LifecycleNotificationEvent[] = [];
+
+  for (const thread of input.nextThreads) {
+    const previousThread = previousByThreadId.get(thread.id) ?? null;
+    const threadTarget = formatThreadTarget(thread, projectNameById.get(thread.projectId));
+
+    const previousPendingApprovals = new Set(
+      derivePendingApprovals(previousThread?.activities ?? []).map(
+        (approval) => approval.requestId,
+      ),
+    );
+    const newApprovals = derivePendingApprovals(thread.activities).filter(
+      (approval) => !previousPendingApprovals.has(approval.requestId),
+    );
+    for (const approval of newApprovals) {
+      notifications.push({
+        id: `approval:${thread.id}:${approval.requestId}`,
+        kind: "approval-requested",
+        title: "Approval needed",
+        body: `Agent needs approval in ${threadTarget}.`,
+        threadId: thread.id,
+      });
+    }
+
+    const previousPendingUserInputs = new Set(
+      derivePendingUserInputs(previousThread?.activities ?? []).map((request) => request.requestId),
+    );
+    const newUserInputs = derivePendingUserInputs(thread.activities).filter(
+      (request) => !previousPendingUserInputs.has(request.requestId),
+    );
+    for (const request of newUserInputs) {
+      notifications.push({
+        id: `user-input:${thread.id}:${request.requestId}`,
+        kind: "user-input-requested",
+        title: "Input needed",
+        body: `Agent is waiting for your input in ${threadTarget}.`,
+        threadId: thread.id,
+      });
+    }
+
+    if (newApprovals.length > 0 || newUserInputs.length > 0) {
+      continue;
+    }
+
+    const latestTurn = thread.latestTurn;
+    if (
+      !latestTurn ||
+      latestTurn.state !== "completed" ||
+      !latestTurn.completedAt ||
+      !isLatestTurnSettled(latestTurn, thread.session)
+    ) {
+      continue;
+    }
+
+    const previousLatestTurn = previousThread?.latestTurn ?? null;
+    const previousCompletion =
+      previousLatestTurn?.turnId === latestTurn.turnId ? previousLatestTurn.completedAt : null;
+    const previousSettled = previousLatestTurn
+      ? isLatestTurnSettled(previousLatestTurn, previousThread?.session ?? null)
+      : false;
+
+    if (previousSettled && previousCompletion === latestTurn.completedAt) {
+      continue;
+    }
+
+    notifications.push({
+      id: `turn-completed:${thread.id}:${latestTurn.turnId}:${latestTurn.completedAt}`,
+      kind: "turn-completed",
+      title: "Turn completed",
+      body: `Agent finished work in ${threadTarget}.`,
+      threadId: thread.id,
+    });
+  }
+
+  return notifications;
+}

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -24,6 +24,7 @@ export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 
 export const ClientSettingsSchema = Schema.Struct({
+  attentionNotifications: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
   diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),


### PR DESCRIPTION
Closes #376

## Summary

This adds a small first slice of local lifecycle notifications in the web app.

Users can now opt into local attention notifications that fire while T3 Code is in the background when:
- a turn actually settles as completed
- the agent opens an approval request
- the agent requests user input

## What changed

- added a new `attentionNotifications` client setting
- added an "Attention notifications" toggle in General settings
- request browser notification permission when the setting is enabled
- watch thread lifecycle state globally and send notifications only when the app is not in the foreground
- avoid sending a completion notification when the latest change is actually a new approval or user-input request
- added focused tests around the lifecycle notification diff logic

## Notes

This stays deliberately small and local:
- no external hook API yet
- no Electron/main-process integration yet
- no sound packs or third-party notifier integration yet

The goal here is to cover the basic local notification path first while keeping the completion signal tied to the settled turn state instead of intermediate activity.

## Validation

Ran in `apps/web`:

- `bun x vitest run src/hooks/useLifecycleNotifications.test.ts`
- `bun run typecheck`
- `bun x oxlint apps/web/src/components/AppSidebarLayout.tsx apps/web/src/components/settings/SettingsPanels.tsx apps/web/src/hooks/useLifecycleNotifications.test.ts apps/web/src/hooks/useLifecycleNotifications.ts apps/web/src/lib/localNotifications.ts apps/web/src/lifecycleNotifications.ts packages/contracts/src/settings.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an opt-in, global side effect that observes thread state and triggers browser `Notification` API calls, which could cause noisy/duplicated notifications or unexpected behavior across environments if the diffing logic or permission handling is wrong.
> 
> **Overview**
> Adds **opt-in background “attention notifications”** to the web app: a new `attentionNotifications` client setting and a General Settings toggle that requests local notification permission and warns when blocked/unsupported.
> 
> Introduces lifecycle notification plumbing (`collectLifecycleNotifications` + `useLifecycleNotifications`) to diff thread snapshots and, when the app is not foregrounded, send local notifications for **new approvals**, **new user-input requests**, or **a newly settled completed turn** (with attention requests taking precedence to avoid misleading completion pings). Includes focused unit tests for the notification diffing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 775c8ba40b81f518f4f69e9eb3f3a9db300dc527. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add background attention notifications for thread lifecycle events
> - Adds a new `attentionNotifications` setting (default `false`) in [`packages/contracts/src/settings.ts`](https://github.com/pingdotgg/t3code/pull/1573/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) and a toggle in the General Settings panel that requests browser notification permission on enable, surfacing a warning toast if blocked or unsupported.
> - Introduces [`apps/web/src/lifecycleNotifications.ts`](https://github.com/pingdotgg/t3code/pull/1573/files#diff-e3491b4f1c52f24e0f6268bc319f8fdbacaef093c92517401cf439bd02b4c85b) with `collectLifecycleNotifications`, which diffs thread snapshots to emit events for new approval requests, user input requests, and newly settled turn completions, prioritizing attention requests over completions.
> - Adds the [`useLifecycleNotifications`](https://github.com/pingdotgg/t3code/pull/1573/files#diff-7d4bf2771680bc1a3d7dddcfa4fd95137edbdc6926ec3fbb63422bf009bb3e3d) hook, mounted in the app layout, which fires local notifications via the [`localNotifications`](https://github.com/pingdotgg/t3code/pull/1573/files#diff-1205e3fd5ba42e4f479add1fa8568fbcf80d1b37783b128ab377abfde31e1a3c) module when the setting is enabled and the app is backgrounded (not visible or not focused).
> - Behavioral Change: notifications are only sent while the app is in the background; the first snapshot on mount is used as a baseline so no notifications fire on initial load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 775c8ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->