### PR TITLE
Fix chat replay recovery during WebSocket reconnect (resubscribe)

### DIFF
--- a/apps/web/src/orchestrationRecovery.ts
+++ b/apps/web/src/orchestrationRecovery.ts
@@ -1,4 +1,8 @@
-export type OrchestrationRecoveryReason = "bootstrap" | "sequence-gap" | "replay-failed";
+export type OrchestrationRecoveryReason =
+  | "bootstrap"
+  | "sequence-gap"
+  | "resubscribe"
+  | "replay-failed";
 
 export interface OrchestrationRecoveryPhase {
   kind: "snapshot" | "replay";

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -488,7 +488,7 @@ function EventRouter() {
     const fallbackToSnapshotRecovery = async (): Promise<void> => {
       await runSnapshotRecovery("replay-failed");
     };
-    const unsubDomainEvent = getWsRpcClient().orchestration.onDomainEvent(
+    const unsubDomainEvent = api.orchestration.onDomainEvent(
       (event) => {
         const action = recovery.classifyDomainEvent(event.sequence);
         if (action === "apply") {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -423,8 +423,8 @@ function EventRouter() {
       queueMicrotask(flushPendingDomainEvents);
     };
 
-    const recoverFromSequenceGap = async (): Promise<void> => {
-      if (!recovery.beginReplayRecovery("sequence-gap")) {
+    const runReplayRecovery = async (reason: "sequence-gap" | "resubscribe"): Promise<void> => {
+      if (!recovery.beginReplayRecovery(reason)) {
         return;
       }
 
@@ -441,7 +441,7 @@ function EventRouter() {
       }
 
       if (!disposed && recovery.completeReplayRecovery()) {
-        void recoverFromSequenceGap();
+        void runReplayRecovery(reason);
       }
     };
 
@@ -471,7 +471,7 @@ function EventRouter() {
           syncServerReadModel(snapshot);
           reconcileSnapshotDerivedState();
           if (recovery.completeSnapshotRecovery(snapshot.snapshotSequence)) {
-            void recoverFromSequenceGap();
+            void runReplayRecovery("sequence-gap");
           }
         }
       } catch {
@@ -488,18 +488,29 @@ function EventRouter() {
     const fallbackToSnapshotRecovery = async (): Promise<void> => {
       await runSnapshotRecovery("replay-failed");
     };
-    const unsubDomainEvent = api.orchestration.onDomainEvent((event) => {
-      const action = recovery.classifyDomainEvent(event.sequence);
-      if (action === "apply") {
-        pendingDomainEvents.push(event);
-        schedulePendingDomainEventFlush();
-        return;
-      }
-      if (action === "recover") {
-        flushPendingDomainEvents();
-        void recoverFromSequenceGap();
-      }
-    });
+    const unsubDomainEvent = getWsRpcClient().orchestration.onDomainEvent(
+      (event) => {
+        const action = recovery.classifyDomainEvent(event.sequence);
+        if (action === "apply") {
+          pendingDomainEvents.push(event);
+          schedulePendingDomainEventFlush();
+          return;
+        }
+        if (action === "recover") {
+          flushPendingDomainEvents();
+          void runReplayRecovery("sequence-gap");
+        }
+      },
+      {
+        onResubscribe: () => {
+          if (disposed) {
+            return;
+          }
+          flushPendingDomainEvents();
+          void runReplayRecovery("resubscribe");
+        },
+      },
+    );
     const unsubTerminalEvent = api.terminal.onEvent((event) => {
       const thread = useStore.getState().threads.find((entry) => entry.id === event.threadId);
       if (thread && thread.archivedAt !== null) {

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -243,6 +243,20 @@ describe("wsNativeApi", () => {
     expect(onDomainEvent).toHaveBeenCalledWith(orchestrationEvent);
   });
 
+  it("forwards orchestration stream subscription options to the RPC client", async () => {
+    const { createWsNativeApi } = await import("./wsNativeApi");
+
+    const api = createWsNativeApi();
+    const onDomainEvent = vi.fn();
+    const onResubscribe = vi.fn();
+
+    api.orchestration.onDomainEvent(onDomainEvent, { onResubscribe });
+
+    expect(rpcClientMock.orchestration.onDomainEvent).toHaveBeenCalledWith(onDomainEvent, {
+      onResubscribe,
+    });
+  });
+
   it("sends orchestration dispatch commands as the direct RPC payload", async () => {
     rpcClientMock.orchestration.dispatchCommand.mockResolvedValue({ sequence: 1 });
     const { createWsNativeApi } = await import("./wsNativeApi");

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -98,7 +98,8 @@ export function createWsNativeApi(): NativeApi {
         rpcClient.orchestration
           .replayEvents({ fromSequenceExclusive })
           .then((events) => [...events]),
-      onDomainEvent: (callback) => rpcClient.orchestration.onDomainEvent(callback),
+      onDomainEvent: (callback, options) =>
+        rpcClient.orchestration.onDomainEvent(callback, options),
     },
   };
 

--- a/apps/web/src/wsRpcClient.ts
+++ b/apps/web/src/wsRpcClient.ts
@@ -16,6 +16,10 @@ type RpcTag = keyof WsRpcProtocolClient & string;
 type RpcMethod<TTag extends RpcTag> = WsRpcProtocolClient[TTag];
 type RpcInput<TTag extends RpcTag> = Parameters<RpcMethod<TTag>>[0];
 
+interface StreamSubscriptionOptions {
+  readonly onResubscribe?: () => void;
+}
+
 type RpcUnaryMethod<TTag extends RpcTag> =
   RpcMethod<TTag> extends (input: any, options?: any) => Effect.Effect<infer TSuccess, any, any>
     ? (input: RpcInput<TTag>) => Promise<TSuccess>
@@ -28,7 +32,7 @@ type RpcUnaryNoArgMethod<TTag extends RpcTag> =
 
 type RpcStreamMethod<TTag extends RpcTag> =
   RpcMethod<TTag> extends (input: any, options?: any) => Stream.Stream<infer TEvent, any, any>
-    ? (listener: (event: TEvent) => void) => () => void
+    ? (listener: (event: TEvent) => void, options?: StreamSubscriptionOptions) => () => void
     : never;
 
 interface GitRunStackedActionOptions {
@@ -120,8 +124,12 @@ export function createWsRpcClient(transport = new WsTransport()): WsRpcClient {
       clear: (input) => transport.request((client) => client[WS_METHODS.terminalClear](input)),
       restart: (input) => transport.request((client) => client[WS_METHODS.terminalRestart](input)),
       close: (input) => transport.request((client) => client[WS_METHODS.terminalClose](input)),
-      onEvent: (listener) =>
-        transport.subscribe((client) => client[WS_METHODS.subscribeTerminalEvents]({}), listener),
+      onEvent: (listener, options) =>
+        transport.subscribe(
+          (client) => client[WS_METHODS.subscribeTerminalEvents]({}),
+          listener,
+          options,
+        ),
     },
     projects: {
       searchEntries: (input) =>
@@ -179,10 +187,18 @@ export function createWsRpcClient(transport = new WsTransport()): WsRpcClient {
       getSettings: () => transport.request((client) => client[WS_METHODS.serverGetSettings]({})),
       updateSettings: (patch) =>
         transport.request((client) => client[WS_METHODS.serverUpdateSettings]({ patch })),
-      subscribeConfig: (listener) =>
-        transport.subscribe((client) => client[WS_METHODS.subscribeServerConfig]({}), listener),
-      subscribeLifecycle: (listener) =>
-        transport.subscribe((client) => client[WS_METHODS.subscribeServerLifecycle]({}), listener),
+      subscribeConfig: (listener, options) =>
+        transport.subscribe(
+          (client) => client[WS_METHODS.subscribeServerConfig]({}),
+          listener,
+          options,
+        ),
+      subscribeLifecycle: (listener, options) =>
+        transport.subscribe(
+          (client) => client[WS_METHODS.subscribeServerLifecycle]({}),
+          listener,
+          options,
+        ),
     },
     orchestration: {
       getSnapshot: () =>
@@ -197,10 +213,11 @@ export function createWsRpcClient(transport = new WsTransport()): WsRpcClient {
         transport
           .request((client) => client[ORCHESTRATION_WS_METHODS.replayEvents](input))
           .then((events) => [...events]),
-      onDomainEvent: (listener) =>
+      onDomainEvent: (listener, options) =>
         transport.subscribe(
           (client) => client[WS_METHODS.subscribeOrchestrationDomainEvents]({}),
           listener,
+          options,
         ),
     },
   };

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -250,10 +250,12 @@ describe("WsTransport", () => {
   it("re-subscribes stream listeners after the stream exits", async () => {
     const transport = new WsTransport("ws://localhost:3020");
     const listener = vi.fn();
+    const onResubscribe = vi.fn();
 
     const unsubscribe = transport.subscribe(
       (client) => client[WS_METHODS.subscribeServerLifecycle]({}),
       listener,
+      { onResubscribe },
     );
     await waitFor(() => {
       expect(sockets).toHaveLength(1);
@@ -301,6 +303,7 @@ describe("WsTransport", () => {
         .find((message) => message._tag === "Request" && message.id !== firstRequest.id);
       expect(nextRequest).toBeDefined();
     });
+    expect(onResubscribe).toHaveBeenCalledOnce();
 
     const secondRequest = socket.sent
       .map((message) => JSON.parse(message) as { _tag?: string; id?: string; tag?: string })

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -342,6 +342,52 @@ describe("WsTransport", () => {
     await transport.dispose();
   });
 
+  it("does not fire onResubscribe when the first stream attempt exits before any value", async () => {
+    const transport = new WsTransport("ws://localhost:3020");
+    const listener = vi.fn();
+    const onResubscribe = vi.fn();
+
+    const unsubscribe = transport.subscribe(
+      (client) => client[WS_METHODS.subscribeServerLifecycle]({}),
+      listener,
+      { onResubscribe },
+    );
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    const socket = getSocket();
+    socket.open();
+
+    await waitFor(() => {
+      expect(socket.sent).toHaveLength(1);
+    });
+
+    const firstRequest = JSON.parse(socket.sent[0] ?? "{}") as { id: string };
+    socket.serverMessage(
+      JSON.stringify({
+        _tag: "Exit",
+        requestId: firstRequest.id,
+        exit: {
+          _tag: "Success",
+          value: null,
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      const nextRequest = socket.sent
+        .map((message) => JSON.parse(message) as { _tag?: string; id?: string })
+        .find((message) => message._tag === "Request" && message.id !== firstRequest.id);
+      expect(nextRequest).toBeDefined();
+    });
+    expect(onResubscribe).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+    await transport.dispose();
+  });
+
   it("streams finite request events without re-subscribing", async () => {
     const transport = new WsTransport("ws://localhost:3020");
     const listener = vi.fn();

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -83,12 +83,11 @@ export class WsTransport {
     }
 
     let active = true;
-    let firstAttempt = true;
+    let hasReceivedValue = false;
     const retryDelayMs = options?.retryDelay ?? DEFAULT_SUBSCRIPTION_RETRY_DELAY_MS;
     const cancel = this.runtime.runCallback(
       Effect.sync(() => {
-        if (firstAttempt) {
-          firstAttempt = false;
+        if (!hasReceivedValue) {
           return;
         }
         try {
@@ -104,6 +103,7 @@ export class WsTransport {
               if (!active) {
                 return;
               }
+              hasReceivedValue = true;
               try {
                 listener(value);
               } catch {

--- a/apps/web/src/wsTransport.ts
+++ b/apps/web/src/wsTransport.ts
@@ -9,6 +9,7 @@ import { RpcClient } from "effect/unstable/rpc";
 
 interface SubscribeOptions {
   readonly retryDelay?: Duration.Input;
+  readonly onResubscribe?: () => void;
 }
 
 interface RequestOptions {
@@ -82,9 +83,21 @@ export class WsTransport {
     }
 
     let active = true;
+    let firstAttempt = true;
     const retryDelayMs = options?.retryDelay ?? DEFAULT_SUBSCRIPTION_RETRY_DELAY_MS;
     const cancel = this.runtime.runCallback(
-      Effect.promise(() => this.clientPromise).pipe(
+      Effect.sync(() => {
+        if (firstAttempt) {
+          firstAttempt = false;
+          return;
+        }
+        try {
+          options?.onResubscribe?.();
+        } catch {
+          // Swallow reconnect hook errors so the stream can recover.
+        }
+      }).pipe(
+        Effect.andThen(Effect.promise(() => this.clientPromise)),
         Effect.flatMap((client) =>
           Stream.runForEach(connect(client), (value) =>
             Effect.sync(() => {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -180,6 +180,11 @@ export interface NativeApi {
       input: OrchestrationGetFullThreadDiffInput,
     ) => Promise<OrchestrationGetFullThreadDiffResult>;
     replayEvents: (fromSequenceExclusive: number) => Promise<OrchestrationEvent[]>;
-    onDomainEvent: (callback: (event: OrchestrationEvent) => void) => () => void;
+    onDomainEvent: (
+      callback: (event: OrchestrationEvent) => void,
+      options?: {
+        onResubscribe?: () => void;
+      },
+    ) => () => void;
   };
 }


### PR DESCRIPTION
## Why

If t3code web is served over an unstable and frequent-reconnect network, there was a problem in chat replay recovery where the UI could stay stale until a manual refresh.

This change starts replay recovery on WebSocket resubscribe so missed chat/orchestration events are recovered as soon as the stream comes back.

## What Changed

This fixes a blind spot in chat replay recovery after WebSocket interruption.

The client already handled sequence gaps and snapshot fallback for orchestration events, but it only recovered missed events when a later domain event arrived and exposed the gap. If the WebSocket dropped, the client missed the last chat/orchestration events, and the thread then went quiet, the UI could stay stale until a manual refresh.

This change adds reconnect-aware replay on orchestration stream re-subscribe so the client asks for missed events as soon as the stream is re-established.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the WebSocket subscription/retry path and orchestration recovery flow; incorrect resubscribe signaling could cause redundant replays or missed updates, but changes are scoped and covered by new tests.
> 
> **Overview**
> Ensures orchestration/chat state catches up immediately after a WebSocket reconnect by triggering replay recovery on stream *resubscribe* (new recovery reason `"resubscribe"`).
> 
> Adds an optional `onResubscribe` callback plumbed through contracts (`NativeApi`), `wsNativeApi`, `WsRpcClient`, and `WsTransport.subscribe`, with `WsTransport` only firing the hook after the stream has emitted at least one value; updates and extends tests to verify option forwarding and correct hook behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fbb5880b3c4ba397d14b206dd2cff5604a9d0d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix chat replay recovery during WebSocket reconnect by triggering resubscribe recovery
> - Adds `onResubscribe` callback support to `WsTransport.subscribe`, invoked on reconnection after at least one value has been received; errors are swallowed so recovery proceeds.
> - Propagates `onResubscribe` through the RPC client stream methods and up to the `NativeApi.orchestration.onDomainEvent` contract.
> - In the `EventRouter` component, the `onResubscribe` handler flushes pending domain events and triggers replay recovery with the new `'resubscribe'` reason, mirroring the existing `'sequence-gap'` path.
> - Adds `'resubscribe'` as a valid `OrchestrationRecoveryReason` and refactors sequence-gap recovery into a shared `runReplayRecovery(reason)` function.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9fbb588.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->