### PR TITLE
fix: add svelte-specific favicon candidates to the resolver

### DIFF
--- a/apps/server/src/project/Layers/ProjectFaviconResolver.test.ts
+++ b/apps/server/src/project/Layers/ProjectFaviconResolver.test.ts
@@ -60,6 +60,24 @@ it.layer(TestLayer)("ProjectFaviconResolverLive", (it) => {
       }),
     );
 
+    it.effect("resolves SvelteKit app icons from src/app.html into static assets", () =>
+      Effect.gen(function* () {
+        const resolver = yield* ProjectFaviconResolver;
+        const cwd = yield* makeTempDir;
+        yield* writeTextFile(
+          cwd,
+          "src/app.html",
+          '<link rel="icon" href="%sveltekit.assets%/brand/logo.svg">',
+        );
+        yield* writeTextFile(cwd, "static/brand/logo.svg", "<svg>brand</svg>");
+
+        const resolved = yield* resolver.resolvePath(cwd);
+
+        expect(resolved).not.toBeNull();
+        expect(resolved).toContain("static/brand/logo.svg");
+      }),
+    );
+
     it.effect("returns null when no icon is present", () =>
       Effect.gen(function* () {
         const resolver = yield* ProjectFaviconResolver;

--- a/apps/server/src/project/Layers/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/Layers/ProjectFaviconResolver.ts
@@ -45,6 +45,7 @@ const ICON_SOURCE_FILES = [
   "app/root.tsx",
   "src/root.tsx",
   "src/index.html",
+  "src/app.html",
   "app.html",
 ] as const;
 
@@ -66,9 +67,24 @@ export const makeProjectFaviconResolver = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
 
-  const resolveIconHref = (projectCwd: string, href: string): string[] => {
-    const clean = href.replace(/^\//, "");
-    return [path.join(projectCwd, "public", clean), path.join(projectCwd, clean)];
+  const resolveIconHref = (projectCwd: string, sourcePath: string, href: string): string[] => {
+    if (/^(?:[a-z]+:)?\/\//i.test(href) || href.startsWith("data:")) {
+      return [];
+    }
+
+    const normalizedHref = href.replace(/^%sveltekit\.assets%/, "");
+    const clean = normalizedHref.replace(/^\/+/, "").replace(/^\.\//, "");
+    const projectCandidates = [
+      path.join(projectCwd, "public", clean),
+      path.join(projectCwd, "static", clean),
+      path.join(projectCwd, clean),
+    ];
+
+    if (href.startsWith("/") || href.startsWith("%sveltekit.assets%")) {
+      return projectCandidates;
+    }
+
+    return [path.join(path.dirname(sourcePath), clean), ...projectCandidates];
   };
 
   const isPathWithinProject = (projectCwd: string, candidatePath: string): boolean => {
@@ -117,7 +133,7 @@ export const makeProjectFaviconResolver = Effect.gen(function* () {
       if (!href) {
         continue;
       }
-      const existing = yield* findExistingFile(cwd, resolveIconHref(cwd, href));
+      const existing = yield* findExistingFile(cwd, resolveIconHref(cwd, sourcePath, href));
       if (existing) {
         return existing;
       }

--- a/apps/server/src/project/Layers/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/Layers/ProjectFaviconResolver.ts
@@ -27,6 +27,13 @@ const FAVICON_CANDIDATES = [
   "assets/icon.png",
   "assets/logo.svg",
   "assets/logo.png",
+  "static/favicon.svg",
+  "static/favicon.ico",
+  "static/favicon.png",
+  "static/icon.svg",
+  "static/icon.png",
+  "static/logo.svg",
+  "static/logo.png",
 ] as const;
 
 // Files that may contain a <link rel="icon"> or icon metadata declaration.

--- a/apps/server/src/project/Layers/ProjectFaviconResolver.ts
+++ b/apps/server/src/project/Layers/ProjectFaviconResolver.ts
@@ -45,6 +45,7 @@ const ICON_SOURCE_FILES = [
   "app/root.tsx",
   "src/root.tsx",
   "src/index.html",
+  "app.html",
 ] as const;
 
 // Matches <link ...> tags or object-like icon metadata where rel/href can appear in any order.

--- a/apps/server/src/projectFaviconRoute.test.ts
+++ b/apps/server/src/projectFaviconRoute.test.ts
@@ -175,6 +175,27 @@ describe("tryHandleProjectFaviconRequest", () => {
     });
   });
 
+  it("resolves SvelteKit src/app.html icon hrefs from static assets", async () => {
+    const projectDir = makeTempDir("t3code-favicon-route-sveltekit-static-");
+    const iconPath = path.join(projectDir, "static", "brand", "app.svg");
+    fs.mkdirSync(path.dirname(iconPath), { recursive: true });
+    fs.mkdirSync(path.join(projectDir, "src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectDir, "src", "app.html"),
+      '<link rel="icon" href="%sveltekit.assets%/brand/app.svg">',
+      "utf8",
+    );
+    fs.writeFileSync(iconPath, "<svg>sveltekit-static</svg>", "utf8");
+
+    await withRouteServer(async (baseUrl) => {
+      const pathname = `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}`;
+      const response = await request(baseUrl, pathname);
+      expect(response.statusCode).toBe(200);
+      expect(response.contentType).toContain("image/svg+xml");
+      expect(response.body).toBe("<svg>sveltekit-static</svg>");
+    });
+  });
+
   it("serves a fallback favicon when no icon exists", async () => {
     const projectDir = makeTempDir("t3code-favicon-route-fallback-");
 


### PR DESCRIPTION
pretty "important" for svelte devs since we'd also like to see our favicons in the sidebar


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped path-resolution changes and added tests; minimal risk aside from potentially changing which local icon file is selected when multiple candidates exist.
> 
> **Overview**
> Improves the project favicon resolver to detect SvelteKit-style icons by scanning `src/app.html`/`app.html`, supporting `%sveltekit.assets%` hrefs, and including `static/` as a candidate asset root (in addition to `public/`).
> 
> Updates resolution logic to ignore remote/data URLs and to try relative-to-source and project-root candidates, and adds tests covering SvelteKit `static/` icon serving through `/api/project-favicon`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f87a54ab74a905e25cfc2347a3879e2f813c1f30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `/static` favicon candidates and `src/app.html` scanning to `ProjectFaviconResolver`
> - Appends `static/favicon.*`, `static/icon.*`, and `static/logo.*` to the `FAVICON_CANDIDATES` search list in [ProjectFaviconResolver.ts](https://github.com/pingdotgg/t3code/pull/1613/files#diff-75e10c7bd6b1ceefcab76a7d49afd5bcbfb7e2cbe4bc9cac6a2b2ec210cde54c).
> - Adds `src/app.html` and `app.html` to `ICON_SOURCE_FILES` so `<link rel="icon">` declarations in SvelteKit app shells are scanned.
> - Updates `resolveIconHref` to strip the `%sveltekit.assets%` prefix, resolve hrefs relative to their source file, and skip external or `data:` URIs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f87a54a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->