### PR TITLE
Fix stale send spinner after completed turns

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -52,6 +52,7 @@ import {
   deriveWorkLogEntries,
   hasActionableProposedPlan,
   hasToolActivityForTurn,
+  isSessionActivelyRunningTurn,
   isLatestTurnSettled,
   formatElapsed,
 } from "../session-logic";
@@ -926,7 +927,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     activePendingUserInput: activePendingUserInput?.requestId ?? null,
     threadError: activeThread?.error,
   });
-  const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const isTurnRunning = isSessionActivelyRunningTurn(
+    activeLatestTurn,
+    activeThread?.session ?? null,
+  );
+  const isWorking = isTurnRunning || isSendBusy || isConnecting || isRevertingCheckpoint;
   const nowIso = new Date(nowTick).toISOString();
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
@@ -943,7 +948,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (activePendingProgress) {
       return `pending:${activePendingProgress.questionIndex}:${activePendingProgress.isLastQuestion}:${activePendingIsResponding}`;
     }
-    if (phase === "running") {
+    if (isTurnRunning) {
       return "running";
     }
     if (showPlanFollowUpPrompt) {
@@ -957,7 +962,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     isConnecting,
     isPreparingWorktree,
     isSendBusy,
-    phase,
+    isTurnRunning,
     prompt,
     showPlanFollowUpPrompt,
   ]);
@@ -2143,10 +2148,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
     scheduleStickToBottom();
   }, [messageCount, scheduleStickToBottom]);
   useEffect(() => {
-    if (phase !== "running") return;
+    if (!isTurnRunning) return;
     if (!shouldAutoScrollRef.current) return;
     scheduleStickToBottom();
-  }, [phase, scheduleStickToBottom, timelineEntries]);
+  }, [isTurnRunning, scheduleStickToBottom, timelineEntries]);
 
   useEffect(() => {
     setExpandedWorkGroups({});
@@ -2365,14 +2370,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
       : "local";
 
   useEffect(() => {
-    if (phase !== "running") return;
+    if (!isTurnRunning) return;
     const timer = window.setInterval(() => {
       setNowTick(Date.now());
     }, 1000);
     return () => {
       window.clearInterval(timer);
     };
-  }, [phase]);
+  }, [isTurnRunning]);
 
   useEffect(() => {
     if (!activeThreadId) return;
@@ -2592,7 +2597,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       const api = readNativeApi();
       if (!api || !activeThread || isRevertingCheckpoint) return;
 
-      if (phase === "running" || isSendBusy || isConnecting) {
+      if (isTurnRunning || isSendBusy || isConnecting) {
         setThreadError(activeThread.id, "Interrupt the current turn before reverting checkpoints.");
         return;
       }
@@ -2625,7 +2630,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
       setIsRevertingCheckpoint(false);
     },
-    [activeThread, isConnecting, isRevertingCheckpoint, isSendBusy, phase, setThreadError],
+    [activeThread, isConnecting, isRevertingCheckpoint, isSendBusy, isTurnRunning, setThreadError],
   );
 
   const onSend = async (e?: { preventDefault: () => void }) => {
@@ -4214,7 +4219,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                                 }
                               : null
                           }
-                          isRunning={phase === "running"}
+                          isRunning={isTurnRunning}
                           showPlanFollowUpPrompt={
                             pendingUserInputs.length === 0 && showPlanFollowUpPrompt
                           }

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -20,6 +20,7 @@ import {
   findSidebarProposedPlan,
   hasActionableProposedPlan,
   hasToolActivityForTurn,
+  isSessionActivelyRunningTurn,
   isLatestTurnSettled,
 } from "./session-logic";
 
