### PR TITLE
[codex] Canonicalize PR number references

### DIFF
--- a/apps/web/src/pullRequestReference.test.ts
+++ b/apps/web/src/pullRequestReference.test.ts
@@ -14,7 +14,7 @@ describe("parsePullRequestReference", () => {
   });
 
   it("accepts #number references", () => {
-    expect(parsePullRequestReference("#42")).toBe("#42");
+    expect(parsePullRequestReference("#42")).toBe("42");
   });
 
   it("accepts gh pr checkout commands with raw numbers", () => {
@@ -22,7 +22,7 @@ describe("parsePullRequestReference", () => {
   });
 
   it("accepts gh pr checkout commands with #number references", () => {
-    expect(parsePullRequestReference("gh pr checkout #42")).toBe("#42");
+    expect(parsePullRequestReference("gh pr checkout #42")).toBe("42");
   });
 
   it("accepts gh pr checkout commands with GitHub pull request URLs", () => {

--- a/apps/web/src/pullRequestReference.ts
+++ b/apps/web/src/pullRequestReference.ts
@@ -22,7 +22,7 @@ export function parsePullRequestReference(input: string): string | null {
 
   const numberMatch = PULL_REQUEST_NUMBER_PATTERN.exec(normalizedInput);
   if (numberMatch?.[1]) {
-    return normalizedInput.startsWith("#") ? normalizedInput : numberMatch[1];
+    return numberMatch[1];
   }
 
   return null;


### PR DESCRIPTION
## Summary
- canonicalize numeric pull request references on the client so `42` and `#42` resolve to the same value
- update the parser tests to cover the normalized `#42` behavior

## Why
The web client accepted both `42` and `#42` for the same pull request, but preserved them as different strings. That meant client-side query and cache keys could diverge for the same PR even though the server already normalizes `#42` to `42`.

## Impact
Equivalent numeric PR references now share the same client-side representation, which avoids redundant PR-resolution cache entries and keeps client normalization aligned with the server.

## Validation
- `bun run test src/pullRequestReference.test.ts`
- `bun fmt`
- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip leading `#` from PR number references in `parsePullRequestReference`
> Updates [`parsePullRequestReference`](https://github.com/pingdotgg/t3code/pull/1749/files#diff-fe60e3e299c26243e892e3076256c5120d0ef29cb28422e29f878640e200da6c) to always return the bare numeric string for PR number matches. Previously, inputs like `#42` returned `#42`; they now return `42`. Tests are updated to match the new behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ffea8f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small normalization change limited to client-side PR reference parsing, with tests updated to lock in behavior. Main risk is minor behavior change for any consumers that previously relied on the leading `#` being preserved.
> 
> **Overview**
> `parsePullRequestReference` now canonicalizes numeric PR inputs by stripping a leading `#` and always returning the bare number (e.g., `#42` -> `42`, including `gh pr checkout #42`).
> 
> Tests were updated to assert the normalized output so equivalent PR references share the same client-side representation and cache/query keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffea8f243e77cbed9552bb5b64a01b28ee04ed6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->