### PR TITLE
[codex] migrate Effect.fn in apps/server/src/terminal/Layers/Manager.ts

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -1516,7 +1516,7 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
     ).pipe(Effect.forkIn(workerScope));
 
     yield* Effect.addFinalizer(() =>
-      Effect.gen(function* () {
+      Effect.fn("terminal.cleanupAllSessions")(function* () {
         const sessions = yield* modifyManagerState(
           (state) =>
             [
@@ -1541,7 +1541,7 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
           concurrency: "unbounded",
           discard: true,
         });
-      }).pipe(Effect.ignoreCause({ log: true })),
+      })().pipe(Effect.ignoreCause({ log: true })),
     );
 
     const open: TerminalManagerShape["open"] = (input) =>


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `apps/server/src/terminal/Layers/Manager.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate inline `Effect.gen` to named `Effect.fn` in terminal manager cleanup
> Replaces the anonymous `Effect.gen` in the finalizer of `makeTerminalManagerWithOptions` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/1643/files#diff-51f9668a4493e7cf6ec7c836a4af9946110091ee50cd822c9c4a4d5bdcedf496) with a named `Effect.fn("terminal.cleanupAllSessions")` call. This gives the cleanup routine a traceable name in Effect's runtime tooling while preserving identical cleanup logic and `ignoreCause` piping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 447642d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->