### PR TITLE
[codex] migrate Effect.fn in apps/server/src/orchestration/Layers/OrchestrationEngine.ts

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -8,13 +8,17 @@ import {
   TurnId,
   type OrchestrationEvent,
 } from "@t3tools/contracts";
-import { Effect, Layer, ManagedRuntime, Queue, Stream } from "effect";
+import { Effect, Layer, ManagedRuntime, Option, Queue, Stream } from "effect";
 import { describe, expect, it } from "vitest";
 
 import { PersistenceSqlError } from "../../persistence/Errors.ts";
 import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
 import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
+import {
+  OrchestrationCommandReceiptRepository,
+  type OrchestrationCommandReceiptRepositoryShape,
+} from "../../persistence/Services/OrchestrationCommandReceipts.ts";
 import {
   OrchestrationEventStore,
   type OrchestrationEventStoreShape,
@@ -471,6 +475,101 @@ describe("OrchestrationEngine", () => {
         threadId: ThreadId.makeUnsafe("thread-flaky-ok"),
         projectId: asProjectId("project-flaky"),
         title: "flaky-ok",
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt,
+      }),
+    );
+
+    expect(result.sequence).toBe(2);
+    expect((await runtime.runPromise(engine.getReadModel())).snapshotSequence).toBe(2);
+    await runtime.dispose();
+  });
+
+  it("keeps processing queued commands after a receipt lookup failure", async () => {
+    const failingReceiptRepository: OrchestrationCommandReceiptRepositoryShape = {
+      upsert: () => Effect.void,
+      getByCommandId: ({ commandId }) => {
+        if (commandId === CommandId.makeUnsafe("cmd-receipt-fail")) {
+          return Effect.fail(
+            new PersistenceSqlError({
+              operation: "test.getByCommandId",
+              detail: "receipt lookup failed",
+            }),
+          );
+        }
+        return Effect.succeed(Option.none());
+      },
+    };
+
+    const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
+      prefix: "t3-orchestration-engine-test-",
+    });
+
+    const runtime = ManagedRuntime.make(
+      OrchestrationEngineLive.pipe(
+        Layer.provide(OrchestrationProjectionPipelineLive),
+        Layer.provide(OrchestrationEventStoreLive),
+        Layer.provide(
+          Layer.succeed(OrchestrationCommandReceiptRepository, failingReceiptRepository),
+        ),
+        Layer.provide(SqlitePersistenceMemory),
+        Layer.provideMerge(ServerConfigLayer),
+        Layer.provideMerge(NodeServices.layer),
+      ),
+    );
+    const engine = await runtime.runPromise(Effect.service(OrchestrationEngineService));
+    const createdAt = now();
+
+    await runtime.runPromise(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-project-receipt-create"),
+        projectId: asProjectId("project-receipt"),
+        title: "Receipt Project",
+        workspaceRoot: "/tmp/project-receipt",
+        defaultModelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        createdAt,
+      }),
+    );
+
+    await expect(
+      runtime.runPromise(
+        engine.dispatch({
+          type: "thread.create",
+          commandId: CommandId.makeUnsafe("cmd-receipt-fail"),
+          threadId: ThreadId.makeUnsafe("thread-receipt-fail"),
+          projectId: asProjectId("project-receipt"),
+          title: "receipt-fail",
+          modelSelection: {
+            provider: "codex",
+            model: "gpt-5-codex",
+          },
+          interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+          runtimeMode: "approval-required",
+          branch: null,
+          worktreePath: null,
+          createdAt,
+        }),
+      ),
+    ).rejects.toThrow("receipt lookup failed");
+
+    const result = await runtime.runPromise(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-receipt-ok"),
+        threadId: ThreadId.makeUnsafe("thread-receipt-ok"),
+        projectId: asProjectId("project-receipt"),
+        title: "receipt-ok",
         modelSelection: {
           provider: "codex",
           model: "gpt-5-codex",

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -118,86 +118,87 @@ const makeOrchestrationEngine = Effect.gen(function* () {
       yield* Deferred.fail(envelope.result, error);
     });
 
-    const existingReceipt = yield* commandReceiptRepository.getByCommandId({
-      commandId: envelope.command.commandId,
-    });
-    if (Option.isSome(existingReceipt)) {
-      if (existingReceipt.value.status === "accepted") {
-        yield* Deferred.succeed(envelope.result, {
-          sequence: existingReceipt.value.resultSequence,
-        });
+    return yield* Effect.gen(function* () {
+      const existingReceipt = yield* commandReceiptRepository.getByCommandId({
+        commandId: envelope.command.commandId,
+      });
+      if (Option.isSome(existingReceipt)) {
+        if (existingReceipt.value.status === "accepted") {
+          yield* Deferred.succeed(envelope.result, {
+            sequence: existingReceipt.value.resultSequence,
+          });
+          return;
+        }
+        yield* Deferred.fail(
+          envelope.result,
+          new OrchestrationCommandPreviouslyRejectedError({
+            commandId: envelope.command.commandId,
+            detail: existingReceipt.value.error ?? "Previously rejected.",
+          }),
+        );
         return;
       }
-      yield* Deferred.fail(
-        envelope.result,
-        new OrchestrationCommandPreviouslyRejectedError({
-          commandId: envelope.command.commandId,
-          detail: existingReceipt.value.error ?? "Previously rejected.",
-        }),
-      );
-      return;
-    }
 
-    const eventBase = yield* decideOrchestrationCommand({
-      command: envelope.command,
-      readModel,
-    });
-    const eventBases = Array.isArray(eventBase) ? eventBase : [eventBase];
-    const committedCommand = yield* sql
-      .withTransaction(
-        Effect.gen(function* () {
-          const committedEvents: OrchestrationEvent[] = [];
-          let nextReadModel = readModel;
+      const eventBase = yield* decideOrchestrationCommand({
+        command: envelope.command,
+        readModel,
+      });
+      const eventBases = Array.isArray(eventBase) ? eventBase : [eventBase];
+      const committedCommand = yield* sql
+        .withTransaction(
+          Effect.gen(function* () {
+            const committedEvents: OrchestrationEvent[] = [];
+            let nextReadModel = readModel;
 
-          for (const nextEvent of eventBases) {
-            const savedEvent = yield* eventStore.append(nextEvent);
-            nextReadModel = yield* projectEvent(nextReadModel, savedEvent);
-            yield* projectionPipeline.projectEvent(savedEvent);
-            committedEvents.push(savedEvent);
-          }
+            for (const nextEvent of eventBases) {
+              const savedEvent = yield* eventStore.append(nextEvent);
+              nextReadModel = yield* projectEvent(nextReadModel, savedEvent);
+              yield* projectionPipeline.projectEvent(savedEvent);
+              committedEvents.push(savedEvent);
+            }
 
-          const lastSavedEvent = committedEvents.at(-1) ?? null;
-          if (lastSavedEvent === null) {
-            return yield* new OrchestrationCommandInvariantError({
-              commandType: envelope.command.type,
-              detail: "Command produced no events.",
+            const lastSavedEvent = committedEvents.at(-1) ?? null;
+            if (lastSavedEvent === null) {
+              return yield* new OrchestrationCommandInvariantError({
+                commandType: envelope.command.type,
+                detail: "Command produced no events.",
+              });
+            }
+
+            yield* commandReceiptRepository.upsert({
+              commandId: envelope.command.commandId,
+              aggregateKind: lastSavedEvent.aggregateKind,
+              aggregateId: lastSavedEvent.aggregateId,
+              acceptedAt: lastSavedEvent.occurredAt,
+              resultSequence: lastSavedEvent.sequence,
+              status: "accepted",
+              error: null,
             });
-          }
 
-          yield* commandReceiptRepository.upsert({
-            commandId: envelope.command.commandId,
-            aggregateKind: lastSavedEvent.aggregateKind,
-            aggregateId: lastSavedEvent.aggregateId,
-            acceptedAt: lastSavedEvent.occurredAt,
-            resultSequence: lastSavedEvent.sequence,
-            status: "accepted",
-            error: null,
-          });
-
-          return {
-            committedEvents,
-            lastSequence: lastSavedEvent.sequence,
-            nextReadModel,
-          } as const;
-        }),
-      )
-      .pipe(
-        Effect.catchTag("SqlError", (sqlError) =>
-          Effect.fail(
-            toPersistenceSqlError("OrchestrationEngine.processEnvelope:transaction")(sqlError),
+            return {
+              committedEvents,
+              lastSequence: lastSavedEvent.sequence,
+              nextReadModel,
+            } as const;
+          }),
+        )
+        .pipe(
+          Effect.catchTag("SqlError", (sqlError) =>
+            Effect.fail(
+              toPersistenceSqlError("OrchestrationEngine.processEnvelope:transaction")(sqlError),
+            ),
           ),
-        ),
-        Effect.catch(handleError),
-      );
-    if (!committedCommand) {
-      return;
-    }
+        );
+      if (!committedCommand) {
+        return;
+      }
 
-    readModel = committedCommand.nextReadModel;
-    for (const event of committedCommand.committedEvents) {
-      yield* PubSub.publish(eventPubSub, event);
-    }
-    yield* Deferred.succeed(envelope.result, { sequence: committedCommand.lastSequence });
+      readModel = committedCommand.nextReadModel;
+      for (const event of committedCommand.committedEvents) {
+        yield* PubSub.publish(eventPubSub, event);
+      }
+      yield* Deferred.succeed(envelope.result, { sequence: committedCommand.lastSequence });
+    }).pipe(Effect.catch(handleError), Effect.asVoid);
   });
 
   yield* projectionPipeline.bootstrap;


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/orchestration/Layers/OrchestrationEngine.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `OrchestrationEngine` worker loop to continue processing after command dispatch failures
> - Refactors `processEnvelope` in [OrchestrationEngine.ts](https://github.com/pingdotgg/t3code/pull/1628/files#diff-996de6bdce67b7926493255cf29e93653d211eca31023cf4c476b42f7dc59570) into a named `Effect.fn` with named error-handling helpers, migrating away from inline generator functions.
> - On dispatch error, the failing command's `Deferred` is rejected and the in-memory read model is reconciled from the event store; reconciliation failures are swallowed with a warning log so the worker loop continues.
> - Adds a null-check after the transactional block so the handler returns early if no command was committed, preventing a runtime error on subsequent property access.
> - Adds a new test case verifying that a subsequent command is accepted and processed normally after a receipt lookup failure for a prior command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 563808b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the orchestration command dispatch path and its error/reconciliation flow; intended as a refactor, but small changes here could affect how failures propagate and whether the worker keeps draining the queue.
> 
> **Overview**
> Refactors `OrchestrationEngine`’s command processing to use named `Effect.fn` wrappers (e.g. `processEnvelope`, `bootstrapReadModel`, `dispatch`) and extracts error handling into a dedicated `handleError` path that reconciles the in-memory read model after failures and persists *rejected* receipts for invariant violations.
> 
> Adds a guard to stop processing when the transactional dispatch did not produce a committed result, and extends the engine test suite with a case ensuring queued commands continue to be processed after a command receipt lookup failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 563808b6cfe24d0444fcfbf5d697ef730d8aec33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->