### PR TITLE
Split PR creation into granular progress stages

### DIFF
--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -2739,7 +2739,17 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect.objectContaining({
           kind: "phase_started",
           phase: "pr",
-          label: "Creating PR...",
+          label: "Preparing PR...",
+        }),
+        expect.objectContaining({
+          kind: "phase_started",
+          phase: "pr",
+          label: "Generating PR content...",
+        }),
+        expect.objectContaining({
+          kind: "phase_started",
+          phase: "pr",
+          label: "Creating GitHub pull request...",
         }),
       ]);
     }),

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -37,6 +37,7 @@ const STATUS_RESULT_CACHE_TTL = Duration.seconds(1);
 const STATUS_RESULT_CACHE_CAPACITY = 2_048;
 type StripProgressContext<T> = T extends any ? Omit<T, "actionId" | "cwd" | "action"> : never;
 type GitActionProgressPayload = StripProgressContext<GitActionProgressEvent>;
+type GitActionProgressEmitter = (event: GitActionProgressPayload) => Effect.Effect<void, never>;
 
 interface OpenPrInfo {
   number: number;
@@ -1200,6 +1201,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     modelSelection: ModelSelection,
     cwd: string,
     fallbackBranch: string | null,
+    emit: GitActionProgressEmitter,
   ) {
     const details = yield* gitCore.statusDetails(cwd);
     const branch = details.branch ?? fallbackBranch;
@@ -1234,6 +1236,11 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     }
 
     const baseBranch = yield* resolveBaseBranch(cwd, branch, details.upstreamRef, headContext);
+    yield* emit({
+      kind: "phase_started",
+      phase: "pr",
+      label: "Generating PR content...",
+    });
     const rangeContext = yield* gitCore.readRangeContext(cwd, baseBranch);
 
     const generated = yield* textGeneration.generatePrContent({
@@ -1254,6 +1261,11 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
           gitManagerError("runPrStep", "Failed to write pull request body temp file.", cause),
         ),
       );
+    yield* emit({
+      kind: "phase_started",
+      phase: "pr",
+      label: "Creating GitHub pull request...",
+    });
     yield* gitHubCli
       .createPullRequest({
         cwd,
@@ -1612,11 +1624,13 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
               .emit({
                 kind: "phase_started",
                 phase: "pr",
-                label: "Creating PR...",
+                label: "Preparing PR...",
               })
               .pipe(
                 Effect.tap(() => Ref.set(currentPhase, Option.some("pr"))),
-                Effect.flatMap(() => runPrStep(modelSelection, input.cwd, currentBranch)),
+                Effect.flatMap(() =>
+                  runPrStep(modelSelection, input.cwd, currentBranch, progress.emit),
+                ),
               )
           : { status: "skipped_not_requested" as const };
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -877,7 +877,12 @@ describe("buildGitActionProgressStages", () => {
       pushTarget: "origin/feature/test",
       shouldPushBeforePr: true,
     });
-    assert.deepEqual(stages, ["Pushing to origin/feature/test...", "Creating PR..."]);
+    assert.deepEqual(stages, [
+      "Pushing to origin/feature/test...",
+      "Preparing PR...",
+      "Generating PR content...",
+      "Creating GitHub pull request...",
+    ]);
   });
 
   it("shows only PR progress when create-pr can skip the push", () => {
@@ -887,7 +892,11 @@ describe("buildGitActionProgressStages", () => {
       hasWorkingTreeChanges: false,
       shouldPushBeforePr: false,
     });
-    assert.deepEqual(stages, ["Creating PR..."]);
+    assert.deepEqual(stages, [
+      "Preparing PR...",
+      "Generating PR content...",
+      "Creating GitHub pull request...",
+    ]);
   });
 
   it("includes commit stages for commit+push when working tree is dirty", () => {
@@ -901,6 +910,22 @@ describe("buildGitActionProgressStages", () => {
       "Generating commit message...",
       "Committing...",
       "Pushing to origin/feature/test...",
+    ]);
+  });
+
+  it("includes granular PR stages for commit+push+PR actions", () => {
+    const stages = buildGitActionProgressStages({
+      action: "commit_push_pr",
+      hasCustomCommitMessage: true,
+      hasWorkingTreeChanges: true,
+      pushTarget: "origin/feature/test",
+    });
+    assert.deepEqual(stages, [
+      "Committing...",
+      "Pushing to origin/feature/test...",
+      "Preparing PR...",
+      "Generating PR content...",
+      "Creating GitHub pull request...",
     ]);
   });
 });

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -47,12 +47,17 @@ export function buildGitActionProgressStages(input: {
 }): string[] {
   const branchStages = input.featureBranch ? ["Preparing feature branch..."] : [];
   const pushStage = input.pushTarget ? `Pushing to ${input.pushTarget}...` : "Pushing...";
+  const prStages = [
+    "Preparing PR...",
+    "Generating PR content...",
+    "Creating GitHub pull request...",
+  ];
 
   if (input.action === "push") {
     return [pushStage];
   }
   if (input.action === "create_pr") {
-    return input.shouldPushBeforePr ? [pushStage, "Creating PR..."] : ["Creating PR..."];
+    return input.shouldPushBeforePr ? [pushStage, ...prStages] : prStages;
   }
 
   const shouldIncludeCommitStages = input.action === "commit" || input.hasWorkingTreeChanges;
@@ -67,7 +72,7 @@ export function buildGitActionProgressStages(input: {
   if (input.action === "commit_push") {
     return [...branchStages, ...commitStages, pushStage];
   }
-  return [...branchStages, ...commitStages, pushStage, "Creating PR..."];
+  return [...branchStages, ...commitStages, pushStage, ...prStages];
 }
 
 export function buildMenuItems(


### PR DESCRIPTION
## Summary
- Breaks PR creation progress into three clearer stages: preparing, generating content, and creating the GitHub pull request.
- Updates server-side progress emission so PR work reports each phase separately instead of a single coarse status.
- Aligns the web UI progress stage builder with the new PR lifecycle and expands unit coverage for the updated flow.

## Testing
- Not run (PR description only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to progress event labeling/emission and UI stage mapping, with unit tests updated to enforce the new sequence.
> 
> **Overview**
> PR creation progress is now reported as **three explicit PR sub-stages** instead of a single "Creating PR" stage: `Preparing PR...`, `Generating PR content...`, and `Creating GitHub pull request...`.
> 
> On the server, `runPrStep` now accepts a progress emitter and emits additional `phase_started` events around PR content generation and the `gh pr create` call; the web UI’s `buildGitActionProgressStages` is updated to mirror these new labels for `create_pr` and `commit_push_pr`, with tests expanded/updated to validate the new stage order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4299740e6feb3d5ebe3391b1fd0b298fb519ff3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split PR creation into three granular progress stages
> Replaces the single `'Creating PR...'` progress event with three sequential stages: `'Preparing PR...'`, `'Generating PR content...'`, and `'Creating GitHub pull request...'`. The new stages are emitted from `runPrStep` in [GitManager.ts](https://github.com/pingdotgg/t3code/pull/1694/files#diff-3d2a98876a28b6b4d401b67afc09729806523bb0997970e508a7f4a9368b404e) and reflected in `buildGitActionProgressStages` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/1694/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) for `create_pr` and `commit_push_pr` actions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b429974.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->