### PR TITLE
fix: close claude query in probe finalizer

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -589,11 +589,13 @@ const probeClaudeCapabilities = (
     });
   }).pipe(
     Effect.ensuring(
-      Effect.gen(function* () {
-        yield* Effect.sync(() => {
+      Effect.sync(() => {
+        try {
           if (!abort.signal.aborted) abort.abort();
-        }).pipe(Effect.ignoreCause({ log: false }));
-        yield* Effect.sync(() => q?.close()).pipe(Effect.ignoreCause({ log: false }));
+        } catch {}
+        try {
+          q?.close();
+        } catch {}
       }),
     ),
     Effect.timeoutOption(CAPABILITIES_PROBE_TIMEOUT_MS),

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -551,10 +551,11 @@ const probeClaudeCapabilities = (
   environment?: NodeJS.ProcessEnv,
 ) => {
   const abort = new AbortController();
+  let q: ReturnType<typeof claudeQuery> | undefined;
   return Effect.gen(function* () {
     const claudeEnvironment = yield* makeClaudeEnvironment(claudeSettings, environment);
     return yield* Effect.tryPromise(async () => {
-      const q = claudeQuery({
+      q = claudeQuery({
         // Never yield — we only need initialization data, not a conversation.
         // This prevents any prompt from reaching the Anthropic API.
         // oxlint-disable-next-line require-yield
@@ -588,8 +589,11 @@ const probeClaudeCapabilities = (
     });
   }).pipe(
     Effect.ensuring(
-      Effect.sync(() => {
-        if (!abort.signal.aborted) abort.abort();
+      Effect.gen(function* () {
+        yield* Effect.sync(() => {
+          if (!abort.signal.aborted) abort.abort();
+        }).pipe(Effect.ignoreCause({ log: false }));
+        yield* Effect.sync(() => q?.close()).pipe(Effect.ignoreCause({ log: false }));
       }),
     ),
     Effect.timeoutOption(CAPABILITIES_PROBE_TIMEOUT_MS),


### PR DESCRIPTION
## What Changed

`ClaudeProvider.ts` uses `q.close()` for cleanup instead of `abort.abort()`.

## Why

`abort.abort()` could throw `AbortError` during shutdown and crash startup. `q.close()` uses the SDK's own disposal path, so the probe still gets `initializationResult()` and no longer crashes on cleanup.

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to probe teardown in Claude provider startup; no auth or data-path logic changes.
> 
> **Overview**
> **`probeClaudeCapabilities`** now keeps the `claudeQuery` handle in outer scope so the `Effect.ensuring` finalizer can dispose it with **`q?.close()`**, not only **`abort.abort()`**.
> 
> Cleanup wraps both **abort** and **close** in **try/catch** so thrown errors (e.g. **`AbortError`** during shutdown) do not bubble up and crash startup while the probe still reads **`initializationResult()`** before teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 088eb5ab52acc953c111e9bd60448601647f6ea5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `probeClaudeCapabilities` to close the Claude query in its finalizer
> The cleanup block in `probeClaudeCapabilities` now calls `q?.close()` on the query object if it was initialized, preventing lingering query sessions. `abort.abort()` is also wrapped in a try/catch so errors during cleanup are swallowed rather than propagated as unhandled exceptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 088eb5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/1757" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
