### PR TITLE
Return replay retry state from orchestration recovery

### DIFF
--- a/apps/web/src/orchestrationRecovery.test.ts
+++ b/apps/web/src/orchestrationRecovery.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { createOrchestrationRecoveryCoordinator } from "./orchestrationRecovery";
+import {
+  createOrchestrationRecoveryCoordinator,
+  deriveReplayRetryDecision,
+} from "./orchestrationRecovery";
 
 describe("createOrchestrationRecoveryCoordinator", () => {
   it("defers live events until bootstrap completes and then requests replay", () => {
@@ -146,6 +149,157 @@ describe("createOrchestrationRecoveryCoordinator", () => {
       inFlight: {
         kind: "replay",
         reason: "sequence-gap",
+      },
+    });
+  });
+});
+
+describe("deriveReplayRetryDecision", () => {
+  it("retries immediately when replay made progress", () => {
+    expect(
+      deriveReplayRetryDecision({
+        previousTracker: {
+          attempts: 2,
+          latestSequence: 3,
+          highestObservedSequence: 5,
+        },
+        completion: {
+          replayMadeProgress: true,
+          shouldReplay: true,
+        },
+        recoveryState: {
+          latestSequence: 5,
+          highestObservedSequence: 5,
+        },
+        baseDelayMs: 100,
+        maxNoProgressRetries: 3,
+      }),
+    ).toEqual({
+      shouldRetry: true,
+      delayMs: 0,
+      tracker: null,
+    });
+  });
+
+  it("caps no-progress retries for the same frontier", () => {
+    const first = deriveReplayRetryDecision({
+      previousTracker: null,
+      completion: {
+        replayMadeProgress: false,
+        shouldReplay: true,
+      },
+      recoveryState: {
+        latestSequence: 3,
+        highestObservedSequence: 5,
+      },
+      baseDelayMs: 100,
+      maxNoProgressRetries: 3,
+    });
+
+    const second = deriveReplayRetryDecision({
+      previousTracker: first.tracker,
+      completion: {
+        replayMadeProgress: false,
+        shouldReplay: true,
+      },
+      recoveryState: {
+        latestSequence: 3,
+        highestObservedSequence: 5,
+      },
+      baseDelayMs: 100,
+      maxNoProgressRetries: 3,
+    });
+
+    const third = deriveReplayRetryDecision({
+      previousTracker: second.tracker,
+      completion: {
+        replayMadeProgress: false,
+        shouldReplay: true,
+      },
+      recoveryState: {
+        latestSequence: 3,
+        highestObservedSequence: 5,
+      },
+      baseDelayMs: 100,
+      maxNoProgressRetries: 3,
+    });
+
+    const fourth = deriveReplayRetryDecision({
+      previousTracker: third.tracker,
+      completion: {
+        replayMadeProgress: false,
+        shouldReplay: true,
+      },
+      recoveryState: {
+        latestSequence: 3,
+        highestObservedSequence: 5,
+      },
+      baseDelayMs: 100,
+      maxNoProgressRetries: 3,
+    });
+
+    expect(first).toEqual({
+      shouldRetry: true,
+      delayMs: 100,
+      tracker: {
+        attempts: 1,
+        latestSequence: 3,
+        highestObservedSequence: 5,
+      },
+    });
+    expect(second).toEqual({
+      shouldRetry: true,
+      delayMs: 200,
+      tracker: {
+        attempts: 2,
+        latestSequence: 3,
+        highestObservedSequence: 5,
+      },
+    });
+    expect(third).toEqual({
+      shouldRetry: true,
+      delayMs: 400,
+      tracker: {
+        attempts: 3,
+        latestSequence: 3,
+        highestObservedSequence: 5,
+      },
+    });
+    expect(fourth).toEqual({
+      shouldRetry: false,
+      delayMs: 0,
+      tracker: null,
+    });
+  });
+
+  it("resets the retry budget when the replay frontier changes", () => {
+    const exhausted = {
+      attempts: 3,
+      latestSequence: 3,
+      highestObservedSequence: 5,
+    };
+
+    expect(
+      deriveReplayRetryDecision({
+        previousTracker: exhausted,
+        completion: {
+          replayMadeProgress: false,
+          shouldReplay: true,
+        },
+        recoveryState: {
+          latestSequence: 3,
+          highestObservedSequence: 6,
+        },
+        baseDelayMs: 100,
+        maxNoProgressRetries: 3,
+      }),
+    ).toEqual({
+      shouldRetry: true,
+      delayMs: 100,
+      tracker: {
+        attempts: 1,
+        latestSequence: 3,
+        highestObservedSequence: 6,
       },
     });
   });

--- a/apps/web/src/orchestrationRecovery.ts
+++ b/apps/web/src/orchestrationRecovery.ts
@@ -18,7 +18,68 @@ export interface ReplayRecoveryCompletion {
   shouldReplay: boolean;
 }
 
+export interface ReplayRetryTracker {
+  attempts: number;
+  latestSequence: number;
+  highestObservedSequence: number;
+}
+
+export interface ReplayRetryDecision {
+  shouldRetry: boolean;
+  delayMs: number;
+  tracker: ReplayRetryTracker | null;
+}
+
 type SequencedEvent = Readonly<{ sequence: number }>;
+
+export function deriveReplayRetryDecision(input: {
+  previousTracker: ReplayRetryTracker | null;
+  completion: ReplayRecoveryCompletion;
+  recoveryState: Pick<OrchestrationRecoveryState, "latestSequence" | "highestObservedSequence">;
+  baseDelayMs: number;
+  maxNoProgressRetries: number;
+}): ReplayRetryDecision {
+  if (!input.completion.shouldReplay) {
+    return {
+      shouldRetry: false,
+      delayMs: 0,
+      tracker: null,
+    };
+  }
+
+  if (input.completion.replayMadeProgress) {
+    return {
+      shouldRetry: true,
+      delayMs: 0,
+      tracker: null,
+    };
+  }
+
+  const previousTracker = input.previousTracker;
+  const sameFrontier =
+    previousTracker !== null &&
+    previousTracker.latestSequence === input.recoveryState.latestSequence &&
+    previousTracker.highestObservedSequence === input.recoveryState.highestObservedSequence;
+
+  const attempts = sameFrontier && previousTracker !== null ? previousTracker.attempts + 1 : 1;
+  if (attempts > input.maxNoProgressRetries) {
+    return {
+      shouldRetry: false,
+      delayMs: 0,
+      tracker: null,
+    };
+  }
+
+  return {
+    shouldRetry: true,
+    delayMs: input.baseDelayMs * 2 ** (attempts - 1),
+    tracker: {
+      attempts,
+      latestSequence: input.recoveryState.latestSequence,
+      highestObservedSequence: input.recoveryState.highestObservedSequence,
+    },
+  };
+}
 
 export function createOrchestrationRecoveryCoordinator() {
   let state: OrchestrationRecoveryState = {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -43,6 +43,7 @@ import { projectQueryKeys } from "../lib/projectReactQuery";
 import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
 import { deriveOrchestrationBatchEffects } from "../orchestrationEventEffects";
 import { createOrchestrationRecoveryCoordinator } from "../orchestrationRecovery";
+import { deriveReplayRetryDecision } from "../orchestrationRecovery";
 import { getWsRpcClient } from "~/wsRpcClient";
 
 export const Route = createRootRouteWithContext<{
@@ -190,6 +191,7 @@ function coalesceOrchestrationUiEvents(
 }
 
 const REPLAY_RECOVERY_RETRY_DELAY_MS = 100;
+const MAX_NO_PROGRESS_REPLAY_RETRIES = 3;
 
 function ServerStateBootstrap() {
   useEffect(() => startServerStateSync(getWsRpcClient().server), []);
@@ -311,6 +313,7 @@ function EventRouter() {
     let disposed = false;
     disposedRef.current = false;
     const recovery = createOrchestrationRecoveryCoordinator();
+    let replayRetryTracker: import("../orchestrationRecovery").ReplayRetryTracker | null = null;
     let needsProviderInvalidation = false;
     const pendingDomainEvents: OrchestrationEvent[] = [];
     let flushPendingDomainEventsScheduled = false;
@@ -437,6 +440,7 @@ function EventRouter() {
           applyEventBatch(events);
         }
       } catch {
+        replayRetryTracker = null;
         recovery.failReplayRecovery();
         void fallbackToSnapshotRecovery();
         return;
@@ -444,16 +448,33 @@ function EventRouter() {
 
       if (!disposed) {
         const replayCompletion = recovery.completeReplayRecovery();
-        if (replayCompletion.shouldReplay) {
-          if (!replayCompletion.replayMadeProgress) {
+        const retryDecision = deriveReplayRetryDecision({
+          previousTracker: replayRetryTracker,
+          completion: replayCompletion,
+          recoveryState: recovery.getState(),
+          baseDelayMs: REPLAY_RECOVERY_RETRY_DELAY_MS,
+          maxNoProgressRetries: MAX_NO_PROGRESS_REPLAY_RETRIES,
+        });
+        replayRetryTracker = retryDecision.tracker;
+
+        if (retryDecision.shouldRetry) {
+          if (retryDecision.delayMs > 0) {
             await new Promise<void>((resolve) => {
-              setTimeout(resolve, REPLAY_RECOVERY_RETRY_DELAY_MS);
+              setTimeout(resolve, retryDecision.delayMs);
             });
             if (disposed) {
               return;
             }
           }
           void recoverFromSequenceGap();
+        } else if (replayCompletion.shouldReplay && import.meta.env.MODE !== "test") {
+          console.warn(
+            "[orchestration-recovery]",
+            "Stopping replay recovery after no-progress retries.",
+            {
+              state: recovery.getState(),
+            },
+          );
         }
       }
     };


### PR DESCRIPTION
## Summary
- Change `completeReplayRecovery()` to return structured replay outcome data instead of a bare boolean.
- Preserve the replay progress signal while separately surfacing whether another replay should be attempted.
- Add coverage for the new retry behavior when replay makes no progress with and without newer observed sequences.

## Testing
- Updated `apps/web/src/orchestrationRecovery.test.ts` to assert the new completion shape and retry cases.
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`
- Not run: `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes orchestration replay recovery control flow and retry behavior in the app root event router, which can impact client/server state synchronization during sequence gaps. Risk is mitigated by added unit tests but could still affect recovery edge cases (e.g., no-progress replays, disposal timing).
> 
> **Overview**
> **Replay recovery now returns structured completion data instead of a boolean.** `completeReplayRecovery()` returns `{ replayMadeProgress, shouldReplay }`, separating “did the replay advance the sequence” from “do we still need another replay.”
> 
> **Adds bounded, backoff-based retries for no-progress replays.** New `deriveReplayRetryDecision` tracks consecutive no-progress attempts for the same replay frontier, retries with exponential delays (100ms base) up to a max (3), resets the budget when the frontier changes, and logs a warning when stopping early.
> 
> **Updates callers and tests.** `EventRouter` uses the new completion shape and retry decision (including clearing the tracker on replay failure), and `orchestrationRecovery.test.ts` is expanded to assert the new return type and retry/stop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1880f09ae8097cfa4bf1328b4e8d9045e89148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return structured replay retry state with exponential backoff from orchestration recovery
> - `completeReplayRecovery` now returns a `ReplayRecoveryCompletion` object (`{ replayMadeProgress, shouldReplay }`) instead of a boolean, and no longer unconditionally clears `pendingReplay` on no-progress completion.
> - Adds `deriveReplayRetryDecision` in [orchestrationRecovery.ts](https://github.com/pingdotgg/t3code/pull/1728/files#diff-b53c793eb7cbd0b7d45b0cf3ad74b937a71ab631f46b8b5386bf6a907676a6c2) to compute whether to retry a replay and with what delay: immediate retry on progress, capped exponential backoff (base 100ms, up to 3 attempts) when there is no progress on the same frontier, and budget reset when the frontier changes.
> - [routes/__root.tsx](https://github.com/pingdotgg/t3code/pull/1728/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) uses the new return value to schedule retries, logging a warning when no-progress retries are exhausted.
> - Behavioral Change: previously a truthy return from `completeReplayRecovery` triggered an immediate retry unconditionally; now retries are budgeted and backoff-gated when no progress is observed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb1880f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->