### PR TITLE
Show full command details in approval request panel

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -12,6 +12,7 @@ import {
   CodexAppServerManager,
   classifyCodexStderrLine,
   isRecoverableThreadResumeError,
+  mapCodexRuntimeMode,
   normalizeCodexModelSlug,
   readCodexAccountSnapshot,
   resolveCodexModelForAccount,
@@ -369,6 +370,13 @@ describe("resolveCodexModelForAccount", () => {
 });
 
 describe("startSession", () => {
+  it("maps approval-required runtime mode to untrusted Codex approvals", () => {
+    expect(mapCodexRuntimeMode("approval-required")).toEqual({
+      approvalPolicy: "untrusted",
+      sandbox: "workspace-write",
+    });
+  });
+
   it("enables Codex experimental api capabilities during initialize", () => {
     expect(buildCodexInitializeParams()).toEqual({
       clientInfo: {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -289,13 +289,13 @@ The \`request_user_input\` tool is unavailable in Default mode. If you call it w
 In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
 </collaboration_mode>`;
 
-function mapCodexRuntimeMode(runtimeMode: RuntimeMode): {
-  readonly approvalPolicy: "on-request" | "never";
+export function mapCodexRuntimeMode(runtimeMode: RuntimeMode): {
+  readonly approvalPolicy: "untrusted" | "never";
   readonly sandbox: "workspace-write" | "danger-full-access";
 } {
   if (runtimeMode === "approval-required") {
     return {
-      approvalPolicy: "on-request",
+      approvalPolicy: "untrusted",
       sandbox: "workspace-write",
     };
   }

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1638,6 +1638,14 @@ describe("ProviderRuntimeIngestion", () => {
   it("maps canonical request events into approval activities with requestKind", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();
+    const detail = [
+      `/bin/zsh -lc "printf 'command line 1\\n'"`,
+      `printf 'command line 2\\n'`,
+      `printf 'command line 3\\n'`,
+      `printf 'command line 4\\n'`,
+      `printf 'command line 5\\n'`,
+      `printf 'command line 6\\n'"`,
+    ].join("\n");
 
     harness.emit({
       type: "request.opened",
@@ -1648,7 +1656,7 @@ describe("ProviderRuntimeIngestion", () => {
       requestId: ApprovalRequestId.makeUnsafe("req-open"),
       payload: {
         requestType: "command_execution_approval",
-        detail: "pwd",
+        detail,
       },
     });
 
@@ -1689,6 +1697,7 @@ describe("ProviderRuntimeIngestion", () => {
         : undefined;
     expect(requestedPayload?.requestKind).toBe("command");
     expect(requestedPayload?.requestType).toBe("command_execution_approval");
+    expect(requestedPayload?.detail).toBe(detail);
 
     const resolved = thread?.activities.find(
       (activity: ProviderRuntimeTestActivity) => activity.id === "evt-request-resolved",

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -191,7 +191,7 @@ function runtimeEventToActivities(
             requestId: toApprovalRequestId(event.requestId),
             ...(requestKind ? { requestKind } : {}),
             requestType: event.payload.requestType,
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.detail ? { detail: event.payload.detail } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1623,27 +1623,33 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
 
     if (event.type === "content_block_start") {
       const { index, content_block: block } = event;
-      if (block.type === "text") {
+      const blockType = (block as { type?: string }).type;
+      if (blockType === "text") {
         yield* ensureAssistantTextBlock(context, index, {
           fallbackText: extractContentBlockText(block),
         });
         return;
       }
       if (
-        block.type !== "tool_use" &&
-        block.type !== "server_tool_use" &&
-        block.type !== "mcp_tool_use"
+        blockType !== "tool_use" &&
+        blockType !== "server_tool_use" &&
+        blockType !== "mcp_tool_use"
       ) {
         return;
       }
 
-      const toolName = block.name;
+      const toolBlock = block as {
+        readonly id: string;
+        readonly name: string;
+        readonly input?: unknown;
+      };
+      const toolName = toolBlock.name;
       const itemType = classifyToolItemType(toolName);
       const toolInput =
-        typeof block.input === "object" && block.input !== null
-          ? (block.input as Record<string, unknown>)
+        typeof toolBlock.input === "object" && toolBlock.input !== null
+          ? (toolBlock.input as Record<string, unknown>)
           : {};
-      const itemId = block.id;
+      const itemId = toolBlock.id;
       const detail = summarizeToolRequest(toolName, toolInput);
       const inputFingerprint =
         Object.keys(toolInput).length > 0 ? toolInputFingerprint(toolInput) : undefined;

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4163,39 +4163,30 @@ export default function ChatView({ threadId }: ChatViewProps) {
                           ))}
                         </div>
                       )}
-                    <ComposerPromptEditor
-                      ref={composerEditorRef}
-                      value={
-                        isComposerApprovalState
-                          ? ""
-                          : activePendingProgress
-                            ? activePendingProgress.customAnswer
-                            : prompt
-                      }
-                      cursor={composerCursor}
-                      terminalContexts={
-                        !isComposerApprovalState && pendingUserInputs.length === 0
-                          ? composerTerminalContexts
-                          : []
-                      }
-                      onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
-                      onChange={onPromptChange}
-                      onCommandKeyDown={onComposerCommandKey}
-                      onPaste={onComposerPaste}
-                      placeholder={
-                        isComposerApprovalState
-                          ? (activePendingApproval?.detail ??
-                            "Resolve this approval request to continue")
-                          : activePendingProgress
+                    {!isComposerApprovalState ? (
+                      <ComposerPromptEditor
+                        ref={composerEditorRef}
+                        value={activePendingProgress ? activePendingProgress.customAnswer : prompt}
+                        cursor={composerCursor}
+                        terminalContexts={
+                          pendingUserInputs.length === 0 ? composerTerminalContexts : []
+                        }
+                        onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
+                        onChange={onPromptChange}
+                        onCommandKeyDown={onComposerCommandKey}
+                        onPaste={onComposerPaste}
+                        placeholder={
+                          activePendingProgress
                             ? "Type your own answer, or leave this blank to use the selected option"
                             : showPlanFollowUpPrompt && activeProposedPlan
                               ? "Add feedback to refine the plan, or leave this blank to implement it"
                               : phase === "disconnected"
                                 ? "Ask for follow-up changes or attach images"
                                 : "Ask anything, @tag files/folders, or use / to show available commands"
-                      }
-                      disabled={isConnecting || isComposerApprovalState}
-                    />
+                        }
+                        disabled={isConnecting}
+                      />
+                    ) : null}
                   </div>
 
                   {/* Bottom toolbar */}

--- a/apps/web/src/components/chat/ComposerPendingApprovalPanel.test.tsx
+++ b/apps/web/src/components/chat/ComposerPendingApprovalPanel.test.tsx
@@ -1,0 +1,44 @@
+import { ApprovalRequestId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ComposerPendingApprovalPanel } from "./ComposerPendingApprovalPanel";
+
+describe("ComposerPendingApprovalPanel", () => {
+  it("renders command approval details when provided", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerPendingApprovalPanel
+        approval={{
+          requestId: ApprovalRequestId.makeUnsafe("approval-1"),
+          requestKind: "command",
+          createdAt: "2026-04-03T00:00:00.000Z",
+          detail: "/bin/zsh -lc \"printf 'command line 1\\n'\"",
+        }}
+        pendingCount={2}
+      />,
+    );
+
+    expect(markup).toContain("PENDING APPROVAL");
+    expect(markup).toContain("Command approval requested");
+    expect(markup).toContain("1/2");
+    expect(markup).toContain("Details");
+    expect(markup).toContain("/bin/zsh -lc");
+    expect(markup).toContain("whitespace-pre-wrap");
+  });
+
+  it("omits the details section when no approval detail exists", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerPendingApprovalPanel
+        approval={{
+          requestId: ApprovalRequestId.makeUnsafe("approval-2"),
+          requestKind: "file-read",
+          createdAt: "2026-04-03T00:00:00.000Z",
+        }}
+        pendingCount={1}
+      />,
+    );
+
+    expect(markup).toContain("File-read approval requested");
+    expect(markup).not.toContain("Details");
+  });
+});

--- a/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingApprovalPanel.tsx
@@ -16,6 +16,7 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
       : approval.requestKind === "file-read"
         ? "File-read approval requested"
         : "File-change approval requested";
+  const approvalDetail = approval.detail?.trim() ?? "";
 
   return (
     <div className="px-4 py-3.5 sm:px-5 sm:py-4">
@@ -26,6 +27,19 @@ export const ComposerPendingApprovalPanel = memo(function ComposerPendingApprova
           <span className="text-xs text-muted-foreground">1/{pendingCount}</span>
         ) : null}
       </div>
+      {approvalDetail.length > 0 ? (
+        <div className="mt-2 rounded-xl border border-border/60 bg-background/80 px-3 py-2">
+          <p className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground/80">
+            Details
+          </p>
+          <pre
+            className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap break-all font-mono text-[11px] leading-relaxed text-foreground/85"
+            title={approvalDetail}
+          >
+            {approvalDetail}
+          </pre>
+        </div>
+      ) : null}
     </div>
   );
 });


### PR DESCRIPTION
## Summary
- render the full approval command in the pending approval panel
- preserve full approval request detail payloads instead of truncating them
- require Codex supervised sessions to surface untrusted command approvals
- hide the duplicate disabled composer content while approval is pending

## Problem
The approval request UI only exposed a truncated command, which made long commands impossible to inspect before approving. In supervised Codex sessions, the runtime policy could also avoid surfacing the approval controls for commands that should have required review. Once the full details were shown in the panel, the disabled composer underneath also duplicated the same command text.

## Testing
- bun fmt
- bun lint
- bun typecheck
- cd apps/web && bun run test src/components/chat/ComposerPendingApprovalPanel.test.tsx
- cd apps/server && bun run test src/orchestration/Layers/ProviderRuntimeIngestion.test.ts src/codexAppServerManager.test.ts

Closes #1534

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how supervised Codex sessions request approvals (switching to `approvalPolicy: "untrusted"`) and stops truncating approval `detail`, which could affect safety/UX and payload sizes.
> 
> **Overview**
> Improves approval UX by **preserving and displaying full approval request details** (e.g. full multi-line command strings) instead of truncating them, with updated ingestion and test coverage.
> 
> Adjusts Codex supervised sessions so `runtimeMode: "approval-required"` maps to `approvalPolicy: "untrusted"` (workspace-write sandbox), ensuring command approvals surface as expected.
> 
> Cleans up the chat composer during pending approvals by hiding the duplicate disabled editor, and adds `ComposerPendingApprovalPanel` rendering tests for the new details section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d966da8dfaa5755eb88ed9c68f8e9f1af03d1ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show full command details in the approval request panel
> - The `ComposerPendingApprovalPanel` now renders a scrollable `Details` section showing the full `approval.detail` string (trimmed, in a `pre` block) when present.
> - The composer input editor is hidden entirely during approval state instead of being shown as disabled with a placeholder.
> - `runtimeEventToActivities` passes through the full detail string without truncation for `approval.requested` activities.
> - `mapCodexRuntimeMode` now maps `approval-required` runtime mode to `approvalPolicy: 'untrusted'` instead of `'on-request'`.
> - Behavioral Change: the `approvalPolicy` change may affect downstream permission checks for sessions using `approval-required` mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d966da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->