### PR TITLE
feat(cli): allow optional positional cwd argument

### DIFF
--- a/apps/server/src/cli-config.test.ts
+++ b/apps/server/src/cli-config.test.ts
@@ -40,6 +40,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           port: Option.none(),
           host: Option.none(),
           baseDir: Option.none(),
+          cwd: Option.none(),
           devUrl: Option.none(),
           noBrowser: Option.none(),
           authToken: Option.none(),
@@ -102,6 +103,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           port: Option.some(8788),
           host: Option.some("127.0.0.1"),
           baseDir: Option.some(baseDir),
+          cwd: Option.none(),
           devUrl: Option.some(new URL("http://127.0.0.1:4173")),
           noBrowser: Option.some(true),
           authToken: Option.some("flag-token"),
@@ -178,6 +180,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           port: Option.none(),
           host: Option.none(),
           baseDir: Option.none(),
+          cwd: Option.none(),
           devUrl: Option.none(),
           noBrowser: Option.none(),
           authToken: Option.none(),
@@ -228,6 +231,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-cli-config-dirs-" });
+      const customCwd = path.join(baseDir, "nested", "project");
 
       const resolved = yield* resolveServerConfig(
         {
@@ -235,6 +239,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           port: Option.some(4888),
           host: Option.none(),
           baseDir: Option.some(baseDir),
+          cwd: Option.some(customCwd),
           devUrl: Option.some(new URL("http://127.0.0.1:5173")),
           noBrowser: Option.none(),
           authToken: Option.none(),
@@ -253,6 +258,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
       );
 
       for (const directory of [
+        customCwd,
         resolved.stateDir,
         resolved.logsDir,
         resolved.providerLogsDir,
@@ -264,6 +270,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
       ]) {
         expect(yield* fs.exists(directory)).toBe(true);
       }
+      expect(resolved.cwd).toBe(path.resolve(customCwd));
     }),
   );
 
@@ -290,6 +297,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           port: Option.some(8788),
           host: Option.some("127.0.0.1"),
           baseDir: Option.none(),
+          cwd: Option.none(),
           devUrl: Option.some(new URL("http://127.0.0.1:4173")),
           noBrowser: Option.none(),
           authToken: Option.some("flag-token"),
@@ -360,6 +368,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           port: Option.some(4888),
           host: Option.none(),
           baseDir: Option.some(baseDir),
+          cwd: Option.none(),
           devUrl: Option.none(),
           noBrowser: Option.none(),
           authToken: Option.none(),

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -1,7 +1,7 @@
 import { NetService } from "@t3tools/shared/Net";
 import { parsePersistedServerObservabilitySettings } from "@t3tools/shared/serverSettings";
 import { Config, Effect, FileSystem, LogLevel, Option, Path, Schema } from "effect";
-import { Command, Flag, GlobalFlag } from "effect/unstable/cli";
+import { Argument, Command, Flag, GlobalFlag } from "effect/unstable/cli";
 
 import {
   DEFAULT_PORT,
@@ -13,7 +13,7 @@ import {
   type ServerConfigShape,
 } from "./config";
 import { readBootstrapEnvelope } from "./bootstrap";
-import { resolveBaseDir } from "./os-jank";
+import { expandHomePath, resolveBaseDir } from "./os-jank";
 import { runServer } from "./server";
 
 const PortSchema = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65535 }));
@@ -140,6 +140,7 @@ interface CliServerFlags {
   readonly port: Option.Option<number>;
   readonly host: Option.Option<string>;
   readonly baseDir: Option.Option<string>;
+  readonly cwd: Option.Option<string>;
   readonly devUrl: Option.Option<URL>;
   readonly noBrowser: Option.Option<boolean>;
   readonly authToken: Option.Option<string>;
@@ -225,6 +226,9 @@ export const resolveServerConfig = (
         ),
       ),
     );
+    const rawCwd = Option.getOrElse(flags.cwd, () => process.cwd());
+    const cwd = path.resolve(yield* expandHomePath(rawCwd.trim()));
+    yield* fs.makeDirectory(cwd, { recursive: true });
     const derivedPaths = yield* deriveServerPaths(baseDir, devUrl);
     yield* ensureServerDirectories(derivedPaths);
     const persistedObservabilitySettings = yield* loadPersistedObservabilitySettings(
@@ -315,7 +319,7 @@ export const resolveServerConfig = (
       otlpServiceName: env.otlpServiceName,
       mode,
       port,
-      cwd: process.cwd(),
+      cwd,
       baseDir,
       ...derivedPaths,
       serverTracePath,
@@ -336,6 +340,12 @@ const commandFlags = {
   port: portFlag,
   host: hostFlag,
   baseDir: baseDirFlag,
+  cwd: Argument.string("cwd").pipe(
+    Argument.withDescription(
+      "Working directory for provider sessions (defaults to the current directory).",
+    ),
+    Argument.optional,
+  ),
   devUrl: devUrlFlag,
   noBrowser: noBrowserFlag,
   authToken: authTokenFlag,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

- Added an optional positional `cwd` argument to the `t3` CLI command.
- Updated server config resolution to use the provided positional cwd when present, otherwise fallback to `process.cwd()`.
- Normalized the cwd via home expansion + absolute resolution, and ensured the target cwd directory is created recursively if it does not exist.
- Updated CLI config tests to include the new argument shape and verify custom cwd directory creation behavior.

## Why

The CLI previously always hardcoded `cwd` to `process.cwd()`, which prevented commands like `npx t3 ~/Developer/my-project` from targeting a specific project directory. This change enables explicit cwd selection while preserving existing default behavior and ensuring missing directories are upserted automatically.

## Testing

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --cwd apps/server test src/cli-config.test.ts src/cli.test.ts`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bba96371-60b1-48a8-84cf-2277026065ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bba96371-60b1-48a8-84cf-2277026065ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional positional `cwd` argument to the server CLI
> - The CLI now accepts an optional positional argument `cwd` to set the working directory for provider sessions, defined in [cli.ts](https://github.com/pingdotgg/t3code/pull/1727/files#diff-ebe406c489ea6e309f8e44473904187f2bc2b18465b1f6e8d4da94c07c829197).
> - `resolveServerConfig` expands home directory tokens, resolves the path to absolute, and creates the directory recursively if it does not exist; previously `config.cwd` was always `process.cwd()`.
> - Behavioral Change: when `cwd` is provided, the resolved config's `cwd` reflects the supplied path rather than the process working directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0acaf5d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->