### PR TITLE
Optimize streaming message projection path

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -623,31 +623,46 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
     )(function* (event, attachmentSideEffects) {
       switch (event.type) {
         case "thread.message-sent": {
-          const existingRows = yield* projectionThreadMessageRepository.listByThreadId({
-            threadId: event.payload.threadId,
-          });
-          const existingMessage = existingRows.find(
-            (row) => row.messageId === event.payload.messageId,
-          );
-          const nextText =
-            existingMessage && event.payload.streaming
-              ? `${existingMessage.text}${event.payload.text}`
-              : existingMessage && event.payload.text.length === 0
-                ? existingMessage.text
-                : event.payload.text;
           const nextAttachments =
             event.payload.attachments !== undefined
               ? yield* materializeAttachmentsForProjection({
                   attachments: event.payload.attachments,
                 })
-              : existingMessage?.attachments;
+              : undefined;
+          if (event.payload.streaming) {
+            yield* projectionThreadMessageRepository.appendTextDelta({
+              messageId: event.payload.messageId,
+              threadId: event.payload.threadId,
+              turnId: event.payload.turnId,
+              role: event.payload.role,
+              delta: event.payload.text,
+              ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
+              isStreaming: true,
+              createdAt: event.payload.createdAt,
+              updatedAt: event.payload.updatedAt,
+            });
+            return;
+          }
+
+          const existingMessage = yield* projectionThreadMessageRepository
+            .getByMessageId({
+              messageId: event.payload.messageId,
+            })
+            .pipe(Effect.map(Option.getOrUndefined));
+          const nextText =
+            existingMessage !== undefined && event.payload.text.length === 0
+              ? existingMessage.text
+              : event.payload.text;
+          const persistedAttachments = nextAttachments ?? existingMessage?.attachments;
           yield* projectionThreadMessageRepository.upsert({
             messageId: event.payload.messageId,
             threadId: event.payload.threadId,
             turnId: event.payload.turnId,
             role: event.payload.role,
             text: nextText,
-            ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
+            ...(persistedAttachments !== undefined
+              ? { attachments: [...persistedAttachments] }
+              : {}),
             isStreaming: event.payload.streaming,
             createdAt: existingMessage?.createdAt ?? event.payload.createdAt,
             updatedAt: event.payload.updatedAt,

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.test.ts
@@ -1,6 +1,6 @@
 import { MessageId, ThreadId } from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Option } from "effect";
 
 import { ProjectionThreadMessageRepository } from "../Services/ProjectionThreadMessages.ts";
 import { ProjectionThreadMessageRepositoryLive } from "./ProjectionThreadMessages.ts";
@@ -101,6 +101,86 @@ layer("ProjectionThreadMessageRepository", (it) => {
       assert.equal(rows.length, 1);
       assert.equal(rows[0]?.text, "cleared");
       assert.deepEqual(rows[0]?.attachments, []);
+    }),
+  );
+
+  it.effect("looks up a projected message by id", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProjectionThreadMessageRepository;
+      const threadId = ThreadId.makeUnsafe("thread-get-by-message-id");
+      const messageId = MessageId.makeUnsafe("message-get-by-message-id");
+      const createdAt = "2026-02-28T19:20:00.000Z";
+      const updatedAt = "2026-02-28T19:20:01.000Z";
+
+      yield* repository.upsert({
+        messageId,
+        threadId,
+        turnId: null,
+        role: "assistant",
+        text: "lookup me",
+        isStreaming: false,
+        createdAt,
+        updatedAt,
+      });
+
+      const maybeRow = yield* repository.getByMessageId({ messageId });
+      assert.isTrue(Option.isSome(maybeRow));
+      const row = Option.getOrThrow(maybeRow);
+      assert.equal(row.messageId, messageId);
+      assert.equal(row.threadId, threadId);
+      assert.equal(row.text, "lookup me");
+      assert.equal(row.createdAt, createdAt);
+      assert.equal(row.updatedAt, updatedAt);
+    }),
+  );
+
+  it.effect("appends streaming deltas without losing createdAt or attachments", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProjectionThreadMessageRepository;
+      const threadId = ThreadId.makeUnsafe("thread-append-delta");
+      const messageId = MessageId.makeUnsafe("message-append-delta");
+      const createdAt = "2026-02-28T19:30:00.000Z";
+      const persistedAttachments = [
+        {
+          type: "image" as const,
+          id: "thread-append-delta-att-1",
+          name: "example.png",
+          mimeType: "image/png",
+          sizeBytes: 5,
+        },
+      ];
+
+      yield* repository.appendTextDelta({
+        messageId,
+        threadId,
+        turnId: null,
+        role: "assistant",
+        delta: "Hello",
+        attachments: persistedAttachments,
+        isStreaming: true,
+        createdAt,
+        updatedAt: "2026-02-28T19:30:01.000Z",
+      });
+
+      yield* repository.appendTextDelta({
+        messageId,
+        threadId,
+        turnId: null,
+        role: "assistant",
+        delta: " world",
+        isStreaming: true,
+        createdAt: "2026-02-28T19:30:05.000Z",
+        updatedAt: "2026-02-28T19:30:06.000Z",
+      });
+
+      const maybeRow = yield* repository.getByMessageId({ messageId });
+      assert.isTrue(Option.isSome(maybeRow));
+      const row = Option.getOrThrow(maybeRow);
+      assert.equal(row.text, "Hello world");
+      assert.equal(row.createdAt, createdAt);
+      assert.equal(row.updatedAt, "2026-02-28T19:30:06.000Z");
+      assert.deepEqual(row.attachments, persistedAttachments);
+      assert.isTrue(row.isStreaming);
     }),
   );
 });

