### PR TITLE
Clarify Codex skill invocation hint in the composer

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useStore } from "../store";
 
 import {
+  buildDefaultComposerPlaceholder,
+  buildDisconnectedComposerPlaceholder,
   buildExpiredTerminalContextToastCopy,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
@@ -72,6 +74,34 @@ describe("buildExpiredTerminalContextToastCopy", () => {
       title: "Expired terminal contexts omitted from message",
       description: "Re-add it if you want that terminal output included.",
     });
+  });
+});
+
+describe("buildDefaultComposerPlaceholder", () => {
+  it("mentions skills for Codex threads", () => {
+    expect(buildDefaultComposerPlaceholder("codex")).toBe(
+      "Ask anything, @tag files/folders, type $ to mention skills, or use / to show available commands",
+    );
+  });
+
+  it("keeps non-Codex placeholders focused on supported composer commands", () => {
+    expect(buildDefaultComposerPlaceholder("claudeAgent")).toBe(
+      "Ask anything, @tag files/folders, or use / to show available commands",
+    );
+  });
+});
+
+describe("buildDisconnectedComposerPlaceholder", () => {
+  it("mentions skills for disconnected Codex threads", () => {
+    expect(buildDisconnectedComposerPlaceholder("codex")).toBe(
+      "Ask for follow-up changes, type $ to mention skills, or attach images",
+    );
+  });
+
+  it("keeps disconnected non-Codex placeholders unchanged", () => {
+    expect(buildDisconnectedComposerPlaceholder("claudeAgent")).toBe(
+      "Ask for follow-up changes or attach images",
+    );
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,4 +1,10 @@
-import { ProjectId, type ModelSelection, type ThreadId, type TurnId } from "@t3tools/contracts";
+import {
+  ProjectId,
+  type ModelSelection,
+  type ProviderKind,
+  type ThreadId,
+  type TurnId,
+} from "@t3tools/contracts";
 import { type ChatMessage, type SessionPhase, type Thread, type ThreadSession } from "../types";
 import { randomUUID } from "~/lib/utils";
 import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
@@ -158,6 +164,20 @@ export function buildExpiredTerminalContextToastCopy(
     title: `${noun} omitted from message`,
     description: "Re-add it if you want that terminal output included.",
   };
+}
+
+export function buildDefaultComposerPlaceholder(provider: ProviderKind): string {
+  if (provider === "codex") {
+    return "Ask anything, @tag files/folders, type $ to mention skills, or use / to show available commands";
+  }
+  return "Ask anything, @tag files/folders, or use / to show available commands";
+}
+
+export function buildDisconnectedComposerPlaceholder(provider: ProviderKind): string {
+  if (provider === "codex") {
+    return "Ask for follow-up changes, type $ to mention skills, or attach images";
+  }
+  return "Ask for follow-up changes or attach images";
 }
 
 export function threadHasStarted(thread: Thread | null | undefined): boolean {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -171,6 +171,8 @@ import {
 import { ProviderStatusBanner } from "./chat/ProviderStatusBanner";
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
 import {
+  buildDefaultComposerPlaceholder,
+  buildDisconnectedComposerPlaceholder,
   buildExpiredTerminalContextToastCopy,
   buildLocalDraftThread,
   buildTemporaryWorktreeBranchName,
@@ -3951,8 +3953,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
                             : showPlanFollowUpPrompt && activeProposedPlan
                               ? "Add feedback to refine the plan, or leave this blank to implement it"
                               : phase === "disconnected"
-                                ? "Ask for follow-up changes or attach images"
-                                : "Ask anything, @tag files/folders, or use / to show available commands"
+                                ? buildDisconnectedComposerPlaceholder(selectedProvider)
+                                : buildDefaultComposerPlaceholder(selectedProvider)
                       }
                       disabled={isConnecting || isComposerApprovalState}
                     />


### PR DESCRIPTION
## What Changed

Updated the web composer placeholder copy to explicitly mention that Codex users can type `$` in the message box to mention skills.

The hint is only shown for Codex so Claude threads keep their existing copy.

I also extracted the placeholder strings into small helpers and added focused tests for the Codex and non-Codex variants.

## Why

T3 Code already supports passing raw prompt text through to Codex, but the composer UI only advertised `@` mentions and `/` commands.

That makes skill invocation easy to miss. This keeps the change small and local while clarifying the supported syntax in the place users actually type it.

## UI Changes

Before (Codex new/disconnected thread):
- `Ask for follow-up changes or attach images`

After (Codex new/disconnected thread):
- `Ask for follow-up changes, type $ to mention skills, or attach images`

Before (Codex connected/default composer state):
- `Ask anything, @tag files/folders, or use / to show available commands`

After (Codex connected/default composer state):
- `Ask anything, @tag files/folders, type $ to mention skills, or use / to show available commands`

No motion or interaction behavior changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI copy-only change gated by provider (`codex`) plus small helper extraction; no message dispatching or state logic is modified.
> 
> **Overview**
> Updates the chat composer placeholder text to **explicitly advertise `$` skill invocation for Codex** (both default and disconnected phases), while keeping non-Codex providers’ placeholder copy unchanged.
> 
> Extracts the placeholder strings into `buildDefaultComposerPlaceholder` / `buildDisconnectedComposerPlaceholder` helpers in `ChatView.logic`, updates `ChatView` to use them, and adds focused unit tests to lock in the provider-specific copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f98b0019d7420a8e996c0f1c2fd1d83af9f3bc0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show skill invocation hint in composer placeholder for Codex provider
> Adds provider-aware placeholder text to the composer input in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1653/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e). Two new utility functions, `buildDefaultComposerPlaceholder` and `buildDisconnectedComposerPlaceholder` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/1653/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114), return a placeholder that includes "type '$' to mention skills" when the provider is `codex`, and the previous placeholder text for all other providers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f98b001.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->