### PR TITLE
Extensible slash command registry with dynamic project skill discovery

### DIFF
--- a/apps/server/src/workspace/skillScanner.ts
+++ b/apps/server/src/workspace/skillScanner.ts
@@ -1,0 +1,58 @@
+import * as fsPromises from "node:fs/promises";
+import * as nodePath from "node:path";
+
+import type { ProjectListSkillsResult } from "@t3tools/contracts";
+
+const SKILL_DIRS = [".agents/skills", ".agent/skills"] as const;
+
+function parseFrontmatter(content: string): Record<string, string> {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+  if (!match?.[1]) return {};
+  const result: Record<string, string> = {};
+  for (const line of match[1].split("\n")) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex < 0) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+export async function scanProjectSkills(cwd: string): Promise<ProjectListSkillsResult> {
+  const seen = new Set<string>();
+  const skills: Array<ProjectListSkillsResult["skills"][number]> = [];
+
+  for (const dir of SKILL_DIRS) {
+    const skillsRoot = nodePath.join(cwd, dir);
+    let entries: string[];
+    try {
+      entries = await fsPromises.readdir(skillsRoot);
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const skillMdPath = nodePath.join(skillsRoot, entry, "SKILL.md");
+      let content: string;
+      try {
+        content = await fsPromises.readFile(skillMdPath, "utf-8");
+      } catch {
+        continue;
+      }
+
+      const fm = parseFrontmatter(content);
+      const name = fm.name || entry;
+      if (seen.has(name)) continue;
+      seen.add(name);
+
+      skills.push({
+        name,
+        description: fm.description ?? "",
+        userInvocable: fm["user-invocable"] !== "false",
+      });
+    }
+  }
+
+  return { skills };
+}

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -11,6 +11,7 @@ import {
   OrchestrationGetSnapshotError,
   OrchestrationGetTurnDiffError,
   ORCHESTRATION_WS_METHODS,
+  ProjectListSkillsError,
   ProjectSearchEntriesError,
   ProjectWriteFileError,
   OrchestrationReplayEventsError,
@@ -44,6 +45,7 @@ import { ServerSettingsService } from "./serverSettings";
 import { TerminalManager } from "./terminal/Services/Manager";
 import { WorkspaceEntries } from "./workspace/Services/WorkspaceEntries";
 import { WorkspaceFileSystem } from "./workspace/Services/WorkspaceFileSystem";
+import { scanProjectSkills } from "./workspace/skillScanner";
 import { WorkspacePathOutsideRootError } from "./workspace/Services/WorkspacePaths";
 import { ProjectSetupScriptRunner } from "./project/Services/ProjectSetupScriptRunner";
 
@@ -553,6 +555,19 @@ const WsRpcLayer = WsRpcGroup.toLayer(
               });
             }),
           ),
+          { "rpc.aggregate": "workspace" },
+        ),
+      [WS_METHODS.projectsListSkills]: (input) =>
+        observeRpcEffect(
+          WS_METHODS.projectsListSkills,
+          Effect.tryPromise({
+            try: () => scanProjectSkills(input.cwd),
+            catch: (cause) =>
+              new ProjectListSkillsError({
+                message: `Failed to scan project skills: ${String(cause)}`,
+                cause: cause instanceof Error ? cause : undefined,
+              }),
+          }),
           { "rpc.aggregate": "workspace" },
         ),
       [WS_METHODS.shellOpenInEditor]: (input) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -28,7 +28,10 @@ import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { gitStatusQueryOptions } from "~/lib/gitReactQuery";
