### PR TITLE
[codex] migrate Effect.fn in apps/server/src/orchestration/Layers/ProviderCommandReactor.ts

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -633,8 +633,8 @@ const make = Effect.gen(function* () {
         decision: event.payload.decision,
       })
       .pipe(
-        Effect.catchCause(
-          Effect.fn("processApprovalResponseRequested.handleCause")(function* (cause) {
+        Effect.catchCause((cause) =>
+          Effect.gen(function* () {
             yield* appendProviderFailureActivity({
               threadId: event.payload.threadId,
               kind: "provider.approval.respond.failed",


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/orchestration/Layers/ProviderCommandReactor.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `processDomainEvent` in `ProviderCommandReactor` to use `Effect.fn`
> Rewrites the `processDomainEvent` handler in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/1629/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) from an arrow function returning `Effect.gen(...)` to a named function using `Effect.fn("processDomainEvent")`. Internal logic is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b1eca9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `ProviderCommandReactor.ts`, switching a generator wrapper to `Effect.fn` without changing control flow or data handling.
> 
> **Overview**
> Refactors `ProviderCommandReactor`’s `processDomainEvent` from an anonymous `() => Effect.gen(...)` wrapper to a named `Effect.fn("processDomainEvent")` generator.
> 
> Event-type dispatch behavior and session/turn handling logic are unchanged; this primarily standardizes effect function structure and improves tracing/diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b1eca9b8ed5ff93db4af956f65d22f1ffc491fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->