### PR TITLE
[codex] migrate Effect.fn in apps/server/src/telemetry/Identify.ts

### DIFF
--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -60,11 +60,11 @@ const upsertAnonymousId = Effect.gen(function* () {
 
   const anonymousId = yield* fileSystem.readFileString(anonymousIdPath).pipe(
     Effect.catch(() =>
-      Effect.gen(function* () {
+      Effect.fn("upsertAnonymousId.createAnonymousId")(function* () {
         const randomId = yield* Random.nextUUIDv4;
         yield* fileSystem.writeFileString(anonymousIdPath, randomId);
         return randomId;
-      }),
+      })(),
     ),
   );
 


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/telemetry/Identify.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `upsertAnonymousId` inline `Effect.gen` to named `Effect.fn` in Identify.ts
> Replaces the inline `Effect.gen` call in the `Effect.catch` fallback of `upsertAnonymousId` in [Identify.ts](https://github.com/pingdotgg/t3code/pull/1641/files#diff-a50c9348071512e0bea296dca3a49a3f8fe4e903cf32378d3d94c5341161b174) with a named effect via `Effect.fn("upsertAnonymousId.createAnonymousId")`. The generator body and its behavior are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8aa8f98.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to telemetry identifier generation; behavior should remain the same aside from improved effect naming/traceability.
> 
> **Overview**
> Updates `apps/server/src/telemetry/Identify.ts` to replace the inline `Effect.gen` used in the `Effect.catch` fallback of `upsertAnonymousId` with a named `Effect.fn("upsertAnonymousId.createAnonymousId")`.
> 
> No functional logic changes are intended; this is a small migration to the preferred Effect wrapper style for the anonymous ID creation path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8aa8f981c5923998dfb67357d2ba27c8bd175bc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->