### PR TITLE
Add terminal profile settings groundwork

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -86,6 +86,7 @@ import {
   BrowserTraceCollector,
   type BrowserTraceCollectorShape,
 } from "./observability/Services/BrowserTraceCollector.ts";
+import { resolveCurrentShell } from "./terminal/terminalProfile.ts";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver.ts";
 import {
   ProjectSetupScriptRunner,
@@ -1848,6 +1849,12 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         assert.equal(first.config.observability.otlpTracesEnabled, true);
         assert.equal(first.config.observability.otlpMetricsUrl, "http://localhost:4318/v1/metrics");
         assert.equal(first.config.observability.otlpMetricsEnabled, true);
+        assert.equal(first.config.terminal.platform, process.platform);
+        assert.equal(
+          first.config.terminal.currentShell,
+          resolveCurrentShell(process.platform, process.env),
+        );
+        assert.isTrue(Array.isArray(first.config.terminal.discoveredShells));
         assert.deepEqual(first.config.settings, DEFAULT_SERVER_SETTINGS);
       }
       assert.deepEqual(second, {
@@ -1855,6 +1862,35 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         type: "keybindingsUpdated",
         payload: { issues: [] },
       });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("routes websocket rpc serverGetConfig with terminal discovery", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest({
+        layers: {
+          keybindings: {
+            loadConfigState: Effect.succeed({
+              keybindings: [],
+              issues: [],
+            }),
+            streamChanges: Stream.empty,
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const response = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) => client[WS_METHODS.serverGetConfig]({})),
+      );
+
+      assert.equal(response.terminal.platform, process.platform);
+      assert.equal(
+        response.terminal.currentShell,
+        resolveCurrentShell(process.platform, process.env),
+      );
+      assert.isTrue(Array.isArray(response.terminal.discoveredShells));
+      assert.deepEqual(response.settings, DEFAULT_SERVER_SETTINGS);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -41,6 +41,25 @@ it.layer(NodeServices.layer)("server settings", (it) => {
           },
         },
       );
+
+      assert.deepEqual(
+        decodePatch({
+          terminal: {
+            profile: {
+              shellPath: "/bin/zsh",
+              shellArgs: ["-f"],
+            },
+          },
+        }),
+        {
+          terminal: {
+            profile: {
+              shellPath: "/bin/zsh",
+              shellArgs: ["-f"],
+            },
+          },
+        },
+      );
     }),
   );
 
@@ -208,6 +227,47 @@ it.layer(NodeServices.layer)("server settings", (it) => {
 
       assert.equal(next.providers.codex.binaryPath, "codex");
       assert.equal(next.providers.claudeAgent.binaryPath, "claude");
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
+  it.effect("writes terminal profile overrides without serializing default values", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsService;
+      const serverConfig = yield* ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+
+      const next = yield* serverSettings.updateSettings({
+        terminal: {
+          profile: {
+            shellPath: "/bin/zsh",
+            shellArgs: ["-f"],
+            env: {
+              ZDOTDIR: "/tmp/t3code-zsh",
+            },
+          },
+        },
+      });
+
+      assert.deepEqual(next.terminal.profile, {
+        shellPath: "/bin/zsh",
+        shellArgs: ["-f"],
+        env: {
+          ZDOTDIR: "/tmp/t3code-zsh",
+        },
+      });
+
+      const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
+      assert.deepEqual(JSON.parse(raw), {
+        terminal: {
+          profile: {
+            shellPath: "/bin/zsh",
+            shellArgs: ["-f"],
+            env: {
+              ZDOTDIR: "/tmp/t3code-zsh",
+            },
+          },
+        },
+      });
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 

--- a/apps/server/src/terminal/Layers/Manager.test.ts
+++ b/apps/server/src/terminal/Layers/Manager.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_TERMINAL_ID,
   type TerminalEvent,
   type TerminalOpenInput,
+  type TerminalProfileSettings,
   type TerminalRestartInput,
 } from "@t3tools/contracts";
 import {
@@ -188,6 +189,7 @@ function multiTerminalHistoryLogPath(
 
 interface CreateManagerOptions {
   shellResolver?: () => string;
+  terminalProfileResolver?: Effect.Effect<TerminalProfileSettings>;
   subprocessChecker?: (terminalPid: number) => Effect.Effect<boolean>;
   subprocessPollIntervalMs?: number;
   processKillGraceMs?: number;
@@ -222,6 +224,9 @@ const createManager = (
         historyLineLimit,
         ptyAdapter,
         ...(options.shellResolver !== undefined ? { shellResolver: options.shellResolver } : {}),
+        ...(options.terminalProfileResolver !== undefined
+          ? { terminalProfileResolver: options.terminalProfileResolver }
+          : {}),
         ...(options.subprocessChecker !== undefined
           ? { subprocessChecker: options.subprocessChecker }
           : {}),
@@ -320,6 +325,41 @@ it.layer(NodeServices.layer, { excludeTestServices: true })("TerminalManager", (
       assert.equal(snapshot.status, "running");
       expect(ptyAdapter.spawnInputs).toHaveLength(1);
       expect(ptyAdapter.processes).toHaveLength(1);
+    }),
+  );
+
+  it.effect("spawns terminals with the configured shell profile", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        shellResolver: () => "/bin/bash",
+        terminalProfileResolver: Effect.succeed({
+          shellPath: "/bin/zsh",
+          shellArgs: ["-f"],
+          env: {
+            ZDOTDIR: "/tmp/t3code-zdotdir",
+            PATH: "/opt/t3/bin",
+          },
+        }),
+      });
+
+      yield* manager.open(
+        openInput({
+          env: {
+            PATH: "/workspace/bin",
+            CUSTOM_FLAG: "1",
+          },
+        }),
+      );
+
+      const spawned = ptyAdapter.spawnInputs[0];
+      expect(spawned).toBeDefined();
+      if (!spawned) return;
+
+      expect(spawned.shell).toBe("/bin/zsh");
+      expect(spawned.args).toEqual(["-f"]);
+      expect(spawned.env.ZDOTDIR).toBe("/tmp/t3code-zdotdir");
+      expect(spawned.env.PATH).toBe("/workspace/bin");
+      expect(spawned.env.CUSTOM_FLAG).toBe("1");
     }),
   );
 

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   DEFAULT_TERMINAL_ID,
   type TerminalEvent,
+  type TerminalProfileSettings,
   type TerminalSessionSnapshot,
   type TerminalSessionStatus,
 } from "@t3tools/contracts";
@@ -29,11 +30,13 @@ import {
   terminalSessionsTotal,
 } from "../../observability/Metrics";
 import { runProcess } from "../../processRunner";
+import { ServerSettingsService } from "../../serverSettings";
 import {
   TerminalCwdError,
   TerminalHistoryError,
   TerminalManager,
   TerminalNotRunningError,
+  type ShellCandidate,
   TerminalSessionLookupError,
   type TerminalManagerShape,
 } from "../Services/Manager";
@@ -44,6 +47,7 @@ import {
   type PtyExitEvent,
   type PtyProcess,
 } from "../Services/PTY";
+import { resolveCurrentShell, resolveTerminalShellSpawnConfig } from "../terminalProfile";
 
 const DEFAULT_HISTORY_LINE_LIMIT = 5_000;
 const DEFAULT_PERSIST_DEBOUNCE_MS = 40;
