### PR TITLE
[codex] migrate Effect.fn in apps/server/src/provider/Layers/ProviderAdapterRegistry.ts

### DIFF
--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -22,30 +22,31 @@ export interface ProviderAdapterRegistryLiveOptions {
   readonly adapters?: ReadonlyArray<ProviderAdapterShape<ProviderAdapterError>>;
 }
 
-const makeProviderAdapterRegistry = (options?: ProviderAdapterRegistryLiveOptions) =>
-  Effect.gen(function* () {
-    const adapters =
-      options?.adapters !== undefined
-        ? options.adapters
-        : [yield* CodexAdapter, yield* ClaudeAdapter];
-    const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));
+const makeProviderAdapterRegistry = Effect.fn("makeProviderAdapterRegistry")(function* (
+  options?: ProviderAdapterRegistryLiveOptions,
+) {
+  const adapters =
+    options?.adapters !== undefined
+      ? options.adapters
+      : [yield* CodexAdapter, yield* ClaudeAdapter];
+  const byProvider = new Map(adapters.map((adapter) => [adapter.provider, adapter]));
 
-    const getByProvider: ProviderAdapterRegistryShape["getByProvider"] = (provider) => {
-      const adapter = byProvider.get(provider);
-      if (!adapter) {
-        return Effect.fail(new ProviderUnsupportedError({ provider }));
-      }
-      return Effect.succeed(adapter);
-    };
+  const getByProvider: ProviderAdapterRegistryShape["getByProvider"] = (provider) => {
+    const adapter = byProvider.get(provider);
+    if (!adapter) {
+      return Effect.fail(new ProviderUnsupportedError({ provider }));
+    }
+    return Effect.succeed(adapter);
+  };
 
-    const listProviders: ProviderAdapterRegistryShape["listProviders"] = () =>
-      Effect.sync(() => Array.from(byProvider.keys()));
+  const listProviders: ProviderAdapterRegistryShape["listProviders"] = () =>
+    Effect.sync(() => Array.from(byProvider.keys()));
 
-    return {
-      getByProvider,
-      listProviders,
-    } satisfies ProviderAdapterRegistryShape;
-  });
+  return {
+    getByProvider,
+    listProviders,
+  } satisfies ProviderAdapterRegistryShape;
+});
 
 export const ProviderAdapterRegistryLive = Layer.effect(
   ProviderAdapterRegistry,


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/provider/Layers/ProviderAdapterRegistry.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `makeProviderAdapterRegistry` to use `Effect.fn` in `ProviderAdapterRegistry`
> Rewrites the `makeProviderAdapterRegistry` factory in [ProviderAdapterRegistry.ts](https://github.com/pingdotgg/t3code/pull/1637/files#diff-b879067a9bc43e4209d2eacb2653e32a91ae11adf8f998201edd56119eba06e9) to use `Effect.fn("makeProviderAdapterRegistry")` instead of a plain arrow function returning `Effect.gen`. The internal logic is unchanged; the migration gives the effect a named constructor for better traceability.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd44226.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how the effect is constructed/named; adapter selection and provider lookup logic remain the same.
> 
> **Overview**
> Refactors `apps/server/src/provider/Layers/ProviderAdapterRegistry.ts` to construct `makeProviderAdapterRegistry` via `Effect.fn("makeProviderAdapterRegistry")` instead of an arrow function returning `Effect.gen`.
> 
> No functional behavior changes: it still builds the adapter map, fails with `ProviderUnsupportedError` for unknown providers, and exposes the same `getByProvider`/`listProviders` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd44226a44e6eb6ae5f5f0a20458dc5740cdd26a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->