### PR TITLE
Add server-side workspaceRoot uniqueness invariant

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -804,4 +804,47 @@ describe("OrchestrationEngine", () => {
 
     await system.dispose();
   });
+
+  it("rejects project creation with duplicate workspaceRoot", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const createdAt = now();
+
+    await system.run(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-project-ws-first"),
+        projectId: asProjectId("project-ws-first"),
+        title: "First Project",
+        workspaceRoot: "/tmp/project-same-workspace",
+        defaultModelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        createdAt,
+      }),
+    );
+
+    await expect(
+      system.run(
+        engine.dispatch({
+          type: "project.create",
+          commandId: CommandId.makeUnsafe("cmd-project-ws-second"),
+          projectId: asProjectId("project-ws-second"),
+          title: "Second Project",
+          workspaceRoot: "/tmp/project-same-workspace",
+          defaultModelSelection: {
+            provider: "codex",
+            model: "gpt-5-codex",
+          },
+          createdAt,
+        }),
+      ),
+    ).rejects.toThrow("already used by project");
+
+    const readModel = await system.run(engine.getReadModel());
+    expect(readModel.projects.map((p) => p.id)).toEqual([asProjectId("project-ws-first")]);
+
+    await system.dispose();
+  });
 });

--- a/apps/server/src/orchestration/commandInvariants.test.ts
+++ b/apps/server/src/orchestration/commandInvariants.test.ts
@@ -313,4 +313,63 @@ describe("commandInvariants", () => {
       }),
     );
   });
+
+  it("allows self-update when pre-existing duplicates place excluded project later in array", async () => {
+    const duplicateReadModel: OrchestrationReadModel = {
+      ...readModel,
+      projects: [
+        {
+          id: ProjectId.makeUnsafe("project-dup-1"),
+          title: "Dup 1",
+          workspaceRoot: "/tmp/shared-root",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+        },
+        {
+          id: ProjectId.makeUnsafe("project-dup-2"),
+          title: "Dup 2",
+          workspaceRoot: "/tmp/shared-root",
+          defaultModelSelection: null,
+          scripts: [],
+          createdAt: now,
+          updatedAt: now,
+          deletedAt: null,
+        },
+      ],
+    };
+
+    const updateCommand: OrchestrationCommand = {
+      type: "project.meta.update",
+      commandId: CommandId.makeUnsafe("cmd-update-dup"),
+      projectId: ProjectId.makeUnsafe("project-dup-2"),
+      title: "Renamed",
+    };
+
+    // project-dup-2 updates its own workspaceRoot - should detect project-dup-1 as a conflict
+    await expect(
+      Effect.runPromise(
+        requireWorkspaceRootUnique({
+          readModel: duplicateReadModel,
+          command: updateCommand,
+          workspaceRoot: "/tmp/shared-root",
+          excludeProjectId: ProjectId.makeUnsafe("project-dup-2"),
+        }),
+      ),
+    ).rejects.toThrow("already used by project");
+
+    // project-dup-1 updates its own workspaceRoot - should detect project-dup-2 as a conflict
+    await expect(
+      Effect.runPromise(
+        requireWorkspaceRootUnique({
+          readModel: duplicateReadModel,
+          command: updateCommand,
+          workspaceRoot: "/tmp/shared-root",
+          excludeProjectId: ProjectId.makeUnsafe("project-dup-1"),
+        }),
+      ),
+    ).rejects.toThrow("already used by project");
+  });
 });

--- a/apps/server/src/orchestration/commandInvariants.test.ts
+++ b/apps/server/src/orchestration/commandInvariants.test.ts
@@ -11,11 +11,13 @@ import {
 import { Effect } from "effect";
 
 import {
+  findProjectByWorkspaceRoot,
   findThreadById,
   listThreadsByProjectId,
   requireNonNegativeInteger,
   requireThread,
   requireThreadAbsent,
+  requireWorkspaceRootUnique,
 } from "./commandInvariants.ts";
 
 const now = new Date().toISOString();
@@ -49,6 +51,19 @@ const readModel: OrchestrationReadModel = {
       createdAt: now,
       updatedAt: now,
       deletedAt: null,
+    },
+    {
+      id: ProjectId.makeUnsafe("project-deleted"),
+      title: "Deleted Project",
+      workspaceRoot: "/tmp/project-deleted",
+      defaultModelSelection: {
+        provider: "codex",
+        model: "gpt-5-codex",
+      },
+      scripts: [],
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: now,
     },
   ],
   threads: [
@@ -216,5 +231,86 @@ describe("commandInvariants", () => {
         }),
       ),
     ).rejects.toThrow("greater than or equal to 0");