@@ -1073,14 +1074,29 @@ describe("isLatestTurnSettled", () => {
 
   it("returns false while the same turn is still active in a running session", () => {
     expect(
+      isLatestTurnSettled(
+        {
+          ...latestTurn,
+          completedAt: null,
+        },
+        {
+          orchestrationStatus: "running",
+          activeTurnId: TurnId.makeUnsafe("turn-1"),
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when the turn completed but the session status stayed stale-running", () => {
+    expect(
       isLatestTurnSettled(latestTurn, {
         orchestrationStatus: "running",
         activeTurnId: TurnId.makeUnsafe("turn-1"),
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it("returns false while any turn is running to avoid stale latest-turn banners", () => {
+  it("returns false while a different turn is still running", () => {
     expect(
       isLatestTurnSettled(latestTurn, {
         orchestrationStatus: "running",
@@ -1112,6 +1128,56 @@ describe("isLatestTurnSettled", () => {
   });
 });
 
+describe("isSessionActivelyRunningTurn", () => {
+  const completedTurn = {
+    turnId: TurnId.makeUnsafe("turn-1"),
+    startedAt: "2026-02-27T21:10:00.000Z",
+    completedAt: "2026-02-27T21:10:06.000Z",
+  } as const;
+
+  it("returns true when the current turn has not completed yet", () => {
+    expect(
+      isSessionActivelyRunningTurn(
+        {
+          ...completedTurn,
+          completedAt: null,
+        },
+        {
+          orchestrationStatus: "running",
+          activeTurnId: TurnId.makeUnsafe("turn-1"),
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when the same turn already completed and only the session is stale", () => {
+    expect(
+      isSessionActivelyRunningTurn(completedTurn, {
+        orchestrationStatus: "running",
+        activeTurnId: TurnId.makeUnsafe("turn-1"),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when a different turn is still active", () => {
+    expect(
+      isSessionActivelyRunningTurn(completedTurn, {
+        orchestrationStatus: "running",
+        activeTurnId: TurnId.makeUnsafe("turn-2"),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when the session is not running", () => {
+    expect(
+      isSessionActivelyRunningTurn(completedTurn, {
+        orchestrationStatus: "ready",
+        activeTurnId: undefined,
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("deriveActiveWorkStartedAt", () => {
   const latestTurn = {
     turnId: TurnId.makeUnsafe("turn-1"),
@@ -1122,7 +1188,10 @@ describe("deriveActiveWorkStartedAt", () => {
   it("prefers the in-flight turn start when the latest turn is not settled", () => {
     expect(
       deriveActiveWorkStartedAt(
-        latestTurn,
+        {
+          ...latestTurn,
+          completedAt: null,
+        },
         {
           orchestrationStatus: "running",
           activeTurnId: TurnId.makeUnsafe("turn-1"),
@@ -1130,6 +1199,19 @@ describe("deriveActiveWorkStartedAt", () => {
         "2026-02-27T21:11:00.000Z",
       ),
     ).toBe("2026-02-27T21:10:00.000Z");
+  });
+
+  it("falls back to sendStartedAt when only the session status is stale-running", () => {
+    expect(
+      deriveActiveWorkStartedAt(
+        latestTurn,
+        {
+          orchestrationStatus: "running",
+          activeTurnId: TurnId.makeUnsafe("turn-1"),
+        },
+        "2026-02-27T21:11:00.000Z",
+      ),
+    ).toBe("2026-02-27T21:11:00.000Z");
   });
 
   it("falls back to sendStartedAt once the latest turn is settled", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -128,15 +128,30 @@ export function formatElapsed(startIso: string, endIso: string | undefined): str
 type LatestTurnTiming = Pick<OrchestrationLatestTurn, "turnId" | "startedAt" | "completedAt">;
 type SessionActivityState = Pick<ThreadSession, "orchestrationStatus" | "activeTurnId">;
 
+export function isSessionActivelyRunningTurn(
+  latestTurn: LatestTurnTiming | null,
+  session: SessionActivityState | null,
+): boolean {
+  if (!session || session.orchestrationStatus !== "running") return false;
+  if (!latestTurn) return true;
+
+  const activeTurnId = session.activeTurnId;
+  if (activeTurnId === undefined) {
+    return latestTurn.completedAt === null;
+  }
+  if (latestTurn.turnId !== activeTurnId) {
+    return true;
+  }
+  return latestTurn.completedAt === null;
+}
+
 export function isLatestTurnSettled(
   latestTurn: LatestTurnTiming | null,
   session: SessionActivityState | null,
 ): boolean {
   if (!latestTurn?.startedAt) return false;
   if (!latestTurn.completedAt) return false;
-  if (!session) return true;
-  if (session.orchestrationStatus === "running") return false;
-  return true;
+  return !isSessionActivelyRunningTurn(latestTurn, session);
 }
 
 export function deriveActiveWorkStartedAt(


### PR DESCRIPTION
## Summary
- stop treating the composer as actively running when the latest turn already has a completion timestamp
- use the real active-turn state for the composer spinner, interrupt button, auto-scroll, and elapsed-work timer
- cover the stale-running-session case in session logic tests

## Problem
Sometimes the assistant visibly finishes a turn, but the desktop/web composer keeps showing the running spinner and blocks the next send until refresh. This happens when the latest turn has already completed through message updates, but the session state is still stale at `running`.

## Verification
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `cd apps/web && bun run test src/session-logic.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to derived session/turn state and corresponding UI gating (spinner/interrupt/autoscroll/timer), with added unit coverage for stale `running` sessions.
> 
> **Overview**
> Fixes cases where the composer stays *stuck in “running”* after a turn has already completed by deriving a new `isSessionActivelyRunningTurn` signal from `latestTurn.completedAt` + `session.activeTurnId` (instead of trusting session `phase` alone).
> 
> `ChatView` now uses this active-turn signal to drive the composer running spinner, auto-scroll while running, elapsed-work timer tick, and to block checkpoint reverts only when a turn is truly in-flight. Tests update `isLatestTurnSettled` expectations for stale-running sessions and add coverage for `isSessionActivelyRunningTurn` plus the related `deriveActiveWorkStartedAt` fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f03b5903b6d9735ca70916d4be27042edfcde98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale send spinner by deriving running state from active turn completion
> - Adds `isSessionActivelyRunningTurn` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/1700/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) to check whether a turn is truly in-progress by comparing session `orchestrationStatus`, `activeTurnId`, and latest turn completion status.
> - Fixes `isLatestTurnSettled` to treat a completed turn as settled even when the session `orchestrationStatus` remains `'running'`, eliminating the stale spinner.
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1700/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to derive `isTurnRunning` from the new helper, replacing the `phase === "running"` check that drove auto-scroll, the elapsed timer, composer footer layout, and checkpoint revert blocking.
> - Behavioral Change: revert-to-turn, auto-scroll, and elapsed timer now stop as soon as the turn completes, regardless of session status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f03b59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->