-import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
+import {
+  projectListSkillsQueryOptions,
+  projectSearchEntriesQueryOptions,
+} from "~/lib/projectReactQuery";
 import { isElectron } from "../env";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import {
@@ -40,6 +43,8 @@ import {
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
 } from "../composer-logic";
+import { slashCommandRegistry, useSlashCommands } from "../slashCommandRegistry";
+import { registerProjectSkills } from "../slashCommandSkills";
 import {
   deriveCompletionDividerBeforeEntryId,
   derivePendingApprovals,
@@ -1399,6 +1404,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const effectivePathQuery = pathTriggerQuery.length > 0 ? debouncedPathQuery : "";
   const gitStatusQuery = useQuery(gitStatusQueryOptions(gitCwd));
+  const slashCommands = useSlashCommands();
+  const projectSkillsQuery = useQuery(projectListSkillsQueryOptions({ cwd: gitCwd }));
+  const projectSkills = projectSkillsQuery.data?.skills;
+  useEffect(() => registerProjectSkills(projectSkills), [projectSkills]);
   const keybindings = useServerKeybindings();
   const availableEditors = useServerAvailableEditors();
   const modelOptionsByProvider = useMemo(
@@ -1455,36 +1464,16 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
 
     if (composerTrigger.kind === "slash-command") {
-      const slashCommandItems = [
-        {
-          id: "slash:model",
-          type: "slash-command",
-          command: "model",
-          label: "/model",
-          description: "Switch response model for this thread",
-        },
-        {
-          id: "slash:plan",
-          type: "slash-command",
-          command: "plan",
-          label: "/plan",
-          description: "Switch this thread into plan mode",
-        },
-        {
-          id: "slash:default",
-          type: "slash-command",
-          command: "default",
-          label: "/default",
-          description: "Switch this thread back to normal chat mode",
-        },
-      ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
-      const query = composerTrigger.query.trim().toLowerCase();
-      if (!query) {
-        return [...slashCommandItems];
-      }
-      return slashCommandItems.filter(
-        (item) => item.command.includes(query) || item.label.slice(1).includes(query),
-      );
+      const q = composerTrigger.query.trim().toLowerCase();
+      const matched = q ? slashCommands.filter((cmd) => cmd.name.includes(q)) : slashCommands;
+      return matched.map((cmd) => ({
+        id: `slash:${cmd.name}`,
+        type: "slash-command" as const,
+        command: cmd.name,
+        ...(cmd.icon ? { icon: cmd.icon } : {}),
+        label: `/${cmd.name}`,
+        description: cmd.description,
+      }));
     }
 
     return searchableModelOptions
@@ -1503,7 +1492,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
         label: name,
         description: `${providerLabel} · ${slug}`,
       }));
-  }, [composerTrigger, searchableModelOptions, workspaceEntries]);
+  }, [composerTrigger, searchableModelOptions, slashCommands, workspaceEntries]);
   const composerMenuOpen = Boolean(composerTrigger);
   const activeComposerMenuItem = useMemo(
     () =>
@@ -2883,7 +2872,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
-      handleInteractionModeChange(standaloneSlashCommand);
+      const def = slashCommandRegistry.get(standaloneSlashCommand);
+      if (def?.action.type === "set-interaction-mode") {
+        handleInteractionModeChange(def.action.mode);
+      }
       promptRef.current = "";
       clearComposerDraftContent(activeThread.id);
       setComposerHighlightedItemId(null);
@@ -3708,8 +3700,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
         return;
       }
       if (item.type === "slash-command") {
-        if (item.command === "model") {
-          const replacement = "/model ";
+        const def = slashCommandRegistry.get(item.command);
+        if (!def) return;
+        const action = def.action;
+        if (action.type === "trigger-transition") {
+          const replacement = action.replacement;
           const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
             snapshot.value,
             trigger.rangeEnd,
@@ -3726,12 +3721,37 @@ export default function ChatView({ threadId }: ChatViewProps) {
           }
           return;
         }
-        void handleInteractionModeChange(item.command === "plan" ? "plan" : "default");
-        const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
-          expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
-        });
-        if (applied) {
-          setComposerHighlightedItemId(null);
+        if (action.type === "set-interaction-mode") {
+          void handleInteractionModeChange(action.mode);
+          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+            expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+          });
+          if (applied) {
+            setComposerHighlightedItemId(null);
+          }
+          return;
+        }
+        if (action.type === "prompt-prefix") {
+          const applied = applyPromptReplacement(
+            trigger.rangeStart,
+            trigger.rangeEnd,
+            action.prefix,
+            { expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd) },
+          );
+          if (applied) {
+            setComposerHighlightedItemId(null);
+          }
+          return;
+        }
+        if (action.type === "callback") {
+          action.execute();
+          const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
+            expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
+          });
+          if (applied) {
+            setComposerHighlightedItemId(null);
+          }
+          return;
         }
         return;
       }

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -1,6 +1,6 @@
 import { type ProjectEntry, type ProviderKind } from "@t3tools/contracts";
-import { memo, useLayoutEffect, useRef } from "react";
-import { type ComposerSlashCommand, type ComposerTriggerKind } from "../../composer-logic";
+import { type ComponentType, memo, useLayoutEffect, useRef } from "react";
+import { type ComposerTriggerKind } from "../../composer-logic";
 import { BotIcon } from "lucide-react";
 import { cn } from "~/lib/utils";
 import { Badge } from "../ui/badge";
@@ -19,7 +19,8 @@ export type ComposerCommandItem =
   | {
       id: string;
       type: "slash-command";
-      command: ComposerSlashCommand;
+      command: string;
+      icon?: ComponentType<{ className?: string }>;
       label: string;
       description: string;
     }
