### PR TITLE
fix(web): narrow stale send spinner recovery to composer state

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -2,6 +2,7 @@
 import "../index.css";
 
 import {
+  CheckpointRef,
   EventId,
   ORCHESTRATION_WS_METHODS,
   type MessageId,
@@ -294,6 +295,70 @@ function createSnapshotForTargetUser(options: {
       },
     ],
     updatedAt: NOW_ISO,
+  };
+}
+
+function withLatestTurnState(
+  snapshot: OrchestrationReadModel,
+  options?: {
+    turnId?: TurnId;
+    completedAt?: string;
+    includeCheckpoint?: boolean;
+    sessionStatus?: OrchestrationSessionStatus;
+  },
+): OrchestrationReadModel {
+  const turnId = options?.turnId ?? ("turn-browser-running" as TurnId);
+  const completedAt = options?.completedAt ?? isoAt(180);
+  const sessionStatus = options?.sessionStatus ?? "running";
+  const threads = [...snapshot.threads];
+  const threadIndex = threads.findIndex((thread) => thread.id === THREAD_ID);
+  if (threadIndex < 0) {
+    return snapshot;
+  }
+
+  const thread = threads[threadIndex];
+  if (!thread) {
+    return snapshot;
+  }
+
+  threads[threadIndex] = {
+    ...thread,
+    latestTurn: {
+      turnId,
+      state: "completed",
+      requestedAt: isoAt(120),
+      startedAt: isoAt(121),
+      completedAt,
+      assistantMessageId: null,
+    },
+    session: thread.session
+      ? {
+          ...thread.session,
+          status: sessionStatus,
+          activeTurnId: sessionStatus === "running" ? turnId : null,
+          updatedAt: options?.includeCheckpoint ? isoAt(181) : isoAt(121),
+        }
+      : null,
+    checkpoints: options?.includeCheckpoint
+      ? [
+          {
+            turnId,
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.makeUnsafe(
+              "refs/t3/checkpoints/thread-browser-test/turn/1",
+            ),
+            status: "ready",
+            files: [],
+            assistantMessageId: null,
+            completedAt: isoAt(181),
+          },
+        ]
+      : [],
+  };
+
+  return {
+    ...snapshot,
+    threads,
   };
 }
 
@@ -2099,6 +2164,97 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
 
       expect(getComputedStyle(stopButton).cursor).toBe("pointer");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("restores the composer send button when a running session already has a finalized checkpoint for its latest turn", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: withLatestTurnState(
+        createSnapshotForTargetUser({
+          targetMessageId: "msg-user-stale-running-target" as MessageId,
+          targetText: "stale running target",
+        }),
+        { includeCheckpoint: true },
+      ),
+    });
+
+    try {
+      const sendButton = await waitForSendButton();
+      expect(sendButton).toBeTruthy();
+      expect(
+        document.querySelector<HTMLButtonElement>('button[aria-label="Stop generation"]'),
+      ).toBeNull();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("keeps the composer stop button while a running session lacks a finalized checkpoint for its latest turn", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: withLatestTurnState(
+        createSnapshotForTargetUser({
+          targetMessageId: "msg-user-active-running-target" as MessageId,
+          targetText: "active running target",
+        }),
+      ),
+    });
+
+    try {
+      const stopButton = await waitForElement(
+        () => document.querySelector<HTMLButtonElement>('button[aria-label="Stop generation"]'),
+        "Unable to find stop generation button.",
+      );
+      expect(stopButton).toBeTruthy();
+      expect(
+        document.querySelector<HTMLButtonElement>('button[aria-label="Send message"]'),
+      ).toBeNull();
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("keeps the composer in sending state during a delayed turn start", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: withLatestTurnState(
+        createSnapshotForTargetUser({
+          targetMessageId: "msg-user-delayed-turn-start" as MessageId,
+          targetText: "delayed turn start target",
+        }),
+        { includeCheckpoint: true, sessionStatus: "ready" },
+      ),
+      resolveRpc: (body) => {
+        if (
+          body._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+          body.type === "thread.turn.start"
+        ) {
+          return new Promise(() => undefined);
+        }
+        return undefined;
+      },
+    });
+
+    try {
+      await page.getByTestId("composer-editor").fill("follow up while waiting");
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          expect(
+            document.querySelector<HTMLButtonElement>('button[aria-label="Sending"]'),
+          ).toBeTruthy();
+          expect(
+            document.querySelector<HTMLButtonElement>('button[aria-label="Stop generation"]'),
+          ).toBeNull();
+        },
+        { timeout: 8_000, interval: 16 },
+      );
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -9,6 +9,7 @@ import {
   deriveComposerSendState,
   hasServerAcknowledgedLocalDispatch,
   reconcileMountedTerminalThreadIds,
+  shouldShowComposerRunningState,
   waitForStartedServerThread,
 } from "./ChatView.logic";
 
