### PR TITLE
feat(web): add workspace-aware terminal panel layout

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -27,6 +27,8 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import { createPortal } from "react-dom";
+import type { TerminalBottomScope } from "@t3tools/contracts/settings";
 import { gitStatusQueryOptions } from "~/lib/gitReactQuery";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { isElectron } from "../env";
@@ -90,7 +92,7 @@ import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import BranchToolbar from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import PlanSidebar from "./PlanSidebar";
-import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
+import ThreadTerminalPanel from "./ThreadTerminalPanel";
 import {
   BotIcon,
   ChevronDownIcon,
@@ -124,6 +126,7 @@ import {
 } from "../providerModels";
 import { useSettings } from "../hooks/useSettings";
 import { resolveAppModelSelection } from "../modelSelection";
+import type { TerminalDockTarget } from "../workspacePanels";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import {
   type ComposerImageAttachment,
@@ -198,6 +201,7 @@ import {
   useServerKeybindings,
 } from "~/rpc/serverState";
 import { sanitizeThreadErrorMessage } from "~/rpc/transportError";
+import { useWorkspaceTerminalPortalTargets } from "~/workspaceTerminalPortal";
 
 const ATTACHMENT_PREVIEW_HANDOFF_TTL_MS = 5000;
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
@@ -329,6 +333,11 @@ const terminalContextIdListsEqual = (
   contexts.length === ids.length && contexts.every((context, index) => context.id === ids[index]);
 
 interface ChatViewProps {
+  layoutState: {
+    diffToggleActive: boolean;
+    terminalDockTarget: TerminalDockTarget;
+    terminalToggleActive: boolean;
+  };
   threadId: ThreadId;
 }
 
@@ -407,7 +416,7 @@ function useLocalDispatchState(input: {
   };
 }
 
-interface PersistentThreadTerminalDrawerProps {
+interface PersistentThreadTerminalPanelProps {
   threadId: ThreadId;
   visible: boolean;
   launchContext: PersistentTerminalLaunchContext | null;
@@ -416,9 +425,13 @@ interface PersistentThreadTerminalDrawerProps {
   newShortcutLabel: string | undefined;
   closeShortcutLabel: string | undefined;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  bottomScope: TerminalBottomScope;
+  layout: "bottom" | "side";
+  portalTarget: HTMLElement | null;
+  renderInline: boolean;
 }
 
-function PersistentThreadTerminalDrawer({
+function PersistentThreadTerminalPanel({
   threadId,
   visible,
   launchContext,
@@ -427,7 +440,11 @@ function PersistentThreadTerminalDrawer({
   newShortcutLabel,
   closeShortcutLabel,
   onAddTerminalContext,
-}: PersistentThreadTerminalDrawerProps) {
+  bottomScope,
+  layout,
+  portalTarget,
+  renderInline,
+}: PersistentThreadTerminalPanelProps) {
   const serverThread = useThreadById(threadId);
   const draftThread = useComposerDraftStore(
     (store) => store.draftThreadsByThreadId[threadId] ?? null,
@@ -546,45 +563,60 @@ function PersistentThreadTerminalDrawer({
     return null;
   }
 
-  return (
-    <div className={visible ? undefined : "hidden"}>
-      <ThreadTerminalDrawer
-        threadId={threadId}
-        cwd={cwd}
-        worktreePath={effectiveWorktreePath}
-        runtimeEnv={runtimeEnv}
-        visible={visible}
-        height={terminalState.terminalHeight}
-        terminalIds={terminalState.terminalIds}
-        activeTerminalId={terminalState.activeTerminalId}
-        terminalGroups={terminalState.terminalGroups}
-        activeTerminalGroupId={terminalState.activeTerminalGroupId}
-        focusRequestId={focusRequestId + localFocusRequestId + (visible ? 1 : 0)}
-        onSplitTerminal={splitTerminal}
-        onNewTerminal={createNewTerminal}
-        splitShortcutLabel={visible ? splitShortcutLabel : undefined}
-        newShortcutLabel={visible ? newShortcutLabel : undefined}
-        closeShortcutLabel={visible ? closeShortcutLabel : undefined}
-        onActiveTerminalChange={activateTerminal}
-        onCloseTerminal={closeTerminal}
-        onHeightChange={setTerminalHeight}
-        onAddTerminalContext={handleAddTerminalContext}
-      />
-    </div>
+  const panel = (
+    <ThreadTerminalPanel
+      threadId={threadId}
+      cwd={cwd}
+      worktreePath={effectiveWorktreePath}
+      runtimeEnv={runtimeEnv}
+      visible={visible}
+      height={terminalState.terminalHeight}
+      bottomScope={bottomScope}
+      layout={layout}
+      terminalIds={terminalState.terminalIds}
+      activeTerminalId={terminalState.activeTerminalId}
+      terminalGroups={terminalState.terminalGroups}
+      activeTerminalGroupId={terminalState.activeTerminalGroupId}
+      focusRequestId={focusRequestId + localFocusRequestId + (visible ? 1 : 0)}
+      onSplitTerminal={splitTerminal}
+      onNewTerminal={createNewTerminal}
+      splitShortcutLabel={visible ? splitShortcutLabel : undefined}
+      newShortcutLabel={visible ? newShortcutLabel : undefined}
+      closeShortcutLabel={visible ? closeShortcutLabel : undefined}
+      onActiveTerminalChange={activateTerminal}
+      onCloseTerminal={closeTerminal}
+      onHeightChange={setTerminalHeight}
+      onAddTerminalContext={handleAddTerminalContext}
+    />
   );
+
+  if (!visible) {
+    return <div className="hidden">{panel}</div>;
+  }
+
+  if (!renderInline) {
+    if (!portalTarget) {
+      return <div className="hidden">{panel}</div>;
+    }
+    return createPortal(panel, portalTarget);
+  }
+
+  return panel;
 }
 
-export default function ChatView({ threadId }: ChatViewProps) {
+export default function ChatView({ layoutState, threadId }: ChatViewProps) {
   const serverThread = useThreadById(threadId);
   const setStoreThreadError = useStore((store) => store.setError);
   const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
   const activeThreadLastVisitedAt = useUiStateStore(
     (store) => store.threadLastVisitedAtById[threadId],
   );
+  const workspaceTerminalPortalTargets = useWorkspaceTerminalPortalTargets();
   const settings = useSettings();
   const setStickyComposerModelSelection = useComposerDraftStore(
     (store) => store.setStickyModelSelection,
   );
+  const terminalPosition = settings.terminalPosition;
   const timestampFormat = settings.timestampFormat;
   const navigate = useNavigate();
   const rawSearch = useSearch({
@@ -1570,17 +1602,60 @@ export default function ChatView({ threadId }: ChatViewProps) {
     () => shortcutLabelForCommand(keybindings, "diff.toggle", nonTerminalShortcutLabelOptions),
     [keybindings, nonTerminalShortcutLabelOptions],
   );
-  const onToggleDiff = useCallback(() => {
+  const terminalToggleActive = layoutState.terminalToggleActive;
+  const diffToggleActive = layoutState.diffToggleActive;
+  const closeDiffPanel = useCallback(() => {
+    void navigate({
+      to: "/$threadId",
+      params: { threadId },
+      replace: true,
+      search: (previous) => ({
+        ...stripDiffSearchParams(previous),
+        diff: undefined,
+      }),
+    });
+  }, [navigate, threadId]);
+  const openDiffPanel = useCallback(() => {
     void navigate({
       to: "/$threadId",
       params: { threadId },
       replace: true,
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
+        return { ...rest, diff: "1" };
       },
     });
-  }, [diffOpen, navigate, threadId]);
+  }, [navigate, threadId]);
+  const setTerminalOpen = useCallback(
+    (open: boolean) => {
+      if (!activeThreadId) return;
+      storeSetTerminalOpen(activeThreadId, open);
+    },
+    [activeThreadId, storeSetTerminalOpen],
+  );
+  const onToggleDiff = useCallback(() => {
+    if (terminalPosition === "right") {
+      if (diffToggleActive) {
+        closeDiffPanel();
+        return;
+      }
+      setTerminalOpen(false);
+      openDiffPanel();
+      return;
+    }
+    if (diffOpen) {
+      closeDiffPanel();
+      return;
+    }
+    openDiffPanel();
+  }, [
+    closeDiffPanel,
+    diffOpen,
+    diffToggleActive,
+    openDiffPanel,
+    setTerminalOpen,
+    terminalPosition,
+  ]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -1668,17 +1743,33 @@ export default function ChatView({ threadId }: ChatViewProps) {
     },
     [activeThread, composerCursor, composerTerminalContexts, insertComposerDraftTerminalContext],
   );
-  const setTerminalOpen = useCallback(
-    (open: boolean) => {
-      if (!activeThreadId) return;
-      storeSetTerminalOpen(activeThreadId, open);
-    },
-    [activeThreadId, storeSetTerminalOpen],
-  );
   const toggleTerminalVisibility = useCallback(() => {
     if (!activeThreadId) return;
+    if (terminalPosition === "right") {
+      if (terminalToggleActive) {
+        setTerminalOpen(false);
+        return;
+      }
+      if (diffOpen) {
+        setTerminalOpen(true);
+        closeDiffPanel();
+        return;
+      }
+      if (!terminalState.terminalOpen) {
+        setTerminalOpen(true);
+      }
+      return;
+    }
     setTerminalOpen(!terminalState.terminalOpen);
-  }, [activeThreadId, setTerminalOpen, terminalState.terminalOpen]);
+  }, [
+    activeThreadId,
+    closeDiffPanel,
+    diffOpen,
+    setTerminalOpen,
+    terminalToggleActive,
+    terminalPosition,
+    terminalState.terminalOpen,
+  ]);
   const splitTerminal = useCallback(() => {
     if (!activeThreadId || hasReachedSplitLimit) return;
     const terminalId = `terminal-${randomUUID()}`;
@@ -3917,6 +4008,19 @@ export default function ChatView({ threadId }: ChatViewProps) {
     );
   }
 
+  const activeTerminalPortalTarget =
+    layoutState.terminalDockTarget === "bottom-workspace"
+      ? workspaceTerminalPortalTargets.bottom
+      : layoutState.terminalDockTarget === "right"
+        ? workspaceTerminalPortalTargets.right
+        : null;
+  const activeTerminalLayout = layoutState.terminalDockTarget?.startsWith("bottom")
+    ? "bottom"
+    : "side";
+  const activeTerminalBottomScope: TerminalBottomScope =
+    layoutState.terminalDockTarget === "bottom-workspace" ? "workspace" : "chat";
+  const renderActiveTerminalInline = layoutState.terminalDockTarget === "bottom-inline";
+
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
       {/* Top bar */}
@@ -3939,11 +4043,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
           keybindings={keybindings}
           availableEditors={availableEditors}
           terminalAvailable={activeProject !== undefined}
-          terminalOpen={terminalState.terminalOpen}
+          terminalOpen={terminalToggleActive}
           terminalToggleShortcutLabel={terminalToggleShortcutLabel}
           diffToggleShortcutLabel={diffPanelShortcutLabel}
           gitCwd={gitCwd}
-          diffOpen={diffOpen}
+          diffOpen={diffToggleActive}
           onRunProjectScript={(script) => {
             void runProjectScript(script);
           }}
@@ -4454,7 +4558,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       {/* end horizontal flex container */}
 
       {mountedTerminalThreadIds.map((mountedThreadId) => (
-        <PersistentThreadTerminalDrawer
+        <PersistentThreadTerminalPanel
           key={mountedThreadId}
           threadId={mountedThreadId}
           visible={mountedThreadId === activeThreadId && terminalState.terminalOpen}
@@ -4466,6 +4570,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
           newShortcutLabel={newTerminalShortcutLabel ?? undefined}
           closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
           onAddTerminalContext={addTerminalContextToDraft}
+          bottomScope={activeTerminalBottomScope}
+          layout={activeTerminalLayout}
+          portalTarget={mountedThreadId === activeThreadId ? activeTerminalPortalTarget : null}
+          renderInline={renderActiveTerminalInline}
         />
       ))}
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -29,7 +29,6 @@ import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { createPortal } from "react-dom";
 import type { TerminalBottomScope } from "@t3tools/contracts/settings";
-import { gitStatusQueryOptions } from "~/lib/gitReactQuery";
 import { useGitStatus } from "~/lib/gitStatusState";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { isElectron } from "../env";
@@ -3741,7 +3740,9 @@ export default function ChatView({ layoutState, threadId }: ChatViewProps) {
           trigger.rangeStart,
           replacementRangeEnd,
           replacement,
-          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+          {
+            expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd),
+          },
         );
         if (applied) {
           setComposerHighlightedItemId(null);
@@ -3760,7 +3761,9 @@ export default function ChatView({ layoutState, threadId }: ChatViewProps) {
             trigger.rangeStart,
             replacementRangeEnd,
             replacement,
-            { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+            {
+              expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd),
+            },
           );
           if (applied) {
             setComposerHighlightedItemId(null);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -29,7 +29,6 @@ import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { createPortal } from "react-dom";
 import type { TerminalBottomScope } from "@t3tools/contracts/settings";
-import { gitStatusQueryOptions } from "~/lib/gitReactQuery";
 import { useGitStatus } from "~/lib/gitStatusState";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
 import { isElectron } from "../env";
@@ -3735,7 +3734,9 @@ export default function ChatView({ layoutState, threadId }: ChatViewProps) {
           trigger.rangeStart,
           replacementRangeEnd,
           replacement,
-          { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+          {
+            expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd),
+          },
         );
         if (applied) {
           setComposerHighlightedItemId(null);
@@ -3754,7 +3755,9 @@ export default function ChatView({ layoutState, threadId }: ChatViewProps) {
             trigger.rangeStart,
             replacementRangeEnd,
             replacement,
-            { expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd) },
+            {
+              expectedText: snapshot.value.slice(trigger.rangeStart, replacementRangeEnd),
+            },
           );
           if (applied) {
             setComposerHighlightedItemId(null);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -125,6 +125,7 @@ import {
   resolveSelectableProvider,
 } from "../providerModels";
 import { useSettings } from "../hooks/useSettings";
+import { useWorkspacePanelController } from "../hooks/useWorkspacePanelController";
 import { resolveAppModelSelection } from "../modelSelection";
 import type { TerminalDockTarget } from "../workspacePanels";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -1604,58 +1605,23 @@ export default function ChatView({ layoutState, threadId }: ChatViewProps) {
   );
   const terminalToggleActive = layoutState.terminalToggleActive;
   const diffToggleActive = layoutState.diffToggleActive;
-  const closeDiffPanel = useCallback(() => {
-    void navigate({
-      to: "/$threadId",
-      params: { threadId },
-      replace: true,
-      search: (previous) => ({
-        ...stripDiffSearchParams(previous),
-        diff: undefined,
-      }),
-    });
-  }, [navigate, threadId]);
-  const openDiffPanel = useCallback(() => {
-    void navigate({
-      to: "/$threadId",
-      params: { threadId },
-      replace: true,
-      search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
-      },
-    });
-  }, [navigate, threadId]);
   const setTerminalOpen = useCallback(
     (open: boolean) => {
-      if (!activeThreadId) return;
-      storeSetTerminalOpen(activeThreadId, open);
+      storeSetTerminalOpen(threadId, open);
     },
-    [activeThreadId, storeSetTerminalOpen],
+    [storeSetTerminalOpen, threadId],
   );
-  const onToggleDiff = useCallback(() => {
-    if (terminalPosition === "right") {
-      if (diffToggleActive) {
-        closeDiffPanel();
-        return;
-      }
-      setTerminalOpen(false);
-      openDiffPanel();
-      return;
-    }
-    if (diffOpen) {
-      closeDiffPanel();
-      return;
-    }
-    openDiffPanel();
-  }, [
-    closeDiffPanel,
+  const panelController = useWorkspacePanelController({
     diffOpen,
     diffToggleActive,
-    openDiffPanel,
+    replaceHistory: true,
     setTerminalOpen,
+    terminalOpen: terminalState.terminalOpen,
     terminalPosition,
-  ]);
+    terminalToggleActive,
+    threadId,
+  });
+  const onToggleDiff = panelController.toggleDiffPanel;
 
   const envLocked = Boolean(
     activeThread &&
@@ -1743,33 +1709,7 @@ export default function ChatView({ layoutState, threadId }: ChatViewProps) {
     },
     [activeThread, composerCursor, composerTerminalContexts, insertComposerDraftTerminalContext],
   );
-  const toggleTerminalVisibility = useCallback(() => {
-    if (!activeThreadId) return;
-    if (terminalPosition === "right") {
-      if (terminalToggleActive) {
-        setTerminalOpen(false);
-        return;
-      }
-      if (diffOpen) {
-        setTerminalOpen(true);
-        closeDiffPanel();
-        return;
-      }
-      if (!terminalState.terminalOpen) {
-        setTerminalOpen(true);
-      }
-      return;
-    }
-    setTerminalOpen(!terminalState.terminalOpen);
-  }, [
-    activeThreadId,
-    closeDiffPanel,
-    diffOpen,
-    setTerminalOpen,
-    terminalToggleActive,
-    terminalPosition,
-    terminalState.terminalOpen,
-  ]);
+  const toggleTerminalVisibility = panelController.toggleTerminalPanel;
   const splitTerminal = useCallback(() => {
     if (!activeThreadId || hasReachedSplitLimit) return;
     const terminalId = `terminal-${randomUUID()}`;

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -10,7 +10,7 @@ export type DiffPanelMode = "inline" | "sheet" | "sidebar";
 function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
   const shouldUseDragRegion = isElectron && mode !== "sheet";
   return cn(
-    "flex items-center justify-between gap-2 px-4",
+    "flex min-w-0 items-center gap-2 overflow-hidden px-4",
     shouldUseDragRegion ? "drag-region h-[52px] border-b border-border" : "h-12",
   );
 }
@@ -25,7 +25,7 @@ export function DiffPanelShell(props: {
   return (
     <div
       className={cn(
-        "flex h-full min-w-0 flex-col bg-background",
+        "flex h-full min-w-0 flex-col overflow-hidden bg-background",
         props.mode === "inline"
           ? "w-[42vw] min-w-[360px] max-w-[560px] shrink-0 border-l border-border"
           : "w-full",

--- a/apps/web/src/components/ThreadTerminalPanel.test.ts
+++ b/apps/web/src/components/ThreadTerminalPanel.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   clampTerminalPanelHeight,
   resolveTerminalPanelMaxHeight,
+  resolveTerminalSplitViewGridStyle,
   resolveTerminalSelectionActionPosition,
   selectPendingTerminalEventEntries,
   selectTerminalEventEntriesAfterSnapshot,
@@ -44,6 +45,20 @@ describe("clampTerminalPanelHeight", () => {
         viewportHeight: 1200,
       }),
     ).toBe(260);
+  });
+});
+
+describe("resolveTerminalSplitViewGridStyle", () => {
+  it("uses columns for bottom-docked terminal splits", () => {
+    expect(resolveTerminalSplitViewGridStyle("bottom", 3)).toEqual({
+      gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+    });
+  });
+
+  it("uses rows for right-docked terminal splits", () => {
+    expect(resolveTerminalSplitViewGridStyle("side", 3)).toEqual({
+      gridTemplateRows: "repeat(3, minmax(0, 1fr))",
+    });
   });
 });
 

--- a/apps/web/src/components/ThreadTerminalPanel.test.ts
+++ b/apps/web/src/components/ThreadTerminalPanel.test.ts
@@ -1,12 +1,51 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  clampTerminalPanelHeight,
+  resolveTerminalPanelMaxHeight,
   resolveTerminalSelectionActionPosition,
   selectPendingTerminalEventEntries,
   selectTerminalEventEntriesAfterSnapshot,
   shouldHandleTerminalSelectionMouseUp,
   terminalSelectionActionDelayForClickCount,
-} from "./ThreadTerminalDrawer";
+} from "./ThreadTerminalPanel";
+
+describe("resolveTerminalPanelMaxHeight", () => {
+  it("reserves room for the workspace row when the bottom terminal spans the workspace", () => {
+    expect(
+      resolveTerminalPanelMaxHeight({
+        layout: "bottom",
+        bottomScope: "workspace",
+        parentHeight: 480,
+        viewportHeight: 1200,
+      }),
+    ).toBe(260);
+  });
+
+  it("uses the viewport ratio for chat-scoped bottom terminals", () => {
+    expect(
+      resolveTerminalPanelMaxHeight({
+        layout: "bottom",
+        bottomScope: "chat",
+        parentHeight: 480,
+        viewportHeight: 1200,
+      }),
+    ).toBe(900);
+  });
+});
+
+describe("clampTerminalPanelHeight", () => {
+  it("clamps workspace-spanning bottom terminals to the available workspace height", () => {
+    expect(
+      clampTerminalPanelHeight(420, {
+        layout: "bottom",
+        bottomScope: "workspace",
+        parentHeight: 480,
+        viewportHeight: 1200,
+      }),
+    ).toBe(260);
+  });
+});
 
 describe("resolveTerminalSelectionActionPosition", () => {
   it("prefers the selection rect over the last pointer position", () => {

--- a/apps/web/src/components/ThreadTerminalPanel.tsx
+++ b/apps/web/src/components/ThreadTerminalPanel.tsx
@@ -544,8 +544,6 @@ function TerminalViewport({
     });
 
     const applyTerminalEvent = (event: TerminalEvent) => {
-    const unsubscribe = api?.terminal.onEvent((event) => {
-      if (event.threadId !== threadId || event.terminalId !== terminalId) return;
       const activeTerminal = terminalRef.current;
       if (!activeTerminal) {
         return;
@@ -605,6 +603,10 @@ function TerminalViewport({
         }, 0);
       }
     };
+    const unsubscribe = api?.terminal.onEvent((event) => {
+      if (event.threadId !== threadId || event.terminalId !== terminalId) return;
+      applyTerminalEvent(event);
+    });
     const applyPendingTerminalEvents = (
       terminalEventEntries: ReadonlyArray<{ id: number; event: TerminalEvent }>,
     ) => {

--- a/apps/web/src/components/ThreadTerminalPanel.tsx
+++ b/apps/web/src/components/ThreadTerminalPanel.tsx
@@ -79,6 +79,17 @@ export function clampTerminalPanelHeight(
   return Math.min(Math.max(Math.round(safeHeight), MIN_DRAWER_HEIGHT), maxHeight);
 }
 
+export function resolveTerminalSplitViewGridStyle(
+  layout: "bottom" | "side",
+  terminalCount: number,
+): {
+  gridTemplateColumns?: string;
+  gridTemplateRows?: string;
+} {
+  const template = `repeat(${terminalCount}, minmax(0, 1fr))`;
+  return layout === "side" ? { gridTemplateRows: template } : { gridTemplateColumns: template };
+}
+
 function writeSystemMessage(terminal: Terminal, message: string): void {
   terminal.write(`\r\n[terminal] ${message}\r\n`);
 }
@@ -1087,6 +1098,10 @@ export default function ThreadTerminalPanel({
     resolvedTerminalGroups.length > 1 ||
     resolvedTerminalGroups.some((terminalGroup) => terminalGroup.terminalIds.length > 1);
   const hasReachedSplitLimit = visibleTerminalIds.length >= MAX_TERMINALS_PER_GROUP;
+  const splitViewGridStyle = useMemo(
+    () => resolveTerminalSplitViewGridStyle(layout, visibleTerminalIds.length),
+    [layout, visibleTerminalIds.length],
+  );
   const terminalLabelById = useMemo(
     () =>
       new Map(
@@ -1105,6 +1120,7 @@ export default function ThreadTerminalPanel({
   const closeTerminalActionLabel = closeShortcutLabel
     ? `Close Terminal (${closeShortcutLabel})`
     : "Close Terminal";
+  const splitTerminalIconClassName = isSideLayout ? "size-3.25 rotate-90" : "size-3.25";
   const onSplitTerminalAction = useCallback(() => {
     if (hasReachedSplitLimit) return;
     onSplitTerminal();
@@ -1252,7 +1268,7 @@ export default function ThreadTerminalPanel({
               onClick={onSplitTerminalAction}
               label={splitTerminalActionLabel}
             >
-              <SquareSplitHorizontal className="size-3.25" />
+              <SquareSplitHorizontal className={splitTerminalIconClassName} />
             </TerminalActionButton>
             <div className="h-4 w-px bg-border/80" />
             <TerminalActionButton
@@ -1280,14 +1296,14 @@ export default function ThreadTerminalPanel({
             {isSplitView ? (
               <div
                 className="grid h-full w-full min-w-0 gap-0 overflow-hidden"
-                style={{
-                  gridTemplateColumns: `repeat(${visibleTerminalIds.length}, minmax(0, 1fr))`,
-                }}
+                style={splitViewGridStyle}
               >
                 {visibleTerminalIds.map((terminalId) => (
                   <div
                     key={terminalId}
-                    className={`min-h-0 min-w-0 border-l first:border-l-0 ${
+                    className={`min-h-0 min-w-0 ${
+                      isSideLayout ? "border-t first:border-t-0" : "border-l first:border-l-0"
+                    } ${
                       terminalId === resolvedActiveTerminalId ? "border-border" : "border-border/70"
                     }`}
                     onMouseDown={() => {
@@ -1351,7 +1367,7 @@ export default function ThreadTerminalPanel({
                     onClick={onSplitTerminalAction}
                     label={splitTerminalActionLabel}
                   >
-                    <SquareSplitHorizontal className="size-3.25" />
+                    <SquareSplitHorizontal className={splitTerminalIconClassName} />
                   </TerminalActionButton>
                   <TerminalActionButton
                     className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"

--- a/apps/web/src/components/ThreadTerminalPanel.tsx
+++ b/apps/web/src/components/ThreadTerminalPanel.tsx
@@ -5,6 +5,7 @@ import {
   type TerminalSessionSnapshot,
   type ThreadId,
 } from "@t3tools/contracts";
+import type { TerminalBottomScope } from "@t3tools/contracts/settings";
 import { Terminal, type ITheme } from "@xterm/xterm";
 import {
   type PointerEvent as ReactPointerEvent,
@@ -36,16 +37,45 @@ import { selectTerminalEventEntries, useTerminalStateStore } from "../terminalSt
 
 const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
+const MIN_BOTTOM_WORKSPACE_CONTENT_HEIGHT = 220;
 const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
+const MIN_TERMINAL_COLS = 20;
+const MIN_TERMINAL_ROWS = 5;
 
-function maxDrawerHeight(): number {
-  if (typeof window === "undefined") return DEFAULT_THREAD_TERMINAL_HEIGHT;
-  return Math.max(MIN_DRAWER_HEIGHT, Math.floor(window.innerHeight * MAX_DRAWER_HEIGHT_RATIO));
+interface TerminalPanelHeightBoundsInput {
+  bottomScope: TerminalBottomScope;
+  layout: "bottom" | "side";
+  parentHeight?: number | null;
+  viewportHeight?: number;
 }
 
-function clampDrawerHeight(height: number): number {
+export function resolveTerminalPanelMaxHeight(input: TerminalPanelHeightBoundsInput): number {
+  const viewportHeight =
+    input.viewportHeight ??
+    (typeof window === "undefined" ? DEFAULT_THREAD_TERMINAL_HEIGHT : window.innerHeight);
+  let maxHeight = Math.floor(viewportHeight * MAX_DRAWER_HEIGHT_RATIO);
+
+  if (
+    input.layout === "bottom" &&
+    input.bottomScope === "workspace" &&
+    typeof input.parentHeight === "number" &&
+    Number.isFinite(input.parentHeight)
+  ) {
+    maxHeight = Math.min(
+      maxHeight,
+      Math.floor(input.parentHeight - MIN_BOTTOM_WORKSPACE_CONTENT_HEIGHT),
+    );
+  }
+
+  return Math.max(MIN_DRAWER_HEIGHT, maxHeight);
+}
+
+export function clampTerminalPanelHeight(
+  height: number,
+  input: TerminalPanelHeightBoundsInput,
+): number {
   const safeHeight = Number.isFinite(height) ? height : DEFAULT_THREAD_TERMINAL_HEIGHT;
-  const maxHeight = maxDrawerHeight();
+  const maxHeight = resolveTerminalPanelMaxHeight(input);
   return Math.min(Math.max(Math.round(safeHeight), MIN_DRAWER_HEIGHT), maxHeight);
 }
 
@@ -72,6 +102,18 @@ export function selectPendingTerminalEventEntries(
   lastAppliedTerminalEventId: number,
 ): ReadonlyArray<{ id: number; event: TerminalEvent }> {
   return entries.filter((entry) => entry.id > lastAppliedTerminalEventId);
+}
+
+function resolveTerminalViewportSize(terminal: Terminal): { cols: number; rows: number } | null {
+  const cols = Math.round(terminal.cols);
+  const rows = Math.round(terminal.rows);
+  if (!Number.isFinite(cols) || !Number.isFinite(rows)) {
+    return null;
+  }
+  if (cols < MIN_TERMINAL_COLS || rows < MIN_TERMINAL_ROWS) {
+    return null;
+  }
+  return { cols, rows };
 }
 
 function terminalThemeFromApp(): ITheme {
@@ -220,6 +262,7 @@ interface TerminalViewportProps {
   autoFocus: boolean;
   resizeEpoch: number;
   drawerHeight: number;
+  layout: "bottom" | "side";
 }
 
 function TerminalViewport({
@@ -235,6 +278,7 @@ function TerminalViewport({
   autoFocus,
   resizeEpoch,
   drawerHeight,
+  layout,
 }: TerminalViewportProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
@@ -254,6 +298,13 @@ function TerminalViewport({
     onAddTerminalContext(selection);
   });
   const readTerminalLabel = useEffectEvent(() => terminalLabel);
+  const sessionOpenRef = useRef(false);
+  const openingSessionRef = useRef(false);
+
+  useEffect(() => {
+    sessionOpenRef.current = false;
+    openingSessionRef.current = false;
+  }, [cwd, runtimeEnv, terminalId, threadId]);
 
   useEffect(() => {
     const mount = containerRef.current;
@@ -493,6 +544,8 @@ function TerminalViewport({
     });
 
     const applyTerminalEvent = (event: TerminalEvent) => {
+    const unsubscribe = api?.terminal.onEvent((event) => {
+      if (event.threadId !== threadId || event.terminalId !== terminalId) return;
       const activeTerminal = terminalRef.current;
       if (!activeTerminal) {
         return;
@@ -509,6 +562,7 @@ function TerminalViewport({
       }
 
       if (event.type === "started" || event.type === "restarted") {
+        sessionOpenRef.current = true;
         hasHandledExitRef.current = false;
         clearSelectionAction();
         writeTerminalSnapshot(activeTerminal, event.snapshot);
@@ -527,26 +581,29 @@ function TerminalViewport({
         return;
       }
 
-      const details = [
-        typeof event.exitCode === "number" ? `code ${event.exitCode}` : null,
-        typeof event.exitSignal === "number" ? `signal ${event.exitSignal}` : null,
-      ]
-        .filter((value): value is string => value !== null)
-        .join(", ");
-      writeSystemMessage(
-        activeTerminal,
-        details.length > 0 ? `Process exited (${details})` : "Process exited",
-      );
-      if (hasHandledExitRef.current) {
-        return;
-      }
-      hasHandledExitRef.current = true;
-      window.setTimeout(() => {
-        if (!hasHandledExitRef.current) {
+      if (event.type === "exited") {
+        sessionOpenRef.current = false;
+        const details = [
+          typeof event.exitCode === "number" ? `code ${event.exitCode}` : null,
+          typeof event.exitSignal === "number" ? `signal ${event.exitSignal}` : null,
+        ]
+          .filter((value): value is string => value !== null)
+          .join(", ");
+        writeSystemMessage(
+          activeTerminal,
+          details.length > 0 ? `Process exited (${details})` : "Process exited",
+        );
+        if (hasHandledExitRef.current) {
           return;
         }
-        handleSessionExited();
-      }, 0);
+        hasHandledExitRef.current = true;
+        window.setTimeout(() => {
+          if (!hasHandledExitRef.current) {
+            return;
+          }
+          handleSessionExited();
+        }, 0);
+      }
     };
     const applyPendingTerminalEvents = (
       terminalEventEntries: ReadonlyArray<{ id: number; event: TerminalEvent }>,
@@ -590,21 +647,31 @@ function TerminalViewport({
     });
 
     const openTerminal = async () => {
+      if (openingSessionRef.current || sessionOpenRef.current) {
+        return;
+      }
       try {
         const activeTerminal = terminalRef.current;
         const activeFitAddon = fitAddonRef.current;
         if (!activeTerminal || !activeFitAddon) return;
         activeFitAddon.fit();
+        const viewportSize = resolveTerminalViewportSize(activeTerminal);
+        if (!viewportSize) {
+          return;
+        }
+        openingSessionRef.current = true;
         const snapshot = await api.terminal.open({
           threadId,
           terminalId,
           cwd,
           ...(worktreePath !== undefined ? { worktreePath } : {}),
-          cols: activeTerminal.cols,
-          rows: activeTerminal.rows,
+          cols: viewportSize.cols,
+          rows: viewportSize.rows,
           ...(runtimeEnv ? { env: runtimeEnv } : {}),
         });
         if (disposed) return;
+        sessionOpenRef.current = true;
+        hasHandledExitRef.current = false;
         writeTerminalSnapshot(activeTerminal, snapshot);
         const bufferedEntries = selectTerminalEventEntries(
           useTerminalStateStore.getState().terminalEventEntriesByKey,
@@ -631,6 +698,8 @@ function TerminalViewport({
           terminal,
           err instanceof Error ? err.message : "Failed to open terminal",
         );
+      } finally {
+        openingSessionRef.current = false;
       }
     };
 
@@ -641,15 +710,23 @@ function TerminalViewport({
       const wasAtBottom =
         activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
       activeFitAddon.fit();
+      const viewportSize = resolveTerminalViewportSize(activeTerminal);
       if (wasAtBottom) {
         activeTerminal.scrollToBottom();
+      }
+      if (!viewportSize) {
+        return;
+      }
+      if (!sessionOpenRef.current) {
+        void openTerminal();
+        return;
       }
       void api.terminal
         .resize({
           threadId,
           terminalId,
-          cols: activeTerminal.cols,
-          rows: activeTerminal.rows,
+          cols: viewportSize.cols,
+          rows: viewportSize.rows,
         })
         .catch(() => undefined);
     }, 30);
@@ -659,6 +736,7 @@ function TerminalViewport({
       disposed = true;
       terminalHydratedRef.current = false;
       lastAppliedTerminalEventIdRef.current = 0;
+      unsubscribe?.();
       unsubscribeTerminalEvents();
       window.clearTimeout(fitTimer);
       inputDisposable.dispose();
@@ -670,6 +748,8 @@ function TerminalViewport({
       window.removeEventListener("mouseup", handleMouseUp);
       mount.removeEventListener("pointerdown", handlePointerDown);
       themeObserver.disconnect();
+      sessionOpenRef.current = false;
+      openingSessionRef.current = false;
       terminalRef.current = null;
       fitAddonRef.current = null;
       terminal.dispose();
@@ -692,6 +772,86 @@ function TerminalViewport({
   }, [autoFocus, focusRequestId]);
 
   useEffect(() => {
+    const container = containerRef.current;
+    const api = readNativeApi();
+    if (!container || !api || typeof ResizeObserver === "undefined") return;
+
+    let frame: number | null = null;
+
+    const fitToContainer = () => {
+      const terminal = terminalRef.current;
+      const fitAddon = fitAddonRef.current;
+      if (!terminal || !fitAddon) return;
+      const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
+      fitAddon.fit();
+      const viewportSize = resolveTerminalViewportSize(terminal);
+      if (wasAtBottom) {
+        terminal.scrollToBottom();
+      }
+      if (!viewportSize) {
+        return;
+      }
+      if (!sessionOpenRef.current) {
+        void (async () => {
+          const activeTerminal = terminalRef.current;
+          const activeFitAddon = fitAddonRef.current;
+          if (!activeTerminal || !activeFitAddon) return;
+          activeFitAddon.fit();
+          const nextViewportSize = resolveTerminalViewportSize(activeTerminal);
+          if (!nextViewportSize || openingSessionRef.current || sessionOpenRef.current) {
+            return;
+          }
+          openingSessionRef.current = true;
+          try {
+            const snapshot = await api.terminal.open({
+              threadId,
+              terminalId,
+              cwd,
+              cols: nextViewportSize.cols,
+              rows: nextViewportSize.rows,
+              ...(runtimeEnv ? { env: runtimeEnv } : {}),
+            });
+            sessionOpenRef.current = true;
+            activeTerminal.write("\u001bc");
+            if (snapshot.history.length > 0) {
+              activeTerminal.write(snapshot.history);
+            }
+          } catch {
+            // Let the next valid resize retry opening the session.
+          } finally {
+            openingSessionRef.current = false;
+          }
+        })();
+        return;
+      }
+      void api.terminal
+        .resize({
+          threadId,
+          terminalId,
+          cols: viewportSize.cols,
+          rows: viewportSize.rows,
+        })
+        .catch(() => undefined);
+    };
+
+    const observer = new ResizeObserver(() => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        fitToContainer();
+      });
+    });
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+    };
+  }, [cwd, runtimeEnv, terminalId, threadId]);
+
+  useEffect(() => {
     const api = readNativeApi();
     const terminal = terminalRef.current;
     const fitAddon = fitAddonRef.current;
@@ -699,34 +859,39 @@ function TerminalViewport({
     const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
     const frame = window.requestAnimationFrame(() => {
       fitAddon.fit();
+      const viewportSize = resolveTerminalViewportSize(terminal);
       if (wasAtBottom) {
         terminal.scrollToBottom();
+      }
+      if (!viewportSize || !sessionOpenRef.current) {
+        return;
       }
       void api.terminal
         .resize({
           threadId,
           terminalId,
-          cols: terminal.cols,
-          rows: terminal.rows,
+          cols: viewportSize.cols,
+          rows: viewportSize.rows,
         })
         .catch(() => undefined);
     });
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [drawerHeight, resizeEpoch, terminalId, threadId]);
+  }, [drawerHeight, layout, resizeEpoch, terminalId, threadId]);
   return (
     <div ref={containerRef} className="relative h-full w-full overflow-hidden rounded-[4px]" />
   );
 }
 
-interface ThreadTerminalDrawerProps {
+interface ThreadTerminalPanelProps {
   threadId: ThreadId;
   cwd: string;
   worktreePath?: string | null;
   runtimeEnv?: Record<string, string>;
   visible?: boolean;
   height: number;
+  bottomScope?: TerminalBottomScope;
   terminalIds: string[];
   activeTerminalId: string;
   terminalGroups: ThreadTerminalGroup[];
@@ -741,6 +906,7 @@ interface ThreadTerminalDrawerProps {
   onCloseTerminal: (terminalId: string) => void;
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
+  layout?: "bottom" | "side";
 }
 
 interface TerminalActionButtonProps {
@@ -772,13 +938,14 @@ function TerminalActionButton({ label, className, onClick, children }: TerminalA
   );
 }
 
-export default function ThreadTerminalDrawer({
+export default function ThreadTerminalPanel({
   threadId,
   cwd,
   worktreePath,
   runtimeEnv,
   visible = true,
   height,
+  bottomScope = "chat",
   terminalIds,
   activeTerminalId,
   terminalGroups,
@@ -793,11 +960,30 @@ export default function ThreadTerminalDrawer({
   onCloseTerminal,
   onHeightChange,
   onAddTerminalContext,
-}: ThreadTerminalDrawerProps) {
-  const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height));
+  layout = "bottom",
+}: ThreadTerminalPanelProps) {
+  const isSideLayout = layout === "side";
+  const panelRef = useRef<HTMLElement | null>(null);
+  const resolveParentHeight = useCallback(
+    () =>
+      panelRef.current?.closest<HTMLElement>("[data-workspace-shell='true']")?.clientHeight ?? null,
+    [],
+  );
+  const clampPanelHeight = useCallback(
+    (nextHeight: number) =>
+      clampTerminalPanelHeight(nextHeight, {
+        bottomScope,
+        layout,
+        parentHeight: resolveParentHeight(),
+      }),
+    [bottomScope, layout, resolveParentHeight],
+  );
+  const [drawerHeight, setDrawerHeight] = useState(() =>
+    clampTerminalPanelHeight(height, { bottomScope, layout }),
+  );
   const [resizeEpoch, setResizeEpoch] = useState(0);
   const drawerHeightRef = useRef(drawerHeight);
-  const lastSyncedHeightRef = useRef(clampDrawerHeight(height));
+  const lastSyncedHeightRef = useRef(clampTerminalPanelHeight(height, { bottomScope, layout }));
   const onHeightChangeRef = useRef(onHeightChange);
   const resizeStateRef = useRef<{
     pointerId: number;
@@ -933,19 +1119,24 @@ export default function ThreadTerminalDrawer({
     drawerHeightRef.current = drawerHeight;
   }, [drawerHeight]);
 
-  const syncHeight = useCallback((nextHeight: number) => {
-    const clampedHeight = clampDrawerHeight(nextHeight);
-    if (lastSyncedHeightRef.current === clampedHeight) return;
-    lastSyncedHeightRef.current = clampedHeight;
-    onHeightChangeRef.current(clampedHeight);
-  }, []);
+  const syncHeight = useCallback(
+    (nextHeight: number) => {
+      if (isSideLayout) return;
+      const clampedHeight = clampPanelHeight(nextHeight);
+      if (lastSyncedHeightRef.current === clampedHeight) return;
+      lastSyncedHeightRef.current = clampedHeight;
+      onHeightChangeRef.current(clampedHeight);
+    },
+    [clampPanelHeight, isSideLayout],
+  );
 
   useEffect(() => {
-    const clampedHeight = clampDrawerHeight(height);
+    if (isSideLayout) return;
+    const clampedHeight = clampPanelHeight(height);
     setDrawerHeight(clampedHeight);
     drawerHeightRef.current = clampedHeight;
     lastSyncedHeightRef.current = clampedHeight;
-  }, [height, threadId]);
+  }, [clampPanelHeight, height, isSideLayout, threadId]);
 
   const handleResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
     if (event.button !== 0) return;
@@ -959,20 +1150,23 @@ export default function ThreadTerminalDrawer({
     };
   }, []);
 
-  const handleResizePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const resizeState = resizeStateRef.current;
-    if (!resizeState || resizeState.pointerId !== event.pointerId) return;
-    event.preventDefault();
-    const clampedHeight = clampDrawerHeight(
-      resizeState.startHeight + (resizeState.startY - event.clientY),
-    );
-    if (clampedHeight === drawerHeightRef.current) {
-      return;
-    }
-    didResizeDuringDragRef.current = true;
-    drawerHeightRef.current = clampedHeight;
-    setDrawerHeight(clampedHeight);
-  }, []);
+  const handleResizePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const resizeState = resizeStateRef.current;
+      if (!resizeState || resizeState.pointerId !== event.pointerId) return;
+      event.preventDefault();
+      const clampedHeight = clampPanelHeight(
+        resizeState.startHeight + (resizeState.startY - event.clientY),
+      );
+      if (clampedHeight === drawerHeightRef.current) {
+        return;
+      }
+      didResizeDuringDragRef.current = true;
+      drawerHeightRef.current = clampedHeight;
+      setDrawerHeight(clampedHeight);
+    },
+    [clampPanelHeight],
+  );
 
   const handleResizePointerEnd = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -992,12 +1186,11 @@ export default function ThreadTerminalDrawer({
   );
 
   useEffect(() => {
-    if (!visible) {
+    if (!visible || isSideLayout) {
       return;
     }
-
     const onWindowResize = () => {
-      const clampedHeight = clampDrawerHeight(drawerHeightRef.current);
+      const clampedHeight = clampPanelHeight(drawerHeightRef.current);
       const changed = clampedHeight !== drawerHeightRef.current;
       if (changed) {
         setDrawerHeight(clampedHeight);
@@ -1012,7 +1205,7 @@ export default function ThreadTerminalDrawer({
     return () => {
       window.removeEventListener("resize", onWindowResize);
     };
-  }, [syncHeight, visible]);
+  }, [clampPanelHeight, isSideLayout, syncHeight, visible]);
 
   useEffect(() => {
     if (!visible) {
@@ -1029,16 +1222,21 @@ export default function ThreadTerminalDrawer({
 
   return (
     <aside
-      className="thread-terminal-drawer relative flex min-w-0 shrink-0 flex-col overflow-hidden border-t border-border/80 bg-background"
-      style={{ height: `${drawerHeight}px` }}
+      ref={panelRef}
+      className={`thread-terminal-panel relative flex min-h-0 min-w-0 flex-col overflow-hidden bg-background ${
+        isSideLayout ? "h-full flex-1" : "shrink-0 border-t border-border/80"
+      }`}
+      style={isSideLayout ? undefined : { height: `${drawerHeight}px` }}
     >
-      <div
-        className="absolute inset-x-0 top-0 z-20 h-1.5 cursor-row-resize"
-        onPointerDown={handleResizePointerDown}
-        onPointerMove={handleResizePointerMove}
-        onPointerUp={handleResizePointerEnd}
-        onPointerCancel={handleResizePointerEnd}
-      />
+      {!isSideLayout ? (
+        <div
+          className="absolute inset-x-0 top-0 z-20 h-1.5 cursor-row-resize"
+          onPointerDown={handleResizePointerDown}
+          onPointerMove={handleResizePointerMove}
+          onPointerUp={handleResizePointerEnd}
+          onPointerCancel={handleResizePointerEnd}
+        />
+      ) : null}
 
       {!hasTerminalSidebar && (
         <div className="pointer-events-none absolute right-2 top-2 z-20">
@@ -1110,6 +1308,7 @@ export default function ThreadTerminalDrawer({
                         autoFocus={terminalId === resolvedActiveTerminalId}
                         resizeEpoch={resizeEpoch}
                         drawerHeight={drawerHeight}
+                        layout={layout}
                       />
                     </div>
                   </div>
@@ -1131,6 +1330,7 @@ export default function ThreadTerminalDrawer({
                   autoFocus
                   resizeEpoch={resizeEpoch}
                   drawerHeight={drawerHeight}
+                  layout={layout}
                 />
               </div>
             )}

--- a/apps/web/src/components/WorkspacePanels.tsx
+++ b/apps/web/src/components/WorkspacePanels.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import { Sheet, SheetPopup } from "./ui/sheet";
+import { cn } from "~/lib/utils";
+import { WorkspaceRightSidebar } from "./WorkspaceRightSidebar";
+
+type WorkspaceSideSheetProps = {
+  children: ReactNode;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+};
+
+type WorkspaceRightRailProps = {
+  children: ReactNode;
+  defaultWidth: string;
+  minWidth: number;
+  onOpenChange?: (open: boolean) => void;
+  open: boolean;
+  storageKey: string;
+};
+
+type WorkspacePanelLayoutProps = {
+  bodyClassName?: string;
+  children: ReactNode;
+};
+
+export function WorkspaceSideSheet({ children, onOpenChange, open }: WorkspaceSideSheetProps) {
+  return (
+    <Sheet onOpenChange={onOpenChange} open={open}>
+      <SheetPopup
+        side="right"
+        showCloseButton={false}
+        keepMounted
+        className="w-[min(88vw,820px)] max-w-[820px] p-0"
+      >
+        {children}
+      </SheetPopup>
+    </Sheet>
+  );
+}
+
+export function WorkspaceRightRail({
+  children,
+  defaultWidth,
+  minWidth,
+  onOpenChange,
+  open,
+  storageKey,
+}: WorkspaceRightRailProps) {
+  return (
+    <WorkspaceRightSidebar
+      defaultWidth={defaultWidth}
+      minWidth={minWidth}
+      open={open}
+      storageKey={storageKey}
+      {...(onOpenChange ? { onOpenChange } : {})}
+    >
+      {children}
+    </WorkspaceRightSidebar>
+  );
+}
+
+export function WorkspacePanelLayout({ bodyClassName, children }: WorkspacePanelLayoutProps) {
+  return (
+    <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden">
+      <div className={cn("flex min-h-0 min-w-0 flex-1 overflow-hidden", bodyClassName)}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/WorkspaceRightSidebar.tsx
+++ b/apps/web/src/components/WorkspaceRightSidebar.tsx
@@ -82,6 +82,7 @@ export function WorkspaceRightSidebar({
       defaultOpen={false}
       open={open}
       onOpenChange={handleOpenChange}
+      persistState={false}
       className="w-auto min-h-0 flex-none bg-transparent"
       style={{ "--sidebar-width": defaultWidth } as CSSProperties}
     >

--- a/apps/web/src/components/WorkspaceRightSidebar.tsx
+++ b/apps/web/src/components/WorkspaceRightSidebar.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactNode } from "react";
 import { useCallback } from "react";
 import { Sidebar, SidebarProvider, SidebarRail } from "./ui/sidebar";
+import { shouldAcceptWorkspaceSidebarWidth } from "../workspaceSidebarSizing";
 
 type WorkspaceRightSidebarProps = {
   children: ReactNode;
@@ -10,57 +11,6 @@ type WorkspaceRightSidebarProps = {
   open: boolean;
   storageKey: string;
 };
-
-const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
-
-function shouldAcceptWorkspaceSidebarWidth({
-  nextWidth,
-  wrapper,
-}: {
-  nextWidth: number;
-  wrapper: HTMLElement;
-}) {
-  const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
-  if (!composerForm) return true;
-  const composerViewport = composerForm.parentElement;
-  if (!composerViewport) return true;
-  const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
-  wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
-
-  const viewportStyle = window.getComputedStyle(composerViewport);
-  const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
-  const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
-  const viewportContentWidth = Math.max(
-    0,
-    composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
-  );
-  const formRect = composerForm.getBoundingClientRect();
-  const composerFooter = composerForm.querySelector<HTMLElement>(
-    "[data-chat-composer-footer='true']",
-  );
-  const composerRightActions = composerForm.querySelector<HTMLElement>(
-    "[data-chat-composer-actions='right']",
-  );
-  const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
-  const composerFooterGap = composerFooter
-    ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
-      Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
-      0
-    : 0;
-  const minimumComposerWidth =
-    COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
-  const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
-  const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
-  const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
-
-  if (previousSidebarWidth.length > 0) {
-    wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
-  } else {
-    wrapper.style.removeProperty("--sidebar-width");
-  }
-
-  return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
-}
 
 export function WorkspaceRightSidebar({
   children,

--- a/apps/web/src/components/WorkspaceRightSidebar.tsx
+++ b/apps/web/src/components/WorkspaceRightSidebar.tsx
@@ -1,0 +1,104 @@
+import type { CSSProperties, ReactNode } from "react";
+import { useCallback } from "react";
+import { Sidebar, SidebarProvider, SidebarRail } from "./ui/sidebar";
+
+type WorkspaceRightSidebarProps = {
+  children: ReactNode;
+  defaultWidth: string;
+  minWidth: number;
+  onOpenChange?: (open: boolean) => void;
+  open: boolean;
+  storageKey: string;
+};
+
+const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
+
+function shouldAcceptWorkspaceSidebarWidth({
+  nextWidth,
+  wrapper,
+}: {
+  nextWidth: number;
+  wrapper: HTMLElement;
+}) {
+  const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
+  if (!composerForm) return true;
+  const composerViewport = composerForm.parentElement;
+  if (!composerViewport) return true;
+  const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
+  wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
+
+  const viewportStyle = window.getComputedStyle(composerViewport);
+  const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
+  const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
+  const viewportContentWidth = Math.max(
+    0,
+    composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
+  );
+  const formRect = composerForm.getBoundingClientRect();
+  const composerFooter = composerForm.querySelector<HTMLElement>(
+    "[data-chat-composer-footer='true']",
+  );
+  const composerRightActions = composerForm.querySelector<HTMLElement>(
+    "[data-chat-composer-actions='right']",
+  );
+  const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
+  const composerFooterGap = composerFooter
+    ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
+      Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
+      0
+    : 0;
+  const minimumComposerWidth =
+    COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
+  const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
+  const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
+  const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
+
+  if (previousSidebarWidth.length > 0) {
+    wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
+  } else {
+    wrapper.style.removeProperty("--sidebar-width");
+  }
+
+  return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
+}
+
+export function WorkspaceRightSidebar({
+  children,
+  defaultWidth,
+  minWidth,
+  onOpenChange,
+  open,
+  storageKey,
+}: WorkspaceRightSidebarProps) {
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      onOpenChange?.(nextOpen);
+    },
+    [onOpenChange],
+  );
+
+  return (
+    <SidebarProvider
+      defaultOpen={false}
+      open={open}
+      onOpenChange={handleOpenChange}
+      className="w-auto min-h-0 flex-none bg-transparent"
+      style={{ "--sidebar-width": defaultWidth } as CSSProperties}
+    >
+      <Sidebar
+        side="right"
+        collapsible="offcanvas"
+        desktopMode="inline"
+        className="border-l border-border bg-card text-foreground"
+        resizable={{
+          minWidth,
+          shouldAcceptWidth: shouldAcceptWorkspaceSidebarWidth,
+          storageKey,
+        }}
+      >
+        {children}
+        <SidebarRail />
+      </Sidebar>
+    </SidebarProvider>
+  );
+}

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -109,7 +109,7 @@ export const ChatHeader = memo(function ChatHeader({
                 className="shrink-0"
                 pressed={terminalOpen}
                 onPressedChange={onToggleTerminal}
-                aria-label="Toggle terminal drawer"
+                aria-label="Toggle terminal panel"
                 variant="outline"
                 size="xs"
                 disabled={!terminalAvailable}
@@ -122,8 +122,8 @@ export const ChatHeader = memo(function ChatHeader({
             {!terminalAvailable
               ? "Terminal is unavailable until this thread has an active project."
               : terminalToggleShortcutLabel
-                ? `Toggle terminal drawer (${terminalToggleShortcutLabel})`
-                : "Toggle terminal drawer"}
+                ? `Toggle terminal panel (${terminalToggleShortcutLabel})`
+                : "Toggle terminal panel"}
           </TooltipPopup>
         </Tooltip>
         <Tooltip>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -18,7 +18,12 @@ import {
   type ServerProviderModel,
   ThreadId,
 } from "@t3tools/contracts";
-import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import {
+  DEFAULT_TERMINAL_BOTTOM_SCOPE,
+  DEFAULT_TERMINAL_POSITION,
+  DEFAULT_TERMINAL_RIGHT_RAIL_WIDTH_MODE,
+  DEFAULT_UNIFIED_SETTINGS,
+} from "@t3tools/contracts/settings";
 import { normalizeModelSlug } from "@t3tools/shared/model";
 import { Equal } from "effect";
 import { APP_VERSION } from "../../branding";
@@ -84,6 +89,21 @@ const TIMESTAMP_FORMAT_LABELS = {
   locale: "System default",
   "12-hour": "12-hour",
   "24-hour": "24-hour",
+} as const;
+
+const TERMINAL_BOTTOM_SCOPE_LABELS = {
+  chat: "Match chat",
+  workspace: "Span workspace",
+} as const;
+
+const TERMINAL_POSITION_LABELS = {
+  bottom: "Bottom",
+  right: "Right",
+} as const;
+
+const TERMINAL_RIGHT_RAIL_WIDTH_MODE_LABELS = {
+  linked: "Share one width",
+  independent: "Remember separately",
 } as const;
 
 type InstallProviderSettings = {
@@ -463,6 +483,17 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
+      ...(settings.terminalPosition === "bottom" &&
+      settings.terminalBottomScope !== DEFAULT_UNIFIED_SETTINGS.terminalBottomScope
+        ? ["Terminal width"]
+        : []),
+      ...(settings.terminalPosition !== DEFAULT_UNIFIED_SETTINGS.terminalPosition
+        ? ["Terminal position"]
+        : []),
+      ...(settings.terminalPosition === "right" &&
+      settings.terminalRightRailWidthMode !== DEFAULT_UNIFIED_SETTINGS.terminalRightRailWidthMode
+        ? ["Right rail width"]
+        : []),
       ...(settings.diffWordWrap !== DEFAULT_UNIFIED_SETTINGS.diffWordWrap
         ? ["Diff line wrapping"]
         : []),
@@ -489,6 +520,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.defaultThreadEnvMode,
       settings.diffWordWrap,
       settings.enableAssistantStreaming,
+      settings.terminalBottomScope,
+      settings.terminalPosition,
+      settings.terminalRightRailWidthMode,
       settings.timestampFormat,
       theme,
     ],
@@ -853,6 +887,132 @@ export function GeneralSettingsPanel() {
             </Select>
           }
         />
+
+        <SettingsRow
+          title="Terminal position"
+          description="Choose whether the terminal opens below the conversation or docks to one side."
+          resetAction={
+            settings.terminalPosition !== DEFAULT_UNIFIED_SETTINGS.terminalPosition ? (
+              <SettingResetButton
+                label="terminal position"
+                onClick={() =>
+                  updateSettings({
+                    terminalPosition: DEFAULT_TERMINAL_POSITION,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.terminalPosition}
+              onValueChange={(value) => {
+                if (value === "bottom" || value === "right") {
+                  updateSettings({ terminalPosition: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Terminal position">
+                <SelectValue>{TERMINAL_POSITION_LABELS[settings.terminalPosition]}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="bottom">
+                  {TERMINAL_POSITION_LABELS.bottom}
+                </SelectItem>
+                <SelectItem hideIndicator value="right">
+                  {TERMINAL_POSITION_LABELS.right}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        {settings.terminalPosition === "bottom" ? (
+          <SettingsRow
+            title="Bottom terminal width"
+            description="Keep the bottom terminal aligned to the chat column, or let it span the full workspace under the diff area."
+            resetAction={
+              settings.terminalBottomScope !== DEFAULT_UNIFIED_SETTINGS.terminalBottomScope ? (
+                <SettingResetButton
+                  label="bottom terminal width"
+                  onClick={() =>
+                    updateSettings({
+                      terminalBottomScope: DEFAULT_TERMINAL_BOTTOM_SCOPE,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <Select
+                value={settings.terminalBottomScope}
+                onValueChange={(value) => {
+                  if (value === "chat" || value === "workspace") {
+                    updateSettings({ terminalBottomScope: value });
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full sm:w-44" aria-label="Bottom terminal width">
+                  <SelectValue>
+                    {TERMINAL_BOTTOM_SCOPE_LABELS[settings.terminalBottomScope]}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="chat">
+                    {TERMINAL_BOTTOM_SCOPE_LABELS.chat}
+                  </SelectItem>
+                  <SelectItem hideIndicator value="workspace">
+                    {TERMINAL_BOTTOM_SCOPE_LABELS.workspace}
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+            }
+          />
+        ) : null}
+
+        {settings.terminalPosition === "right" ? (
+          <SettingsRow
+            title="Right rail width"
+            description="Let the diff and terminal share one saved width, or remember a different width for each tool."
+            resetAction={
+              settings.terminalRightRailWidthMode !==
+              DEFAULT_UNIFIED_SETTINGS.terminalRightRailWidthMode ? (
+                <SettingResetButton
+                  label="right rail width"
+                  onClick={() =>
+                    updateSettings({
+                      terminalRightRailWidthMode: DEFAULT_TERMINAL_RIGHT_RAIL_WIDTH_MODE,
+                    })
+                  }
+                />
+              ) : null
+            }
+            control={
+              <Select
+                value={settings.terminalRightRailWidthMode}
+                onValueChange={(value) => {
+                  if (value === "linked" || value === "independent") {
+                    updateSettings({ terminalRightRailWidthMode: value });
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full sm:w-52" aria-label="Right rail width mode">
+                  <SelectValue>
+                    {TERMINAL_RIGHT_RAIL_WIDTH_MODE_LABELS[settings.terminalRightRailWidthMode]}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  <SelectItem hideIndicator value="linked">
+                    {TERMINAL_RIGHT_RAIL_WIDTH_MODE_LABELS.linked}
+                  </SelectItem>
+                  <SelectItem hideIndicator value="independent">
+                    {TERMINAL_RIGHT_RAIL_WIDTH_MODE_LABELS.independent}
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+            }
+          />
+        ) : null}
 
         <SettingsRow
           title="Diff line wrapping"

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -90,6 +90,7 @@ function SidebarProvider({
   defaultOpen = true,
   open: openProp,
   onOpenChange: setOpenProp,
+  persistState = true,
   className,
   style,
   children,
@@ -98,6 +99,7 @@ function SidebarProvider({
   defaultOpen?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  persistState?: boolean;
 }) {
   const isMobile = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
@@ -115,6 +117,10 @@ function SidebarProvider({
         _setOpen(openState);
       }
 
+      if (!persistState) {
+        return;
+      }
+
       // This sets the cookie to keep the sidebar state.
       await cookieStore.set({
         expires: Date.now() + SIDEBAR_COOKIE_MAX_AGE * 1000,
@@ -123,7 +129,7 @@ function SidebarProvider({
         value: String(openState),
       });
     },
-    [setOpenProp, open],
+    [persistState, setOpenProp, open],
   );
 
   // Helper to toggle the sidebar.

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -69,6 +69,7 @@ type SidebarResolvedResizableOptions = {
 };
 
 type SidebarInstanceContextProps = {
+  desktopMode: "inline" | "viewport";
   resizable: SidebarResolvedResizableOptions | null;
   side: "left" | "right";
 };
@@ -174,6 +175,7 @@ function Sidebar({
   side = "left",
   variant = "sidebar",
   collapsible = "offcanvas",
+  desktopMode = "viewport",
   resizable = false,
   className,
   children,
@@ -182,6 +184,7 @@ function Sidebar({
   side?: "left" | "right";
   variant?: "sidebar" | "floating" | "inset";
   collapsible?: "offcanvas" | "icon" | "none";
+  desktopMode?: "inline" | "viewport";
   resizable?: boolean | SidebarResizableOptions;
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
@@ -200,8 +203,8 @@ function Sidebar({
     };
   }, [collapsible, isMobile, resizable]);
   const instanceContextValue = React.useMemo<SidebarInstanceContextProps>(
-    () => ({ side, resizable: resolvedResizable }),
-    [resolvedResizable, side],
+    () => ({ desktopMode, side, resizable: resolvedResizable }),
+    [desktopMode, resolvedResizable, side],
   );
 
   if (collapsible === "none") {
@@ -255,7 +258,10 @@ function Sidebar({
   return (
     <SidebarInstanceContext.Provider value={instanceContextValue}>
       <div
-        className="group peer hidden text-sidebar-foreground md:block"
+        className={cn(
+          "group peer hidden text-sidebar-foreground md:block",
+          desktopMode === "inline" ? "relative min-h-0 flex-none" : "",
+        )}
         data-collapsible={state === "collapsed" ? collapsible : ""}
         data-side={side}
         data-slot="sidebar"
@@ -267,7 +273,7 @@ function Sidebar({
           className={cn(
             "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
             "group-data-[collapsible=offcanvas]:w-0",
-            "group-data-[side=right]:rotate-180",
+            desktopMode === "viewport" ? "group-data-[side=right]:rotate-180" : "",
             variant === "floating" || variant === "inset"
               ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
               : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
@@ -276,7 +282,9 @@ function Sidebar({
         />
         <div
           className={cn(
-            "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+            desktopMode === "inline"
+              ? "absolute inset-y-0 z-10 hidden h-full w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex"
+              : "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
             side === "left"
               ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
               : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",

--- a/apps/web/src/hooks/useWorkspacePanelController.ts
+++ b/apps/web/src/hooks/useWorkspacePanelController.ts
@@ -1,0 +1,137 @@
+import type { TerminalPosition, ThreadId } from "@t3tools/contracts";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback } from "react";
+import { stripDiffSearchParams } from "../diffRouteSearch";
+import type { RightRailPanel } from "../workspacePanels";
+
+type UseWorkspacePanelControllerInput = {
+  diffOpen: boolean;
+  diffToggleActive: boolean;
+  replaceHistory?: boolean;
+  terminalOpen: boolean;
+  terminalPosition: TerminalPosition;
+  terminalToggleActive: boolean;
+  setTerminalOpen: (open: boolean) => void;
+  threadId: ThreadId;
+};
+
+export function useWorkspacePanelController(input: UseWorkspacePanelControllerInput) {
+  const navigate = useNavigate();
+  const replace = input.replaceHistory ?? false;
+  const {
+    diffOpen,
+    diffToggleActive,
+    setTerminalOpen,
+    terminalOpen,
+    terminalPosition,
+    terminalToggleActive,
+    threadId,
+  } = input;
+
+  const closeDiffPanel = useCallback(() => {
+    void navigate({
+      to: "/$threadId",
+      params: { threadId },
+      ...(replace ? { replace: true } : {}),
+      search: (previous) => ({
+        ...stripDiffSearchParams(previous),
+        diff: undefined,
+      }),
+    });
+  }, [navigate, replace, threadId]);
+
+  const openDiffPanel = useCallback(() => {
+    void navigate({
+      to: "/$threadId",
+      params: { threadId },
+      ...(replace ? { replace: true } : {}),
+      search: (previous) => {
+        const rest = stripDiffSearchParams(previous);
+        return { ...rest, diff: "1" };
+      },
+    });
+  }, [navigate, replace, threadId]);
+
+  const toggleDiffPanel = useCallback(() => {
+    if (terminalPosition === "right") {
+      if (diffToggleActive) {
+        closeDiffPanel();
+        return;
+      }
+      setTerminalOpen(false);
+      openDiffPanel();
+      return;
+    }
+    if (diffOpen) {
+      closeDiffPanel();
+      return;
+    }
+    openDiffPanel();
+  }, [
+    closeDiffPanel,
+    diffOpen,
+    diffToggleActive,
+    openDiffPanel,
+    setTerminalOpen,
+    terminalPosition,
+  ]);
+
+  const toggleTerminalPanel = useCallback(() => {
+    if (terminalPosition === "right") {
+      if (terminalToggleActive) {
+        setTerminalOpen(false);
+        return;
+      }
+      if (diffOpen) {
+        setTerminalOpen(true);
+        closeDiffPanel();
+        return;
+      }
+      if (!terminalOpen) {
+        setTerminalOpen(true);
+      }
+      return;
+    }
+    setTerminalOpen(!terminalOpen);
+  }, [
+    closeDiffPanel,
+    diffOpen,
+    setTerminalOpen,
+    terminalOpen,
+    terminalPosition,
+    terminalToggleActive,
+  ]);
+
+  const reopenRightRailPanel = useCallback(
+    (panel: Exclude<RightRailPanel, null>) => {
+      if (panel === "terminal") {
+        setTerminalOpen(true);
+        return;
+      }
+      openDiffPanel();
+    },
+    [openDiffPanel, setTerminalOpen],
+  );
+
+  const closeRightRailPanel = useCallback(
+    (panel: RightRailPanel) => {
+      if (panel === "terminal") {
+        setTerminalOpen(false);
+        return;
+      }
+      if (panel === "diff") {
+        closeDiffPanel();
+      }
+    },
+    [closeDiffPanel, setTerminalOpen],
+  );
+
+  return {
+    closeDiffPanel,
+    closeRightRailPanel,
+    openDiffPanel,
+    reopenRightRailPanel,
+    toggleDiffPanel,
+    toggleTerminalPanel,
+  };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -213,15 +213,15 @@ input {
 }
 
 /* Terminal drawer scrollbar parity with chat */
-.thread-terminal-drawer .xterm .xterm-scrollable-element > .scrollbar.vertical {
+.thread-terminal-panel .xterm .xterm-scrollable-element > .scrollbar.vertical {
   width: 6px !important;
 }
 
-.thread-terminal-drawer .xterm .xterm-scrollable-element > .scrollbar > .slider {
+.thread-terminal-panel .xterm .xterm-scrollable-element > .scrollbar > .slider {
   border-radius: 3px;
 }
 
-.thread-terminal-drawer .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider {
+.thread-terminal-panel .xterm .xterm-scrollable-element > .scrollbar.vertical > .slider {
   width: 6px !important;
   left: 0 !important;
 }

--- a/apps/web/src/lib/terminalFocus.test.ts
+++ b/apps/web/src/lib/terminalFocus.test.ts
@@ -11,7 +11,7 @@ class MockHTMLElement {
   };
 
   closest(selector: string): MockHTMLElement | null {
-    return selector === ".thread-terminal-drawer .xterm" && this.isConnected ? this : null;
+    return selector === ".thread-terminal-panel .xterm" && this.isConnected ? this : null;
   }
 }
 

--- a/apps/web/src/lib/terminalFocus.ts
+++ b/apps/web/src/lib/terminalFocus.ts
@@ -3,5 +3,5 @@ export function isTerminalFocused(): boolean {
   if (!(activeElement instanceof HTMLElement)) return false;
   if (!activeElement.isConnected) return false;
   if (activeElement.classList.contains("xterm-helper-textarea")) return true;
-  return activeElement.closest(".thread-terminal-drawer .xterm") !== null;
+  return activeElement.closest(".thread-terminal-panel .xterm") !== null;
 }

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,6 +1,15 @@
 import { ThreadId } from "@t3tools/contracts";
 import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
-import { Suspense, lazy, type ReactNode, useCallback, useEffect, useState } from "react";
+import {
+  Suspense,
+  lazy,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import ChatView from "../components/ChatView";
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
@@ -10,23 +19,24 @@ import {
   DiffPanelShell,
   type DiffPanelMode,
 } from "../components/DiffPanelShell";
+import { WorkspaceRightSidebar } from "../components/WorkspaceRightSidebar";
 import { useComposerDraftStore } from "../composerDraftStore";
-import {
-  type DiffRouteSearch,
-  parseDiffRouteSearch,
-  stripDiffSearchParams,
-} from "../diffRouteSearch";
+import { type DiffRouteSearch, parseDiffRouteSearch } from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import { useSettings } from "../hooks/useSettings";
 import { useStore } from "../store";
+import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { Sheet, SheetPopup } from "../components/ui/sheet";
-import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
+import { SidebarInset } from "~/components/ui/sidebar";
+import { WorkspaceTerminalPortalTargetsContext } from "../workspaceTerminalPortal";
+import { cn } from "~/lib/utils";
+import { resolveWorkspacePanels, WORKSPACE_PANEL_STORAGE_KEYS } from "../workspacePanels";
 
 const DiffPanel = lazy(() => import("../components/DiffPanel"));
+
 const DIFF_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 1180px)";
-const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
 const DIFF_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
 const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 26 * 16;
-const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
 
 const DiffPanelSheet = (props: {
   children: ReactNode;
@@ -42,6 +52,25 @@ const DiffPanelSheet = (props: {
         }
       }}
     >
+      <SheetPopup
+        side="right"
+        showCloseButton={false}
+        keepMounted
+        className="w-[min(88vw,820px)] max-w-[820px] p-0"
+      >
+        {props.children}
+      </SheetPopup>
+    </Sheet>
+  );
+};
+
+const TerminalPanelSheet = (props: {
+  children: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  return (
+    <Sheet open={props.open} onOpenChange={props.onOpenChange}>
       <SheetPopup
         side="right"
         showCloseButton={false}
@@ -72,101 +101,89 @@ const LazyDiffPanel = (props: { mode: DiffPanelMode }) => {
   );
 };
 
-const DiffPanelInlineSidebar = (props: {
-  diffOpen: boolean;
-  onCloseDiff: () => void;
-  onOpenDiff: () => void;
-  renderDiffContent: boolean;
-}) => {
-  const { diffOpen, onCloseDiff, onOpenDiff, renderDiffContent } = props;
-  const onOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        onOpenDiff();
-        return;
-      }
-      onCloseDiff();
-    },
-    [onCloseDiff, onOpenDiff],
-  );
-  const shouldAcceptInlineSidebarWidth = useCallback(
-    ({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }) => {
-      const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
-      if (!composerForm) return true;
-      const composerViewport = composerForm.parentElement;
-      if (!composerViewport) return true;
-      const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
-      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
-
-      const viewportStyle = window.getComputedStyle(composerViewport);
-      const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
-      const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
-      const viewportContentWidth = Math.max(
-        0,
-        composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
-      );
-      const formRect = composerForm.getBoundingClientRect();
-      const composerFooter = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-footer='true']",
-      );
-      const composerRightActions = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-actions='right']",
-      );
-      const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
-      const composerFooterGap = composerFooter
-        ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
-          Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
-          0
-        : 0;
-      const minimumComposerWidth =
-        COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
-      const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
-      const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
-      const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
-
-      if (previousSidebarWidth.length > 0) {
-        wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
-      } else {
-        wrapper.style.removeProperty("--sidebar-width");
-      }
-
-      return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
-    },
-    [],
-  );
+const DiffPanelInlineSidebar = (props: { open: boolean; renderDiffContent: boolean }) => {
+  const { open, renderDiffContent } = props;
 
   return (
-    <SidebarProvider
-      defaultOpen={false}
-      open={diffOpen}
-      onOpenChange={onOpenChange}
-      className="w-auto min-h-0 flex-none bg-transparent"
-      style={{ "--sidebar-width": DIFF_INLINE_DEFAULT_WIDTH } as React.CSSProperties}
+    <WorkspaceRightSidebar
+      defaultWidth={DIFF_INLINE_DEFAULT_WIDTH}
+      minWidth={DIFF_INLINE_SIDEBAR_MIN_WIDTH}
+      open={open}
+      storageKey={WORKSPACE_PANEL_STORAGE_KEYS.diffRight}
     >
-      <Sidebar
-        side="right"
-        collapsible="offcanvas"
-        className="border-l border-border bg-card text-foreground"
-        resizable={{
-          minWidth: DIFF_INLINE_SIDEBAR_MIN_WIDTH,
-          shouldAcceptWidth: shouldAcceptInlineSidebarWidth,
-          storageKey: DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
-        }}
-      >
-        {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
-        <SidebarRail />
-      </Sidebar>
-    </SidebarProvider>
+      <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden">
+        <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+          {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
+        </div>
+      </div>
+    </WorkspaceRightSidebar>
+  );
+};
+
+const SharedRightWorkspaceRail = (props: {
+  activePanel: "diff" | "terminal" | null;
+  fallbackPanel: "diff" | "terminal";
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  renderDiffContent: boolean;
+  setTerminalPortalTarget: (element: HTMLElement | null) => void;
+  storageKey: string;
+}) => {
+  const {
+    activePanel,
+    fallbackPanel,
+    onOpenChange,
+    open,
+    renderDiffContent,
+    setTerminalPortalTarget,
+    storageKey,
+  } = props;
+  const renderedPanel = activePanel ?? fallbackPanel;
+
+  return (
+    <WorkspaceRightSidebar
+      defaultWidth={DIFF_INLINE_DEFAULT_WIDTH}
+      minWidth={DIFF_INLINE_SIDEBAR_MIN_WIDTH}
+      onOpenChange={onOpenChange}
+      open={open}
+      storageKey={storageKey}
+    >
+      <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden">
+        <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
+          <div
+            className={cn(
+              "min-h-0 min-w-0 flex-1 overflow-hidden",
+              renderedPanel === "diff" ? "flex" : "hidden",
+            )}
+          >
+            {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
+          </div>
+          <div
+            ref={setTerminalPortalTarget}
+            className={cn(
+              "min-h-0 min-w-0 flex-1 overflow-hidden",
+              renderedPanel === "terminal" ? "flex" : "hidden",
+            )}
+            data-workspace-terminal-slot="right"
+          />
+        </div>
+      </div>
+    </WorkspaceRightSidebar>
   );
 };
 
 function ChatThreadRouteView() {
   const bootstrapComplete = useStore((store) => store.bootstrapComplete);
   const navigate = useNavigate();
+  const settings = useSettings();
   const threadId = Route.useParams({
     select: (params) => ThreadId.makeUnsafe(params.threadId),
   });
   const search = Route.useSearch();
+  const terminalState = useTerminalStateStore((state) =>
+    selectThreadTerminalState(state.terminalStateByThreadId, threadId),
+  );
+  const setTerminalOpen = useTerminalStateStore((state) => state.setTerminalOpen);
   const threadExists = useStore((store) => store.threads.some((thread) => thread.id === threadId));
   const draftThreadExists = useComposerDraftStore((store) =>
     Object.hasOwn(store.draftThreadsByThreadId, threadId),
@@ -174,24 +191,19 @@ function ChatThreadRouteView() {
   const routeThreadExists = threadExists || draftThreadExists;
   const diffOpen = search.diff === "1";
   const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
-  // TanStack Router keeps active route components mounted across param-only navigations
-  // unless remountDeps are configured, so this stays warm across thread switches.
+  const [workspaceBottomTerminalPortalTarget, setWorkspaceBottomTerminalPortalTarget] =
+    useState<HTMLElement | null>(null);
+  const [workspaceRightTerminalPortalTarget, setWorkspaceRightTerminalPortalTarget] =
+    useState<HTMLElement | null>(null);
   const [hasOpenedDiff, setHasOpenedDiff] = useState(diffOpen);
+  const lastRightRailPanelRef = useRef<"diff" | "terminal">(
+    terminalState.terminalOpen ? "terminal" : "diff",
+  );
   const closeDiff = useCallback(() => {
     void navigate({
       to: "/$threadId",
       params: { threadId },
       search: { diff: undefined },
-    });
-  }, [navigate, threadId]);
-  const openDiff = useCallback(() => {
-    void navigate({
-      to: "/$threadId",
-      params: { threadId },
-      search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
-      },
     });
   }, [navigate, threadId]);
 
@@ -208,41 +220,143 @@ function ChatThreadRouteView() {
 
     if (!routeThreadExists) {
       void navigate({ to: "/", replace: true });
+    }
+  }, [bootstrapComplete, navigate, routeThreadExists]);
+
+  const workspacePanels = resolveWorkspacePanels({
+    terminalPosition: settings.terminalPosition,
+    terminalBottomScope: settings.terminalBottomScope,
+    shouldUseDiffSheet,
+    diffOpen,
+    terminalOpen: terminalState.terminalOpen,
+  });
+  const activeRightRailPanel = workspacePanels.rightRailPanel;
+
+  useEffect(() => {
+    if (activeRightRailPanel === null) {
       return;
     }
-  }, [bootstrapComplete, navigate, routeThreadExists, threadId]);
+    lastRightRailPanelRef.current = activeRightRailPanel;
+  }, [activeRightRailPanel]);
+
+  const rightRailStorageKey =
+    settings.terminalRightRailWidthMode === "linked"
+      ? WORKSPACE_PANEL_STORAGE_KEYS.sharedRight
+      : (activeRightRailPanel ?? lastRightRailPanelRef.current) === "terminal"
+        ? WORKSPACE_PANEL_STORAGE_KEYS.terminalRight
+        : WORKSPACE_PANEL_STORAGE_KEYS.diffRight;
+  const chatViewLayoutState = useMemo(
+    () => ({
+      diffToggleActive: workspacePanels.diffToggleActive,
+      terminalDockTarget: workspacePanels.terminalDockTarget,
+      terminalToggleActive: workspacePanels.terminalToggleActive,
+    }),
+    [
+      workspacePanels.diffToggleActive,
+      workspacePanels.terminalDockTarget,
+      workspacePanels.terminalToggleActive,
+    ],
+  );
+  const portalTargets = useMemo(
+    () => ({
+      bottom: workspaceBottomTerminalPortalTarget,
+      right: workspaceRightTerminalPortalTarget,
+    }),
+    [workspaceBottomTerminalPortalTarget, workspaceRightTerminalPortalTarget],
+  );
 
   if (!bootstrapComplete || !routeThreadExists) {
     return null;
   }
 
   const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
+  const shouldMountInlineDiffRail = workspacePanels.supportsInlineDiffRail && hasOpenedDiff;
+  const chatWorkspace = (
+    <SidebarInset className="min-h-0 min-w-0 flex-1 overflow-hidden bg-background text-foreground">
+      <ChatView key={threadId} layoutState={chatViewLayoutState} threadId={threadId} />
+    </SidebarInset>
+  );
 
-  if (!shouldUseDiffSheet) {
-    return (
-      <>
-        <SidebarInset className="h-dvh  min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
-          <ChatView threadId={threadId} />
-        </SidebarInset>
-        <DiffPanelInlineSidebar
-          diffOpen={diffOpen}
-          onCloseDiff={closeDiff}
-          onOpenDiff={openDiff}
-          renderDiffContent={shouldRenderDiffContent}
-        />
-      </>
-    );
-  }
+  const rightWorkspacePanel =
+    settings.terminalPosition === "right" && !workspacePanels.showTerminalSheet ? (
+      <SharedRightWorkspaceRail
+        activePanel={activeRightRailPanel}
+        fallbackPanel={lastRightRailPanelRef.current}
+        open={activeRightRailPanel !== null}
+        onOpenChange={(open) => {
+          if (open) {
+            if (lastRightRailPanelRef.current === "terminal") {
+              setTerminalOpen(threadId, true);
+              return;
+            }
+            void navigate({
+              to: "/$threadId",
+              params: { threadId },
+              search: (previous) => ({ ...previous, diff: "1" }),
+            });
+            return;
+          }
+
+          if (activeRightRailPanel === "terminal") {
+            setTerminalOpen(threadId, false);
+            return;
+          }
+
+          void closeDiff();
+        }}
+        renderDiffContent={shouldRenderDiffContent}
+        setTerminalPortalTarget={setWorkspaceRightTerminalPortalTarget}
+        storageKey={rightRailStorageKey}
+      />
+    ) : shouldMountInlineDiffRail ? (
+      <DiffPanelInlineSidebar
+        open={workspacePanels.showInlineDiffRail}
+        renderDiffContent={shouldRenderDiffContent}
+      />
+    ) : null;
+
+  const workspaceRow = (
+    <div className="flex min-h-0 min-w-0 flex-1">
+      {chatWorkspace}
+      {rightWorkspacePanel}
+    </div>
+  );
 
   return (
-    <>
-      <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
-        <ChatView threadId={threadId} />
-      </SidebarInset>
-      <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={closeDiff}>
-        {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
-      </DiffPanelSheet>
-    </>
+    <WorkspaceTerminalPortalTargetsContext.Provider value={portalTargets}>
+      <div
+        className="flex h-dvh min-h-0 min-w-0 flex-1 flex-col overflow-hidden overscroll-y-none bg-background text-foreground"
+        data-workspace-shell="true"
+      >
+        {workspaceRow}
+        <div
+          ref={setWorkspaceBottomTerminalPortalTarget}
+          className="min-w-0 shrink-0"
+          data-workspace-bottom-terminal-slot="true"
+        />
+      </div>
+      {shouldUseDiffSheet ? (
+        <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={closeDiff}>
+          {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
+        </DiffPanelSheet>
+      ) : null}
+      {workspacePanels.showTerminalSheet ? (
+        <TerminalPanelSheet
+          open={workspacePanels.showTerminalSheet}
+          onOpenChange={(open) => {
+            if (!open) {
+              setTerminalOpen(threadId, false);
+            }
+          }}
+        >
+          <div
+            ref={setWorkspaceRightTerminalPortalTarget}
+            className="flex h-full min-h-0 min-w-0 overflow-hidden"
+            data-workspace-terminal-slot="right-sheet"
+          />
+        </TerminalPanelSheet>
+      ) : null}
+    </WorkspaceTerminalPortalTargetsContext.Provider>
   );
 }
 

--- a/apps/web/src/routes/_chat.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$threadId.tsx
@@ -1,15 +1,6 @@
 import { ThreadId } from "@t3tools/contracts";
 import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
-import {
-  Suspense,
-  lazy,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
 
 import ChatView from "../components/ChatView";
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
@@ -19,14 +10,18 @@ import {
   DiffPanelShell,
   type DiffPanelMode,
 } from "../components/DiffPanelShell";
-import { WorkspaceRightSidebar } from "../components/WorkspaceRightSidebar";
+import {
+  WorkspacePanelLayout,
+  WorkspaceRightRail,
+  WorkspaceSideSheet,
+} from "../components/WorkspacePanels";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { type DiffRouteSearch, parseDiffRouteSearch } from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { useSettings } from "../hooks/useSettings";
+import { useWorkspacePanelController } from "../hooks/useWorkspacePanelController";
 import { useStore } from "../store";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
-import { Sheet, SheetPopup } from "../components/ui/sheet";
 import { SidebarInset } from "~/components/ui/sidebar";
 import { WorkspaceTerminalPortalTargetsContext } from "../workspaceTerminalPortal";
 import { cn } from "~/lib/utils";
@@ -37,51 +32,6 @@ const DiffPanel = lazy(() => import("../components/DiffPanel"));
 const DIFF_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 1180px)";
 const DIFF_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
 const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 26 * 16;
-
-const DiffPanelSheet = (props: {
-  children: ReactNode;
-  diffOpen: boolean;
-  onCloseDiff: () => void;
-}) => {
-  return (
-    <Sheet
-      open={props.diffOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          props.onCloseDiff();
-        }
-      }}
-    >
-      <SheetPopup
-        side="right"
-        showCloseButton={false}
-        keepMounted
-        className="w-[min(88vw,820px)] max-w-[820px] p-0"
-      >
-        {props.children}
-      </SheetPopup>
-    </Sheet>
-  );
-};
-
-const TerminalPanelSheet = (props: {
-  children: ReactNode;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) => {
-  return (
-    <Sheet open={props.open} onOpenChange={props.onOpenChange}>
-      <SheetPopup
-        side="right"
-        showCloseButton={false}
-        keepMounted
-        className="w-[min(88vw,820px)] max-w-[820px] p-0"
-      >
-        {props.children}
-      </SheetPopup>
-    </Sheet>
-  );
-};
 
 const DiffLoadingFallback = (props: { mode: DiffPanelMode }) => {
   return (
@@ -98,25 +48,6 @@ const LazyDiffPanel = (props: { mode: DiffPanelMode }) => {
         <DiffPanel mode={props.mode} />
       </Suspense>
     </DiffWorkerPoolProvider>
-  );
-};
-
-const DiffPanelInlineSidebar = (props: { open: boolean; renderDiffContent: boolean }) => {
-  const { open, renderDiffContent } = props;
-
-  return (
-    <WorkspaceRightSidebar
-      defaultWidth={DIFF_INLINE_DEFAULT_WIDTH}
-      minWidth={DIFF_INLINE_SIDEBAR_MIN_WIDTH}
-      open={open}
-      storageKey={WORKSPACE_PANEL_STORAGE_KEYS.diffRight}
-    >
-      <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden">
-        <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
-          {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
-        </div>
-      </div>
-    </WorkspaceRightSidebar>
   );
 };
 
@@ -141,34 +72,32 @@ const SharedRightWorkspaceRail = (props: {
   const renderedPanel = activePanel ?? fallbackPanel;
 
   return (
-    <WorkspaceRightSidebar
+    <WorkspaceRightRail
       defaultWidth={DIFF_INLINE_DEFAULT_WIDTH}
       minWidth={DIFF_INLINE_SIDEBAR_MIN_WIDTH}
       onOpenChange={onOpenChange}
       open={open}
       storageKey={storageKey}
     >
-      <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden">
-        <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
-          <div
-            className={cn(
-              "min-h-0 min-w-0 flex-1 overflow-hidden",
-              renderedPanel === "diff" ? "flex" : "hidden",
-            )}
-          >
-            {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
-          </div>
-          <div
-            ref={setTerminalPortalTarget}
-            className={cn(
-              "min-h-0 min-w-0 flex-1 overflow-hidden",
-              renderedPanel === "terminal" ? "flex" : "hidden",
-            )}
-            data-workspace-terminal-slot="right"
-          />
+      <WorkspacePanelLayout bodyClassName="relative">
+        <div
+          className={cn(
+            "min-h-0 min-w-0 flex-1 overflow-hidden",
+            renderedPanel === "diff" ? "flex" : "hidden",
+          )}
+        >
+          {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
         </div>
-      </div>
-    </WorkspaceRightSidebar>
+        <div
+          ref={setTerminalPortalTarget}
+          className={cn(
+            "min-h-0 min-w-0 flex-1 overflow-hidden",
+            renderedPanel === "terminal" ? "flex" : "hidden",
+          )}
+          data-workspace-terminal-slot="right"
+        />
+      </WorkspacePanelLayout>
+    </WorkspaceRightRail>
   );
 };
 
@@ -199,14 +128,6 @@ function ChatThreadRouteView() {
   const lastRightRailPanelRef = useRef<"diff" | "terminal">(
     terminalState.terminalOpen ? "terminal" : "diff",
   );
-  const closeDiff = useCallback(() => {
-    void navigate({
-      to: "/$threadId",
-      params: { threadId },
-      search: { diff: undefined },
-    });
-  }, [navigate, threadId]);
-
   useEffect(() => {
     if (diffOpen) {
       setHasOpenedDiff(true);
@@ -231,6 +152,15 @@ function ChatThreadRouteView() {
     terminalOpen: terminalState.terminalOpen,
   });
   const activeRightRailPanel = workspacePanels.rightRailPanel;
+  const panelController = useWorkspacePanelController({
+    diffOpen,
+    diffToggleActive: workspacePanels.diffToggleActive,
+    setTerminalOpen: (open) => setTerminalOpen(threadId, open),
+    terminalOpen: terminalState.terminalOpen,
+    terminalPosition: settings.terminalPosition,
+    terminalToggleActive: workspacePanels.terminalToggleActive,
+    threadId,
+  });
 
   useEffect(() => {
     if (activeRightRailPanel === null) {
@@ -285,34 +215,26 @@ function ChatThreadRouteView() {
         open={activeRightRailPanel !== null}
         onOpenChange={(open) => {
           if (open) {
-            if (lastRightRailPanelRef.current === "terminal") {
-              setTerminalOpen(threadId, true);
-              return;
-            }
-            void navigate({
-              to: "/$threadId",
-              params: { threadId },
-              search: (previous) => ({ ...previous, diff: "1" }),
-            });
+            panelController.reopenRightRailPanel(lastRightRailPanelRef.current);
             return;
           }
-
-          if (activeRightRailPanel === "terminal") {
-            setTerminalOpen(threadId, false);
-            return;
-          }
-
-          void closeDiff();
+          panelController.closeRightRailPanel(activeRightRailPanel);
         }}
         renderDiffContent={shouldRenderDiffContent}
         setTerminalPortalTarget={setWorkspaceRightTerminalPortalTarget}
         storageKey={rightRailStorageKey}
       />
     ) : shouldMountInlineDiffRail ? (
-      <DiffPanelInlineSidebar
+      <WorkspaceRightRail
+        defaultWidth={DIFF_INLINE_DEFAULT_WIDTH}
+        minWidth={DIFF_INLINE_SIDEBAR_MIN_WIDTH}
         open={workspacePanels.showInlineDiffRail}
-        renderDiffContent={shouldRenderDiffContent}
-      />
+        storageKey={WORKSPACE_PANEL_STORAGE_KEYS.diffRight}
+      >
+        <WorkspacePanelLayout>
+          {shouldRenderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
+        </WorkspacePanelLayout>
+      </WorkspaceRightRail>
     ) : null;
 
   const workspaceRow = (
@@ -336,12 +258,19 @@ function ChatThreadRouteView() {
         />
       </div>
       {shouldUseDiffSheet ? (
-        <DiffPanelSheet diffOpen={diffOpen} onCloseDiff={closeDiff}>
+        <WorkspaceSideSheet
+          open={diffOpen}
+          onOpenChange={(open) => {
+            if (!open) {
+              panelController.closeDiffPanel();
+            }
+          }}
+        >
           {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
-        </DiffPanelSheet>
+        </WorkspaceSideSheet>
       ) : null}
       {workspacePanels.showTerminalSheet ? (
-        <TerminalPanelSheet
+        <WorkspaceSideSheet
           open={workspacePanels.showTerminalSheet}
           onOpenChange={(open) => {
             if (!open) {
@@ -354,7 +283,7 @@ function ChatThreadRouteView() {
             className="flex h-full min-h-0 min-w-0 overflow-hidden"
             data-workspace-terminal-slot="right-sheet"
           />
-        </TerminalPanelSheet>
+        </WorkspaceSideSheet>
       ) : null}
     </WorkspaceTerminalPortalTargetsContext.Provider>
   );

--- a/apps/web/src/terminal-links.test.ts
+++ b/apps/web/src/terminal-links.test.ts
@@ -8,8 +8,7 @@ import {
 
 describe("extractTerminalLinks", () => {
   it("finds http urls and path tokens", () => {
-    const line =
-      "failed at https://example.com/docs and src/components/ThreadTerminalDrawer.tsx:42";
+    const line = "failed at https://example.com/docs and src/components/ThreadTerminalPanel.tsx:42";
     expect(extractTerminalLinks(line)).toEqual([
       {
         kind: "url",
@@ -19,9 +18,9 @@ describe("extractTerminalLinks", () => {
       },
       {
         kind: "path",
-        text: "src/components/ThreadTerminalDrawer.tsx:42",
+        text: "src/components/ThreadTerminalPanel.tsx:42",
         start: 39,
-        end: 81,
+        end: 80,
       },
     ]);
   });
@@ -74,11 +73,8 @@ describe("extractTerminalLinks", () => {
 describe("resolvePathLinkTarget", () => {
   it("resolves relative paths against cwd", () => {
     expect(
-      resolvePathLinkTarget(
-        "src/components/ThreadTerminalDrawer.tsx:42:7",
-        "/Users/julius/project",
-      ),
-    ).toBe("/Users/julius/project/src/components/ThreadTerminalDrawer.tsx:42:7");
+      resolvePathLinkTarget("src/components/ThreadTerminalPanel.tsx:42:7", "/Users/julius/project"),
+    ).toBe("/Users/julius/project/src/components/ThreadTerminalPanel.tsx:42:7");
   });
 
   it("keeps absolute paths unchanged", () => {

--- a/apps/web/src/workspacePanels.test.ts
+++ b/apps/web/src/workspacePanels.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveActiveRightRailPanel, resolveWorkspacePanels } from "./workspacePanels";
+
+describe("resolveActiveRightRailPanel", () => {
+  it("prefers diff when both diff and terminal are open on the right", () => {
+    expect(
+      resolveActiveRightRailPanel({
+        terminalPosition: "right",
+        diffOpen: true,
+        terminalOpen: true,
+      }),
+    ).toBe("diff");
+  });
+
+  it("falls back to the terminal when diff is closed", () => {
+    expect(
+      resolveActiveRightRailPanel({
+        terminalPosition: "right",
+        diffOpen: false,
+        terminalOpen: true,
+      }),
+    ).toBe("terminal");
+  });
+});
+
+describe("resolveWorkspacePanels", () => {
+  it("does not show the inline diff rail when diff is closed in bottom mode", () => {
+    expect(
+      resolveWorkspacePanels({
+        terminalPosition: "bottom",
+        terminalBottomScope: "chat",
+        shouldUseDiffSheet: false,
+        diffOpen: false,
+        terminalOpen: true,
+      }),
+    ).toEqual({
+      diffToggleActive: false,
+      rightRailPanel: null,
+      showDiffSheet: false,
+      showInlineDiffRail: false,
+      showTerminalSheet: false,
+      supportsInlineDiffRail: true,
+      terminalDockTarget: "bottom-inline",
+      terminalToggleActive: true,
+    });
+  });
+
+  it("keeps a chat-scoped bottom terminal inline and leaves diff independent", () => {
+    expect(
+      resolveWorkspacePanels({
+        terminalPosition: "bottom",
+        terminalBottomScope: "chat",
+        shouldUseDiffSheet: false,
+        diffOpen: true,
+        terminalOpen: true,
+      }),
+    ).toEqual({
+      diffToggleActive: true,
+      rightRailPanel: null,
+      showDiffSheet: false,
+      showInlineDiffRail: true,
+      showTerminalSheet: false,
+      supportsInlineDiffRail: true,
+      terminalDockTarget: "bottom-inline",
+      terminalToggleActive: true,
+    });
+  });
+
+  it("uses the workspace bottom slot when the bottom terminal should span the full workspace", () => {
+    expect(
+      resolveWorkspacePanels({
+        terminalPosition: "bottom",
+        terminalBottomScope: "workspace",
+        shouldUseDiffSheet: false,
+        diffOpen: false,
+        terminalOpen: true,
+      }),
+    ).toEqual({
+      diffToggleActive: false,
+      rightRailPanel: null,
+      showDiffSheet: false,
+      showInlineDiffRail: false,
+      showTerminalSheet: false,
+      supportsInlineDiffRail: true,
+      terminalDockTarget: "bottom-workspace",
+      terminalToggleActive: true,
+    });
+  });
+
+  it("uses the shared right rail when the terminal is positioned on the right", () => {
+    expect(
+      resolveWorkspacePanels({
+        terminalPosition: "right",
+        terminalBottomScope: "chat",
+        shouldUseDiffSheet: false,
+        diffOpen: true,
+        terminalOpen: true,
+      }),
+    ).toEqual({
+      diffToggleActive: true,
+      rightRailPanel: "diff",
+      showDiffSheet: false,
+      showInlineDiffRail: false,
+      showTerminalSheet: false,
+      supportsInlineDiffRail: false,
+      terminalDockTarget: "right",
+      terminalToggleActive: false,
+    });
+  });
+
+  it("falls back to the diff sheet on narrow right layouts and preserves terminal docking state", () => {
+    expect(
+      resolveWorkspacePanels({
+        terminalPosition: "right",
+        terminalBottomScope: "chat",
+        shouldUseDiffSheet: true,
+        diffOpen: true,
+        terminalOpen: true,
+      }),
+    ).toEqual({
+      diffToggleActive: true,
+      rightRailPanel: null,
+      showDiffSheet: true,
+      showInlineDiffRail: false,
+      showTerminalSheet: false,
+      supportsInlineDiffRail: false,
+      terminalDockTarget: "right",
+      terminalToggleActive: false,
+    });
+  });
+
+  it("falls back to a terminal sheet on narrow right layouts when diff is closed", () => {
+    expect(
+      resolveWorkspacePanels({
+        terminalPosition: "right",
+        terminalBottomScope: "chat",
+        shouldUseDiffSheet: true,
+        diffOpen: false,
+        terminalOpen: true,
+      }),
+    ).toEqual({
+      diffToggleActive: false,
+      rightRailPanel: null,
+      showDiffSheet: false,
+      showInlineDiffRail: false,
+      showTerminalSheet: true,
+      supportsInlineDiffRail: false,
+      terminalDockTarget: "right",
+      terminalToggleActive: true,
+    });
+  });
+});

--- a/apps/web/src/workspacePanels.ts
+++ b/apps/web/src/workspacePanels.ts
@@ -1,0 +1,77 @@
+import type { TerminalBottomScope, TerminalPosition } from "@t3tools/contracts/settings";
+
+export type RightRailPanel = "diff" | "terminal" | null;
+
+export const WORKSPACE_PANEL_STORAGE_KEYS = {
+  diffRight: "chat_diff_sidebar_width",
+  sharedRight: "chat_shared_right_sidebar_width",
+  terminalRight: "chat_terminal_right_sidebar_width",
+} as const;
+
+export type TerminalDockTarget = "bottom-inline" | "bottom-workspace" | "right" | null;
+
+export function resolveActiveRightRailPanel(input: {
+  terminalPosition: TerminalPosition;
+  diffOpen: boolean;
+  terminalOpen: boolean;
+}): RightRailPanel {
+  if (input.terminalPosition !== "right") {
+    return null;
+  }
+
+  if (input.diffOpen) {
+    return "diff";
+  }
+
+  if (input.terminalOpen) {
+    return "terminal";
+  }
+
+  return null;
+}
+
+export function resolveWorkspacePanels(input: {
+  terminalPosition: TerminalPosition;
+  terminalBottomScope: TerminalBottomScope;
+  shouldUseDiffSheet: boolean;
+  diffOpen: boolean;
+  terminalOpen: boolean;
+}): {
+  diffToggleActive: boolean;
+  rightRailPanel: RightRailPanel;
+  showDiffSheet: boolean;
+  showInlineDiffRail: boolean;
+  showTerminalSheet: boolean;
+  supportsInlineDiffRail: boolean;
+  terminalDockTarget: TerminalDockTarget;
+  terminalToggleActive: boolean;
+} {
+  const visibleRightTool = resolveActiveRightRailPanel({
+    terminalPosition: input.terminalPosition,
+    diffOpen: input.diffOpen,
+    terminalOpen: input.terminalOpen,
+  });
+  const supportsInlineDiffRail = !input.shouldUseDiffSheet && input.terminalPosition !== "right";
+  const rightRailPanel = input.shouldUseDiffSheet ? null : visibleRightTool;
+
+  const terminalDockTarget: TerminalDockTarget = !input.terminalOpen
+    ? null
+    : input.terminalPosition === "bottom"
+      ? input.terminalBottomScope === "workspace"
+        ? "bottom-workspace"
+        : "bottom-inline"
+      : input.terminalPosition;
+
+  return {
+    diffToggleActive:
+      input.terminalPosition === "right" ? visibleRightTool === "diff" : input.diffOpen,
+    rightRailPanel,
+    showDiffSheet: input.shouldUseDiffSheet && visibleRightTool === "diff",
+    showInlineDiffRail: input.diffOpen && supportsInlineDiffRail,
+    showTerminalSheet: input.shouldUseDiffSheet && visibleRightTool === "terminal",
+    supportsInlineDiffRail,
+    terminalDockTarget,
+    terminalToggleActive:
+      input.terminalPosition === "right" ? visibleRightTool === "terminal" : input.terminalOpen,
+  };
+}

--- a/apps/web/src/workspaceSidebarSizing.ts
+++ b/apps/web/src/workspaceSidebarSizing.ts
@@ -1,0 +1,50 @@
+const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
+
+export function shouldAcceptWorkspaceSidebarWidth({
+  nextWidth,
+  wrapper,
+}: {
+  nextWidth: number;
+  wrapper: HTMLElement;
+}) {
+  const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
+  if (!composerForm) return true;
+  const composerViewport = composerForm.parentElement;
+  if (!composerViewport) return true;
+  const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
+  wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
+
+  const viewportStyle = window.getComputedStyle(composerViewport);
+  const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
+  const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
+  const viewportContentWidth = Math.max(
+    0,
+    composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
+  );
+  const formRect = composerForm.getBoundingClientRect();
+  const composerFooter = composerForm.querySelector<HTMLElement>(
+    "[data-chat-composer-footer='true']",
+  );
+  const composerRightActions = composerForm.querySelector<HTMLElement>(
+    "[data-chat-composer-actions='right']",
+  );
+  const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
+  const composerFooterGap = composerFooter
+    ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
+      Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
+      0
+    : 0;
+  const minimumComposerWidth =
+    COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
+  const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
+  const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
+  const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
+
+  if (previousSidebarWidth.length > 0) {
+    wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
+  } else {
+    wrapper.style.removeProperty("--sidebar-width");
+  }
+
+  return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
+}

--- a/apps/web/src/workspaceTerminalPortal.ts
+++ b/apps/web/src/workspaceTerminalPortal.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+
+type WorkspaceTerminalPortalTargets = {
+  bottom: HTMLElement | null;
+  right: HTMLElement | null;
+};
+
+const EMPTY_WORKSPACE_TERMINAL_PORTAL_TARGETS: WorkspaceTerminalPortalTargets = {
+  bottom: null,
+  right: null,
+};
+
+export const WorkspaceTerminalPortalTargetsContext = createContext<WorkspaceTerminalPortalTargets>(
+  EMPTY_WORKSPACE_TERMINAL_PORTAL_TARGETS,
+);
+
+export function useWorkspaceTerminalPortalTargets(): WorkspaceTerminalPortalTargets {
+  return useContext(WorkspaceTerminalPortalTargetsContext);
+}

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -1,0 +1,58 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+
+import {
+  ClientSettingsSchema,
+  DEFAULT_TERMINAL_BOTTOM_SCOPE,
+  DEFAULT_TERMINAL_POSITION,
+  DEFAULT_TERMINAL_RIGHT_RAIL_WIDTH_MODE,
+  DEFAULT_UNIFIED_SETTINGS,
+} from "./settings";
+
+it.effect("defaults bottom terminal scope to the chat column", () =>
+  Effect.gen(function* () {
+    const settings = yield* Schema.decodeUnknownEffect(ClientSettingsSchema)({});
+
+    assert.strictEqual(settings.terminalBottomScope, DEFAULT_TERMINAL_BOTTOM_SCOPE);
+    assert.strictEqual(settings.terminalPosition, DEFAULT_TERMINAL_POSITION);
+    assert.strictEqual(settings.terminalRightRailWidthMode, DEFAULT_TERMINAL_RIGHT_RAIL_WIDTH_MODE);
+    assert.strictEqual(DEFAULT_UNIFIED_SETTINGS.terminalBottomScope, DEFAULT_TERMINAL_BOTTOM_SCOPE);
+    assert.strictEqual(DEFAULT_UNIFIED_SETTINGS.terminalPosition, DEFAULT_TERMINAL_POSITION);
+    assert.strictEqual(
+      DEFAULT_UNIFIED_SETTINGS.terminalRightRailWidthMode,
+      DEFAULT_TERMINAL_RIGHT_RAIL_WIDTH_MODE,
+    );
+  }),
+);
+
+it.effect("accepts the workspace bottom terminal scope", () =>
+  Effect.gen(function* () {
+    const settings = yield* Schema.decodeUnknownEffect(ClientSettingsSchema)({
+      terminalBottomScope: "workspace",
+    });
+
+    assert.strictEqual(settings.terminalBottomScope, "workspace");
+  }),
+);
+
+it.effect("accepts the right terminal position and independent right rail widths", () =>
+  Effect.gen(function* () {
+    const settings = yield* Schema.decodeUnknownEffect(ClientSettingsSchema)({
+      terminalPosition: "right",
+      terminalRightRailWidthMode: "independent",
+    });
+
+    assert.strictEqual(settings.terminalPosition, "right");
+    assert.strictEqual(settings.terminalRightRailWidthMode, "independent");
+  }),
+);
+
+it.effect("migrates the removed left terminal position back to bottom", () =>
+  Effect.gen(function* () {
+    const settings = yield* Schema.decodeUnknownEffect(ClientSettingsSchema)({
+      terminalPosition: "left",
+    });
+
+    assert.strictEqual(settings.terminalPosition, "bottom");
+  }),
+);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -15,6 +15,29 @@ export const TimestampFormat = Schema.Literals(["locale", "12-hour", "24-hour"])
 export type TimestampFormat = typeof TimestampFormat.Type;
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
 
+export const TerminalBottomScope = Schema.Literals(["chat", "workspace"]);
+export type TerminalBottomScope = typeof TerminalBottomScope.Type;
+export const DEFAULT_TERMINAL_BOTTOM_SCOPE: TerminalBottomScope = "chat";
+
+const LegacyTerminalPosition = Schema.Literals(["bottom", "left", "right"]);
+const CurrentTerminalPosition = Schema.Literals(["bottom", "right"]);
+export const TerminalPosition = LegacyTerminalPosition.pipe(
+  Schema.decodeTo(
+    CurrentTerminalPosition,
+    SchemaTransformation.transformOrFail({
+      decode: (value) =>
+        Effect.succeed((value === "left" ? "bottom" : value) as "bottom" | "right"),
+      encode: (value) => Effect.succeed(value),
+    }),
+  ),
+);
+export type TerminalPosition = typeof TerminalPosition.Type;
+export const DEFAULT_TERMINAL_POSITION: TerminalPosition = "bottom";
+
+export const TerminalRightRailWidthMode = Schema.Literals(["linked", "independent"]);
+export type TerminalRightRailWidthMode = typeof TerminalRightRailWidthMode.Type;
+export const DEFAULT_TERMINAL_RIGHT_RAIL_WIDTH_MODE: TerminalRightRailWidthMode = "linked";
+
 export const SidebarProjectSortOrder = Schema.Literals(["updated_at", "created_at", "manual"]);
 export type SidebarProjectSortOrder = typeof SidebarProjectSortOrder.Type;
 export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "updated_at";
@@ -32,6 +55,15 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   sidebarThreadSortOrder: SidebarThreadSortOrder.pipe(
     Schema.withDecodingDefault(() => DEFAULT_SIDEBAR_THREAD_SORT_ORDER),
+  ),
+  terminalBottomScope: TerminalBottomScope.pipe(
+    Schema.withDecodingDefault(() => DEFAULT_TERMINAL_BOTTOM_SCOPE),
+  ),
+  terminalPosition: TerminalPosition.pipe(
+    Schema.withDecodingDefault(() => DEFAULT_TERMINAL_POSITION),
+  ),
+  terminalRightRailWidthMode: TerminalRightRailWidthMode.pipe(
+    Schema.withDecodingDefault(() => DEFAULT_TERMINAL_RIGHT_RAIL_WIDTH_MODE),
   ),
   timestampFormat: TimestampFormat.pipe(Schema.withDecodingDefault(() => DEFAULT_TIMESTAMP_FORMAT)),
 });


### PR DESCRIPTION
## What Changed

Added workspace-aware terminal layout options in the web app.

<table>
<tr>
 <td>Workspace scoped terminal (full-width)

<img width="1845" height="989" alt="Screenshot 2026-04-02 154906" src="https://github.com/user-attachments/assets/ec38ecea-dd41-4a3e-bea6-49e76263753d" />
 <td>Right panel side terminal

<img width="1866" height="939" alt="Screenshot 2026-04-02 162503" src="https://github.com/user-attachments/assets/958bc4f7-2b01-4460-a9fc-99b602a9c1f9" />

</table>


https://github.com/user-attachments/assets/7c396752-e869-4ae7-9c29-0432a2bbf6e4




This PR:
- adds terminal position settings for `bottom` and `right`
- adds bottom terminal scope settings so the bottom terminal can either:
  - match the chat width, or
  - span the full workspace width
- moves terminal placement out of `ChatView` and into the route/workspace layout
- replaces the old terminal drawer naming with `ThreadTerminalPanel`
- adds a shared right-side workspace panel so diff and terminal can use the same right rail
- makes the wide right rail use the shared sidebar primitive again, with an inline/workspace mode
- keeps narrow right-side behavior as a sheet
- adds persistence for linked vs independent right-rail widths
- fixes Windows startup issues caused by invalid terminal open/resize dimensions
- removes the `left` terminal position after trying it and deciding it was not a good fit

## Why

The built-in terminal was previously hard-wired to a bottom drawer inside the chat area. That caused a few UX problems:

- the bottom terminal could not span the full workspace when the diff panel was open
- there was no way to place the terminal on the right
- the right-side diff and terminal could not share one clean panel
- terminal layout logic was tied too closely to chat rendering

This approach keeps the bottom workspace-scoped terminal working while making the terminal placement a real workspace concern instead of a chat-only concern. It also reuses the shared sidebar primitive for the wide right rail so the panel behavior is much closer to the existing main-branch sidebar behavior instead of relying on a separate custom animation system.

## UI Changes

Before:
- terminal only opened as a bottom drawer inside the chat area
- bottom terminal width was constrained by the chat column
- no right-side terminal option
- diff and terminal could not share a single right panel

After:
- terminal can be positioned at the bottom or on the right
- bottom terminal can either match chat width or span the full workspace
- right-side terminal uses the same right workspace rail as diff
- on narrow screens, right-side terminal falls back to a sheet
- right rail width can be linked with diff or remembered separately

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add workspace-aware terminal panel layout with right-rail docking and position settings
> - Renames `ThreadTerminalDrawer` to `ThreadTerminalPanel` throughout and adds `layout` (`'bottom'` | `'side'`) and `bottomScope` (`'chat'` | `'workspace'`) props that control resize behavior, split orientation, and height clamping
> - Introduces a shared right rail in the chat thread route that hosts either the diff panel or the terminal, with mutual exclusivity enforced by a new `useWorkspacePanelController` hook
> - Adds `resolveWorkspacePanels` to derive docking targets (`bottom-inline`, `bottom-workspace`, `right`) and sheet/rail visibility flags; terminal renders into its target via React portal using `WorkspaceTerminalPortalTargetsContext`
> - Exposes three new user-configurable settings (`terminalPosition`, `terminalBottomScope`, `terminalRightRailWidthMode`) with UI controls in the General settings panel and legacy `'left'` position migrated to `'bottom'`
> - Adds `shouldAcceptWorkspaceSidebarWidth` to guard sidebar resize against composer minimum-width constraints
> - Risk: switching `terminalPosition` to `'right'` makes the diff and terminal panels mutually exclusive in the right rail — opening one closes the other
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27c0886.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->