### PR TITLE
Prioritize control-plane orchestration commands

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -245,6 +245,77 @@ describe("OrchestrationEngine", () => {
     await system.dispose();
   });
 
+  it("prioritizes client commands ahead of queued internal stream commands", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const createdAt = now();
+    const threadId = ThreadId.makeUnsafe("thread-priority-lane");
+
+    await system.run(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-project-priority-lane-create"),
+        projectId: asProjectId("project-priority-lane"),
+        title: "Priority Lane Project",
+        workspaceRoot: "/tmp/project-priority-lane",
+        defaultModelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-thread-priority-lane-create"),
+        threadId,
+        projectId: asProjectId("project-priority-lane"),
+        title: "Priority Lane Thread",
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        branch: null,
+        worktreePath: null,
+        createdAt,
+      }),
+    );
+
+    const lowPriorityCommandCount = 250;
+    const lowPriorityDispatches = Array.from({ length: lowPriorityCommandCount }, (_, index) =>
+      system.run(
+        engine.dispatch({
+          type: "thread.message.assistant.delta",
+          commandId: CommandId.makeUnsafe(`cmd-thread-priority-lane-delta-${index}`),
+          threadId,
+          messageId: asMessageId("assistant-priority-lane"),
+          delta: `chunk-${index}`,
+          turnId: asTurnId("turn-priority-lane"),
+          createdAt,
+        }),
+      ),
+    );
+
+    const archiveResult = await system.run(
+      engine.dispatch({
+        type: "thread.archive",
+        commandId: CommandId.makeUnsafe("cmd-thread-priority-lane-archive"),
+        threadId,
+      }),
+    );
+    const lowPriorityResults = await Promise.all(lowPriorityDispatches);
+    const lowPriorityCommandsAheadOfArchive = lowPriorityResults.filter(
+      (result) => result.sequence < archiveResult.sequence,
+    ).length;
+
+    expect(lowPriorityCommandsAheadOfArchive).toBeLessThan(lowPriorityCommandCount / 3);
+    expect(archiveResult.sequence).toBeLessThan(lowPriorityResults.at(-1)?.sequence ?? Infinity);
+    await system.dispose();
+  });
+
   it("streams persisted domain events in order", async () => {
     const system = await createOrchestrationSystem();
     const { engine } = system;

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -316,6 +316,86 @@ describe("OrchestrationEngine", () => {
     await system.dispose();
   });
 
+  it("treats normalized thread.turn.start as a prioritized client command", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const createdAt = now();
+    const threadId = ThreadId.makeUnsafe("thread-priority-turn-start");
+
+    await system.run(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.makeUnsafe("cmd-project-priority-turn-start-create"),
+        projectId: asProjectId("project-priority-turn-start"),
+        title: "Priority Turn Start Project",
+        workspaceRoot: "/tmp/project-priority-turn-start",
+        defaultModelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.makeUnsafe("cmd-thread-priority-turn-start-create"),
+        threadId,
+        projectId: asProjectId("project-priority-turn-start"),
+        title: "Priority Turn Start Thread",
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        branch: null,
+        worktreePath: null,
+        createdAt,
+      }),
+    );
+
+    const lowPriorityCommandCount = 150;
+    const lowPriorityDispatches = Array.from({ length: lowPriorityCommandCount }, (_, index) =>
+      system.run(
+        engine.dispatch({
+          type: "thread.message.assistant.delta",
+          commandId: CommandId.makeUnsafe(`cmd-thread-priority-turn-start-delta-${index}`),
+          threadId,
+          messageId: asMessageId("assistant-priority-turn-start"),
+          delta: `chunk-${index}`,
+          turnId: asTurnId("turn-priority-turn-start-internal"),
+          createdAt,
+        }),
+      ),
+    );
+
+    const turnStartResult = await system.run(
+      engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.makeUnsafe("cmd-thread-priority-turn-start"),
+        threadId,
+        message: {
+          messageId: asMessageId("user-priority-turn-start"),
+          role: "user",
+          text: "hello",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        createdAt,
+      }),
+    );
+    const lowPriorityResults = await Promise.all(lowPriorityDispatches);
+    const lowPriorityCommandsAheadOfTurnStart = lowPriorityResults.filter(
+      (result) => result.sequence < turnStartResult.sequence,
+    ).length;
+
+    expect(lowPriorityCommandsAheadOfTurnStart).toBeLessThan(lowPriorityCommandCount / 3);
+    expect(turnStartResult.sequence).toBeLessThan(lowPriorityResults.at(-1)?.sequence ?? Infinity);
+    await system.dispose();
+  });
+
   it("streams persisted domain events in order", async () => {
     const system = await createOrchestrationSystem();
     const { engine } = system;

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -5,7 +5,17 @@ import type {
   ThreadId,
 } from "@t3tools/contracts";
 import { OrchestrationCommand } from "@t3tools/contracts";
-import { Deferred, Effect, Layer, Option, PubSub, Queue, Schema, Stream } from "effect";
+import {
+  Deferred,
+  Effect,
+  Layer,
+  Option,
+  Order,
+  PubSub,
+  Schema,
+  Stream,
+  TxPriorityQueue,
+} from "effect";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { toPersistenceSqlError } from "../../persistence/Errors.ts";
@@ -29,6 +39,24 @@ interface CommandEnvelope {
   result: Deferred.Deferred<{ sequence: number }, OrchestrationDispatchError>;
 }
 
+type CommandPriority = 0 | 1;
+
+interface PrioritizedCommandEnvelope {
+  readonly priority: CommandPriority;
+  readonly insertionSequence: number;
+  readonly envelope: CommandEnvelope;
+}
+
+const COMMAND_PRIORITY = {
+  control: 0,
+  stream: 1,
+} as const satisfies Record<string, CommandPriority>;
+
+const prioritizedCommandEnvelopeOrder = Order.combine(
+  Order.mapInput(Order.Number, (item: PrioritizedCommandEnvelope) => item.priority),
+  Order.mapInput(Order.Number, (item: PrioritizedCommandEnvelope) => item.insertionSequence),
+);
+
 function commandToAggregateRef(command: OrchestrationCommand): {
   readonly aggregateKind: "project" | "thread";
   readonly aggregateId: ProjectId | ThreadId;
@@ -49,6 +77,21 @@ function commandToAggregateRef(command: OrchestrationCommand): {
   }
 }
 
+function commandPriority(command: OrchestrationCommand): CommandPriority {
+  switch (command.type) {
+    case "thread.session.set":
+    case "thread.message.assistant.delta":
+    case "thread.message.assistant.complete":
+    case "thread.proposed-plan.upsert":
+    case "thread.turn.diff.complete":
+    case "thread.activity.append":
+    case "thread.revert.complete":
+      return COMMAND_PRIORITY.stream;
+    default:
+      return COMMAND_PRIORITY.control;
+  }
+}
+
 const makeOrchestrationEngine = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
   const eventStore = yield* OrchestrationEventStore;
@@ -56,8 +99,11 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   const projectionPipeline = yield* OrchestrationProjectionPipeline;
 
   let readModel = createEmptyReadModel(new Date().toISOString());
+  let nextCommandInsertionSequence = 0;
 
-  const commandQueue = yield* Queue.unbounded<CommandEnvelope>();
+  const commandQueue = yield* TxPriorityQueue.empty<PrioritizedCommandEnvelope>(
+    prioritizedCommandEnvelopeOrder,
+  );
   const eventPubSub = yield* PubSub.unbounded<OrchestrationEvent>();
 
   const processEnvelope = (envelope: CommandEnvelope): Effect.Effect<void> => {
@@ -203,7 +249,13 @@ const makeOrchestrationEngine = Effect.gen(function* () {
     }),
   );
 
-  const worker = Effect.forever(Queue.take(commandQueue).pipe(Effect.flatMap(processEnvelope)));
+  const worker = Effect.forever(
+    TxPriorityQueue.take(commandQueue).pipe(
+      Effect.tx,
+      Effect.map((item) => item.envelope),
+      Effect.flatMap(processEnvelope),
+    ),
+  );
   yield* Effect.forkScoped(worker);
   yield* Effect.logDebug("orchestration engine started").pipe(
     Effect.annotateLogs({ sequence: readModel.snapshotSequence }),
@@ -218,7 +270,11 @@ const makeOrchestrationEngine = Effect.gen(function* () {
   const dispatch: OrchestrationEngineShape["dispatch"] = (command) =>
     Effect.gen(function* () {
       const result = yield* Deferred.make<{ sequence: number }, OrchestrationDispatchError>();
-      yield* Queue.offer(commandQueue, { command, result });
+      yield* TxPriorityQueue.offer(commandQueue, {
+        priority: commandPriority(command),
+        insertionSequence: nextCommandInsertionSequence++,
+        envelope: { command, result },
+      }).pipe(Effect.tx);
       return yield* Deferred.await(result);
     });
 

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.ts
@@ -4,7 +4,7 @@ import type {
   ProjectId,
   ThreadId,
 } from "@t3tools/contracts";
-import { OrchestrationCommand } from "@t3tools/contracts";
+import { DispatchableClientOrchestrationCommand, OrchestrationCommand } from "@t3tools/contracts";
 import {
   Deferred,
   Effect,
@@ -78,18 +78,10 @@ function commandToAggregateRef(command: OrchestrationCommand): {
 }
 
 function commandPriority(command: OrchestrationCommand): CommandPriority {
-  switch (command.type) {
-    case "thread.session.set":
-    case "thread.message.assistant.delta":
-    case "thread.message.assistant.complete":
-    case "thread.proposed-plan.upsert":
-    case "thread.turn.diff.complete":
-    case "thread.activity.append":
-    case "thread.revert.complete":
-      return COMMAND_PRIORITY.stream;
-    default:
-      return COMMAND_PRIORITY.control;
+  if (Schema.is(DispatchableClientOrchestrationCommand)(command)) {
+    return COMMAND_PRIORITY.control;
   }
+  return COMMAND_PRIORITY.stream;
 }
 
 const makeOrchestrationEngine = Effect.gen(function* () {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -463,7 +463,7 @@ const ThreadSessionStopCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
-const DispatchableClientOrchestrationCommand = Schema.Union([
+export const DispatchableClientOrchestrationCommand = Schema.Union([
   ProjectCreateCommand,
   ProjectMetaUpdateCommand,
   ProjectDeleteCommand,

--- a/performance.md
+++ b/performance.md
@@ -34,7 +34,24 @@ Measure end-to-end server latency for control-plane commands through the real we
 | `t3code/perf-control-plane-priority-lane`        | Spam canary rerun                    | completed | [control-plane-stream-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775121334761/control-plane-stream-baseline.json) |
 | `t3code/perf-control-plane-priority-lane`        | Terminal + mixed git rerun           | completed | [terminal-mixed-git-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775121336380/terminal-mixed-git-baseline.json)     |
 
-## Results
+## Best So Far
+
+- `create-turn-spam-8x` `thread.create dispatch -> thread.created`
+  Baseline: `3.61ms / 58.38ms`
+  Best so far: `2.38ms / 20.36ms` on `t3code/perf-projection-thread-message-hot-path`
+  Tail improvement: `-65%` on p95
+- `create-turn-spam-8x` `thread.archive dispatch -> thread.archived`
+  Baseline: `5.71ms / 50.80ms`
+  Best so far: `1.09ms / 12.60ms` on `t3code/perf-control-plane-priority-lane`
+  Tail improvement: `-75%` on p95
+- `mixed-stream-terminal-git` `thread.create dispatch -> thread.created`
+  Baseline: `0.89ms / 1.57ms`
+  Best so far: `1.16ms / 1.33ms` on `t3code/perf-control-plane-priority-lane`
+  Tail improvement: `-15%` on p95
+- `git.status`
+  No clear improvement yet. The measurements move around, but there is no stable win I would claim from these changes.
+
+## Detailed Results
 
 | Branch                                           | Change         | Profile                     | Metric                                       | Before p50 / p95      | After p50 / p95       | Notes                                                                              |
 | ------------------------------------------------ | -------------- | --------------------------- | -------------------------------------------- | --------------------- | --------------------- | ---------------------------------------------------------------------------------- |

--- a/performance.md
+++ b/performance.md
@@ -1,0 +1,68 @@
+# Performance
+
+## Goal
+
+Measure end-to-end server latency for control-plane commands through the real websocket/API surface, establish reproducible baselines under representative load, and track the effect of each optimization branch with before/after artifacts.
+
+## Hypotheses
+
+- `H1` Control-plane commands are waiting behind provider stream ingestion because `thread.create`, `thread.archive`, and chunk-derived commands all share the same serialized orchestration path.
+- `H2` Projection work per streamed chunk is inflating queue occupancy enough to delay unrelated commands.
+- `H3` Terminal output and git-heavy repositories add secondary pressure that can compound the control-plane delay seen in the sidebar.
+
+## Workstreams
+
+- `[completed]` Add server-first perf baselines for websocket command latency under stream, terminal, and git load.
+- `[completed]` Establish baseline artifacts and summarize p50/p95 timings here.
+- `[completed]` Reconcile the baseline with the manual sidebar lag repro before cutting optimization branches.
+- `[completed]` Optimization 2: reduce per-event projection overhead.
+- `[completed]` Optimization 3: prioritize control-plane dispatch over internal stream traffic.
+- `[pending]` Optimization 4: reduce global worker head-of-line blocking in runtime ingestion/reactors.
+- `[pending]` Optimization 5: evaluate adapter/service queue hops and any additional bottlenecks found during measurement.
+
+## Artifact Log
+
+| Branch                                           | Scope                                | Status    | Artifact                                                                                                                                                                                                           |
+| ------------------------------------------------ | ------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `t3code/performance-regression-tests`            | Server perf harness + baseline specs | completed | [control-plane-stream-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775120110519/control-plane-stream-baseline.json) |
+| `t3code/performance-regression-tests`            | Terminal + mixed git baseline        | completed | [terminal-mixed-git-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775120111902/terminal-mixed-git-baseline.json)     |
+| `t3code/performance-regression-tests`            | Spam canary baseline                 | completed | [control-plane-stream-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775120442873/control-plane-stream-baseline.json) |
+| `t3code/perf-checkpoint-reactor-fanout`          | Spam canary rerun                    | completed | [control-plane-stream-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775120608211/control-plane-stream-baseline.json) |
+| `t3code/perf-checkpoint-reactor-fanout`          | Terminal + mixed git rerun           | completed | [terminal-mixed-git-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775120609839/terminal-mixed-git-baseline.json)     |
+| `t3code/perf-projection-thread-message-hot-path` | Spam canary rerun                    | completed | [control-plane-stream-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775120998407/control-plane-stream-baseline.json) |
+| `t3code/perf-projection-thread-message-hot-path` | Terminal + mixed git rerun           | completed | [terminal-mixed-git-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775121000048/terminal-mixed-git-baseline.json)     |
+| `t3code/perf-control-plane-priority-lane`        | Spam canary rerun                    | completed | [control-plane-stream-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775121334761/control-plane-stream-baseline.json) |
+| `t3code/perf-control-plane-priority-lane`        | Terminal + mixed git rerun           | completed | [terminal-mixed-git-baseline.json](/Users/julius/.t3/worktrees/codething-mvp/t3code-93392e80/artifacts/perf/server/server-latency-critical-commands-burst_base-1775121336380/terminal-mixed-git-baseline.json)     |
+
+## Results
+
+| Branch                                           | Change         | Profile                     | Metric                                       | Before p50 / p95      | After p50 / p95       | Notes                                                                              |
+| ------------------------------------------------ | -------------- | --------------------------- | -------------------------------------------- | --------------------- | --------------------- | ---------------------------------------------------------------------------------- |
+| `t3code/performance-regression-tests`            | Baseline       | `idle`                      | `thread.create dispatch -> thread.created`   | `1.48ms / 14.95ms`    | `n/a`                 | one cold-start outlier remains, steady-state is low single-digit ms                |
+| `t3code/performance-regression-tests`            | Baseline       | `idle`                      | `thread.archive dispatch -> thread.archived` | `1.64ms / 2.22ms`     | `n/a`                 | no material queueing at the WS boundary                                            |
+| `t3code/performance-regression-tests`            | Baseline       | `assistant-stream-5x`       | `thread.create dispatch -> thread.created`   | `1.34ms / 1.85ms`     | `n/a`                 | 5 passive background streams still look healthy                                    |
+| `t3code/performance-regression-tests`            | Baseline       | `assistant-stream-5x`       | `thread.archive dispatch -> thread.archived` | `1.03ms / 1.27ms`     | `n/a`                 | still effectively realtime                                                         |
+| `t3code/performance-regression-tests`            | Baseline       | `create-turn-spam-8x`       | `thread.create dispatch -> thread.created`   | `3.61ms / 58.38ms`    | `n/a`                 | first server-first profile that reproduces visible event delay                     |
+| `t3code/performance-regression-tests`            | Baseline       | `create-turn-spam-8x`       | `thread.archive dispatch -> thread.archived` | `5.71ms / 50.80ms`    | `n/a`                 | `dispatch -> ack` stays low; delay is mostly `ack -> event`                        |
+| `t3code/performance-regression-tests`            | Baseline       | `terminal-output-3x`        | `thread.create dispatch -> thread.created`   | `1.55ms / 1.92ms`     | `n/a`                 | terminal output alone did not move command latency much                            |
+| `t3code/performance-regression-tests`            | Baseline       | `mixed-stream-terminal-git` | `thread.create dispatch -> thread.created`   | `0.89ms / 1.57ms`     | `n/a`                 | combined load still fast at the command/event boundary                             |
+| `t3code/performance-regression-tests`            | Baseline       | `idle-repo-pressure`        | `git.status`                                 | `135.30ms / 149.97ms` | `n/a`                 | 240 branches + 160 untracked files                                                 |
+| `t3code/performance-regression-tests`            | Baseline       | `mixed-stream-terminal-git` | `git.status`                                 | `150.08ms / 169.73ms` | `n/a`                 | git RPC remains the largest measured server-side cost                              |
+| `t3code/performance-regression-tests`            | Baseline       | `idle-repo-pressure`        | `git.listBranches`                           | `47.60ms / 54.00ms`   | `n/a`                 | branch enumeration cost is measurable but stable                                   |
+| `t3code/perf-checkpoint-reactor-fanout`          | Optimization 1 | `create-turn-spam-8x`       | `thread.create dispatch -> thread.created`   | `3.61ms / 58.38ms`    | `2.44ms / 67.52ms`    | p50 improved, tail got noisier; likely still backlog-dominated                     |
+| `t3code/perf-checkpoint-reactor-fanout`          | Optimization 1 | `create-turn-spam-8x`       | `thread.archive dispatch -> thread.archived` | `5.71ms / 50.80ms`    | `0.93ms / 17.98ms`    | meaningful improvement in typical and tail latency                                 |
+| `t3code/perf-checkpoint-reactor-fanout`          | Optimization 1 | `mixed-stream-terminal-git` | `git.status`                                 | `150.08ms / 169.73ms` | `146.87ms / 170.45ms` | effectively unchanged                                                              |
+| `t3code/perf-projection-thread-message-hot-path` | Optimization 2 | `create-turn-spam-8x`       | `thread.create dispatch -> thread.created`   | `3.61ms / 58.38ms`    | `2.38ms / 20.36ms`    | large tail reduction; `ack -> event` fell from `56.95ms` to `19.22ms`              |
+| `t3code/perf-projection-thread-message-hot-path` | Optimization 2 | `create-turn-spam-8x`       | `thread.archive dispatch -> thread.archived` | `5.71ms / 50.80ms`    | `0.97ms / 16.53ms`    | consistent improvement over both baseline and Optimization 1                       |
+| `t3code/perf-projection-thread-message-hot-path` | Optimization 2 | `mixed-stream-terminal-git` | `thread.create dispatch -> thread.created`   | `0.89ms / 1.57ms`     | `1.21ms / 4.50ms`     | slight noise increase, still effectively realtime                                  |
+| `t3code/perf-projection-thread-message-hot-path` | Optimization 2 | `mixed-stream-terminal-git` | `git.status`                                 | `150.08ms / 169.73ms` | `141.05ms / 162.86ms` | modest improvement, likely secondary to lower orchestration pressure               |
+| `t3code/perf-control-plane-priority-lane`        | Optimization 3 | `create-turn-spam-8x`       | `thread.create dispatch -> thread.created`   | `3.61ms / 58.38ms`    | `1.90ms / 26.57ms`    | queue prioritization mainly removed `ack -> event` delay (`0.11ms / 25.45ms`)      |
+| `t3code/perf-control-plane-priority-lane`        | Optimization 3 | `create-turn-spam-8x`       | `thread.archive dispatch -> thread.archived` | `5.71ms / 50.80ms`    | `1.09ms / 12.60ms`    | best archive tail so far; user-visible control commands now preempt stream traffic |
+| `t3code/perf-control-plane-priority-lane`        | Optimization 3 | `mixed-stream-terminal-git` | `thread.create dispatch -> thread.created`   | `0.89ms / 1.57ms`     | `1.16ms / 1.33ms`     | realistic mixed-load control-plane latency stays near-baseline                     |
+| `t3code/perf-control-plane-priority-lane`        | Optimization 3 | `mixed-stream-terminal-git` | `git.status`                                 | `150.08ms / 169.73ms` | `156.29ms / 182.32ms` | no git improvement; likely unrelated measurement noise                             |
+
+## Notes
+
+- The initial perf suite is characterization-first. It should fail only on obvious hangs/timeouts while we collect stable p50/p95 numbers for this machine and repository.
+- Each optimization will land on its own branch and append a new row here with the measured delta and artifact path.
+- Current takeaway: the redline server-side repro is real. The biggest measured wins came from shrinking per-chunk projection cost and then prioritizing control-plane commands over internal stream traffic. The remaining work, if we keep pushing, is in worker topology and the provider-side queue hops rather than the websocket boundary itself.


### PR DESCRIPTION
## Summary
- replace the single FIFO orchestration queue with a prioritized queue that keeps control-plane commands ahead of internal stream-derived commands while preserving FIFO order within each priority lane
- add engine coverage proving client commands are processed ahead of queued internal assistant-delta commands
- update `performance.md` with the stacked-branch results and best-so-far numbers

## Perf impact
- `create-turn-spam-8x` `thread.create dispatch -> thread.created`: `3.61ms / 58.38ms` -> `1.90ms / 26.57ms`
- `create-turn-spam-8x` `thread.archive dispatch -> thread.archived`: `5.71ms / 50.80ms` -> `1.09ms / 12.60ms`
- this branch mainly reduces `ack -> event` delay for user-visible commands while mixed-load command latency stays near baseline

## Testing
- `bun run --cwd apps/server test src/orchestration/Layers/OrchestrationEngine.test.ts`
- `bun run --cwd apps/server test src/persistence/Layers/ProjectionThreadMessages.test.ts src/orchestration/Layers/ProjectionPipeline.test.ts src/orchestration/Layers/OrchestrationEngine.test.ts src/orchestration/Layers/CheckpointReactor.test.ts`
- `bun run --cwd apps/server test:perf`
- `bun run fmt .`
- `bun run lint`
- `bun run typecheck`

Stacked on the projection hot-path PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration command scheduling from FIFO to a priority-based queue, which can reorder execution and surface new ordering/throughput edge cases under load.
> 
> **Overview**
> **Control-plane orchestration commands now preempt stream-derived commands.** The orchestration engine replaces its single FIFO command queue with a `TxPriorityQueue` ordered by `(priority, insertionSequence)`, preserving FIFO within each lane while processing client-dispatchable commands ahead of internal stream traffic.
> 
> Adds a `commandPriority` classifier based on `DispatchableClientOrchestrationCommand` (exported from `contracts`) and new engine tests that assert `thread.archive` and normalized `thread.turn.start` complete ahead of large backlogs of `thread.message.assistant.delta` commands. Updates `performance.md` with measured before/after latency results for this prioritization work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c775cceda5d73323145aceaea02286c13dc42aa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prioritize control-plane orchestration commands over internal stream commands
> - Replaces the internal FIFO `Queue<CommandEnvelope>` in `makeOrchestrationEngine` with a `TxPriorityQueue<PrioritizedCommandEnvelope>` ordered by priority then insertion sequence.
> - Client-dispatchable commands (conforming to `DispatchableClientOrchestrationCommand`) are assigned `control` priority (0); all other commands (e.g. `thread.message.assistant.delta`) get `stream` priority (1), ensuring user-facing commands are processed first.
> - An `insertionSequence` counter preserves arrival order among commands with equal priority.
> - Exports `DispatchableClientOrchestrationCommand` from [orchestration.ts](https://github.com/pingdotgg/t3code/pull/1689/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af) so the priority classifier in the engine can reference it.
> - Behavioral Change: `engine.dispatch` no longer processes commands strictly in FIFO order — client commands will jump ahead of queued stream deltas.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c775cce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->