@@ -453,5 +454,76 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
         threadError: null,
       }),
     ).toBe(true);
+  });
+});
+
+describe("shouldShowComposerRunningState", () => {
+  const latestTurn = {
+    turnId: TurnId.makeUnsafe("turn-running"),
+    state: "completed" as const,
+    requestedAt: "2026-03-29T00:01:00.000Z",
+    startedAt: "2026-03-29T00:01:01.000Z",
+    completedAt: "2026-03-29T00:01:30.000Z",
+    assistantMessageId: null,
+  };
+
+  it("hides the composer stop state once the running turn has a finalized checkpoint", () => {
+    expect(
+      shouldShowComposerRunningState({
+        phase: "running",
+        latestTurn,
+        turnDiffSummaries: [
+          {
+            turnId: latestTurn.turnId,
+            completedAt: "2026-03-29T00:01:31.000Z",
+            status: "ready",
+            files: [],
+            checkpointTurnCount: 1,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps the composer in stop state while the turn is still running without a finalized checkpoint", () => {
+    expect(
+      shouldShowComposerRunningState({
+        phase: "running",
+        latestTurn,
+        turnDiffSummaries: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the composer in stop state while the latest turn has not completed yet", () => {
+    expect(
+      shouldShowComposerRunningState({
+        phase: "running",
+        latestTurn: {
+          ...latestTurn,
+          state: "running",
+          completedAt: null,
+        },
+        turnDiffSummaries: [
+          {
+            turnId: latestTurn.turnId,
+            completedAt: "2026-03-29T00:01:31.000Z",
+            status: "ready",
+            files: [],
+            checkpointTurnCount: 1,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when the session itself is not running", () => {
+    expect(
+      shouldShowComposerRunningState({
+        phase: "ready",
+        latestTurn,
+        turnDiffSummaries: [],
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -304,3 +304,20 @@ export function hasServerAcknowledgedLocalDispatch(input: {
     input.localDispatch.sessionUpdatedAt !== (session?.updatedAt ?? null)
   );
 }
+
+export function shouldShowComposerRunningState(input: {
+  phase: SessionPhase;
+  latestTurn: Thread["latestTurn"] | null;
+  turnDiffSummaries: ReadonlyArray<Thread["turnDiffSummaries"][number]>;
+}): boolean {
+  if (input.phase !== "running") {
+    return false;
+  }
+
+  const latestTurn = input.latestTurn;
+  if (!latestTurn?.completedAt) {
+    return true;
+  }
+
+  return !input.turnDiffSummaries.some((summary) => summary.turnId === latestTurn.turnId);
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -190,6 +190,7 @@ import {
   reconcileMountedTerminalThreadIds,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
+  shouldShowComposerRunningState,
   threadHasStarted,
   waitForStartedServerThread,
 } from "./ChatView.logic";
@@ -869,6 +870,8 @@ export default function ChatView({ threadId }: ChatViewProps) {
   }, [activeThreadId, existingOpenTerminalThreadIds, terminalState.terminalOpen]);
   const latestTurnSettled = isLatestTurnSettled(activeLatestTurn, activeThread?.session ?? null);
   const activeProject = useProjectById(activeThread?.projectId);
+  const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
+    useTurnDiffSummaries(activeThread);
 
   const openPullRequestDialog = useCallback(
     (reference?: string) => {
@@ -1121,6 +1124,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
     threadError: activeThread?.error,
   });
   const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const composerShowsRunningState = shouldShowComposerRunningState({
+    phase,
+    latestTurn: activeLatestTurn,
+    turnDiffSummaries,
+  });
   const nowIso = new Date(nowTick).toISOString();
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
@@ -1137,7 +1145,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     if (activePendingProgress) {
       return `pending:${activePendingProgress.questionIndex}:${activePendingProgress.isLastQuestion}:${activePendingIsResponding}`;
     }
-    if (phase === "running") {
+    if (composerShowsRunningState) {
       return "running";
     }
     if (showPlanFollowUpPrompt) {
@@ -1148,10 +1156,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
     activePendingIsResponding,
     activePendingProgress,
     composerSendState.hasSendableContent,
+    composerShowsRunningState,
     isConnecting,
     isPreparingWorktree,
     isSendBusy,
-    phase,
     prompt,
     showPlanFollowUpPrompt,
   ]);
@@ -1318,8 +1326,6 @@ export default function ChatView({ threadId }: ChatViewProps) {
       deriveTimelineEntries(timelineMessages, activeThread?.proposedPlans ?? [], workLogEntries),
     [activeThread?.proposedPlans, timelineMessages, workLogEntries],
   );
-  const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
-    useTurnDiffSummaries(activeThread);
   const turnDiffSummaryByAssistantMessageId = useMemo(() => {
     const byMessageId = new Map<MessageId, TurnDiffSummary>();
     for (const summary of turnDiffSummaries) {
@@ -4382,7 +4388,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
                                 }
                               : null
                           }
-                          isRunning={phase === "running"}
+                          isRunning={composerShowsRunningState}
                           showPlanFollowUpPrompt={
                             pendingUserInputs.length === 0 && showPlanFollowUpPrompt
                           }


### PR DESCRIPTION
## Root cause

The stale send-spinner symptom is local to the composer, but the session lifecycle is not.

Today the composer stop/running state is driven by `phase === "running"`, which comes from the thread session state. In stale cases, that session state can remain `running` after the latest turn is actually done, so the composer keeps showing the stop state and blocks the next send.

However, `latestTurn.completedAt` is not a safe global replacement for running state. That was the core mistake in `#1700`: assistant completion can happen before the turn is fully settled. `#1704` reverted that broader semantic change because it overcompensated for legitimate running cases. The earlier discussion in `#1393` also correctly identified that follow-up sends and delayed turn-start windows must not clear busy state early.

## Why `#1700` regressed behavior

`#1700` changed shared running semantics by treating a completed `latestTurn` as no longer running, and then reused that across the composer spinner/stop button, footer layout, auto-scroll, and timer behavior.

That was too broad. It made the composer stop showing running state as soon as `latestTurn.completedAt` existed, including cases where assistant output had finished but the turn itself was still legitimately running.

## Why this fix is narrower and safer

This change leaves shared session semantics alone:

- no change to `derivePhase`
- no change to `isLatestTurnSettled`
- no change to broader `Working` / running indicators outside the composer

Instead, it narrows the stale-spinner recovery to the composer primary action only. The composer now stops showing the running/stop state only when:

- the session still says `running`, and
- the latest turn has completed, and
- that same turn already has a finalized checkpoint / turn-diff summary

That final checkpoint is a stronger proof of true turn settlement than `latestTurn.completedAt` alone, because it occurs downstream of full turn completion. This preserves the legitimate-running case that `#1700` broke while still recovering the stale composer state when the session lags behind.

## Exact verification performed

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --cwd apps/web test src/components/ChatView.logic.test.ts`
- `bun run --cwd apps/web test src/session-logic.test.ts`
- `bun run --cwd apps/web test:browser src/components/ChatView.browser.tsx`

## Regression scenarios covered

- stale spinner after a completed turn:
  - browser test covers a `running` session whose latest turn already has a finalized checkpoint; composer returns to send state instead of staying on stop
- legitimately running session must still show running state:
  - browser test covers a `running` session with assistant completion but without a finalized checkpoint; composer still shows stop/running
- follow-up send must not prematurely clear busy state:
  - browser test covers a completed prior turn followed by a delayed `thread.turn.start`; composer stays in `Sending`
- long pre-send / delayed turn-start behavior:
  - covered by the delayed `thread.turn.start` browser case and existing local-dispatch logic tests


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale send spinner by narrowing composer running state to session phase and checkpoint presence
> - Adds `shouldShowComposerRunningState` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/1706/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to determine composer running state based on session phase, latest turn completion, and presence of a finalized checkpoint summary for that turn.
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1706/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to use this function so the Stop button is only shown while the session is running and the latest turn either has no `completedAt` or lacks a finalized checkpoint; otherwise the Send button is restored.
> - Behavioral Change: previously the composer stayed in running/stop state as long as `phase === "running"`; now it reverts to idle/send once a finalized checkpoint exists for the latest turn, even if the session is still running.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1228dab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->