### PR TITLE
feat(settings): bulk select and actions for archived threads

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -6,6 +6,7 @@ import {
   LoaderIcon,
   PlusIcon,
   RefreshCwIcon,
+  Trash2,
   Undo2Icon,
   XIcon,
 } from "lucide-react";
@@ -49,7 +50,17 @@ import { ensureNativeApi, readNativeApi } from "../../nativeApi";
 import { useStore } from "../../store";
 import { formatRelativeTime, formatRelativeTimeLabel } from "../../timestampFormat";
 import { cn } from "../../lib/utils";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
 import { Button } from "../ui/button";
+import { Checkbox } from "../ui/checkbox";
 import { Collapsible, CollapsibleContent } from "../ui/collapsible";
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
 import { Input } from "../ui/input";
@@ -1416,7 +1427,11 @@ export function GeneralSettingsPanel() {
 export function ArchivedThreadsPanel() {
   const projects = useStore((store) => store.projects);
   const threads = useStore((store) => store.threads);
-  const { unarchiveThread, confirmAndDeleteThread } = useThreadActions();
+  const appSettings = useSettings();
+  const { unarchiveThread, confirmAndDeleteThread, deleteThread } = useThreadActions();
+  const [selectedArchivedIds, setSelectedArchivedIds] = useState(() => new Set<ThreadId>());
+  const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
+
   const archivedGroups = useMemo(() => {
     const projectById = new Map(projects.map((project) => [project.id, project] as const));
     return [...projectById.values()]
@@ -1432,6 +1447,92 @@ export function ArchivedThreadsPanel() {
       }))
       .filter((group) => group.threads.length > 0);
   }, [projects, threads]);
