### PR TITLE
[codex] Revert stale send spinner fix

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -52,7 +52,6 @@ import {
   deriveWorkLogEntries,
   hasActionableProposedPlan,
   hasToolActivityForTurn,
-  isSessionActivelyRunningTurn,
   isLatestTurnSettled,
   formatElapsed,
 } from "../session-logic";
@@ -1121,11 +1120,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     activePendingUserInput: activePendingUserInput?.requestId ?? null,
     threadError: activeThread?.error,
   });
-  const isTurnRunning = isSessionActivelyRunningTurn(
-    activeLatestTurn,
-    activeThread?.session ?? null,
-  );
-  const isWorking = isTurnRunning || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
   const nowIso = new Date(nowTick).toISOString();
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
@@ -1142,7 +1137,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (activePendingProgress) {
       return `pending:${activePendingProgress.questionIndex}:${activePendingProgress.isLastQuestion}:${activePendingIsResponding}`;
     }
-    if (isTurnRunning) {
+    if (phase === "running") {
       return "running";
     }
     if (showPlanFollowUpPrompt) {
@@ -1156,7 +1151,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     isConnecting,
     isPreparingWorktree,
     isSendBusy,
-    isTurnRunning,
+    phase,
     prompt,
     showPlanFollowUpPrompt,
   ]);
@@ -2316,10 +2311,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
     scheduleStickToBottom();
   }, [messageCount, scheduleStickToBottom]);
   useEffect(() => {
-    if (!isTurnRunning) return;
+    if (phase !== "running") return;
     if (!shouldAutoScrollRef.current) return;
     scheduleStickToBottom();
-  }, [isTurnRunning, scheduleStickToBottom, timelineEntries]);
+  }, [phase, scheduleStickToBottom, timelineEntries]);
 
   useEffect(() => {
     setExpandedWorkGroups({});
@@ -2538,14 +2533,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
       : "local";
 
   useEffect(() => {
-    if (!isTurnRunning) return;
+    if (phase !== "running") return;
     const timer = window.setInterval(() => {
       setNowTick(Date.now());
     }, 1000);
     return () => {
       window.clearInterval(timer);
     };
-  }, [isTurnRunning]);
+  }, [phase]);
 
   useEffect(() => {
     if (!activeThreadId) return;
@@ -2765,7 +2760,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       const api = readNativeApi();
       if (!api || !activeThread || isRevertingCheckpoint) return;
 
-      if (isTurnRunning || isSendBusy || isConnecting) {
+      if (phase === "running" || isSendBusy || isConnecting) {
         setThreadError(activeThread.id, "Interrupt the current turn before reverting checkpoints.");
         return;
       }
@@ -2798,7 +2793,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
       }
       setIsRevertingCheckpoint(false);
     },
-    [activeThread, isConnecting, isRevertingCheckpoint, isSendBusy, isTurnRunning, setThreadError],
+    [activeThread, isConnecting, isRevertingCheckpoint, isSendBusy, phase, setThreadError],
   );
 
   const onSend = async (e?: { preventDefault: () => void }) => {
@@ -4387,7 +4382,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                                 }
                               : null
                           }
-                          isRunning={isTurnRunning}
+                          isRunning={phase === "running"}
                           showPlanFollowUpPrompt={
                             pendingUserInputs.length === 0 && showPlanFollowUpPrompt
                           }

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -20,7 +20,6 @@ import {
   findSidebarProposedPlan,
   hasActionableProposedPlan,
   hasToolActivityForTurn,
-  isSessionActivelyRunningTurn,
   isLatestTurnSettled,
 } from "./session-logic";
 