@@ -75,11 +79,6 @@ class TerminalProcessSignalError extends Schema.TaggedErrorClass<TerminalProcess
 
 interface TerminalSubprocessChecker {
   (terminalPid: number): Effect.Effect<boolean, TerminalSubprocessCheckError>;
-}
-
-interface ShellCandidate {
-  shell: string;
-  args?: string[];
 }
 
 interface TerminalStartInput {
@@ -187,75 +186,12 @@ function enqueueProcessEvent(
 }
 
 function defaultShellResolver(): string {
-  if (process.platform === "win32") {
-    return process.env.ComSpec ?? "cmd.exe";
-  }
-  return process.env.SHELL ?? "bash";
-}
-
-function normalizeShellCommand(value: string | undefined): string | null {
-  if (!value) return null;
-  const trimmed = value.trim();
-  if (trimmed.length === 0) return null;
-
-  if (process.platform === "win32") {
-    return trimmed;
-  }
-
-  const firstToken = trimmed.split(/\s+/g)[0]?.trim();
-  if (!firstToken) return null;
-  return firstToken.replace(/^['"]|['"]$/g, "");
-}
-
-function shellCandidateFromCommand(command: string | null): ShellCandidate | null {
-  if (!command || command.length === 0) return null;
-  const shellName = path.basename(command).toLowerCase();
-  if (process.platform !== "win32" && shellName === "zsh") {
-    return { shell: command, args: ["-o", "nopromptsp"] };
-  }
-  return { shell: command };
+  return resolveCurrentShell(process.platform, process.env);
 }
 
 function formatShellCandidate(candidate: ShellCandidate): string {
   if (!candidate.args || candidate.args.length === 0) return candidate.shell;
   return `${candidate.shell} ${candidate.args.join(" ")}`;
-}
-
-function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellCandidate[] {
-  const seen = new Set<string>();
-  const ordered: ShellCandidate[] = [];
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    const key = formatShellCandidate(candidate);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    ordered.push(candidate);
-  }
-  return ordered;
-}
-
-function resolveShellCandidates(shellResolver: () => string): ShellCandidate[] {
-  const requested = shellCandidateFromCommand(normalizeShellCommand(shellResolver()));
-
-  if (process.platform === "win32") {
-    return uniqueShellCandidates([
-      requested,
-      shellCandidateFromCommand(process.env.ComSpec ?? null),
-      shellCandidateFromCommand("powershell.exe"),
-      shellCandidateFromCommand("cmd.exe"),
-    ]);
-  }
-
-  return uniqueShellCandidates([
-    requested,
-    shellCandidateFromCommand(normalizeShellCommand(process.env.SHELL)),
-    shellCandidateFromCommand("/bin/zsh"),
-    shellCandidateFromCommand("/bin/bash"),
-    shellCandidateFromCommand("/bin/sh"),
-    shellCandidateFromCommand("zsh"),
-    shellCandidateFromCommand("bash"),
-    shellCandidateFromCommand("sh"),
-  ]);
 }
 
 function isRetryableShellSpawnError(error: PtySpawnError): boolean {
@@ -621,6 +557,7 @@ function shouldExcludeTerminalEnvKey(key: string): boolean {
 
 function createTerminalSpawnEnv(
   baseEnv: NodeJS.ProcessEnv,
+  profileEnv?: Record<string, string> | null,
   runtimeEnv?: Record<string, string> | null,
 ): NodeJS.ProcessEnv {
   const spawnEnv: NodeJS.ProcessEnv = {};
@@ -628,6 +565,11 @@ function createTerminalSpawnEnv(
     if (value === undefined) continue;
     if (shouldExcludeTerminalEnvKey(key)) continue;
     spawnEnv[key] = value;
+  }
+  if (profileEnv) {
+    for (const [key, value] of Object.entries(profileEnv)) {
+      spawnEnv[key] = value;
+    }
   }
   if (runtimeEnv) {
     for (const [key, value] of Object.entries(runtimeEnv)) {
@@ -651,6 +593,7 @@ interface TerminalManagerOptions {
   historyLineLimit?: number;
   ptyAdapter: PtyAdapterShape;
   shellResolver?: () => string;
+  terminalProfileResolver?: Effect.Effect<TerminalProfileSettings>;
   subprocessChecker?: TerminalSubprocessChecker;
   subprocessPollIntervalMs?: number;
   processKillGraceMs?: number;
@@ -660,9 +603,30 @@ interface TerminalManagerOptions {
 const makeTerminalManager = Effect.fn("makeTerminalManager")(function* () {
   const { terminalLogsDir } = yield* ServerConfig;
   const ptyAdapter = yield* PtyAdapter;
+  const serverSettings = yield* Effect.serviceOption(ServerSettingsService);
+  const terminalProfileResolver = Option.match(serverSettings, {
+    onNone: () =>
+      Effect.succeed({
+        shellPath: "",
+        shellArgs: [],
+        env: {},
+      } satisfies TerminalProfileSettings),
+    onSome: (settingsService) =>
+      settingsService.getSettings.pipe(
+        Effect.map((settings) => settings.terminal.profile),
+        Effect.catch(() =>
+          Effect.succeed({
+            shellPath: "",
+            shellArgs: [],
+            env: {},
+          } satisfies TerminalProfileSettings),
+        ),
+      ),
+  });
   return yield* makeTerminalManagerWithOptions({
     logsDir: terminalLogsDir,
     ptyAdapter,
+    terminalProfileResolver,
   });
 });
 
@@ -675,6 +639,13 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
     const logsDir = options.logsDir;
     const historyLineLimit = options.historyLineLimit ?? DEFAULT_HISTORY_LINE_LIMIT;
     const shellResolver = options.shellResolver ?? defaultShellResolver;
+    const terminalProfileResolver =
+      options.terminalProfileResolver ??
+      Effect.succeed({
+        shellPath: "",
+        shellArgs: [],
+        env: {},
+      } satisfies TerminalProfileSettings);
     const subprocessChecker = options.subprocessChecker ?? defaultSubprocessChecker;
     const subprocessPollIntervalMs =
       options.subprocessPollIntervalMs ?? DEFAULT_SUBPROCESS_POLL_INTERVAL_MS;
@@ -1337,8 +1308,19 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
         increment(terminalSessionsTotal, { lifecycle: eventType }).pipe(
           Effect.andThen(
             Effect.gen(function* () {
-              const shellCandidates = resolveShellCandidates(shellResolver);
-              const terminalEnv = createTerminalSpawnEnv(process.env, session.runtimeEnv);
+              const terminalProfile = yield* terminalProfileResolver;
+              const resolvedSpawnConfig = resolveTerminalShellSpawnConfig({
+                platform: process.platform,
+                processEnv: process.env,
+                shellResolver,
+                profile: terminalProfile,
+              });
+              const shellCandidates = resolvedSpawnConfig.shellCandidates;
+              const terminalEnv = createTerminalSpawnEnv(
+                process.env,
+                resolvedSpawnConfig.profileEnv,
+                session.runtimeEnv,
+              );
               const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
               ptyProcess = spawnResult.process;
               startedShell = spawnResult.shellLabel;

--- a/apps/server/src/terminal/terminalProfile.test.ts
+++ b/apps/server/src/terminal/terminalProfile.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  discoverTerminalShells,
+  discoverWindowsTerminalShells,
+  resolveTerminalShellSpawnConfig,
+  type TerminalShellPathProbe,
+} from "./terminalProfile";
+
+const rejectingCmdProbe: TerminalShellPathProbe = async (candidate) => {
+  if (candidate === "C:\\Windows\\System32\\cmd.exe") {
+    throw new Error("permission denied");
+  }
+  return false;
+};
+
+describe("resolveTerminalShellSpawnConfig", () => {
+  it("uses the explicit custom shell profile when one is configured", () => {
+    const result = resolveTerminalShellSpawnConfig({
+      platform: "darwin",
+      processEnv: { SHELL: "/bin/bash" },
+      shellResolver: () => "/bin/bash",
+      profile: {
+        shellPath: "/bin/zsh",
+        shellArgs: ["-f", " "],
+        env: {
+          ZDOTDIR: "/tmp/t3code-zdotdir",
+          " PATH ": "/custom/bin",
+        },
+      },
+    });
+
+    expect(result.shellCandidates).toEqual([{ shell: "/bin/zsh", args: ["-f"] }]);
+    expect(result.profileEnv).toEqual({
+      PATH: "/custom/bin",
+      ZDOTDIR: "/tmp/t3code-zdotdir",
+    });
+  });
+
+  it("preserves the existing fallback order when no custom shell path is configured", () => {
+    const result = resolveTerminalShellSpawnConfig({
+      platform: "darwin",
+      processEnv: { SHELL: "/bin/bash" },
+      shellResolver: () => "/bin/bash",
+      profile: {
+        shellPath: "",
+        shellArgs: [],
+        env: {},
+      },
+    });
+
+    expect(result.shellCandidates.slice(0, 4)).toEqual([
+      { shell: "/bin/bash" },
+      { shell: "/bin/zsh", args: ["-o", "nopromptsp"] },
+      { shell: "/bin/sh" },
+      { shell: "zsh", args: ["-o", "nopromptsp"] },
+    ]);
+  });
+
+  it("applies custom shell args to the first fallback shell when no shell path is set", () => {
+    const result = resolveTerminalShellSpawnConfig({
+      platform: "win32",
+      processEnv: { ComSpec: "C:\\Windows\\System32\\cmd.exe" },
+      shellResolver: () => "powershell.exe",
+      profile: {
+        shellPath: "",
+        shellArgs: ["-NoLogo", "-NoProfile"],
+        env: {},
+      },
+    });
+
+    expect(result.shellCandidates[0]).toEqual({
+      shell: "powershell.exe",
+      args: ["-NoLogo", "-NoProfile"],
+    });
+    expect(result.shellCandidates[1]).toEqual({
+      shell: "C:\\Windows\\System32\\cmd.exe",
+    });
+  });
+});
+
+describe("discoverWindowsTerminalShells", () => {
+  it("reports common Windows shell availability for future preset UX", async () => {
+    const existingPaths = new Set([
+      "C:\\Windows\\System32\\cmd.exe",
+      "C:\\Program Files\\Git\\bin\\bash.exe",
+      "C:\\Windows\\System32\\wsl.exe",
+    ]);
+    const probe: TerminalShellPathProbe = async (candidate) => existingPaths.has(candidate);
+
+    const result = await discoverWindowsTerminalShells({
+      env: {
+        ComSpec: "C:\\Windows\\System32\\cmd.exe",
+        SystemRoot: "C:\\Windows",
+      },
+      probe,
+    });
+
+    expect(result.cmd).toEqual({
+      available: true,
+      path: "C:\\Windows\\System32\\cmd.exe",
+    });
+    expect(result.powershell).toEqual({
+      available: false,
+      path: null,
+    });
+    expect(result.gitBash).toEqual({
+      available: true,
+      path: "C:\\Program Files\\Git\\bin\\bash.exe",
+    });
+    expect(result.wsl).toEqual({
+      available: true,
+      path: "C:\\Windows\\System32\\wsl.exe",
+    });
+  });
+});
+
+describe("discoverTerminalShells", () => {
+  it("returns an empty discovery list on non-Windows platforms", async () => {
+    let probeCalls = 0;
+    const result = await discoverTerminalShells({
+      platform: "darwin",
+      env: {},
+      probe: async () => {
+        probeCalls += 1;
+        return false;
+      },
+    });
+
+    expect(result).toEqual({
+      platform: "darwin",
+      currentShell: "bash",
+      discoveredShells: [],
+    });
+    expect(probeCalls).toBe(0);
+  });
+
+  it("maps Windows shell discovery into stable server config entries", async () => {
+    const existingPaths = new Set([
+      "C:\\Windows\\System32\\cmd.exe",
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      "C:\\Program Files\\Git\\bin\\bash.exe",
+      "C:\\Windows\\System32\\wsl.exe",
+    ]);
+    const probe: TerminalShellPathProbe = async (candidate) => existingPaths.has(candidate);
+
+    const result = await discoverTerminalShells({
+      platform: "win32",
+      env: {
+        ComSpec: "C:\\Windows\\System32\\cmd.exe",
+        SystemRoot: "C:\\Windows",
+      },
+      probe,
+    });
+
+    expect(result).toEqual({
+      platform: "win32",
+      currentShell: "C:\\Windows\\System32\\cmd.exe",
+      discoveredShells: [
+        {
+          id: "powershell",
+          label: "PowerShell",
+          available: true,
+          path: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        },
+        {
+          id: "cmd",
+          label: "Command Prompt",
+          available: true,
+          path: "C:\\Windows\\System32\\cmd.exe",
+        },
+        {
+          id: "gitBash",
+          label: "Git Bash",
+          available: true,
+          path: "C:\\Program Files\\Git\\bin\\bash.exe",
+        },
+        {
+          id: "wsl",
+          label: "WSL",
+          available: true,
+          path: "C:\\Windows\\System32\\wsl.exe",
+        },
+      ],
+    });
+  });
+
+  it("treats probe failures as unavailable shells instead of failing discovery", async () => {
+    const result = await discoverTerminalShells({
+      platform: "win32",
+      env: {
+        ComSpec: "C:\\Windows\\System32\\cmd.exe",
+        SystemRoot: "C:\\Windows",
+      },
+      probe: rejectingCmdProbe,
+    });
+
+    expect(result).toEqual({
+      platform: "win32",
+      currentShell: "C:\\Windows\\System32\\cmd.exe",
+      discoveredShells: [
+        {
+          id: "powershell",
+          label: "PowerShell",
+          available: false,
+          path: null,
+        },
+        {
+          id: "cmd",
+          label: "Command Prompt",
+          available: false,
+          path: null,
+        },
+        {
+          id: "gitBash",
+          label: "Git Bash",
+          available: false,
+          path: null,
+        },
+        {
+          id: "wsl",
+          label: "WSL",
+          available: false,
+          path: null,
+        },
+      ],
+    });
+  });
+});

--- a/apps/server/src/terminal/terminalProfile.ts
+++ b/apps/server/src/terminal/terminalProfile.ts
@@ -1,0 +1,265 @@
+import path from "node:path";
+
+import {
+  type ServerTerminal,
+  type ServerTerminalDiscoveredShell,
+  type TerminalProfileSettings,
+} from "@t3tools/contracts";
+
+import { type ShellCandidate } from "./Services/Manager";
+
+export type TerminalPlatform = NodeJS.Platform;
+
+export interface ResolveTerminalShellSpawnConfigInput {
+  platform: TerminalPlatform;
+  processEnv: NodeJS.ProcessEnv;
+  shellResolver: () => string;
+  profile: TerminalProfileSettings | null | undefined;
+}
+
+export interface ResolvedTerminalShellSpawnConfig {
+  shellCandidates: ShellCandidate[];
+  profileEnv: Record<string, string> | null;
+}
+
+export type TerminalShellPathProbe = (candidatePath: string) => Promise<boolean>;
+
+export interface WindowsTerminalShellDiscovery {
+  cmd: { available: boolean; path: string | null };
+  powershell: { available: boolean; path: string | null };
+  gitBash: { available: boolean; path: string | null };
+  wsl: { available: boolean; path: string | null };
+}
+
+export function resolveCurrentShell(
+  platform: TerminalPlatform,
+  processEnv: NodeJS.ProcessEnv,
+): string {
+  if (platform === "win32") {
+    return processEnv.ComSpec ?? "cmd.exe";
+  }
+  return processEnv.SHELL ?? "bash";
+}
+
+function createDiscoveredShell(
+  id: ServerTerminalDiscoveredShell["id"],
+  label: string,
+  shell: { available: boolean; path: string | null },
+): ServerTerminalDiscoveredShell {
+  return {
+    id,
+    label,
+    available: shell.available,
+    path: shell.path,
+  };
+}
+
+function normalizeShellCommand(
+  value: string | undefined,
+  platform: TerminalPlatform,
+): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+
+  if (platform === "win32") {
+    return trimmed;
+  }
+
+  const firstToken = trimmed.split(/\s+/g)[0]?.trim();
+  if (!firstToken) return null;
+  return firstToken.replace(/^['"]|['"]$/g, "");
+}
+
+function shellCandidateFromCommand(
+  command: string | null,
+  platform: TerminalPlatform,
+): ShellCandidate | null {
+  if (!command || command.length === 0) return null;
+  const shellName = path.basename(command).toLowerCase();
+  if (platform !== "win32" && shellName === "zsh") {
+    return { shell: command, args: ["-o", "nopromptsp"] };
+  }
+  return { shell: command };
+}
+
+function formatShellCandidate(candidate: ShellCandidate): string {
+  if (!candidate.args || candidate.args.length === 0) return candidate.shell;
+  return `${candidate.shell} ${candidate.args.join(" ")}`;
+}
+
+function uniqueShellCandidates(candidates: Array<ShellCandidate | null>): ShellCandidate[] {
+  const seen = new Set<string>();
+  const ordered: ShellCandidate[] = [];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const key = formatShellCandidate(candidate);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    ordered.push(candidate);
+  }
+  return ordered;
+}
+
+function resolveDefaultShellCandidates(input: {
+  platform: TerminalPlatform;
+  processEnv: NodeJS.ProcessEnv;
+  shellResolver: () => string;
+}): ShellCandidate[] {
+  const requested = shellCandidateFromCommand(
+    normalizeShellCommand(input.shellResolver(), input.platform),
+    input.platform,
+  );
+
+  if (input.platform === "win32") {
+    return uniqueShellCandidates([
+      requested,
+      shellCandidateFromCommand(input.processEnv.ComSpec ?? null, input.platform),
+      shellCandidateFromCommand("powershell.exe", input.platform),
+      shellCandidateFromCommand("cmd.exe", input.platform),
+    ]);
+  }
+
+  return uniqueShellCandidates([
+    requested,
+    shellCandidateFromCommand(
+      normalizeShellCommand(input.processEnv.SHELL, input.platform),
+      input.platform,
+    ),
+    shellCandidateFromCommand("/bin/zsh", input.platform),
+    shellCandidateFromCommand("/bin/bash", input.platform),
+    shellCandidateFromCommand("/bin/sh", input.platform),
+    shellCandidateFromCommand("zsh", input.platform),
+    shellCandidateFromCommand("bash", input.platform),
+    shellCandidateFromCommand("sh", input.platform),
+  ]);
+}
+
+function normalizeShellArgs(shellArgs: ReadonlyArray<string> | undefined): string[] {
+  if (!shellArgs || shellArgs.length === 0) return [];
+  return shellArgs.map((arg) => arg.trim()).filter((arg) => arg.length > 0);
+}
+
+function normalizeTerminalProfileEnv(
+  env: TerminalProfileSettings["env"] | undefined,
+): Record<string, string> | null {
+  if (!env) return null;
+  const entries = Object.entries(env)
+    .map(([key, value]) => [key.trim(), value] as const)
+    .filter(([key]) => key.length > 0);
+  if (entries.length === 0) return null;
+  return Object.fromEntries(entries);
+}
+
+export function resolveTerminalShellSpawnConfig(
+  input: ResolveTerminalShellSpawnConfigInput,
+): ResolvedTerminalShellSpawnConfig {
+  const shellPath = normalizeShellCommand(input.profile?.shellPath, input.platform);
+  const shellArgs = normalizeShellArgs(input.profile?.shellArgs);
+  const profileEnv = normalizeTerminalProfileEnv(input.profile?.env);
+
+  if (shellPath) {
+    return {
+      shellCandidates: uniqueShellCandidates([
+        {
+          shell: shellPath,
+          ...(shellArgs.length > 0 ? { args: shellArgs } : {}),
+        },
+      ]),
+      profileEnv,
+    };
+  }
+
+  const shellCandidates = resolveDefaultShellCandidates(input);
+  if (shellArgs.length === 0) {
+    return { shellCandidates, profileEnv };
+  }
+
+  return {
+    shellCandidates: shellCandidates.map((candidate, index) =>
+      index === 0 ? { shell: candidate.shell, args: shellArgs } : candidate,
+    ),
+    profileEnv,
+  };
+}
+
+async function firstExistingPath(
+  candidates: string[],
+  probe: TerminalShellPathProbe,
+): Promise<string | null> {
+  for (const candidate of candidates) {
+    try {
+      if (await probe(candidate)) {
+        return candidate;
+      }
+    } catch {
+      // Discovery is best-effort; treat probe failures as unavailable paths.
+    }
+  }
+  return null;
+}
+
+export async function discoverWindowsTerminalShells(input: {
+  env: NodeJS.ProcessEnv;
+  probe: TerminalShellPathProbe;
+}): Promise<WindowsTerminalShellDiscovery> {
+  const systemRoot = input.env.SystemRoot ?? "C:\\Windows";
+  const cmdPath = await firstExistingPath(
+    [input.env.ComSpec ?? path.win32.join(systemRoot, "System32", "cmd.exe")],
+    input.probe,
+  );
+  const powershellPath = await firstExistingPath(
+    [path.win32.join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")],
+    input.probe,
+  );
+  const gitBashPath = await firstExistingPath(
+    [
+      "C:\\Program Files\\Git\\bin\\bash.exe",
+      "C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+      "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+      "C:\\Program Files (x86)\\Git\\usr\\bin\\bash.exe",
+    ],
+    input.probe,
+  );
+  const wslPath = await firstExistingPath(
+    [path.win32.join(systemRoot, "System32", "wsl.exe")],
+    input.probe,
+  );
+
+  return {
+    cmd: { available: cmdPath !== null, path: cmdPath },
+    powershell: { available: powershellPath !== null, path: powershellPath },
+    gitBash: { available: gitBashPath !== null, path: gitBashPath },
+    wsl: { available: wslPath !== null, path: wslPath },
+  };
+}
+
+export async function discoverTerminalShells(input: {
+  platform: TerminalPlatform;
+  env: NodeJS.ProcessEnv;
+  probe: TerminalShellPathProbe;
+}): Promise<ServerTerminal> {
+  if (input.platform !== "win32") {
+    return {
+      platform: input.platform,
+      currentShell: resolveCurrentShell(input.platform, input.env),
+      discoveredShells: [],
+    };
+  }
+
+  const windowsShells = await discoverWindowsTerminalShells({
+    env: input.env,
+    probe: input.probe,
+  });
+
+  return {
+    platform: input.platform,
+    currentShell: resolveCurrentShell(input.platform, input.env),
+    discoveredShells: [
+      createDiscoveredShell("powershell", "PowerShell", windowsShells.powershell),
+      createDiscoveredShell("cmd", "Command Prompt", windowsShells.cmd),
+      createDiscoveredShell("gitBash", "Git Bash", windowsShells.gitBash),
+      createDiscoveredShell("wsl", "WSL", windowsShells.wsl),
+    ],
+  };
+}

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1,4 +1,15 @@
-import { Cause, Duration, Effect, Layer, Option, Queue, Ref, Schema, Stream } from "effect";
+import {
+  Cause,
+  Duration,
+  Effect,
+  FileSystem,
+  Layer,
+  Option,
+  Queue,
+  Ref,
+  Schema,
+  Stream,
+} from "effect";
 import {
   type AuthAccessStreamEvent,
   AuthSessionId,
@@ -47,6 +58,7 @@ import { ServerLifecycleEvents } from "./serverLifecycleEvents";
 import { ServerRuntimeStartup } from "./serverRuntimeStartup";
 import { ServerSettingsService } from "./serverSettings";
 import { TerminalManager } from "./terminal/Services/Manager";
+import { discoverTerminalShells } from "./terminal/terminalProfile";
 import { WorkspaceEntries } from "./workspace/Services/WorkspaceEntries";
 import { WorkspaceFileSystem } from "./workspace/Services/WorkspaceFileSystem";
 import { WorkspacePathOutsideRootError } from "./workspace/Services/WorkspacePaths";
@@ -147,6 +159,7 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
       const startup = yield* ServerRuntimeStartup;
       const workspaceEntries = yield* WorkspaceEntries;
       const workspaceFileSystem = yield* WorkspaceFileSystem;
+      const fileSystem = yield* FileSystem.FileSystem;
       const projectSetupScriptRunner = yield* ProjectSetupScriptRunner;
       const repositoryIdentityResolver = yield* RepositoryIdentityResolver;
       const serverEnvironment = yield* ServerEnvironment;
@@ -515,6 +528,13 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         const settings = yield* serverSettings.getSettings;
         const environment = yield* serverEnvironment.getDescriptor;
         const auth = yield* serverAuth.getDescriptor();
+        const terminal = yield* Effect.promise(() =>
+          discoverTerminalShells({
+            platform: process.platform,
+            env: process.env,
+            probe: (candidatePath) => Effect.runPromise(fileSystem.exists(candidatePath)),
+          }),
+        );
 
         return {
           environment,
@@ -525,6 +545,7 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
           issues: keybindingsConfig.issues,
           providers,
           availableEditors: resolveAvailableEditors(),
+          terminal,
           observability: {
             logsDirectoryPath: config.logsDir,
             localTracingEnabled: true,

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -178,6 +178,11 @@ function createBaseServerConfig(): ServerConfig {
       otlpTracesEnabled: false,
       otlpMetricsEnabled: false,
     },
+    terminal: {
+      platform: "darwin",
+      currentShell: "/bin/zsh",
+      discoveredShells: [],
+    },
     settings: {
       ...DEFAULT_SERVER_SETTINGS,
       ...DEFAULT_CLIENT_SETTINGS,

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -91,6 +91,11 @@ function createBaseServerConfig(): ServerConfig {
       otlpTracesEnabled: false,
       otlpMetricsEnabled: false,
     },
+    terminal: {
+      platform: "darwin",
+      currentShell: "/bin/zsh",
+      discoveredShells: [],
+    },
     settings: {
       ...DEFAULT_SERVER_SETTINGS,
       enableAssistantStreaming: false,
@@ -99,6 +104,13 @@ function createBaseServerConfig(): ServerConfig {
       providers: {
         codex: { enabled: true, binaryPath: "", homePath: "", customModels: [] },
         claudeAgent: { enabled: true, binaryPath: "", customModels: [] },
+      },
+      terminal: {
+        profile: {
+          shellPath: "",
+          shellArgs: [],
+          env: {},
+        },
       },
     },
   };

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -197,6 +197,11 @@ function createBaseServerConfig(): ServerConfig {
       otlpTracesEnabled: true,
       otlpMetricsEnabled: false,
     },
+    terminal: {
+      platform: "darwin",
+      currentShell: "/bin/zsh",
+      discoveredShells: [],
+    },
     settings: DEFAULT_SERVER_SETTINGS,
   };
 }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -9,7 +9,7 @@ import {
   XIcon,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   PROVIDER_DISPLAY_NAMES,
   type DesktopUpdateChannel,
@@ -61,6 +61,7 @@ import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "..
 import { Input } from "../ui/input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
+import { Textarea } from "../ui/textarea";
 import { toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
@@ -73,6 +74,7 @@ import {
 import { ProjectFavicon } from "../ProjectFavicon";
 import {
   useServerAvailableEditors,
+  useServerConfig,
   useServerKeybindingsConfigPath,
   useServerObservability,
   useServerProviders,
@@ -414,6 +416,58 @@ function AboutVersionSection() {
   );
 }
 
+function formatTerminalShellArgs(shellArgs: ReadonlyArray<string>) {
+  return shellArgs.join("\n");
+}
+
+function parseTerminalShellArgs(shellArgsText: string) {
+  return shellArgsText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function formatTerminalEnv(env: Record<string, string>) {
+  return Object.entries(env)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+}
+
+function parseTerminalEnv(envText: string) {
+  const env: Record<string, string> = {};
+  const lines = envText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  for (const line of lines) {
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex <= 0) {
+      return {
+        env: null,
+        error: "Environment variables must use KEY=VALUE format.",
+      } as const;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1);
+
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      return {
+        env: null,
+        error: "Environment variable names must start with a letter or underscore.",
+      } as const;
+    }
+
+    env[key] = value;
+  }
+
+  return {
+    env,
+    error: null,
+  } as const;
+}
+
 export function useSettingsRestore(onRestored?: () => void) {
   const { theme, setTheme } = useTheme();
   const settings = useSettings();
@@ -428,6 +482,10 @@ export function useSettingsRestore(onRestored?: () => void) {
     const defaultSettings = DEFAULT_UNIFIED_SETTINGS.providers[providerSettings.provider];
     return !Equal.equals(currentSettings, defaultSettings);
   });
+  const isTerminalProfileDirty = !Equal.equals(
+    settings.terminal,
+    DEFAULT_UNIFIED_SETTINGS.terminal,
+  );
 
   const changedSettingLabels = useMemo(
     () => [
@@ -455,10 +513,12 @@ export function useSettingsRestore(onRestored?: () => void) {
         : []),
       ...(isGitWritingModelDirty ? ["Git writing model"] : []),
       ...(areProviderSettingsDirty ? ["Providers"] : []),
+      ...(isTerminalProfileDirty ? ["Terminal profile"] : []),
     ],
     [
       areProviderSettingsDirty,
       isGitWritingModelDirty,
+      isTerminalProfileDirty,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
@@ -523,6 +583,13 @@ export function GeneralSettingsPanel() {
   const [customModelErrorByProvider, setCustomModelErrorByProvider] = useState<
     Partial<Record<ProviderKind, string | null>>
   >({});
+  const [terminalShellArgsDraft, setTerminalShellArgsDraft] = useState(() =>
+    formatTerminalShellArgs(settings.terminal.profile.shellArgs),
+  );
+  const [terminalEnvDraft, setTerminalEnvDraft] = useState(() =>
+    formatTerminalEnv(settings.terminal.profile.env),
+  );
+  const [terminalEnvError, setTerminalEnvError] = useState<string | null>(null);
   const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
   const refreshingRef = useRef(false);
   const modelListRefs = useRef<Partial<Record<ProviderKind, HTMLDivElement | null>>>({});
@@ -544,7 +611,9 @@ export function GeneralSettingsPanel() {
   const keybindingsConfigPath = useServerKeybindingsConfigPath();
   const availableEditors = useServerAvailableEditors();
   const observability = useServerObservability();
+  const serverConfig = useServerConfig();
   const serverProviders = useServerProviders();
+  const currentShell = serverConfig?.terminal.currentShell ?? "";
   const codexHomePath = settings.providers.codex.homePath;
   const logsDirectoryPath = observability?.logsDirectoryPath ?? null;
   const diagnosticsDescription = (() => {
@@ -573,6 +642,47 @@ export function GeneralSettingsPanel() {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
+  const updateTerminalProfile = useCallback(
+    (
+      patch: Partial<{
+        shellPath: string;
+        shellArgs: ReadonlyArray<string>;
+        env: Record<string, string>;
+      }>,
+    ) => {
+      updateSettings({
+        terminal: {
+          profile: {
+            ...settings.terminal.profile,
+            ...patch,
+          },
+        },
+      });
+    },
+    [settings.terminal.profile, updateSettings],
+  );
+
+  useEffect(() => {
+    setTerminalShellArgsDraft((currentDraft) =>
+      Equal.equals(parseTerminalShellArgs(currentDraft), settings.terminal.profile.shellArgs)
+        ? currentDraft
+        : formatTerminalShellArgs(settings.terminal.profile.shellArgs),
+    );
+  }, [settings.terminal.profile.shellArgs]);
+
+  useEffect(() => {
+    setTerminalEnvDraft((currentDraft) => {
+      const parsedDraft = parseTerminalEnv(currentDraft);
+      if (
+        parsedDraft.error === null &&
+        Equal.equals(parsedDraft.env, settings.terminal.profile.env)
+      ) {
+        return currentDraft;
+      }
+      return formatTerminalEnv(settings.terminal.profile.env);
+    });
+    setTerminalEnvError(null);
+  }, [settings.terminal.profile.env]);
 
   const openInPreferredEditor = useCallback(
     (target: "keybindings" | "logsDirectory", path: string | null, failureMessage: string) => {
@@ -1414,6 +1524,128 @@ export function GeneralSettingsPanel() {
             </div>
           );
         })}
+      </SettingsSection>
+
+      <SettingsSection title="Terminal">
+        <SettingsRow
+          title="Shell executable override"
+          description="Optional absolute path for a different shell."
+          resetAction={
+            settings.terminal.profile.shellPath !==
+            DEFAULT_UNIFIED_SETTINGS.terminal.profile.shellPath ? (
+              <SettingResetButton
+                label="terminal shell path"
+                onClick={() =>
+                  updateTerminalProfile({
+                    shellPath: DEFAULT_UNIFIED_SETTINGS.terminal.profile.shellPath,
+                  })
+                }
+              />
+            ) : null
+          }
+        >
+          <div className="mt-3">
+            <label htmlFor="terminal-shell-path" className="block">
+              <span className="sr-only">Terminal shell path</span>
+              <Input
+                id="terminal-shell-path"
+                aria-label="Terminal shell path"
+                value={settings.terminal.profile.shellPath}
+                onChange={(event) => updateTerminalProfile({ shellPath: event.target.value })}
+                placeholder={currentShell}
+                spellCheck={false}
+              />
+            </label>
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title="Shell arguments"
+          description="Optional startup arguments for the terminal shell. When no shell override is set, these apply to the current shell. Enter one argument per line."
+          resetAction={
+            !Equal.equals(
+              settings.terminal.profile.shellArgs,
+              DEFAULT_UNIFIED_SETTINGS.terminal.profile.shellArgs,
+            ) ? (
+              <SettingResetButton
+                label="terminal shell arguments"
+                onClick={() =>
+                  updateTerminalProfile({
+                    shellArgs: DEFAULT_UNIFIED_SETTINGS.terminal.profile.shellArgs,
+                  })
+                }
+              />
+            ) : null
+          }
+        >
+          <div className="mt-3">
+            <label htmlFor="terminal-shell-args" className="block">
+              <span className="sr-only">Terminal shell arguments</span>
+              <Textarea
+                id="terminal-shell-args"
+                aria-label="Terminal shell arguments"
+                value={terminalShellArgsDraft}
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+                  setTerminalShellArgsDraft(nextValue);
+                  updateTerminalProfile({ shellArgs: parseTerminalShellArgs(nextValue) });
+                }}
+                placeholder={"-l\n--norc"}
+                spellCheck={false}
+              />
+            </label>
+          </div>
+        </SettingsRow>
+
+        <SettingsRow
+          title="Environment variables"
+          description="Extra environment variables for new and restarted terminals. These apply even when keeping the current shell. Enter one KEY=VALUE pair per line."
+          resetAction={
+            !Equal.equals(
+              settings.terminal.profile.env,
+              DEFAULT_UNIFIED_SETTINGS.terminal.profile.env,
+            ) ? (
+              <SettingResetButton
+                label="terminal environment variables"
+                onClick={() =>
+                  updateTerminalProfile({
+                    env: DEFAULT_UNIFIED_SETTINGS.terminal.profile.env,
+                  })
+                }
+              />
+            ) : null
+          }
+        >
+          <div className="mt-3">
+            <label htmlFor="terminal-env" className="block">
+              <span className="sr-only">Terminal environment variables</span>
+              <Textarea
+                id="terminal-env"
+                aria-label="Terminal environment variables"
+                value={terminalEnvDraft}
+                onChange={(event) => {
+                  const nextValue = event.target.value;
+                  setTerminalEnvDraft(nextValue);
+
+                  const parsed = parseTerminalEnv(nextValue);
+                  setTerminalEnvError(parsed.error);
+                  if (!parsed.env) {
+                    return;
+                  }
+
+                  updateTerminalProfile({ env: parsed.env });
+                }}
+                placeholder={
+                  "TERM_PROGRAM=T3Code\nTERM=xterm-256color\nZDOTDIR=/Users/you/.config/t3code-zsh"
+                }
+                spellCheck={false}
+              />
+            </label>
+            {terminalEnvError ? (
+              <p className="mt-2 text-xs text-destructive">{terminalEnvError}</p>
+            ) : null}
+          </div>
+        </SettingsRow>
       </SettingsSection>
 
       <SettingsSection title="Advanced">

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -253,6 +253,11 @@ const baseServerConfig: ServerConfig = {
     otlpTracesEnabled: false,
     otlpMetricsEnabled: false,
   },
+  terminal: {
+    platform: "darwin",
+    currentShell: "/bin/zsh",
+    discoveredShells: [],
+  },
   settings: DEFAULT_SERVER_SETTINGS,
 };
 

--- a/apps/web/src/rpc/serverState.test.ts
+++ b/apps/web/src/rpc/serverState.test.ts
@@ -86,6 +86,11 @@ const baseServerConfig: ServerConfig = {
     otlpTracesEnabled: false,
     otlpMetricsEnabled: false,
   },
+  terminal: {
+    platform: "darwin",
+    currentShell: "/bin/zsh",
+    discoveredShells: [],
+  },
   settings: DEFAULT_SERVER_SETTINGS,
 };
 

--- a/packages/contracts/src/environment.ts
+++ b/packages/contracts/src/environment.ts
@@ -20,7 +20,7 @@ export const ExecutionEnvironmentPlatform = Schema.Struct({
 export type ExecutionEnvironmentPlatform = typeof ExecutionEnvironmentPlatform.Type;
 
 export const ExecutionEnvironmentCapabilities = Schema.Struct({
-  repositoryIdentity: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  repositoryIdentity: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(false))),
 });
 export type ExecutionEnvironmentCapabilities = typeof ExecutionEnvironmentCapabilities.Type;
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -178,9 +178,11 @@ export const OrchestrationProposedPlan = Schema.Struct({
   id: OrchestrationProposedPlanId,
   turnId: Schema.NullOr(TurnId),
   planMarkdown: TrimmedNonEmptyString,
-  implementedAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
+  implementedAt: Schema.NullOr(IsoDateTime).pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed(null)),
+  ),
   implementationThreadId: Schema.NullOr(ThreadId).pipe(
-    Schema.withDecodingDefault(Effect.succeed(null)),
+    Schema.withDecodingDefaultKey(Effect.succeed(null)),
   ),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
@@ -207,7 +209,9 @@ export const OrchestrationSession = Schema.Struct({
   threadId: ThreadId,
   status: OrchestrationSessionStatus,
   providerName: Schema.NullOr(TrimmedNonEmptyString),
-  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
+  runtimeMode: RuntimeMode.pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_RUNTIME_MODE)),
+  ),
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(TrimmedNonEmptyString),
   updatedAt: IsoDateTime,
@@ -282,18 +286,18 @@ export const OrchestrationThread = Schema.Struct({
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
   latestTurn: Schema.NullOr(OrchestrationLatestTurn),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
-  archivedAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
+  archivedAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefaultKey(Effect.succeed(null))),
   deletedAt: Schema.NullOr(IsoDateTime),
   messages: Schema.Array(OrchestrationMessage),
   proposedPlans: Schema.Array(OrchestrationProposedPlan).pipe(
-    Schema.withDecodingDefault(Effect.succeed([])),
+    Schema.withDecodingDefaultKey(Effect.succeed([])),
   ),
   activities: Schema.Array(OrchestrationThreadActivity),
   checkpoints: Schema.Array(OrchestrationCheckpointSummary),
@@ -328,14 +332,14 @@ export const OrchestrationThreadShell = Schema.Struct({
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
   latestTurn: Schema.NullOr(OrchestrationLatestTurn),
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
-  archivedAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
+  archivedAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefaultKey(Effect.succeed(null))),
   session: Schema.NullOr(OrchestrationSession),
   latestUserMessageAt: Schema.NullOr(IsoDateTime),
   hasPendingApprovals: Schema.Boolean,
@@ -432,7 +436,7 @@ const ThreadCreateCommand = Schema.Struct({
   modelSelection: ModelSelection,
   runtimeMode: RuntimeMode,
   interactionMode: ProviderInteractionMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
@@ -520,9 +524,11 @@ export const ThreadTurnStartCommand = Schema.Struct({
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
-  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
+  runtimeMode: RuntimeMode.pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_RUNTIME_MODE)),
+  ),
   interactionMode: ProviderInteractionMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),
   bootstrap: Schema.optional(ThreadTurnStartBootstrap),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
@@ -773,9 +779,11 @@ export const ThreadCreatedPayload = Schema.Struct({
   projectId: ProjectId,
   title: TrimmedNonEmptyString,
   modelSelection: ModelSelection,
-  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
+  runtimeMode: RuntimeMode.pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_RUNTIME_MODE)),
+  ),
   interactionMode: ProviderInteractionMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),
   branch: Schema.NullOr(TrimmedNonEmptyString),
   worktreePath: Schema.NullOr(TrimmedNonEmptyString),
@@ -817,7 +825,7 @@ export const ThreadRuntimeModeSetPayload = Schema.Struct({
 export const ThreadInteractionModeSetPayload = Schema.Struct({
   threadId: ThreadId,
   interactionMode: ProviderInteractionMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),
   updatedAt: IsoDateTime,
 });
@@ -839,9 +847,11 @@ export const ThreadTurnStartRequestedPayload = Schema.Struct({
   messageId: MessageId,
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
-  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
+  runtimeMode: RuntimeMode.pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_RUNTIME_MODE)),
+  ),
   interactionMode: ProviderInteractionMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
   createdAt: IsoDateTime,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -92,9 +92,9 @@ export const ServerProvider = Schema.Struct({
   message: Schema.optional(TrimmedNonEmptyString),
   models: Schema.Array(ServerProviderModel),
   slashCommands: Schema.Array(ServerProviderSlashCommand).pipe(
-    Schema.withDecodingDefault(Effect.succeed([])),
+    Schema.withDecodingDefaultKey(Effect.succeed([])),
   ),
-  skills: Schema.Array(ServerProviderSkill).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  skills: Schema.Array(ServerProviderSkill).pipe(Schema.withDecodingDefaultKey(Effect.succeed([]))),
 });
 export type ServerProvider = typeof ServerProvider.Type;
 
@@ -111,6 +111,29 @@ export const ServerObservability = Schema.Struct({
 });
 export type ServerObservability = typeof ServerObservability.Type;
 
+export const ServerTerminalDiscoveredShellId = Schema.Literals([
+  "cmd",
+  "powershell",
+  "gitBash",
+  "wsl",
+]);
+export type ServerTerminalDiscoveredShellId = typeof ServerTerminalDiscoveredShellId.Type;
+
+export const ServerTerminalDiscoveredShell = Schema.Struct({
+  id: ServerTerminalDiscoveredShellId,
+  label: TrimmedNonEmptyString,
+  available: Schema.Boolean,
+  path: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type ServerTerminalDiscoveredShell = typeof ServerTerminalDiscoveredShell.Type;
+
+export const ServerTerminal = Schema.Struct({
+  platform: TrimmedNonEmptyString,
+  currentShell: TrimmedNonEmptyString,
+  discoveredShells: Schema.Array(ServerTerminalDiscoveredShell),
+});
+export type ServerTerminal = typeof ServerTerminal.Type;
+
 export const ServerConfig = Schema.Struct({
   environment: ExecutionEnvironmentDescriptor,
   auth: ServerAuthDescriptor,
@@ -121,6 +144,7 @@ export const ServerConfig = Schema.Struct({
   providers: ServerProviders,
   availableEditors: Schema.Array(EditorId),
   observability: ServerObservability,
+  terminal: ServerTerminal,
   settings: ServerSettings,
 });
 export type ServerConfig = typeof ServerConfig.Type;

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { Schema } from "effect";
+import { DEFAULT_CLIENT_SETTINGS, DEFAULT_SERVER_SETTINGS, ServerSettings } from "./settings";
+
+describe("DEFAULT_CLIENT_SETTINGS", () => {
+  it("includes archive confirmation with a false default", () => {
+    expect(DEFAULT_CLIENT_SETTINGS.confirmThreadArchive).toBe(false);
+  });
+});
+
+describe("DEFAULT_SERVER_SETTINGS", () => {
+  it("includes an empty terminal profile by default", () => {
+    expect(DEFAULT_SERVER_SETTINGS.terminal.profile.shellPath).toBe("");
+    expect(DEFAULT_SERVER_SETTINGS.terminal.profile.shellArgs).toEqual([]);
+    expect(DEFAULT_SERVER_SETTINGS.terminal.profile.env).toEqual({});
+  });
+
+  it("decodes terminal profile defaults when omitted", () => {
+    const settings = Schema.decodeSync(ServerSettings)({});
+
+    expect(settings.terminal.profile.shellPath).toBe("");
+    expect(settings.terminal.profile.shellArgs).toEqual([]);
+    expect(settings.terminal.profile.env).toEqual({});
+  });
+});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -24,17 +24,17 @@ export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 
 export const ClientSettingsSchema = Schema.Struct({
-  confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
-  diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(false))),
+  confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(true))),
+  diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(false))),
   sidebarProjectSortOrder: SidebarProjectSortOrder.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_SORT_ORDER)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_SORT_ORDER)),
   ),
   sidebarThreadSortOrder: SidebarThreadSortOrder.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER)),
   ),
   timestampFormat: TimestampFormat.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
+    Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
   ),
 });
 export type ClientSettings = typeof ClientSettingsSchema.Type;
@@ -55,38 +55,59 @@ const makeBinaryPathSetting = (fallback: string) =>
         encode: (value) => Effect.succeed(value),
       }),
     ),
-    Schema.withDecodingDefault(Effect.succeed(fallback)),
+    Schema.withDecodingDefaultKey(Effect.succeed(fallback)),
   );
 
 export const CodexSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  enabled: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(true))),
   binaryPath: makeBinaryPathSetting("codex"),
-  homePath: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
-  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  homePath: TrimmedString.pipe(Schema.withDecodingDefaultKey(Effect.succeed(""))),
+  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefaultKey(Effect.succeed([]))),
 });
 export type CodexSettings = typeof CodexSettings.Type;
 
 export const ClaudeSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  enabled: Schema.Boolean.pipe(Schema.withDecodingDefaultKey(Effect.succeed(true))),
   binaryPath: makeBinaryPathSetting("claude"),
