### PR TITLE
fix(claude): surface API errors from success results

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1097,6 +1097,74 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect(
+    "treats Claude success results with is_error=true as failed and surfaces result text",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+
+        const session = yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: "claudeAgent",
+          runtimeMode: "full-access",
+        });
+
+        const turn = yield* adapter.sendTurn({
+          threadId: session.threadId,
+          input: "hello",
+          attachments: [],
+        });
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          result: "API Error: Rate limit reached",
+          errors: [],
+          session_id: "sdk-session-rate-limit",
+          uuid: "result-rate-limit",
+        } as unknown as SDKMessage);
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        assert.deepEqual(
+          runtimeEvents.map((event) => event.type),
+          [
+            "session.started",
+            "session.configured",
+            "session.state.changed",
+            "turn.started",
+            "thread.started",
+            "runtime.error",
+            "turn.completed",
+          ],
+        );
+
+        const runtimeError = runtimeEvents.find((event) => event.type === "runtime.error");
+        assert.equal(runtimeError?.type, "runtime.error");
+        if (runtimeError?.type === "runtime.error") {
+          assert.equal(runtimeError.payload.message, "API Error: Rate limit reached");
+        }
+
+        const turnCompleted = runtimeEvents[runtimeEvents.length - 1];
+        assert.equal(turnCompleted?.type, "turn.completed");
+        if (turnCompleted?.type === "turn.completed") {
+          assert.equal(String(turnCompleted.turnId), String(turn.turnId));
+          assert.equal(turnCompleted.payload.state, "failed");
+          assert.equal(turnCompleted.payload.errorMessage, "API Error: Rate limit reached");
+        }
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect("closes the session when the Claude stream aborts after a turn starts", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -616,7 +616,7 @@ const buildUserMessageEffect = Effect.fn("buildUserMessageEffect")(function* (
 
 function turnStatusFromResult(result: SDKResultMessage): ProviderRuntimeTurnStatus {
   if (result.subtype === "success") {
-    return "completed";
+    return result.is_error === true ? "failed" : "completed";
   }
 
   const errors = resultErrorsText(result);
@@ -627,6 +627,17 @@ function turnStatusFromResult(result: SDKResultMessage): ProviderRuntimeTurnStat
     return "cancelled";
   }
   return "failed";
+}
+
+function errorMessageFromResult(result: SDKResultMessage): string | undefined {
+  if (result.subtype === "success") {
+    if (result.is_error !== true) {
+      return undefined;
+    }
+    const trimmed = result.result.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return result.errors[0];
 }
 
 function streamKindFromDeltaType(deltaType: string): ClaudeTextStreamKind {
@@ -1907,7 +1918,7 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     const status = turnStatusFromResult(message);
-    const errorMessage = message.subtype === "success" ? undefined : message.errors[0];
+    const errorMessage = errorMessageFromResult(message);
 
     if (status === "failed") {
       yield* emitRuntimeError(context, errorMessage ?? "Claude turn failed.");


### PR DESCRIPTION
## What Changed

Fixed a bug where some Claude API errors were being treated like successful turns.

Claude can sometimes send a final result shaped like a success message, but with `is_error: true`. When that happened, T3 Code marked the turn as completed and did not properly surface the failure.

This PR changes that behavior so those results are treated as failed turns. The Claude error text is now surfaced through the normal runtime error path, and the turn completes with `state: "failed"`.

Also added a regression test for this case.

## Why

Claude can report API/runtime failures through a final `result` message with `subtype: "success"` and `is_error: true`.

Before this change, T3 Code treated those turns as completed, so the failure was effectively hidden. This made the session state, work log, and error reporting incorrect.

## UI Changes

No UI changes but here's how it would surface to the user

<img width="1455" height="618" alt="image" src="https://github.com/user-attachments/assets/895c38b0-949a-45dc-9814-5a5479d40d82" />
<img width="1448" height="556" alt="image" src="https://github.com/user-attachments/assets/11fb9751-f1a8-42a3-b770-5a35a0ae3af5" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes turn completion/error classification for Claude `result` messages, which can affect downstream session state and error reporting. Scope is small but touches core provider runtime event emission.
> 
> **Overview**
> Fixes Claude turn completion logic so SDK `result` messages with `subtype: "success"` and `is_error: true` are treated as **failed** rather than completed, emitting `runtime.error` and completing the turn with `state: "failed"` and the returned error text.
> 
> Adds a regression test covering the `is_error: true` success-result case (e.g. rate limit) to ensure the error message is surfaced via the normal runtime error path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b648a07413e53a474ba11c7945e58bb5d04b2746. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude adapter to surface API errors from success results with `is_error=true`
> - `turnStatusFromResult` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/1602/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) now returns `'failed'` when a `success` subtype result has `is_error=true`, instead of `'completed'`.
> - A new `errorMessageFromResult` helper extracts the result text as the error message for these cases.
> - The `handleResultMessage` handler now emits a `runtime.error` event and completes the turn with `state: 'failed'` and a populated `errorMessage` when `is_error=true`.
> - Behavioral Change: Claude success results with `is_error=true` previously completed silently; they now fail with the result text as the error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b648a07. 2 files reviewed, 3 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->