### PR TITLE
[codex] migrate Effect.fn in apps/server/scripts/cli.ts

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -184,9 +184,9 @@ const publishCmd = Command.make(
       }
     }
 
-      yield* Effect.acquireUseRelease(
-        // Acquire: backup package.json, resolve catalog: deps, strip devDependencies/scripts
-        Effect.fn("publishCmd.acquire")(function* () {
+    yield* Effect.acquireUseRelease(
+      // Acquire: backup package.json, resolve catalog: deps, strip devDependencies/scripts
+      Effect.fn("publishCmd.acquire")(function* () {
         // Resolve catalog dependencies before any file mutations. If this throws,
         // acquire fails and no release hook runs, so filesystem must still be untouched.
         const version = Option.getOrElse(config.appVersion, () => serverPackageJson.version);
@@ -214,38 +214,38 @@ const publishCmd = Command.make(
 
         const iconBackups = yield* applyPublishIconOverrides(repoRoot, serverDir);
         return { iconBackups };
-        })(),
-        // Use: npm publish
-        () =>
-          Effect.fn("publishCmd.use")(function* () {
-            const args = ["publish", "--access", config.access, "--tag", config.tag];
-            if (config.provenance) args.push("--provenance");
-            if (config.dryRun) args.push("--dry-run");
+      })(),
+      // Use: npm publish
+      () =>
+        Effect.fn("publishCmd.use")(function* () {
+          const args = ["publish", "--access", config.access, "--tag", config.tag];
+          if (config.provenance) args.push("--provenance");
+          if (config.dryRun) args.push("--dry-run");
 
-        yield* Effect.log(`[cli] Running: npm ${args.join(" ")}`);
-        yield* runCommand(
-          ChildProcess.make("npm", [...args], {
-            cwd: serverDir,
-            stdout: config.verbose ? "inherit" : "ignore",
-            stderr: "inherit",
-            // Windows needs shell mode to resolve .cmd shims.
-            shell: process.platform === "win32",
-              }),
-            );
-          })(),
-        // Release: restore
-        Effect.fn("publishCmd.release")(function* (resource: {
-          readonly iconBackups: ReadonlyArray<PublishIconBackup>;
-        }) {
+          yield* Effect.log(`[cli] Running: npm ${args.join(" ")}`);
+          yield* runCommand(
+            ChildProcess.make("npm", [...args], {
+              cwd: serverDir,
+              stdout: config.verbose ? "inherit" : "ignore",
+              stderr: "inherit",
+              // Windows needs shell mode to resolve .cmd shims.
+              shell: process.platform === "win32",
+            }),
+          );
+        })(),
+      // Release: restore
+      Effect.fn("publishCmd.release")(function* (resource: {
+        readonly iconBackups: ReadonlyArray<PublishIconBackup>;
+      }) {
         yield* restorePublishIconOverrides(resource.iconBackups).pipe(
           Effect.catch((error) =>
             Effect.logError(`[cli] Failed to restore publish icon overrides: ${String(error)}`),
           ),
-          );
-          yield* fs.rename(backupPath, packageJsonPath);
-          if (config.verbose) yield* Effect.log("[cli] Restored original package.json");
-        }),
-      );
+        );
+        yield* fs.rename(backupPath, packageJsonPath);
+        if (config.verbose) yield* Effect.log("[cli] Restored original package.json");
+      }),
+    );
   }),
 ).pipe(Command.withDescription("Publish the server package to npm."));
 


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/scripts/cli.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `buildCmd` and `publishCmd` in cli.ts to named `Effect.fn` wrappers
> Converts anonymous `Effect.gen` callbacks in [cli.ts](https://github.com/pingdotgg/t3code/pull/1621/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) to named `Effect.fn` wrappers for `buildCmd`, `publishCmd`, and its three `acquireUseRelease` phases. No changes to operational logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7807e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily changes effect construction/wrapping in the CLI; behavior should be unchanged, but it touches the publish flow’s acquire/use/release wiring.
> 
> **Overview**
> Updates `apps/server/scripts/cli.ts` to replace the remaining anonymous `Effect.gen` handlers with named `Effect.fn` wrappers for `buildCmd` and `publishCmd`.
> 
> Within `publishCmd`, the `acquireUseRelease` phases are also converted to named `Effect.fn` blocks (`publishCmd.acquire`, `publishCmd.use`, `publishCmd.release`) to standardize effect naming/structure, with no intended operational changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7807e5e8a55e0be3c247c225edc20c2584e5269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->