### PR TITLE
[codex] migrate Effect.fn in apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts
@@ -21,8 +21,8 @@ const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const checkpointStore = yield* CheckpointStore;
 
-  const getTurnDiff: CheckpointDiffQueryShape["getTurnDiff"] = (input) =>
-    Effect.gen(function* () {
+  const getTurnDiff: CheckpointDiffQueryShape["getTurnDiff"] = Effect.fn("getTurnDiff")(
+    function* (input) {
       const operation = "CheckpointDiffQuery.getTurnDiff";
 
       if (input.fromTurnCount === input.toTurnCount) {
@@ -149,7 +149,8 @@ const make = Effect.gen(function* () {
       }
 
       return turnDiff;
-    });
+    },
+  );
 
   const getFullThreadDiff: CheckpointDiffQueryShape["getFullThreadDiff"] = (
     input: OrchestrationGetFullThreadDiffInput,


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/checkpointing/Layers/CheckpointDiffQuery.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `getTurnDiff` in `CheckpointDiffQuery` to use `Effect.fn`
> Rewrites `getTurnDiff` in [CheckpointDiffQuery.ts](https://github.com/pingdotgg/t3code/pull/1622/files#diff-a7f6357814d1957a562de3ea25f26bd4dc2f18e4ccf790082ae04e2bc484da51) from an arrow function wrapping `Effect.gen` to the `Effect.fn("getTurnDiff")` form. No logic or generator body changes are made.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c036667.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor that changes only how `getTurnDiff` is wrapped (to `Effect.fn`) without altering the generator body or diff computation logic; low chance of behavior change beyond instrumentation/naming effects.
> 
> **Overview**
> Refactors `CheckpointDiffQuery`’s `getTurnDiff` in `CheckpointDiffQuery.ts` from an arrow function returning `Effect.gen` to the named `Effect.fn("getTurnDiff")` form.
> 
> No functional logic changes were made to turn-diff computation, validation, or error handling; this is a wrapper/style migration to the standardized `Effect.fn` pattern.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0366679daef314e7876d26c834cb85016fde6eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->