### PR TITLE
[codex] migrate Effect.fn in apps/server/src/checkpointing/Layers/CheckpointStore.ts

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -86,139 +86,140 @@ const makeCheckpointStore = Effect.gen(function* () {
         Effect.catch(() => Effect.succeed(false)),
       );
 
-  const captureCheckpoint: CheckpointStoreShape["captureCheckpoint"] = (input) =>
-    Effect.gen(function* () {
-      const operation = "CheckpointStore.captureCheckpoint";
+  const captureCheckpoint: CheckpointStoreShape["captureCheckpoint"] = Effect.fn(
+    "captureCheckpoint",
+  )(function* (input) {
+    const operation = "CheckpointStore.captureCheckpoint";
 
-      yield* Effect.acquireUseRelease(
-        fs.makeTempDirectory({ prefix: "t3-fs-checkpoint-" }),
-        (tempDir) =>
-          Effect.gen(function* () {
-            const tempIndexPath = path.join(tempDir, `index-${randomUUID()}`);
-            const commitEnv: NodeJS.ProcessEnv = {
-              ...process.env,
-              GIT_INDEX_FILE: tempIndexPath,
-              GIT_AUTHOR_NAME: "T3 Code",
-              GIT_AUTHOR_EMAIL: "t3code@users.noreply.github.com",
-              GIT_COMMITTER_NAME: "T3 Code",
-              GIT_COMMITTER_EMAIL: "t3code@users.noreply.github.com",
-            };
+    yield* Effect.acquireUseRelease(
+      fs.makeTempDirectory({ prefix: "t3-fs-checkpoint-" }),
+      Effect.fn("captureCheckpoint.withTempDirectory")(function* (tempDir) {
+        const tempIndexPath = path.join(tempDir, `index-${randomUUID()}`);
+        const commitEnv: NodeJS.ProcessEnv = {
+          ...process.env,
+          GIT_INDEX_FILE: tempIndexPath,
+          GIT_AUTHOR_NAME: "T3 Code",
+          GIT_AUTHOR_EMAIL: "t3code@users.noreply.github.com",
+          GIT_COMMITTER_NAME: "T3 Code",
+          GIT_COMMITTER_EMAIL: "t3code@users.noreply.github.com",
+        };
 
-            const headExists = yield* hasHeadCommit(input.cwd);
-            if (headExists) {
-              yield* git.execute({
-                operation,
-                cwd: input.cwd,
-                args: ["read-tree", "HEAD"],
-                env: commitEnv,
-              });
-            }
+        const headExists = yield* hasHeadCommit(input.cwd);
+        if (headExists) {
+          yield* git.execute({
+            operation,
+            cwd: input.cwd,
+            args: ["read-tree", "HEAD"],
+            env: commitEnv,
+          });
+        }
 
-            yield* git.execute({
-              operation,
-              cwd: input.cwd,
-              args: ["add", "-A", "--", "."],
-              env: commitEnv,
-            });
+        yield* git.execute({
+          operation,
+          cwd: input.cwd,
+          args: ["add", "-A", "--", "."],
+          env: commitEnv,
+        });
 
-            const writeTreeResult = yield* git.execute({
-              operation,
-              cwd: input.cwd,
-              args: ["write-tree"],
-              env: commitEnv,
-            });
-            const treeOid = writeTreeResult.stdout.trim();
-            if (treeOid.length === 0) {
-              return yield* new GitCommandError({
-                operation,
-                command: "git write-tree",
-                cwd: input.cwd,
-                detail: "git write-tree returned an empty tree oid.",
-              });
-            }
+        const writeTreeResult = yield* git.execute({
+          operation,
+          cwd: input.cwd,
+          args: ["write-tree"],
+          env: commitEnv,
+        });
+        const treeOid = writeTreeResult.stdout.trim();
+        if (treeOid.length === 0) {
+          return yield* new GitCommandError({
+            operation,
+            command: "git write-tree",
+            cwd: input.cwd,
+            detail: "git write-tree returned an empty tree oid.",
+          });
+        }
 
-            const message = `t3 checkpoint ref=${input.checkpointRef}`;
-            const commitTreeResult = yield* git.execute({
-              operation,
-              cwd: input.cwd,
-              args: ["commit-tree", treeOid, "-m", message],
-              env: commitEnv,
-            });
-            const commitOid = commitTreeResult.stdout.trim();
-            if (commitOid.length === 0) {
-              return yield* new GitCommandError({
-                operation,
-                command: "git commit-tree",
-                cwd: input.cwd,
-                detail: "git commit-tree returned an empty commit oid.",
-              });
-            }
+        const message = `t3 checkpoint ref=${input.checkpointRef}`;
+        const commitTreeResult = yield* git.execute({
+          operation,
+          cwd: input.cwd,
+          args: ["commit-tree", treeOid, "-m", message],
+          env: commitEnv,
+        });
+        const commitOid = commitTreeResult.stdout.trim();
+        if (commitOid.length === 0) {
+          return yield* new GitCommandError({
+            operation,
+            command: "git commit-tree",
+            cwd: input.cwd,
+            detail: "git commit-tree returned an empty commit oid.",
+          });
+        }
 
-            yield* git.execute({
-              operation,
-              cwd: input.cwd,
-              args: ["update-ref", input.checkpointRef, commitOid],
-            });
-          }),
-        (tempDir) => fs.remove(tempDir, { recursive: true }),
-      ).pipe(
-        Effect.catchTags({
-          PlatformError: (error) =>
-            Effect.fail(
-              new CheckpointInvariantError({
-                operation: "CheckpointStore.captureCheckpoint",
-                detail: "Failed to capture checkpoint.",
-                cause: error,
-              }),
-            ),
-        }),
-      );
-    });
+        yield* git.execute({
+          operation,
+          cwd: input.cwd,
+          args: ["update-ref", input.checkpointRef, commitOid],
+        });
+      }),
+      (tempDir) => fs.remove(tempDir, { recursive: true }),
+    ).pipe(
+      Effect.catchTags({
+        PlatformError: (error) =>
+          Effect.fail(
+            new CheckpointInvariantError({
+              operation: "CheckpointStore.captureCheckpoint",
+              detail: "Failed to capture checkpoint.",
+              cause: error,
+            }),
+          ),
+      }),
+    );
+  });
 
   const hasCheckpointRef: CheckpointStoreShape["hasCheckpointRef"] = (input) =>
     resolveCheckpointCommit(input.cwd, input.checkpointRef).pipe(
       Effect.map((commit) => commit !== null),
     );
 
-  const restoreCheckpoint: CheckpointStoreShape["restoreCheckpoint"] = (input) =>
-    Effect.gen(function* () {
-      const operation = "CheckpointStore.restoreCheckpoint";
+  const restoreCheckpoint: CheckpointStoreShape["restoreCheckpoint"] = Effect.fn(
+    "restoreCheckpoint",
+  )(function* (input) {
+    const operation = "CheckpointStore.restoreCheckpoint";
 
-      let commitOid = yield* resolveCheckpointCommit(input.cwd, input.checkpointRef);
+    let commitOid = yield* resolveCheckpointCommit(input.cwd, input.checkpointRef);
 
-      if (!commitOid && input.fallbackToHead === true) {
-        commitOid = yield* resolveHeadCommit(input.cwd);
-      }
+    if (!commitOid && input.fallbackToHead === true) {
+      commitOid = yield* resolveHeadCommit(input.cwd);
+    }
 
-      if (!commitOid) {
-        return false;
-      }
+    if (!commitOid) {
+      return false;
+    }
 
-      yield* git.execute({
-        operation,
-        cwd: input.cwd,
-        args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", "."],
-      });
-      yield* git.execute({
-        operation,
-        cwd: input.cwd,
-        args: ["clean", "-fd", "--", "."],
-      });
-
-      const headExists = yield* hasHeadCommit(input.cwd);
-      if (headExists) {
-        yield* git.execute({
-          operation,
-          cwd: input.cwd,
-          args: ["reset", "--quiet", "--", "."],
-        });
-      }
-
-      return true;
+    yield* git.execute({
+      operation,
+      cwd: input.cwd,
+      args: ["restore", "--source", commitOid, "--worktree", "--staged", "--", "."],
+    });
+    yield* git.execute({
+      operation,
+      cwd: input.cwd,
+      args: ["clean", "-fd", "--", "."],
     });
 
-  const diffCheckpoints: CheckpointStoreShape["diffCheckpoints"] = (input) =>
-    Effect.gen(function* () {
+    const headExists = yield* hasHeadCommit(input.cwd);
+    if (headExists) {
+      yield* git.execute({
+        operation,
+        cwd: input.cwd,
+        args: ["reset", "--quiet", "--", "."],
+      });
+    }
+
+    return true;
+  });
+
+  const diffCheckpoints: CheckpointStoreShape["diffCheckpoints"] = Effect.fn("diffCheckpoints")(
+    function* (input) {
       const operation = "CheckpointStore.diffCheckpoints";
 
       let fromCommitOid = yield* resolveCheckpointCommit(input.cwd, input.fromCheckpointRef);
@@ -247,24 +248,26 @@ const makeCheckpointStore = Effect.gen(function* () {
       });
 
       return result.stdout;
-    });
+    },
+  );
 
-  const deleteCheckpointRefs: CheckpointStoreShape["deleteCheckpointRefs"] = (input) =>
-    Effect.gen(function* () {
-      const operation = "CheckpointStore.deleteCheckpointRefs";
+  const deleteCheckpointRefs: CheckpointStoreShape["deleteCheckpointRefs"] = Effect.fn(
+    "deleteCheckpointRefs",
+  )(function* (input) {
+    const operation = "CheckpointStore.deleteCheckpointRefs";
 
-      yield* Effect.forEach(
-        input.checkpointRefs,
-        (checkpointRef) =>
-          git.execute({
-            operation,
-            cwd: input.cwd,
-            args: ["update-ref", "-d", checkpointRef],
-            allowNonZeroExit: true,
-          }),
-        { discard: true },
-      );
-    });
+    yield* Effect.forEach(
+      input.checkpointRefs,
+      (checkpointRef) =>
+        git.execute({
+          operation,
+          cwd: input.cwd,
+          args: ["update-ref", "-d", checkpointRef],
+          allowNonZeroExit: true,
+        }),
+      { discard: true },
+    );
+  });
 
   return {
     isGitRepository,


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/checkpointing/Layers/CheckpointStore.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate checkpoint functions in `CheckpointStore.ts` to named `Effect.fn`
> Wraps `captureCheckpoint`, `restoreCheckpoint`, `diffCheckpoints`, and `deleteCheckpointRefs` in [CheckpointStore.ts](https://github.com/pingdotgg/t3code/pull/1623/files#diff-246091edd41db39269d7b4458744037fe70cb1d30ee21e10ad8ad4ad80e2d705) with `Effect.fn("<name>")` instead of anonymous `Effect.gen` calls. No logic, control flow, or error handling changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e848bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of checkpointing layer functions to use `Effect.fn` instead of anonymous `Effect.gen` wrappers, with no intended behavior changes. Risk is low and mainly limited to potential subtle differences in effect naming/stack traces.
> 
> **Overview**
> Migrates the remaining checkpointing operations in `CheckpointStore.ts` from anonymous `Effect.gen` wrappers to named `Effect.fn` forms (including an inner `captureCheckpoint.withTempDirectory`). This standardizes effect naming for `captureCheckpoint`, `restoreCheckpoint`, `diffCheckpoints`, and `deleteCheckpointRefs` without changing the underlying Git commands, control flow, or error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e848bcfb0916a07c0e2d06de4fa175f724117b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->