@@ -124,7 +125,11 @@ const ComposerCommandMenuItem = memo(function ComposerCommandMenuItem(props: {
         />
       ) : null}
       {props.item.type === "slash-command" ? (
-        <BotIcon className="size-4 text-muted-foreground/80" />
+        props.item.icon ? (
+          <props.item.icon className="size-4 text-muted-foreground/80" />
+        ) : (
+          <BotIcon className="size-4 text-muted-foreground/80" />
+        )
       ) : null}
       {props.item.type === "model" ? (
         <Badge variant="outline" className="px-1.5 py-0 text-[10px]">

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -11,10 +11,13 @@ import {
 } from "./composer-logic";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
+const BUILTIN_NAMES = ["model", "plan", "default"] as const;
+const STANDALONE_NAMES = ["plan", "default"] as const;
+
 describe("detectComposerTrigger", () => {
   it("detects @path trigger at cursor", () => {
     const text = "Please check @src/com";
-    const trigger = detectComposerTrigger(text, text.length);
+    const trigger = detectComposerTrigger(text, text.length, BUILTIN_NAMES);
 
     expect(trigger).toEqual({
       kind: "path",
@@ -26,7 +29,7 @@ describe("detectComposerTrigger", () => {
 
   it("detects slash command token while typing command name", () => {
     const text = "/mo";
-    const trigger = detectComposerTrigger(text, text.length);
+    const trigger = detectComposerTrigger(text, text.length, BUILTIN_NAMES);
 
     expect(trigger).toEqual({
       kind: "slash-command",
@@ -38,7 +41,7 @@ describe("detectComposerTrigger", () => {
 
   it("detects slash model query after /model", () => {
     const text = "/model spark";
-    const trigger = detectComposerTrigger(text, text.length);
+    const trigger = detectComposerTrigger(text, text.length, BUILTIN_NAMES);
 
     expect(trigger).toEqual({
       kind: "slash-model",
@@ -50,7 +53,7 @@ describe("detectComposerTrigger", () => {
 
   it("detects non-model slash commands while typing", () => {
     const text = "/pl";
-    const trigger = detectComposerTrigger(text, text.length);
+    const trigger = detectComposerTrigger(text, text.length, BUILTIN_NAMES);
 
     expect(trigger).toEqual({
       kind: "slash-command",
@@ -65,7 +68,7 @@ describe("detectComposerTrigger", () => {
     const text = "Please inspect @in this sentence";
     const cursorAfterAt = "Please inspect @".length;
 
-    const trigger = detectComposerTrigger(text, cursorAfterAt);
+    const trigger = detectComposerTrigger(text, cursorAfterAt, BUILTIN_NAMES);
     expect(trigger).toEqual({
       kind: "path",
       query: "",
@@ -79,7 +82,7 @@ describe("detectComposerTrigger", () => {
     const text = "Please inspect @srin this sentence";
     const cursorAfterQuery = "Please inspect @sr".length;
 
-    const trigger = detectComposerTrigger(text, cursorAfterQuery);
+    const trigger = detectComposerTrigger(text, cursorAfterQuery, BUILTIN_NAMES);
     expect(trigger).toEqual({
       kind: "path",
       query: "sr",
@@ -94,7 +97,7 @@ describe("detectComposerTrigger", () => {
     const text = "Please inspect @in this sentence";
     const cursorAfterAt = "Please inspect @".length;
 
-    const trigger = detectComposerTrigger(text, cursorAfterAt);
+    const trigger = detectComposerTrigger(text, cursorAfterAt, BUILTIN_NAMES);
     expect(trigger).not.toBeNull();
     expect(trigger?.kind).toBe("path");
     expect(trigger?.query).toBe("");
@@ -131,7 +134,7 @@ describe("expandCollapsedComposerCursor", () => {
     const collapsedCursorAfterMention = "what's in my ".length + 2;
     const expandedCursor = expandCollapsedComposerCursor(text, collapsedCursorAfterMention);
 
-    expect(detectComposerTrigger(text, expandedCursor)).toBeNull();
+    expect(detectComposerTrigger(text, expandedCursor, BUILTIN_NAMES)).toBeNull();
   });
 });
 
@@ -237,14 +240,40 @@ describe("isCollapsedCursorAdjacentToInlineToken", () => {
 
 describe("parseStandaloneComposerSlashCommand", () => {
   it("parses standalone /plan command", () => {
-    expect(parseStandaloneComposerSlashCommand(" /plan ")).toBe("plan");
+    expect(parseStandaloneComposerSlashCommand(" /plan ", STANDALONE_NAMES)).toBe("plan");
   });
 
   it("parses standalone /default command", () => {
-    expect(parseStandaloneComposerSlashCommand("/default")).toBe("default");
+    expect(parseStandaloneComposerSlashCommand("/default", STANDALONE_NAMES)).toBe("default");
   });
 
   it("ignores slash commands with extra message text", () => {
-    expect(parseStandaloneComposerSlashCommand("/plan explain this")).toBeNull();
+    expect(parseStandaloneComposerSlashCommand("/plan explain this", STANDALONE_NAMES)).toBeNull();
+  });
+});
+
+describe("mid-text slash detection", () => {
+  it("detects slash command after whitespace mid-text", () => {
+    const text = "hello /pl";
+    const trigger = detectComposerTrigger(text, text.length, BUILTIN_NAMES);
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "pl",
+      rangeStart: "hello ".length,
+      rangeEnd: text.length,
+    });
+  });
+});
+
+describe("custom command names", () => {
+  it("detects a custom command name when provided", () => {
+    const text = "/myskill";
+    const trigger = detectComposerTrigger(text, text.length, [...BUILTIN_NAMES, "myskill"]);
+    expect(trigger).toEqual({
+      kind: "slash-command",
+      query: "myskill",
+      rangeStart: 0,
+      rangeEnd: text.length,
+    });
   });
 });

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -1,8 +1,8 @@
 import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
+import { slashCommandRegistry } from "./slashCommandRegistry";
 
 export type ComposerTriggerKind = "path" | "slash-command" | "slash-model";
-export type ComposerSlashCommand = "model" | "plan" | "default";
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -10,8 +10,6 @@ export interface ComposerTrigger {
   rangeStart: number;
   rangeEnd: number;
 }
-
-const SLASH_COMMANDS: readonly ComposerSlashCommand[] = ["model", "plan", "default"];
 const isInlineTokenSegment = (
   segment: { type: "text"; text: string } | { type: "mention" } | { type: "terminal-context" },
 ): boolean => segment.type !== "text";
@@ -184,10 +182,15 @@ export function isCollapsedCursorAdjacentToInlineToken(
 
 export const isCollapsedCursorAdjacentToMention = isCollapsedCursorAdjacentToInlineToken;
 
-export function detectComposerTrigger(text: string, cursorInput: number): ComposerTrigger | null {
+export function detectComposerTrigger(
+  text: string,
+  cursorInput: number,
+  commandNames?: readonly string[],
+): ComposerTrigger | null {
   const cursor = clampCursor(text, cursorInput);
   const lineStart = text.lastIndexOf("\n", Math.max(0, cursor - 1)) + 1;
   const linePrefix = text.slice(lineStart, cursor);
+  const names = commandNames ?? slashCommandRegistry.getNames();
 
   if (linePrefix.startsWith("/")) {
     const commandMatch = /^\/(\S*)$/.exec(linePrefix);
@@ -201,7 +204,7 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
           rangeEnd: cursor,
         };
       }
-      if (SLASH_COMMANDS.some((command) => command.startsWith(commandQuery.toLowerCase()))) {
+      if (names.some((command) => command.startsWith(commandQuery.toLowerCase()))) {
         return {
           kind: "slash-command",
           query: commandQuery,
@@ -223,8 +226,21 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
     }
   }
 
+  // Mid-text slash detection: check for `/` preceded by whitespace
   const tokenStart = tokenStartForCursor(text, cursor);
   const token = text.slice(tokenStart, cursor);
+  if (token.startsWith("/")) {
+    const slashQuery = token.slice(1);
+    if (names.some((command) => command.startsWith(slashQuery.toLowerCase()))) {
+      return {
+        kind: "slash-command",
+        query: slashQuery,
+        rangeStart: tokenStart,
+        rangeEnd: cursor,
+      };
+    }
+  }
+
   if (!token.startsWith("@")) {
     return null;
   }
@@ -239,14 +255,16 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
 
 export function parseStandaloneComposerSlashCommand(
   text: string,
-): Exclude<ComposerSlashCommand, "model"> | null {
-  const match = /^\/(plan|default)\s*$/i.exec(text.trim());
+  standaloneNames?: readonly string[],
+): string | null {
+  const names = standaloneNames ?? slashCommandRegistry.getStandaloneNames();
+  const match = /^\/(\S+)\s*$/i.exec(text.trim());
   if (!match) {
     return null;
   }
   const command = match[1]?.toLowerCase();
-  if (command === "plan") return "plan";
-  return "default";
+  if (command && names.includes(command)) return command;
+  return null;
 }
 
 export function replaceTextRange(

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1749,6 +1749,7 @@ export const useComposerDraftStore = create<ComposerDraftStoreState>()(
             nextStickyMap = { ...state.stickyModelSelectionByProvider };
             const stickyBase =
               nextStickyMap[normalizedProvider] ??
+              nextMap[normalizedProvider] ??
               base.modelSelectionByProvider[normalizedProvider] ??
               ({
                 provider: normalizedProvider,

--- a/apps/web/src/lib/projectReactQuery.ts
+++ b/apps/web/src/lib/projectReactQuery.ts
@@ -1,4 +1,4 @@
-import type { ProjectSearchEntriesResult } from "@t3tools/contracts";
+import type { ProjectListSkillsResult, ProjectSearchEntriesResult } from "@t3tools/contracts";
 import { queryOptions } from "@tanstack/react-query";
 import { ensureNativeApi } from "~/nativeApi";
 
@@ -6,6 +6,7 @@ export const projectQueryKeys = {
   all: ["projects"] as const,
   searchEntries: (cwd: string | null, query: string, limit: number) =>
     ["projects", "search-entries", cwd, query, limit] as const,
+  listSkills: (cwd: string | null) => ["projects", "skills", cwd] as const,
 };
 
 const DEFAULT_SEARCH_ENTRIES_LIMIT = 80;
@@ -39,5 +40,24 @@ export function projectSearchEntriesQueryOptions(input: {
     enabled: (input.enabled ?? true) && input.cwd !== null && input.query.length > 0,
     staleTime: input.staleTime ?? DEFAULT_SEARCH_ENTRIES_STALE_TIME,
     placeholderData: (previous) => previous ?? EMPTY_SEARCH_ENTRIES_RESULT,
+  });
+}
+
+const SKILLS_STALE_TIME = 60_000;
+const EMPTY_SKILLS_RESULT: ProjectListSkillsResult = { skills: [] };
+
+export function projectListSkillsQueryOptions(input: { cwd: string | null }) {
+  return queryOptions({
+    queryKey: projectQueryKeys.listSkills(input.cwd),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      if (!input.cwd) {
+        throw new Error("Skill listing is unavailable without a project.");
+      }
+      return api.projects.listSkills({ cwd: input.cwd });
+    },
+    enabled: input.cwd !== null,
+    staleTime: SKILLS_STALE_TIME,
+    placeholderData: (previous) => previous ?? EMPTY_SKILLS_RESULT,
   });
 }

--- a/apps/web/src/slashCommandRegistry.test.ts
+++ b/apps/web/src/slashCommandRegistry.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { slashCommandRegistry } from "./slashCommandRegistry";
+
+describe("slashCommandRegistry", () => {
+  describe("built-in commands", () => {
+    it("registers /model, /plan, and /default on import", () => {
+      expect(slashCommandRegistry.has("model")).toBe(true);
+      expect(slashCommandRegistry.has("plan")).toBe(true);
+      expect(slashCommandRegistry.has("default")).toBe(true);
+    });
+
+    it("marks /plan and /default as standalone", () => {
+      expect(slashCommandRegistry.getStandaloneNames()).toContain("plan");
+      expect(slashCommandRegistry.getStandaloneNames()).toContain("default");
+      expect(slashCommandRegistry.getStandaloneNames()).not.toContain("model");
+    });
+
+    it("exposes all registered command names", () => {
+      const names = slashCommandRegistry.getNames();
+      expect(names).toContain("model");
+      expect(names).toContain("plan");
+      expect(names).toContain("default");
+    });
+
+    it("/model uses trigger-transition action", () => {
+      const def = slashCommandRegistry.get("model");
+      expect(def?.action.type).toBe("trigger-transition");
+    });
+
+    it("/plan uses set-interaction-mode action with mode plan", () => {
+      const def = slashCommandRegistry.get("plan");
+      expect(def?.action).toEqual({ type: "set-interaction-mode", mode: "plan" });
+    });
+
+    it("/default uses set-interaction-mode action with mode default", () => {
+      const def = slashCommandRegistry.get("default");
+      expect(def?.action).toEqual({ type: "set-interaction-mode", mode: "default" });
+    });
+  });
+
+  describe("register/unregister", () => {
+    it("registers a custom command and returns an unregister function", () => {
+      const unregister = slashCommandRegistry.register({
+        name: "test-cmd",
+        description: "A test command",
+        action: { type: "callback", execute: () => {} },
+      });
+      expect(slashCommandRegistry.has("test-cmd")).toBe(true);
+      unregister();
+      expect(slashCommandRegistry.has("test-cmd")).toBe(false);
+    });
+
+    it("overwrites a command with the same name", () => {
+      const unregister1 = slashCommandRegistry.register({
+        name: "overwrite-test",
+        description: "First",
+        action: { type: "callback", execute: () => {} },
+      });
+      const unregister2 = slashCommandRegistry.register({
+        name: "overwrite-test",
+        description: "Second",
+        action: { type: "callback", execute: () => {} },
+      });
+      expect(slashCommandRegistry.get("overwrite-test")?.description).toBe("Second");
+      unregister1();
+      expect(slashCommandRegistry.has("overwrite-test")).toBe(true);
+      unregister2();
+      expect(slashCommandRegistry.has("overwrite-test")).toBe(false);
+    });
+  });
+
+  describe("match", () => {
+    it("returns all commands for empty query", () => {
+      expect(slashCommandRegistry.match("")).toEqual(slashCommandRegistry.getAll());
+    });
+
+    it("filters commands by partial name match", () => {
+      const results = slashCommandRegistry.match("pl");
+      expect(results.some((c) => c.name === "plan")).toBe(true);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("notifies listeners on register", () => {
+      let called = 0;
+      const unsub = slashCommandRegistry.subscribe(() => {
+        called++;
+      });
+      const unreg = slashCommandRegistry.register({
+        name: "sub-test",
+        description: "sub",
+        action: { type: "callback", execute: () => {} },
+      });
+      expect(called).toBe(1);
+      unreg();
+      unsub();
+    });
+  });
+});

--- a/apps/web/src/slashCommandRegistry.ts
+++ b/apps/web/src/slashCommandRegistry.ts
@@ -1,0 +1,114 @@
+import type { ProviderInteractionMode } from "@t3tools/contracts";
+import type { ComponentType } from "react";
+import { useSyncExternalStore } from "react";
+
+export type SlashCommandAction =
+  | { readonly type: "set-interaction-mode"; readonly mode: ProviderInteractionMode }
+  | { readonly type: "trigger-transition"; readonly replacement: string }
+  | { readonly type: "prompt-prefix"; readonly prefix: string }
+  | { readonly type: "callback"; readonly execute: () => void };
+
+export interface SlashCommandDefinition {
+  readonly name: string;
+  readonly description: string;
+  readonly icon?: ComponentType<{ className?: string }>;
+  readonly action: SlashCommandAction;
+  readonly standalone?: boolean;
+}
+
+type Listener = () => void;
+
+class SlashCommandRegistry {
+  private _commands = new Map<string, SlashCommandDefinition>();
+  private _snapshot: readonly SlashCommandDefinition[] = [];
+  private _names: readonly string[] = [];
+  private _standaloneNames: readonly string[] = [];
+  private _listeners = new Set<Listener>();
+
+  register(definition: SlashCommandDefinition): () => void {
+    this._commands.set(definition.name, definition);
+    this._rebuild();
+    return () => {
+      if (this._commands.get(definition.name) === definition) {
+        this._commands.delete(definition.name);
+        this._rebuild();
+      }
+    };
+  }
+
+  get(name: string): SlashCommandDefinition | undefined {
+    return this._commands.get(name);
+  }
+
+  getAll(): readonly SlashCommandDefinition[] {
+    return this._snapshot;
+  }
+
+  getNames(): readonly string[] {
+    return this._names;
+  }
+
+  getStandaloneNames(): readonly string[] {
+    return this._standaloneNames;
+  }
+
+  has(name: string): boolean {
+    return this._commands.has(name);
+  }
+
+  match(query: string): readonly SlashCommandDefinition[] {
+    const q = query.toLowerCase();
+    if (!q) return this._snapshot;
+    return this._snapshot.filter((cmd) => cmd.name.includes(q));
+  }
+
+  subscribe = (listener: Listener): (() => void) => {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): readonly SlashCommandDefinition[] => {
+    return this._snapshot;
+  };
+
+  private _rebuild(): void {
+    this._snapshot = Array.from(this._commands.values());
+    this._names = this._snapshot.map((c) => c.name);
+    this._standaloneNames = this._snapshot.filter((c) => c.standalone).map((c) => c.name);
+    for (const listener of this._listeners) {
+      listener();
+    }
+  }
+}
+
+export const slashCommandRegistry = new SlashCommandRegistry();
+
+slashCommandRegistry.register({
+  name: "model",
+  description: "Switch response model for this thread",
+  action: { type: "trigger-transition", replacement: "/model " },
+});
+
+slashCommandRegistry.register({
+  name: "plan",
+  description: "Switch this thread into plan mode",
+  action: { type: "set-interaction-mode", mode: "plan" },
+  standalone: true,
+});
+
+slashCommandRegistry.register({
+  name: "default",
+  description: "Switch this thread back to normal chat mode",
+  action: { type: "set-interaction-mode", mode: "default" },
+  standalone: true,
+});
+
+export function useSlashCommands(): readonly SlashCommandDefinition[] {
+  return useSyncExternalStore(
+    slashCommandRegistry.subscribe,
+    slashCommandRegistry.getSnapshot,
+    slashCommandRegistry.getSnapshot,
+  );
+}

--- a/apps/web/src/slashCommandSkills.ts
+++ b/apps/web/src/slashCommandSkills.ts
@@ -1,0 +1,29 @@
+import type { ProjectSkill } from "@t3tools/contracts";
+import { WandIcon } from "lucide-react";
+import { slashCommandRegistry } from "./slashCommandRegistry";
+
+export function registerProjectSkills(skills: readonly ProjectSkill[] | undefined): () => void {
+  if (!skills || skills.length === 0) return () => {};
+
+  const unregisterFns: Array<() => void> = [];
+  for (const skill of skills) {
+    if (!skill.userInvocable) continue;
+    unregisterFns.push(
+      slashCommandRegistry.register({
+        name: skill.name,
+        description: skill.description || `Use the ${skill.name} skill`,
+        icon: WandIcon,
+        action: {
+          type: "prompt-prefix",
+          prefix: `Use the /${skill.name} skill.\n\n`,
+        },
+      }),
+    );
+  }
+
+  return () => {
+    for (const unregister of unregisterFns) {
+      unregister();
+    }
+  };
+}

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -44,6 +44,7 @@ export function createWsNativeApi(): NativeApi {
     projects: {
       searchEntries: rpcClient.projects.searchEntries,
       writeFile: rpcClient.projects.writeFile,
+      listSkills: rpcClient.projects.listSkills,
     },
     shell: {
       openInEditor: (cwd, editor) => rpcClient.shell.openInEditor({ cwd, editor }),

--- a/apps/web/src/wsRpcClient.ts
+++ b/apps/web/src/wsRpcClient.ts
@@ -49,6 +49,7 @@ export interface WsRpcClient {
   readonly projects: {
     readonly searchEntries: RpcUnaryMethod<typeof WS_METHODS.projectsSearchEntries>;
     readonly writeFile: RpcUnaryMethod<typeof WS_METHODS.projectsWriteFile>;
+    readonly listSkills: RpcUnaryMethod<typeof WS_METHODS.projectsListSkills>;
   };
   readonly shell: {
     readonly openInEditor: (input: {
@@ -128,6 +129,8 @@ export function createWsRpcClient(transport = new WsTransport()): WsRpcClient {
         transport.request((client) => client[WS_METHODS.projectsSearchEntries](input)),
       writeFile: (input) =>
         transport.request((client) => client[WS_METHODS.projectsWriteFile](input)),
+      listSkills: (input) =>
+        transport.request((client) => client[WS_METHODS.projectsListSkills](input)),
     },
     shell: {
       openInEditor: (input) =>

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -17,6 +17,8 @@ import type {
   GitStatusResult,
 } from "./git";
 import type {
+  ProjectListSkillsInput,
+  ProjectListSkillsResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
   ProjectWriteFileInput,
@@ -138,6 +140,7 @@ export interface NativeApi {
   projects: {
     searchEntries: (input: ProjectSearchEntriesInput) => Promise<ProjectSearchEntriesResult>;
     writeFile: (input: ProjectWriteFileInput) => Promise<ProjectWriteFileResult>;
+    listSkills: (input: ProjectListSkillsInput) => Promise<ProjectListSkillsResult>;
   };
   shell: {
     openInEditor: (cwd: string, editor: EditorId) => Promise<void>;

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -53,3 +53,32 @@ export class ProjectWriteFileError extends Schema.TaggedErrorClass<ProjectWriteF
     cause: Schema.optional(Schema.Defect),
   },
 ) {}
+
+// ---------------------------------------------------------------------------
+// Project skills (discovered from .agents/skills/ and .agent/skills/)
+// ---------------------------------------------------------------------------
+
+export const ProjectListSkillsInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString,
+});
+export type ProjectListSkillsInput = typeof ProjectListSkillsInput.Type;
+
+export const ProjectSkill = Schema.Struct({
+  name: TrimmedNonEmptyString,
+  description: Schema.String,
+  userInvocable: Schema.Boolean,
+});
+export type ProjectSkill = typeof ProjectSkill.Type;
+
+export const ProjectListSkillsResult = Schema.Struct({
+  skills: Schema.Array(ProjectSkill),
+});
+export type ProjectListSkillsResult = typeof ProjectListSkillsResult.Type;
+
+export class ProjectListSkillsError extends Schema.TaggedErrorClass<ProjectListSkillsError>()(
+  "ProjectListSkillsError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {}

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -42,6 +42,9 @@ import {
   OrchestrationRpcSchemas,
 } from "./orchestration";
 import {
+  ProjectListSkillsError,
+  ProjectListSkillsInput,
+  ProjectListSkillsResult,
   ProjectSearchEntriesError,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
@@ -77,6 +80,7 @@ export const WS_METHODS = {
   projectsRemove: "projects.remove",
   projectsSearchEntries: "projects.searchEntries",
   projectsWriteFile: "projects.writeFile",
+  projectsListSkills: "projects.listSkills",
 
   // Shell methods
   shellOpenInEditor: "shell.openInEditor",
@@ -155,6 +159,12 @@ export const WsProjectsWriteFileRpc = Rpc.make(WS_METHODS.projectsWriteFile, {
   payload: ProjectWriteFileInput,
   success: ProjectWriteFileResult,
   error: ProjectWriteFileError,
+});
+
+export const WsProjectsListSkillsRpc = Rpc.make(WS_METHODS.projectsListSkills, {
+  payload: ProjectListSkillsInput,
+  success: ProjectListSkillsResult,
+  error: ProjectListSkillsError,
 });
 
 export const WsShellOpenInEditorRpc = Rpc.make(WS_METHODS.shellOpenInEditor, {
@@ -329,6 +339,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerUpdateSettingsRpc,
   WsProjectsSearchEntriesRpc,
   WsProjectsWriteFileRpc,
+  WsProjectsListSkillsRpc,
   WsShellOpenInEditorRpc,
   WsGitStatusRpc,
   WsGitPullRpc,


### PR DESCRIPTION
## What Changed

- Replace the hardcoded slash command system (`/model`, `/plan`, `/default`) with a dynamic `SlashCommandRegistry` that supports runtime registration and unregistration of commands.
- Commands are defined as `SlashCommandDefinition` objects with typed actions (`set-interaction-mode`, `trigger-transition`, `prompt-prefix`, `callback`).
- Add a `projects.listSkills` RPC endpoint that scans `.agents/skills/` and `.agent/skills/` directories for `SKILL.md` frontmatter, returning discovered skills to the web client.
- Skills marked `user-invocable: true` (the default) are dynamically registered as slash commands when a project is active, and cleaned up when switching projects.
- Slash commands are now detected at any word boundary (not just line start), so typing `/plan` mid-sentence shows the command menu.
- Fix a bug where changing effort on Claude Opus 4.6 silently switched the model to Sonnet 4.6 due to a missing fallback in the sticky state persistence chain.

## Why

The previous slash command system was hardcoded in 4 separate places — adding a new command required touching `composer-logic.ts`, `ChatView.tsx`, `ComposerCommandMenu.tsx`, and understanding the execution flow. This made it impractical to add project-specific or plugin-provided commands.

The new registry centralises command definitions and makes registration a single call:
```typescript
slashCommandRegistry.register({
  name: "search",
  description: "Search the codebase",
  action: { type: "callback", execute: () => { /* ... */ } },
});
```

The effort/model bug was discovered during testing — `setProviderModelOptions` fell through to `DEFAULT_MODEL_BY_PROVIDER["claudeAgent"]` (`claude-sonnet-4-6`) when persisting sticky state, instead of using the model the user actually selected.

## Testing

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test` (all pass)
- Added 11 registry tests and 4 new composer-logic tests

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add extensible slash command registry with dynamic project skill discovery
> - Introduces `SlashCommandRegistry` in [slashCommandRegistry.ts](https://github.com/pingdotgg/t3code/pull/1742/files#diff-a84bd2a45b7cce771a5f278b460b93440729c473e8575e4a8969a0a38c112868) to manage slash commands at runtime with register/unregister, matching, snapshotting, and React subscription via `useSlashCommands`.
> - Registers three built-in commands (`/model`, `/plan`, `/default`) and supports four action types: `trigger-transition`, `set-interaction-mode`, `prompt-prefix`, and `callback`.
> - Adds server-side skill scanning in [skillScanner.ts](https://github.com/pingdotgg/t3code/pull/1742/files#diff-702f3ffa15cad35818e5b86f117e28683168760ca03fdfa060d0129db10e6a8b) that reads `SKILL.md` frontmatter from `.agents/skills` and `.agent/skills` directories, exposed via a new `projects.listSkills` RPC.
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1742/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to query project skills on load and register user-invocable ones as `/`-prefixed slash commands with a `WandIcon` and prompt-prefix action.
> - `detectComposerTrigger` and `parseStandaloneComposerSlashCommand` in [composer-logic.ts](https://github.com/pingdotgg/t3code/pull/1742/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6) now derive command names from the registry rather than a hardcoded list, and mid-text slash tokens are now detected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6688d83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->