### PR TITLE
fix(web): preserve menu context for disabled git actions

### DIFF
--- a/apps/web/src/components/GitActionsControl.browser.tsx
+++ b/apps/web/src/components/GitActionsControl.browser.tsx
@@ -1,7 +1,11 @@
 import { ThreadId } from "@t3tools/contracts";
 import { useState } from "react";
+import { page } from "vitest/browser";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
+import { Button } from "./ui/button";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "./ui/menu";
+import { Popover, PopoverPopup, PopoverTrigger } from "./ui/popover";
 
 const THREAD_A = ThreadId.makeUnsafe("thread-a");
 const THREAD_B = ThreadId.makeUnsafe("thread-b");
@@ -230,6 +234,48 @@ describe("GitActionsControl thread-scoped progress toast", () => {
           type: "loading",
         }),
       );
+    } finally {
+      await screen.unmount();
+      host.remove();
+    }
+  });
+});
+
+describe("GitActionsControl menu composition", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders a disabled menu item through PopoverTrigger without breaking menu context", async () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    const screen = await render(
+      <Menu>
+        <MenuTrigger render={<Button aria-label="Open menu" />}>Open</MenuTrigger>
+        <MenuPopup align="end">
+          <Popover>
+            <PopoverTrigger
+              openOnHover
+              nativeButton={false}
+              render={<MenuItem className="w-full cursor-not-allowed" disabled />}
+            >
+              Disabled action
+            </PopoverTrigger>
+            <PopoverPopup tooltipStyle side="left" align="center">
+              Disabled because a branch is missing.
+            </PopoverPopup>
+          </Popover>
+        </MenuPopup>
+      </Menu>,
+      { container: host },
+    );
+
+    try {
+      await page.getByRole("button", { name: "Open menu" }).click();
+
+      await vi.waitFor(() => {
+        expect(document.body.textContent ?? "").toContain("Disabled action");
+      });
     } finally {
       await screen.unmount();
       host.remove();

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -824,12 +824,10 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
                       <PopoverTrigger
                         openOnHover
                         nativeButton={false}
-                        render={<span className="block w-max cursor-not-allowed" />}
+                        render={<MenuItem className="w-full cursor-not-allowed" disabled />}
                       >
-                        <MenuItem className="w-full" disabled>
-                          <GitActionItemIcon icon={item.icon} />
-                          {item.label}
-                        </MenuItem>
+                        <GitActionItemIcon icon={item.icon} />
+                        {item.label}
                       </PopoverTrigger>
                       <PopoverPopup tooltipStyle side="left" align="center">
                         {disabledReason}


### PR DESCRIPTION
## Summary
- render the disabled git action tooltip trigger as the `MenuItem` itself so it stays inside Base UI menu context
- keep the disabled-item tooltip behavior unchanged while removing the context-breaking wrapper composition
- add a browser regression test for the disabled menu item + popover trigger path

## Verification
- bun fmt
- bun lint
- bun typecheck
- bun run test:browser src/components/GitActionsControl.browser.tsx
- bun run test src/components/GitActionsControl.logic.test.ts
- npx -y react-doctor@latest . --verbose --diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI composition change limited to how disabled menu items are rendered, with added browser coverage to prevent regressions.
> 
> **Overview**
> **Fixes disabled git action menu items to preserve menu context.** The disabled-action tooltip trigger is now rendered as the `MenuItem` itself via `PopoverTrigger` (instead of wrapping a separate element), keeping Base UI menu behavior intact while retaining the hover tooltip.
> 
> Adds a browser regression test that opens a menu and verifies a disabled `MenuItem` rendered through `PopoverTrigger` still appears correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd595e38fa320bc0f09592d0fdc52abf1f3c18d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix menu context preservation for disabled git actions in `GitActionsControl`
> In [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/1731/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f), the `PopoverTrigger` for disabled actions previously rendered a `span` wrapper containing a nested disabled `MenuItem`. It now renders the `MenuItem` directly as the trigger element, fixing broken menu context for disabled items.
>
> A browser test is added in [GitActionsControl.browser.tsx](https://github.com/pingdotgg/t3code/pull/1731/files#diff-e6ec5c08e0520d2c5a24d3717e69f670dfcbd0f6be2a7c380d75cf0278804708) to verify that a disabled `MenuItem` rendered via `PopoverTrigger` appears correctly in the menu.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd595e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->