### PR TITLE
fix: enable diverged branch sync and target origin repo for PR creation

### DIFF
--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1424,6 +1424,20 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     },
   );
 
+  const resetToUpstream: GitCoreShape["resetToUpstream"] = (cwd) =>
+    Effect.gen(function* () {
+      const upstream = yield* runGitStdout(
+        "GitCore.resetToUpstream.upstream",
+        cwd,
+        ["rev-parse", "--abbrev-ref", "@{upstream}"],
+      );
+      yield* runGit("GitCore.resetToUpstream.reset", cwd, [
+        "reset",
+        "--hard",
+        upstream.trim(),
+      ]);
+    });
+
   const readRangeContext: GitCoreShape["readRangeContext"] = Effect.fn("readRangeContext")(
     function* (cwd, baseBranch) {
       const range = `${baseBranch}..HEAD`;
@@ -1966,6 +1980,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     commit,
     pushCurrentBranch,
     pullCurrentBranch,
+    resetToUpstream,
     readRangeContext,
     readConfigValue,
     isInsideWorkTree,

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -247,6 +247,7 @@ const makeGitHubCli = Effect.sync(() => {
         args: [
           "pr",
           "create",
+          ...(input.repo ? ["--repo", input.repo] : []),
           "--base",
           input.baseBranch,
           "--head",

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -74,6 +74,8 @@ interface BranchHeadContext {
   remoteName: string | null;
   headRepositoryNameWithOwner: string | null;
   headRepositoryOwnerLogin: string | null;
+  /** The origin remote's owner/repo — used to target the correct repo for PR creation in forks. */
+  originRepositoryNameWithOwner: string | null;
   isCrossRepository: boolean;
 }
 
@@ -808,6 +810,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
       remoteName,
       headRepositoryNameWithOwner: remoteRepository.repositoryNameWithOwner,
       headRepositoryOwnerLogin: remoteRepository.ownerLogin,
+      originRepositoryNameWithOwner: originRepository.repositoryNameWithOwner,
       isCrossRepository,
     } satisfies BranchHeadContext;
   });
@@ -1261,6 +1264,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
         headSelector: headContext.preferredHeadSelector,
         title: generated.title,
         bodyFile,
+        repo: headContext.originRepositoryNameWithOwner,
       })
       .pipe(Effect.ensuring(fileSystem.remove(bodyFile).pipe(Effect.catch(() => Effect.void))));
 

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -231,6 +231,11 @@ export interface GitCoreShape {
   readonly pullCurrentBranch: (cwd: string) => Effect.Effect<GitPullResult, GitCommandError>;
 
   /**
+   * Hard-reset the current branch to its upstream tracking ref.
+   */
+  readonly resetToUpstream: (cwd: string) => Effect.Effect<void, GitCommandError>;
+
+  /**
    * Create a worktree and branch from a base branch.
    */
   readonly createWorktree: (

--- a/apps/server/src/git/Services/GitHubCli.ts
+++ b/apps/server/src/git/Services/GitHubCli.ts
@@ -76,6 +76,8 @@ export interface GitHubCliShape {
     readonly headSelector: string;
     readonly title: string;
     readonly bodyFile: string;
+    /** Optional owner/repo to target. Without this, `gh` defaults to the upstream parent for forks. */
+    readonly repo?: string | null;
   }) => Effect.Effect<void, GitHubCliError>;
 
   /**

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -222,7 +222,34 @@ const WsRpcLayer = WsRpcGroup.toLayer(
         ),
       [WS_METHODS.shellOpenInEditor]: (input) => open.openInEditor(input),
       [WS_METHODS.gitStatus]: (input) => gitManager.status(input),
-      [WS_METHODS.gitPull]: (input) => git.pullCurrentBranch(input.cwd),
+      [WS_METHODS.gitPull]: (input) =>
+        git.pullCurrentBranch(input.cwd).pipe(
+          Effect.catch((pullError) =>
+            Effect.gen(function* () {
+              // Only attempt reset-to-upstream when the branch has actually diverged.
+              // Re-throw for network errors, auth failures, missing upstream, etc.
+              const details = yield* git.statusDetails(input.cwd);
+              if (details.aheadCount === 0 || details.behindCount === 0) {
+                return yield* Effect.fail(pullError);
+              }
+              if (details.hasWorkingTreeChanges) {
+                return yield* Effect.fail(
+                  new GitManagerServiceError({
+                    message:
+                      "Branch has diverged and has local changes. Stash or commit changes before syncing.",
+                  }),
+                );
+              }
+              yield* git.resetToUpstream(input.cwd);
+              const refreshed = yield* git.statusDetails(input.cwd);
+              return {
+                status: "pulled" as const,
+                branch: refreshed.branch ?? "unknown",
+                upstreamBranch: refreshed.upstreamRef,
+              };
+            }),
+          ),
+        ),
       [WS_METHODS.gitRunStackedAction]: (input) =>
         Stream.callback<GitActionProgressEvent, GitManagerServiceError>((queue) =>
           gitManager

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -70,6 +70,13 @@ describe("when: branch is clean and has an open PR", () => {
         dialogAction: "commit",
       },
       {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
+      },
+      {
         id: "push",
         label: "Push",
         disabled: true,
@@ -109,6 +116,13 @@ describe("when: actions are busy", () => {
         icon: "commit",
         kind: "open_dialog",
         dialogAction: "commit",
+      },
+      {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
       },
       {
         id: "push",
@@ -191,6 +205,13 @@ describe("when: branch is clean, ahead, and has an open PR", () => {
         dialogAction: "commit",
       },
       {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
+      },
+      {
         id: "push",
         label: "Push",
         disabled: false,
@@ -229,6 +250,13 @@ describe("when: branch is clean, ahead, and has no open PR", () => {
         icon: "commit",
         kind: "open_dialog",
         dialogAction: "commit",
+      },
+      {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
       },
       {
         id: "push",
@@ -271,6 +299,13 @@ describe("when: branch is clean, up to date, and has no open PR", () => {
         dialogAction: "commit",
       },
       {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
+      },
+      {
         id: "push",
         label: "Push",
         disabled: true,
@@ -296,7 +331,7 @@ describe("when: branch is behind upstream", () => {
     assert.deepInclude(quick, { kind: "run_pull", label: "Pull", disabled: false });
   });
 
-  it("buildMenuItems disables push and create PR", () => {
+  it("buildMenuItems enables pull and disables push and create PR", () => {
     const items = buildMenuItems(status({ behindCount: 1, pr: null }), false);
     assert.deepEqual(items, [
       {
@@ -306,6 +341,13 @@ describe("when: branch is behind upstream", () => {
         icon: "commit",
         kind: "open_dialog",
         dialogAction: "commit",
+      },
+      {
+        id: "pull",
+        label: "Pull",
+        disabled: false,
+        icon: "pull",
+        kind: "run_pull",
       },
       {
         id: "push",
@@ -328,13 +370,12 @@ describe("when: branch is behind upstream", () => {
 });
 
 describe("when: branch has diverged from upstream", () => {
-  it("resolveQuickAction returns a disabled sync hint", () => {
+  it("resolveQuickAction enables sync when working tree is clean", () => {
     const quick = resolveQuickAction(status({ aheadCount: 2, behindCount: 1 }), false);
     assert.deepEqual(quick, {
       label: "Sync branch",
-      disabled: true,
-      kind: "show_hint",
-      hint: "Branch has diverged from upstream. Rebase/merge first.",
+      disabled: false,
+      kind: "run_pull",
     });
   });
 });
@@ -396,6 +437,13 @@ describe("when: working tree has local changes", () => {
         icon: "commit",
         kind: "open_dialog",
         dialogAction: "commit",
+      },
+      {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
       },
       {
         id: "push",
@@ -472,6 +520,13 @@ describe("when: working tree has local changes and branch is behind upstream", (
         dialogAction: "commit",
       },
       {
+        id: "pull",
+        label: "Pull",
+        disabled: false,
+        icon: "pull",
+        kind: "run_pull",
+      },
+      {
         id: "push",
         label: "Push",
         disabled: true,
@@ -500,7 +555,7 @@ describe("when: HEAD is detached and there are no local changes", () => {
     assert.deepInclude(quick, { kind: "show_hint", label: "Commit", disabled: true });
   });
 
-  it("buildMenuItems keeps commit, push, and PR disabled", () => {
+  it("buildMenuItems keeps commit, pull, push, and PR disabled", () => {
     const items = buildMenuItems(status({ branch: null, hasWorkingTreeChanges: false }), false);
     assert.deepEqual(items, [
       {
@@ -510,6 +565,13 @@ describe("when: HEAD is detached and there are no local changes", () => {
         icon: "commit",
         kind: "open_dialog",
         dialogAction: "commit",
+      },
+      {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
       },
       {
         id: "push",
@@ -604,6 +666,13 @@ describe("when: branch has no upstream configured", () => {
         dialogAction: "commit",
       },
       {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
+      },
+      {
         id: "push",
         label: "Push",
         disabled: true,
@@ -670,6 +739,13 @@ describe("when: branch has no upstream configured", () => {
         dialogAction: "commit",
       },
       {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
+      },
+      {
         id: "push",
         label: "Push",
         disabled: false,
@@ -702,6 +778,13 @@ describe("when: branch has no upstream configured", () => {
         icon: "commit",
         kind: "open_dialog",
         dialogAction: "commit",
+      },
+      {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
       },
       {
         id: "push",
@@ -778,6 +861,13 @@ describe("when: branch has no upstream configured", () => {
         icon: "commit",
         kind: "open_dialog",
         dialogAction: "commit",
+      },
+      {
+        id: "pull",
+        label: "Pull",
+        disabled: true,
+        icon: "pull",
+        kind: "run_pull",
       },
       {
         id: "push",

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -4,16 +4,16 @@ import type {
   GitStatusResult,
 } from "@t3tools/contracts";
 
-export type GitActionIconName = "commit" | "push" | "pr";
+export type GitActionIconName = "commit" | "push" | "pull" | "pr";
 
 export type GitDialogAction = "commit" | "push" | "create_pr";
 
 export interface GitActionMenuItem {
-  id: "commit" | "push" | "pr";
+  id: "commit" | "push" | "pull" | "pr";
   label: string;
   disabled: boolean;
   icon: GitActionIconName;
-  kind: "open_dialog" | "open_pr";
+  kind: "open_dialog" | "open_pr" | "run_pull";
   dialogAction?: GitDialogAction;
 }
 
@@ -80,22 +80,25 @@ export function buildMenuItems(
   const hasBranch = gitStatus.branch !== null;
   const hasChanges = gitStatus.hasWorkingTreeChanges;
   const hasOpenPr = gitStatus.pr?.state === "open";
+  const isAhead = gitStatus.aheadCount > 0;
   const isBehind = gitStatus.behindCount > 0;
   const canPushWithoutUpstream = hasOriginRemote && !gitStatus.hasUpstream;
   const canCommit = !isBusy && hasChanges;
+  const canPull =
+    !isBusy && hasBranch && gitStatus.hasUpstream && isBehind;
   const canPush =
     !isBusy &&
     hasBranch &&
     !hasChanges &&
     !isBehind &&
-    gitStatus.aheadCount > 0 &&
+    isAhead &&
     (gitStatus.hasUpstream || canPushWithoutUpstream);
   const canCreatePr =
     !isBusy &&
     hasBranch &&
     !hasChanges &&
     !hasOpenPr &&
-    gitStatus.aheadCount > 0 &&
+    isAhead &&
     !isBehind &&
     (gitStatus.hasUpstream || canPushWithoutUpstream);
   const canOpenPr = !isBusy && hasOpenPr;
@@ -108,6 +111,13 @@ export function buildMenuItems(
       icon: "commit",
       kind: "open_dialog",
       dialogAction: "commit",
+    },
+    {
+      id: "pull",
+      label: isAhead && isBehind ? "Sync (force pull)" : "Pull",
+      disabled: !canPull,
+      icon: "pull",
+      kind: "run_pull",
     },
     {
       id: "push",
@@ -226,12 +236,15 @@ export function resolveQuickAction(
   }
 
   if (isDiverged) {
-    return {
-      label: "Sync branch",
-      disabled: true,
-      kind: "show_hint",
-      hint: "Branch has diverged from upstream. Rebase/merge first.",
-    };
+    if (hasChanges) {
+      return {
+        label: "Sync branch",
+        disabled: true,
+        kind: "show_hint",
+        hint: "Stash or commit local changes before syncing.",
+      };
+    }
+    return { label: "Sync branch", disabled: false, kind: "run_pull" };
   }
 
   if (isBehind) {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -7,7 +7,13 @@ import type {
 } from "@t3tools/contracts";
 import { useIsMutating, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
-import { ChevronDownIcon, CloudUploadIcon, GitCommitIcon, InfoIcon } from "lucide-react";
+import {
+  ArrowDownToLineIcon,
+  ChevronDownIcon,
+  CloudUploadIcon,
+  GitCommitIcon,
+  InfoIcon,
+} from "lucide-react";
 import { GitHubIcon } from "./Icons";
 import {
   buildGitActionProgressStages,
@@ -141,6 +147,19 @@ function getMenuActionDisabledReason({
     return "Commit is currently unavailable.";
   }
 
+  if (item.id === "pull") {
+    if (!hasBranch) {
+      return "Detached HEAD: checkout a branch before pulling.";
+    }
+    if (!gitStatus.hasUpstream) {
+      return "No upstream configured. Push with upstream first.";
+    }
+    if (!isBehind) {
+      return "Branch is already up to date with upstream.";
+    }
+    return "Pull is currently unavailable.";
+  }
+
   if (item.id === "push") {
     if (!hasBranch) {
       return "Detached HEAD: checkout a branch before pushing.";
@@ -187,6 +206,7 @@ const COMMIT_DIALOG_DESCRIPTION =
 
 function GitActionItemIcon({ icon }: { icon: GitActionIconName }) {
   if (icon === "commit") return <GitCommitIcon />;
+  if (icon === "pull") return <ArrowDownToLineIcon />;
   if (icon === "push") return <CloudUploadIcon />;
   return <GitHubIcon />;
 }
@@ -194,7 +214,7 @@ function GitActionItemIcon({ icon }: { icon: GitActionIconName }) {
 function GitQuickActionIcon({ quickAction }: { quickAction: GitQuickAction }) {
   const iconClassName = "size-3.5";
   if (quickAction.kind === "open_pr") return <GitHubIcon className={iconClassName} />;
-  if (quickAction.kind === "run_pull") return <InfoIcon className={iconClassName} />;
+  if (quickAction.kind === "run_pull") return <ArrowDownToLineIcon className={iconClassName} />;
   if (quickAction.kind === "run_action") {
     if (quickAction.action === "commit") return <GitCommitIcon className={iconClassName} />;
     if (quickAction.action === "push" || quickAction.action === "commit_push") {
@@ -702,6 +722,27 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
         void openExistingPr();
         return;
       }
+      if (item.kind === "run_pull") {
+        const promise = pullMutation.mutateAsync();
+        toastManager.promise(promise, {
+          loading: { title: "Pulling...", data: threadToastData },
+          success: (result) => ({
+            title: result.status === "pulled" ? "Pulled" : "Already up to date",
+            description:
+              result.status === "pulled"
+                ? `Updated ${result.branch} from ${result.upstreamBranch ?? "upstream"}`
+                : `${result.branch} is already synchronized.`,
+            data: threadToastData,
+          }),
+          error: (err) => ({
+            title: "Pull failed",
+            description: err instanceof Error ? err.message : "An error occurred.",
+            data: threadToastData,
+          }),
+        });
+        void promise.catch(() => undefined);
+        return;
+      }
       if (item.dialogAction === "push") {
         void runGitActionWithToast({ action: "push" });
         return;
@@ -714,7 +755,7 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
       setIsEditingFiles(false);
       setIsCommitDialogOpen(true);
     },
-    [openExistingPr, setIsCommitDialogOpen],
+    [openExistingPr, pullMutation, runGitActionWithToast, setIsCommitDialogOpen, threadToastData, toastManager],
   );
 
   const runDialogAction = useCallback(() => {


### PR DESCRIPTION
## Summary
- When a local branch has diverged from its upstream (e.g. after a force-push), allow force-pull (reset to upstream) if the working tree is clean
- Pass `--repo` flag to `gh pr create` so PRs target the correct fork repository instead of defaulting to upstream parent
- Update GitActionsControl UI with new pull menu item for diverged branches

## Test plan
- [ ] Force-push a branch remotely, verify the UI offers a sync option
- [ ] Verify PR creation targets the correct repository in a fork setup
- [ ] Verify diverged sync is blocked when working tree has uncommitted changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because `gitPull` can now hard-reset a diverged branch to its upstream, discarding local commits when the working tree is clean. Also changes PR creation targeting via `gh --repo`, which could affect fork/upstream selection.
> 
> **Overview**
> Improves git syncing and PR creation in forked/diverged scenarios.
> 
> On the server, `gitPull` now falls back to a new `GitCore.resetToUpstream` (hard reset to `@{upstream}`) when a fast-forward pull fails due to *true divergence* (ahead+behind) and the working tree is clean; it blocks this fallback when there are local uncommitted changes.
> 
> For PR creation, `GitManager` now resolves the `origin` repository `owner/repo` and passes it through `GitHubCli.createPullRequest`, which forwards it to `gh pr create` via `--repo` to ensure PRs are opened against the correct fork. The web UI adds a `Pull`/`Sync (force pull)` action (menu + quick action), wires it to the pull mutation with toasts, and updates logic/tests to enable sync on diverged clean branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b7ec8c444a04aa2753100e6aaeda56c30cfdf35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pull/sync action to git controls and fix PR creation to target origin repo
> - Adds a Pull menu item and quick action to [`GitActionsControl`](https://github.com/pingdotgg/t3code/pull/1678/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f); labels it 'Sync (force pull)' when the branch has diverged, 'Pull' otherwise
> - When a diverged branch has a clean working tree, the `gitPull` WS handler now hard-resets to upstream via a new `resetToUpstream` command instead of failing
> - When the working tree has uncommitted changes on a diverged branch, the pull is blocked with a message to stash or commit first
> - Passes `--repo <owner/repo>` to `gh pr create` using the origin remote's repository name, fixing PR creation in forks
> - Risk: `resetToUpstream` performs a hard reset (`git reset --hard`), discarding any local commits on the branch without additional confirmation
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b7ec8c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->