### PR TITLE
feat: add ability to see live output of commands

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1858,6 +1858,11 @@ describe("ProviderRuntimeIngestion", () => {
         status: "in_progress",
         title: "Read file",
         detail: "/tmp/file.ts",
+        data: {
+          item: {
+            command: ["sed", "-n", "1,40p", "/tmp/file.ts"],
+          },
+        },
       },
     });
 
@@ -1877,6 +1882,18 @@ describe("ProviderRuntimeIngestion", () => {
         (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.started",
       ),
     ).toBe(true);
+    const toolStarted = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) => activity.id === "evt-tool-started",
+    );
+    const toolStartedPayload =
+      toolStarted?.payload && typeof toolStarted.payload === "object"
+        ? (toolStarted.payload as Record<string, unknown>)
+        : undefined;
+    expect(toolStartedPayload?.data).toEqual({
+      item: {
+        command: ["sed", "-n", "1,40p", "/tmp/file.ts"],
+      },
+    });
   });
 
   it("consumes P1 runtime events into thread metadata, diff checkpoints, and activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -326,6 +326,32 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.lastError).toBe("turn failed");
   });
 
+  it("does not project command output deltas into persisted tool activities", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-command-output"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-1"),
+      itemId: asItemId("item-command-1"),
+      createdAt: now,
+      payload: {
+        streamKind: "command_output",
+        delta: "hello from stdout\n",
+      },
+    });
+
+    await harness.drain();
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === asThreadId("thread-1"));
+    expect(
+      thread?.activities.some((entry) => entry.id === asEventId("evt-command-output")) ?? false,
+    ).toBe(false);
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -441,6 +441,7 @@ function runtimeEventToActivities(
           summary: event.payload.title ?? "Tool updated",
           payload: {
             itemType: event.payload.itemType,
+            ...(event.itemId ? { itemId: event.itemId } : {}),
             ...(event.payload.status ? { status: event.payload.status } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
@@ -464,6 +465,7 @@ function runtimeEventToActivities(
           summary: event.payload.title ?? "Tool",
           payload: {
             itemType: event.payload.itemType,
+            ...(event.itemId ? { itemId: event.itemId } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
@@ -485,6 +487,7 @@ function runtimeEventToActivities(
           summary: `${event.payload.title ?? "Tool"} started`,
           payload: {
             itemType: event.payload.itemType,
+            ...(event.itemId ? { itemId: event.itemId } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -489,6 +489,7 @@ function runtimeEventToActivities(
             itemType: event.payload.itemType,
             ...(event.itemId ? { itemId: event.itemId } : {}),
             ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -29,6 +29,7 @@ import { normalizeDispatchCommand } from "./orchestration/Normalizer";
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery";
 import { ProviderRegistry } from "./provider/Services/ProviderRegistry";
+import { ProviderService } from "./provider/Services/ProviderService";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents";
 import { ServerRuntimeStartup } from "./serverRuntimeStartup";
 import { ServerSettingsService } from "./serverSettings";
@@ -185,6 +186,18 @@ const WsRpcLayer = WsRpcGroup.toLayer(
                 ),
               ),
               Stream.flatMap((events) => Stream.fromIterable(events)),
+            );
+          }),
+        ),
+      [WS_METHODS.subscribeProviderRuntimeToolOutputEvents]: (_input) =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            const providerService = yield* ProviderService;
+            return providerService.streamEvents.pipe(
+              Stream.filter(
+                (event) =>
+                  event.type === "content.delta" && event.payload.streamKind === "command_output",
+              ),
             );
           }),
         ),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -65,6 +65,7 @@ import {
 import { useStore } from "../store";
 import { useProjectById, useThreadById } from "../storeSelectors";
 import { useUiStateStore } from "../uiStateStore";
+import { useRuntimeToolOutputStore } from "../runtimeToolOutputStore";
 import {
   buildPlanImplementationThreadTitle,
   buildPlanImplementationPrompt,
@@ -834,9 +835,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
   const selectedModelForPicker = selectedModel;
   const phase = derivePhase(activeThread?.session ?? null);
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  const runtimeToolOutputByItemIdRaw = useRuntimeToolOutputStore((state) =>
+    activeThread ? (state.outputsByThreadId[activeThread.id] ?? null) : null,
+  );
+  const runtimeToolOutputByItemId = useMemo(
+    () => new Map(Object.entries(runtimeToolOutputByItemIdRaw ?? {})),
+    [runtimeToolOutputByItemIdRaw],
+  );
   const workLogEntries = useMemo(
-    () => deriveWorkLogEntries(threadActivities, activeLatestTurn?.turnId ?? undefined),
-    [activeLatestTurn?.turnId, threadActivities],
+    () => deriveWorkLogEntries(threadActivities, undefined, runtimeToolOutputByItemId),
+    [runtimeToolOutputByItemId, threadActivities],
   );
   const latestTurnHasToolActivity = useMemo(
     () => hasToolActivityForTurn(threadActivities, activeLatestTurn?.turnId),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -47,13 +47,14 @@ import {
   deriveTimelineEntries,
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
+  deriveBaseWorkLogEntries,
   findSidebarProposedPlan,
   findLatestProposedPlan,
-  deriveWorkLogEntries,
   hasActionableProposedPlan,
   hasToolActivityForTurn,
   isLatestTurnSettled,
   formatElapsed,
+  mergeRuntimeOutputIntoWorkLogEntries,
 } from "../session-logic";
 import { isScrollContainerNearBottom } from "../chat-scroll";
 import {
@@ -842,14 +843,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
     () => new Map(Object.entries(runtimeToolOutputByItemIdRaw ?? {})),
     [runtimeToolOutputByItemIdRaw],
   );
+  const baseWorkLogEntries = useMemo(
+    () => deriveBaseWorkLogEntries(threadActivities, activeLatestTurn?.turnId ?? undefined),
+    [activeLatestTurn?.turnId, threadActivities],
+  );
   const workLogEntries = useMemo(
-    () =>
-      deriveWorkLogEntries(
-        threadActivities,
-        activeLatestTurn?.turnId ?? undefined,
-        runtimeToolOutputByItemId,
-      ),
-    [activeLatestTurn?.turnId, runtimeToolOutputByItemId, threadActivities],
+    () => mergeRuntimeOutputIntoWorkLogEntries(baseWorkLogEntries, runtimeToolOutputByItemId),
+    [baseWorkLogEntries, runtimeToolOutputByItemId],
   );
   const latestTurnHasToolActivity = useMemo(
     () => hasToolActivityForTurn(threadActivities, activeLatestTurn?.turnId),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -843,8 +843,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [runtimeToolOutputByItemIdRaw],
   );
   const workLogEntries = useMemo(
-    () => deriveWorkLogEntries(threadActivities, undefined, runtimeToolOutputByItemId),
-    [runtimeToolOutputByItemId, threadActivities],
+    () =>
+      deriveWorkLogEntries(
+        threadActivities,
+        activeLatestTurn?.turnId ?? undefined,
+        runtimeToolOutputByItemId,
+      ),
+    [activeLatestTurn?.turnId, runtimeToolOutputByItemId, threadActivities],
   );
   const latestTurnHasToolActivity = useMemo(
     () => hasToolActivityForTurn(threadActivities, activeLatestTurn?.turnId),

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -186,7 +186,7 @@ describe("MessagesTimeline", () => {
       />,
     );
 
-    expect(markup).toContain("bun fmt");
+    expect(markup.match(/bun fmt/g)?.length).toBe(1);
     expect(markup).toContain("Show output");
     expect(markup).not.toContain("apps/web/src/session-logic.ts");
     expect(markup).not.toContain(

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -140,4 +140,57 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Context compacted");
     expect(markup).toContain("Work log");
   });
+
+  it("renders command output collapsed by default for tool work entries", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        hasMessages
+        isWorking={false}
+        activeTurnInProgress={false}
+        activeTurnStartedAt={null}
+        scrollContainer={null}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Ran command completed",
+              tone: "tool",
+              command: "bun fmt",
+              output:
+                "apps/web/src/session-logic.ts\napps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts\n",
+              toolTitle: "Ran command",
+              itemType: "command_execution",
+            },
+          },
+        ]}
+        completionDividerBeforeEntryId={null}
+        completionSummary={null}
+        turnDiffSummaryByAssistantMessageId={new Map()}
+        nowIso="2026-03-17T19:12:30.000Z"
+        expandedWorkGroups={{}}
+        onToggleWorkGroup={() => {}}
+        onOpenTurnDiff={() => {}}
+        revertTurnCountByUserMessageId={new Map()}
+        onRevertUserMessage={() => {}}
+        isRevertingCheckpoint={false}
+        onImageExpand={() => {}}
+        markdownCwd={undefined}
+        resolvedTheme="light"
+        timestampFormat="locale"
+        workspaceRoot={undefined}
+      />,
+    );
+
+    expect(markup).toContain("bun fmt");
+    expect(markup).toContain("Show output");
+    expect(markup).not.toContain("apps/web/src/session-logic.ts");
+    expect(markup).not.toContain(
+      "apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts",
+    );
+  });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -863,6 +863,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   workEntry: TimelineWorkEntry;
 }) {
   const { workEntry } = props;
+  const [outputExpanded, setOutputExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
   const EntryIcon = workEntryIcon(workEntry);
   const heading = toolWorkEntryHeading(workEntry);
@@ -870,6 +871,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const displayText = preview ? `${heading} - ${preview}` : heading;
   const hasChangedFiles = (workEntry.changedFiles?.length ?? 0) > 0;
   const previewIsChangedFiles = hasChangedFiles && !workEntry.command && !workEntry.detail;
+  const hasOutput = typeof workEntry.output === "string" && workEntry.output.length > 0;
 
   return (
     <div className="rounded-lg px-1 py-1">
@@ -895,6 +897,29 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           </p>
         </div>
       </div>
+      {workEntry.command && (
+        <div className="mt-1 pl-6">
+          <pre className="overflow-x-auto rounded-md border border-border/55 bg-background/75 px-2 py-1 font-mono text-[10px] leading-relaxed text-foreground/80">
+            {workEntry.command}
+          </pre>
+        </div>
+      )}
+      {hasOutput && (
+        <div className="mt-1 pl-6">
+          <button
+            type="button"
+            className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65 transition-colors duration-150 hover:text-foreground/75"
+            onClick={() => setOutputExpanded((current) => !current)}
+          >
+            {outputExpanded ? "Hide output" : "Show output"}
+          </button>
+          {outputExpanded && (
+            <pre className="mt-1 max-h-56 overflow-auto rounded-md border border-border/55 bg-background/75 px-2 py-1 font-mono text-[10px] leading-relaxed whitespace-pre-wrap break-words text-foreground/80">
+              {workEntry.output}
+            </pre>
+          )}
+        </div>
+      )}
       {hasChangedFiles && !previewIsChangedFiles && (
         <div className="mt-1 flex flex-wrap gap-1 pl-6">
           {workEntry.changedFiles?.slice(0, 4).map((filePath) => (

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -897,13 +897,6 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           </p>
         </div>
       </div>
-      {workEntry.command && (
-        <div className="mt-1 pl-6">
-          <pre className="overflow-x-auto rounded-md border border-border/55 bg-background/75 px-2 py-1 font-mono text-[10px] leading-relaxed text-foreground/80">
-            {workEntry.command}
-          </pre>
-        </div>
-      )}
       {hasOutput && (
         <div className="mt-1 pl-6">
           <button

--- a/apps/web/src/orchestrationEventEffects.test.ts
+++ b/apps/web/src/orchestrationEventEffects.test.ts
@@ -42,6 +42,7 @@ describe("deriveOrchestrationBatchEffects", () => {
   it("targets draft promotion and terminal cleanup from thread lifecycle events", () => {
     const createdThreadId = ThreadId.makeUnsafe("thread-created");
     const deletedThreadId = ThreadId.makeUnsafe("thread-deleted");
+    const startedThreadId = ThreadId.makeUnsafe("thread-started");
 
     const effects = deriveOrchestrationBatchEffects([
       makeEvent("thread.created", {
@@ -60,10 +61,19 @@ describe("deriveOrchestrationBatchEffects", () => {
         threadId: deletedThreadId,
         deletedAt: "2026-02-27T00:00:01.000Z",
       }),
+      makeEvent("thread.turn-start-requested", {
+        threadId: startedThreadId,
+        messageId: MessageId.makeUnsafe("message-started"),
+        modelSelection: { provider: "codex", model: "gpt-5-codex" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        createdAt: "2026-02-27T00:00:02.000Z",
+      }),
     ]);
 
     expect(effects.clearPromotedDraftThreadIds).toEqual([createdThreadId]);
     expect(effects.clearDeletedThreadIds).toEqual([deletedThreadId]);
+    expect(effects.clearRuntimeToolOutputThreadIds).toEqual([deletedThreadId, startedThreadId]);
     expect(effects.removeTerminalStateThreadIds).toEqual([deletedThreadId]);
     expect(effects.needsProviderInvalidation).toBe(false);
   });
@@ -102,6 +112,7 @@ describe("deriveOrchestrationBatchEffects", () => {
 
     expect(effects.clearPromotedDraftThreadIds).toEqual([threadId]);
     expect(effects.clearDeletedThreadIds).toEqual([]);
+    expect(effects.clearRuntimeToolOutputThreadIds).toEqual([]);
     expect(effects.removeTerminalStateThreadIds).toEqual([]);
     expect(effects.needsProviderInvalidation).toBe(true);
   });

--- a/apps/web/src/orchestrationEventEffects.ts
+++ b/apps/web/src/orchestrationEventEffects.ts
@@ -3,6 +3,7 @@ import type { OrchestrationEvent, ThreadId } from "@t3tools/contracts";
 export interface OrchestrationBatchEffects {
   clearPromotedDraftThreadIds: ThreadId[];
   clearDeletedThreadIds: ThreadId[];
+  clearRuntimeToolOutputThreadIds: ThreadId[];
   removeTerminalStateThreadIds: ThreadId[];
   needsProviderInvalidation: boolean;
 }
@@ -15,6 +16,7 @@ export function deriveOrchestrationBatchEffects(
     {
       clearPromotedDraft: boolean;
       clearDeletedThread: boolean;
+      clearRuntimeToolOutput: boolean;
       removeTerminalState: boolean;
     }
   >();
@@ -32,7 +34,19 @@ export function deriveOrchestrationBatchEffects(
         threadLifecycleEffects.set(event.payload.threadId, {
           clearPromotedDraft: true,
           clearDeletedThread: false,
+          clearRuntimeToolOutput: false,
           removeTerminalState: false,
+        });
+        break;
+      }
+
+      case "thread.turn-start-requested": {
+        const previous = threadLifecycleEffects.get(event.payload.threadId);
+        threadLifecycleEffects.set(event.payload.threadId, {
+          clearPromotedDraft: previous?.clearPromotedDraft ?? false,
+          clearDeletedThread: previous?.clearDeletedThread ?? false,
+          clearRuntimeToolOutput: true,
+          removeTerminalState: previous?.removeTerminalState ?? false,
         });
         break;
       }
@@ -41,6 +55,7 @@ export function deriveOrchestrationBatchEffects(
         threadLifecycleEffects.set(event.payload.threadId, {
           clearPromotedDraft: false,
           clearDeletedThread: true,
+          clearRuntimeToolOutput: true,
           removeTerminalState: true,
         });
         break;
@@ -54,6 +69,7 @@ export function deriveOrchestrationBatchEffects(
 
   const clearPromotedDraftThreadIds: ThreadId[] = [];
   const clearDeletedThreadIds: ThreadId[] = [];
+  const clearRuntimeToolOutputThreadIds: ThreadId[] = [];
   const removeTerminalStateThreadIds: ThreadId[] = [];
   for (const [threadId, effect] of threadLifecycleEffects) {
     if (effect.clearPromotedDraft) {
@@ -61,6 +77,9 @@ export function deriveOrchestrationBatchEffects(
     }
     if (effect.clearDeletedThread) {
       clearDeletedThreadIds.push(threadId);
+    }
+    if (effect.clearRuntimeToolOutput) {
+      clearRuntimeToolOutputThreadIds.push(threadId);
     }
     if (effect.removeTerminalState) {
       removeTerminalStateThreadIds.push(threadId);
@@ -70,6 +89,7 @@ export function deriveOrchestrationBatchEffects(
   return {
     clearPromotedDraftThreadIds,
     clearDeletedThreadIds,
+    clearRuntimeToolOutputThreadIds,
     removeTerminalStateThreadIds,
     needsProviderInvalidation,
   };

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -202,6 +202,7 @@ function EventRouter() {
   const removeOrphanedTerminalStates = useTerminalStateStore(
     (store) => store.removeOrphanedTerminalStates,
   );
+  const clearThreadRuntimeToolOutput = useRuntimeToolOutputStore((store) => store.clearThread);
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
@@ -394,6 +395,9 @@ function EventRouter() {
         draftStore.clearDraftThread(threadId);
         clearThreadUi(threadId);
       }
+      for (const threadId of batchEffects.clearRuntimeToolOutputThreadIds) {
+        clearThreadRuntimeToolOutput(threadId);
+      }
       for (const threadId of batchEffects.removeTerminalStateThreadIds) {
         removeTerminalState(threadId);
       }
@@ -520,6 +524,7 @@ function EventRouter() {
     removeTerminalState,
     removeOrphanedTerminalStates,
     clearThreadUi,
+    clearThreadRuntimeToolOutput,
     setProjectExpanded,
     syncProjects,
     syncServerReadModel,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -42,6 +42,7 @@ import { projectQueryKeys } from "../lib/projectReactQuery";
 import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
 import { deriveOrchestrationBatchEffects } from "../orchestrationEventEffects";
 import { createOrchestrationRecoveryCoordinator } from "../orchestrationRecovery";
+import { useRuntimeToolOutputStore } from "../runtimeToolOutputStore";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -430,6 +431,18 @@ function EventRouter() {
           hasRunningSubprocess,
         );
     });
+    const runtimeToolOutputStore = useRuntimeToolOutputStore.getState();
+    runtimeToolOutputStore.clearAll();
+    const unsubRuntimeToolOutputEvent = api.orchestration.onRuntimeToolOutputEvent((event) => {
+      if (
+        event.type !== "content.delta" ||
+        event.payload.streamKind !== "command_output" ||
+        !event.itemId
+      ) {
+        return;
+      }
+      runtimeToolOutputStore.appendOutput(event.threadId, event.itemId, event.payload.delta);
+    });
     return () => {
       disposed = true;
       disposedRef.current = true;
@@ -437,6 +450,7 @@ function EventRouter() {
       queryInvalidationThrottler.cancel();
       unsubDomainEvent();
       unsubTerminalEvent();
+      unsubRuntimeToolOutputEvent();
     };
   }, [
     applyOrchestrationEvents,

--- a/apps/web/src/runtimeToolOutputStore.ts
+++ b/apps/web/src/runtimeToolOutputStore.ts
@@ -1,0 +1,43 @@
+import { ThreadId } from "@t3tools/contracts";
+import { create } from "zustand";
+
+interface RuntimeToolOutputState {
+  outputsByThreadId: Record<string, Record<string, string>>;
+  appendOutput: (threadId: ThreadId, itemId: string, delta: string) => void;
+  clearThread: (threadId: ThreadId) => void;
+  clearAll: () => void;
+}
+
+const MAX_OUTPUT_CHARS_PER_ITEM = 24_000;
+
+export const useRuntimeToolOutputStore = create<RuntimeToolOutputState>((set) => ({
+  outputsByThreadId: {},
+  appendOutput: (threadId, itemId, delta) =>
+    set((state) => {
+      const threadOutputs = state.outputsByThreadId[threadId] ?? {};
+      const previous = threadOutputs[itemId] ?? "";
+      const next = `${previous}${delta}`;
+      return {
+        outputsByThreadId: {
+          ...state.outputsByThreadId,
+          [threadId]: {
+            ...threadOutputs,
+            [itemId]:
+              next.length > MAX_OUTPUT_CHARS_PER_ITEM
+                ? next.slice(next.length - MAX_OUTPUT_CHARS_PER_ITEM)
+                : next,
+          },
+        },
+      };
+    }),
+  clearThread: (threadId) =>
+    set((state) => {
+      if (!(threadId in state.outputsByThreadId)) {
+        return state;
+      }
+      const next = { ...state.outputsByThreadId };
+      delete next[threadId];
+      return { outputsByThreadId: next };
+    }),
+  clearAll: () => set({ outputsByThreadId: {} }),
+}));

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -978,6 +978,48 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("collapses a single replayed command completion by group when itemId is absent", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-start-no-item-id",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "npm run build",
+          data: {
+            item: {
+              command: ["npm", "run", "build"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-complete-no-item-id",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "<exited with exit code 0>",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "command-complete-no-item-id",
+      command: "npm run build",
+      itemType: "command_execution",
+      toolTitle: "Ran command",
+    });
+  });
+
   it("collapses replayed command started and updated rows when only the summary differs by lifecycle suffix", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -1111,6 +1153,63 @@ describe("deriveWorkLogEntries", () => {
       command: "npm run lint",
       itemType: "command_execution",
     });
+  });
+
+  it("does not collapse ambiguous replayed command completions when multiple open commands share a group and itemId is absent", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-1-start-no-item-id",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "npm run build",
+          data: {
+            item: {
+              command: ["npm", "run", "build"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-2-start-no-item-id",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "npm run lint",
+          data: {
+            item: {
+              command: ["npm", "run", "lint"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-complete-ambiguous",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "<exited with exit code 0>",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(3);
+    expect(entries.map((entry) => entry.id)).toEqual([
+      "command-1-start-no-item-id",
+      "command-2-start-no-item-id",
+      "command-complete-ambiguous",
+    ]);
   });
 
   it("preserves output on the first command when multiple replayed commands are present", () => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -825,6 +825,451 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("merges ephemeral command output into the matching command entry", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-1",
+          title: "Ran command",
+          data: {
+            item: {
+              command: ["bun", "fmt"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-progress-1",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-1",
+          title: "Ran command",
+        },
+      }),
+      makeActivity({
+        id: "command-progress-2",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-1",
+          title: "Ran command",
+        },
+      }),
+      makeActivity({
+        id: "command-complete",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-1",
+          title: "Ran command",
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(
+      activities,
+      undefined,
+      new Map([
+        [
+          "item-command-1",
+          "apps/web/src/session-logic.ts\napps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts\n",
+        ],
+      ]),
+    );
+
+    expect(entry).toMatchObject({
+      id: "command-complete",
+      command: "bun fmt",
+      output:
+        "apps/web/src/session-logic.ts\napps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts\n",
+      itemType: "command_execution",
+      toolTitle: "Ran command",
+    });
+  });
+
+  it("keeps command tool.started entries so output can stream before completion", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-start-only",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-live",
+          title: "Ran command",
+          data: {
+            item: {
+              command: ["bun", "run", "build"],
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(
+      activities,
+      undefined,
+      new Map([["item-command-live", "building...\n"]]),
+    );
+
+    expect(entry).toMatchObject({
+      id: "command-start-only",
+      command: "bun run build",
+      output: "building...\n",
+      itemType: "command_execution",
+      toolTitle: "Ran command",
+    });
+  });
+
+  it("collapses command started and completed rows even when their details differ", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "npm run build",
+          data: {
+            item: {
+              command: ["npm", "run", "build"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          detail: "<exited with exit code 0>",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "command-complete",
+      command: "npm run build",
+      itemType: "command_execution",
+      toolTitle: "Ran command",
+    });
+  });
+
+  it("collapses replayed command started and updated rows when only the summary differs by lifecycle suffix", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          detail: "npm run build",
+          data: {
+            item: {
+              command: ["npm", "run", "build"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-update",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          detail: "npm run build",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "command-update",
+      command: "npm run build",
+      itemType: "command_execution",
+      label: "Ran command",
+    });
+  });
+
+  it("collapses replayed multi-command rows even when all started events sort before later lifecycle events", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-1-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          detail: "npm run build",
+          data: {
+            item: {
+              command: ["npm", "run", "build"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-2-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          detail: "npm run lint",
+          data: {
+            item: {
+              command: ["npm", "run", "lint"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-1-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          detail: "npm run build",
+        },
+      }),
+      makeActivity({
+        id: "command-1-complete",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          detail: "<exited with exit code 0>",
+        },
+      }),
+      makeActivity({
+        id: "command-2-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          detail: "npm run lint",
+        },
+      }),
+      makeActivity({
+        id: "command-2-complete",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          detail: "<exited with exit code 0>",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      id: "command-1-complete",
+      command: "npm run build",
+      itemType: "command_execution",
+    });
+    expect(entries[1]).toMatchObject({
+      id: "command-2-complete",
+      command: "npm run lint",
+      itemType: "command_execution",
+    });
+  });
+
+  it("preserves output on the first command when multiple replayed commands are present", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-1-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-1",
+          detail: "npm run build",
+          data: {
+            item: {
+              command: ["npm", "run", "build"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-2-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-2",
+          detail: "npm run lint",
+          data: {
+            item: {
+              command: ["npm", "run", "lint"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-1-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-1",
+          detail: "<exited with exit code 0>",
+        },
+      }),
+      makeActivity({
+        id: "command-2-complete",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-2",
+          detail: "<exited with exit code 0>",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(
+      activities,
+      undefined,
+      new Map([
+        ["item-command-1", "build output\n"],
+        ["item-command-2", "lint output\n"],
+      ]),
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      id: "command-1-complete",
+      command: "npm run build",
+      output: "build output\n",
+      itemType: "command_execution",
+    });
+    expect(entries[1]).toMatchObject({
+      id: "command-2-complete",
+      command: "npm run lint",
+      output: "lint output\n",
+      itemType: "command_execution",
+    });
+  });
+
+  it("preserves output for both commands while a second command is still in progress", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-1-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-1",
+          title: "Ran command",
+          data: {
+            item: {
+              command: ["npm", "run", "build"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-1-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command completed",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-1",
+          title: "Ran command",
+          detail: "<exited with exit code 0>",
+        },
+      }),
+      makeActivity({
+        id: "command-2-start",
+        createdAt: "2026-02-23T00:00:03.000Z",
+        kind: "tool.started",
+        summary: "Ran command started",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-2",
+          title: "Ran command",
+          data: {
+            item: {
+              command: ["npm", "run", "lint"],
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-2-update",
+        createdAt: "2026-02-23T00:00:04.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          itemId: "item-command-2",
+          title: "Ran command",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(
+      activities,
+      undefined,
+      new Map([
+        ["item-command-1", "build output\n"],
+        ["item-command-2", "lint output\n"],
+      ]),
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      id: "command-1-complete",
+      command: "npm run build",
+      output: "build output\n",
+      itemType: "command_execution",
+    });
+    expect(entries[1]).toMatchObject({
+      id: "command-2-update",
+      command: "npm run lint",
+      output: "lint output\n",
+      itemType: "command_execution",
+    });
+  });
+
   it("keeps separate tool entries when an identical call starts after the prior one completed", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -943,6 +943,7 @@ describe("deriveWorkLogEntries", () => {
         summary: "Ran command started",
         payload: {
           itemType: "command_execution",
+          itemId: "item-command-build",
           title: "Ran command",
           detail: "npm run build",
           data: {
@@ -959,6 +960,7 @@ describe("deriveWorkLogEntries", () => {
         summary: "Ran command completed",
         payload: {
           itemType: "command_execution",
+          itemId: "item-command-build",
           title: "Ran command",
           detail: "<exited with exit code 0>",
         },
@@ -1016,7 +1018,7 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
-  it("collapses replayed multi-command rows even when all started events sort before later lifecycle events", () => {
+  it("collapses replayed multi-command rows by itemId when all started events sort before later lifecycle events", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "command-1-start",
@@ -1025,6 +1027,7 @@ describe("deriveWorkLogEntries", () => {
         summary: "Ran command started",
         payload: {
           itemType: "command_execution",
+          itemId: "item-command-1",
           detail: "npm run build",
           data: {
             item: {
@@ -1040,6 +1043,7 @@ describe("deriveWorkLogEntries", () => {
         summary: "Ran command started",
         payload: {
           itemType: "command_execution",
+          itemId: "item-command-2",
           detail: "npm run lint",
           data: {
             item: {
@@ -1055,6 +1059,7 @@ describe("deriveWorkLogEntries", () => {
         summary: "Ran command",
         payload: {
           itemType: "command_execution",
+          itemId: "item-command-1",
           detail: "npm run build",
         },
       }),
@@ -1065,6 +1070,7 @@ describe("deriveWorkLogEntries", () => {
         summary: "Ran command completed",
         payload: {
           itemType: "command_execution",
+          itemId: "item-command-1",
           detail: "<exited with exit code 0>",
         },
       }),
@@ -1075,6 +1081,7 @@ describe("deriveWorkLogEntries", () => {
         summary: "Ran command",
         payload: {
           itemType: "command_execution",
+          itemId: "item-command-2",
           detail: "npm run lint",
         },
       }),
@@ -1085,6 +1092,7 @@ describe("deriveWorkLogEntries", () => {
         summary: "Ran command completed",
         payload: {
           itemType: "command_execution",
+          itemId: "item-command-2",
           detail: "<exited with exit code 0>",
         },
       }),

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -472,7 +472,7 @@ export function deriveWorkLogEntries(
     .filter((activity) => !isPlanBoundaryToolActivity(activity))
     .map(toDerivedWorkLogEntry);
   return collapseDerivedWorkLogEntries(entries).map(
-    ({ activityKind: _activityKind, collapseKey: _collapseKey, itemId, ...entry }) => {
+    ({ activityKind: _activityKind, collapseKey: _collapseKey, groupKey: _groupKey, itemId, ...entry }) => {
       if (!itemId || !runtimeOutputByItemId.has(itemId)) {
         return entry;
       }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -46,11 +46,14 @@ export interface WorkLogEntry {
   requestKind?: PendingApproval["requestKind"];
 }
 
-interface DerivedWorkLogEntry extends WorkLogEntry {
+export interface RuntimeAttachableWorkLogEntry extends WorkLogEntry {
+  itemId?: string;
+}
+
+interface DerivedWorkLogEntry extends RuntimeAttachableWorkLogEntry {
   activityKind: OrchestrationThreadActivity["kind"];
   collapseKey?: string;
   groupKey?: string;
-  itemId?: string;
 }
 
 export interface PendingApproval {
@@ -462,6 +465,16 @@ export function deriveWorkLogEntries(
   latestTurnId: TurnId | undefined,
   runtimeOutputByItemId: ReadonlyMap<string, string> = new Map(),
 ): WorkLogEntry[] {
+  return mergeRuntimeOutputIntoWorkLogEntries(
+    deriveBaseWorkLogEntries(activities, latestTurnId),
+    runtimeOutputByItemId,
+  );
+}
+
+export function deriveBaseWorkLogEntries(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+  latestTurnId: TurnId | undefined,
+): RuntimeAttachableWorkLogEntry[] {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   const entries = ordered
     .filter((activity) => (latestTurnId ? activity.turnId === latestTurnId : true))
@@ -472,19 +485,21 @@ export function deriveWorkLogEntries(
     .filter((activity) => !isPlanBoundaryToolActivity(activity))
     .map(toDerivedWorkLogEntry);
   return collapseDerivedWorkLogEntries(entries).map(
-    ({
-      activityKind: _activityKind,
-      collapseKey: _collapseKey,
-      groupKey: _groupKey,
-      itemId,
-      ...entry
-    }) => {
-      if (!itemId || !runtimeOutputByItemId.has(itemId)) {
-        return entry;
-      }
-      return Object.assign(entry, { output: runtimeOutputByItemId.get(itemId) });
-    },
+    ({ activityKind: _activityKind, collapseKey: _collapseKey, groupKey: _groupKey, ...entry }) =>
+      entry,
   );
+}
+
+export function mergeRuntimeOutputIntoWorkLogEntries(
+  entries: ReadonlyArray<RuntimeAttachableWorkLogEntry>,
+  runtimeOutputByItemId: ReadonlyMap<string, string>,
+): WorkLogEntry[] {
+  return entries.map(({ itemId, ...entry }) => {
+    if (!itemId || !runtimeOutputByItemId.has(itemId)) {
+      return entry;
+    }
+    return Object.assign(entry, { output: runtimeOutputByItemId.get(itemId) });
+  });
 }
 
 function shouldIncludeWorkLogActivity(activity: OrchestrationThreadActivity): boolean {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -627,7 +627,11 @@ function findOpenLifecycleIndex(
       }
     }
   }
-  return undefined;
+  const fallbackCandidates = openIndices.filter((index) => {
+    const previous = collapsed[index];
+    return previous !== undefined && shouldCollapseToolLifecycleEntries(previous, next);
+  });
+  return fallbackCandidates.length === 1 ? fallbackCandidates[0] : undefined;
 }
 
 function shouldCollapseToolLifecycleEntries(

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -472,7 +472,13 @@ export function deriveWorkLogEntries(
     .filter((activity) => !isPlanBoundaryToolActivity(activity))
     .map(toDerivedWorkLogEntry);
   return collapseDerivedWorkLogEntries(entries).map(
-    ({ activityKind: _activityKind, collapseKey: _collapseKey, groupKey: _groupKey, itemId, ...entry }) => {
+    ({
+      activityKind: _activityKind,
+      collapseKey: _collapseKey,
+      groupKey: _groupKey,
+      itemId,
+      ...entry
+    }) => {
       if (!itemId || !runtimeOutputByItemId.has(itemId)) {
         return entry;
       }
@@ -621,7 +627,7 @@ function findOpenLifecycleIndex(
       }
     }
   }
-  return openIndices[0];
+  return undefined;
 }
 
 function shouldCollapseToolLifecycleEntries(

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -38,6 +38,7 @@ export interface WorkLogEntry {
   label: string;
   detail?: string;
   command?: string;
+  output?: string;
   changedFiles?: ReadonlyArray<string>;
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
@@ -48,6 +49,8 @@ export interface WorkLogEntry {
 interface DerivedWorkLogEntry extends WorkLogEntry {
   activityKind: OrchestrationThreadActivity["kind"];
   collapseKey?: string;
+  groupKey?: string;
+  itemId?: string;
 }
 
 export interface PendingApproval {
@@ -457,19 +460,37 @@ export function hasActionableProposedPlan(
 export function deriveWorkLogEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
   latestTurnId: TurnId | undefined,
+  runtimeOutputByItemId: ReadonlyMap<string, string> = new Map(),
 ): WorkLogEntry[] {
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
   const entries = ordered
     .filter((activity) => (latestTurnId ? activity.turnId === latestTurnId : true))
-    .filter((activity) => activity.kind !== "tool.started")
+    .filter((activity) => shouldIncludeWorkLogActivity(activity))
     .filter((activity) => activity.kind !== "task.started" && activity.kind !== "task.completed")
     .filter((activity) => activity.kind !== "context-window.updated")
     .filter((activity) => activity.summary !== "Checkpoint captured")
     .filter((activity) => !isPlanBoundaryToolActivity(activity))
     .map(toDerivedWorkLogEntry);
   return collapseDerivedWorkLogEntries(entries).map(
-    ({ activityKind: _activityKind, collapseKey: _collapseKey, ...entry }) => entry,
+    ({ activityKind: _activityKind, collapseKey: _collapseKey, itemId, ...entry }) => {
+      if (!itemId || !runtimeOutputByItemId.has(itemId)) {
+        return entry;
+      }
+      return Object.assign(entry, { output: runtimeOutputByItemId.get(itemId) });
+    },
   );
+}
+
+function shouldIncludeWorkLogActivity(activity: OrchestrationThreadActivity): boolean {
+  if (activity.kind !== "tool.started") {
+    return true;
+  }
+  const payload =
+    activity.payload && typeof activity.payload === "object"
+      ? (activity.payload as Record<string, unknown>)
+      : null;
+  const itemType = extractWorkLogItemType(payload);
+  return itemType === "command_execution" || itemType === "file_change";
 }
 
 function isPlanBoundaryToolActivity(activity: OrchestrationThreadActivity): boolean {
@@ -519,12 +540,20 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (itemType) {
     entry.itemType = itemType;
   }
+  const itemId = extractWorkLogItemId(payload);
+  if (itemId) {
+    entry.itemId = itemId;
+  }
   if (requestKind) {
     entry.requestKind = requestKind;
   }
   const collapseKey = deriveToolLifecycleCollapseKey(entry);
   if (collapseKey) {
     entry.collapseKey = collapseKey;
+  }
+  const groupKey = deriveToolLifecycleGroupKey(entry);
+  if (groupKey) {
+    entry.groupKey = groupKey;
   }
   return entry;
 }
@@ -533,31 +562,99 @@ function collapseDerivedWorkLogEntries(
   entries: ReadonlyArray<DerivedWorkLogEntry>,
 ): DerivedWorkLogEntry[] {
   const collapsed: DerivedWorkLogEntry[] = [];
+  const openIndicesByGroupKey = new Map<string, Array<number>>();
+
   for (const entry of entries) {
-    const previous = collapsed.at(-1);
-    if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
-      collapsed[collapsed.length - 1] = mergeDerivedWorkLogEntries(previous, entry);
+    const isLifecycleEntry =
+      entry.activityKind === "tool.started" ||
+      entry.activityKind === "tool.updated" ||
+      entry.activityKind === "tool.completed";
+    const groupKey = entry.groupKey;
+    const openIndices =
+      isLifecycleEntry && groupKey ? openIndicesByGroupKey.get(groupKey) : undefined;
+    const openIndex = findOpenLifecycleIndex(collapsed, openIndices, entry);
+    const openEntry = openIndex !== undefined ? collapsed[openIndex] : undefined;
+
+    if (
+      openIndex !== undefined &&
+      openEntry &&
+      shouldCollapseToolLifecycleEntries(openEntry, entry)
+    ) {
+      collapsed[openIndex] = mergeDerivedWorkLogEntries(openEntry, entry);
+      if (entry.activityKind === "tool.completed") {
+        if (openIndices) {
+          const queueIndex = openIndices.indexOf(openIndex);
+          if (queueIndex >= 0) {
+            openIndices.splice(queueIndex, 1);
+          }
+        }
+        if (groupKey && (!openIndices || openIndices.length === 0)) {
+          openIndicesByGroupKey.delete(groupKey);
+        }
+      }
       continue;
     }
-    collapsed.push(entry);
+
+    const nextIndex = collapsed.push(entry) - 1;
+    if (isLifecycleEntry && groupKey && entry.activityKind !== "tool.completed") {
+      const queue = openIndicesByGroupKey.get(groupKey) ?? [];
+      queue.push(nextIndex);
+      openIndicesByGroupKey.set(groupKey, queue);
+    }
   }
   return collapsed;
+}
+
+function findOpenLifecycleIndex(
+  collapsed: ReadonlyArray<DerivedWorkLogEntry>,
+  openIndices: ReadonlyArray<number> | undefined,
+  next: DerivedWorkLogEntry,
+): number | undefined {
+  if (!openIndices || openIndices.length === 0) {
+    return undefined;
+  }
+  const matchingCollapseKey = next.collapseKey;
+  if (matchingCollapseKey) {
+    for (const index of openIndices) {
+      if (collapsed[index]?.collapseKey === matchingCollapseKey) {
+        return index;
+      }
+    }
+  }
+  return openIndices[0];
 }
 
 function shouldCollapseToolLifecycleEntries(
   previous: DerivedWorkLogEntry,
   next: DerivedWorkLogEntry,
 ): boolean {
-  if (previous.activityKind !== "tool.updated" && previous.activityKind !== "tool.completed") {
+  if (
+    previous.activityKind !== "tool.started" &&
+    previous.activityKind !== "tool.updated" &&
+    previous.activityKind !== "tool.completed"
+  ) {
     return false;
   }
-  if (next.activityKind !== "tool.updated" && next.activityKind !== "tool.completed") {
+  if (
+    next.activityKind !== "tool.started" &&
+    next.activityKind !== "tool.updated" &&
+    next.activityKind !== "tool.completed"
+  ) {
     return false;
   }
   if (previous.activityKind === "tool.completed") {
     return false;
   }
-  return previous.collapseKey !== undefined && previous.collapseKey === next.collapseKey;
+  if (previous.itemId && next.itemId && previous.itemId !== next.itemId) {
+    return false;
+  }
+  if (previous.collapseKey && next.collapseKey && previous.collapseKey === next.collapseKey) {
+    return true;
+  }
+  if (!previous.groupKey || previous.groupKey !== next.groupKey) {
+    return false;
+  }
+  return previous.collapseKey === previous.groupKey || next.collapseKey === next.groupKey;
 }
 
 function mergeDerivedWorkLogEntries(
@@ -571,6 +668,8 @@ function mergeDerivedWorkLogEntries(
   const itemType = next.itemType ?? previous.itemType;
   const requestKind = next.requestKind ?? previous.requestKind;
   const collapseKey = next.collapseKey ?? previous.collapseKey;
+  const groupKey = next.groupKey ?? previous.groupKey;
+  const itemId = next.itemId ?? previous.itemId;
   return {
     ...previous,
     ...next,
@@ -581,6 +680,8 @@ function mergeDerivedWorkLogEntries(
     ...(itemType ? { itemType } : {}),
     ...(requestKind ? { requestKind } : {}),
     ...(collapseKey ? { collapseKey } : {}),
+    ...(groupKey ? { groupKey } : {}),
+    ...(itemId ? { itemId } : {}),
   };
 }
 
@@ -596,20 +697,68 @@ function mergeChangedFiles(
 }
 
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {
-  if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
+  if (
+    entry.activityKind !== "tool.started" &&
+    entry.activityKind !== "tool.updated" &&
+    entry.activityKind !== "tool.completed"
+  ) {
     return undefined;
   }
+  if (entry.itemId && entry.itemId.trim().length > 0) {
+    return entry.itemId;
+  }
   const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
-  const detail = entry.detail?.trim() ?? "";
   const itemType = entry.itemType ?? "";
+  if (itemType === "command_execution" || itemType === "file_change") {
+    const commandIdentity = deriveLifecycleCommandIdentity(entry);
+    if (commandIdentity) {
+      return [itemType, normalizedLabel, commandIdentity].join("\u001f");
+    }
+    if (normalizedLabel.length === 0 && itemType.length === 0) {
+      return undefined;
+    }
+    return [itemType, normalizedLabel].join("\u001f");
+  }
+  const detail = entry.detail?.trim() ?? "";
   if (normalizedLabel.length === 0 && detail.length === 0 && itemType.length === 0) {
     return undefined;
   }
   return [itemType, normalizedLabel, detail].join("\u001f");
 }
 
+function deriveToolLifecycleGroupKey(entry: DerivedWorkLogEntry): string | undefined {
+  if (
+    entry.activityKind !== "tool.started" &&
+    entry.activityKind !== "tool.updated" &&
+    entry.activityKind !== "tool.completed"
+  ) {
+    return undefined;
+  }
+  if (entry.itemId && entry.itemId.trim().length > 0) {
+    return entry.itemId;
+  }
+  const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
+  const itemType = entry.itemType ?? "";
+  if (normalizedLabel.length === 0 && itemType.length === 0) {
+    return undefined;
+  }
+  return [itemType, normalizedLabel].join("\u001f");
+}
+
+function deriveLifecycleCommandIdentity(entry: DerivedWorkLogEntry): string | undefined {
+  const normalizedCommand = entry.command?.trim();
+  if (normalizedCommand) {
+    return normalizedCommand;
+  }
+  const normalizedDetail = entry.detail?.trim();
+  if (!normalizedDetail || /^<exited with exit code \d+>$/i.test(normalizedDetail)) {
+    return undefined;
+  }
+  return normalizedDetail;
+}
+
 function normalizeCompactToolLabel(value: string): string {
-  return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
+  return value.replace(/\s+(?:start|started|update|updated|complete|completed)\s*$/i, "").trim();
 }
 
 function toLatestProposedPlanState(proposedPlan: ProposedPlan): LatestProposedPlanState {
@@ -696,6 +845,10 @@ function extractWorkLogItemType(
     return payload.itemType;
   }
   return undefined;
+}
+
+function extractWorkLogItemId(payload: Record<string, unknown> | null): string | undefined {
+  return typeof payload?.itemId === "string" ? payload.itemId : undefined;
 }
 
 function extractWorkLogRequestKind(

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -5,6 +5,8 @@ import {
   EventId,
   ProjectId,
   type OrchestrationEvent,
+  type ProviderRuntimeEvent,
+  RuntimeItemId,
   type ServerConfig,
   type ServerProvider,
   type TerminalEvent,
@@ -31,6 +33,7 @@ function registerListener<T>(listeners: Set<(event: T) => void>, listener: (even
 
 const terminalEventListeners = new Set<(event: TerminalEvent) => void>();
 const orchestrationEventListeners = new Set<(event: OrchestrationEvent) => void>();
+const runtimeToolOutputEventListeners = new Set<(event: ProviderRuntimeEvent) => void>();
 
 const rpcClientMock = {
   dispose: vi.fn(),
@@ -82,6 +85,9 @@ const rpcClientMock = {
     replayEvents: vi.fn(),
     onDomainEvent: vi.fn((listener: (event: OrchestrationEvent) => void) =>
       registerListener(orchestrationEventListeners, listener),
+    ),
+    onRuntimeToolOutputEvent: vi.fn((listener: (event: ProviderRuntimeEvent) => void) =>
+      registerListener(runtimeToolOutputEventListeners, listener),
     ),
   },
 };
@@ -168,6 +174,7 @@ beforeEach(() => {
   showContextMenuFallbackMock.mockReset();
   terminalEventListeners.clear();
   orchestrationEventListeners.clear();
+  runtimeToolOutputEventListeners.clear();
   Reflect.deleteProperty(getWindowForTest(), "desktopBridge");
 });
 
@@ -194,9 +201,11 @@ describe("wsNativeApi", () => {
     const api = createWsNativeApi();
     const onTerminalEvent = vi.fn();
     const onDomainEvent = vi.fn();
+    const onRuntimeToolOutputEvent = vi.fn();
 
     api.terminal.onEvent(onTerminalEvent);
     api.orchestration.onDomainEvent(onDomainEvent);
+    api.orchestration.onRuntimeToolOutputEvent(onRuntimeToolOutputEvent);
 
     const terminalEvent = {
       threadId: "thread-1",
@@ -233,8 +242,23 @@ describe("wsNativeApi", () => {
     } satisfies Extract<OrchestrationEvent, { type: "project.created" }>;
     emitEvent(orchestrationEventListeners, orchestrationEvent);
 
+    const runtimeToolOutputEvent = {
+      eventId: EventId.makeUnsafe("runtime-1"),
+      provider: "codex",
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      itemId: RuntimeItemId.makeUnsafe("item-1"),
+      createdAt: "2026-02-24T00:00:00.000Z",
+      type: "content.delta",
+      payload: {
+        streamKind: "command_output",
+        delta: "hello\n",
+      },
+    } as const satisfies Extract<ProviderRuntimeEvent, { type: "content.delta" }>;
+    emitEvent(runtimeToolOutputEventListeners, runtimeToolOutputEvent);
+
     expect(onTerminalEvent).toHaveBeenCalledWith(terminalEvent);
     expect(onDomainEvent).toHaveBeenCalledWith(orchestrationEvent);
+    expect(onRuntimeToolOutputEvent).toHaveBeenCalledWith(runtimeToolOutputEvent);
   });
 
   it("sends orchestration dispatch commands as the direct RPC payload", async () => {

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -99,6 +99,8 @@ export function createWsNativeApi(): NativeApi {
           .replayEvents({ fromSequenceExclusive })
           .then((events) => [...events]),
       onDomainEvent: (callback) => rpcClient.orchestration.onDomainEvent(callback),
+      onRuntimeToolOutputEvent: (callback) =>
+        rpcClient.orchestration.onRuntimeToolOutputEvent(callback),
     },
   };
 

--- a/apps/web/src/wsRpcClient.ts
+++ b/apps/web/src/wsRpcClient.ts
@@ -92,6 +92,9 @@ export interface WsRpcClient {
     readonly getFullThreadDiff: RpcUnaryMethod<typeof ORCHESTRATION_WS_METHODS.getFullThreadDiff>;
     readonly replayEvents: RpcUnaryMethod<typeof ORCHESTRATION_WS_METHODS.replayEvents>;
     readonly onDomainEvent: RpcStreamMethod<typeof WS_METHODS.subscribeOrchestrationDomainEvents>;
+    readonly onRuntimeToolOutputEvent: RpcStreamMethod<
+      typeof WS_METHODS.subscribeProviderRuntimeToolOutputEvents
+    >;
   };
 }
 
@@ -200,6 +203,11 @@ export function createWsRpcClient(transport = new WsTransport()): WsRpcClient {
       onDomainEvent: (listener) =>
         transport.subscribe(
           (client) => client[WS_METHODS.subscribeOrchestrationDomainEvents]({}),
+          listener,
+        ),
+      onRuntimeToolOutputEvent: (listener) =>
+        transport.subscribe(
+          (client) => client[WS_METHODS.subscribeProviderRuntimeToolOutputEvents]({}),
           listener,
         ),
     },

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -47,6 +47,7 @@ import type {
   OrchestrationEvent,
   OrchestrationReadModel,
 } from "./orchestration";
+import type { ProviderRuntimeEvent } from "./providerRuntime";
 import { EditorId } from "./editor";
 import { ServerSettings, ServerSettingsPatch } from "./settings";
 
@@ -181,5 +182,6 @@ export interface NativeApi {
     ) => Promise<OrchestrationGetFullThreadDiffResult>;
     replayEvents: (fromSequenceExclusive: number) => Promise<OrchestrationEvent[]>;
     onDomainEvent: (callback: (event: OrchestrationEvent) => void) => () => void;
+    onRuntimeToolOutputEvent: (callback: (event: ProviderRuntimeEvent) => void) => () => void;
   };
 }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -41,6 +41,7 @@ import {
   OrchestrationReplayEventsInput,
   OrchestrationRpcSchemas,
 } from "./orchestration";
+import { ProviderRuntimeEvent } from "./providerRuntime";
 import {
   ProjectSearchEntriesError,
   ProjectSearchEntriesInput,
@@ -111,6 +112,7 @@ export const WS_METHODS = {
 
   // Streaming subscriptions
   subscribeOrchestrationDomainEvents: "subscribeOrchestrationDomainEvents",
+  subscribeProviderRuntimeToolOutputEvents: "subscribeProviderRuntimeToolOutputEvents",
   subscribeTerminalEvents: "subscribeTerminalEvents",
   subscribeServerConfig: "subscribeServerConfig",
   subscribeServerLifecycle: "subscribeServerLifecycle",
@@ -302,6 +304,15 @@ export const WsSubscribeOrchestrationDomainEventsRpc = Rpc.make(
   },
 );
 
+export const WsSubscribeProviderRuntimeToolOutputEventsRpc = Rpc.make(
+  WS_METHODS.subscribeProviderRuntimeToolOutputEvents,
+  {
+    payload: Schema.Struct({}),
+    success: ProviderRuntimeEvent,
+    stream: true,
+  },
+);
+
 export const WsSubscribeTerminalEventsRpc = Rpc.make(WS_METHODS.subscribeTerminalEvents, {
   payload: Schema.Struct({}),
   success: TerminalEvent,
@@ -348,6 +359,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsTerminalRestartRpc,
   WsTerminalCloseRpc,
   WsSubscribeOrchestrationDomainEventsRpc,
+  WsSubscribeProviderRuntimeToolOutputEventsRpc,
   WsSubscribeTerminalEventsRpc,
   WsSubscribeServerConfigRpc,
   WsSubscribeServerLifecycleRpc,


### PR DESCRIPTION
I know this is not exactly a small PR, but its not really that huge and most of the stuff is boilerplate + tests and there aren't a lot of complicated changes.

## What Changed

The tool calls are shown in the UI when they start (this is especially useful for seeing that the model ran a command like running tests or benchmarks which can take significant time and the user is not stuck seeing "working...") and the output of the terminal commands are streamed into the UI (just kept in memory for the current session, not persisted, just like the Codex App) so that the user can see what's happening

## Why

- It's useful to see what the model is running as soon as it starts running it (rather than after it completes running it) so that we can stop it if its doing something wrong (for example, it might not be using something from our build system by default due to it not being mentioned in the Agents.md (or equivalent) and we can stop the model and ask it to change).
- Its also useful to see the outputs of the commands that the agent has run due to obvious reasons!

## UI Changes

A "Show Output" button is added for the commands:

<img width="1049" height="404" alt="image" src="https://github.com/user-attachments/assets/a885cee3-3151-4ca4-b2cf-7d6a2a45d8d3" />

<img width="1068" height="578" alt="image" src="https://github.com/user-attachments/assets/f637146a-5dc6-4537-92e3-64475b655467" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new WebSocket stream and client-side buffering/merging logic for provider runtime `command_output`, which could affect event ordering, memory usage, and work-log collapsing behavior across threads/turns.
> 
> **Overview**
> Adds end-to-end streaming of provider runtime command stdout into the web app via a new WS RPC subscription (`subscribeProviderRuntimeToolOutputEvents`) and corresponding client API wiring.
> 
> On the web side, introduces an in-memory `runtimeToolOutputStore` (per thread + `itemId`, size-capped) and updates chat/work-log derivation to include relevant `tool.started` entries and to *merge* ephemeral command output into matching work-log rows using `itemId`, with more robust lifecycle collapsing for concurrent/replayed commands.
> 
> UI updates the work log to show a per-entry **Show/Hide output** toggle (collapsed by default), and orchestration batching now clears buffered runtime output on turn start and thread deletion. Server ingestion is adjusted to include `itemId`/`data` in tool lifecycle activity payloads while explicitly not persisting `command_output` deltas.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72ef2d3ac1b090922d37263b86a8210ff35a336f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add live command output streaming to chat work log entries
> - Introduces a new WebSocket subscription (`subscribeProviderRuntimeToolOutputEvents`) that streams `content.delta` events with `streamKind === 'command_output'` from the provider runtime to the client.
> - Adds [`runtimeToolOutputStore.ts`](https://github.com/pingdotgg/t3code/pull/1665/files#diff-e38c657c51d2c52a4bab4c2d0dcfdef5d069baf866ceaf3515e384e765d45e1d), a Zustand store that accumulates streaming command output per thread and item, capped at 24,000 characters per item.
> - Extends work log derivation in [`session-logic.ts`](https://github.com/pingdotgg/t3code/pull/1665/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) to include `tool.started` entries for command and file change activities, attach live output by `itemId`, and collapse lifecycle entries (started/updated/completed) more robustly.
> - Renders a collapsible
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72ef2d3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->