### PR TITLE
[codex] migrate Effect.fn in apps/server/src/git/Layers/ClaudeTextGeneration.ts

### DIFF
--- a/apps/server/src/git/Layers/ClaudeTextGeneration.ts
+++ b/apps/server/src/git/Layers/ClaudeTextGeneration.ts
@@ -66,7 +66,7 @@ const makeClaudeTextGeneration = Effect.gen(function* () {
    * Spawn the Claude CLI with structured JSON output and return the parsed,
    * schema-validated result.
    */
-  const runClaudeJson = <S extends Schema.Top>({
+  const runClaudeJson = Effect.fn("runClaudeJson")(function* <S extends Schema.Top>({
     operation,
     cwd,
     prompt,
@@ -82,135 +82,125 @@ const makeClaudeTextGeneration = Effect.gen(function* () {
     prompt: string;
     outputSchemaJson: S;
     modelSelection: ClaudeModelSelection;
-  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
-    Effect.fn("runClaudeJson")(function* (): Effect.fn.Return<
-      S["Type"],
-      TextGenerationError,
-      S["DecodingServices"]
-    > {
-      const jsonSchemaStr = JSON.stringify(toJsonSchemaObject(outputSchemaJson));
-      const normalizedOptions = normalizeClaudeModelOptionsWithCapabilities(
-        getClaudeModelCapabilities(modelSelection.model),
-        modelSelection.options,
-      );
-      const settings = {
-        ...(typeof normalizedOptions?.thinking === "boolean"
-          ? { alwaysThinkingEnabled: normalizedOptions.thinking }
-          : {}),
-        ...(normalizedOptions?.fastMode ? { fastMode: true } : {}),
-      };
+  }): Effect.fn.Return<S["Type"], TextGenerationError, S["DecodingServices"]> {
+    const jsonSchemaStr = JSON.stringify(toJsonSchemaObject(outputSchemaJson));
+    const normalizedOptions = normalizeClaudeModelOptionsWithCapabilities(
+      getClaudeModelCapabilities(modelSelection.model),
+      modelSelection.options,
+    );
+    const settings = {
+      ...(typeof normalizedOptions?.thinking === "boolean"
+        ? { alwaysThinkingEnabled: normalizedOptions.thinking }
+        : {}),
+      ...(normalizedOptions?.fastMode ? { fastMode: true } : {}),
+    };
 
-      const claudeSettings = yield* Effect.map(
-        serverSettingsService.getSettings,
-        (settings) => settings.providers.claudeAgent,
-      ).pipe(Effect.catch(() => Effect.undefined));
+    const claudeSettings = yield* Effect.map(
+      serverSettingsService.getSettings,
+      (settings) => settings.providers.claudeAgent,
+    ).pipe(Effect.catch(() => Effect.undefined));
 
-      const runClaudeCommand = Effect.fn("runClaudeJson.runClaudeCommand")(function* () {
-        const command = ChildProcess.make(
-          claudeSettings?.binaryPath || "claude",
-          [
-            "-p",
-            "--output-format",
-            "json",
-            "--json-schema",
-            jsonSchemaStr,
-            "--model",
-            resolveApiModelId(modelSelection),
-            ...(normalizedOptions?.effort ? ["--effort", normalizedOptions.effort] : []),
-            ...(Object.keys(settings).length > 0 ? ["--settings", JSON.stringify(settings)] : []),
-            "--dangerously-skip-permissions",
-          ],
-          {
-            cwd,
-            shell: process.platform === "win32",
-            stdin: {
-              stream: Stream.encodeText(Stream.make(prompt)),
-            },
+    const runClaudeCommand = Effect.fn("runClaudeJson.runClaudeCommand")(function* () {
+      const command = ChildProcess.make(
+        claudeSettings?.binaryPath || "claude",
+        [
+          "-p",
+          "--output-format",
+          "json",
+          "--json-schema",
+          jsonSchemaStr,
+          "--model",
+          resolveApiModelId(modelSelection),
+          ...(normalizedOptions?.effort ? ["--effort", normalizedOptions.effort] : []),
+          ...(Object.keys(settings).length > 0 ? ["--settings", JSON.stringify(settings)] : []),
+          "--dangerously-skip-permissions",
+        ],
+        {
+          cwd,
+          shell: process.platform === "win32",
+          stdin: {
+            stream: Stream.encodeText(Stream.make(prompt)),
           },
+        },
+      );
+
+      const child = yield* commandSpawner
+        .spawn(command)
+        .pipe(
+          Effect.mapError((cause) =>
+            normalizeCliError("claude", operation, cause, "Failed to spawn Claude CLI process"),
+          ),
         );
 
-        const child = yield* commandSpawner
-          .spawn(command)
-          .pipe(
+      const [stdout, stderr, exitCode] = yield* Effect.all(
+        [
+          readStreamAsString(operation, child.stdout),
+          readStreamAsString(operation, child.stderr),
+          child.exitCode.pipe(
             Effect.mapError((cause) =>
-              normalizeCliError("claude", operation, cause, "Failed to spawn Claude CLI process"),
+              normalizeCliError("claude", operation, cause, "Failed to read Claude CLI exit code"),
             ),
-          );
+          ),
+        ],
+        { concurrency: "unbounded" },
+      );
 
-        const [stdout, stderr, exitCode] = yield* Effect.all(
-          [
-            readStreamAsString(operation, child.stdout),
-            readStreamAsString(operation, child.stderr),
-            child.exitCode.pipe(
-              Effect.mapError((cause) =>
-                normalizeCliError(
-                  "claude",
-                  operation,
-                  cause,
-                  "Failed to read Claude CLI exit code",
-                ),
-              ),
+      if (exitCode !== 0) {
+        const stderrDetail = stderr.trim();
+        const stdoutDetail = stdout.trim();
+        const detail = stderrDetail.length > 0 ? stderrDetail : stdoutDetail;
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            detail.length > 0
+              ? `Claude CLI command failed: ${detail}`
+              : `Claude CLI command failed with code ${exitCode}.`,
+        });
+      }
+
+      return stdout;
+    });
+
+    const rawStdout = yield* runClaudeCommand().pipe(
+      Effect.scoped,
+      Effect.timeoutOption(CLAUDE_TIMEOUT_MS),
+      Effect.flatMap(
+        Option.match({
+          onNone: () =>
+            Effect.fail(
+              new TextGenerationError({ operation, detail: "Claude CLI request timed out." }),
             ),
-          ],
-          { concurrency: "unbounded" },
-        );
+          onSome: (value) => Effect.succeed(value),
+        }),
+      ),
+    );
 
-        if (exitCode !== 0) {
-          const stderrDetail = stderr.trim();
-          const stdoutDetail = stdout.trim();
-          const detail = stderrDetail.length > 0 ? stderrDetail : stdoutDetail;
-          return yield* new TextGenerationError({
+    const envelope = yield* Schema.decodeEffect(Schema.fromJsonString(ClaudeOutputEnvelope))(
+      rawStdout,
+    ).pipe(
+      Effect.catchTag("SchemaError", (cause) =>
+        Effect.fail(
+          new TextGenerationError({
             operation,
-            detail:
-              detail.length > 0
-                ? `Claude CLI command failed: ${detail}`
-                : `Claude CLI command failed with code ${exitCode}.`,
-          });
-        }
-
-        return stdout;
-      });
-
-      const rawStdout = yield* runClaudeCommand.pipe(
-        Effect.scoped,
-        Effect.timeoutOption(CLAUDE_TIMEOUT_MS),
-        Effect.flatMap(
-          Option.match({
-            onNone: () =>
-              Effect.fail(
-                new TextGenerationError({ operation, detail: "Claude CLI request timed out." }),
-              ),
-            onSome: (value) => Effect.succeed(value),
+            detail: "Claude CLI returned unexpected output format.",
+            cause,
           }),
         ),
-      );
+      ),
+    );
 
-      const envelope = yield* Schema.decodeEffect(Schema.fromJsonString(ClaudeOutputEnvelope))(
-        rawStdout,
-      ).pipe(
-        Effect.catchTag("SchemaError", (cause) =>
-          Effect.fail(
-            new TextGenerationError({
-              operation,
-              detail: "Claude CLI returned unexpected output format.",
-              cause,
-            }),
-          ),
+    return yield* Schema.decodeEffect(outputSchemaJson)(envelope.structured_output).pipe(
+      Effect.catchTag("SchemaError", (cause) =>
+        Effect.fail(
+          new TextGenerationError({
+            operation,
+            detail: "Claude returned invalid structured output.",
+            cause,
+          }),
         ),
-      );
-
-      return yield* Schema.decodeEffect(outputSchemaJson)(envelope.structured_output).pipe(
-        Effect.catchTag("SchemaError", (cause) =>
-          Effect.fail(
-            new TextGenerationError({
-              operation,
-              detail: "Claude returned invalid structured output.",
-              cause,
-            }),
-          ),
-        ),
-      );
-    })();
+      ),
+    );
+  });
 
   // ---------------------------------------------------------------------------
   // TextGenerationShape methods


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/git/Layers/ClaudeTextGeneration.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `runClaudeJson` and `runClaudeCommand` to named `Effect.fn` functions in ClaudeTextGeneration
> Refactors [ClaudeTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/1625/files#diff-2cec96e9af1a064b51669ce10efea9e0b376fe5084feb053e53c7f663bd33080) to use the `Effect.fn` pattern as part of a broader codebase migration.
>
> - `runClaudeJson` is converted from an inline `Effect.gen` constant to a named `Effect.fn("runClaudeJson")` generator function with an explicit `Effect.fn.Return` generic.
> - The previously inlined command execution block is extracted into a named `Effect.fn("runClaudeJson.runClaudeCommand")` function and called explicitly rather than piped.
> - Error handling, timeout logic, and command argument construction are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1b211f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change that updates effect wrapper style for `runClaudeJson`/`runClaudeCommand` without altering Claude CLI invocation or parsing logic; low behavioral risk aside from potential tracing/type inference differences.
> 
> **Overview**
> Migrates `runClaudeJson` and its inner Claude CLI runner in `ClaudeTextGeneration.ts` from `Effect.gen` wrappers to named `Effect.fn` functions.
> 
> This keeps the same inputs/outputs and error handling while improving traceability (explicit function names) and aligning with the codebase’s `Effect.fn` style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1b211fc55b1805b058dc4dd28797a43d0fd42dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->