### PR TITLE
Prioritize pinned projects in sidebar sorting

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -553,6 +553,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
       ...defaultModelSelection,
     },
     expanded: true,
+    pinned: false,
     createdAt: "2026-03-09T10:00:00.000Z",
     updatedAt: "2026-03-09T10:00:00.000Z",
     scripts: [],
@@ -884,11 +885,63 @@ describe("sortProjectsForSidebar", () => {
 
   it("preserves manual project ordering", () => {
     const projects = [
-      makeProject({ id: ProjectId.makeUnsafe("project-2"), name: "Second" }),
-      makeProject({ id: ProjectId.makeUnsafe("project-1"), name: "First" }),
+      makeProject({ id: ProjectId.makeUnsafe("project-2"), name: "Second", pinned: true }),
+      makeProject({ id: ProjectId.makeUnsafe("project-1"), name: "First", pinned: false }),
     ];
 
     const sorted = sortProjectsForSidebar(projects, [], "manual");
+
+    expect(sorted.map((project) => project.id)).toEqual([
+      ProjectId.makeUnsafe("project-2"),
+      ProjectId.makeUnsafe("project-1"),
+    ]);
+  });
+
+  it("keeps pinned projects ahead of unpinned projects in auto sort modes", () => {
+    const sorted = sortProjectsForSidebar(
+      [
+        makeProject({
+          id: ProjectId.makeUnsafe("project-1"),
+          name: "Unpinned newer",
+          pinned: false,
+          updatedAt: "2026-03-09T10:05:00.000Z",
+        }),
+        makeProject({
+          id: ProjectId.makeUnsafe("project-2"),
+          name: "Pinned older",
+          pinned: true,
+          updatedAt: "2026-03-09T10:01:00.000Z",
+        }),
+      ],
+      [],
+      "updated_at",
+    );
+
+    expect(sorted.map((project) => project.id)).toEqual([
+      ProjectId.makeUnsafe("project-2"),
+      ProjectId.makeUnsafe("project-1"),
+    ]);
+  });
+
+  it("still sorts pinned projects relative to each other by the active auto sort", () => {
+    const sorted = sortProjectsForSidebar(
+      [
+        makeProject({
+          id: ProjectId.makeUnsafe("project-1"),
+          name: "Pinned older",
+          pinned: true,
+          updatedAt: "2026-03-09T10:01:00.000Z",
+        }),
+        makeProject({
+          id: ProjectId.makeUnsafe("project-2"),
+          name: "Pinned newer",
+          pinned: true,
+          updatedAt: "2026-03-09T10:05:00.000Z",
+        }),
+      ],
+      [],
+      "updated_at",
+    );
 
     expect(sorted.map((project) => project.id)).toEqual([
       ProjectId.makeUnsafe("project-2"),

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -14,6 +14,7 @@ export type SidebarNewThreadEnvMode = "local" | "worktree";
 type SidebarProject = {
   id: string;
   name: string;
+  pinned: boolean;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
 };
@@ -486,6 +487,8 @@ export function sortProjectsForSidebar<TProject extends SidebarProject, TThread 
   }
 
   return [...projects].toSorted((left, right) => {
+    const byPinned = Number(right.pinned) - Number(left.pinned);
+    if (byPinned !== 0) return byPinned;
     const rightTimestamp = getProjectSortTimestamp(
       right,
       threadsByProjectId.get(right.id) ?? [],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRightIcon,
   FolderIcon,
   GitPullRequestIcon,
+  PinIcon,
   PlusIcon,
   SettingsIcon,
   SquarePenIcon,
@@ -364,6 +365,7 @@ export default function Sidebar() {
   const threads = useStore((store) => store.threads);
   const markThreadUnread = useStore((store) => store.markThreadUnread);
   const toggleProject = useStore((store) => store.toggleProject);
+  const toggleProjectPinned = useStore((store) => store.toggleProjectPinned);
   const reorderProjects = useStore((store) => store.reorderProjects);
   const clearComposerDraftForThread = useComposerDraftStore((store) => store.clearDraftThread);
   const getDraftThreadByProjectId = useComposerDraftStore(
@@ -909,11 +911,16 @@ export default function Sidebar() {
 
       const clicked = await api.contextMenu.show(
         [
+          { id: "toggle-pin", label: project.pinned ? "Unpin project" : "Pin project" },
           { id: "copy-path", label: "Copy Project Path" },
           { id: "delete", label: "Remove project", destructive: true },
         ],
         position,
       );
+      if (clicked === "toggle-pin") {
+        toggleProjectPinned(projectId);
+        return;
+      }
       if (clicked === "copy-path") {
         copyPathToClipboard(project.cwd, { path: project.cwd });
         return;
@@ -961,6 +968,7 @@ export default function Sidebar() {
       getDraftThreadByProjectId,
       projects,
       threads,
+      toggleProjectPinned,
     ],
   );
 
@@ -1559,6 +1567,12 @@ export default function Sidebar() {
             <span className="flex-1 truncate text-xs font-medium text-foreground/90">
               {project.name}
             </span>
+            {project.pinned ? (
+              <PinIcon
+                aria-hidden="true"
+                className="size-3 shrink-0 rotate-45 text-muted-foreground/55"
+              />
+            ) : null}
           </SidebarMenuButton>
           <Tooltip>
             <TooltipTrigger

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -7,7 +7,13 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { markThreadUnread, reorderProjects, syncServerReadModel, type AppState } from "./store";
+import {
+  markThreadUnread,
+  reorderProjects,
+  syncServerReadModel,
+  toggleProjectPinned,
+  type AppState,
+} from "./store";
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "./types";
 
 function makeThread(overrides: Partial<Thread> = {}): Thread {
@@ -49,6 +55,7 @@ function makeState(thread: Thread): AppState {
           model: "gpt-5-codex",
         },
         expanded: true,
+        pinned: false,
         scripts: [],
       },
     ],
@@ -181,6 +188,7 @@ describe("store pure functions", () => {
             model: DEFAULT_MODEL_BY_PROVIDER.codex,
           },
           expanded: true,
+          pinned: false,
           scripts: [],
         },
         {
@@ -192,6 +200,7 @@ describe("store pure functions", () => {
             model: DEFAULT_MODEL_BY_PROVIDER.codex,
           },
           expanded: true,
+          pinned: false,
           scripts: [],
         },
         {
@@ -203,6 +212,7 @@ describe("store pure functions", () => {
             model: DEFAULT_MODEL_BY_PROVIDER.codex,
           },
           expanded: true,
+          pinned: false,
           scripts: [],
         },
       ],
@@ -213,6 +223,16 @@ describe("store pure functions", () => {
     const next = reorderProjects(state, project1, project3);
 
     expect(next.projects.map((project) => project.id)).toEqual([project2, project3, project1]);
+  });
+
+  it("toggleProjectPinned flips the pinned flag for the selected project", () => {
+    const projectId = ProjectId.makeUnsafe("project-1");
+    const initialState = makeState(makeThread());
+
+    const next = toggleProjectPinned(initialState, projectId);
+
+    expect(next.projects[0]?.pinned).toBe(true);
+    expect(initialState.projects[0]?.pinned).toBe(false);
   });
 });
 
@@ -302,6 +322,7 @@ describe("store read model sync", () => {
             model: DEFAULT_MODEL_BY_PROVIDER.codex,
           },
           expanded: true,
+          pinned: true,
           scripts: [],
         },
         {
@@ -313,6 +334,7 @@ describe("store read model sync", () => {
             model: DEFAULT_MODEL_BY_PROVIDER.codex,
           },
           expanded: true,
+          pinned: false,
           scripts: [],
         },
       ],
@@ -345,5 +367,6 @@ describe("store read model sync", () => {
     const next = syncServerReadModel(initialState, readModel);
 
     expect(next.projects.map((project) => project.id)).toEqual([project2, project1, project3]);
+    expect(next.projects.map((project) => project.pinned)).toEqual([true, false, false]);
   });
 });

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -37,6 +37,7 @@ const initialState: AppState = {
   threadsHydrated: false,
 };
 const persistedExpandedProjectCwds = new Set<string>();
+const persistedPinnedProjectCwds = new Set<string>();
 const persistedProjectOrderCwds: string[] = [];
 
 // ── Persist helpers ──────────────────────────────────────────────────
@@ -48,13 +49,20 @@ function readPersistedState(): AppState {
     if (!raw) return initialState;
     const parsed = JSON.parse(raw) as {
       expandedProjectCwds?: string[];
+      pinnedProjectCwds?: string[];
       projectOrderCwds?: string[];
     };
     persistedExpandedProjectCwds.clear();
+    persistedPinnedProjectCwds.clear();
     persistedProjectOrderCwds.length = 0;
     for (const cwd of parsed.expandedProjectCwds ?? []) {
       if (typeof cwd === "string" && cwd.length > 0) {
         persistedExpandedProjectCwds.add(cwd);
+      }
+    }
+    for (const cwd of parsed.pinnedProjectCwds ?? []) {
+      if (typeof cwd === "string" && cwd.length > 0) {
+        persistedPinnedProjectCwds.add(cwd);
       }
     }
     for (const cwd of parsed.projectOrderCwds ?? []) {
@@ -78,6 +86,9 @@ function persistState(state: AppState): void {
       JSON.stringify({
         expandedProjectCwds: state.projects
           .filter((project) => project.expanded)
+          .map((project) => project.cwd),
+        pinnedProjectCwds: state.projects
+          .filter((project) => project.pinned)
           .map((project) => project.cwd),
         projectOrderCwds: state.projects.map((project) => project.cwd),
       }),
@@ -148,6 +159,7 @@ function mapProjectsFromReadModel(
         (persistedExpandedProjectCwds.size > 0
           ? persistedExpandedProjectCwds.has(project.workspaceRoot)
           : true),
+      pinned: existing?.pinned ?? persistedPinnedProjectCwds.has(project.workspaceRoot),
       createdAt: project.createdAt,
       updatedAt: project.updatedAt,
       scripts: project.scripts.map((script) => ({ ...script })),
@@ -379,6 +391,16 @@ export function setProjectExpanded(
   return changed ? { ...state, projects } : state;
 }
 
+export function toggleProjectPinned(state: AppState, projectId: Project["id"]): AppState {
+  let changed = false;
+  const projects = state.projects.map((project) => {
+    if (project.id !== projectId) return project;
+    changed = true;
+    return { ...project, pinned: !project.pinned };
+  });
+  return changed ? { ...state, projects } : state;
+}
+
 export function reorderProjects(
   state: AppState,
   draggedProjectId: Project["id"],
@@ -429,6 +451,7 @@ interface AppStore extends AppState {
   markThreadVisited: (threadId: ThreadId, visitedAt?: string) => void;
   markThreadUnread: (threadId: ThreadId) => void;
   toggleProject: (projectId: Project["id"]) => void;
+  toggleProjectPinned: (projectId: Project["id"]) => void;
   setProjectExpanded: (projectId: Project["id"], expanded: boolean) => void;
   reorderProjects: (draggedProjectId: Project["id"], targetProjectId: Project["id"]) => void;
   setError: (threadId: ThreadId, error: string | null) => void;
@@ -442,6 +465,7 @@ export const useStore = create<AppStore>((set) => ({
     set((state) => markThreadVisited(state, threadId, visitedAt)),
   markThreadUnread: (threadId) => set((state) => markThreadUnread(state, threadId)),
   toggleProject: (projectId) => set((state) => toggleProject(state, projectId)),
+  toggleProjectPinned: (projectId) => set((state) => toggleProjectPinned(state, projectId)),
   setProjectExpanded: (projectId, expanded) =>
     set((state) => setProjectExpanded(state, projectId, expanded)),
   reorderProjects: (draggedProjectId, targetProjectId) =>

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -83,6 +83,7 @@ export interface Project {
   cwd: string;
   defaultModelSelection: ModelSelection | null;
   expanded: boolean;
+  pinned: boolean;
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
   scripts: ProjectScript[];


### PR DESCRIPTION
## Summary
- Added persistent `pinned` state to projects and surfaced it through the shared project type and store read model.
- Updated sidebar project sorting so pinned projects always appear ahead of unpinned projects while still respecting the active auto-sort within each group.
- Added sidebar UI affordances for pinned projects, including a pin indicator and a context-menu action to pin or unpin a project.
- Expanded tests to cover pinned-project sorting, persistence, read-model sync, and the new store toggle behavior.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes project state shape and localStorage persistence, and adjusts sidebar sorting behavior; regressions could reorder projects unexpectedly or lose persisted pin state.
> 
> **Overview**
> Adds a persistent `pinned` flag to `Project` state (including localStorage hydration/persistence and read-model syncing) and exposes a new store action `toggleProjectPinned`.
> 
> Updates sidebar behavior so **pinned projects are always sorted ahead of unpinned projects** in auto-sort modes (while still applying the active sort within each group), and adds UI affordances to pin/unpin via the project context menu plus a pin indicator in the project row. Tests are expanded to cover pin toggling, persistence/sync, and the new sorting rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67e3f2c7d57226e6f469dc3936ca035ecb02aafc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prioritize pinned projects in sidebar sorting with persist support
> - Adds a `pinned` boolean to the `Project` type and `SidebarProject` type, surfaced via a new `toggleProjectPinned` store action.
> - Extends `sortProjectsForSidebar` to place pinned projects before unpinned ones in all non-manual sort modes, while still applying the active sort key within each group.
> - Adds a pin/unpin option to the sidebar project context menu and renders a `PinIcon` next to pinned project names.
> - Persists pinned state to `localStorage` (keyed by workspace root) and restores it when the store is rehydrated from the server read model.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67e3f2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->