### PR TITLE
feat(web): add browser notifications for thread lifecycle events

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -35,6 +35,10 @@ import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
 import { isElectron } from "../../env";
 import { useTheme } from "../../hooks/useTheme";
 import { useSettings, useUpdateSettings } from "../../hooks/useSettings";
+import {
+  getNotificationPermissionState,
+  requestNotificationPermission,
+} from "../../hooks/useThreadNotifications";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import {
   setDesktopUpdateStateQueryData,
@@ -462,6 +466,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
+      ...(settings.notificationsEnabled !== DEFAULT_UNIFIED_SETTINGS.notificationsEnabled
+        ? ["Notifications"]
+        : []),
       ...(settings.diffWordWrap !== DEFAULT_UNIFIED_SETTINGS.diffWordWrap
         ? ["Diff line wrapping"]
         : []),
@@ -488,6 +495,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.defaultThreadEnvMode,
       settings.diffWordWrap,
       settings.enableAssistantStreaming,
+      settings.notificationsEnabled,
       settings.timestampFormat,
       theme,
     ],
@@ -768,6 +776,46 @@ export function GeneralSettingsPanel() {
                 ))}
               </SelectPopup>
             </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Notifications"
+          description="Get notified when a task completes, or needs approval or input while the app is in the background."
+          status={
+            settings.notificationsEnabled && getNotificationPermissionState() === "unsupported" ? (
+              <span className="text-warning">Notifications are not supported in this browser.</span>
+            ) : settings.notificationsEnabled && getNotificationPermissionState() === "denied" ? (
+              <span className="text-warning">
+                Browser notifications are blocked. Allow them in your browser settings to receive
+                alerts.
+              </span>
+            ) : null
+          }
+          resetAction={
+            settings.notificationsEnabled !== DEFAULT_UNIFIED_SETTINGS.notificationsEnabled ? (
+              <SettingResetButton
+                label="notifications"
+                onClick={() =>
+                  updateSettings({
+                    notificationsEnabled: DEFAULT_UNIFIED_SETTINGS.notificationsEnabled,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.notificationsEnabled}
+              onCheckedChange={(checked) => {
+                const enabled = Boolean(checked);
+                updateSettings({ notificationsEnabled: enabled });
+                if (enabled) {
+                  void requestNotificationPermission();
+                }
+              }}
+              aria-label="Enable notifications"
+            />
           }
         />
 

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -218,6 +218,10 @@ export function buildLegacyClientSettingsMigrationPatch(
     patch.timestampFormat = legacySettings.timestampFormat;
   }
 
+  if (Predicate.isBoolean(legacySettings.notificationsEnabled)) {
+    patch.notificationsEnabled = legacySettings.notificationsEnabled;
+  }
+
   return patch;
 }
 

--- a/apps/web/src/hooks/useThreadNotifications.ts
+++ b/apps/web/src/hooks/useThreadNotifications.ts
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from "react";
+import type { ThreadId } from "@t3tools/contracts";
+import { isElectron } from "../env";
+import { useStore } from "../store";
+import {
+  type ThreadNotificationSnapshot,
+  collectThreadNotificationSnapshots,
+  consolidateNotifications,
+  diffThreadNotifications,
+} from "../lib/threadNotifications";
+
+function isAppBackgrounded(): boolean {
+  return document.visibilityState === "hidden" || !document.hasFocus();
+}
+
+function canSendNotifications(): boolean {
+  return typeof Notification !== "undefined" && Notification.permission === "granted";
+}
+
+export async function requestNotificationPermission(): Promise<boolean> {
+  if (typeof Notification === "undefined") return false;
+  if (Notification.permission === "granted") return true;
+  if (Notification.permission === "denied") return false;
+  const result = await Notification.requestPermission();
+  return result === "granted";
+}
+
+export function getNotificationPermissionState(): NotificationPermission | "unsupported" {
+  if (typeof Notification === "undefined") return "unsupported";
+  return Notification.permission;
+}
+
+export function useThreadNotifications(enabled: boolean): void {
+  const previousSnapshotRef = useRef<ReadonlyMap<ThreadId, ThreadNotificationSnapshot> | null>(
+    null,
+  );
+  const bootstrapComplete = useStore((state) => state.bootstrapComplete);
+  const threads = useStore((state) => state.threads);
+  const projects = useStore((state) => state.projects);
+
+  useEffect(() => {
+    if (!bootstrapComplete) return;
+
+    const currentSnapshot = collectThreadNotificationSnapshots(threads, projects);
+
+    if (!enabled) {
+      // Keep in sync so toggling on doesn't fire for stale transitions.
+      previousSnapshotRef.current = currentSnapshot;
+      return;
+    }
+
+    if (previousSnapshotRef.current === null) {
+      previousSnapshotRef.current = currentSnapshot;
+      return;
+    }
+
+    if (!isAppBackgrounded() || !canSendNotifications()) {
+      previousSnapshotRef.current = currentSnapshot;
+      return;
+    }
+
+    const rawNotifications = diffThreadNotifications(previousSnapshotRef.current, currentSnapshot);
+
+    if (rawNotifications.length > 0) {
+      const consolidated = consolidateNotifications(rawNotifications);
+      for (const notification of consolidated) {
+        const browserNotification = new Notification(notification.title, {
+          body: notification.body,
+          tag: notification.threadId ?? "t3code-batch",
+        });
+
+        if (notification.threadId) {
+          const threadId = notification.threadId;
+          browserNotification.addEventListener("click", () => {
+            window.focus();
+            if (isElectron) {
+              window.location.hash = `#/${threadId}`;
+            } else {
+              window.history.pushState(null, "", `/${threadId}`);
+              window.dispatchEvent(new PopStateEvent("popstate"));
+            }
+          });
+        } else {
+          browserNotification.addEventListener("click", () => {
+            window.focus();
+          });
+        }
+      }
+    }
+
+    previousSnapshotRef.current = currentSnapshot;
+  }, [bootstrapComplete, enabled, projects, threads]);
+}

--- a/apps/web/src/lib/threadNotifications.test.ts
+++ b/apps/web/src/lib/threadNotifications.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from "vitest";
+import { ProjectId, ThreadId, TurnId } from "@t3tools/contracts";
+import {
+  type ThreadNotificationSnapshot,
+  type ThreadNotification,
+  collectThreadNotificationSnapshots,
+  consolidateNotifications,
+  diffThreadNotifications,
+  getNotificationBody,
+  getNotificationTitle,
+} from "./threadNotifications";
+import type { Project, Thread } from "../types";
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function makeThreadId(id: string): ThreadId {
+  return ThreadId.makeUnsafe(id);
+}
+
+const TEST_PROJECT: Project = {
+  id: ProjectId.makeUnsafe("project-1"),
+  name: "My Project",
+  cwd: "/tmp/test",
+  defaultModelSelection: null,
+  scripts: [],
+};
+
+function snap(
+  threadId: string,
+  status: ThreadNotificationSnapshot["status"],
+  overrides?: Partial<
+    Pick<
+      ThreadNotificationSnapshot,
+      | "threadTitle"
+      | "projectName"
+      | "pendingApprovalCount"
+      | "pendingInputCount"
+      | "lastCompletedTurnId"
+    >
+  >,
+): [ThreadId, ThreadNotificationSnapshot] {
+  const id = makeThreadId(threadId);
+  return [
+    id,
+    {
+      threadId: id,
+      projectName: overrides?.projectName ?? "My Project",
+      threadTitle: overrides?.threadTitle ?? "Test thread",
+      status,
+      pendingApprovalCount: overrides?.pendingApprovalCount ?? 0,
+      pendingInputCount: overrides?.pendingInputCount ?? 0,
+      lastCompletedTurnId: overrides?.lastCompletedTurnId ?? null,
+    },
+  ];
+}
+
+function makeMinimalThread(
+  overrides: Omit<Partial<Thread>, "id"> & { id: string; title?: string },
+): Thread {
+  return {
+    id: ThreadId.makeUnsafe(overrides.id),
+    codexThreadId: null,
+    projectId: ProjectId.makeUnsafe("project-1"),
+    title: overrides.title ?? "Test thread",
+    modelSelection: { provider: "codex", model: "test" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    session: overrides.session ?? null,
+    messages: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    archivedAt: overrides.archivedAt ?? null,
+    latestTurn: overrides.latestTurn ?? null,
+    branch: null,
+    worktreePath: null,
+    turnDiffSummaries: [],
+    activities: overrides.activities ?? [],
+  } as Thread;
+}
+
+// ── diffThreadNotifications ───────────────────────────────────────────
+
+describe("diffThreadNotifications", () => {
+  it("notifies on working -> completed", () => {
+    const prev = new Map([snap("t1", "working")]);
+    const curr = new Map([snap("t1", "completed", { lastCompletedTurnId: "turn-1" })]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "completed", threadId: makeThreadId("t1") });
+  });
+
+  it("notifies on working -> pending-approval", () => {
+    const prev = new Map([snap("t1", "working")]);
+    const curr = new Map([snap("t1", "pending-approval", { pendingApprovalCount: 1 })]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "pending-approval" });
+  });
+
+  it("notifies on working -> pending-input", () => {
+    const prev = new Map([snap("t1", "working")]);
+    const curr = new Map([snap("t1", "pending-input", { pendingInputCount: 1 })]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "pending-input" });
+  });
+
+  it("notifies on null -> pending-approval for new thread", () => {
+    const prev = new Map<ThreadId, ThreadNotificationSnapshot>();
+    const curr = new Map([snap("t1", "pending-approval", { pendingApprovalCount: 1 })]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "pending-approval" });
+  });
+
+  it("does not notify when status and counts stay the same", () => {
+    const prev = new Map([snap("t1", "pending-approval", { pendingApprovalCount: 1 })]);
+    const curr = new Map([snap("t1", "pending-approval", { pendingApprovalCount: 1 })]);
+    expect(diffThreadNotifications(prev, curr)).toEqual([]);
+  });
+
+  it("does not notify on null -> completed (no prior working state)", () => {
+    const prev = new Map<ThreadId, ThreadNotificationSnapshot>();
+    const curr = new Map([snap("t1", "completed", { lastCompletedTurnId: "turn-1" })]);
+    expect(diffThreadNotifications(prev, curr)).toEqual([]);
+  });
+
+  it("does not notify on completed -> completed with same turn", () => {
+    const prev = new Map([snap("t1", "completed", { lastCompletedTurnId: "turn-1" })]);
+    const curr = new Map([snap("t1", "completed", { lastCompletedTurnId: "turn-1" })]);
+    expect(diffThreadNotifications(prev, curr)).toEqual([]);
+  });
+
+  it("includes project name in notification", () => {
+    const prev = new Map([
+      snap("t1", "working", { threadTitle: "Fix bug", projectName: "my-app" }),
+    ]);
+    const curr = new Map([
+      snap("t1", "completed", {
+        threadTitle: "Fix bug",
+        projectName: "my-app",
+        lastCompletedTurnId: "turn-1",
+      }),
+    ]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ projectName: "my-app", threadTitle: "Fix bug" });
+  });
+
+  it("handles multiple threads with mixed transitions", () => {
+    const prev = new Map([snap("t1", "working"), snap("t2", "working"), snap("t3", null)]);
+    const curr = new Map([
+      snap("t1", "completed", { lastCompletedTurnId: "turn-1" }),
+      snap("t2", "pending-approval", { pendingApprovalCount: 1 }),
+      snap("t3", null),
+    ]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.kind).toSorted()).toEqual(["completed", "pending-approval"]);
+  });
+
+  // ── Edge cases from audit ─────────────────────────────────────────
+
+  it("notifies when a new approval arrives on an already pending-approval thread", () => {
+    const prev = new Map([snap("t1", "pending-approval", { pendingApprovalCount: 1 })]);
+    const curr = new Map([snap("t1", "pending-approval", { pendingApprovalCount: 2 })]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "pending-approval" });
+  });
+
+  it("notifies when a new input request arrives on an already pending-input thread", () => {
+    const prev = new Map([snap("t1", "pending-input", { pendingInputCount: 1 })]);
+    const curr = new Map([snap("t1", "pending-input", { pendingInputCount: 2 })]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "pending-input" });
+  });
+
+  it("notifies when a different turn completes on an already completed thread", () => {
+    const prev = new Map([snap("t1", "completed", { lastCompletedTurnId: "turn-1" })]);
+    const curr = new Map([snap("t1", "completed", { lastCompletedTurnId: "turn-2" })]);
+    const result = diffThreadNotifications(prev, curr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "completed" });
+  });
+});
+
+// ── collectThreadNotificationSnapshots ────────────────────────────────
+
+describe("collectThreadNotificationSnapshots", () => {
+  it("skips archived threads", () => {
+    const threads = [
+      makeMinimalThread({ id: "t1", archivedAt: "2026-01-01T00:00:00Z" }),
+      makeMinimalThread({ id: "t2" }),
+    ];
+    const snapshots = collectThreadNotificationSnapshots(threads, [TEST_PROJECT]);
+    expect(snapshots.size).toBe(1);
+    expect(snapshots.has(makeThreadId("t2"))).toBe(true);
+  });
+
+  it("derives working status from session", () => {
+    const thread = makeMinimalThread({
+      id: "t1",
+      session: {
+        provider: "codex",
+        status: "running",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+        orchestrationStatus: "running",
+      },
+    });
+    const snapshots = collectThreadNotificationSnapshots([thread], [TEST_PROJECT]);
+    expect(snapshots.get(makeThreadId("t1"))?.status).toBe("working");
+  });
+
+  it("derives completed status from latestTurn with state=completed", () => {
+    const thread = makeMinimalThread({
+      id: "t1",
+      latestTurn: {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        state: "completed",
+        requestedAt: "2026-01-01T00:00:00Z",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: "2026-01-01T00:01:00Z",
+        assistantMessageId: null,
+      },
+    });
+    const snapshots = collectThreadNotificationSnapshots([thread], [TEST_PROJECT]);
+    expect(snapshots.get(makeThreadId("t1"))?.status).toBe("completed");
+  });
+
+  it("does NOT derive completed status from interrupted turns", () => {
+    const thread = makeMinimalThread({
+      id: "t1",
+      latestTurn: {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        state: "interrupted",
+        requestedAt: "2026-01-01T00:00:00Z",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: "2026-01-01T00:01:00Z",
+        assistantMessageId: null,
+      },
+    });
+    const snapshots = collectThreadNotificationSnapshots([thread], [TEST_PROJECT]);
+    expect(snapshots.get(makeThreadId("t1"))?.status).toBeNull();
+  });
+
+  it("does NOT derive completed status from errored turns", () => {
+    const thread = makeMinimalThread({
+      id: "t1",
+      latestTurn: {
+        turnId: TurnId.makeUnsafe("turn-1"),
+        state: "error",
+        requestedAt: "2026-01-01T00:00:00Z",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: "2026-01-01T00:01:00Z",
+        assistantMessageId: null,
+      },
+    });
+    const snapshots = collectThreadNotificationSnapshots([thread], [TEST_PROJECT]);
+    expect(snapshots.get(makeThreadId("t1"))?.status).toBeNull();
+  });
+
+  it("resolves project name from projects list", () => {
+    const thread = makeMinimalThread({ id: "t1" });
+    const snapshots = collectThreadNotificationSnapshots([thread], [TEST_PROJECT]);
+    expect(snapshots.get(makeThreadId("t1"))?.projectName).toBe("My Project");
+  });
+
+  it("falls back to 'Unknown project' when project is missing", () => {
+    const thread = makeMinimalThread({ id: "t1" });
+    const snapshots = collectThreadNotificationSnapshots([thread], []);
+    expect(snapshots.get(makeThreadId("t1"))?.projectName).toBe("Unknown project");
+  });
+
+  it("uses thread title or fallback", () => {
+    const thread = makeMinimalThread({ id: "t1", title: "" });
+    const snapshots = collectThreadNotificationSnapshots([thread], [TEST_PROJECT]);
+    expect(snapshots.get(makeThreadId("t1"))?.threadTitle).toBe("Untitled thread");
+  });
+});
+
+// ── consolidateNotifications ──────────────────────────────────────────
+
+describe("consolidateNotifications", () => {
+  it("returns empty for no notifications", () => {
+    expect(consolidateNotifications([])).toEqual([]);
+  });
+
+  it("returns individual notifications for small batches", () => {
+    const notifications: ThreadNotification[] = [
+      {
+        threadId: makeThreadId("t1"),
+        projectName: "Proj",
+        threadTitle: "Thread 1",
+        kind: "completed",
+      },
+      {
+        threadId: makeThreadId("t2"),
+        projectName: "Proj",
+        threadTitle: "Thread 2",
+        kind: "pending-approval",
+      },
+    ];
+    const result = consolidateNotifications(notifications);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.threadId).toEqual(makeThreadId("t1"));
+    expect(result[1]?.threadId).toEqual(makeThreadId("t2"));
+  });
+
+  it("consolidates when exceeding threshold", () => {
+    const notifications: ThreadNotification[] = [
+      { threadId: makeThreadId("t1"), projectName: "P", threadTitle: "T1", kind: "completed" },
+      { threadId: makeThreadId("t2"), projectName: "P", threadTitle: "T2", kind: "completed" },
+      {
+        threadId: makeThreadId("t3"),
+        projectName: "P",
+        threadTitle: "T3",
+        kind: "pending-approval",
+      },
+      { threadId: makeThreadId("t4"), projectName: "P", threadTitle: "T4", kind: "pending-input" },
+    ];
+    const result = consolidateNotifications(notifications);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.title).toBe("4 threads need attention");
+    expect(result[0]?.threadId).toBeNull();
+  });
+});
+
+// ── Notification text helpers ─────────────────────────────────────────
+
+describe("getNotificationTitle", () => {
+  it("returns correct title for each kind", () => {
+    expect(getNotificationTitle("completed")).toBe("Task completed");
+    expect(getNotificationTitle("pending-approval")).toBe("Approval required");
+    expect(getNotificationTitle("pending-input")).toBe("Input required");
+  });
+});
+
+describe("getNotificationBody", () => {
+  it("formats as ProjectName / ThreadTitle + suffix", () => {
+    expect(getNotificationBody("completed", "my-app", "Fix login bug")).toBe(
+      "my-app / Fix login bug has finished working.",
+    );
+    expect(getNotificationBody("pending-approval", "my-app", "Add auth")).toBe(
+      "my-app / Add auth needs your approval to continue.",
+    );
+    expect(getNotificationBody("pending-input", "my-app", "Setup CI")).toBe(
+      "my-app / Setup CI is waiting for your input.",
+    );
+  });
+});