--- a/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadMessages.ts
@@ -1,10 +1,12 @@
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
-import { Effect, Layer, Schema, Struct } from "effect";
+import { Effect, Layer, Option, Schema, Struct } from "effect";
 import { ChatAttachment } from "@t3tools/contracts";
 
 import { toPersistenceSqlError } from "../Errors.ts";
 import {
+  AppendProjectionThreadMessageDeltaInput,
+  GetProjectionThreadMessageInput,
   ProjectionThreadMessageRepository,
   type ProjectionThreadMessageRepositoryShape,
   DeleteProjectionThreadMessagesInput,
@@ -18,6 +20,19 @@ const ProjectionThreadMessageDbRowSchema = ProjectionThreadMessage.mapFields(
     attachments: Schema.NullOr(Schema.fromJsonString(Schema.Array(ChatAttachment))),
   }),
 );
+type ProjectionThreadMessageDbRow = typeof ProjectionThreadMessageDbRowSchema.Type;
+
+const toProjectionThreadMessage = (row: ProjectionThreadMessageDbRow) => ({
+  messageId: row.messageId,
+  threadId: row.threadId,
+  turnId: row.turnId,
+  role: row.role,
+  text: row.text,
+  isStreaming: row.isStreaming === 1,
+  createdAt: row.createdAt,
+  updatedAt: row.updatedAt,
+  ...(row.attachments !== null ? { attachments: row.attachments } : {}),
+});
 
 const makeProjectionThreadMessageRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
