### PR TITLE
fix: support mobile access when dev server binds to 0.0.0.0

### DIFF
--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -52,12 +52,18 @@ export const resolveServerUrl = (options?: {
   pathname?: string | undefined;
   searchParams?: Record<string, string> | undefined;
 }): string => {
-  const rawUrl = firstNonEmptyString(
+  let rawUrl = firstNonEmptyString(
     options?.url,
     window.desktopBridge?.getWsUrl(),
     import.meta.env.VITE_WS_URL,
     window.location.origin,
   );
+
+  // When accessing from a remote host (e.g. mobile), replace localhost in the
+  // resolved URL with the actual page hostname so the connection reaches the server.
+  if (rawUrl.includes("localhost") && window.location.hostname !== "localhost") {
+    rawUrl = rawUrl.replace("localhost", window.location.hostname);
+  }
 
   const parsedUrl = new URL(rawUrl);
   if (options?.protocol) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig } from "vite";
 import pkg from "./package.json" with { type: "json" };
 
 const port = Number(process.env.PORT ?? 5733);
+const host = process.env.T3CODE_HOST ?? "localhost";
 const sourcemapEnv = process.env.T3CODE_WEB_SOURCEMAP?.trim().toLowerCase();
 
 const buildSourcemap =
@@ -42,14 +43,12 @@ export default defineConfig({
   },
   server: {
     port,
+    host,
     strictPort: true,
-    hmr: {
-      // Explicit config so Vite's HMR WebSocket connects reliably
-      // inside Electron's BrowserWindow. Vite 8 uses console.debug for
-      // connection logs — enable "Verbose" in DevTools to see them.
-      protocol: "ws",
-      host: "localhost",
-    },
+    hmr:
+      host === "localhost"
+        ? { protocol: "ws", host: "localhost" }
+        : { protocol: "ws" },
   },
   build: {
     outDir: "dist",

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,8 @@
     "T3CODE_NO_BROWSER",
     "T3CODE_HOME",
     "T3CODE_AUTH_TOKEN",
-    "T3CODE_DESKTOP_WS_URL"
+    "T3CODE_DESKTOP_WS_URL",
+    "T3CODE_HOST"
   ],
   "tasks": {
     "build": {


### PR DESCRIPTION
## Summary
- Vite dev server respects `T3CODE_HOST` env var for network binding (e.g. `T3CODE_HOST=0.0.0.0`)
- HMR auto-detects host when binding to `0.0.0.0` instead of hardcoding `localhost`
- Add `T3CODE_HOST` to turbo.json global env passthrough

## Test plan
- [ ] Run with `T3CODE_HOST=0.0.0.0 bun dev` and access from another device on the same network
- [ ] Verify HMR still works when accessing from a remote host
- [ ] Verify default `localhost` behavior is unchanged when `T3CODE_HOST` is not set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dev-only configuration and URL resolution changes; main risk is misrouting HMR/WebSocket connections when running with custom hosts.
> 
> **Overview**
> Improves remote-device access to the dev server by making Vite bind to a configurable host via `T3CODE_HOST` (defaulting to `localhost`) and adjusting HMR config to avoid hardcoding `localhost` when not running locally.
> 
> Updates `resolveServerUrl` to rewrite `localhost` to the current `window.location.hostname` when the app is accessed from a non-localhost host, ensuring WebSocket connections reach the correct machine. Exposes `T3CODE_HOST` through Turborepo `globalEnv` so the setting propagates in tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2a9afe10de009525223528e7e911ef0c85a1bef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile access when dev server binds to 0.0.0.0
> - Adds `T3CODE_HOST` env var support to [vite.config.ts](https://github.com/pingdotgg/t3code/pull/1680/files#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786) so the dev server binds to a configurable host (default `localhost`). HMR omits an explicit host when not on localhost to allow correct host resolution.
> - Updates `resolveServerUrl` in [utils.ts](https://github.com/pingdotgg/t3code/pull/1680/files#diff-a77b1983abf81ad3ac9e3d762f4ea683e77399fc446a1f34a6c0d57cde0ab767) to replace `localhost` in resolved URLs with `window.location.hostname` when the page is accessed from a non-localhost host.
> - Exposes `T3CODE_HOST` as a global env var in [turbo.json](https://github.com/pingdotgg/t3code/pull/1680/files#diff-dc1ab82934504704ef0b80c4bd508be042f74800ed3a52df23850d62c8f2e600).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2a9afe.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->