### PR TITLE
[codex] migrate Effect.fn in packages/shared/src/DrainableWorker.ts

### DIFF
--- a/packages/shared/src/DrainableWorker.ts
+++ b/packages/shared/src/DrainableWorker.ts
@@ -38,7 +38,11 @@ export interface DrainableWorker<A> {
 export const makeDrainableWorker = <A, E, R>(
   process: (item: A) => Effect.Effect<void, E, R>,
 ): Effect.Effect<DrainableWorker<A>, never, Scope.Scope | R> =>
-  Effect.gen(function* () {
+  Effect.fn("makeDrainableWorker")(function* (): Effect.fn.Return<
+    DrainableWorker<A>,
+    never,
+    Scope.Scope | R
+  > {
     const queue = yield* Effect.acquireRelease(TxQueue.unbounded<A>(), TxQueue.shutdown);
     const outstanding = yield* TxRef.make(0);
 
@@ -65,4 +69,4 @@ export const makeDrainableWorker = <A, E, R>(
       );
 
     return { enqueue, drain } satisfies DrainableWorker<A>;
-  });
+  })();


### PR DESCRIPTION
## Summary
- migrate the remaining `() => Effect.gen(...)` wrapper in `packages/shared/src/DrainableWorker.ts` to `Effect.fn`
- keep this PR scoped to a single file as part of the checklist split

## Why
- finish the remaining checklist migrations without batching multiple files into one review
- keep exact-empty-arg `Effect.gen` wrappers out of the codebase

## Validation
- `bun fmt`
- `bun lint`
- `packages/shared: bun run test src/DrainableWorker.test.ts`
- `apps/server: bun run test src/provider/Layers/EventNdjsonLogger.test.ts src/provider/Layers/ProviderRegistry.test.ts src/provider/Layers/ProviderService.test.ts src/provider/Layers/ProviderAdapterRegistry.test.ts src/keybindings.test.ts src/open.test.ts`
- `apps/server: bun run test src/orchestration/projector.test.ts`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "returns deterministic read models for repeated reads"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "archives and unarchives threads through orchestration commands"`
- `apps/server: bun run test src/orchestration/Layers/OrchestrationEngine.test.ts -t "streams persisted domain events in order"`

## Notes
- validation was run from the completed checklist scratch branch before splitting these per-file PRs
- `bun run test` and `bun typecheck` at the repo root currently fail in `apps/web` because `@effect/atom-react` cannot be resolved
- `apps/server` still has unrelated pre-existing typecheck failures outside this file

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate `makeDrainableWorker` in `DrainableWorker.ts` to use `Effect.fn`
> Replaces the `Effect.gen` wrapper in `makeDrainableWorker` with `Effect.fn("makeDrainableWorker")`, adding a named trace boundary. Also adds an explicit return type annotation using `Effect.fn.Return`. Inner logic is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0852905.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->