--- a/apps/web/src/lib/threadNotifications.ts
+++ b/apps/web/src/lib/threadNotifications.ts
@@ -1,0 +1,215 @@
+import type { ProjectId, ThreadId } from "@t3tools/contracts";
+import { derivePendingApprovals, derivePendingUserInputs } from "../session-logic";
+import type { Project, Thread } from "../types";
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export type ThreadNotificationStatus =
+  | "completed"
+  | "pending-approval"
+  | "pending-input"
+  | "working"
+  | null;
+
+export interface ThreadNotificationSnapshot {
+  threadId: ThreadId;
+  projectName: string;
+  threadTitle: string;
+  status: ThreadNotificationStatus;
+  pendingApprovalCount: number;
+  pendingInputCount: number;
+  lastCompletedTurnId: string | null;
+}
+
+export type ThreadNotificationKind = "completed" | "pending-approval" | "pending-input";
+
+export interface ThreadNotification {
+  threadId: ThreadId;
+  projectName: string;
+  threadTitle: string;
+  kind: ThreadNotificationKind;
+}
+
+// ── Snapshot collection ───────────────────────────────────────────────
+
+const PENDING_STATUS_DEFS = [
+  {
+    status: "pending-approval" as const,
+    kind: "pending-approval" as const,
+    countKey: "pendingApprovalCount" as const,
+  },
+  {
+    status: "pending-input" as const,
+    kind: "pending-input" as const,
+    countKey: "pendingInputCount" as const,
+  },
+] as const;
+
+export function collectThreadNotificationSnapshots(
+  threads: ReadonlyArray<Thread>,
+  projects: ReadonlyArray<Project>,
+): Map<ThreadId, ThreadNotificationSnapshot> {
+  const projectNameById = new Map<ProjectId, string>();
+  for (const project of projects) {
+    projectNameById.set(project.id, project.name);
+  }
+
+  const snapshots = new Map<ThreadId, ThreadNotificationSnapshot>();
+  for (const thread of threads) {
+    if (thread.archivedAt !== null) continue;
+
+    const pendingApprovals = derivePendingApprovals(thread.activities);
+    const pendingInputs = derivePendingUserInputs(thread.activities);
+
+    let status: ThreadNotificationStatus = null;
+    if (pendingApprovals.length > 0) {
+      status = "pending-approval";
+    } else if (pendingInputs.length > 0) {
+      status = "pending-input";
+    } else if (
+      thread.session?.status === "running" ||
+      thread.session?.orchestrationStatus === "running"
+    ) {
+      status = "working";
+    } else if (thread.latestTurn?.state === "completed" && thread.latestTurn.completedAt) {
+      // Interrupted and errored turns also set completedAt but should not
+      // fire a success notification.
+      status = "completed";
+    }
+
+    snapshots.set(thread.id, {
+      threadId: thread.id,
+      projectName: projectNameById.get(thread.projectId) ?? "Unknown project",
+      threadTitle: thread.title || "Untitled thread",
+      status,
+      pendingApprovalCount: pendingApprovals.length,
+      pendingInputCount: pendingInputs.length,
+      lastCompletedTurnId:
+        thread.latestTurn?.state === "completed" ? thread.latestTurn.turnId : null,
+    });
+  }
+  return snapshots;
+}
+
+// ── Diff logic ────────────────────────────────────────────────────────
+
+export function diffThreadNotifications(
+  previous: ReadonlyMap<ThreadId, ThreadNotificationSnapshot>,
+  current: ReadonlyMap<ThreadId, ThreadNotificationSnapshot>,
+): ThreadNotification[] {
+  const notifications: ThreadNotification[] = [];
+
+  for (const [threadId, currentSnap] of current) {
+    const previousSnap = previous.get(threadId);
+    const previousStatus = previousSnap?.status ?? null;
+    const currentStatus = currentSnap.status;
+    const base = {
+      threadId,
+      projectName: currentSnap.projectName,
+      threadTitle: currentSnap.threadTitle,
+    };
+
+    let handledAsPending = false;
+    for (const def of PENDING_STATUS_DEFS) {
+      if (currentStatus !== def.status) continue;
+      handledAsPending = true;
+      const countChanged =
+        previousSnap !== undefined && currentSnap[def.countKey] > previousSnap[def.countKey];
+      if (previousStatus !== currentStatus || countChanged) {
+        notifications.push({ ...base, kind: def.kind });
+      }
+      break;
+    }
+    if (handledAsPending) continue;
+
+    if (currentStatus === "completed") {
+      const turnChanged =
+        previousSnap !== undefined &&
+        currentSnap.lastCompletedTurnId !== null &&
+        currentSnap.lastCompletedTurnId !== previousSnap.lastCompletedTurnId;
+      if (previousStatus === "working" || turnChanged) {
+        notifications.push({ ...base, kind: "completed" });
+      }
+    }
+  }
+
+  return notifications;
+}
+
+// ── Notification text ─────────────────────────────────────────────────
+
+const NOTIFICATION_TITLE_BY_KIND: Record<ThreadNotificationKind, string> = {
+  completed: "Task completed",
+  "pending-approval": "Approval required",
+  "pending-input": "Input required",
+};
+
+const NOTIFICATION_BODY_SUFFIX_BY_KIND: Record<ThreadNotificationKind, string> = {
+  completed: "has finished working.",
+  "pending-approval": "needs your approval to continue.",
+  "pending-input": "is waiting for your input.",
+};
+
+export function getNotificationTitle(kind: ThreadNotificationKind): string {
+  return NOTIFICATION_TITLE_BY_KIND[kind];
+}
+
+export function getNotificationBody(
+  kind: ThreadNotificationKind,
+  projectName: string,
+  threadTitle: string,
+): string {
+  return `${projectName} / ${threadTitle} ${NOTIFICATION_BODY_SUFFIX_BY_KIND[kind]}`;
+}
+
+// ── Consolidation ─────────────────────────────────────────────────────
+
+const MAX_INDIVIDUAL_NOTIFICATIONS = 3;
+
+export interface ConsolidatedNotification {
+  title: string;
+  body: string;
+  threadId: ThreadId | null;
+}
+
+export function consolidateNotifications(
+  notifications: ReadonlyArray<ThreadNotification>,
+): ConsolidatedNotification[] {
+  if (notifications.length === 0) return [];
+
+  if (notifications.length <= MAX_INDIVIDUAL_NOTIFICATIONS) {
+    return notifications.map((notification) => ({
+      title: getNotificationTitle(notification.kind),
+      body: getNotificationBody(
+        notification.kind,
+        notification.projectName,
+        notification.threadTitle,
+      ),
+      threadId: notification.threadId,
+    }));
+  }
+
+  const counts: Record<ThreadNotificationKind, number> = {
+    "pending-approval": 0,
+    "pending-input": 0,
+    completed: 0,
+  };
+  for (const n of notifications) counts[n.kind]++;
+
+  const parts: string[] = [];
+  if (counts["pending-approval"] > 0)
+    parts.push(
+      `${counts["pending-approval"]} need${counts["pending-approval"] === 1 ? "s" : ""} approval`,
+    );
+  if (counts["pending-input"] > 0)
+    parts.push(`${counts["pending-input"]} need${counts["pending-input"] === 1 ? "s" : ""} input`);
+  if (counts.completed > 0) parts.push(`${counts.completed} completed`);
+
+  return [
+    {
+      title: `${notifications.length} threads need attention`,
+      body: parts.join(", "),
+      threadId: null,
+    },
+  ];
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -36,7 +36,8 @@ import { useStore } from "../store";
 import { useUiStateStore } from "../uiStateStore";
 import { useTerminalStateStore } from "../terminalStateStore";
 import { terminalRunningSubprocessFromEvent } from "../terminalActivity";
-import { migrateLocalSettingsToServer } from "../hooks/useSettings";
+import { migrateLocalSettingsToServer, useSettings } from "../hooks/useSettings";
+import { useThreadNotifications } from "../hooks/useThreadNotifications";
 import { providerQueryKeys } from "../lib/providerReactQuery";
 import { projectQueryKeys } from "../lib/projectReactQuery";
 import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
@@ -72,6 +73,7 @@ function RootRouteView() {
       <ToastProvider>
         <AnchoredToastProvider>
           <EventRouter />
+          <ThreadNotificationWatcher />
           <DesktopProjectBootstrap />
           <AppSidebarLayout>
             <Outlet />
@@ -454,6 +456,12 @@ function EventRouter() {
   useServerWelcomeSubscription(handleWelcome);
   useServerConfigUpdatedSubscription(handleServerConfigUpdated);
 
+  return null;
+}
+
+function ThreadNotificationWatcher() {
+  const settings = useSettings();
+  useThreadNotifications(settings.notificationsEnabled);
   return null;
 }
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -27,6 +27,7 @@ export const ClientSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
   diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
+  notificationsEnabled: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   sidebarProjectSortOrder: SidebarProjectSortOrder.pipe(
     Schema.withDecodingDefault(() => DEFAULT_SIDEBAR_PROJECT_SORT_ORDER),
   ),


### PR DESCRIPTION
Closes #780

## What Changed

- Added a `notificationsEnabled` client setting (boolean, default off) to `ClientSettingsSchema`
- Created `threadNotifications.ts` with pure snapshot-diffing logic that detects when a thread transitions to completed, pending-approval, or pending-input
- Created `useThreadNotifications` hook that subscribes to the Zustand store, diffs thread state snapshots, and fires browser Notification API calls when the app is backgrounded
- Mounted a `ThreadNotificationWatcher` component in `RootRouteView` alongside `EventRouter`
- Added a Notifications toggle row in Settings → General with permission request on enable and a blocked-permission warning
- Notification body shows project name and thread title (e.g. `my-app / Fix login bug has finished working.`)
- Clicking a notification focuses the app and navigates to the thread (handles both browser history and Electron hash history)
- Batches 4+ simultaneous notifications into a single summary to prevent flood on reconnect

## Why

Issue #780: when a task finishes or needs approval/input while the user is in another app or tab, there is no signal. Users have to keep checking back manually. This adds opt-in browser notifications so users get alerted without polling.

## UI Changes

**Settings toggle (off):**

<img width="2560" height="1496" alt="settings-notifications-off" src="https://github.com/user-attachments/assets/470a0fe2-11f0-4e0b-8151-becfaa6cb0db" />

**Settings toggle (on):**

<img width="2560" height="1496" alt="settings-notifications-on" src="https://github.com/user-attachments/assets/06785a98-ddcc-4149-a300-646e65979e52" />

**Notification demo:**

![notification-demo](https://github.com/user-attachments/assets/7fb605ef-97bb-4ca1-b7a1-7895891c314f)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client settings and a background watcher that triggers the browser Notification API and deep-links on click; mistakes could cause notification spam or unexpected navigation/permission UX, but changes are isolated and default-off.
> 
> **Overview**
> Adds **opt-in browser notifications** for thread lifecycle events (completed, needs approval, needs input) when the app is backgrounded.
> 
> Introduces a new `notificationsEnabled` client setting (default off) surfaced as a Settings toggle with permission request + blocked/unsupported warnings, mounts a root-level watcher (`useThreadNotifications`) to diff thread/project snapshots and fire notifications, and includes batching/summary notifications to avoid floods plus click-to-focus and navigate behavior (web history vs Electron hash routing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa1adaf7a4cc336d5cb086731ccaff9713173872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add browser notifications for thread lifecycle events
> - Adds a `notificationsEnabled` setting (default `false`) to [`ClientSettingsSchema`](https://github.com/pingdotgg/t3code/pull/1657/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) and a toggle in the General settings panel that requests browser permission on enable.
> - Introduces [`useThreadNotifications`](https://github.com/pingdotgg/t3code/pull/1657/files#diff-076e62a23de966733e6a9107ba7c8d7625ed575122beaf40d67eaad8e2074f10), which diffs per-thread snapshots on each update and fires browser notifications for completions, pending approvals, and input requests when the app is backgrounded.
> - Clicking a notification focuses the window and navigates to the relevant thread (hash navigation in Electron, history push on web); batches of >3 events are consolidated into a single summary notification.
> - Adds [`threadNotifications.ts`](https://github.com/pingdotgg/t3code/pull/1657/files#diff-eb146b11e0b9002ac794a7488456dbaa8f34dbf259ed97de77ff34a2544a7318) with snapshot collection, diffing, text helpers, and consolidation logic, covered by a Vitest suite.
> - Mounts a `ThreadNotificationWatcher` at the app root in [`__root.tsx`](https://github.com/pingdotgg/t3code/pull/1657/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) to wire the hook to user settings globally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa1adaf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->