+  });
+
+  it("finds non-deleted project by workspaceRoot", () => {
+    expect(findProjectByWorkspaceRoot(readModel, "/tmp/project-a")?.id).toBe("project-a");
+    expect(findProjectByWorkspaceRoot(readModel, "/tmp/missing")).toBeUndefined();
+    expect(findProjectByWorkspaceRoot(readModel, "/tmp/project-deleted")).toBeUndefined();
+  });
+
+  it("requires unique workspaceRoot for project creation", async () => {
+    const createCommand: OrchestrationCommand = {
+      type: "project.create",
+      commandId: CommandId.makeUnsafe("cmd-create"),
+      projectId: ProjectId.makeUnsafe("project-new"),
+      title: "New Project",
+      workspaceRoot: "/tmp/project-new",
+      createdAt: now,
+    };
+
+    await Effect.runPromise(
+      requireWorkspaceRootUnique({
+        readModel,
+        command: createCommand,
+        workspaceRoot: "/tmp/project-new",
+      }),
+    );
+
+    await expect(
+      Effect.runPromise(
+        requireWorkspaceRootUnique({
+          readModel,
+          command: createCommand,
+          workspaceRoot: "/tmp/project-a",
+        }),
+      ),
+    ).rejects.toThrow("already used by project");
+
+    await Effect.runPromise(
+      requireWorkspaceRootUnique({
+        readModel,
+        command: createCommand,
+        workspaceRoot: "/tmp/project-deleted",
+      }),
+    );
+  });
+
+  it("requires unique workspaceRoot for project update, excluding self", async () => {
+    const updateCommand: OrchestrationCommand = {
+      type: "project.meta.update",
+      commandId: CommandId.makeUnsafe("cmd-update"),
+      projectId: ProjectId.makeUnsafe("project-a"),
+      workspaceRoot: "/tmp/project-a",
+    };
+
+    await Effect.runPromise(
+      requireWorkspaceRootUnique({
+        readModel,
+        command: updateCommand,
+        workspaceRoot: "/tmp/project-a",
+        excludeProjectId: ProjectId.makeUnsafe("project-a"),
+      }),
+    );
+
+    await expect(
+      Effect.runPromise(
+        requireWorkspaceRootUnique({
+          readModel,
+          command: updateCommand,
+          workspaceRoot: "/tmp/project-b",
+          excludeProjectId: ProjectId.makeUnsafe("project-a"),
+        }),
+      ),
+    ).rejects.toThrow("already used by project");
+
+    await Effect.runPromise(
+      requireWorkspaceRootUnique({
+        readModel,
+        command: updateCommand,
+        workspaceRoot: "/tmp/project-new-path",
+        excludeProjectId: ProjectId.makeUnsafe("project-a"),
+      }),
+    );
   });
 });

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -31,6 +31,33 @@ export function findProjectById(
   return readModel.projects.find((project) => project.id === projectId);
 }
 
