### PR TITLE
[codex] migrate Effect.fn in apps/server/src/orchestration/projector.ts

### DIFF
--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -174,6 +174,249 @@ export function projectEvent(
     updatedAt: event.occurredAt,
   };
 
+  const projectThreadCreated = Effect.fn("projectEvent.threadCreated")(function* () {
+    const payload = yield* decodeForEvent(
+      ThreadCreatedPayload,
+      event.payload,
+      event.type,
+      "payload",
+    );
+    const thread: OrchestrationThread = yield* decodeForEvent(
+      OrchestrationThread,
+      {
+        id: payload.threadId,
+        projectId: payload.projectId,
+        title: payload.title,
+        modelSelection: payload.modelSelection,
+        runtimeMode: payload.runtimeMode,
+        interactionMode: payload.interactionMode,
+        branch: payload.branch,
+        worktreePath: payload.worktreePath,
+        latestTurn: null,
+        createdAt: payload.createdAt,
+        updatedAt: payload.updatedAt,
+        archivedAt: null,
+        deletedAt: null,
+        messages: [],
+        activities: [],
+        checkpoints: [],
+        session: null,
+      },
+      event.type,
+      "thread",
+    );
+    const existing = nextBase.threads.find((entry) => entry.id === thread.id);
+    return {
+      ...nextBase,
+      threads: existing
+        ? nextBase.threads.map((entry) => (entry.id === thread.id ? thread : entry))
+        : [...nextBase.threads, thread],
+    };
+  });
+
+  const projectThreadMessageSent = Effect.fn("projectEvent.threadMessageSent")(function* () {
+    const payload = yield* decodeForEvent(
+      MessageSentPayloadSchema,
+      event.payload,
+      event.type,
+      "payload",
+    );
+    const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+    if (!thread) {
+      return nextBase;
+    }
+
+    const message: OrchestrationMessage = yield* decodeForEvent(
+      OrchestrationMessage,
+      {
+        id: payload.messageId,
+        role: payload.role,
+        text: payload.text,
+        ...(payload.attachments !== undefined ? { attachments: payload.attachments } : {}),
+        turnId: payload.turnId,
+        streaming: payload.streaming,
+        createdAt: payload.createdAt,
+        updatedAt: payload.updatedAt,
+      },
+      event.type,
+      "message",
+    );
+
+    const existingMessage = thread.messages.find((entry) => entry.id === message.id);
+    const messages = existingMessage
+      ? thread.messages.map((entry) =>
+          entry.id === message.id
+            ? {
+                ...entry,
+                text: message.streaming
+                  ? `${entry.text}${message.text}`
+                  : message.text.length > 0
+                    ? message.text
+                    : entry.text,
+                streaming: message.streaming,
+                updatedAt: message.updatedAt,
+                turnId: message.turnId,
+                ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
+              }
+            : entry,
+        )
+      : [...thread.messages, message];
+    const cappedMessages = messages.slice(-MAX_THREAD_MESSAGES);
+
+    return {
+      ...nextBase,
+      threads: updateThread(nextBase.threads, payload.threadId, {
+        messages: cappedMessages,
+        updatedAt: event.occurredAt,
+      }),
+    };
+  });
+
+  const projectThreadSessionSet = Effect.fn("projectEvent.threadSessionSet")(function* () {
+    const payload = yield* decodeForEvent(
+      ThreadSessionSetPayload,
+      event.payload,
+      event.type,
+      "payload",
+    );
+    const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+    if (!thread) {
+      return nextBase;
+    }
+
+    const session: OrchestrationSession = yield* decodeForEvent(
+      OrchestrationSession,
+      payload.session,
+      event.type,
+      "session",
+    );
+
+    return {
+      ...nextBase,
+      threads: updateThread(nextBase.threads, payload.threadId, {
+        session,
+        latestTurn:
+          session.status === "running" && session.activeTurnId !== null
+            ? {
+                turnId: session.activeTurnId,
+                state: "running",
+                requestedAt:
+                  thread.latestTurn?.turnId === session.activeTurnId
+                    ? thread.latestTurn.requestedAt
+                    : session.updatedAt,
+                startedAt:
+                  thread.latestTurn?.turnId === session.activeTurnId
+                    ? (thread.latestTurn.startedAt ?? session.updatedAt)
+                    : session.updatedAt,
+                completedAt: null,
+                assistantMessageId:
+                  thread.latestTurn?.turnId === session.activeTurnId
+                    ? thread.latestTurn.assistantMessageId
+                    : null,
+              }
+            : thread.latestTurn,
+        updatedAt: event.occurredAt,
+      }),
+    };
+  });
+
+  const projectThreadProposedPlanUpserted = Effect.fn("projectEvent.threadProposedPlanUpserted")(
+    function* () {
+      const payload = yield* decodeForEvent(
+        ThreadProposedPlanUpsertedPayload,
+        event.payload,
+        event.type,
+        "payload",
+      );
+      const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+      if (!thread) {
+        return nextBase;
+      }
+
+      const proposedPlans = [
+        ...thread.proposedPlans.filter((entry) => entry.id !== payload.proposedPlan.id),
+        payload.proposedPlan,
+      ]
+        .toSorted(
+          (left, right) =>
+            left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
+        )
+        .slice(-200);
+
+      return {
+        ...nextBase,
+        threads: updateThread(nextBase.threads, payload.threadId, {
+          proposedPlans,
+          updatedAt: event.occurredAt,
+        }),
+      };
+    },
+  );
+
+  const projectThreadTurnDiffCompleted = Effect.fn("projectEvent.threadTurnDiffCompleted")(
+    function* () {
+      const payload = yield* decodeForEvent(
+        ThreadTurnDiffCompletedPayload,
+        event.payload,
+        event.type,
+        "payload",
+      );
+      const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+      if (!thread) {
+        return nextBase;
+      }
+
+      const checkpoint = yield* decodeForEvent(
+        OrchestrationCheckpointSummary,
+        {
+          turnId: payload.turnId,
+          checkpointTurnCount: payload.checkpointTurnCount,
+          checkpointRef: payload.checkpointRef,
+          status: payload.status,
+          files: payload.files,
+          assistantMessageId: payload.assistantMessageId,
+          completedAt: payload.completedAt,
+        },
+        event.type,
+        "checkpoint",
+      );
+
+      const existing = thread.checkpoints.find((entry) => entry.turnId === checkpoint.turnId);
+      if (existing && existing.status !== "missing" && checkpoint.status === "missing") {
+        return nextBase;
+      }
+
+      const checkpoints = [
+        ...thread.checkpoints.filter((entry) => entry.turnId !== checkpoint.turnId),
+        checkpoint,
+      ]
+        .toSorted((left, right) => left.checkpointTurnCount - right.checkpointTurnCount)
+        .slice(-MAX_THREAD_CHECKPOINTS);
+
+      return {
+        ...nextBase,
+        threads: updateThread(nextBase.threads, payload.threadId, {
+          checkpoints,
+          latestTurn: {
+            turnId: payload.turnId,
+            state: checkpointStatusToLatestTurnState(payload.status),
+            requestedAt:
+              thread.latestTurn?.turnId === payload.turnId
+                ? thread.latestTurn.requestedAt
+                : payload.completedAt,
+            startedAt:
+              thread.latestTurn?.turnId === payload.turnId
+                ? (thread.latestTurn.startedAt ?? payload.completedAt)
+                : payload.completedAt,
+            completedAt: payload.completedAt,
+            assistantMessageId: payload.assistantMessageId,
+          },
+          updatedAt: event.occurredAt,
+        }),
+      };
+    },
+  );
+
   switch (event.type) {
     case "project.created":
       return decodeForEvent(ProjectCreatedPayload, event.payload, event.type, "payload").pipe(
@@ -241,45 +484,7 @@ export function projectEvent(
       );
 
     case "thread.created":
-      return Effect.gen(function* () {
-        const payload = yield* decodeForEvent(
-          ThreadCreatedPayload,
-          event.payload,
-          event.type,
-          "payload",
-        );
-        const thread: OrchestrationThread = yield* decodeForEvent(
-          OrchestrationThread,
-          {
-            id: payload.threadId,
-            projectId: payload.projectId,
-            title: payload.title,
-            modelSelection: payload.modelSelection,
-            runtimeMode: payload.runtimeMode,
-            interactionMode: payload.interactionMode,
-            branch: payload.branch,
-            worktreePath: payload.worktreePath,
-            latestTurn: null,
-            createdAt: payload.createdAt,
-            updatedAt: payload.updatedAt,
-            archivedAt: null,
-            deletedAt: null,
-            messages: [],
-            activities: [],
-            checkpoints: [],
-            session: null,
-          },
-          event.type,
-          "thread",
-        );
-        const existing = nextBase.threads.find((entry) => entry.id === thread.id);
-        return {
-          ...nextBase,
-          threads: existing
-            ? nextBase.threads.map((entry) => (entry.id === thread.id ? thread : entry))
-            : [...nextBase.threads, thread],
-        };
-      });
+      return projectThreadCreated();
 
     case "thread.deleted":
       return decodeForEvent(ThreadDeletedPayload, event.payload, event.type, "payload").pipe(
@@ -358,214 +563,16 @@ export function projectEvent(
       );
 
     case "thread.message-sent":
-      return Effect.gen(function* () {
-        const payload = yield* decodeForEvent(
-          MessageSentPayloadSchema,
-          event.payload,
-          event.type,
-          "payload",
-        );
-        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
-        if (!thread) {
-          return nextBase;
-        }
-
-        const message: OrchestrationMessage = yield* decodeForEvent(
-          OrchestrationMessage,
-          {
-            id: payload.messageId,
-            role: payload.role,
-            text: payload.text,
-            ...(payload.attachments !== undefined ? { attachments: payload.attachments } : {}),
-            turnId: payload.turnId,
-            streaming: payload.streaming,
-            createdAt: payload.createdAt,
-            updatedAt: payload.updatedAt,
-          },
-          event.type,
-          "message",
-        );
-
-        const existingMessage = thread.messages.find((entry) => entry.id === message.id);
-        const messages = existingMessage
-          ? thread.messages.map((entry) =>
-              entry.id === message.id
-                ? {
-                    ...entry,
-                    text: message.streaming
-                      ? `${entry.text}${message.text}`
-                      : message.text.length > 0
-                        ? message.text
-                        : entry.text,
-                    streaming: message.streaming,
-                    updatedAt: message.updatedAt,
-                    turnId: message.turnId,
-                    ...(message.attachments !== undefined
-                      ? { attachments: message.attachments }
-                      : {}),
-                  }
-                : entry,
-            )
-          : [...thread.messages, message];
-        const cappedMessages = messages.slice(-MAX_THREAD_MESSAGES);
-
-        return {
-          ...nextBase,
-          threads: updateThread(nextBase.threads, payload.threadId, {
-            messages: cappedMessages,
-            updatedAt: event.occurredAt,
-          }),
-        };
-      });
+      return projectThreadMessageSent();
 
     case "thread.session-set":
-      return Effect.gen(function* () {
-        const payload = yield* decodeForEvent(
-          ThreadSessionSetPayload,
-          event.payload,
-          event.type,
-          "payload",
-        );
-        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
-        if (!thread) {
-          return nextBase;
-        }
-
-        const session: OrchestrationSession = yield* decodeForEvent(
-          OrchestrationSession,
-          payload.session,
-          event.type,
-          "session",
-        );
-
-        return {
-          ...nextBase,
-          threads: updateThread(nextBase.threads, payload.threadId, {
-            session,
-            latestTurn:
-              session.status === "running" && session.activeTurnId !== null
-                ? {
-                    turnId: session.activeTurnId,
-                    state: "running",
-                    requestedAt:
-                      thread.latestTurn?.turnId === session.activeTurnId
-                        ? thread.latestTurn.requestedAt
-                        : session.updatedAt,
-                    startedAt:
-                      thread.latestTurn?.turnId === session.activeTurnId
-                        ? (thread.latestTurn.startedAt ?? session.updatedAt)
-                        : session.updatedAt,
-                    completedAt: null,
-                    assistantMessageId:
-                      thread.latestTurn?.turnId === session.activeTurnId
-                        ? thread.latestTurn.assistantMessageId
-                        : null,
-                  }
-                : thread.latestTurn,
-            updatedAt: event.occurredAt,
-          }),
-        };
-      });
+      return projectThreadSessionSet();
 
     case "thread.proposed-plan-upserted":
-      return Effect.gen(function* () {
-        const payload = yield* decodeForEvent(
-          ThreadProposedPlanUpsertedPayload,
-          event.payload,
-          event.type,
-          "payload",
-        );
-        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
-        if (!thread) {
-          return nextBase;
-        }
-
-        const proposedPlans = [
-          ...thread.proposedPlans.filter((entry) => entry.id !== payload.proposedPlan.id),
-          payload.proposedPlan,
-        ]
-          .toSorted(
-            (left, right) =>
-              left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id),
-          )
-          .slice(-200);
-
-        return {
-          ...nextBase,
-          threads: updateThread(nextBase.threads, payload.threadId, {
-            proposedPlans,
-            updatedAt: event.occurredAt,
-          }),
-        };
-      });
+      return projectThreadProposedPlanUpserted();
 
     case "thread.turn-diff-completed":
-      return Effect.gen(function* () {
-        const payload = yield* decodeForEvent(
-          ThreadTurnDiffCompletedPayload,
-          event.payload,
-          event.type,
-          "payload",
-        );
-        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
-        if (!thread) {
-          return nextBase;
-        }
-
-        const checkpoint = yield* decodeForEvent(
-          OrchestrationCheckpointSummary,
-          {
-            turnId: payload.turnId,
-            checkpointTurnCount: payload.checkpointTurnCount,
-            checkpointRef: payload.checkpointRef,
-            status: payload.status,
-            files: payload.files,
-            assistantMessageId: payload.assistantMessageId,
-            completedAt: payload.completedAt,
-          },
-          event.type,
-          "checkpoint",
-        );
-
-        // Do not let a placeholder (status "missing") overwrite a checkpoint
-        // that has already been captured with a real git ref (status "ready").
-        // ProviderRuntimeIngestion may fire multiple turn.diff.updated events
-        // per turn; without this guard later placeholders would clobber the
-        // real capture dispatched by CheckpointReactor.
-        const existing = thread.checkpoints.find((entry) => entry.turnId === checkpoint.turnId);
-        if (existing && existing.status !== "missing" && checkpoint.status === "missing") {
-          return nextBase;
-        }
-
-        const checkpoints = [
-          ...thread.checkpoints.filter((entry) => entry.turnId !== checkpoint.turnId),
-          checkpoint,
-        ]
-          .toSorted((left, right) => left.checkpointTurnCount - right.checkpointTurnCount)
-          .slice(-MAX_THREAD_CHECKPOINTS);
-
-        return {
-          ...nextBase,
-          threads: updateThread(nextBase.threads, payload.threadId, {
-            checkpoints,
-            latestTurn: {
-              turnId: payload.turnId,
-              state: checkpointStatusToLatestTurnState(payload.status),
-              requestedAt:
-                thread.latestTurn?.turnId === payload.turnId
-                  ? thread.latestTurn.requestedAt
-                  : payload.completedAt,
-              startedAt:
-                thread.latestTurn?.turnId === payload.turnId
-                  ? (thread.latestTurn.startedAt ?? payload.completedAt)
-                  : payload.completedAt,
-              completedAt: payload.completedAt,
-              assistantMessageId: payload.assistantMessageId,
-            },
-            updatedAt: event.occurredAt,
-          }),
-        };
-      });
+      return projectThreadTurnDiffCompleted();
 
     case "thread.reverted":
       return decodeForEvent(ThreadRevertedPayload, event.payload, event.type, "payload").pipe(


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/orchestration/projector.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `projectEvent` switch-case bodies to `Effect.fn` helpers in projector
> Extracts each case body in the `projectEvent` switch statement in [projector.ts](https://github.com/pingdotgg/t3code/pull/1630/files#diff-3da4865ecd7a117ebdca42c25e9526bc69b87696dc8209029ecb2809f8e6a937) into a dedicated `Effect.fn` helper (`projectThreadCreated`, `projectThreadMessageSent`, `projectThreadSessionSet`, `projectThreadProposedPlanUpserted`, `projectThreadTurnDiffCompleted`). The switch cases now delegate to these helpers. Logic is unchanged; only an inline comment in the `thread.turn-diff-completed` case was removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e4c80c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that restructures `projectEvent` by extracting several thread-related switch cases into `Effect.fn` helpers; behavior should remain the same aside from comment removal.
> 
> **Overview**
> Refactors `apps/server/src/orchestration/projector.ts` by extracting the `thread.created`, `thread.message-sent`, `thread.session-set`, `thread.proposed-plan-upserted`, and `thread.turn-diff-completed` switch-case bodies into dedicated `Effect.fn` helpers and delegating to them.
> 
> No functional changes are intended; the only semantic diff is removing an inline explanatory comment in the `thread.turn-diff-completed` handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e4c80c55bd6f21cc1823fdd6aa2d965ce1643c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->