### PR TITLE
Raise slow RPC ack warning threshold to 15s

### DIFF
--- a/apps/web/src/rpc/requestLatencyState.ts
+++ b/apps/web/src/rpc/requestLatencyState.ts
@@ -5,6 +5,7 @@ import { appAtomRegistry } from "./atomRegistry";
 
 export const SLOW_RPC_ACK_THRESHOLD_MS = 15_000;
 export const MAX_TRACKED_RPC_ACK_REQUESTS = 256;
+let slowRpcAckThresholdMs = SLOW_RPC_ACK_THRESHOLD_MS;
 
 export interface SlowRpcAckRequest {
   readonly requestId: string;
@@ -56,12 +57,12 @@ export function trackRpcRequestSent(requestId: string, tag: string): void {
     startedAt: new Date(startedAtMs).toISOString(),
     startedAtMs,
     tag,
-    thresholdMs: SLOW_RPC_ACK_THRESHOLD_MS,
+    thresholdMs: slowRpcAckThresholdMs,
   };
   const timeoutId = setTimeout(() => {
     pendingRpcAckRequests.delete(requestId);
     appendSlowRpcAckRequest(request);
-  }, SLOW_RPC_ACK_THRESHOLD_MS);
+  }, slowRpcAckThresholdMs);
 
   pendingRpcAckRequests.set(requestId, {
     request,
@@ -119,7 +120,12 @@ function evictOldestPendingRpcRequestIfNeeded(): void {
 }
 
 export function resetRequestLatencyStateForTests(): void {
+  slowRpcAckThresholdMs = SLOW_RPC_ACK_THRESHOLD_MS;
   clearAllTrackedRpcRequests();
+}
+
+export function setSlowRpcAckThresholdMsForTests(thresholdMs: number): void {
+  slowRpcAckThresholdMs = thresholdMs;
 }
 
 export function useSlowRpcAckRequests(): ReadonlyArray<SlowRpcAckRequest> {

--- a/apps/web/src/wsTransport.test.ts
+++ b/apps/web/src/wsTransport.test.ts
@@ -5,7 +5,11 @@ import {
   __resetClientTracingForTests,
   configureClientTracing,
 } from "./observability/clientTracing";
-import { getSlowRpcAckRequests, resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
+import {
+  getSlowRpcAckRequests,
+  resetRequestLatencyStateForTests,
+  setSlowRpcAckThresholdMsForTests,
+} from "./rpc/requestLatencyState";
 import {
   getWsConnectionStatus,
   getWsConnectionUiState,
@@ -292,6 +296,8 @@ describe("WsTransport", () => {
   });
 
   it("marks unary requests as slow until the first server ack arrives", async () => {
+    const slowAckThresholdMs = 25;
+    setSlowRpcAckThresholdMsForTests(slowAckThresholdMs);
     const transport = new WsTransport("ws://localhost:3020");
 
     const requestPromise = transport.request((client) =>
@@ -320,7 +326,7 @@ describe("WsTransport", () => {
           tag: WS_METHODS.serverUpsertKeybinding,
         },
       ]);
-    }, 5_000);
+    }, 1_000);
 
     socket.serverMessage(
       JSON.stringify({
@@ -343,7 +349,7 @@ describe("WsTransport", () => {
     expect(getSlowRpcAckRequests()).toEqual([]);
 
     await transport.dispose();
-  }, 10_000);
+  }, 5_000);
 
   it("sends unary RPC requests and resolves successful exits", async () => {
     const transport = new WsTransport("ws://localhost:3020");


### PR DESCRIPTION
`git.status` is quite slow, so 3s is a bit low. increasing it til we make that query faster

## Summary
- Increased `SLOW_RPC_ACK_THRESHOLD_MS` from 2.5 seconds to 15 seconds in `apps/web/src/rpc/requestLatencyState.ts`.
- This reduces premature slow-ack tracking for RPC requests that are still within an acceptable response window.

## Testing
- Not run (change is a one-line constant update).
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adjusts a client-side slow-ack warning timeout and updates a unit test to use a configurable threshold, without changing RPC behavior or data handling.
> 
> **Overview**
> Raises the slow RPC ack tracking threshold from `2.5s` to `15s` so unary RPC requests are only flagged as slow after a longer delay.
> 
> Introduces a test-only override (`setSlowRpcAckThresholdMsForTests`) and resets it in `resetRequestLatencyStateForTests`, then updates the `WsTransport` slow-ack test to use a short threshold and tighter timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b179e57ba6b84462c48ed656bd6c33024a7082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise slow RPC ack warning threshold from 2.5s to 15s
> Increases `SLOW_RPC_ACK_THRESHOLD_MS` from `2_500` to `15_000` in [requestLatencyState.ts](https://github.com/pingdotgg/t3code/pull/1760/files#diff-084b89e2becd47f287bdcaaf7d1ac9de731014c0b96d196afd4d1f54814eb085) to reduce false-positive slow-ack warnings. The constant is also promoted to a mutable module-scoped variable to allow test-time overrides via the new `setSlowRpcAckThresholdMsForTests` utility, avoiding slow timers in tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09b179e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->