### PR TITLE
[codex] migrate Effect.fn in apps/server/src/telemetry/Layers/AnalyticsService.ts

### DIFF
--- a/apps/server/src/telemetry/Layers/AnalyticsService.ts
+++ b/apps/server/src/telemetry/Layers/AnalyticsService.ts
@@ -70,34 +70,35 @@ const makeAnalyticsService = Effect.gen(function* () {
       }),
     );
 
-  const sendBatch = (events: ReadonlyArray<BufferedAnalyticsEvent>) =>
-    Effect.gen(function* () {
-      if (!telemetryConfig.enabled || !identifier) return;
+  const sendBatch = Effect.fn("sendBatch")(function* (
+    events: ReadonlyArray<BufferedAnalyticsEvent>,
+  ) {
+    if (!telemetryConfig.enabled || !identifier) return;
 
-      const payload = {
-        api_key: telemetryConfig.posthogKey,
-        batch: events.map((event) => ({
-          event: event.event,
-          distinct_id: identifier,
-          properties: {
-            ...event.properties,
-            $process_person_profile: false,
-            platform: process.platform,
-            wsl: process.env.WSL_DISTRO_NAME,
-            arch: process.arch,
-            t3CodeVersion: version,
-            clientType,
-          },
-          timestamp: event.capturedAt,
-        })),
-      };
+    const payload = {
+      api_key: telemetryConfig.posthogKey,
+      batch: events.map((event) => ({
+        event: event.event,
+        distinct_id: identifier,
+        properties: {
+          ...event.properties,
+          $process_person_profile: false,
+          platform: process.platform,
+          wsl: process.env.WSL_DISTRO_NAME,
+          arch: process.arch,
+          t3CodeVersion: version,
+          clientType,
+        },
+        timestamp: event.capturedAt,
+      })),
+    };
 
-      yield* HttpClientRequest.post(`${telemetryConfig.posthogHost}/batch/`).pipe(
-        HttpClientRequest.bodyJson(payload),
-        Effect.flatMap(httpClient.execute),
-        Effect.flatMap(HttpClientResponse.filterStatusOk),
-      );
-    });
+    yield* HttpClientRequest.post(`${telemetryConfig.posthogHost}/batch/`).pipe(
+      HttpClientRequest.bodyJson(payload),
+      Effect.flatMap(httpClient.execute),
+      Effect.flatMap(HttpClientResponse.filterStatusOk),
+    );
+  });
 
   const flush: AnalyticsServiceShape["flush"] = Effect.gen(function* () {
     while (true) {


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/telemetry/Layers/AnalyticsService.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `sendBatch` in `AnalyticsService` to `Effect.fn` style
> Rewrites the `sendBatch` helper in [AnalyticsService.ts](https://github.com/pingdotgg/t3code/pull/1642/files#diff-160d0b6c89e522c818baa7f2970b03b123e43fbf79fa8139ac1a58028f66259c) from a plain function returning `Effect.gen(...)` to the named `Effect.fn("sendBatch")(function* ...)` form. Internal logic for constructing the payload and posting to `/batch/` is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b7e838.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to telemetry batching; logic and payload construction are unchanged, with only the Effect wrapper style modified.
> 
> **Overview**
> Refactors `AnalyticsService`’s `sendBatch` helper from a `() => Effect.gen(...)` wrapper to a named `Effect.fn("sendBatch")` generator.
> 
> The PostHog batch payload composition and `/batch/` request/response handling remain the same; this is purely a migration to the preferred Effect API style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b7e838188671ae1b2d0ddc02773b4fe6105f3c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->