### PR TITLE
Allow deleting projects with chats

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   createThreadJumpHintVisibilityController,
+  getFallbackThreadIdAfterBulkDelete,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
   getFallbackThreadIdAfterDelete,
@@ -862,6 +863,43 @@ describe("getFallbackThreadIdAfterDelete", () => {
     });
 
     expect(fallbackThreadId).toBe(ThreadId.makeUnsafe("thread-next"));
+  });
+});
+
+describe("getFallbackThreadIdAfterBulkDelete", () => {
+  it("returns the top remaining non-archived thread across projects", () => {
+    const fallbackThreadId = getFallbackThreadIdAfterBulkDelete({
+      threads: [
+        {
+          id: ThreadId.makeUnsafe("thread-1"),
+          projectId: ProjectId.makeUnsafe("project-1"),
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          archivedAt: null,
+          latestUserMessageAt: null,
+        },
+        {
+          id: ThreadId.makeUnsafe("thread-2"),
+          projectId: ProjectId.makeUnsafe("project-2"),
+          createdAt: "2026-01-02T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          archivedAt: null,
+          latestUserMessageAt: null,
+        },
+        {
+          id: ThreadId.makeUnsafe("thread-3"),
+          projectId: ProjectId.makeUnsafe("project-3"),
+          createdAt: "2026-01-03T00:00:00.000Z",
+          updatedAt: "2026-01-03T00:00:00.000Z",
+          archivedAt: "2026-01-04T00:00:00.000Z",
+          latestUserMessageAt: null,
+        },
+      ],
+      deletedThreadIds: new Set([ThreadId.makeUnsafe("thread-1"), ThreadId.makeUnsafe("thread-3")]),
+      sortOrder: "updated_at",
+    });
+
+    expect(fallbackThreadId).toBe(ThreadId.makeUnsafe("thread-2"));
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -521,6 +521,23 @@ export function getFallbackThreadIdAfterDelete<
   );
 }
 
+export function getFallbackThreadIdAfterBulkDelete<
+  T extends Pick<Thread, "id" | "createdAt" | "updatedAt" | "archivedAt"> & SidebarThreadSortInput,
+>(input: {
+  threads: readonly T[];
+  deletedThreadIds: ReadonlySet<T["id"]>;
+  sortOrder: SidebarThreadSortOrder;
+}): T["id"] | null {
+  const { deletedThreadIds, sortOrder, threads } = input;
+
+  return (
+    sortThreadsForSidebar(
+      threads.filter((thread) => !deletedThreadIds.has(thread.id) && thread.archivedAt === null),
+      sortOrder,
+    )[0]?.id ?? null
+  );
+}
+
 export function getProjectSortTimestamp(
   project: SidebarProject,
   projectThreads: readonly SidebarThreadSortInput[],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -112,6 +112,7 @@ import { isNonEmpty as isNonEmptyString } from "effect/String";
 import {
   getVisibleSidebarThreadIds,
   getVisibleThreadsForProject,
+  getFallbackThreadIdAfterBulkDelete,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
   resolveProjectStatusIndicator,
@@ -131,6 +132,15 @@ import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
 import { useServerKeybindings } from "../rpc/serverState";
 import { useSidebarThreadSummaryById } from "../storeSelectors";
 import type { Project } from "../types";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
 const THREAD_PREVIEW_LIMIT = 6;
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
@@ -163,6 +173,12 @@ interface PrStatusIndicator {
 }
 
 type ThreadPr = GitStatusResult["pr"];
+interface PendingProjectDelete {
+  projectId: ProjectId;
+  projectName: string;
+  threadIds: ThreadId[];
+  threadCount: number;
+}
 
 function ThreadStatusLabel({
   status,
@@ -719,6 +735,10 @@ export default function Sidebar() {
   const suppressProjectClickAfterDragRef = useRef(false);
   const suppressProjectClickForContextMenuRef = useRef(false);
   const [desktopUpdateState, setDesktopUpdateState] = useState<DesktopUpdateState | null>(null);
+  const [pendingProjectDelete, setPendingProjectDelete] = useState<PendingProjectDelete | null>(
+    null,
+  );
+  const [isDeletingProject, setIsDeletingProject] = useState(false);
   const selectedThreadIds = useThreadSelectionStore((s) => s.selectedThreadIds);
   const toggleThreadSelection = useThreadSelectionStore((s) => s.toggleThread);
   const rangeSelectTo = useThreadSelectionStore((s) => s.rangeSelectTo);
@@ -1251,50 +1271,94 @@ export default function Sidebar() {
         return;
       }
       if (clicked !== "delete") return;
-
-      const projectThreadIds = threadIdsByProjectId[projectId] ?? [];
-      if (projectThreadIds.length > 0) {
-        toastManager.add({
-          type: "warning",
-          title: "Project is not empty",
-          description: "Delete all threads in this project before removing it.",
-        });
-        return;
-      }
-
-      const confirmed = await api.dialogs.confirm(`Remove project "${project.name}"?`);
-      if (!confirmed) return;
-
-      try {
-        const projectDraftThread = getDraftThreadByProjectId(projectId);
-        if (projectDraftThread) {
-          clearComposerDraftForThread(projectDraftThread.threadId);
-        }
-        clearProjectDraftThreadId(projectId);
-        await api.orchestration.dispatchCommand({
-          type: "project.delete",
-          commandId: newCommandId(),
-          projectId,
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error removing project.";
-        console.error("Failed to remove project", { projectId, error });
-        toastManager.add({
-          type: "error",
-          title: `Failed to remove "${project.name}"`,
-          description: message,
-        });
-      }
+      const projectThreadIds = [...(threadIdsByProjectId[projectId] ?? [])];
+      setPendingProjectDelete({
+        projectId,
+        projectName: project.name,
+        threadIds: projectThreadIds,
+        threadCount: projectThreadIds.length,
+      });
     },
-    [
-      clearComposerDraftForThread,
-      clearProjectDraftThreadId,
-      copyPathToClipboard,
-      getDraftThreadByProjectId,
-      projects,
-      threadIdsByProjectId,
-    ],
+    [copyPathToClipboard, projects, threadIdsByProjectId],
   );
+
+  const confirmProjectDelete = useCallback(async () => {
+    const api = readNativeApi();
+    const pendingDelete = pendingProjectDelete;
+    if (!api || !pendingDelete || isDeletingProject) return;
+
+    setIsDeletingProject(true);
+    try {
+      const deletedThreadIds = new Set<ThreadId>(pendingDelete.threadIds);
+      const shouldNavigateAway =
+        (routeThreadId !== null && deletedThreadIds.has(routeThreadId)) ||
+        (routeThreadId === null && activeDraftThread?.projectId === pendingDelete.projectId);
+      const fallbackThreadId = shouldNavigateAway
+        ? getFallbackThreadIdAfterBulkDelete({
+            threads: Object.values(sidebarThreadsById),
+            deletedThreadIds,
+            sortOrder: appSettings.sidebarThreadSortOrder,
+          })
+        : null;
+
+      for (const threadId of pendingDelete.threadIds) {
+        await deleteThread(threadId, {
+          deletedThreadIds,
+          skipWorktreeConfirm: true,
+          suppressNavigation: true,
+        });
+      }
+
+      const projectDraftThread = getDraftThreadByProjectId(pendingDelete.projectId);
+      if (projectDraftThread) {
+        clearComposerDraftForThread(projectDraftThread.threadId);
+      }
+      clearProjectDraftThreadId(pendingDelete.projectId);
+      await api.orchestration.dispatchCommand({
+        type: "project.delete",
+        commandId: newCommandId(),
+        projectId: pendingDelete.projectId,
+      });
+      removeFromSelection(pendingDelete.threadIds);
+
+      if (shouldNavigateAway) {
+        if (fallbackThreadId) {
+          await navigate({
+            to: "/$threadId",
+            params: { threadId: fallbackThreadId },
+            replace: true,
+          });
+        } else {
+          await navigate({ to: "/", replace: true });
+        }
+      }
+
+      setPendingProjectDelete(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error removing project.";
+      console.error("Failed to remove project", { projectId: pendingDelete.projectId, error });
+      toastManager.add({
+        type: "error",
+        title: `Failed to remove "${pendingDelete.projectName}"`,
+        description: message,
+      });
+    } finally {
+      setIsDeletingProject(false);
+    }
+  }, [
+    activeDraftThread?.projectId,
+    appSettings.sidebarThreadSortOrder,
+    clearComposerDraftForThread,
+    clearProjectDraftThreadId,
+    deleteThread,
+    getDraftThreadByProjectId,
+    isDeletingProject,
+    navigate,
+    pendingProjectDelete,
+    removeFromSelection,
+    routeThreadId,
+    sidebarThreadsById,
+  ]);
 
   const projectDnDSensors = useSensors(
     useSensor(PointerSensor, {
@@ -1994,6 +2058,41 @@ export default function Sidebar() {
 
   return (
     <>
+      <AlertDialog
+        open={pendingProjectDelete !== null}
+        onOpenChange={(open) => {
+          if (!open && !isDeletingProject) {
+            setPendingProjectDelete(null);
+          }
+        }}
+      >
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Remove project "{pendingProjectDelete?.projectName}"?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingProjectDelete
+                ? pendingProjectDelete.threadCount > 0
+                  ? `This permanently deletes the project and its ${pendingProjectDelete.threadCount} ${pendingProjectDelete.threadCount === 1 ? "chat" : "chats"}.`
+                  : "This permanently deletes the project."
+                : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" disabled={isDeletingProject} />}>
+              Cancel
+            </AlertDialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => void confirmProjectDelete()}
+              disabled={isDeletingProject}
+            >
+              {isDeletingProject ? "Removing..." : "Remove project"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
       {isElectron ? (
         <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
           {wordmark}

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -65,7 +65,14 @@ export function useThreadActions() {
   }, []);
 
   const deleteThread = useCallback(
-    async (threadId: ThreadId, opts: { deletedThreadIds?: ReadonlySet<ThreadId> } = {}) => {
+    async (
+      threadId: ThreadId,
+      opts: {
+        deletedThreadIds?: ReadonlySet<ThreadId>;
+        skipWorktreeConfirm?: boolean;
+        suppressNavigation?: boolean;
+      } = {},
+    ) => {
       const api = readNativeApi();
       if (!api) return;
       const { projects, threads } = useStore.getState();
@@ -83,6 +90,7 @@ export function useThreadActions() {
         : null;
       const canDeleteWorktree = orphanedWorktreePath !== null && threadProject !== undefined;
       const shouldDeleteWorktree =
+        !opts.skipWorktreeConfirm &&
         canDeleteWorktree &&
         (await api.dialogs.confirm(
           [
@@ -127,7 +135,7 @@ export function useThreadActions() {
       clearProjectDraftThreadById(thread.projectId, thread.id);
       clearTerminalState(threadId);
 
-      if (shouldNavigateToFallback) {
+      if (shouldNavigateToFallback && !opts.suppressNavigation) {
         if (fallbackThreadId) {
           await navigate({
             to: "/$threadId",


### PR DESCRIPTION
## Summary

This fixes project removal so a project can be deleted even when it still contains chats.

## What changed

- replaced the previous hard stop for non-empty projects with a destructive confirmation dialog in the sidebar
- reused the existing thread deletion flow so deleting a project also clears the project's chats and related draft/terminal state
- added fallback selection logic so navigation stays stable when the active project is removed
- added a focused logic test for the bulk-delete fallback path

## Why

Previously, the UI refused to remove a project until every chat inside it had been deleted individually. That made project cleanup unnecessarily tedious and inconsistent with the destructive action the user was already trying to perform.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`

## Example [After]
<img width="1212" height="892" alt="image" src="https://github.com/user-attachments/assets/ff2c941b-0eb5-4414-abb4-f08a8d36ec7a" />

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow deleting projects with chats via a confirmation dialog in the sidebar
> - Replaces the previous behavior (blocking deletion of non-empty projects) with an `AlertDialog` confirmation that shows the project name and number of chats to be deleted.
> - On confirmation, all threads in the project are bulk-deleted (skipping per-thread worktree prompts and navigation), the project is removed, and the UI navigates to the next surviving thread or home.
> - Adds `getFallbackThreadIdAfterBulkDelete` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/1753/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to select the top non-archived thread after deletion.
> - Extends `deleteThread` in [useThreadActions.ts](https://github.com/pingdotgg/t3code/pull/1753/files#diff-7d3463056176ee1e173c0ae885b4305a70a7cc854fee7040d9b9a5a28dfbda50) with `skipWorktreeConfirm` and `suppressNavigation` options used during bulk deletion.
> - Behavioral Change: projects with chats can now be fully deleted in one action; previously this was blocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e0acdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables bulk deletion of a project’s threads and changes navigation behavior when the active thread/project is removed, which could cause unexpected data loss or routing edge cases if the new flow misfires.
> 
> **Overview**
> Projects can now be removed even when they still contain chats: selecting **Remove project** opens a destructive `AlertDialog` and, on confirmation, deletes all threads in that project before dispatching `project.delete`.
> 
> To keep routing stable, the sidebar computes a cross-project fallback thread via new `getFallbackThreadIdAfterBulkDelete` and navigates to it (or home) if the active thread/draft is affected. Thread deletion is extended with `skipWorktreeConfirm` and `suppressNavigation` options to support this bulk-delete flow without per-thread prompts or intermediate redirects, and a focused logic test covers the bulk fallback selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e0acdd73404596f19ee9751348c8b6ca47cb6a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->