### PR TITLE
Feat: Added Trae IDE support for opening current working directory

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -31,6 +31,15 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
         args: ["/tmp/workspace"],
       });
 
+      const traeLaunch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "trae" },
+        "darwin",
+      );
+      assert.deepEqual(traeLaunch, {
+        command: "trae",
+        args: ["/tmp/workspace"],
+      });
+
       const vscodeLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace", editor: "vscode" },
         "darwin",
@@ -86,6 +95,15 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       );
       assert.deepEqual(lineAndColumn, {
         command: "cursor",
+        args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
+      });
+
+      const traeLineAndColumn = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "trae" },
+        "darwin",
+      );
+      assert.deepEqual(traeLineAndColumn, {
+        command: "trae",
         args: ["--goto", "/tmp/workspace/src/open.ts:71:5"],
       });
 
@@ -256,6 +274,7 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
       const path = yield* Path.Path;
       const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-editors-" });
 
+      yield* fs.writeFileString(path.join(dir, "trae.CMD"), "@echo off\r\n");
       yield* fs.writeFileString(path.join(dir, "code-insiders.CMD"), "@echo off\r\n");
       yield* fs.writeFileString(path.join(dir, "codium.CMD"), "@echo off\r\n");
       yield* fs.writeFileString(path.join(dir, "explorer.CMD"), "MZ");
@@ -263,7 +282,7 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
         PATH: dir,
         PATHEXT: ".COM;.EXE;.BAT;.CMD",
       });
-      assert.deepEqual(editors, ["vscode-insiders", "vscodium", "file-manager"]);
+      assert.deepEqual(editors, ["trae", "vscode-insiders", "vscodium", "file-manager"]);
     }),
   );
 });

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1407,6 +1407,52 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("opens the project cwd with Trae when it is the only available editor", async () => {
+    setDraftThreadWithoutWorktree();
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          availableEditors: ["trae"],
+        };
+      },
+    });
+
+    try {
+      await waitForServerConfigToApply();
+      const openButton = await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Open",
+          ) as HTMLButtonElement | null,
+        "Unable to find Open button.",
+      );
+      await vi.waitFor(() => {
+        expect(openButton.disabled).toBe(false);
+      });
+      openButton.click();
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.shellOpenInEditor,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.shellOpenInEditor,
+            cwd: "/repo/project",
+            editor: "trae",
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("filters the open picker menu and opens VSCodium from the menu", async () => {
     setDraftThreadWithoutWorktree();
 

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -20,6 +20,20 @@ export const CursorIcon: Icon = (props) => (
   </svg>
 );
 
+export const TraeIcon: Icon = (props) => (
+  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
+    {/* Back rectangle: left strip + bottom strip drawn separately — empty bottom-left corner is the gap between them */}
+    <rect x="1" y="4" width="3" height="14" />
+    <rect x="4" y="18" width="18" height="3" />
+    {/* Front frame: top bar + right bar only — left and bottom are replaced by the back strips above */}
+    <rect x="4" y="4" width="18" height="3" />
+    <rect x="19" y="7" width="3" height="11" />
+    {/* Two diamonds, offset slightly to the right within the open area */}
+    <path d="M11 10L13 12L11 14L9 12Z" />
+    <path d="M16 10L18 12L16 14L14 12Z" />
+  </svg>
+);
+
 export const VisualStudioCode: Icon = (props) => {
   const id = useId();
   const maskId = `${id}-vscode-a`;

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -6,7 +6,7 @@ import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { Group, GroupSeparator } from "../ui/group";
 import { Menu, MenuItem, MenuPopup, MenuShortcut, MenuTrigger } from "../ui/menu";
-import { AntigravityIcon, CursorIcon, Icon, VisualStudioCode, Zed } from "../Icons";
+import { AntigravityIcon, CursorIcon, Icon, TraeIcon, VisualStudioCode, Zed } from "../Icons";
 import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { readNativeApi } from "~/nativeApi";
 
@@ -16,6 +16,11 @@ const resolveOptions = (platform: string, availableEditors: ReadonlyArray<Editor
       label: "Cursor",
       Icon: CursorIcon,
       value: "cursor",
+    },
+    {
+      label: "Trae",
+      Icon: TraeIcon,
+      value: "trae",
     },
     {
       label: "VS Code",

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -3,6 +3,7 @@ import { TrimmedNonEmptyString } from "./baseSchemas";
 
 export const EDITORS = [
   { id: "cursor", label: "Cursor", command: "cursor", supportsGoto: true },
+  { id: "trae", label: "Trae", command: "trae", supportsGoto: true },
   { id: "vscode", label: "VS Code", command: "code", supportsGoto: true },
   {
     id: "vscode-insiders",


### PR DESCRIPTION
## What Changed

I added the ability for users to open the current working directory in the Trae IDE if it is installed on the system.

## Why

I use Trae as my default editor, and it was getting tiring to have to manually to to Trae to open projects every single time, so I just added it to the options of editors that can be opened.

## UI Changes

This PR added the Trae icon SVG, seen in the following 2 screenshots when it's the default editor, and when in the "open" dropdown:
<img width="101" height="27" alt="Screenshot 2026-04-01 at 15 45 36" src="https://github.com/user-attachments/assets/764186af-8f3e-43ee-93e7-522b7a066542" />
<img width="148" height="132" alt="Screenshot 2026-04-01 at 15 46 31" src="https://github.com/user-attachments/assets/5f660241-68db-4606-b464-c73b2cee16fd" />

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new editor entry and icon plus a few targeted tests; behavior changes are limited to editor detection/selection and command construction.
> 
> **Overview**
> Adds **Trae IDE** as a first-class `open in editor` target across contracts, server, and web UI.
> 
> Updates `EDITORS` to include `trae` (with `supportsGoto`) so `resolveAvailableEditors` can detect it on PATH and `resolveEditorLaunch` can launch it (including `--goto` for line/column targets). The web `OpenInPicker` now shows Trae with a new `TraeIcon`, and browser/server tests are extended to cover Trae selection, launch args, and Windows availability ordering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a0477e1e3c6dd8bc07383d4be14a87188142758. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Trae IDE support for opening the current working directory
> - Adds `trae` to the [`EDITORS` constant](https://github.com/pingdotgg/t3code/pull/1656/files#diff-952d09e8dcc92b201e44f8f0b5edc71af952e9af9479b5853c41ce6e93d636f7) with `supportsGoto: true` and command `trae`.
> - Adds a [`TraeIcon`](https://github.com/pingdotgg/t3code/pull/1656/files#diff-d19962a9c1cb0bc3363e0d837062d1bd60923e4ea67f675a9f9fc3ec7f7e3442) SVG component and surfaces a 'Trae' option in the [`OpenInPicker`](https://github.com/pingdotgg/t3code/pull/1656/files#diff-e2a98d212ae98eb3ec0902f11d6e8f0daeb2b1729c80a65a8792371f7605e802) when `trae` is in `availableEditors`.
> - Adds launch resolution logic in the open server for macOS, supporting both cwd-only and `--goto` invocations.
> - Extends Windows PATH detection to recognize `trae.CMD`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a0477e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->