### PR TITLE
Scope git query invalidation by cwd

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -45,6 +45,7 @@ import {
   gitPullMutationOptions,
   gitRunStackedActionMutationOptions,
   gitStatusQueryOptions,
+  invalidateGitStatusQuery,
   invalidateGitQueries,
 } from "~/lib/gitReactQuery";
 import { randomUUID } from "~/lib/utils";
@@ -243,8 +244,8 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
 
   useEffect(() => {
     if (!isGitStatusOutOfSync) return;
-    void invalidateGitQueries(queryClient);
-  }, [isGitStatusOutOfSync, queryClient]);
+    void invalidateGitQueries(queryClient, { cwd: gitCwd });
+  }, [gitCwd, isGitStatusOutOfSync, queryClient]);
 
   const gitStatusForActions = isGitStatusOutOfSync ? null : gitStatus;
 
@@ -778,7 +779,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
           <GroupSeparator className="hidden @3xl/header-actions:block" />
           <Menu
             onOpenChange={(open) => {
-              if (open) void invalidateGitQueries(queryClient);
+              if (open) void invalidateGitStatusQuery(queryClient, gitCwd);
             }}
           >
             <MenuTrigger

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -1,10 +1,24 @@
 import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../nativeApi", () => ({
+  ensureNativeApi: vi.fn(),
+}));
+
+vi.mock("../wsRpcClient", () => ({
+  getWsRpcClient: vi.fn(),
+}));
+
 import {
+  gitBranchesQueryOptions,
   gitMutationKeys,
+  gitQueryKeys,
   gitPreparePullRequestThreadMutationOptions,
   gitPullMutationOptions,
   gitRunStackedActionMutationOptions,
+  invalidateGitStatusQuery,
+  gitStatusQueryOptions,
+  invalidateGitQueries,
 } from "./gitReactQuery";
 
 describe("gitMutationKeys", () => {
@@ -47,5 +61,53 @@ describe("git mutation options", () => {
       queryClient,
     });
     expect(options.mutationKey).toEqual(gitMutationKeys.preparePullRequestThread("/repo/a"));
+  });
+});
+
+describe("invalidateGitQueries", () => {
+  it("can invalidate a single cwd without blasting other git query scopes", async () => {
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(gitQueryKeys.status("/repo/a"), { ok: "a" });
+    queryClient.setQueryData(gitQueryKeys.branches("/repo/a"), { ok: "a-branches" });
+    queryClient.setQueryData(gitQueryKeys.status("/repo/b"), { ok: "b" });
+    queryClient.setQueryData(gitQueryKeys.branches("/repo/b"), { ok: "b-branches" });
+
+    await invalidateGitQueries(queryClient, { cwd: "/repo/a" });
+
+    expect(
+      queryClient.getQueryState(gitStatusQueryOptions("/repo/a").queryKey)?.isInvalidated,
+    ).toBe(true);
+    expect(
+      queryClient.getQueryState(gitBranchesQueryOptions("/repo/a").queryKey)?.isInvalidated,
+    ).toBe(true);
+    expect(
+      queryClient.getQueryState(gitStatusQueryOptions("/repo/b").queryKey)?.isInvalidated,
+    ).toBe(false);
+    expect(
+      queryClient.getQueryState(gitBranchesQueryOptions("/repo/b").queryKey)?.isInvalidated,
+    ).toBe(false);
+  });
+});
+
+describe("invalidateGitStatusQuery", () => {
+  it("invalidates only status for the selected cwd", async () => {
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(gitQueryKeys.status("/repo/a"), { ok: "a" });
+    queryClient.setQueryData(gitQueryKeys.branches("/repo/a"), { ok: "a-branches" });
+    queryClient.setQueryData(gitQueryKeys.status("/repo/b"), { ok: "b" });
+
+    await invalidateGitStatusQuery(queryClient, "/repo/a");
+
+    expect(
+      queryClient.getQueryState(gitStatusQueryOptions("/repo/a").queryKey)?.isInvalidated,
+    ).toBe(true);
+    expect(
+      queryClient.getQueryState(gitBranchesQueryOptions("/repo/a").queryKey)?.isInvalidated,
+    ).toBe(false);
+    expect(
+      queryClient.getQueryState(gitStatusQueryOptions("/repo/b").queryKey)?.isInvalidated,
+    ).toBe(false);
   });
 });

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -23,8 +23,24 @@ export const gitMutationKeys = {
     ["git", "mutation", "prepare-pull-request-thread", cwd] as const,
 };
 
-export function invalidateGitQueries(queryClient: QueryClient) {
+export function invalidateGitQueries(queryClient: QueryClient, input?: { cwd?: string | null }) {
+  const cwd = input?.cwd ?? null;
+  if (cwd !== null) {
+    return Promise.all([
+      queryClient.invalidateQueries({ queryKey: gitQueryKeys.status(cwd) }),
+      queryClient.invalidateQueries({ queryKey: gitQueryKeys.branches(cwd) }),
+    ]);
+  }
+
   return queryClient.invalidateQueries({ queryKey: gitQueryKeys.all });
+}
+
+export function invalidateGitStatusQuery(queryClient: QueryClient, cwd: string | null) {
+  if (cwd === null) {
+    return Promise.resolve();
+  }
+
+  return queryClient.invalidateQueries({ queryKey: gitQueryKeys.status(cwd) });
 }
 
 export function gitStatusQueryOptions(cwd: string | null) {


### PR DESCRIPTION
## Summary
- Limit git query invalidation to the active `cwd` instead of invalidating all git queries globally.
- Add a status-only invalidation helper for menu opens so branch queries are left alone.
- Cover the new scoped invalidation behavior with Vitest tests.

## Testing
- Not run (PR description only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes React Query invalidation behavior for git status/branches, which could lead to stale or unexpectedly refreshed UI state if callers rely on global invalidation. Covered by new unit tests, but behavior shifts may surface in multi-repo/worktree scenarios.
> 
> **Overview**
> **Git React Query invalidation is now scoped by `cwd` rather than global.** `invalidateGitQueries` accepts an optional `{ cwd }` to invalidate only that repo’s `status`/`branches`, and a new `invalidateGitStatusQuery` helper invalidates only `status`.
> 
> `GitActionsControl` now uses these scoped helpers: it invalidates only the active repo when status/branch drift is detected, and on menu open it refreshes just `git status` instead of blasting all git queries. Adds Vitest coverage to ensure invalidation doesn’t affect other `cwd` query scopes and that status-only invalidation leaves branches untouched.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7281c73834f5820d595330969e989b4089b52086. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope git query invalidation by cwd in `invalidateGitQueries` and `invalidateGitStatusQuery`
> - Updates `invalidateGitQueries` in [gitReactQuery.ts](https://github.com/pingdotgg/t3code/pull/1670/files#diff-e457916ff52a952330bbc053522398bcf88467e595c5a9c4ec10f7681c65f250) to accept an optional `cwd` parameter; when provided, only the status and branches queries for that directory are invalidated instead of all git queries.
> - Adds a new `invalidateGitStatusQuery` export that invalidates only the status query for a given `cwd`, with a no-op when `cwd` is null.
> - Updates [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/1670/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) to pass `gitCwd` to both invalidation calls so out-of-sync detection and menu open only affect the current repository.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7281c73.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->