@@ -1074,29 +1073,14 @@ describe("isLatestTurnSettled", () => {
 
   it("returns false while the same turn is still active in a running session", () => {
     expect(
-      isLatestTurnSettled(
-        {
-          ...latestTurn,
-          completedAt: null,
-        },
-        {
-          orchestrationStatus: "running",
-          activeTurnId: TurnId.makeUnsafe("turn-1"),
-        },
-      ),
-    ).toBe(false);
-  });
-
-  it("returns true when the turn completed but the session status stayed stale-running", () => {
-    expect(
       isLatestTurnSettled(latestTurn, {
         orchestrationStatus: "running",
         activeTurnId: TurnId.makeUnsafe("turn-1"),
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("returns false while a different turn is still running", () => {
+  it("returns false while any turn is running to avoid stale latest-turn banners", () => {
     expect(
       isLatestTurnSettled(latestTurn, {
         orchestrationStatus: "running",
@@ -1128,56 +1112,6 @@ describe("isLatestTurnSettled", () => {
   });
 });
 
-describe("isSessionActivelyRunningTurn", () => {
-  const completedTurn = {
-    turnId: TurnId.makeUnsafe("turn-1"),
-    startedAt: "2026-02-27T21:10:00.000Z",
-    completedAt: "2026-02-27T21:10:06.000Z",
-  } as const;
-
-  it("returns true when the current turn has not completed yet", () => {
-    expect(
-      isSessionActivelyRunningTurn(
-        {
-          ...completedTurn,
-          completedAt: null,
-        },
-        {
-          orchestrationStatus: "running",
-          activeTurnId: TurnId.makeUnsafe("turn-1"),
-        },
-      ),
-    ).toBe(true);
-  });
-
-  it("returns false when the same turn already completed and only the session is stale", () => {
-    expect(
-      isSessionActivelyRunningTurn(completedTurn, {
-        orchestrationStatus: "running",
-        activeTurnId: TurnId.makeUnsafe("turn-1"),
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true when a different turn is still active", () => {
-    expect(
-      isSessionActivelyRunningTurn(completedTurn, {
-        orchestrationStatus: "running",
-        activeTurnId: TurnId.makeUnsafe("turn-2"),
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false when the session is not running", () => {
-    expect(
-      isSessionActivelyRunningTurn(completedTurn, {
-        orchestrationStatus: "ready",
-        activeTurnId: undefined,
-      }),
-    ).toBe(false);
-  });
-});
-
 describe("deriveActiveWorkStartedAt", () => {
   const latestTurn = {
     turnId: TurnId.makeUnsafe("turn-1"),
@@ -1188,22 +1122,6 @@ describe("deriveActiveWorkStartedAt", () => {
   it("prefers the in-flight turn start when the latest turn is not settled", () => {
     expect(
       deriveActiveWorkStartedAt(
-        {
-          ...latestTurn,
-          completedAt: null,
-        },
-        {
-          orchestrationStatus: "running",
-          activeTurnId: TurnId.makeUnsafe("turn-1"),
-        },
-        "2026-02-27T21:11:00.000Z",
-      ),
-    ).toBe("2026-02-27T21:10:00.000Z");
-  });
-
-  it("falls back to sendStartedAt when only the session status is stale-running", () => {
-    expect(
-      deriveActiveWorkStartedAt(
         latestTurn,
         {
           orchestrationStatus: "running",
@@ -1211,7 +1129,7 @@ describe("deriveActiveWorkStartedAt", () => {
         },
         "2026-02-27T21:11:00.000Z",
       ),
-    ).toBe("2026-02-27T21:11:00.000Z");
+    ).toBe("2026-02-27T21:10:00.000Z");
   });
 
   it("falls back to sendStartedAt once the latest turn is settled", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -128,30 +128,15 @@ export function formatElapsed(startIso: string, endIso: string | undefined): str
 type LatestTurnTiming = Pick<OrchestrationLatestTurn, "turnId" | "startedAt" | "completedAt">;
 type SessionActivityState = Pick<ThreadSession, "orchestrationStatus" | "activeTurnId">;
 
-export function isSessionActivelyRunningTurn(
-  latestTurn: LatestTurnTiming | null,
-  session: SessionActivityState | null,
-): boolean {
-  if (!session || session.orchestrationStatus !== "running") return false;
-  if (!latestTurn) return true;
-
-  const activeTurnId = session.activeTurnId;
-  if (activeTurnId === undefined) {
-    return latestTurn.completedAt === null;
-  }
-  if (latestTurn.turnId !== activeTurnId) {
-    return true;
-  }
-  return latestTurn.completedAt === null;
-}
-
 export function isLatestTurnSettled(
   latestTurn: LatestTurnTiming | null,
   session: SessionActivityState | null,
 ): boolean {
   if (!latestTurn?.startedAt) return false;
   if (!latestTurn.completedAt) return false;
-  return !isSessionActivelyRunningTurn(latestTurn, session);
+  if (!session) return true;
+  if (session.orchestrationStatus === "running") return false;
+  return true;
 }
 
 export function deriveActiveWorkStartedAt(


### PR DESCRIPTION
## What changed
This PR reverts commit `48481aa9233666ae05a369e0ed7d16e06e024586` (`Fix stale send spinner after completed turns (#1700)`).

It removes the `isSessionActivelyRunningTurn` path and restores the previous session-running behavior in the chat composer and session logic tests.

## Why
Revert requested for the change introduced in `#1700`.

## Impact
This restores the prior UI behavior for send-spinner and running-turn state handling.

## Validation
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --cwd apps/web test src/session-logic.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert stale send spinner fix by replacing `isTurnRunning` with `phase === "running"` checks in ChatView
> - Removes the `isSessionActivelyRunningTurn` helper from [session-logic.ts](https://github.com/pingdotgg/t3code/pull/1704/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) and replaces all `isTurnRunning` references in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1704/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) with direct `phase === "running"` checks.
> - `isLatestTurnSettled` now returns `false` whenever `session.orchestrationStatus === "running"`, regardless of `activeTurnId` or the latest turn's `completedAt`.
> - All UI behaviors gated on running state (work indicator, layout key, auto-scroll, timer tick, revert guard, footer `isRunning`) now derive from `phase` instead of the removed helper.
> - Behavioral Change: the session is now considered active based solely on `phase`, so any edge cases where `isSessionActivelyRunningTurn` and `phase` disagreed will resolve differently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c9c997.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the UI determines “running/settled” state for turns, which can affect spinners, auto-scroll, and checkpoint revert gating in active chats. Scope is limited to session state derivation and related tests, but regressions could be user-visible during turn transitions.
> 
> **Overview**
> Reverts the prior “stale running” handling by removing `isSessionActivelyRunningTurn` and switching ChatView’s running/work checks back to `phase === "running"`.
> 
> `isLatestTurnSettled` is simplified to treat any `session.orchestrationStatus === "running"` as unsettled, and tests are updated accordingly (including `deriveActiveWorkStartedAt` expectations), restoring the earlier behavior for latest-turn banners and work timing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c9c9973dd8bd45a16509bd369bf37d040819e20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->