### PR TITLE
Feature: build Linux AppImage for arm64 instead of x64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,11 +95,11 @@ jobs:
             platform: mac
             target: dmg
             arch: x64
-          - label: Linux x64
-            runner: ubuntu-24.04
+          - label: Linux arm64
+            runner: ubuntu-24.04-arm
             platform: linux
             target: AppImage
-            arch: x64
+            arch: arm64
           - label: Windows x64
             runner: windows-2022
             platform: win

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "dist:desktop:dmg": "node scripts/build-desktop-artifact.ts --platform mac --target dmg",
     "dist:desktop:dmg:arm64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch arm64",
     "dist:desktop:dmg:x64": "node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch x64",
-    "dist:desktop:linux": "node scripts/build-desktop-artifact.ts --platform linux --target AppImage --arch x64",
+    "dist:desktop:linux": "node scripts/build-desktop-artifact.ts --platform linux --target AppImage --arch arm64",
     "dist:desktop:win": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64",
     "release:smoke": "node scripts/release-smoke.ts",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules apps/*/dist apps/*/dist-electron packages/*/dist .turbo apps/*/.turbo packages/*/.turbo",


### PR DESCRIPTION
- Update dist:desktop:linux script to use --arch arm64
- Update release workflow to use ubuntu-24.04-arm runner for Linux builds

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release pipeline output for Linux (architecture and runner), which could break Linux distribution or downstream update/install expectations if x64 artifacts are still required.
> 
> **Overview**
> Updates desktop release packaging to target **Linux arm64** instead of x64.
> 
> The release workflow swaps the Linux build matrix entry to `ubuntu-24.04-arm` and `arch: arm64`, and `package.json` updates `dist:desktop:linux` to build an arm64 AppImage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6560ff8e411651fdc37966351803a89906a5ca6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build Linux AppImage for arm64 instead of x64
> Updates the release workflow and `dist:desktop:linux` npm script to target arm64. The CI runner switches from `ubuntu-24.04` to `ubuntu-24.04-arm`, and the build flag changes from `--arch x64` to `--arch arm64` in [package.json](https://github.com/pingdotgg/t3code/pull/1755/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519). Behavioral Change: the Linux release artifact is now an arm64 AppImage; no x64 Linux AppImage is produced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6560ff8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->