### PR TITLE
[codex] migrate Effect.fn in apps/server/src/git/Layers/CodexTextGeneration.ts

### DIFF
--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -85,47 +85,43 @@ const makeCodexTextGeneration = Effect.gen(function* () {
   const safeUnlink = (filePath: string): Effect.Effect<void, never> =>
     fileSystem.remove(filePath).pipe(Effect.catch(() => Effect.void));
 
-  const materializeImageAttachments = (
+  const materializeImageAttachments = Effect.fn("materializeImageAttachments")(function* (
     _operation:
       | "generateCommitMessage"
       | "generatePrContent"
       | "generateBranchName"
       | "generateThreadTitle",
     attachments: BranchNameGenerationInput["attachments"],
-  ): Effect.Effect<MaterializedImageAttachments, TextGenerationError> =>
-    Effect.fn("materializeImageAttachments")(function* (): Effect.fn.Return<
-      MaterializedImageAttachments,
-      TextGenerationError
-    > {
-      if (!attachments || attachments.length === 0) {
-        return { imagePaths: [] };
+  ): Effect.fn.Return<MaterializedImageAttachments, TextGenerationError> {
+    if (!attachments || attachments.length === 0) {
+      return { imagePaths: [] };
+    }
+
+    const imagePaths: string[] = [];
+    for (const attachment of attachments) {
+      if (attachment.type !== "image") {
+        continue;
       }
 
-      const imagePaths: string[] = [];
-      for (const attachment of attachments) {
-        if (attachment.type !== "image") {
-          continue;
-        }
-
-        const resolvedPath = resolveAttachmentPath({
-          attachmentsDir: serverConfig.attachmentsDir,
-          attachment,
-        });
-        if (!resolvedPath || !path.isAbsolute(resolvedPath)) {
-          continue;
-        }
-        const fileInfo = yield* fileSystem
-          .stat(resolvedPath)
-          .pipe(Effect.catch(() => Effect.succeed(null)));
-        if (!fileInfo || fileInfo.type !== "File") {
-          continue;
-        }
-        imagePaths.push(resolvedPath);
+      const resolvedPath = resolveAttachmentPath({
+        attachmentsDir: serverConfig.attachmentsDir,
+        attachment,
+      });
+      if (!resolvedPath || !path.isAbsolute(resolvedPath)) {
+        continue;
       }
-      return { imagePaths };
-    })();
+      const fileInfo = yield* fileSystem
+        .stat(resolvedPath)
+        .pipe(Effect.catch(() => Effect.succeed(null)));
+      if (!fileInfo || fileInfo.type !== "File") {
+        continue;
+      }
+      imagePaths.push(resolvedPath);
+    }
+    return { imagePaths };
+  });
 
-  const runCodexJson = <S extends Schema.Top>({
+  const runCodexJson = Effect.fn("runCodexJson")(function* <S extends Schema.Top>({
     operation,
     cwd,
     prompt,
@@ -145,146 +141,137 @@ const makeCodexTextGeneration = Effect.gen(function* () {
     imagePaths?: ReadonlyArray<string>;
     cleanupPaths?: ReadonlyArray<string>;
     modelSelection: CodexModelSelection;
-  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
-    Effect.fn("runCodexJson")(function* (): Effect.fn.Return<
-      S["Type"],
-      TextGenerationError,
-      S["DecodingServices"]
-    > {
-      const schemaPath = yield* writeTempFile(
-        operation,
-        "codex-schema",
-        JSON.stringify(toJsonSchemaObject(outputSchemaJson)),
+  }): Effect.fn.Return<S["Type"], TextGenerationError, S["DecodingServices"]> {
+    const schemaPath = yield* writeTempFile(
+      operation,
+      "codex-schema",
+      JSON.stringify(toJsonSchemaObject(outputSchemaJson)),
+    );
+    const outputPath = yield* writeTempFile(operation, "codex-output", "");
+
+    const codexSettings = yield* Effect.map(
+      serverSettingsService.getSettings,
+      (settings) => settings.providers.codex,
+    ).pipe(Effect.catch(() => Effect.undefined));
+
+    const runCodexCommand = Effect.fn("runCodexJson.runCodexCommand")(function* () {
+      const normalizedOptions = normalizeCodexModelOptionsWithCapabilities(
+        getCodexModelCapabilities(modelSelection.model),
+        modelSelection.options,
       );
-      const outputPath = yield* writeTempFile(operation, "codex-output", "");
-
-      const codexSettings = yield* Effect.map(
-        serverSettingsService.getSettings,
-        (settings) => settings.providers.codex,
-      ).pipe(Effect.catch(() => Effect.undefined));
-
-      const runCodexCommand = Effect.fn("runCodexJson.runCodexCommand")(function* () {
-        const normalizedOptions = normalizeCodexModelOptionsWithCapabilities(
-          getCodexModelCapabilities(modelSelection.model),
-          modelSelection.options,
-        );
-        const reasoningEffort =
-          modelSelection.options?.reasoningEffort ?? CODEX_GIT_TEXT_GENERATION_REASONING_EFFORT;
-        const command = ChildProcess.make(
-          codexSettings?.binaryPath || "codex",
-          [
-            "exec",
-            "--ephemeral",
-            "-s",
-            "read-only",
-            "--model",
-            modelSelection.model,
-            "--config",
-            `model_reasoning_effort="${reasoningEffort}"`,
-            ...(normalizedOptions?.fastMode ? ["--config", `service_tier="fast"`] : []),
-            "--output-schema",
-            schemaPath,
-            "--output-last-message",
-            outputPath,
-            ...imagePaths.flatMap((imagePath) => ["--image", imagePath]),
-            "-",
-          ],
-          {
-            env: {
-              ...process.env,
-              ...(codexSettings?.homePath ? { CODEX_HOME: codexSettings.homePath } : {}),
-            },
-            cwd,
-            shell: process.platform === "win32",
-            stdin: {
-              stream: Stream.encodeText(Stream.make(prompt)),
-            },
-          },
-        );
-
-        const child = yield* commandSpawner
-          .spawn(command)
-          .pipe(
-            Effect.mapError((cause) =>
-              normalizeCliError("codex", operation, cause, "Failed to spawn Codex CLI process"),
-            ),
-          );
-
-        const [stdout, stderr, exitCode] = yield* Effect.all(
-          [
-            readStreamAsString(operation, child.stdout),
-            readStreamAsString(operation, child.stderr),
-            child.exitCode.pipe(
-              Effect.mapError((cause) =>
-                normalizeCliError("codex", operation, cause, "Failed to read Codex CLI exit code"),
-              ),
-            ),
-          ],
-          { concurrency: "unbounded" },
-        );
-
-        if (exitCode !== 0) {
-          const stderrDetail = stderr.trim();
-          const stdoutDetail = stdout.trim();
-          const detail = stderrDetail.length > 0 ? stderrDetail : stdoutDetail;
-          return yield* new TextGenerationError({
-            operation,
-            detail:
-              detail.length > 0
-                ? `Codex CLI command failed: ${detail}`
-                : `Codex CLI command failed with code ${exitCode}.`,
-          });
-        }
-      });
-
-      const cleanup = Effect.all(
-        [schemaPath, outputPath, ...cleanupPaths].map((filePath) => safeUnlink(filePath)),
+      const reasoningEffort =
+        modelSelection.options?.reasoningEffort ?? CODEX_GIT_TEXT_GENERATION_REASONING_EFFORT;
+      const command = ChildProcess.make(
+        codexSettings?.binaryPath || "codex",
+        [
+          "exec",
+          "--ephemeral",
+          "-s",
+          "read-only",
+          "--model",
+          modelSelection.model,
+          "--config",
+          `model_reasoning_effort="${reasoningEffort}"`,
+          ...(normalizedOptions?.fastMode ? ["--config", `service_tier="fast"`] : []),
+          "--output-schema",
+          schemaPath,
+          "--output-last-message",
+          outputPath,
+          ...imagePaths.flatMap((imagePath) => ["--image", imagePath]),
+          "-",
+        ],
         {
-          concurrency: "unbounded",
+          env: {
+            ...process.env,
+            ...(codexSettings?.homePath ? { CODEX_HOME: codexSettings.homePath } : {}),
+          },
+          cwd,
+          shell: process.platform === "win32",
+          stdin: {
+            stream: Stream.encodeText(Stream.make(prompt)),
+          },
         },
-      ).pipe(Effect.asVoid);
+      );
 
-      return yield* Effect.fn("runCodexJson.readOutput")(function* (): Effect.fn.Return<
-        S["Type"],
-        TextGenerationError,
-        S["DecodingServices"]
-      > {
-        yield* runCodexCommand.pipe(
-          Effect.scoped,
-          Effect.timeoutOption(CODEX_TIMEOUT_MS),
-          Effect.flatMap(
-            Option.match({
-              onNone: () =>
-                Effect.fail(
-                  new TextGenerationError({ operation, detail: "Codex CLI request timed out." }),
-                ),
-              onSome: () => Effect.void,
+      const child = yield* commandSpawner
+        .spawn(command)
+        .pipe(
+          Effect.mapError((cause) =>
+            normalizeCliError("codex", operation, cause, "Failed to spawn Codex CLI process"),
+          ),
+        );
+
+      const [stdout, stderr, exitCode] = yield* Effect.all(
+        [
+          readStreamAsString(operation, child.stdout),
+          readStreamAsString(operation, child.stderr),
+          child.exitCode.pipe(
+            Effect.mapError((cause) =>
+              normalizeCliError("codex", operation, cause, "Failed to read Codex CLI exit code"),
+            ),
+          ),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      if (exitCode !== 0) {
+        const stderrDetail = stderr.trim();
+        const stdoutDetail = stdout.trim();
+        const detail = stderrDetail.length > 0 ? stderrDetail : stdoutDetail;
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            detail.length > 0
+              ? `Codex CLI command failed: ${detail}`
+              : `Codex CLI command failed with code ${exitCode}.`,
+        });
+      }
+    });
+
+    const cleanup = Effect.all(
+      [schemaPath, outputPath, ...cleanupPaths].map((filePath) => safeUnlink(filePath)),
+      {
+        concurrency: "unbounded",
+      },
+    ).pipe(Effect.asVoid);
+
+    return yield* Effect.gen(function* () {
+      yield* runCodexCommand().pipe(
+        Effect.scoped,
+        Effect.timeoutOption(CODEX_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({ operation, detail: "Codex CLI request timed out." }),
+              ),
+            onSome: () => Effect.void,
+          }),
+        ),
+      );
+
+      return yield* fileSystem.readFileString(outputPath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new TextGenerationError({
+              operation,
+              detail: "Failed to read Codex output file.",
+              cause,
+            }),
+        ),
+        Effect.flatMap(Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson))),
+        Effect.catchTag("SchemaError", (cause) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation,
+              detail: "Codex returned invalid structured output.",
+              cause,
             }),
           ),
-        );
-
-        return yield* fileSystem.readFileString(outputPath).pipe(
-          Effect.mapError(
-            (cause) =>
-              new TextGenerationError({
-                operation,
-                detail: "Failed to read Codex output file.",
-                cause,
-              }),
-          ),
-          Effect.flatMap(Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson))),
-          Effect.catchTag("SchemaError", (cause) =>
-            Effect.fail(
-              new TextGenerationError({
-                operation,
-                detail: "Codex returned invalid structured output.",
-                cause,
-              }),
-            ),
-          ),
-        );
-      })().pipe(Effect.ensuring(cleanup));
-    })();
+        ),
+      );
+    }).pipe(Effect.ensuring(cleanup));
+  });
 
   const generateCommitMessage: TextGenerationShape["generateCommitMessage"] = Effect.fn(
     "CodexTextGeneration.generateCommitMessage",


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/git/Layers/CodexTextGeneration.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `Effect.fn` named generators in `CodexTextGeneration.ts`
> Refactors three generator functions in [CodexTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/1624/files#diff-d8b1adc1ecada77cc3a3af0a24f36d847cf3ae7c6bfb861af6689b28564c9054) to use `Effect.fn` named generators (`materializeImageAttachments`, `runCodexJson`, and `runCodexJson.runCodexCommand`) instead of anonymous `Effect.gen` wrappers. The previously inline command-runner logic is extracted into a dedicated named generator `runCodexJson.runCodexCommand`. Logic and runtime behavior are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30757b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of Effect wrapper style in `CodexTextGeneration.ts` with no functional changes to Codex CLI execution, file handling, or decoding logic; low risk aside from potential subtle effect-scoping/invocation differences.
> 
> **Overview**
> Refactors `apps/server/src/git/Layers/CodexTextGeneration.ts` to use named `Effect.fn(...)` wrappers for `materializeImageAttachments`, `runCodexJson`, and the internal `runCodexJson.runCodexCommand`, replacing inline `Effect.gen` blocks.
> 
> Behavior is intended to be unchanged: temp file creation/cleanup, Codex CLI invocation (including images), timeout handling, and schema decoding remain the same, with the main difference being named effects and explicit invocation of the inner command effect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30757b30140e53143b4dfb271b5a35d8989752e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->