### PR TITLE
Map fatal Codex stderr to runtime errors

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -508,6 +508,42 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 
+  it.effect("maps fatal websocket stderr notifications to runtime.error", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      const firstEventFiber = yield* Stream.runHead(adapter.streamEvents).pipe(Effect.forkChild);
+
+      lifecycleManager.emit("event", {
+        id: asEventId("evt-process-stderr-websocket"),
+        kind: "notification",
+        provider: "codex",
+        threadId: asThreadId("thread-1"),
+        createdAt: new Date().toISOString(),
+        method: "process/stderr",
+        turnId: asTurnId("turn-1"),
+        message:
+          "2026-03-31T18:14:06.833399Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: HTTP error: 503 Service Unavailable, url: wss://chatgpt.com/backend-api/codex/responses",
+      } satisfies ProviderEvent);
+
+      const firstEvent = yield* Fiber.join(firstEventFiber);
+
+      assert.equal(firstEvent._tag, "Some");
+      if (firstEvent._tag !== "Some") {
+        return;
+      }
+      assert.equal(firstEvent.value.type, "runtime.error");
+      if (firstEvent.value.type !== "runtime.error") {
+        return;
+      }
+      assert.equal(firstEvent.value.turnId, "turn-1");
+      assert.equal(firstEvent.value.payload.class, "provider_error");
+      assert.equal(
+        firstEvent.value.payload.message,
+        "2026-03-31T18:14:06.833399Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: HTTP error: 503 Service Unavailable, url: wss://chatgpt.com/backend-api/codex/responses",
+      );
+    }),
+  );
+
   it.effect("preserves request type when mapping serverRequest/resolved", () =>
     Effect.gen(function* () {
       const adapter = yield* CodexAdapter;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -112,6 +112,13 @@ function asNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+const FATAL_CODEX_STDERR_SNIPPETS = ["failed to connect to websocket"];
+
+function isFatalCodexProcessStderrMessage(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return FATAL_CODEX_STDERR_SNIPPETS.some((snippet) => normalized.includes(snippet));
+}
+
 function normalizeCodexTokenUsage(value: unknown): ThreadTokenUsageSnapshot | undefined {
   const usage = asObject(value);
   const totalUsage = asObject(usage?.total_token_usage ?? usage?.total);
@@ -1269,15 +1276,27 @@ function mapToRuntimeEvents(
   }
 
   if (event.method === "process/stderr") {
+    const message = event.message ?? "Codex process stderr";
+    const isFatal = isFatalCodexProcessStderrMessage(message);
     return [
-      {
-        type: "runtime.warning",
-        ...runtimeEventBase(event, canonicalThreadId),
-        payload: {
-          message: event.message ?? "Codex process stderr",
-          ...(event.payload !== undefined ? { detail: event.payload } : {}),
-        },
-      },
+      isFatal
+        ? {
+            type: "runtime.error",
+            ...runtimeEventBase(event, canonicalThreadId),
+            payload: {
+              message,
+              class: "provider_error" as const,
+              ...(event.payload !== undefined ? { detail: event.payload } : {}),
+            },
+          }
+        : {
+            type: "runtime.warning",
+            ...runtimeEventBase(event, canonicalThreadId),
+            payload: {
+              message,
+              ...(event.payload !== undefined ? { detail: event.payload } : {}),
+            },
+          },
     ];
   }
 


### PR DESCRIPTION
- Detect websocket connection failures in process stderr
- Emit `runtime.error` with `provider_error` for fatal cases
- Keep nonfatal stderr mapped to warnings

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime event classification for a subset of `process/stderr` messages, which may affect user-visible error handling and any alerting/retry logic keyed off `runtime.warning` vs `runtime.error`. Scope is limited to string-matching a single fatal snippet with added test coverage.
> 
> **Overview**
> Codex `process/stderr` notifications are now conditionally promoted from `runtime.warning` to **`runtime.error`** when the stderr message matches a known fatal websocket-connection failure snippet (emitting `class: "provider_error"`).
> 
> Adds a focused lifecycle test to ensure websocket connection stderr is treated as fatal while non-matching stderr remains a warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c80f188ecea9f8f1e8cdf52cc529905b69d22572. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Map fatal Codex `process/stderr` messages to `runtime.error` events
> In [`CodexAdapter.ts`](https://github.com/pingdotgg/t3code/pull/1615/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d), `mapToRuntimeEvents` now checks `process/stderr` notifications against a list of fatal substrings (currently `"failed to connect to websocket"`). Matching messages produce a `runtime.error` with `class: 'provider_error'` instead of a `runtime.warning`. Non-fatal stderr continues to yield `runtime.warning` as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c80f188.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->