### PR TITLE
[codex] migrate Effect.fn in apps/server/src/open.ts

### DIFF
--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -220,37 +220,38 @@ export const resolveEditorLaunch = Effect.fnUntraced(function* (
   return { command: fileManagerCommandForPlatform(platform), args: [input.cwd] };
 });
 
-export const launchDetached = (launch: EditorLaunch) =>
-  Effect.gen(function* () {
-    if (!isCommandAvailable(launch.command)) {
-      return yield* new OpenError({ message: `Editor command not found: ${launch.command}` });
+export const launchDetached = Effect.fn("launchDetached")(function* (
+  launch: EditorLaunch,
+): Effect.fn.Return<void, OpenError> {
+  if (!isCommandAvailable(launch.command)) {
+    return yield* new OpenError({ message: `Editor command not found: ${launch.command}` });
+  }
+
+  yield* Effect.callback<void, OpenError>((resume) => {
+    let child;
+    try {
+      child = spawn(launch.command, [...launch.args], {
+        detached: true,
+        stdio: "ignore",
+        shell: process.platform === "win32",
+      });
+    } catch (error) {
+      return resume(
+        Effect.fail(new OpenError({ message: "failed to spawn detached process", cause: error })),
+      );
     }
 
-    yield* Effect.callback<void, OpenError>((resume) => {
-      let child;
-      try {
-        child = spawn(launch.command, [...launch.args], {
-          detached: true,
-          stdio: "ignore",
-          shell: process.platform === "win32",
-        });
-      } catch (error) {
-        return resume(
-          Effect.fail(new OpenError({ message: "failed to spawn detached process", cause: error })),
-        );
-      }
+    const handleSpawn = () => {
+      child.unref();
+      resume(Effect.void);
+    };
 
-      const handleSpawn = () => {
-        child.unref();
-        resume(Effect.void);
-      };
-
-      child.once("spawn", handleSpawn);
-      child.once("error", (cause) =>
-        resume(Effect.fail(new OpenError({ message: "failed to spawn detached process", cause }))),
-      );
-    });
+    child.once("spawn", handleSpawn);
+    child.once("error", (cause) =>
+      resume(Effect.fail(new OpenError({ message: "failed to spawn detached process", cause }))),
+    );
   });
+});
 
 const make = Effect.gen(function* () {
   const open = yield* Effect.tryPromise({


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/open.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `launchDetached` in `open.ts` to use `Effect.fn`
> Refactors `launchDetached` in [open.ts](https://github.com/pingdotgg/t3code/pull/1627/files#diff-67f3655f84064d89de7cec58f5e8d2b9d406dd21986dcefc77c335e3036b65be) from an arrow function returning `Effect.gen(...)` to `Effect.fn("launchDetached")`, adding an explicit name and return type signature. Internal logic is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7350dc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->