-  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefaultKey(Effect.succeed([]))),
 });
 export type ClaudeSettings = typeof ClaudeSettings.Type;
 
 export const ObservabilitySettings = Schema.Struct({
-  otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
-  otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefaultKey(Effect.succeed(""))),
+  otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefaultKey(Effect.succeed(""))),
 });
 export type ObservabilitySettings = typeof ObservabilitySettings.Type;
 
-export const ServerSettings = Schema.Struct({
-  enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  defaultThreadEnvMode: ThreadEnvMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
+const TerminalProfileEnvKey = Schema.String.check(
+  Schema.isPattern(/^[A-Za-z_][A-Za-z0-9_]*$/),
+).check(Schema.isMaxLength(128));
+const TerminalProfileEnvValue = Schema.String.check(Schema.isMaxLength(8_192));
+
+export const TerminalProfileSettings = Schema.Struct({
+  shellPath: TrimmedString.pipe(Schema.withDecodingDefaultKey(Effect.succeed(""))),
+  shellArgs: Schema.Array(TrimmedString).pipe(Schema.withDecodingDefaultKey(Effect.succeed([]))),
+  env: Schema.Record(TerminalProfileEnvKey, TerminalProfileEnvValue).pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed({})),
   ),
-  addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+});
+export type TerminalProfileSettings = typeof TerminalProfileSettings.Type;
+
+export const TerminalSettings = Schema.Struct({
+  profile: TerminalProfileSettings.pipe(Schema.withDecodingDefaultKey(Effect.succeed({}))),
+});
+export type TerminalSettings = typeof TerminalSettings.Type;
+
+export const ServerSettings = Schema.Struct({
+  enableAssistantStreaming: Schema.Boolean.pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed(false)),
+  ),
+  defaultThreadEnvMode: ThreadEnvMode.pipe(
+    Schema.withDecodingDefaultKey(Effect.succeed("local" as const satisfies ThreadEnvMode)),
+  ),
+  addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefaultKey(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
-    Schema.withDecodingDefault(
+    Schema.withDecodingDefaultKey(
       Effect.succeed({
         provider: "codex" as const,
         model: DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER.codex,
@@ -96,10 +117,11 @@ export const ServerSettings = Schema.Struct({
 
   // Provider specific settings
   providers: Schema.Struct({
-    codex: CodexSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
-    claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
-  }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
-  observability: ObservabilitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    codex: CodexSettings.pipe(Schema.withDecodingDefaultKey(Effect.succeed({}))),
+    claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefaultKey(Effect.succeed({}))),
+  }).pipe(Schema.withDecodingDefaultKey(Effect.succeed({}))),
+  observability: ObservabilitySettings.pipe(Schema.withDecodingDefaultKey(Effect.succeed({}))),
+  terminal: TerminalSettings.pipe(Schema.withDecodingDefaultKey(Effect.succeed({}))),
 });
 export type ServerSettings = typeof ServerSettings.Type;
 
@@ -166,6 +188,12 @@ const ClaudeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const TerminalProfileSettingsPatch = Schema.Struct({
+  shellPath: Schema.optionalKey(Schema.String),
+  shellArgs: Schema.optionalKey(Schema.Array(Schema.String)),
+  env: Schema.optionalKey(Schema.Record(TerminalProfileEnvKey, TerminalProfileEnvValue)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
@@ -181,6 +209,11 @@ export const ServerSettingsPatch = Schema.Struct({
     Schema.Struct({
       codex: Schema.optionalKey(CodexSettingsPatch),
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
+    }),
+  ),
+  terminal: Schema.optionalKey(
+    Schema.Struct({
+      profile: Schema.optionalKey(TerminalProfileSettingsPatch),
     }),
   ),
 });

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -20,7 +20,7 @@ const TerminalEnvSchema = Schema.Record(TerminalEnvKeySchema, TerminalEnvValueSc
 );
 
 const TerminalIdWithDefaultSchema = TerminalIdSchema.pipe(
-  Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_ID)),
+  Schema.withDecodingDefaultKey(Effect.succeed(DEFAULT_TERMINAL_ID)),
 );
 
 export const TerminalThreadInput = Schema.Struct({


### PR DESCRIPTION
## Summary
- add persisted terminal profile settings and runtime shell/profile handling for integrated terminals
- expose terminal capability data from the server, including current shell and discovered Windows shells, for future shell-selection UX
- add a minimal terminal settings panel for shell override, shell args, and env overrides without taking on the full #292 picker flow

## Notes
- this is groundwork for Windows shell-selection support and does not close #292 on its own

## Test Plan
- bun --cwd apps/server test src/terminal/terminalProfile.test.ts src/wsServer.test.ts
- bunx vitest run --config vitest.browser.config.ts src/components/settings/SettingsPanels.browser.tsx
- bun fmt
- bun lint
- bun typecheck

Refs #292

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add terminal profile settings for shell path, args, and environment variables
> - Adds `TerminalProfileSettings` schema to [`packages/contracts/src/settings.ts`](https://github.com/pingdotgg/t3code/pull/1589/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) with `shellPath`, `shellArgs`, and `env` fields, extending `ServerSettings` and `ServerSettingsPatch` to support terminal profile configuration.
> - Adds a terminal settings section to [`GeneralSettingsPanel`](https://github.com/pingdotgg/t3code/pull/1589/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) where users can configure shell path, arguments, and environment variables, persisted via `updateSettings`.
> - Introduces [`terminalProfile.ts`](https://github.com/pingdotgg/t3code/pull/1589/files#diff-7f03d2b5d59dcbdb45fc58a433ed6a1e782fc6b39962d02b29789ba35f062770) with `resolveTerminalShellSpawnConfig`, `discoverTerminalShells`, and `discoverWindowsTerminalShells` to resolve which shell and args to use when spawning terminals.
> - Updates `TerminalManagerRuntime` in [`Manager.ts`](https://github.com/pingdotgg/t3code/pull/1589/files#diff-51f9668a4493e7cf6ec7c836a4af9946110091ee50cd822c9c4a4d5bdcedf496) to source shell config from the terminal profile resolver at spawn time, merging profile env with runtime env.
> - Extends `server.getConfig` in [`wsServer.ts`](https://github.com/pingdotgg/t3code/pull/1589/files#diff-79c481d2c4b1db89b1ba99aff5254de98a7bcb458ef92360d957cd1eb0061679) to include a `terminal` field with `platform`, `currentShell`, and `discoveredShells`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7bdfbf6. 13 files reviewed, 3 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->