### PR TITLE
feat(desktop): add optional macOS dock bounce on completion

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -49,6 +49,7 @@ syncShellEnvironment();
 
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
+const REQUEST_USER_ATTENTION_CHANNEL = "desktop:request-user-attention";
 const SET_THEME_CHANNEL = "desktop:set-theme";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
@@ -1150,6 +1151,9 @@ function registerIpcHandlers(): void {
     return showDesktopConfirmDialog(message, owner);
   });
 
+  ipcMain.removeHandler(REQUEST_USER_ATTENTION_CHANNEL);
+  ipcMain.handle(REQUEST_USER_ATTENTION_CHANNEL, async () => requestUserAttention());
+
   ipcMain.removeHandler(SET_THEME_CHANNEL);
   ipcMain.handle(SET_THEME_CHANNEL, async (_event, rawTheme: unknown) => {
     const theme = getSafeTheme(rawTheme);
@@ -1289,6 +1293,20 @@ function getIconOption(): { icon: string } | Record<string, never> {
   const ext = process.platform === "win32" ? "ico" : "png";
   const iconPath = resolveIconPath(ext);
   return iconPath ? { icon: iconPath } : {};
+}
+
+function requestUserAttention(): boolean {
+  if (process.platform !== "darwin" || !app.dock) {
+    return false;
+  }
+
+  const anyFocusedWindow = BrowserWindow.getAllWindows().some((window) => window.isFocused());
+  if (anyFocusedWindow) {
+    return false;
+  }
+
+  app.dock.bounce("informational");
+  return true;
 }
 
 function createWindow(): BrowserWindow {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -3,6 +3,7 @@ import type { DesktopBridge } from "@t3tools/contracts";
 
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
 const CONFIRM_CHANNEL = "desktop:confirm";
+const REQUEST_USER_ATTENTION_CHANNEL = "desktop:request-user-attention";
 const SET_THEME_CHANNEL = "desktop:set-theme";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
@@ -21,6 +22,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   },
   pickFolder: () => ipcRenderer.invoke(PICK_FOLDER_CHANNEL),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
+  requestUserAttention: () => ipcRenderer.invoke(REQUEST_USER_ATTENTION_CHANNEL),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),
   showContextMenu: (items, position) => ipcRenderer.invoke(CONTEXT_MENU_CHANNEL, items, position),
   openExternal: (url: string) => ipcRenderer.invoke(OPEN_EXTERNAL_CHANNEL, url),

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -49,7 +49,7 @@ import {
 import { ensureNativeApi, readNativeApi } from "../../nativeApi";
 import { useStore } from "../../store";
 import { formatRelativeTime, formatRelativeTimeLabel } from "../../timestampFormat";
-import { cn } from "../../lib/utils";
+import { cn, isMacPlatform } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { Collapsible, CollapsibleContent } from "../ui/collapsible";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
@@ -475,6 +475,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
+      ...(settings.dockBounceOnCompletion !== DEFAULT_UNIFIED_SETTINGS.dockBounceOnCompletion
+        ? ["Completion dock bounce"]
+        : []),
       ...(isGitWritingModelDirty ? ["Git writing model"] : []),
       ...(areProviderSettingsDirty ? ["Providers"] : []),
     ],
@@ -483,6 +486,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       isGitWritingModelDirty,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
+      settings.dockBounceOnCompletion,
       settings.defaultThreadEnvMode,
       settings.diffWordWrap,
       settings.enableAssistantStreaming,
@@ -516,6 +520,7 @@ export function GeneralSettingsPanel() {
   const { theme, setTheme } = useTheme();
   const settings = useSettings();
   const { updateSettings } = useUpdateSettings();
+  const isMacDesktop = isElectron && isMacPlatform(navigator.platform);
   const serverConfigQuery = useQuery(serverConfigQueryOptions());
   const [isOpeningKeybindings, setIsOpeningKeybindings] = useState(false);
   const [openKeybindingsError, setOpenKeybindingsError] = useState<string | null>(null);
@@ -957,6 +962,35 @@ export function GeneralSettingsPanel() {
             />
           }
         />
+
+        {isMacDesktop ? (
+          <SettingsRow
+            title="Completion dock bounce"
+            description="Bounce the macOS Dock icon when a thread finishes while the app is in the background."
+            resetAction={
+              settings.dockBounceOnCompletion !==
+              DEFAULT_UNIFIED_SETTINGS.dockBounceOnCompletion ? (
+                <SettingResetButton
+                  label="completion dock bounce"
+                  onClick={() =>
+                    updateSettings({
+                      dockBounceOnCompletion: DEFAULT_UNIFIED_SETTINGS.dockBounceOnCompletion,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <Switch
+                checked={settings.dockBounceOnCompletion}
+                onCheckedChange={(checked) =>
+                  updateSettings({ dockBounceOnCompletion: Boolean(checked) })
+                }
+                aria-label="Bounce the macOS Dock icon when a thread completes"
+              />
+            }
+          />
+        ) : null}
 
         <SettingsRow
           title="Text generation model"

--- a/apps/web/src/hooks/useSettings.test.ts
+++ b/apps/web/src/hooks/useSettings.test.ts
@@ -7,10 +7,12 @@ describe("buildLegacyClientSettingsMigrationPatch", () => {
       buildLegacyClientSettingsMigrationPatch({
         confirmThreadArchive: true,
         confirmThreadDelete: false,
+        dockBounceOnCompletion: false,
       }),
     ).toEqual({
       confirmThreadArchive: true,
       confirmThreadDelete: false,
+      dockBounceOnCompletion: false,
     });
   });
 });

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -70,9 +70,7 @@ function splitPatch(patch: Partial<UnifiedSettings>): {
  * only re-render when the slice they care about changes.
  */
 
-export function useSettings<T extends UnifiedSettings = UnifiedSettings>(
-  selector?: (s: UnifiedSettings) => T,
-): T {
+export function useSettings<T = UnifiedSettings>(selector?: (s: UnifiedSettings) => T): T {
   const { data: serverConfig } = useQuery(serverConfigQueryOptions());
   const [clientSettings] = useLocalStorage(
     CLIENT_SETTINGS_STORAGE_KEY,
@@ -208,6 +206,10 @@ export function buildLegacyClientSettingsMigrationPatch(
 
   if (Predicate.isBoolean(legacySettings.confirmThreadDelete)) {
     patch.confirmThreadDelete = legacySettings.confirmThreadDelete;
+  }
+
+  if (Predicate.isBoolean(legacySettings.dockBounceOnCompletion)) {
+    patch.dockBounceOnCompletion = legacySettings.dockBounceOnCompletion;
   }
 
   if (Predicate.isBoolean(legacySettings.diffWordWrap)) {

--- a/apps/web/src/lib/desktopCompletionAttention.test.ts
+++ b/apps/web/src/lib/desktopCompletionAttention.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getCompletionAttentionState,
+  getCompletionAttentionTurnId,
   shouldRequestCompletionAttention,
 } from "./desktopCompletionAttention";
 import type { Thread } from "../types";
@@ -163,5 +164,50 @@ describe("shouldRequestCompletionAttention", () => {
     );
 
     expect(shouldRequestCompletionAttention(previous, next)).toBe(true);
+  });
+
+  it("returns the same attention turn id for a session-ready lag and later turn completion", () => {
+    const running = getCompletionAttentionState(makeRunningThread());
+    const sessionReady = getCompletionAttentionState(
+      makeThread({
+        session: {
+          provider: "claudeAgent",
+          status: "ready",
+          orchestrationStatus: "ready",
+          createdAt: "2026-03-30T10:00:00.000Z",
+          updatedAt: "2026-03-30T10:00:03.000Z",
+        },
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-1"),
+          state: "running",
+          requestedAt: "2026-03-30T10:00:00.000Z",
+          startedAt: "2026-03-30T10:00:01.000Z",
+          completedAt: null,
+          assistantMessageId: null,
+        },
+      }),
+    );
+    const turnCompleted = getCompletionAttentionState(
+      makeThread({
+        session: {
+          provider: "claudeAgent",
+          status: "ready",
+          orchestrationStatus: "ready",
+          createdAt: "2026-03-30T10:00:00.000Z",
+          updatedAt: "2026-03-30T10:00:04.000Z",
+        },
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-1"),
+          state: "completed",
+          requestedAt: "2026-03-30T10:00:00.000Z",
+          startedAt: "2026-03-30T10:00:01.000Z",
+          completedAt: "2026-03-30T10:00:04.000Z",
+          assistantMessageId: null,
+        },
+      }),
+    );
+
+    expect(getCompletionAttentionTurnId(running, sessionReady)).toBe("turn-1");
+    expect(getCompletionAttentionTurnId(sessionReady, turnCompleted)).toBe("turn-1");
   });
 });

--- a/apps/web/src/lib/desktopCompletionAttention.test.ts
+++ b/apps/web/src/lib/desktopCompletionAttention.test.ts
@@ -4,6 +4,7 @@ import {
   getCompletionAttentionState,
   getCompletionAttentionTurnId,
   shouldRequestCompletionAttention,
+  updateCompletionAttentionNotification,
 } from "./desktopCompletionAttention";
 import type { Thread } from "../types";
 import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
@@ -209,5 +210,34 @@ describe("shouldRequestCompletionAttention", () => {
 
     expect(getCompletionAttentionTurnId(running, sessionReady)).toBe("turn-1");
     expect(getCompletionAttentionTurnId(sessionReady, turnCompleted)).toBe("turn-1");
+  });
+
+  it("records later attention turn ids even after an earlier thread already triggered a bounce", () => {
+    const notifiedTurnIds = new Map<string, string>();
+    let shouldBounce = false;
+
+    const firstThreadShouldNotify = updateCompletionAttentionNotification(
+      notifiedTurnIds,
+      "thread-1",
+      undefined,
+      "turn-1",
+    );
+    if (!shouldBounce && firstThreadShouldNotify) {
+      shouldBounce = true;
+    }
+
+    const secondThreadShouldNotify = updateCompletionAttentionNotification(
+      notifiedTurnIds,
+      "thread-2",
+      undefined,
+      "turn-2",
+    );
+    if (!shouldBounce && secondThreadShouldNotify) {
+      shouldBounce = true;
+    }
+
+    expect(shouldBounce).toBe(true);
+    expect(notifiedTurnIds.get("thread-1")).toBe("turn-1");
+    expect(notifiedTurnIds.get("thread-2")).toBe("turn-2");
   });
 });

--- a/apps/web/src/lib/desktopCompletionAttention.test.ts
+++ b/apps/web/src/lib/desktopCompletionAttention.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getCompletionAttentionState,
+  shouldRequestCompletionAttention,
+} from "./desktopCompletionAttention";
+import type { Thread } from "../types";
+import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+
+function makeThread(overrides?: Partial<Pick<Thread, "latestTurn" | "session">>): Thread {
+  return {
+    id: ThreadId.makeUnsafe("thread-1"),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: "Thread",
+    modelSelection: { provider: "codex", model: "gpt-5" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    session: null,
+    messages: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-03-30T10:00:00.000Z",
+    archivedAt: null,
+    updatedAt: "2026-03-30T10:00:00.000Z",
+    latestTurn: null,
+    branch: null,
+    worktreePath: null,
+    turnDiffSummaries: [],
+    activities: [],
+    ...overrides,
+  };
+}
+
+function makeRunningThread(): Thread {
+  return makeThread({
+    session: {
+      provider: "codex",
+      status: "running",
+      orchestrationStatus: "running",
+      activeTurnId: TurnId.makeUnsafe("turn-1"),
+      createdAt: "2026-03-30T10:00:00.000Z",
+      updatedAt: "2026-03-30T10:00:01.000Z",
+    },
+    latestTurn: {
+      turnId: TurnId.makeUnsafe("turn-1"),
+      state: "running",
+      requestedAt: "2026-03-30T10:00:00.000Z",
+      startedAt: "2026-03-30T10:00:01.000Z",
+      completedAt: null,
+      assistantMessageId: null,
+    },
+  });
+}
+
+describe("shouldRequestCompletionAttention", () => {
+  it("requests attention when a working thread completes", () => {
+    const previous = getCompletionAttentionState(makeRunningThread());
+    const next = getCompletionAttentionState(
+      makeThread({
+        session: {
+          provider: "codex",
+          status: "ready",
+          orchestrationStatus: "ready",
+          createdAt: "2026-03-30T10:00:00.000Z",
+          updatedAt: "2026-03-30T10:00:04.000Z",
+        },
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-1"),
+          state: "completed",
+          requestedAt: "2026-03-30T10:00:00.000Z",
+          startedAt: "2026-03-30T10:00:01.000Z",
+          completedAt: "2026-03-30T10:00:04.000Z",
+          assistantMessageId: null,
+        },
+      }),
+    );
+
+    expect(shouldRequestCompletionAttention(previous, next)).toBe(true);
+  });
+
+  it("does not request attention on initial hydration of completed threads", () => {
+    const next = getCompletionAttentionState(
+      makeThread({
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-1"),
+          state: "completed",
+          requestedAt: "2026-03-30T10:00:00.000Z",
+          startedAt: "2026-03-30T10:00:01.000Z",
+          completedAt: "2026-03-30T10:00:04.000Z",
+          assistantMessageId: null,
+        },
+      }),
+    );
+
+    expect(shouldRequestCompletionAttention(undefined, next)).toBe(false);
+  });
+
+  it("does not request attention for repeated completed snapshots", () => {
+    const completedThread = getCompletionAttentionState(
+      makeThread({
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-1"),
+          state: "completed",
+          requestedAt: "2026-03-30T10:00:00.000Z",
+          startedAt: "2026-03-30T10:00:01.000Z",
+          completedAt: "2026-03-30T10:00:04.000Z",
+          assistantMessageId: null,
+        },
+      }),
+    );
+
+    expect(shouldRequestCompletionAttention(completedThread, completedThread)).toBe(false);
+  });
+
+  it("does not request attention when a turn errors", () => {
+    const previous = getCompletionAttentionState(makeRunningThread());
+    const next = getCompletionAttentionState(
+      makeThread({
+        session: {
+          provider: "codex",
+          status: "error",
+          orchestrationStatus: "error",
+          createdAt: "2026-03-30T10:00:00.000Z",
+          updatedAt: "2026-03-30T10:00:04.000Z",
+          lastError: "boom",
+        },
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-1"),
+          state: "error",
+          requestedAt: "2026-03-30T10:00:00.000Z",
+          startedAt: "2026-03-30T10:00:01.000Z",
+          completedAt: "2026-03-30T10:00:04.000Z",
+          assistantMessageId: null,
+        },
+      }),
+    );
+
+    expect(shouldRequestCompletionAttention(previous, next)).toBe(false);
+  });
+
+  it("requests attention when a running session becomes ready without a latest completed turn", () => {
+    const previous = getCompletionAttentionState(makeRunningThread());
+    const next = getCompletionAttentionState(
+      makeThread({
+        session: {
+          provider: "claudeAgent",
+          status: "ready",
+          orchestrationStatus: "ready",
+          activeTurnId: undefined,
+          createdAt: "2026-03-30T10:00:00.000Z",
+          updatedAt: "2026-03-30T10:00:04.000Z",
+        },
+        latestTurn: {
+          turnId: TurnId.makeUnsafe("turn-1"),
+          state: "running",
+          requestedAt: "2026-03-30T10:00:00.000Z",
+          startedAt: "2026-03-30T10:00:01.000Z",
+          completedAt: null,
+          assistantMessageId: null,
+        },
+      }),
+    );
+
+    expect(shouldRequestCompletionAttention(previous, next)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/desktopCompletionAttention.ts
+++ b/apps/web/src/lib/desktopCompletionAttention.ts
@@ -1,0 +1,48 @@
+import type { OrchestrationLatestTurnState, OrchestrationSessionStatus } from "@t3tools/contracts";
+import type { Thread } from "../types";
+
+export interface CompletionAttentionState {
+  activeTurnId: string | null;
+  completedAt: string | null;
+  isWorking: boolean;
+  lastError: string | null;
+  latestTurnState: OrchestrationLatestTurnState | null;
+  sessionStatus: OrchestrationSessionStatus | null;
+}
+
+export function getCompletionAttentionState(
+  thread: Pick<Thread, "latestTurn" | "session"> | undefined,
+): CompletionAttentionState {
+  return {
+    activeTurnId: thread?.session?.activeTurnId ?? null,
+    completedAt: thread?.latestTurn?.completedAt ?? null,
+    isWorking:
+      thread?.session?.orchestrationStatus === "starting" ||
+      thread?.session?.orchestrationStatus === "running" ||
+      thread?.latestTurn?.state === "running",
+    lastError: thread?.session?.lastError ?? null,
+    latestTurnState: thread?.latestTurn?.state ?? null,
+    sessionStatus: thread?.session?.orchestrationStatus ?? null,
+  };
+}
+
+export function shouldRequestCompletionAttention(
+  previous: CompletionAttentionState | undefined,
+  next: CompletionAttentionState,
+): boolean {
+  const completedTurnTransition =
+    next.latestTurnState === "completed" &&
+    next.completedAt !== null &&
+    previous?.completedAt !== next.completedAt &&
+    previous?.isWorking === true &&
+    !next.isWorking;
+
+  const sessionReadyTransition =
+    previous?.isWorking === true &&
+    previous.activeTurnId !== null &&
+    next.sessionStatus === "ready" &&
+    next.activeTurnId === null &&
+    next.lastError === null;
+
+  return completedTurnTransition || sessionReadyTransition;
+}

--- a/apps/web/src/lib/desktopCompletionAttention.ts
+++ b/apps/web/src/lib/desktopCompletionAttention.ts
@@ -56,6 +56,23 @@ export function getCompletionAttentionTurnId(
   return null;
 }
 
+export function updateCompletionAttentionNotification(
+  notifications: Map<string, string>,
+  threadId: string,
+  lastNotifiedTurnId: string | undefined,
+  attentionTurnId: string | null,
+): boolean {
+  if (attentionTurnId === null) {
+    if (lastNotifiedTurnId) {
+      notifications.set(threadId, lastNotifiedTurnId);
+    }
+    return false;
+  }
+
+  notifications.set(threadId, attentionTurnId);
+  return attentionTurnId !== lastNotifiedTurnId;
+}
+
 export function shouldRequestCompletionAttention(
   previous: CompletionAttentionState | undefined,
   next: CompletionAttentionState,

--- a/apps/web/src/lib/desktopCompletionAttention.ts
+++ b/apps/web/src/lib/desktopCompletionAttention.ts
@@ -6,6 +6,7 @@ export interface CompletionAttentionState {
   completedAt: string | null;
   isWorking: boolean;
   lastError: string | null;
+  latestTurnId: string | null;
   latestTurnState: OrchestrationLatestTurnState | null;
   sessionStatus: OrchestrationSessionStatus | null;
 }
@@ -21,16 +22,18 @@ export function getCompletionAttentionState(
       thread?.session?.orchestrationStatus === "running" ||
       thread?.latestTurn?.state === "running",
     lastError: thread?.session?.lastError ?? null,
+    latestTurnId: thread?.latestTurn?.turnId ?? null,
     latestTurnState: thread?.latestTurn?.state ?? null,
     sessionStatus: thread?.session?.orchestrationStatus ?? null,
   };
 }
 
-export function shouldRequestCompletionAttention(
+export function getCompletionAttentionTurnId(
   previous: CompletionAttentionState | undefined,
   next: CompletionAttentionState,
-): boolean {
+): string | null {
   const completedTurnTransition =
+    next.latestTurnId !== null &&
     next.latestTurnState === "completed" &&
     next.completedAt !== null &&
     previous?.completedAt !== next.completedAt &&
@@ -44,5 +47,18 @@ export function shouldRequestCompletionAttention(
     next.activeTurnId === null &&
     next.lastError === null;
 
-  return completedTurnTransition || sessionReadyTransition;
+  if (completedTurnTransition) {
+    return next.latestTurnId;
+  }
+  if (sessionReadyTransition) {
+    return previous.activeTurnId;
+  }
+  return null;
+}
+
+export function shouldRequestCompletionAttention(
+  previous: CompletionAttentionState | undefined,
+  next: CompletionAttentionState,
+): boolean {
+  return getCompletionAttentionTurnId(previous, next) !== null;
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -15,6 +15,13 @@ import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
+import { isElectron } from "../env";
+import { useSettings } from "../hooks/useSettings";
+import {
+  getCompletionAttentionState,
+  shouldRequestCompletionAttention,
+} from "../lib/desktopCompletionAttention";
+import { isMacPlatform } from "../lib/utils";
 import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQuery";
 import { readNativeApi } from "../nativeApi";
 import { clearPromotedDraftThreads, useComposerDraftStore } from "../composerDraftStore";
@@ -54,6 +61,7 @@ function RootRouteView() {
     <ToastProvider>
       <AnchoredToastProvider>
         <EventRouter />
+        <DesktopCompletionAttention />
         <DesktopProjectBootstrap />
         <AppSidebarLayout>
           <Outlet />
@@ -61,6 +69,39 @@ function RootRouteView() {
       </AnchoredToastProvider>
     </ToastProvider>
   );
+}
+
+function DesktopCompletionAttention() {
+  const threads = useStore((store) => store.threads);
+  const dockBounceOnCompletion = useSettings((settings) => settings.dockBounceOnCompletion);
+  const previousStatesRef = useRef<Map<string, ReturnType<typeof getCompletionAttentionState>>>(
+    new Map(),
+  );
+
+  useEffect(() => {
+    const previousStates = previousStatesRef.current;
+    const nextStates = new Map<string, ReturnType<typeof getCompletionAttentionState>>();
+    let shouldBounce = false;
+    for (const thread of threads) {
+      const nextState = getCompletionAttentionState(thread);
+      nextStates.set(thread.id, nextState);
+      if (!shouldBounce) {
+        shouldBounce = shouldRequestCompletionAttention(previousStates.get(thread.id), nextState);
+      }
+    }
+    previousStatesRef.current = nextStates;
+
+    if (!dockBounceOnCompletion || !isElectron || !isMacPlatform(navigator.platform)) {
+      return;
+    }
+    if (!shouldBounce) {
+      return;
+    }
+
+    void window.desktopBridge?.requestUserAttention?.();
+  }, [dockBounceOnCompletion, threads]);
+
+  return null;
 }
 
 function RootRouteErrorView({ error, reset }: ErrorComponentProps) {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -19,7 +19,7 @@ import { isElectron } from "../env";
 import { useSettings } from "../hooks/useSettings";
 import {
   getCompletionAttentionState,
-  shouldRequestCompletionAttention,
+  getCompletionAttentionTurnId,
 } from "../lib/desktopCompletionAttention";
 import { isMacPlatform } from "../lib/utils";
 import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQuery";
@@ -77,19 +77,30 @@ function DesktopCompletionAttention() {
   const previousStatesRef = useRef<Map<string, ReturnType<typeof getCompletionAttentionState>>>(
     new Map(),
   );
+  const notifiedTurnIdsRef = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
     const previousStates = previousStatesRef.current;
+    const previousNotifiedTurnIds = notifiedTurnIdsRef.current;
     const nextStates = new Map<string, ReturnType<typeof getCompletionAttentionState>>();
+    const nextNotifiedTurnIds = new Map<string, string>();
     let shouldBounce = false;
     for (const thread of threads) {
       const nextState = getCompletionAttentionState(thread);
       nextStates.set(thread.id, nextState);
-      if (!shouldBounce) {
-        shouldBounce = shouldRequestCompletionAttention(previousStates.get(thread.id), nextState);
+      const previousState = previousStates.get(thread.id);
+      const attentionTurnId = getCompletionAttentionTurnId(previousState, nextState);
+      const lastNotifiedTurnId = previousNotifiedTurnIds.get(thread.id);
+      if (lastNotifiedTurnId) {
+        nextNotifiedTurnIds.set(thread.id, lastNotifiedTurnId);
+      }
+      if (!shouldBounce && attentionTurnId !== null && attentionTurnId !== lastNotifiedTurnId) {
+        shouldBounce = true;
+        nextNotifiedTurnIds.set(thread.id, attentionTurnId);
       }
     }
     previousStatesRef.current = nextStates;
+    notifiedTurnIdsRef.current = nextNotifiedTurnIds;
 
     if (!dockBounceOnCompletion || !isElectron || !isMacPlatform(navigator.platform)) {
       return;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,6 +20,7 @@ import { useSettings } from "../hooks/useSettings";
 import {
   getCompletionAttentionState,
   getCompletionAttentionTurnId,
+  updateCompletionAttentionNotification,
 } from "../lib/desktopCompletionAttention";
 import { isMacPlatform } from "../lib/utils";
 import { serverConfigQueryOptions, serverQueryKeys } from "../lib/serverReactQuery";
@@ -91,12 +92,14 @@ function DesktopCompletionAttention() {
       const previousState = previousStates.get(thread.id);
       const attentionTurnId = getCompletionAttentionTurnId(previousState, nextState);
       const lastNotifiedTurnId = previousNotifiedTurnIds.get(thread.id);
-      if (lastNotifiedTurnId) {
-        nextNotifiedTurnIds.set(thread.id, lastNotifiedTurnId);
-      }
-      if (!shouldBounce && attentionTurnId !== null && attentionTurnId !== lastNotifiedTurnId) {
+      const shouldNotifyThread = updateCompletionAttentionNotification(
+        nextNotifiedTurnIds,
+        thread.id,
+        lastNotifiedTurnId,
+        attentionTurnId,
+      );
+      if (!shouldBounce && shouldNotifyThread) {
         shouldBounce = true;
-        nextNotifiedTurnIds.set(thread.id, attentionTurnId);
       }
     }
     previousStatesRef.current = nextStates;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -110,6 +110,7 @@ export interface DesktopBridge {
   getWsUrl: () => string | null;
   pickFolder: () => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
+  requestUserAttention: () => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;
   showContextMenu: <T extends string>(
     items: readonly ContextMenuItem<T>[],

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -26,6 +26,7 @@ export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "update
 export const ClientSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
+  dockBounceOnCompletion: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
   diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   sidebarProjectSortOrder: SidebarProjectSortOrder.pipe(
     Schema.withDecodingDefault(() => DEFAULT_SIDEBAR_PROJECT_SORT_ORDER),


### PR DESCRIPTION
## What Changed

Adds a macOS-only desktop setting that bounces the Dock icon when a thread finishes while T3 Code is in the background.

The bounce is triggered from normalized thread/session state instead of provider-specific logic. It only requests attention when work transitions from active to finished and the app is not focused.

## Why

When T3 Code is in the background, there is currently no desktop-level cue that a response has finished.

This adds a small attention signal without expanding scope into notifications, badges, or cross-platform behavior.

## UI Changes

Added a new macOS-only setting in General Settings:

- `Completion dock bounce`

Attached:
- screenshot of the new setting
- short video showing the Dock bounce when a background thread completes

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new cross-process IPC and a thread-state watcher that can trigger OS-level attention requests; low blast radius but sensitive to state transition/dedup logic and platform gating.
> 
> **Overview**
> Adds an optional **macOS-only** “Completion dock bounce” setting (`dockBounceOnCompletion`, default `true`) and surfaces it in the General settings panel.
> 
> Implements a new desktop bridge API (`requestUserAttention`) wired through a `desktop:request-user-attention` IPC handler that bounces the Dock icon only when no app window is focused.
> 
> Introduces `DesktopCompletionAttention` logic that watches thread/session state transitions, deduplicates per thread/turn, and triggers the bounce when work finishes while the app is in the background; includes migration/test coverage for the new setting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afccbfbca5e66a6044c0359b723e13ff5581f7fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional macOS Dock bounce on thread completion in desktop app
> - Adds a `dockBounceOnCompletion` setting (default `true`) that triggers an informational Dock bounce when a thread finishes while no app window is focused, on macOS only.
> - Introduces a new `DesktopCompletionAttention` component in [`__root.tsx`](https://github.com/pingdotgg/t3code/pull/1581/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) that monitors thread state changes and calls `window.desktopBridge.requestUserAttention()` at most once per completed turn.
> - The attention trigger logic lives in [`desktopCompletionAttention.ts`](https://github.com/pingdotgg/t3code/pull/1581/files#diff-af15645aad7d5b386db65a5ee056283c6c0e18949bde3b259961fe17db7c779c), which normalizes thread state to detect working→complete transitions.
> - Exposes the IPC channel `desktop:request-user-attention` in [`main.ts`](https://github.com/pingdotgg/t3code/pull/1581/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb) and [`preload.ts`](https://github.com/pingdotgg/t3code/pull/1581/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac), returning a boolean indicating whether the bounce was triggered.
> - A toggle in General Settings (macOS desktop only) lets users disable the behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afccbfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<img width="814" height="709" alt="image" src="https://github.com/user-attachments/assets/50b00476-7f08-4ddb-9462-776db6915fbc" />
<img width="808" height="631" alt="image" src="https://github.com/user-attachments/assets/e2572782-85ce-496a-815e-df6a6608e8c2" />

https://github.com/user-attachments/assets/29fe399a-264c-4cc3-ac4d-a37cfe17b47c