+
+  const allArchivedThreadIds = useMemo(
+    () => archivedGroups.flatMap((group) => group.threads.map((thread) => thread.id)),
+    [archivedGroups],
+  );
+
+  const archivedIdsKey = useMemo(() => allArchivedThreadIds.join("\0"), [allArchivedThreadIds]);
+
+  useEffect(() => {
+    const valid = new Set(allArchivedThreadIds);
+    setSelectedArchivedIds((previous) => {
+      let changed = false;
+      const next = new Set<ThreadId>();
+      for (const id of previous) {
+        if (valid.has(id)) {
+          next.add(id);
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : previous;
+    });
+  }, [archivedIdsKey, allArchivedThreadIds]);
+
+  const selectedCount = selectedArchivedIds.size;
+  const allSelected =
+    allArchivedThreadIds.length > 0 && selectedCount === allArchivedThreadIds.length;
+  const noneSelected = selectedCount === 0;
+
+  const toggleArchivedSelected = useCallback((threadId: ThreadId, checked: boolean) => {
+    setSelectedArchivedIds((previous) => {
+      const next = new Set(previous);
+      if (checked) {
+        next.add(threadId);
+      } else {
+        next.delete(threadId);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleBulkUnarchiveArchived = useCallback(async () => {
+    const ids = [...selectedArchivedIds];
+    if (ids.length === 0) return;
+    for (const threadId of ids) {
+      try {
+        await unarchiveThread(threadId);
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Failed to unarchive thread",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
+      }
+    }
+    setSelectedArchivedIds(new Set());
+  }, [selectedArchivedIds, unarchiveThread]);
+
+  const executeBulkDeleteArchived = useCallback(async () => {
+    const ids = [...selectedArchivedIds];
+    if (ids.length === 0) return;
+    const deletedIds = new Set<ThreadId>(ids);
+    for (const threadId of ids) {
+      await deleteThread(threadId, { deletedThreadIds: deletedIds });
+    }
+    setSelectedArchivedIds(new Set());
+  }, [deleteThread, selectedArchivedIds]);
+
+  const requestBulkDeleteArchived = useCallback(() => {
+    if (selectedArchivedIds.size === 0) return;
+    if (!appSettings.confirmThreadDelete) {
+      void executeBulkDeleteArchived();
+      return;
+    }
+    setBulkDeleteDialogOpen(true);
+  }, [appSettings.confirmThreadDelete, executeBulkDeleteArchived, selectedArchivedIds.size]);
+
+  const confirmBulkDeleteFromDialog = useCallback(() => {
+    void (async () => {
+      try {
+        await executeBulkDeleteArchived();
+      } finally {
+        setBulkDeleteDialogOpen(false);
+      }
+    })();
+  }, [executeBulkDeleteArchived]);
 
   const handleArchivedThreadContextMenu = useCallback(
     async (threadId: ThreadId, position: { x: number; y: number }) => {
@@ -1480,54 +1581,125 @@ export function ArchivedThreadsPanel() {
           </Empty>
         </SettingsSection>
       ) : (
-        archivedGroups.map(({ project, threads: projectThreads }) => (
-          <SettingsSection
-            key={project.id}
-            title={project.name}
-            icon={<ProjectFavicon cwd={project.cwd} />}
-          >
-            {projectThreads.map((thread) => (
-              <div
-                key={thread.id}
-                className="flex items-center justify-between gap-3 border-t border-border px-4 py-3 first:border-t-0 sm:px-5"
-                onContextMenu={(event) => {
-                  event.preventDefault();
-                  void handleArchivedThreadContextMenu(thread.id, {
-                    x: event.clientX,
-                    y: event.clientY,
-                  });
-                }}
-              >
-                <div className="min-w-0 flex-1">
-                  <h3 className="truncate text-sm font-medium text-foreground">{thread.title}</h3>
-                  <p className="text-xs text-muted-foreground">
-                    Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}
-                    {" \u00b7 Created "}
-                    {formatRelativeTimeLabel(thread.createdAt)}
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-7 shrink-0 cursor-pointer gap-1.5 px-2.5"
-                  onClick={() =>
-                    void unarchiveThread(thread.id).catch((error) => {
-                      toastManager.add({
-                        type: "error",
-                        title: "Failed to unarchive thread",
-                        description: error instanceof Error ? error.message : "An error occurred.",
-                      });
-                    })
+        <>
+          <div className="flex flex-wrap items-center gap-3 border-b border-border pb-4">
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
+              <Checkbox
+                checked={allSelected}
+                indeterminate={!allSelected && !noneSelected}
+                disabled={allArchivedThreadIds.length === 0}
+                onCheckedChange={(value) => {
+                  if (value === true) {
+                    setSelectedArchivedIds(new Set(allArchivedThreadIds));
+                  } else {
+                    setSelectedArchivedIds(new Set());
                   }
+                }}
+              />
+              <span>Select all</span>
+            </label>
+            <Button
+              type="button"
+              size="xs"
+              variant="destructive"
+              disabled={selectedCount === 0}
+              onClick={requestBulkDeleteArchived}
+            >
+              <Trash2 className="size-3.5" />
+              Delete ({selectedCount})
+            </Button>
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              disabled={selectedCount === 0}
+              onClick={() => void handleBulkUnarchiveArchived()}
+            >
+              <ArchiveX className="size-3.5" />
+              Unarchive ({selectedCount})
+            </Button>
+          </div>
+          {archivedGroups.map(({ project, threads: projectThreads }) => (
+            <SettingsSection
+              key={project.id}
+              title={project.name}
+              icon={<ProjectFavicon cwd={project.cwd} />}
+            >
+              {projectThreads.map((thread) => (
+                <div
+                  key={thread.id}
+                  className="flex items-center justify-between gap-3 border-t border-border px-4 py-3 first:border-t-0 sm:px-5"
+                  onContextMenu={(event) => {
+                    event.preventDefault();
+                    void handleArchivedThreadContextMenu(thread.id, {
+                      x: event.clientX,
+                      y: event.clientY,
+                    });
+                  }}
                 >
-                  <ArchiveX className="size-3.5" />
-                  <span>Unarchive</span>
+                  <div className="flex min-w-0 flex-1 items-start gap-3">
+                    <Checkbox
+                      className="mt-0.5"
+                      checked={selectedArchivedIds.has(thread.id)}
+                      onCheckedChange={(value) => toggleArchivedSelected(thread.id, value === true)}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                      }}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <h3 className="truncate text-sm font-medium text-foreground">
+                        {thread.title}
+                      </h3>
+                      <p className="text-xs text-muted-foreground">
+                        Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}
+                        {" \u00b7 Created "}
+                        {formatRelativeTimeLabel(thread.createdAt)}
+                      </p>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 shrink-0 cursor-pointer gap-1.5 px-2.5"
+                    onClick={() =>
+                      void unarchiveThread(thread.id).catch((error) => {
+                        toastManager.add({
+                          type: "error",
+                          title: "Failed to unarchive thread",
+                          description:
+                            error instanceof Error ? error.message : "An error occurred.",
+                        });
+                      })
+                    }
+                  >
+                    <ArchiveX className="size-3.5" />
+                    <span>Unarchive</span>
+                  </Button>
+                </div>
+              ))}
+            </SettingsSection>
+          ))}
+          <AlertDialog open={bulkDeleteDialogOpen} onOpenChange={setBulkDeleteDialogOpen}>
+            <AlertDialogPopup>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  Delete {selectedCount} selected thread{selectedCount === 1 ? "" : "s"}?
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  This permanently removes conversation history for the selected threads. This
+                  cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+                <Button variant="destructive" onClick={confirmBulkDeleteFromDialog}>
+                  Delete threads
                 </Button>
-              </div>
-            ))}
-          </SettingsSection>
-        ))
+              </AlertDialogFooter>
+            </AlertDialogPopup>
+          </AlertDialog>
+        </>
       )}
     </SettingsPageContainer>
   );

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1510,7 +1510,15 @@ export function ArchivedThreadsPanel() {
     if (ids.length === 0) return;
     const deletedIds = new Set<ThreadId>(ids);
     for (const threadId of ids) {
-      await deleteThread(threadId, { deletedThreadIds: deletedIds });
+      try {
+        await deleteThread(threadId, { deletedThreadIds: deletedIds });
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Failed to delete thread",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
+      }
     }
     setSelectedArchivedIds(new Set());
   }, [deleteThread, selectedArchivedIds]);
@@ -1528,6 +1536,12 @@ export function ArchivedThreadsPanel() {
     void (async () => {
       try {
         await executeBulkDeleteArchived();
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Failed to delete threads",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
       } finally {
         setBulkDeleteDialogOpen(false);
       }


### PR DESCRIPTION
## What Changed

- **Settings → Archive:** archived threads support **multi-select** (checkbox per row).
- **Select all:** tri-state checkbox to select or clear **all** archived threads at once.
- **Bulk unarchive:** **Unarchive (N)** runs unarchive for every selected thread (N = selection count).
- **Bulk delete:** **Delete (N)** deletes every selected thread (N = selection count), with the same **bulk worktree / `deletedThreadIds`** behavior as multi-delete elsewhere.
- When “confirm before deleting threads” is on, bulk delete uses the in-app **`AlertDialog`** instead of `window.confirm`. When it’s off, bulk delete runs immediately with no modal.

## Why

- Makes it practical to unarchive or delete many archived threads at once.

## UI Changes

**Before**
<img width="2165" height="300" alt="image" src="https://github.com/user-attachments/assets/018c4160-4c55-4fdb-96ee-2bf0fea15ca3" />

**After**

<img width="2165" height="714" alt="Screenshot 2026-04-02 151923" src="https://github.com/user-attachments/assets/eeeec69a-ae55-4e98-bb47-43050f2c59d9" />

<img width="1317" height="671" alt="Screenshot 2026-04-02 151930" src="https://github.com/user-attachments/assets/8cadb4f0-8c25-43d6-9d78-31bf4cf8a2be" />

**Video**

https://github.com/user-attachments/assets/19d06bfe-6fd0-4f23-a71b-ca74f14ac772

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new bulk delete/unarchive flows in the settings archive panel, increasing the chance of accidental destructive actions or edge cases around selection/state and repeated deletes. Uses existing `deleteThread` behavior (including worktree prompts) but now executed in a loop, so reviewers should sanity-check UX and error handling.
> 
> **Overview**
> Adds **multi-select** to `ArchivedThreadsPanel` via per-row checkboxes plus a tri-state **Select all** control, and introduces a small toolbar showing **Unarchive (N)** and **Delete (N)** actions for the current selection.
> 
> Implements bulk unarchive and bulk delete by iterating selected thread IDs, reusing `deleteThread(..., { deletedThreadIds })` for consistent multi-delete/worktree behavior, and **pruning selection** when the archived list changes.
> 
> Bulk delete now respects `confirmThreadDelete`: when enabled it shows an in-app `AlertDialog` confirmation; when disabled it deletes immediately, with toast errors surfaced per-thread.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c44be35b531c9a5c3ed1aafafd081ab07a6c9ed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bulk select and delete/unarchive actions for archived threads in settings
> - Adds checkboxes to each archived thread row in `ArchivedThreadsPanel` ([SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/1685/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18)), along with a 'Select all' checkbox and bulk action buttons for unarchive and delete.
> - Bulk delete respects the `appSettings.confirmThreadDelete` flag: when enabled, it prompts an `AlertDialog` confirmation before proceeding.
> - Selection state is kept in sync with the archived threads list via `useMemo`/`useEffect`, so removed threads are automatically deselected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c44be35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->