@@ -95,6 +110,70 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
       `,
   });
 
+  const getProjectionThreadMessageRow = SqlSchema.findOneOption({
+    Request: GetProjectionThreadMessageInput,
+    Result: ProjectionThreadMessageDbRowSchema,
+    execute: ({ messageId }) =>
+      sql`
+        SELECT
+          message_id AS "messageId",
+          thread_id AS "threadId",
+          turn_id AS "turnId",
+          role,
+          text,
+          attachments_json AS "attachments",
+          is_streaming AS "isStreaming",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM projection_thread_messages
+        WHERE message_id = ${messageId}
+      `,
+  });
+
+  const appendProjectionThreadMessageDeltaRow = SqlSchema.void({
+    Request: AppendProjectionThreadMessageDeltaInput,
+    execute: (row) => {
+      const nextAttachmentsJson =
+        row.attachments !== undefined ? JSON.stringify(row.attachments) : null;
+      return sql`
+        INSERT INTO projection_thread_messages (
+          message_id,
+          thread_id,
+          turn_id,
+          role,
+          text,
+          attachments_json,
+          is_streaming,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          ${row.messageId},
+          ${row.threadId},
+          ${row.turnId},
+          ${row.role},
+          ${row.delta},
+          ${nextAttachmentsJson},
+          ${row.isStreaming ? 1 : 0},
+          ${row.createdAt},
+          ${row.updatedAt}
+        )
+        ON CONFLICT (message_id)
+        DO UPDATE SET
+          thread_id = excluded.thread_id,
+          turn_id = COALESCE(excluded.turn_id, projection_thread_messages.turn_id),
+          role = excluded.role,
+          text = projection_thread_messages.text || excluded.text,
+          attachments_json = COALESCE(
+            excluded.attachments_json,
+            projection_thread_messages.attachments_json
+          ),
+          is_streaming = excluded.is_streaming,
+          updated_at = excluded.updated_at
+      `;
+    },
+  });
+
   const deleteProjectionThreadMessageRows = SqlSchema.void({
     Request: DeleteProjectionThreadMessagesInput,
     execute: ({ threadId }) =>
@@ -114,18 +193,21 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
       Effect.mapError(
         toPersistenceSqlError("ProjectionThreadMessageRepository.listByThreadId:query"),
       ),
-      Effect.map((rows) =>
-        rows.map((row) => ({
-          messageId: row.messageId,
-          threadId: row.threadId,
-          turnId: row.turnId,
-          role: row.role,
-          text: row.text,
-          isStreaming: row.isStreaming === 1,
-          createdAt: row.createdAt,
-          updatedAt: row.updatedAt,
-          ...(row.attachments !== null ? { attachments: row.attachments } : {}),
-        })),
+      Effect.map((rows) => rows.map(toProjectionThreadMessage)),
+    );
+
+  const getByMessageId: ProjectionThreadMessageRepositoryShape["getByMessageId"] = (input) =>
+    getProjectionThreadMessageRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("ProjectionThreadMessageRepository.getByMessageId:query"),
+      ),
+      Effect.map(Option.map(toProjectionThreadMessage)),
+    );
+
+  const appendTextDelta: ProjectionThreadMessageRepositoryShape["appendTextDelta"] = (input) =>
+    appendProjectionThreadMessageDeltaRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("ProjectionThreadMessageRepository.appendTextDelta:query"),
       ),
     );
 
@@ -139,6 +221,8 @@ const makeProjectionThreadMessageRepository = Effect.gen(function* () {
   return {
     upsert,
     listByThreadId,
+    getByMessageId,
+    appendTextDelta,
     deleteByThreadId,
   } satisfies ProjectionThreadMessageRepositoryShape;
 });

--- a/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadMessages.ts
@@ -14,7 +14,7 @@ import {
   TurnId,
   IsoDateTime,
 } from "@t3tools/contracts";
-import { Schema, ServiceMap } from "effect";
+import { Option, Schema, ServiceMap } from "effect";
 import type { Effect } from "effect";
 
 import type { ProjectionRepositoryError } from "../Errors.ts";
@@ -37,10 +37,29 @@ export const ListProjectionThreadMessagesInput = Schema.Struct({
 });
 export type ListProjectionThreadMessagesInput = typeof ListProjectionThreadMessagesInput.Type;
 
+export const GetProjectionThreadMessageInput = Schema.Struct({
+  messageId: MessageId,
+});
+export type GetProjectionThreadMessageInput = typeof GetProjectionThreadMessageInput.Type;
+
 export const DeleteProjectionThreadMessagesInput = Schema.Struct({
   threadId: ThreadId,
 });
 export type DeleteProjectionThreadMessagesInput = typeof DeleteProjectionThreadMessagesInput.Type;
+
+export const AppendProjectionThreadMessageDeltaInput = Schema.Struct({
+  messageId: MessageId,
+  threadId: ThreadId,
+  turnId: Schema.NullOr(TurnId),
+  role: OrchestrationMessageRole,
+  delta: Schema.String,
+  attachments: Schema.optional(Schema.Array(ChatAttachment)),
+  isStreaming: Schema.Boolean,
+  createdAt: IsoDateTime,
+  updatedAt: IsoDateTime,
+});
+export type AppendProjectionThreadMessageDeltaInput =
+  typeof AppendProjectionThreadMessageDeltaInput.Type;
 
 /**
  * ProjectionThreadMessageRepositoryShape - Service API for projected thread messages.
@@ -63,6 +82,20 @@ export interface ProjectionThreadMessageRepositoryShape {
   readonly listByThreadId: (
     input: ListProjectionThreadMessagesInput,
   ) => Effect.Effect<ReadonlyArray<ProjectionThreadMessage>, ProjectionRepositoryError>;
+
+  /**
+   * Look up a projected message by id.
+   */
+  readonly getByMessageId: (
+    input: GetProjectionThreadMessageInput,
+  ) => Effect.Effect<Option.Option<ProjectionThreadMessage>, ProjectionRepositoryError>;
+
+  /**
+   * Append a streaming text delta to an existing projected message row, or insert it.
+   */
+  readonly appendTextDelta: (
+    input: AppendProjectionThreadMessageDeltaInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
 
   /**
    * Delete projected thread messages by thread.


### PR DESCRIPTION
## Summary
- replace full-thread message scans in the projection hot path with per-message lookup and SQL delta append
- add repository coverage for `getByMessageId` and streaming `appendTextDelta`
- keep the perf artifacts and result log updated in `performance.md`

## Perf impact
- `create-turn-spam-8x` `thread.create dispatch -> thread.created`: `3.61ms / 58.38ms` -> `2.38ms / 20.36ms`
- `create-turn-spam-8x` `thread.archive dispatch -> thread.archived`: `5.71ms / 50.80ms` -> `0.97ms / 16.53ms`
- biggest win here is the control-plane tail: `ack -> event` for `thread.create` dropped from `56.95ms` p95 to `19.22ms` p95

## Testing
- `bun run --cwd apps/server test src/persistence/Layers/ProjectionThreadMessages.test.ts src/orchestration/Layers/ProjectionPipeline.test.ts`
- `bun run --cwd apps/server test:perf`
- `bun run fmt .`
- `bun run lint`
- `bun run typecheck`

Stacked on the checkpoint-reactor PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the message projection persistence/write path and SQL upsert semantics for streaming updates, which could affect message text/attachment consistency if edge cases are missed. Scope is limited to projection read-model storage and is covered by added repository tests.
> 
> **Overview**
> **Optimizes the `thread.message-sent` projection hot path for streaming messages.** Instead of scanning all messages in a thread to find the current one, the pipeline now either appends streaming text via a new SQL `appendTextDelta` operation or does a direct per-message lookup (`getByMessageId`) before a final `upsert`.
> 
> The thread message projection repository API is extended with `getByMessageId` and `appendTextDelta`, with new SQL queries to support single-row lookup and conflict-based delta concatenation while preserving existing `createdAt`/attachments. Tests are added to cover the new lookup and streaming-delta behavior (including attachment/createdAt preservation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bec3d2c8de7fa601583e7c1fc4a8d4da178e742. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize streaming message projection by appending text deltas instead of reconstructing full rows
> - Streaming `thread.message-sent` events now call `appendTextDelta` on [ProjectionThreadMessageRepository](https://github.com/pingdotgg/t3code/pull/1688/files#diff-72dbfc4251beab0913df32bedf59889c9a9dc50f6a0c763754f98d2a764fefd5), concatenating incoming text onto existing rows via SQL `COALESCE` rather than upserting a full reconstruction.
> - Non-streaming upserts now fetch the existing row via `getByMessageId` to preserve `createdAt` and retain prior attachments when the event omits them.
> - Adds `getByMessageId` and `appendTextDelta` to the repository shape in [ProjectionThreadMessages.ts](https://github.com/pingdotgg/t3code/pull/1688/files#diff-ae744b5c81566c892af6d2a36016d2085751f2975b0c294e86fa971cc990881b) with corresponding input schemas.
> - Behavioral Change: streaming events no longer fall back to previously persisted attachments at the projection stage; attachments are only carried forward when explicitly present on the event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3bec3d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->