### PR TITLE
[codex] migrate Effect.fn in apps/server/src/provider/Layers/EventNdjsonLogger.ts

### DIFF
--- a/apps/server/src/provider/Layers/EventNdjsonLogger.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.ts
@@ -168,90 +168,86 @@ const makeThreadWriter = Effect.fn("makeThreadWriter")(function* (input: {
   } satisfies ThreadWriter;
 });
 
-export function makeEventNdjsonLogger(
+export const makeEventNdjsonLogger = Effect.fn("makeEventNdjsonLogger")(function* (
   filePath: string,
   options: EventNdjsonLoggerOptions,
-): Effect.Effect<EventNdjsonLogger | undefined> {
-  return Effect.fn("makeEventNdjsonLogger")(function* (): Effect.fn.Return<
-    EventNdjsonLogger | undefined
-  > {
-    const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
-    const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
-    const batchWindowMs = options.batchWindowMs ?? DEFAULT_BATCH_WINDOW_MS;
-    const streamLabel = resolveStreamLabel(options.stream);
+): Effect.fn.Return<EventNdjsonLogger | undefined> {
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
+  const batchWindowMs = options.batchWindowMs ?? DEFAULT_BATCH_WINDOW_MS;
+  const streamLabel = resolveStreamLabel(options.stream);
 
-    const directoryReady = yield* Effect.sync(() => {
-      try {
-        fs.mkdirSync(path.dirname(filePath), { recursive: true });
-        return true;
-      } catch (error) {
-        return { ok: false as const, error };
-      }
+  const directoryReady = yield* Effect.sync(() => {
+    try {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      return true;
+    } catch (error) {
+      return { ok: false as const, error };
+    }
+  });
+  if (directoryReady !== true) {
+    yield* logWarning("failed to create provider event log directory", {
+      filePath,
+      error: directoryReady.error,
     });
-    if (directoryReady !== true) {
-      yield* logWarning("failed to create provider event log directory", {
-        filePath,
-        error: directoryReady.error,
-      });
+    return undefined;
+  }
+
+  const threadWriters = new Map<string, ThreadWriter>();
+  const failedSegments = new Set<string>();
+
+  const resolveThreadWriter = Effect.fn("resolveThreadWriter")(function* (
+    threadSegment: string,
+  ): Effect.fn.Return<ThreadWriter | undefined> {
+    if (failedSegments.has(threadSegment)) {
+      return undefined;
+    }
+    const existing = threadWriters.get(threadSegment);
+    if (existing) {
+      return existing;
+    }
+
+    const writer = yield* makeThreadWriter({
+      filePath: path.join(path.dirname(filePath), `${threadSegment}.log`),
+      maxBytes,
+      maxFiles,
+      batchWindowMs,
+      streamLabel,
+    });
+    if (!writer) {
+      failedSegments.add(threadSegment);
       return undefined;
     }
 
-    const threadWriters = new Map<string, ThreadWriter>();
-    const failedSegments = new Set<string>();
+    threadWriters.set(threadSegment, writer);
+    return writer;
+  });
 
-    const resolveThreadWriter = Effect.fn("resolveThreadWriter")(function* (
-      threadSegment: string,
-    ): Effect.fn.Return<ThreadWriter | undefined> {
-      if (failedSegments.has(threadSegment)) {
-        return undefined;
-      }
-      const existing = threadWriters.get(threadSegment);
-      if (existing) {
-        return existing;
-      }
+  const write = Effect.fn("write")(function* (event: unknown, threadId: ThreadId | null) {
+    const threadSegment = resolveThreadSegment(threadId);
+    const message = yield* toLogMessage(event);
+    if (!message) {
+      return;
+    }
 
-      const writer = yield* makeThreadWriter({
-        filePath: path.join(path.dirname(filePath), `${threadSegment}.log`),
-        maxBytes,
-        maxFiles,
-        batchWindowMs,
-        streamLabel,
-      });
-      if (!writer) {
-        failedSegments.add(threadSegment);
-        return undefined;
-      }
+    const writer = yield* resolveThreadWriter(threadSegment);
+    if (!writer) {
+      return;
+    }
 
-      threadWriters.set(threadSegment, writer);
-      return writer;
-    });
+    yield* writer.writeMessage(message);
+  });
 
-    const write = Effect.fn("write")(function* (event: unknown, threadId: ThreadId | null) {
-      const threadSegment = resolveThreadSegment(threadId);
-      const message = yield* toLogMessage(event);
-      if (!message) {
-        return;
-      }
+  const close = Effect.fn("close")(function* () {
+    for (const writer of threadWriters.values()) {
+      yield* writer.close();
+    }
+    threadWriters.clear();
+  });
 
-      const writer = yield* resolveThreadWriter(threadSegment);
-      if (!writer) {
-        return;
-      }
-
-      yield* writer.writeMessage(message);
-    });
-
-    const close = Effect.fn("close")(function* () {
-      for (const writer of threadWriters.values()) {
-        yield* writer.close();
-      }
-      threadWriters.clear();
-    });
-
-    return {
-      filePath,
-      write,
-      close,
-    } satisfies EventNdjsonLogger;
-  })();
-}
+  return {
+    filePath,
+    write,
+    close,
+  } satisfies EventNdjsonLogger;
+});


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/provider/Layers/EventNdjsonLogger.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `Effect.fn` usage in `EventNdjsonLogger` to named function declarations
> Refactors [EventNdjsonLogger.ts](https://github.com/pingdotgg/t3code/pull/1636/files#diff-9e7861bc2eacfd2573bb80a1ee8844469e360556c2d989224c7af3771489937f) to use the `Effect.fn("name")(function* ...)` pattern for all generator-based effects. All functions (`toLogMessage`, `makeThreadWriter`, `makeEventNdjsonLogger`, and their nested helpers) are converted to named `Effect.fn` declarations. Internal logic and runtime behavior are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55e68ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `EventNdjsonLogger.ts`, primarily changing Effect function construction/naming without altering IO, batching, or error-handling logic.
> 
> **Overview**
> **Refactors provider NDJSON event logging to the `Effect.fn` style.** All previously anonymous `Effect.gen` wrappers in `EventNdjsonLogger.ts` (including the batch `flush`, writer resolution, `write`, and `close` paths) are replaced with named `Effect.fn(...)` equivalents, keeping the same best-effort logging behavior and warning-on-failure semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55e68ca415f4003702c85cf0949cc635676c35a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->