+export function findProjectByWorkspaceRoot(
+  readModel: OrchestrationReadModel,
+  workspaceRoot: string,
+): OrchestrationProject | undefined {
+  return readModel.projects.find(
+    (project) => project.workspaceRoot === workspaceRoot && project.deletedAt === null,
+  );
+}
+
+export function requireWorkspaceRootUnique(input: {
+  readonly readModel: OrchestrationReadModel;
+  readonly command: OrchestrationCommand;
+  readonly workspaceRoot: string;
+  readonly excludeProjectId?: ProjectId;
+}): Effect.Effect<void, OrchestrationCommandInvariantError> {
+  const existing = findProjectByWorkspaceRoot(input.readModel, input.workspaceRoot);
+  if (!existing || existing.id === input.excludeProjectId) {
+    return Effect.void;
+  }
+  return Effect.fail(
+    invariantError(
+      input.command.type,
+      `Workspace root '${input.workspaceRoot}' is already used by project '${existing.id}'.`,
+    ),
+  );
+}
+
 export function listThreadsByProjectId(
   readModel: OrchestrationReadModel,
   projectId: ProjectId,

--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -46,14 +46,19 @@ export function requireWorkspaceRootUnique(input: {
   readonly workspaceRoot: string;
   readonly excludeProjectId?: ProjectId;
 }): Effect.Effect<void, OrchestrationCommandInvariantError> {
-  const existing = findProjectByWorkspaceRoot(input.readModel, input.workspaceRoot);
-  if (!existing || existing.id === input.excludeProjectId) {
+  const conflict = input.readModel.projects.find(
+    (project) =>
+      project.workspaceRoot === input.workspaceRoot &&
+      project.deletedAt === null &&
+      project.id !== input.excludeProjectId,
+  );
+  if (!conflict) {
     return Effect.void;
   }
   return Effect.fail(
     invariantError(
       input.command.type,
-      `Workspace root '${input.workspaceRoot}' is already used by project '${existing.id}'.`,
+      `Workspace root '${input.workspaceRoot}' is already used by project '${conflict.id}'.`,
     ),
   );
 }

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -9,6 +9,7 @@ import { OrchestrationCommandInvariantError } from "./Errors.ts";
 import {
   requireProject,
   requireProjectAbsent,
+  requireWorkspaceRootUnique,
   requireThread,
   requireThreadArchived,
   requireThreadAbsent,
@@ -64,6 +65,11 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         projectId: command.projectId,
       });
+      yield* requireWorkspaceRootUnique({
+        readModel,
+        command,
+        workspaceRoot: command.workspaceRoot,
+      });
 
       return {
         ...withEventBase({
@@ -91,6 +97,14 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         command,
         projectId: command.projectId,
       });
+      if (command.workspaceRoot !== undefined) {
+        yield* requireWorkspaceRootUnique({
+          readModel,
+          command,
+          workspaceRoot: command.workspaceRoot,
+          excludeProjectId: command.projectId,
+        });
+      }
       const occurredAt = nowIso();
       return {
         ...withEventBase({


### PR DESCRIPTION
Duplicate workspaceRoot detection previously only happened client-side in Sidebar.tsx. This adds a server-side invariant in the orchestration decider that rejects project.create and project.meta.update commands when the target workspaceRoot is already used by another non-deleted project. Soft-deleted projects are excluded from the check. Reason for this change is reported bug #1595

## What Changed

In total 46 additions, the additional 198 additions are test code.

Adds a helper function in `apps/server/src/orchestration/commandInvariants.ts` to easily find existing projects given a workspaceRoot. Only used within `requireWorkspaceRootUnique` function so one could argue that this is unnecessary abstraction at this point, happy to change this to be inline.  

``` ts
export function findProjectByWorkspaceRoot(
  readModel: OrchestrationReadModel,
  workspaceRoot: string,
): OrchestrationProject | undefined {
  return readModel.projects.find(
    (project) => project.workspaceRoot === workspaceRoot && project.deletedAt === null,
  );
}
```

Adds a function that check if there is already a project with the `workspaceRoot` property persited. If so return a `Effect.fail` else void.

``` ts
export function requireWorkspaceRootUnique(input: {
  readonly readModel: OrchestrationReadModel;
  readonly command: OrchestrationCommand;
  readonly workspaceRoot: string;
  readonly excludeProjectId?: ProjectId;
}): Effect.Effect<void, OrchestrationCommandInvariantError> {
  const existing = findProjectByWorkspaceRoot(input.readModel, input.workspaceRoot);
  if (!existing || existing.id === input.excludeProjectId) {
    return Effect.void;
  }
  return Effect.fail(
    invariantError(
      input.command.type,
      `Workspace root '${input.workspaceRoot}' is already used by project '${existing.id}'.`,
    ),
  );
}
```

In the `apps/server/src/orchestration/decider.ts` code I imported the new `requireWorkspaceRootUnique` function and used it inside the `project.create` and `project.meta.update` case handlers to verify that project with same workspaceRoot does not already exist. 

Added relevant new test to assert the checks are working as intended. All existing test pass after change.

## Why

Server code should have the same validations as the client code has to avoid duplicate project creation (same workspaceRoot) in the db. Either this check should be done in the two handlers changed in this PR or the db schema should enforce the workspaceRoot to be unique. 

I would argue that this is a good first step to avoid the issue expressed in #1595 to occur and then if the db should enforce this (which is a much bigger change) db migrations would most likely be added to handle "bad" client state.

## UI Changes

No UI changes have been made.

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new server-side validation that can cause `project.create` and `project.meta.update` commands to start failing for previously-allowed duplicate `workspaceRoot` values; impact is limited to orchestration command handling and covered by new tests.
> 
> **Overview**
> **Enforces server-side uniqueness of `workspaceRoot` across active projects.** The orchestration decider now rejects `project.create` and `project.meta.update` (when changing `workspaceRoot`) if the path is already used by another non-deleted project.
> 
> Adds `findProjectByWorkspaceRoot`/`requireWorkspaceRootUnique` invariants (including an `excludeProjectId` self-update case) and expands unit/integration tests to cover conflicts, soft-deleted projects, and edge cases with pre-existing duplicates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 983f1bb74ed64b7abaeec3afc32496ba00817c6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add server-side uniqueness invariant for `workspaceRoot` on project create and update
> - Adds `requireWorkspaceRootUnique` in [commandInvariants.ts](https://github.com/pingdotgg/t3code/pull/1614/files#diff-426dec65d7876b98b993600840e4b58dcca662d84f3a23e884ea72cc2783e6a0) that scans non-deleted projects and rejects with an `OrchestrationCommandInvariantError` if the given `workspaceRoot` is already in use.
> - Integrates the check into `decider.ts` for both `project.create` and `project.meta.update`; the update path excludes the current project from the check to allow self-retention.
> - Also adds `findProjectByWorkspaceRoot`, a helper that returns the first non-deleted project matching a given path.
> - Behavioral Change: `project.create` and `project.meta.update` commands now fail with an invariant error when another non-deleted project already uses the requested `workspaceRoot`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 983f1bb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->