### PR TITLE
Fix supervised approval command visibility

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -573,6 +573,51 @@ function createSnapshotWithPendingUserInput(): OrchestrationReadModel {
   };
 }
 
+function createSnapshotWithPendingApproval(): OrchestrationReadModel {
+  const snapshot = createSnapshotForTargetUser({
+    targetMessageId: "msg-user-pending-approval-target" as MessageId,
+    targetText: "approval thread",
+  });
+  const approvalDetail = [
+    '"C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" -Command',
+    '"ssh pipe-[REDACTED] \\"vdpkg -l localepurge 2>/dev/null || true; printf \\\\\\"\\\\n--- localepurge --\\\\n\\\\\\"; sed -n 1,80p /etc/locale.nopurge\\""',
+  ].join(" ");
+
+  return {
+    ...snapshot,
+    threads: snapshot.threads.map((thread) =>
+      thread.id === THREAD_ID
+        ? Object.assign({}, thread, {
+            runtimeMode: "approval-required",
+            activities: [
+              {
+                id: EventId.makeUnsafe("activity-approval-requested"),
+                tone: "approval",
+                kind: "approval.requested",
+                summary: "Command approval requested",
+                payload: {
+                  requestId: "req-browser-approval",
+                  requestKind: "command",
+                  detail: approvalDetail,
+                },
+                turnId: null,
+                sequence: 1,
+                createdAt: isoAt(1_000),
+              },
+            ],
+            session: {
+              ...thread.session,
+              runtimeMode: "approval-required",
+              status: "ready",
+              updatedAt: isoAt(1_000),
+            },
+            updatedAt: isoAt(1_000),
+          })
+        : thread,
+    ),
+  };
+}
+
 function createSnapshotWithPlanFollowUpPrompt(): OrchestrationReadModel {
   const snapshot = createSnapshotForTargetUser({
     targetMessageId: "msg-user-plan-follow-up-target" as MessageId,
@@ -2597,6 +2642,33 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       await mounted.setContainerSize(COMPACT_FOOTER_VIEWPORT);
       await expectComposerActionsContained();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("renders pending approval commands in a readable wrapped block", async () => {
+    const mounted = await mountChatView({
+      viewport: COMPACT_FOOTER_VIEWPORT,
+      snapshot: createSnapshotWithPendingApproval(),
+    });
+
+    try {
+      await waitForButtonByText("Approve once");
+      const detail = await waitForElement(
+        () => document.querySelector<HTMLElement>('[data-testid="pending-approval-detail"]'),
+        "Unable to find pending approval detail block.",
+      );
+      const detailStyle = getComputedStyle(detail);
+
+      expect(detail.textContent).toContain("powershell.exe");
+      expect(detail.textContent).toContain("localepurge");
+      expect(detail.textContent).not.toContain("...");
+      expect(detailStyle.whiteSpace).toBe("pre-wrap");
+      expect(detailStyle.userSelect).toBe("text");
+      expect(detailStyle.color).not.toBe("rgba(0, 0, 0, 0)");
+      expect(detail.getBoundingClientRect().height).toBeGreaterThan(32);
+      expect(document.body.textContent).toContain("Resolve this approval request to continue");
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4016,8 +4016,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                       onPaste={onComposerPaste}
                       placeholder={
                         isComposerApprovalState
-                          ? (activePendingApproval?.detail ??
-                            "Resolve this approval request to continue")
+                          ? "Resolve this approval request to continue"
                           : activePendingProgress
                             ? "Type your own answer, or leave this blank to use the selected option"
                             : showPlanFollowUpPrompt && activeProposedPlan

--- a/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
@@ -16,6 +16,12 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
       : approval.requestKind === "file-read"
         ? "File-read approval requested"
         : "File-change approval requested";
+  const detailLabel =
+    approval.requestKind === "command"
+      ? "Command"
+      : approval.requestKind === "file-read"
+        ? "Requested path"
+        : "Requested changes";
 
   return (
     <div className="px-4 py-3.5 sm:px-5 sm:py-4">
@@ -26,6 +32,19 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
           <span className="text-xs text-muted-foreground">1/{pendingCount}</span>
         ) : null}
       </div>
+      {approval.detail ? (
+        <div className="mt-3 rounded-xl border border-border/70 bg-background/80 px-3 py-2.5 shadow-xs/5">
+          <p className="mb-1.5 text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground/80">
+            {detailLabel}
+          </p>
+          <pre
+            data-testid="pending-approval-detail"
+            className="max-h-48 overflow-auto whitespace-pre-wrap break-all select-text font-mono text-[12px] leading-relaxed text-foreground"
+          >
+            {approval.detail}
+          </pre>
+        </div>
+      ) : null}
     </div>
   );
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

- Render pending approval command details in a dedicated wrapped, selectable block inside the composer header instead of using the disabled editor placeholder.
- Keep the approval-state editor placeholder as neutral helper copy.
- Add a focused browser regression test that mounts a pending approval and verifies the command block is readable.

## Why

Supervisor mode approvals need the full command to be readable before the user approves it. Showing the command as low-contrast placeholder text made it hard to review and could visually cut off long commands.

## UI Changes

- Approval requests now show the command/path/change detail in a bordered monospace block that wraps and can be selected.
- Demo video:
[supervised_approval_command_visibility.mp4](https://cursor.com/agents/bc-67a13adc-48c5-403c-bd0d-318a55ce4311/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsupervised_approval_command_visibility.mp4)
- Screenshot:
[Supervised approval command visibility](https://cursor.com/agents/bc-67a13adc-48c5-403c-bd0d-318a55ce4311/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsupervised_approval_command_visibility.webp)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67a13adc-48c5-403c-bd0d-318a55ce4311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67a13adc-48c5-403c-bd0d-318a55ce4311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix supervised approval command visibility in `ComposerPendingApprovalPanel`
> - Adds a labeled detail block to [`ComposerPendingApprovalPanel.tsx`](https://github.com/pingdotgg/t3code/pull/1660/files#diff-3f6a92c07f981fc2fdf01ac0c1c53a1de7da9b08d204cfaf962dc9ddf7d0304f) that renders `approval.detail` in a wrapped, scrollable, selectable monospace `<pre>` element when present, with a label derived from `requestKind` ('Command', 'Requested path', or 'Requested changes').
> - Fixes [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/1660/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) so the composer placeholder always shows 'Resolve this approval request to continue' instead of leaking the raw approval detail string into the input placeholder.
> - Adds a browser test in [`ChatView.browser.tsx`](https://github.com/pingdotgg/t3code/pull/1660/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) that verifies the detail block renders with correct text, wrapping style, and visible color.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f6690f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->