### PR TITLE
fix: clear timed-out codex user input prompts

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1427,7 +1427,7 @@ describe("ProviderCommandReactor", () => {
     expect(resolvedActivity).toBeUndefined();
   });
 
-  it("surfaces stale provider user-input failures without faking user-input resolution", async () => {
+  it("surfaces stale provider user-input failures for codex orphaned requests without faking user-input resolution", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
     harness.respondToUserInput.mockImplementation(() =>
@@ -1435,7 +1435,7 @@ describe("ProviderCommandReactor", () => {
         new ProviderAdapterRequestError({
           provider: "claudeAgent",
           method: "item/tool/respondToUserInput",
-          detail: "Unknown pending user-input request: user-input-request-1",
+          detail: "Unknown pending user input request: user-input-request-1",
         }),
       ),
     );

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -13,6 +13,10 @@ import {
 } from "@t3tools/contracts";
 import { Cache, Cause, Duration, Effect, Equal, Layer, Option, Schema, Stream } from "effect";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import {
+  isUnknownPendingApprovalRequestDetail,
+  isUnknownPendingUserInputRequestDetail,
+} from "@t3tools/shared/pendingRequestErrors";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
@@ -90,25 +94,17 @@ function canReplaceThreadTitle(currentTitle: string, titleSeed?: string): boolea
 function isUnknownPendingApprovalRequestError(cause: Cause.Cause<ProviderServiceError>): boolean {
   const error = Cause.squash(cause);
   if (Schema.is(ProviderAdapterRequestError)(error)) {
-    const detail = error.detail.toLowerCase();
-    return (
-      detail.includes("unknown pending approval request") ||
-      detail.includes("unknown pending permission request")
-    );
+    return isUnknownPendingApprovalRequestDetail(error.detail);
   }
-  const message = Cause.pretty(cause);
-  return (
-    message.includes("unknown pending approval request") ||
-    message.includes("unknown pending permission request")
-  );
+  return isUnknownPendingApprovalRequestDetail(Cause.pretty(cause));
 }
 
 function isUnknownPendingUserInputRequestError(cause: Cause.Cause<ProviderServiceError>): boolean {
   const error = Cause.squash(cause);
   if (Schema.is(ProviderAdapterRequestError)(error)) {
-    return error.detail.toLowerCase().includes("unknown pending user-input request");
+    return isUnknownPendingUserInputRequestDetail(error.detail);
   }
-  return Cause.pretty(cause).toLowerCase().includes("unknown pending user-input request");
+  return isUnknownPendingUserInputRequestDetail(Cause.pretty(cause));
 }
 
 function stalePendingRequestDetail(

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -301,6 +301,48 @@ describe("derivePendingUserInputs", () => {
 
     expect(derivePendingUserInputs(activities)).toEqual([]);
   });
+
+  it("clears stale pending user-input prompts for codex orphaned-request wording", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open-codex-stale",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-codex-stale-1",
+          questions: [
+            {
+              id: "sandbox_mode",
+              header: "Sandbox",
+              question: "Which mode should be used?",
+              options: [
+                {
+                  label: "workspace-write",
+                  description: "Allow workspace writes only",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      makeActivity({
+        id: "user-input-failed-codex-stale",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "provider.user-input.respond.failed",
+        summary: "Provider user input response failed",
+        tone: "error",
+        payload: {
+          requestId: "req-user-input-codex-stale-1",
+          detail:
+            "ProviderAdapterRequestError: Provider adapter request failed (codex) for item/tool/requestUserInput: Unknown pending user input request: req-user-input-codex-stale-1",
+        },
+      }),
+    ];
+
+    expect(derivePendingUserInputs(activities)).toEqual([]);
+  });
 });
 
 describe("deriveActivePlanState", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -10,6 +10,7 @@ import {
   type ThreadId,
   type TurnId,
 } from "@t3tools/contracts";
+import { isStalePendingRequestFailureDetail } from "@t3tools/shared/pendingRequestErrors";
 
 import type {
   ChatMessage,
@@ -163,20 +164,6 @@ function requestKindFromRequestType(requestType: unknown): PendingApproval["requ
     default:
       return null;
   }
-}
-
-function isStalePendingRequestFailureDetail(detail: string | undefined): boolean {
-  const normalized = detail?.toLowerCase();
-  if (!normalized) {
-    return false;
-  }
-  return (
-    normalized.includes("stale pending approval request") ||
-    normalized.includes("stale pending user-input request") ||
-    normalized.includes("unknown pending approval request") ||
-    normalized.includes("unknown pending permission request") ||
-    normalized.includes("unknown pending user-input request")
-  );
 }
 
 export function derivePendingApprovals(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -43,6 +43,10 @@
     "./String": {
       "types": "./src/String.ts",
       "import": "./src/String.ts"
+    },
+    "./pendingRequestErrors": {
+      "types": "./src/pendingRequestErrors.ts",
+      "import": "./src/pendingRequestErrors.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/pendingRequestErrors.ts
+++ b/packages/shared/src/pendingRequestErrors.ts
@@ -1,0 +1,30 @@
+function normalizePendingRequestDetail(detail: string | undefined): string {
+  return detail?.toLowerCase().replace(/\s+/g, " ").trim() ?? "";
+}
+
+export function isUnknownPendingApprovalRequestDetail(detail: string | undefined): boolean {
+  const normalized = normalizePendingRequestDetail(detail);
+  return (
+    normalized.includes("unknown pending approval request") ||
+    normalized.includes("unknown pending permission request")
+  );
+}
+
+export function isUnknownPendingUserInputRequestDetail(detail: string | undefined): boolean {
+  const normalized = normalizePendingRequestDetail(detail);
+  return (
+    normalized.includes("unknown pending user-input request") ||
+    normalized.includes("unknown pending user input request")
+  );
+}
+
+export function isStalePendingRequestFailureDetail(detail: string | undefined): boolean {
+  const normalized = normalizePendingRequestDetail(detail);
+  return (
+    normalized.includes("stale pending approval request") ||
+    normalized.includes("stale pending user-input request") ||
+    normalized.includes("stale pending user input request") ||
+    isUnknownPendingApprovalRequestDetail(normalized) ||
+    isUnknownPendingUserInputRequestDetail(normalized)
+  );
+}


### PR DESCRIPTION
## What Changed

- normalize stale and orphaned pending-request error matching in a shared helper
- use the shared matcher in the server and web pending user-input/approval flows
- add regression coverage for Codex's `Unknown pending user input request` wording

## Why

This fixes a bug where Codex returns a response that is awaiting user input, that pending user-input request later times out, and the thread is then left uncontinuable.

When the expired prompt is answered, Codex can reject it with `Unknown pending user input request` using the non-hyphenated wording. Our stale-request cleanup only matched the hyphenated `user-input` form, so the stale prompt stayed open in the UI instead of being cleared.

That left the thread stuck behind a dead prompt and effectively uncontinuable.

This change makes stale-request detection handle both forms and clears the expired prompt correctly.

## Test Plan

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun --cwd apps/web test src/session-logic.test.ts`
- `bun --cwd apps/server test src/orchestration/Layers/ProviderCommandReactor.test.ts`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to string-matching helpers used to clear stale approvals/user-input prompts, with added regression tests for Codex wording variations.
> 
> **Overview**
> Fixes stale/orphaned pending-request cleanup by **centralizing and normalizing** provider error-detail matching in a new shared `pendingRequestErrors` helper (handles whitespace and both `user-input` and `user input` variants).
> 
> Server `ProviderCommandReactor` and web `session-logic` now use the shared matchers to treat "unknown pending" provider failures as stale requests, and tests add regression coverage for Codex’s non-hyphenated wording so timed-out user-input prompts are removed instead of remaining stuck.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7148cb3ed4dd5eee862e9fe9639800ce9ce21341. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clearing of timed-out codex user input prompts by normalizing pending request error detection
> - Adds a new shared module [`pendingRequestErrors.ts`](https://github.com/pingdotgg/t3code/pull/1606/files#diff-329487d8031d663789b58d33ac2bebe3489025efc7d72d698acfda8f1fada348) with predicates that normalize error detail strings (lowercase, collapse whitespace) before matching, tolerating both `user-input` and `user input` wording variants.
> - Updates [`ProviderCommandReactor.ts`](https://github.com/pingdotgg/t3code/pull/1606/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) and [`session-logic.ts`](https://github.com/pingdotgg/t3code/pull/1606/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) to use these shared predicates, removing duplicated local string-matching logic.
> - Behavioral Change: stale/unknown pending user input requests from codex that use unhyphenated `user input` wording are now correctly recognized and cleared, where previously they were silently ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7148cb3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->