### PR TITLE
chore: add bun enforcement hook and local config patterns

### DIFF
--- a/.claude/hooks/enforce-bun.sh
+++ b/.claude/hooks/enforce-bun.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# PreToolUse hook: Block npm, npx, yarn, and pnpm commands — this project uses bun exclusively.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+
+# Check for npm commands (including npx)
+if echo "$COMMAND" | grep -qE '(^|[;&|][[:space:]]*)npm([[:space:]]|$)'; then
+  echo "This project uses bun, not npm. Use the equivalent bun command instead." >&2
+  exit 2
+fi
+
+if echo "$COMMAND" | grep -qE '(^|[;&|][[:space:]]*)npx([[:space:]]|$)'; then
+  echo "This project uses bun, not npx. Use 'bunx' instead of 'npx'." >&2
+  exit 2
+fi
+
+# Check for yarn commands
+if echo "$COMMAND" | grep -qE '(^|[;&|][[:space:]]*)yarn([[:space:]]|$)'; then
+  echo "This project uses bun, not yarn. Use the equivalent bun command instead." >&2
+  exit 2
+fi
+
+# Check for pnpm commands
+if echo "$COMMAND" | grep -qE '(^|[;&|][[:space:]]*)pnpm([[:space:]]|$)'; then
+  echo "This project uses bun, not pnpm. Use the equivalent bun command instead." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/enforce-bun.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ apps/web/src/components/__screenshots__
 .vitest-*
 __screenshots__/
 .tanstack
+*.local.*
+**/coverage/
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Add `.claude/hooks/enforce-bun.sh` to prevent accidental `npm`/`yarn`/`pnpm` usage in this bun-based monorepo
- Add `.claude/settings.json` with hook configuration
- Add local config patterns to `.gitignore`

## Test plan
- [ ] Verify `bun install` still works normally
- [ ] Verify `npm install` is blocked by the hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Claude Bash pre-hook and expands `.gitignore`; no runtime application logic is affected, though the hook could block some developer workflows if it false-positives.
> 
> **Overview**
> Adds a Claude `PreToolUse` Bash hook that reads the tool command input and **fails fast** if it detects `npm`, `npx`, `yarn`, or `pnpm`, steering usage to bun (including `bunx` for `npx`).
> 
> Registers this hook in `.claude/settings.json` so it runs before Bash tool executions, and expands `.gitignore` to exclude `*.local.*`, `**/coverage/`, and `.playwright-mcp/` artifacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 185abf0c43049f75fb65d3fb099d695a74ea7a9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bun enforcement hook to block npm, npx, yarn, and pnpm in Bash tool executions
> - Adds [enforce-bun.sh](.claude/hooks/enforce-bun.sh), a PreToolUse hook that parses the Bash tool's command input via `jq` and exits with code 2 if it detects `npm`, `npx`, `yarn`, or `pnpm` usage, printing guidance to stderr.
> - Registers the hook in [.claude/settings.json](.claude/settings.json) so it runs automatically before every Bash tool invocation in this environment.
> - Adds `*.local.*`, `**/coverage/`, and `.playwright-mcp/` patterns to [.gitignore](.gitignore).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 185abf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->