### PR TITLE
Clean up terminal state when threads are archived

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1193,6 +1193,41 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("closes thread terminals after a successful archive command", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.makeUnsafe("thread-archive");
+      const closeInputs: Array<Parameters<TerminalManagerShape["close"]>[0]> = [];
+
+      yield* buildAppUnderTest({
+        layers: {
+          terminalManager: {
+            close: (input) =>
+              Effect.sync(() => {
+                closeInputs.push(input);
+              }),
+          },
+          orchestrationEngine: {
+            dispatch: () => Effect.succeed({ sequence: 8 }),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const dispatchResult = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.archive",
+            commandId: CommandId.makeUnsafe("cmd-thread-archive"),
+            threadId,
+          }),
+        ),
+      );
+
+      assert.equal(dispatchResult.sequence, 8);
+      assert.deepEqual(closeInputs, [{ threadId }]);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect(
     "routes websocket rpc subscribeOrchestrationDomainEvents with replay/live overlap resilience",
     () =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -85,7 +85,20 @@ const WsRpcLayer = WsRpcGroup.toLayer(
       [ORCHESTRATION_WS_METHODS.dispatchCommand]: (command) =>
         Effect.gen(function* () {
           const normalizedCommand = yield* normalizeDispatchCommand(command);
-          return yield* startup.enqueueCommand(orchestrationEngine.dispatch(normalizedCommand));
+          const result = yield* startup.enqueueCommand(
+            orchestrationEngine.dispatch(normalizedCommand),
+          );
+          if (normalizedCommand.type === "thread.archive") {
+            yield* terminalManager.close({ threadId: normalizedCommand.threadId }).pipe(
+              Effect.catch((error) =>
+                Effect.logWarning("failed to close thread terminals after archive", {
+                  threadId: normalizedCommand.threadId,
+                  error: error.message,
+                }),
+              ),
+            );
+          }
+          return result;
         }).pipe(
           Effect.mapError((cause) =>
             Schema.is(OrchestrationDispatchCommandError)(cause)

--- a/apps/web/src/lib/terminalStateCleanup.test.ts
+++ b/apps/web/src/lib/terminalStateCleanup.test.ts
@@ -9,8 +9,8 @@ describe("collectActiveTerminalThreadIds", () => {
   it("retains non-deleted server threads", () => {
     const activeThreadIds = collectActiveTerminalThreadIds({
       snapshotThreads: [
-        { id: threadId("server-1"), deletedAt: null },
-        { id: threadId("server-2"), deletedAt: null },
+        { id: threadId("server-1"), deletedAt: null, archivedAt: null },
+        { id: threadId("server-2"), deletedAt: null, archivedAt: null },
       ],
       draftThreadIds: [],
     });
@@ -18,15 +18,41 @@ describe("collectActiveTerminalThreadIds", () => {
     expect(activeThreadIds).toEqual(new Set([threadId("server-1"), threadId("server-2")]));
   });
 
-  it("ignores deleted server threads and keeps local draft threads", () => {
+  it("ignores deleted and archived server threads and keeps local draft threads", () => {
     const activeThreadIds = collectActiveTerminalThreadIds({
       snapshotThreads: [
-        { id: threadId("server-active"), deletedAt: null },
-        { id: threadId("server-deleted"), deletedAt: "2026-03-05T08:00:00.000Z" },
+        { id: threadId("server-active"), deletedAt: null, archivedAt: null },
+        {
+          id: threadId("server-deleted"),
+          deletedAt: "2026-03-05T08:00:00.000Z",
+          archivedAt: null,
+        },
+        {
+          id: threadId("server-archived"),
+          deletedAt: null,
+          archivedAt: "2026-03-05T09:00:00.000Z",
+        },
       ],
       draftThreadIds: [threadId("local-draft")],
     });
 
     expect(activeThreadIds).toEqual(new Set([threadId("server-active"), threadId("local-draft")]));
+  });
+
+  it("does not keep draft-linked terminal state for archived server threads", () => {
+    const archivedThreadId = threadId("server-archived");
+
+    const activeThreadIds = collectActiveTerminalThreadIds({
+      snapshotThreads: [
+        {
+          id: archivedThreadId,
+          deletedAt: null,
+          archivedAt: "2026-03-05T09:00:00.000Z",
+        },
+      ],
+      draftThreadIds: [archivedThreadId, threadId("local-draft")],
+    });
+
+    expect(activeThreadIds).toEqual(new Set([threadId("local-draft")]));
   });
 });

--- a/apps/web/src/lib/terminalStateCleanup.ts
+++ b/apps/web/src/lib/terminalStateCleanup.ts
@@ -3,6 +3,7 @@ import type { ThreadId } from "@t3tools/contracts";
 interface TerminalRetentionThread {
   id: ThreadId;
   deletedAt: string | null;
+  archivedAt: string | null;
 }
 
 interface CollectActiveTerminalThreadIdsInput {
@@ -14,11 +15,20 @@ export function collectActiveTerminalThreadIds(
   input: CollectActiveTerminalThreadIdsInput,
 ): Set<ThreadId> {
   const activeThreadIds = new Set<ThreadId>();
+  const snapshotThreadById = new Map(input.snapshotThreads.map((thread) => [thread.id, thread]));
   for (const thread of input.snapshotThreads) {
     if (thread.deletedAt !== null) continue;
+    if (thread.archivedAt !== null) continue;
     activeThreadIds.add(thread.id);
   }
   for (const draftThreadId of input.draftThreadIds) {
+    const snapshotThread = snapshotThreadById.get(draftThreadId);
+    if (
+      snapshotThread &&
+      (snapshotThread.deletedAt !== null || snapshotThread.archivedAt !== null)
+    ) {
+      continue;
+    }
     activeThreadIds.add(draftThreadId);
   }
   return activeThreadIds;

--- a/apps/web/src/orchestrationEventEffects.test.ts
+++ b/apps/web/src/orchestrationEventEffects.test.ts
@@ -42,6 +42,7 @@ describe("deriveOrchestrationBatchEffects", () => {
   it("targets draft promotion and terminal cleanup from thread lifecycle events", () => {
     const createdThreadId = ThreadId.makeUnsafe("thread-created");
     const deletedThreadId = ThreadId.makeUnsafe("thread-deleted");
+    const archivedThreadId = ThreadId.makeUnsafe("thread-archived");
 
     const effects = deriveOrchestrationBatchEffects([
       makeEvent("thread.created", {
@@ -60,11 +61,16 @@ describe("deriveOrchestrationBatchEffects", () => {
         threadId: deletedThreadId,
         deletedAt: "2026-02-27T00:00:01.000Z",
       }),
+      makeEvent("thread.archived", {
+        threadId: archivedThreadId,
+        archivedAt: "2026-02-27T00:00:02.000Z",
+        updatedAt: "2026-02-27T00:00:02.000Z",
+      }),
     ]);
 
     expect(effects.clearPromotedDraftThreadIds).toEqual([createdThreadId]);
     expect(effects.clearDeletedThreadIds).toEqual([deletedThreadId]);
-    expect(effects.removeTerminalStateThreadIds).toEqual([deletedThreadId]);
+    expect(effects.removeTerminalStateThreadIds).toEqual([deletedThreadId, archivedThreadId]);
     expect(effects.needsProviderInvalidation).toBe(false);
   });
 
@@ -104,5 +110,25 @@ describe("deriveOrchestrationBatchEffects", () => {
     expect(effects.clearDeletedThreadIds).toEqual([]);
     expect(effects.removeTerminalStateThreadIds).toEqual([]);
     expect(effects.needsProviderInvalidation).toBe(true);
+  });
+
+  it("does not retain archive cleanup when a thread is unarchived later in the same batch", () => {
+    const threadId = ThreadId.makeUnsafe("thread-1");
+
+    const effects = deriveOrchestrationBatchEffects([
+      makeEvent("thread.archived", {
+        threadId,
+        archivedAt: "2026-02-27T00:00:01.000Z",
+        updatedAt: "2026-02-27T00:00:01.000Z",
+      }),
+      makeEvent("thread.unarchived", {
+        threadId,
+        updatedAt: "2026-02-27T00:00:02.000Z",
+      }),
+    ]);
+
+    expect(effects.clearPromotedDraftThreadIds).toEqual([]);
+    expect(effects.clearDeletedThreadIds).toEqual([]);
+    expect(effects.removeTerminalStateThreadIds).toEqual([]);
   });
 });

--- a/apps/web/src/orchestrationEventEffects.ts
+++ b/apps/web/src/orchestrationEventEffects.ts
@@ -46,6 +46,24 @@ export function deriveOrchestrationBatchEffects(
         break;
       }
 
+      case "thread.archived": {
+        threadLifecycleEffects.set(event.payload.threadId, {
+          clearPromotedDraft: false,
+          clearDeletedThread: false,
+          removeTerminalState: true,
+        });
+        break;
+      }
+
+      case "thread.unarchived": {
+        threadLifecycleEffects.set(event.payload.threadId, {
+          clearPromotedDraft: false,
+          clearDeletedThread: false,
+          removeTerminalState: false,
+        });
+        break;
+      }
+
       default: {
         break;
       }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -328,7 +328,11 @@ function EventRouter() {
         useComposerDraftStore.getState().draftThreadsByThreadId,
       ) as ThreadId[];
       const activeThreadIds = collectActiveTerminalThreadIds({
-        snapshotThreads: threads.map((thread) => ({ id: thread.id, deletedAt: null })),
+        snapshotThreads: threads.map((thread) => ({
+          id: thread.id,
+          deletedAt: null,
+          archivedAt: thread.archivedAt,
+        })),
         draftThreadIds,
       });
       removeOrphanedTerminalStates(activeThreadIds);
@@ -497,6 +501,10 @@ function EventRouter() {
       }
     });
     const unsubTerminalEvent = api.terminal.onEvent((event) => {
+      const thread = useStore.getState().threads.find((entry) => entry.id === event.threadId);
+      if (thread && thread.archivedAt !== null) {
+        return;
+      }
       useTerminalStateStore.getState().recordTerminalEvent(event);
       const hasRunningSubprocess = terminalRunningSubprocessFromEvent(event);
       if (hasRunningSubprocess === null) {


### PR DESCRIPTION
## Summary
- Close per-thread terminal sessions after a successful `thread.archive` dispatch on the server.
- Treat archived threads as inactive in terminal state cleanup on the web client.
- Add orchestration lifecycle handling for `thread.archived` and `thread.unarchived` so terminal cleanup follows the latest thread state within a batch.
- Update tests to cover archive cleanup, archived draft-thread filtering, and batch lifecycle edge cases.

## Testing
- Not run (PR description only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new side effects to the orchestration `dispatchCommand` WebSocket path and changes client-side terminal retention rules; mistakes could close active terminals or drop terminal events for threads unexpectedly. Scope is limited to archive/unarchive handling and is covered by new unit tests.
> 
> **Overview**
> Ensures terminal resources are cleaned up when threads are archived.
> 
> On the **server**, `ORCHESTRATION_WS_METHODS.dispatchCommand` now closes the thread’s terminals after a successful `thread.archive` dispatch (with failures only logged), and a new test asserts the close call occurs.
> 
> On the **web client**, terminal state retention now treats `archivedAt` threads as inactive (including draft-linked state), orchestration batch effects now remove terminal state on `thread.archived` but not if a later `thread.unarchived` appears in the same batch, and terminal events for archived threads are ignored; tests were updated/added for these cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6d000dfae6dfb8383c648e17623b122ccd3d8f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean up terminal state when threads are archived
> - When a `thread.archive` command is dispatched via the WebSocket RPC, the server now calls `terminalManager.close` for that thread after a successful dispatch; failures are logged as warnings and do not affect the RPC result.
> - `collectActiveTerminalThreadIds` now excludes archived threads from the active terminal set, and draft-linked terminal state is no longer retained for archived or deleted server threads.
> - `deriveOrchestrationBatchEffects` adds `thread.archived` and `thread.unarchived` handling: archived threads are added to `removeTerminalStateThreadIds`, and a subsequent `thread.unarchived` in the same batch cancels that cleanup.
> - During bootstrap and live event routing in [__root.tsx](https://github.com/pingdotgg/t3code/pull/1702/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100), archived threads are treated as inactive and incoming terminal events for archived threads are ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6d000d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->