### PR TITLE
[codex] Break web composer circular dependency

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -125,6 +125,7 @@ import {
   resolveSelectableProvider,
 } from "../providerModels";
 import { useSettings } from "../hooks/useSettings";
+import { getComposerProviderState } from "../composerProviderState";
 import { resolveAppModelSelection } from "../modelSelection";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import {
@@ -166,7 +167,6 @@ import { ComposerPendingApprovalPanel } from "./chat/ComposerPendingApprovalPane
 import { ComposerPendingUserInputPanel } from "./chat/ComposerPendingUserInputPanel";
 import { ComposerPlanFollowUpBanner } from "./chat/ComposerPlanFollowUpBanner";
 import {
-  getComposerProviderState,
   renderProviderTraitsMenuContent,
   renderProviderTraitsPicker,
 } from "./chat/composerProviderRegistry";

--- a/apps/web/src/components/chat/composerProviderRegistry.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.tsx
@@ -4,34 +4,10 @@ import {
   type ServerProviderModel,
   type ThreadId,
 } from "@t3tools/contracts";
-import { isClaudeUltrathinkPrompt, resolveEffort } from "@t3tools/shared/model";
 import type { ReactNode } from "react";
-import { getProviderModelCapabilities } from "../../providerModels";
 import { TraitsMenuContent, TraitsPicker } from "./TraitsPicker";
-import {
-  normalizeClaudeModelOptionsWithCapabilities,
-  normalizeCodexModelOptionsWithCapabilities,
-} from "@t3tools/shared/model";
-
-export type ComposerProviderStateInput = {
-  provider: ProviderKind;
-  model: string;
-  models: ReadonlyArray<ServerProviderModel>;
-  prompt: string;
-  modelOptions: ProviderModelOptions | null | undefined;
-};
-
-export type ComposerProviderState = {
-  provider: ProviderKind;
-  promptEffort: string | null;
-  modelOptionsForDispatch: ProviderModelOptions[ProviderKind] | undefined;
-  composerFrameClassName?: string;
-  composerSurfaceClassName?: string;
-  modelPickerIconClassName?: string;
-};
 
 type ProviderRegistryEntry = {
-  getState: (input: ComposerProviderStateInput) => ComposerProviderState;
   renderTraitsMenuContent: (input: {
     threadId: ThreadId;
     model: string;
@@ -50,49 +26,8 @@ type ProviderRegistryEntry = {
   }) => ReactNode;
 };
 
-function getProviderStateFromCapabilities(
-  input: ComposerProviderStateInput,
-): ComposerProviderState {
-  const { provider, model, models, prompt, modelOptions } = input;
-  const caps = getProviderModelCapabilities(models, model, provider);
-  const providerOptions = modelOptions?.[provider];
-
-  // Resolve effort
-  const rawEffort = providerOptions
-    ? "effort" in providerOptions
-      ? providerOptions.effort
-      : "reasoningEffort" in providerOptions
-        ? providerOptions.reasoningEffort
-        : null
-    : null;
-
-  const promptEffort = resolveEffort(caps, rawEffort) ?? null;
-
-  // Normalize options for dispatch
-  const normalizedOptions =
-    provider === "codex"
-      ? normalizeCodexModelOptionsWithCapabilities(caps, providerOptions)
-      : normalizeClaudeModelOptionsWithCapabilities(caps, providerOptions);
-
-  // Ultrathink styling (driven by capabilities data, not provider identity)
-  const ultrathinkActive =
-    caps.promptInjectedEffortLevels.length > 0 && isClaudeUltrathinkPrompt(prompt);
-
-  return {
-    provider,
-    promptEffort,
-    modelOptionsForDispatch: normalizedOptions,
-    ...(ultrathinkActive ? { composerFrameClassName: "ultrathink-frame" } : {}),
-    ...(ultrathinkActive
-      ? { composerSurfaceClassName: "shadow-[0_0_0_1px_rgba(255,255,255,0.04)_inset]" }
-      : {}),
-    ...(ultrathinkActive ? { modelPickerIconClassName: "ultrathink-chroma" } : {}),
-  };
-}
-
 const composerProviderRegistry: Record<ProviderKind, ProviderRegistryEntry> = {
   codex: {
-    getState: (input) => getProviderStateFromCapabilities(input),
     renderTraitsMenuContent: ({
       threadId,
       model,
@@ -124,7 +59,6 @@ const composerProviderRegistry: Record<ProviderKind, ProviderRegistryEntry> = {
     ),
   },
   claudeAgent: {
-    getState: (input) => getProviderStateFromCapabilities(input),
     renderTraitsMenuContent: ({
       threadId,
       model,
@@ -156,10 +90,6 @@ const composerProviderRegistry: Record<ProviderKind, ProviderRegistryEntry> = {
     ),
   },
 };
-
-export function getComposerProviderState(input: ComposerProviderStateInput): ComposerProviderState {
-  return composerProviderRegistry[input.provider].getState(input);
-}
 
 export function renderProviderTraitsMenuContent(input: {
   provider: ProviderKind;

--- a/apps/web/src/composerProviderState.test.ts
+++ b/apps/web/src/composerProviderState.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ServerProviderModel } from "@t3tools/contracts";
-import { getComposerProviderState } from "./composerProviderRegistry";
+import { getComposerProviderState } from "./composerProviderState";
 
 const CODEX_MODELS: ReadonlyArray<ServerProviderModel> = [
   {

--- a/apps/web/src/composerProviderState.ts
+++ b/apps/web/src/composerProviderState.ts
@@ -1,0 +1,62 @@
+import {
+  type ProviderKind,
+  type ProviderModelOptions,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import {
+  isClaudeUltrathinkPrompt,
+  normalizeClaudeModelOptionsWithCapabilities,
+  normalizeCodexModelOptionsWithCapabilities,
+  resolveEffort,
+} from "@t3tools/shared/model";
+import { getProviderModelCapabilities } from "./providerModels";
+
+export type ComposerProviderStateInput = {
+  provider: ProviderKind;
+  model: string;
+  models: ReadonlyArray<ServerProviderModel>;
+  prompt: string;
+  modelOptions: ProviderModelOptions | null | undefined;
+};
+
+export type ComposerProviderState = {
+  provider: ProviderKind;
+  promptEffort: string | null;
+  modelOptionsForDispatch: ProviderModelOptions[ProviderKind] | undefined;
+  composerFrameClassName?: string;
+  composerSurfaceClassName?: string;
+  modelPickerIconClassName?: string;
+};
+
+export function getComposerProviderState(input: ComposerProviderStateInput): ComposerProviderState {
+  const { provider, model, models, prompt, modelOptions } = input;
+  const caps = getProviderModelCapabilities(models, model, provider);
+  const providerOptions = modelOptions?.[provider];
+
+  const rawEffort = providerOptions
+    ? "effort" in providerOptions
+      ? providerOptions.effort
+      : "reasoningEffort" in providerOptions
+        ? providerOptions.reasoningEffort
+        : null
+    : null;
+
+  const promptEffort = resolveEffort(caps, rawEffort) ?? null;
+  const modelOptionsForDispatch =
+    provider === "codex"
+      ? normalizeCodexModelOptionsWithCapabilities(caps, providerOptions)
+      : normalizeClaudeModelOptionsWithCapabilities(caps, providerOptions);
+  const ultrathinkActive =
+    caps.promptInjectedEffortLevels.length > 0 && isClaudeUltrathinkPrompt(prompt);
+
+  return {
+    provider,
+    promptEffort,
+    modelOptionsForDispatch,
+    ...(ultrathinkActive ? { composerFrameClassName: "ultrathink-frame" } : {}),
+    ...(ultrathinkActive
+      ? { composerSurfaceClassName: "shadow-[0_0_0_1px_rgba(255,255,255,0.04)_inset]" }
+      : {}),
+    ...(ultrathinkActive ? { modelPickerIconClassName: "ultrathink-chroma" } : {}),
+  };
+}

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -5,8 +5,8 @@ import {
   type ServerProvider,
 } from "@t3tools/contracts";
 import { normalizeModelSlug, resolveSelectableModel } from "@t3tools/shared/model";
-import { getComposerProviderState } from "./components/chat/composerProviderRegistry";
 import { UnifiedSettings } from "@t3tools/contracts/settings";
+import { getComposerProviderState } from "./composerProviderState";
 import {
   getDefaultServerModel,
   getProviderModels,

--- a/docs/web-circular-deps-plan.md
+++ b/docs/web-circular-deps-plan.md
@@ -1,0 +1,60 @@
+# Web Circular Dependency Cleanup Plan
+
+## Goal
+
+Break the verified web import cycle reported in [`ctx-analysis.md`](../ctx-analysis.md) without changing composer behavior.
+
+## Evidence
+
+### ctx report
+
+- [`ctx-analysis.md`](../ctx-analysis.md) identifies this cycle:
+  - `apps/web/src/components/chat/TraitsPicker.tsx`
+  - `apps/web/src/composerDraftStore.ts`
+  - `apps/web/src/modelSelection.ts`
+  - `apps/web/src/components/chat/composerProviderRegistry.tsx`
+
+### Live source references
+
+- `apps/web/src/modelSelection.ts:171` resolves settings-backed model selection and currently reaches into the chat registry for provider-state normalization.
+- `apps/web/src/components/chat/composerProviderRegistry.tsx:53` contains pure provider-state logic, while `apps/web/src/components/chat/composerProviderRegistry.tsx:93` also owns React rendering for traits controls.
+- `apps/web/src/components/chat/TraitsPicker.tsx:163` reads the composer store during render.
+- `apps/web/src/composerDraftStore.ts:628` calls back into model selection when deriving effective draft state.
+
+### SCIP checks
+
+The local SCIP index confirms the same edge chain:
+
+```text
+tools/scip-query deps apps/web/src/modelSelection.ts
+  -> apps/web/src/components/chat/composerProviderRegistry.tsx
+
+tools/scip-query deps apps/web/src/components/chat/composerProviderRegistry.tsx
+  -> apps/web/src/components/chat/TraitsPicker.tsx
+
+tools/scip-query deps apps/web/src/components/chat/TraitsPicker.tsx
+  -> apps/web/src/composerDraftStore.ts
+
+tools/scip-query deps apps/web/src/composerDraftStore.ts
+  -> apps/web/src/modelSelection.ts
+```
+
+`tools/scip-query refs getComposerProviderState` also shows that the pure provider-state helper is consumed outside the registry, which is the coupling we want to undo.
+
+## Checklist
+
+- [x] Extract the pure provider-state normalization from `apps/web/src/components/chat/composerProviderRegistry.tsx:53` into a non-React helper module that does not import traits UI.
+- [x] Update `apps/web/src/modelSelection.ts:171` to use the new pure helper directly.
+- [x] Keep `apps/web/src/components/chat/composerProviderRegistry.tsx:93` focused on rendering traits UI and provider-specific composition.
+- [x] Move or update the provider-state tests so they exercise the extracted helper directly.
+- [x] Re-run graph checks plus `bun fmt`, `bun lint`, and `bun typecheck`, and confirm the web cycle no longer appears.
+
+## Verification
+
+- `bun fmt`
+- `bun lint`
+- `bun typecheck`
+- `mcp__socraticode__codebase_graph_circular`
+  - Remaining cycle: `packages/contracts/src/model.ts -> packages/contracts/src/orchestration.ts -> packages/contracts/src/model.ts`
+- `tools/scip-query deps apps/web/src/modelSelection.ts`
+  - Now points to `apps/web/src/composerProviderState.ts` instead of `apps/web/src/components/chat/composerProviderRegistry.tsx`


### PR DESCRIPTION
## What changed
- extracted the pure composer provider-state normalization into `apps/web/src/composerProviderState.ts`
- updated non-UI callers to import the pure helper directly
- trimmed `composerProviderRegistry.tsx` back to traits rendering only
- added a markdown checklist plan at `docs/web-circular-deps-plan.md`

## Why
- `ctx-analysis.md` and the live dependency graph both identified a real web import cycle through `composerDraftStore.ts`, `modelSelection.ts`, `composerProviderRegistry.tsx`, and `TraitsPicker.tsx`
- the cycle made `modelSelection.ts` pull chat UI and store setup into non-UI code paths

## Impact
- removes the web circular dependency while keeping composer behavior unchanged
- leaves the remaining contracts cycle untouched because it is still the separate type-coupling issue we discussed

## Validation
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`
- refreshed SocratiCode graph: only the contracts cycle remains
- refreshed SCIP index: `modelSelection.ts` now depends on `composerProviderState.ts` instead of the chat registry


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Break circular dependency by extracting `getComposerProviderState` into a standalone module
> - Moves `getComposerProviderState`, `ComposerProviderState`, and `ComposerProviderStateInput` out of [composerProviderRegistry.tsx](https://github.com/pingdotgg/t3code/pull/1659/files#diff-7fee0d4349ece2e52bca02afdb88a77512bfae8a66ab2c275e93c3a716a60df0) into a new [composerProviderState.ts](https://github.com/pingdotgg/t3code/pull/1659/files#diff-ca5c31a64195a29622b7b26d940c3e627caaf95106dcde8fe228754496571d45) module.
> - `composerProviderRegistry` now only contains UI rendering logic (`renderTraitsMenuContent`, `renderTraitsPicker`), dropping all state-computation imports.
> - [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1659/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [modelSelection.ts](https://github.com/pingdotgg/t3code/pull/1659/files#diff-3bbcb619a0f4b212f9d0b396a6b561103b0630227331138956971e1e960d86f2) are updated to import from the new module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5415598.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that primarily moves provider-state normalization into a standalone module; main risk is subtle behavioral drift in model option normalization or ultrathink styling if the extraction missed edge cases.
> 
> **Overview**
> Breaks a web circular dependency by extracting the *pure* composer provider-state normalization (`getComposerProviderState` and related types) into a new `apps/web/src/composerProviderState.ts` module.
> 
> Updates non-UI callers (`modelSelection.ts`, `ChatView.tsx`) to import the new helper directly, and trims `composerProviderRegistry.tsx` down to traits UI rendering only. Provider-state tests are repointed to the new module, and a new `docs/web-circular-deps-plan.md` documents the dependency cycle and verification steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5415598ca967b633bfa64ba60e5de75171c38c21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->