### PR TITLE
fix: keep iPad PWA in standalone mode

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,8 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="T3 Code" />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,0 +1,30 @@
+{
+  "name": "T3 Code",
+  "short_name": "T3 Code",
+  "description": "Minimal web GUI for coding agents like Codex and Claude.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -137,12 +137,29 @@ html,
 body,
 #root {
   height: 100%;
+  min-height: 100%;
   width: 100%;
   max-width: 100%;
   overflow-y: hidden;
   overflow-x: hidden;
   overflow-x: clip;
   overscroll-behavior-y: none;
+}
+
+@media (display-mode: standalone), (display-mode: fullscreen) {
+  html,
+  body,
+  #root {
+    height: 100dvh;
+    min-height: 100dvh;
+  }
+
+  body {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    overscroll-behavior: none;
+  }
 }
 
 body::after {


### PR DESCRIPTION
## What Changed

Improves the iPad/iOS PWA shell so the app stays in standalone mode more reliably and does not expose Safari chrome during normal use.

This change:
- adds a `manifest.webmanifest` with `display: "standalone"`
- adds the Apple/mobile web app meta tags in `index.html`
- updates the viewport meta to use `viewport-fit=cover`
- pins the root app shell to `100dvh` in standalone/fullscreen display modes and fixes the body to the viewport in that mode

## Why

On iPadOS, the installed PWA could still reveal browser chrome during scroll or certain interactions, which breaks the standalone-app feel.

This approach keeps the fix focused at the app-shell level instead of changing individual screens:
- it makes the app explicitly installable as a standalone web app
- it enables the Apple-specific standalone behavior Safari expects
- it constrains the root layout only when the app is actually running in standalone/fullscreen mode

## UI Changes

Behavior change only. In installed PWA mode on iPad/iOS, the app shell should remain in standalone presentation more consistently instead of allowing Safari chrome to appear.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Before:
<img width="1210" height="834" alt="IMG_0169" src="https://github.com/user-attachments/assets/e5eccf77-45df-4b9d-885a-62e48deac07d" />

After:
<img width="1210" height="834" alt="IMG_0170" src="https://github.com/user-attachments/assets/248a6c4b-cbc8-49e9-bd0d-88a56540a331" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to PWA metadata and CSS app-shell sizing/scroll behavior, with the main risk being unintended layout/scroll regressions in standalone/fullscreen modes.
> 
> **Overview**
> Improves iPad/iOS installed-PWA behavior by making the app explicitly *standalone-capable* and reducing cases where Safari chrome appears.
> 
> Adds a `manifest.webmanifest` (with `display: "standalone"`) and wires it up via new mobile/Apple meta tags (including `viewport-fit=cover`) in `index.html`. Updates the global shell CSS to use `100dvh` and fix the `body` to the viewport *only* in `standalone/fullscreen` display modes, preventing overscroll/scroll-induced chrome.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00c4f3eac79ad854ee68d8fee6b68bd56e581f22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep iPad PWA running in standalone mode
> - Adds a [web app manifest](https://github.com/pingdotgg/t3code/pull/1576/files#diff-d8662580d6bcf0d4587b2fe615dd4126b3632e6eddef6b7b0c7bb554356f112f) defining name, icons, colors, and `display: standalone` so browsers can install the app correctly.
> - Adds Apple PWA meta tags to [index.html](https://github.com/pingdotgg/t3code/pull/1576/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f) (`apple-mobile-web-app-capable`, status bar style, title) to keep the app in standalone mode on iOS/iPadOS.
> - Updates [index.css](https://github.com/pingdotgg/t3code/pull/1576/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) with a `display-mode: standalone` media query that locks the body to the full dynamic viewport height and disables scroll bounce.
> - Updates the viewport meta to include `viewport-fit=cover` so content extends into safe areas on notched devices.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00c4f3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->