### PR TITLE
Allow desktop markdown links to open local files and editor schemes

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -29,6 +29,7 @@ import type { ContextMenuItem } from "@t3tools/contracts";
 import { NetService } from "@t3tools/shared/Net";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { showDesktopConfirmDialog } from "./confirmDialog";
+import { getSafeOpenTarget, type DesktopOpenTarget } from "./openTarget";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
 import {
@@ -152,23 +153,33 @@ function formatErrorMessage(error: unknown): string {
   return String(error);
 }
 
-function getSafeExternalUrl(rawUrl: unknown): string | null {
-  if (typeof rawUrl !== "string" || rawUrl.length === 0) {
-    return null;
+async function openSafeTarget(target: DesktopOpenTarget | null): Promise<boolean> {
+  if (!target) {
+    return false;
   }
 
-  let parsedUrl: URL;
   try {
-    parsedUrl = new URL(rawUrl);
-  } catch {
-    return null;
-  }
+    if (target.kind === "path") {
+      const result = await shell.openPath(target.value);
+      if (result.length > 0) {
+        writeDesktopLogHeader(
+          `open target path failed path=${sanitizeLogValue(target.value)} message=${sanitizeLogValue(result)}`,
+        );
+        return false;
+      }
+      writeDesktopLogHeader(`open target path succeeded path=${sanitizeLogValue(target.value)}`);
+      return true;
+    }
 
-  if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
-    return null;
+    await shell.openExternal(target.value);
+    writeDesktopLogHeader(`open target external succeeded url=${sanitizeLogValue(target.value)}`);
+    return true;
+  } catch (error) {
+    writeDesktopLogHeader(
+      `open target failed target=${sanitizeLogValue(target.value)} message=${sanitizeLogValue(formatErrorMessage(error))}`,
+    );
+    return false;
   }
-
-  return parsedUrl.toString();
 }
 
 function getSafeTheme(rawTheme: unknown): DesktopTheme | null {
@@ -1238,17 +1249,7 @@ function registerIpcHandlers(): void {
 
   ipcMain.removeHandler(OPEN_EXTERNAL_CHANNEL);
   ipcMain.handle(OPEN_EXTERNAL_CHANNEL, async (_event, rawUrl: unknown) => {
-    const externalUrl = getSafeExternalUrl(rawUrl);
-    if (!externalUrl) {
-      return false;
-    }
-
-    try {
-      await shell.openExternal(externalUrl);
-      return true;
-    } catch {
-      return false;
-    }
+    return openSafeTarget(getSafeOpenTarget(rawUrl));
   });
 
   ipcMain.removeHandler(UPDATE_GET_STATE_CHANNEL);
@@ -1353,10 +1354,7 @@ function createWindow(): BrowserWindow {
   });
 
   window.webContents.setWindowOpenHandler(({ url }) => {
-    const externalUrl = getSafeExternalUrl(url);
-    if (externalUrl) {
-      void shell.openExternal(externalUrl);
-    }
+    void openSafeTarget(getSafeOpenTarget(url));
     return { action: "deny" };
   });
 

--- a/apps/desktop/src/openTarget.test.ts
+++ b/apps/desktop/src/openTarget.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { getSafeOpenTarget, stripLocationSuffixFromLocalPath } from "./openTarget";
+
+describe("stripLocationSuffixFromLocalPath", () => {
+  it("expands the home directory prefix", () => {
+    expect(
+      stripLocationSuffixFromLocalPath("~/notes/today.md", {
+        homeDir: "/Users/tester",
+      }),
+    ).toBe("/Users/tester/notes/today.md");
+  });
+
+  it("strips line and hash suffixes when the base path exists", () => {
+    expect(
+      stripLocationSuffixFromLocalPath("/Users/tester/notes/today.md:14#L14", {
+        pathExists: (path) => path === "/Users/tester/notes/today.md",
+      }),
+    ).toBe("/Users/tester/notes/today.md");
+  });
+
+  it("keeps the original path when the suffixed path exists", () => {
+    expect(
+      stripLocationSuffixFromLocalPath("/Users/tester/notes/today.md:14", {
+        pathExists: (path) => path === "/Users/tester/notes/today.md:14",
+      }),
+    ).toBe("/Users/tester/notes/today.md:14");
+  });
+});
+
+describe("getSafeOpenTarget", () => {
+  it("accepts absolute local paths", () => {
+    expect(
+      getSafeOpenTarget("/Users/tester/notes/today.md:14", {
+        pathExists: (path) => path === "/Users/tester/notes/today.md",
+      }),
+    ).toEqual({
+      kind: "path",
+      value: "/Users/tester/notes/today.md",
+    });
+  });
+
+  it("accepts file urls that point to local markdown files", () => {
+    expect(
+      getSafeOpenTarget("file:///Users/tester/notes/today.md:14", {
+        pathExists: (path) => path === "/Users/tester/notes/today.md",
+      }),
+    ).toEqual({
+      kind: "path",
+      value: "/Users/tester/notes/today.md",
+    });
+  });
+
+  it("accepts supported editor and app schemes", () => {
+    expect(getSafeOpenTarget("zed://file/Users/tester/notes/today.md")).toEqual({
+      kind: "external",
+      value: "zed://file/Users/tester/notes/today.md",
+    });
+    expect(getSafeOpenTarget("obsidian://open?vault=notes&file=today")).toEqual({
+      kind: "external",
+      value: "obsidian://open?vault=notes&file=today",
+    });
+  });
+
+  it("rejects unsupported schemes", () => {
+    expect(getSafeOpenTarget("javascript:alert(1)")).toBeNull();
+    expect(getSafeOpenTarget("ftp://example.com/file.md")).toBeNull();
+  });
+});

--- a/apps/desktop/src/openTarget.ts
+++ b/apps/desktop/src/openTarget.ts
@@ -1,0 +1,131 @@
+import * as FS from "node:fs";
+import * as OS from "node:os";
+import * as Path from "node:path";
+
+const ALLOWED_EXTERNAL_PROTOCOLS = new Set([
+  "http:",
+  "https:",
+  "zed:",
+  "obsidian:",
+  "vscode:",
+  "vscode-insiders:",
+  "cursor:",
+  "windsurf:",
+]);
+
+export type DesktopOpenTarget =
+  | {
+      kind: "path";
+      value: string;
+    }
+  | {
+      kind: "external";
+      value: string;
+    };
+
+type OpenTargetResolutionOptions = {
+  homeDir?: string;
+  pathExists?: (path: string) => boolean;
+};
+
+function getHomeDir(options: OpenTargetResolutionOptions): string {
+  return options.homeDir ?? OS.homedir();
+}
+
+function pathExists(path: string, options: OpenTargetResolutionOptions): boolean {
+  return options.pathExists?.(path) ?? FS.existsSync(path);
+}
+
+export function stripLocationSuffixFromLocalPath(
+  rawPath: string,
+  options: OpenTargetResolutionOptions = {},
+): string | null {
+  const trimmedPath = rawPath.trim();
+  if (trimmedPath.length === 0) {
+    return null;
+  }
+
+  let normalizedPath = trimmedPath;
+  if (normalizedPath === "~") {
+    normalizedPath = getHomeDir(options);
+  } else if (normalizedPath.startsWith("~/")) {
+    normalizedPath = Path.join(getHomeDir(options), normalizedPath.slice(2));
+  }
+
+  const hashIndex = normalizedPath.indexOf("#");
+  if (hashIndex !== -1) {
+    normalizedPath = normalizedPath.slice(0, hashIndex);
+  }
+
+  const queryIndex = normalizedPath.indexOf("?");
+  if (queryIndex !== -1) {
+    normalizedPath = normalizedPath.slice(0, queryIndex);
+  }
+
+  const lineSuffixMatch = normalizedPath.match(/^(.*?)(:\d+(?::\d+)?)$/);
+  const basePath = lineSuffixMatch?.[1];
+  if (basePath && !pathExists(normalizedPath, options) && pathExists(basePath, options)) {
+    normalizedPath = basePath;
+  }
+
+  return normalizedPath;
+}
+
+export function getSafeOpenTarget(
+  rawUrl: unknown,
+  options: OpenTargetResolutionOptions = {},
+): DesktopOpenTarget | null {
+  if (typeof rawUrl !== "string") {
+    return null;
+  }
+
+  const normalizedUrl = rawUrl.trim();
+  if (normalizedUrl.length === 0) {
+    return null;
+  }
+
+  if (normalizedUrl.startsWith("/") || normalizedUrl === "~" || normalizedUrl.startsWith("~/")) {
+    const localPath = stripLocationSuffixFromLocalPath(normalizedUrl, options);
+    if (!localPath) {
+      return null;
+    }
+
+    return {
+      kind: "path",
+      value: localPath,
+    };
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(normalizedUrl);
+  } catch {
+    return null;
+  }
+
+  if (parsedUrl.protocol === "file:") {
+    let localPath = decodeURIComponent(parsedUrl.pathname);
+    if (process.platform === "win32" && /^\/[A-Za-z]:/.test(localPath)) {
+      localPath = localPath.slice(1);
+    }
+
+    const normalizedPath = stripLocationSuffixFromLocalPath(localPath, options);
+    if (!normalizedPath) {
+      return null;
+    }
+
+    return {
+      kind: "path",
+      value: normalizedPath,
+    };
+  }
+
+  if (!ALLOWED_EXTERNAL_PROTOCOLS.has(parsedUrl.protocol)) {
+    return null;
+  }
+
+  return {
+    kind: "external",
+    value: parsedUrl.toString(),
+  };
+}


### PR DESCRIPTION
## Summary
- allow the desktop app to open local file targets instead of rejecting everything except `http(s)`
- keep custom editor/app schemes like `zed://`, `obsidian://`, `vscode://`, `cursor://`, and `windsurf://`
- cover the new target-resolution helper with focused desktop unit tests

## Problem
The Electron main process currently only accepts `http:` and `https:` URLs for both `desktop:open-external` and `setWindowOpenHandler`. That blocks markdown file links and custom editor links before macOS can route them to the user's default app.

## Verification
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `cd apps/desktop && bun run test src/openTarget.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes which URLs/paths the Electron main process will open (including local filesystem paths) and alters the sanitization/validation logic guarding `shell.openExternal`/`shell.openPath`. Scope is limited and covered by new unit tests, but incorrect parsing could still enable unintended target opens.
> 
> **Overview**
> Desktop link opening is expanded beyond `http(s)` by introducing `getSafeOpenTarget` to resolve a URL/string into either a local `path` (including `file://` and `~/…` with `:line`/`#…` suffix stripping) or an `external` URL restricted to an allowlist of schemes (e.g. `vscode://`, `zed://`, `obsidian://`, `cursor://`, `windsurf://`).
> 
> The main process now routes both `desktop:open-external` IPC requests and `setWindowOpenHandler` popups through a shared `openSafeTarget` helper that uses `shell.openPath` for local paths, `shell.openExternal` for allowed external schemes, and adds structured success/failure logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c049c6002afae88a1532df9784282c45b9e7f892. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow desktop markdown links to open local files and editor scheme URLs
> - Introduces a `DesktopOpenTarget` discriminated union and `getSafeOpenTarget` in [openTarget.ts](https://github.com/pingdotgg/t3code/pull/1698/files#diff-17e368622aad470a965794013303eefa6889317495450b8d80f6f678ce5b7988) to classify user-provided strings as either local filesystem paths (`shell.openPath`) or external URLs (`shell.openExternal`).
> - Extends the allowed external protocols beyond `http`/`https` to include editor and app schemes: `vscode:`, `vscode-insiders:`, `cursor:`, `windsurf:`, `zed:`, and `obsidian:`.
> - Adds `stripLocationSuffixFromLocalPath` to normalize paths by expanding `~`, stripping hash/query fragments, and removing `:line[:col]` suffixes when the base path exists.
> - Updates the `OPEN_EXTERNAL_CHANNEL` IPC handler and `setWindowOpenHandler` in [main.ts](https://github.com/pingdotgg/t3code/pull/1698/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb) to use the new routing logic, replacing the previous `http`/`https`-only `getSafeExternalUrl` approach.
> - Behavioral Change: local paths and `file://` URLs now open via `shell.openPath` instead of being rejected; the protocol allowlist now includes non-web schemes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c049c60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->