### PR TITLE
[codex] migrate Effect.fn in apps/server/src/provider/makeManagedServerProvider.ts

### DIFF
--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -5,74 +5,70 @@ import * as Semaphore from "effect/Semaphore";
 import type { ServerProviderShape } from "./Services/ServerProvider";
 import { ServerSettingsError } from "@t3tools/contracts";
 
-export function makeManagedServerProvider<Settings>(input: {
+export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(function* <
+  Settings,
+>(input: {
   readonly getSettings: Effect.Effect<Settings>;
   readonly streamSettings: Stream.Stream<Settings>;
   readonly haveSettingsChanged: (previous: Settings, next: Settings) => boolean;
   readonly checkProvider: Effect.Effect<ServerProvider, ServerSettingsError>;
   readonly refreshInterval?: Duration.Input;
-}): Effect.Effect<ServerProviderShape, ServerSettingsError, Scope.Scope> {
-  return Effect.fn("makeManagedServerProvider")(function* (): Effect.fn.Return<
-    ServerProviderShape,
-    ServerSettingsError,
-    Scope.Scope
-  > {
-    const refreshSemaphore = yield* Semaphore.make(1);
-    const changesPubSub = yield* Effect.acquireRelease(
-      PubSub.unbounded<ServerProvider>(),
-      PubSub.shutdown,
-    );
-    const initialSettings = yield* input.getSettings;
-    const initialSnapshot = yield* input.checkProvider;
-    const snapshotRef = yield* Ref.make(initialSnapshot);
-    const settingsRef = yield* Ref.make(initialSettings);
+}): Effect.fn.Return<ServerProviderShape, ServerSettingsError, Scope.Scope> {
+  const refreshSemaphore = yield* Semaphore.make(1);
+  const changesPubSub = yield* Effect.acquireRelease(
+    PubSub.unbounded<ServerProvider>(),
+    PubSub.shutdown,
+  );
+  const initialSettings = yield* input.getSettings;
+  const initialSnapshot = yield* input.checkProvider;
+  const snapshotRef = yield* Ref.make(initialSnapshot);
+  const settingsRef = yield* Ref.make(initialSettings);
 
-    const applySnapshotBase = Effect.fn("applySnapshot")(function* (
-      nextSettings: Settings,
-      options?: { readonly forceRefresh?: boolean },
-    ) {
-      const forceRefresh = options?.forceRefresh === true;
-      const previousSettings = yield* Ref.get(settingsRef);
-      if (!forceRefresh && !input.haveSettingsChanged(previousSettings, nextSettings)) {
-        yield* Ref.set(settingsRef, nextSettings);
-        return yield* Ref.get(snapshotRef);
-      }
-
-      const nextSnapshot = yield* input.checkProvider;
+  const applySnapshotBase = Effect.fn("applySnapshot")(function* (
+    nextSettings: Settings,
+    options?: { readonly forceRefresh?: boolean },
+  ) {
+    const forceRefresh = options?.forceRefresh === true;
+    const previousSettings = yield* Ref.get(settingsRef);
+    if (!forceRefresh && !input.haveSettingsChanged(previousSettings, nextSettings)) {
       yield* Ref.set(settingsRef, nextSettings);
-      yield* Ref.set(snapshotRef, nextSnapshot);
-      yield* PubSub.publish(changesPubSub, nextSnapshot);
-      return nextSnapshot;
-    });
-    const applySnapshot = (nextSettings: Settings, options?: { readonly forceRefresh?: boolean }) =>
-      refreshSemaphore.withPermits(1)(applySnapshotBase(nextSettings, options));
+      return yield* Ref.get(snapshotRef);
+    }
 
-    const refreshSnapshot = Effect.fn("refreshSnapshot")(function* () {
-      const nextSettings = yield* input.getSettings;
-      return yield* applySnapshot(nextSettings, { forceRefresh: true });
-    });
+    const nextSnapshot = yield* input.checkProvider;
+    yield* Ref.set(settingsRef, nextSettings);
+    yield* Ref.set(snapshotRef, nextSnapshot);
+    yield* PubSub.publish(changesPubSub, nextSnapshot);
+    return nextSnapshot;
+  });
+  const applySnapshot = (nextSettings: Settings, options?: { readonly forceRefresh?: boolean }) =>
+    refreshSemaphore.withPermits(1)(applySnapshotBase(nextSettings, options));
 
-    yield* Stream.runForEach(input.streamSettings, (nextSettings) =>
-      Effect.asVoid(applySnapshot(nextSettings)),
-    ).pipe(Effect.forkScoped);
+  const refreshSnapshot = Effect.fn("refreshSnapshot")(function* () {
+    const nextSettings = yield* input.getSettings;
+    return yield* applySnapshot(nextSettings, { forceRefresh: true });
+  });
 
-    yield* Effect.forever(
-      Effect.sleep(input.refreshInterval ?? "60 seconds").pipe(
-        Effect.flatMap(() => refreshSnapshot()),
-        Effect.ignoreCause({ log: true }),
-      ),
-    ).pipe(Effect.forkScoped);
+  yield* Stream.runForEach(input.streamSettings, (nextSettings) =>
+    Effect.asVoid(applySnapshot(nextSettings)),
+  ).pipe(Effect.forkScoped);
 
-    return {
-      getSnapshot: input.getSettings.pipe(
-        Effect.flatMap(applySnapshot),
-        Effect.tapError(Effect.logError),
-        Effect.orDie,
-      ),
-      refresh: refreshSnapshot().pipe(Effect.tapError(Effect.logError), Effect.orDie),
-      get streamChanges() {
-        return Stream.fromPubSub(changesPubSub);
-      },
-    } satisfies ServerProviderShape;
-  })();
-}
+  yield* Effect.forever(
+    Effect.sleep(input.refreshInterval ?? "60 seconds").pipe(
+      Effect.flatMap(() => refreshSnapshot()),
+      Effect.ignoreCause({ log: true }),
+    ),
+  ).pipe(Effect.forkScoped);
+
+  return {
+    getSnapshot: input.getSettings.pipe(
+      Effect.flatMap(applySnapshot),
+      Effect.tapError(Effect.logError),
+      Effect.orDie,
+    ),
+    refresh: refreshSnapshot().pipe(Effect.tapError(Effect.logError), Effect.orDie),
+    get streamChanges() {
+      return Stream.fromPubSub(changesPubSub);
+    },
+  } satisfies ServerProviderShape;
+});


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/provider/makeManagedServerProvider.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `makeManagedServerProvider` to use `Effect.fn`-based generator functions
> Refactors [makeManagedServerProvider.ts](https://github.com/pingdotgg/t3code/pull/1640/files#diff-6f779d2b7ee5062a8780fdef16d4d469dcfffa7b337df11293d941eddcf0440e) to use the `Effect.fn` naming and direct generator style throughout.
>
> - Converts the main exported factory and the snapshot application logic to named `Effect.fn` generators.
> - Extracts `applySnapshotBase` as a named `Effect.fn` and wraps it in `applySnapshot`, which handles semaphore acquisition separately.
> - Refactors the `refreshSnapshot` value into a callable `Effect.fn` generator; all call sites updated to invoke it as `refreshSnapshot()`.
> - Inlines previously nested `Effect.gen` initialization directly into the generator body.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55d88a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor focused on Effect wrapper/naming changes; main behavior risk is around `refreshSnapshot` now being invoked as a function, which could affect scheduling if any call site was missed.
> 
> **Overview**
> Refactors `makeManagedServerProvider` to wrap the top-level implementation in `Effect.fn("makeManagedServerProvider")`, and extracts the snapshot-application and refresh logic into named `Effect.fn` helpers (e.g. `applySnapshotBase`, `refreshSnapshot`) for consistent tracing/naming.
> 
> Updates periodic refresh and exposed `refresh` behavior to call `refreshSnapshot()` (now a function returning an Effect) rather than treating it as an Effect value, while keeping the same semaphore-guarded snapshot update and PubSub publish flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55d88a65d94ffe75f1e8a17bc14dad580533ce82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->