### PR TITLE
Git Sync Settings - Credential Prompt Control

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.test.ts
@@ -12,6 +12,7 @@ import { GitCoreLive } from "../../git/Layers/GitCore.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { GitCommandError } from "@t3tools/contracts";
 import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 import { ThreadId } from "@t3tools/contracts";
 
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
@@ -19,6 +20,7 @@ const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
 });
 const GitCoreTestLayer = GitCoreLive.pipe(
   Layer.provide(ServerConfigLayer),
+  Layer.provide(ServerSettingsService.layerTest()),
   Layer.provide(NodeServices.layer),
 );
 const CheckpointStoreTestLayer = CheckpointStoreLive.pipe(

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -11,12 +11,14 @@ import { GitCore, type GitCoreShape } from "../Services/GitCore.ts";
 import { GitCommandError } from "@t3tools/contracts";
 import { type ProcessRunResult, runProcess } from "../../processRunner.ts";
 import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 
 // ── Helpers ──
 
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), { prefix: "t3-git-core-test-" });
 const GitCoreTestLayer = GitCoreLive.pipe(
   Layer.provide(ServerConfigLayer),
+  Layer.provide(ServerSettingsService.layerTest()),
   Layer.provide(NodeServices.layer),
 );
 const TestLayer = Layer.mergeAll(NodeServices.layer, GitCoreTestLayer);

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -36,6 +36,7 @@ import {
   parseRemoteRefWithRemoteNames,
 } from "../remoteRefs.ts";
 import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
@@ -74,6 +75,7 @@ interface ExecuteGitOptions {
   maxOutputBytes?: number | undefined;
   truncateOutputAtMaxBytes?: boolean | undefined;
   progress?: ExecuteGitProgress | undefined;
+  env?: Record<string, string> | undefined;
 }
 
 function parseBranchAb(value: string): { ahead: number; behind: number } {
@@ -632,6 +634,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const { worktreesDir } = yield* ServerConfig;
+  const serverSettings = yield* ServerSettingsService;
 
   let executeRaw: GitCoreShape["execute"];
 
@@ -770,6 +773,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       cwd,
       args,
       ...(options.stdin !== undefined ? { stdin: options.stdin } : {}),
+      ...(options.env !== undefined ? { env: options.env } : {}),
       allowNonZeroExit: true,
       ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
       ...(options.maxOutputBytes !== undefined ? { maxOutputBytes: options.maxOutputBytes } : {}),
@@ -893,20 +897,35 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
   const fetchUpstreamRefForStatus = (
     gitCommonDir: string,
     upstream: { upstreamRef: string; remoteName: string; upstreamBranch: string },
-  ): Effect.Effect<void, GitCommandError> => {
-    const refspec = `+refs/heads/${upstream.upstreamBranch}:refs/remotes/${upstream.upstreamRef}`;
-    const fetchCwd =
-      path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
-    return executeGit(
-      "GitCore.fetchUpstreamRefForStatus",
-      fetchCwd,
-      ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", upstream.remoteName, refspec],
-      {
-        allowNonZeroExit: true,
-        timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
-      },
-    ).pipe(Effect.asVoid);
-  };
+  ): Effect.Effect<void, GitCommandError> =>
+    Effect.gen(function* () {
+      const settings = yield* serverSettings.getSettings.pipe(
+        Effect.catch(() => Effect.succeed(null)),
+      );
+      const quietEnv: Record<string, string> =
+        settings?.gitQuietBackgroundChecks
+          ? {
+              GIT_TERMINAL_PROMPT: "0",
+              SSH_ASKPASS: "",
+              GIT_ASKPASS: "",
+              GCM_INTERACTIVE: "never",
+            }
+          : {};
+
+      const refspec = `+refs/heads/${upstream.upstreamBranch}:refs/remotes/${upstream.upstreamRef}`;
+      const fetchCwd =
+        path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
+      yield* executeGit(
+        "GitCore.fetchUpstreamRefForStatus",
+        fetchCwd,
+        ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", upstream.remoteName, refspec],
+        {
+          allowNonZeroExit: true,
+          timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
+          env: quietEnv,
+        },
+      );
+    }).pipe(Effect.asVoid);
 
   const resolveGitCommonDir = Effect.fn("resolveGitCommonDir")(function* (cwd: string) {
     const gitCommonDir = yield* runGitStdout("GitCore.resolveGitCommonDir", cwd, [
@@ -940,6 +959,11 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
   const refreshStatusUpstreamIfStale = Effect.fn("refreshStatusUpstreamIfStale")(function* (
     cwd: string,
   ) {
+    const settings = yield* serverSettings.getSettings.pipe(
+      Effect.catch(() => Effect.succeed(null)),
+    );
+    if (settings?.gitPollingMode === "disabled") return;
+
     const upstream = yield* resolveCurrentUpstream(cwd);
     if (!upstream) return;
     const gitCommonDir = yield* resolveGitCommonDir(cwd);

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -624,6 +624,7 @@ function makeManager(input?: {
   const gitCoreLayer = GitCoreLive.pipe(
     Layer.provideMerge(NodeServices.layer),
     Layer.provideMerge(ServerConfigLayer),
+    Layer.provideMerge(serverSettingsLayer),
   );
 
   const managerLayer = Layer.mergeAll(
@@ -649,6 +650,7 @@ const asThreadId = (threadId: string) => threadId as ThreadId;
 
 const GitManagerTestLayer = GitCoreLive.pipe(
   Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-git-manager-test-" })),
+  Layer.provide(ServerSettingsService.layerTest()),
   Layer.provideMerge(NodeServices.layer),
 );
 

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CheckpointStoreLive } from "../../checkpointing/Layers/CheckpointStore.ts";
 import { CheckpointStore } from "../../checkpointing/Services/CheckpointStore.ts";
 import { GitCoreLive } from "../../git/Layers/GitCore.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 import { CheckpointReactorLive } from "./CheckpointReactor.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
@@ -271,6 +272,7 @@ describe("CheckpointReactor", () => {
       Layer.provideMerge(WorkspaceEntriesLive.pipe(Layer.provide(WorkspacePathsLive))),
       Layer.provideMerge(WorkspacePathsLive),
       Layer.provideMerge(GitCoreLive),
+      Layer.provideMerge(ServerSettingsService.layerTest()),
       Layer.provideMerge(ServerConfigLayer),
       Layer.provideMerge(NodeServices.layer),
     );

--- a/apps/server/src/workspace/Layers/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceEntries.test.ts
@@ -6,6 +6,7 @@ import { Effect, FileSystem, Layer, Path, PlatformError } from "effect";
 
 import { ServerConfig } from "../../config.ts";
 import { GitCoreLive } from "../../git/Layers/GitCore.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { WorkspaceEntries } from "../Services/WorkspaceEntries.ts";
 import { WorkspaceEntriesLive } from "./WorkspaceEntries.ts";
@@ -15,6 +16,7 @@ const TestLayer = Layer.empty.pipe(
   Layer.provideMerge(WorkspaceEntriesLive.pipe(Layer.provide(WorkspacePathsLive))),
   Layer.provideMerge(WorkspacePathsLive),
   Layer.provideMerge(GitCoreLive),
+  Layer.provideMerge(ServerSettingsService.layerTest()),
   Layer.provide(
     ServerConfig.layerTest(process.cwd(), {
       prefix: "t3-workspace-entries-test-",

--- a/apps/server/src/workspace/Layers/WorkspaceFileSystem.test.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceFileSystem.test.ts
@@ -4,6 +4,7 @@ import { Effect, FileSystem, Layer, Path } from "effect";
 
 import { ServerConfig } from "../../config.ts";
 import { GitCoreLive } from "../../git/Layers/GitCore.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
 import { WorkspaceEntries } from "../Services/WorkspaceEntries.ts";
 import { WorkspaceFileSystem } from "../Services/WorkspaceFileSystem.ts";
 import { WorkspaceEntriesLive } from "./WorkspaceEntries.ts";
@@ -20,6 +21,7 @@ const TestLayer = Layer.empty.pipe(
   Layer.provideMerge(WorkspaceEntriesLive.pipe(Layer.provide(WorkspacePathsLive))),
   Layer.provideMerge(WorkspacePathsLive),
   Layer.provideMerge(GitCoreLive),
+  Layer.provideMerge(ServerSettingsService.layerTest()),
   Layer.provide(
     ServerConfig.layerTest(process.cwd(), {
       prefix: "t3-workspace-files-test-",

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -20,6 +20,7 @@ import {
   gitStatusQueryOptions,
   invalidateGitQueries,
 } from "../lib/gitReactQuery";
+import { useSettings } from "../hooks/useSettings";
 import { readNativeApi } from "../nativeApi";
 import { parsePullRequestReference } from "../pullRequestReference";
 import {
@@ -89,16 +90,24 @@ export function BranchToolbarBranchSelector({
   const [branchQuery, setBranchQuery] = useState("");
   const deferredBranchQuery = useDeferredValue(branchQuery);
 
-  const branchStatusQuery = useQuery(gitStatusQueryOptions(branchCwd));
+  const { gitPollingMode } = useSettings();
+  const gitPollingEnabled = gitPollingMode !== "disabled";
+  const branchStatusQuery = useQuery(
+    gitStatusQueryOptions(branchCwd, { pollingEnabled: gitPollingEnabled }),
+  );
   const trimmedBranchQuery = branchQuery.trim();
   const deferredTrimmedBranchQuery = deferredBranchQuery.trim();
 
   useEffect(() => {
     if (!branchCwd) return;
     void queryClient.prefetchInfiniteQuery(
-      gitBranchSearchInfiniteQueryOptions({ cwd: branchCwd, query: "" }),
+      gitBranchSearchInfiniteQueryOptions({
+        cwd: branchCwd,
+        query: "",
+        pollingEnabled: gitPollingEnabled,
+      }),
     );
-  }, [branchCwd, queryClient]);
+  }, [branchCwd, queryClient, gitPollingEnabled]);
 
   const {
     data: branchesSearchData,
@@ -111,6 +120,7 @@ export function BranchToolbarBranchSelector({
       cwd: branchCwd,
       query: deferredTrimmedBranchQuery,
       enabled: isBranchMenuOpen,
+      pollingEnabled: gitPollingEnabled,
     }),
   );
   const branches = useMemo(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1399,7 +1399,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
     (debouncerState) => ({ isPending: debouncerState.isPending }),
   );
   const effectivePathQuery = pathTriggerQuery.length > 0 ? debouncedPathQuery : "";
-  const gitStatusQuery = useQuery(gitStatusQueryOptions(gitCwd));
+  const gitPollingEnabled = settings.gitPollingMode !== "disabled";
+  const gitStatusQuery = useQuery(
+    gitStatusQueryOptions(gitCwd, { pollingEnabled: gitPollingEnabled }),
+  );
   const keybindings = useServerKeybindings();
   const availableEditors = useServerAvailableEditors();
   const modelOptionsByProvider = useMemo(

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -189,7 +189,11 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     activeProjectId ? store.projects.find((project) => project.id === activeProjectId) : undefined,
   );
   const activeCwd = activeThread?.worktreePath ?? activeProject?.cwd;
-  const gitStatusQuery = useQuery(gitStatusQueryOptions(activeCwd ?? null));
+  const gitStatusQuery = useQuery(
+    gitStatusQueryOptions(activeCwd ?? null, {
+      pollingEnabled: settings.gitPollingMode !== "disabled",
+    }),
+  );
   const isGitRepo = gitStatusQuery.data?.isRepo ?? true;
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -51,6 +51,7 @@ import {
 import { newCommandId, randomUUID } from "~/lib/utils";
 import { resolvePathLinkTarget } from "~/terminal-links";
 import { readNativeApi } from "~/nativeApi";
+import { useSettings } from "~/hooks/useSettings";
 import { useStore } from "~/store";
 
 interface GitActionsControlProps {
@@ -275,7 +276,10 @@ export default function GitActionsControl({ gitCwd, activeThreadId }: GitActions
     [persistThreadBranchSync],
   );
 
-  const { data: gitStatus = null, error: gitStatusError } = useQuery(gitStatusQueryOptions(gitCwd));
+  const { gitPollingMode } = useSettings();
+  const { data: gitStatus = null, error: gitStatusError } = useQuery(
+    gitStatusQueryOptions(gitCwd, { pollingEnabled: gitPollingMode !== "disabled" }),
+  );
   // Default to true while loading so we don't flash init controls.
   const isRepo = gitStatus?.isRepo ?? true;
   const hasOriginRemote = gitStatus?.hasOriginRemote ?? false;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -782,11 +782,12 @@ export default function Sidebar() {
     ],
     [threadGitTargets],
   );
+  const sidebarGitPollingEnabled = appSettings.gitPollingMode === "all";
   const threadGitStatusQueries = useQueries({
     queries: threadGitStatusCwds.map((cwd) => ({
-      ...gitStatusQueryOptions(cwd),
+      ...gitStatusQueryOptions(cwd, { pollingEnabled: sidebarGitPollingEnabled }),
       staleTime: 30_000,
-      refetchInterval: 60_000,
+      refetchInterval: sidebarGitPollingEnabled ? 60_000 : false,
     })),
   });
   const prByThreadId = useMemo(() => {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -86,6 +86,12 @@ const TIMESTAMP_FORMAT_LABELS = {
   "24-hour": "24-hour",
 } as const;
 
+const GIT_POLLING_MODE_LABELS = {
+  all: "All sessions",
+  "active-session": "Active session only",
+  disabled: "Disabled",
+} as const;
+
 type InstallProviderSettings = {
   provider: ProviderKind;
   title: string;
@@ -1409,6 +1415,80 @@ export function GeneralSettingsPanel() {
             </div>
           );
         })}
+      </SettingsSection>
+
+      <SettingsSection title="Git Sync">
+        <SettingsRow
+          title="Background git polling"
+          description="Controls how t3code automatically fetches from remote and refreshes git status. Disabling stops all automatic git sync, including ahead/behind counts."
+          resetAction={
+            settings.gitPollingMode !== DEFAULT_UNIFIED_SETTINGS.gitPollingMode ? (
+              <SettingResetButton
+                label="background git polling"
+                onClick={() =>
+                  updateSettings({
+                    gitPollingMode: DEFAULT_UNIFIED_SETTINGS.gitPollingMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.gitPollingMode}
+              onValueChange={(value) => {
+                if (value === "all" || value === "active-session" || value === "disabled") {
+                  updateSettings({ gitPollingMode: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-48" aria-label="Git polling mode">
+                <SelectValue>
+                  {GIT_POLLING_MODE_LABELS[settings.gitPollingMode]}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="all">
+                  {GIT_POLLING_MODE_LABELS.all}
+                </SelectItem>
+                <SelectItem hideIndicator value="active-session">
+                  {GIT_POLLING_MODE_LABELS["active-session"]}
+                </SelectItem>
+                <SelectItem hideIndicator value="disabled">
+                  {GIT_POLLING_MODE_LABELS.disabled}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Quiet background fetches"
+          description="Suppress credential prompts during automatic git fetches. Useful with SSH agents like 1Password that require interactive confirmation per request."
+          resetAction={
+            settings.gitQuietBackgroundChecks !==
+            DEFAULT_UNIFIED_SETTINGS.gitQuietBackgroundChecks ? (
+              <SettingResetButton
+                label="quiet background fetches"
+                onClick={() =>
+                  updateSettings({
+                    gitQuietBackgroundChecks: DEFAULT_UNIFIED_SETTINGS.gitQuietBackgroundChecks,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.gitQuietBackgroundChecks}
+              disabled={settings.gitPollingMode === "disabled"}
+              onCheckedChange={(checked) =>
+                updateSettings({ gitQuietBackgroundChecks: Boolean(checked) })
+              }
+              aria-label="Suppress credential prompts during background fetches"
+            />
+          }
+        />
       </SettingsSection>
 
       <SettingsSection title="Advanced">

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -55,7 +55,11 @@ export function invalidateGitStatusQuery(queryClient: QueryClient, cwd: string |
   return queryClient.invalidateQueries({ queryKey: gitQueryKeys.status(cwd) });
 }
 
-export function gitStatusQueryOptions(cwd: string | null) {
+export function gitStatusQueryOptions(
+  cwd: string | null,
+  options?: { pollingEnabled?: boolean },
+) {
+  const polling = options?.pollingEnabled ?? true;
   return queryOptions({
     queryKey: gitQueryKeys.status(cwd),
     queryFn: async () => {
@@ -65,9 +69,9 @@ export function gitStatusQueryOptions(cwd: string | null) {
     },
     enabled: cwd !== null,
     staleTime: GIT_STATUS_STALE_TIME_MS,
-    refetchOnWindowFocus: "always",
-    refetchOnReconnect: "always",
-    refetchInterval: GIT_STATUS_REFETCH_INTERVAL_MS,
+    refetchOnWindowFocus: polling ? "always" : false,
+    refetchOnReconnect: polling ? "always" : false,
+    refetchInterval: polling ? GIT_STATUS_REFETCH_INTERVAL_MS : false,
   });
 }
 
@@ -75,8 +79,10 @@ export function gitBranchSearchInfiniteQueryOptions(input: {
   cwd: string | null;
   query: string;
   enabled?: boolean;
+  pollingEnabled?: boolean;
 }) {
   const normalizedQuery = input.query.trim();
+  const polling = input.pollingEnabled ?? true;
 
   return infiniteQueryOptions({
     queryKey: gitQueryKeys.branchSearch(input.cwd, normalizedQuery),
@@ -94,9 +100,9 @@ export function gitBranchSearchInfiniteQueryOptions(input: {
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     enabled: input.cwd !== null && (input.enabled ?? true),
     staleTime: GIT_BRANCHES_STALE_TIME_MS,
-    refetchOnWindowFocus: true,
-    refetchOnReconnect: true,
-    refetchInterval: GIT_BRANCHES_REFETCH_INTERVAL_MS,
+    refetchOnWindowFocus: polling,
+    refetchOnReconnect: polling,
+    refetchInterval: polling ? GIT_BRANCHES_REFETCH_INTERVAL_MS : false,
   });
 }
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -44,6 +44,9 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 export const ThreadEnvMode = Schema.Literals(["local", "worktree"]);
 export type ThreadEnvMode = typeof ThreadEnvMode.Type;
 
+export const GitPollingMode = Schema.Literals(["all", "active-session", "disabled"]);
+export type GitPollingMode = typeof GitPollingMode.Type;
+
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
     Schema.decodeTo(
@@ -95,6 +98,12 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(() => ({}))),
   }).pipe(Schema.withDecodingDefault(() => ({}))),
   observability: ObservabilitySettings.pipe(Schema.withDecodingDefault(() => ({}))),
+
+  // Git sync settings
+  gitPollingMode: GitPollingMode.pipe(
+    Schema.withDecodingDefault(() => "all" as const satisfies GitPollingMode),
+  ),
+  gitQuietBackgroundChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
 });
 export type ServerSettings = typeof ServerSettings.Type;
 
@@ -177,5 +186,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
     }),
   ),
+  gitPollingMode: Schema.optionalKey(GitPollingMode),
+  gitQuietBackgroundChecks: Schema.optionalKey(Schema.Boolean),
 });
 export type ServerSettingsPatch = typeof ServerSettingsPatch.Type;


### PR DESCRIPTION
Closes #1467

## Problem

t3code performs a background `git fetch` every ~15 seconds to compute ahead/behind counts.
When a repository uses SSH remotes and the user's SSH agent (e.g. 1Password) requires
interactive confirmation, this causes repeated authentication dialogs that steal focus
and get killed by the 5-second fetch timeout before the user can respond.

## Solution

Add **server settings** under a new "Git Sync" section in Settings.
All defaults preserve the current behaviour so existing users are unaffected.

| Setting | Type | Default | What it does |
|---|---|---|---|
| **Background git polling** | Select | `"all"` | `All sessions` — all sessions poll (current behaviour). `Active session only` — only the focused session polls; sidebar background-thread queries pause. `Disabled` — no automatic git sync at all. |
| **Quiet background fetches** | Toggle | OFF | Suppresses credential prompts during automatic git fetches by setting `GIT_TERMINAL_PROMPT=0`, `SSH_ASKPASS=""`, `GIT_ASKPASS=""`, `GCM_INTERACTIVE=never` on the fetch subprocess. Useful with SSH agents like 1Password. |

## How It Works

### Polling Mode (`gitPollingMode`)

- **`"all"`** (default) — Every session and the sidebar poll for git status on their normal intervals (15s for active, 60s for sidebar threads). Server-side upstream fetch runs every 15s. No change from current behaviour.
- **`"active-session"`** — The active/focused session polls normally. Sidebar thread status queries stop polling (`refetchInterval: false`). Server-side upstream fetch still runs when triggered by the active session's status query.
- **`"disabled"`** — All client-side polling intervals are disabled (`refetchInterval: false`, `refetchOnWindowFocus: false`). Server-side `refreshStatusUpstreamIfStale` early-returns without executing `git fetch`. Manual operations (push, pull, checkout) still work.

### Quiet Background Fetches (`gitQuietBackgroundChecks`)

When enabled, the `fetchUpstreamRefForStatus` function passes environment variables to the `git fetch` subprocess that suppress all interactive credential prompts:

| Variable | Purpose |
|---|---|
| `GIT_TERMINAL_PROMPT=0` | Prevents git from prompting on the terminal |
| `SSH_ASKPASS=""` | Prevents SSH from spawning an askpass helper (e.g. 1Password dialog) |
| `GIT_ASKPASS=""` | Prevents git's own askpass mechanism |
| `GCM_INTERACTIVE=never` | Prevents Git Credential Manager from showing dialogs (Windows) |

If credentials are already cached/loaded in the agent, the fetch succeeds silently. If not, it fails silently (the fetch already has `allowNonZeroExit: true` and the caller wraps it in `Effect.ignoreCause`).

This toggle is visually disabled when polling mode is `"disabled"` since there are no background fetches to quiet.

## Architecture

### Data Flow

```
Settings UI (Select / Switch)
  → useUpdateSettings() → ServerSettingsService.updateSettings(patch)
  → settings.json on disk (sparse: only non-default values stored)
  → PubSub → WebSocket subscription → client atom update → component re-render
```

### Server-Side (Effect layers)

`GitCoreLive` now depends on `ServerSettingsService` (yielded in `makeGitCore`). Settings are read via `serverSettings.getSettings` with `Effect.catch(() => Effect.succeed(null))` fallback so settings errors don't break git operations.

### Client-Side (React Query)

`gitStatusQueryOptions` and `gitBranchSearchInfiniteQueryOptions` accept an optional `{ pollingEnabled }` parameter that controls `refetchInterval`, `refetchOnWindowFocus`, and `refetchOnReconnect`. Each consumer component derives `pollingEnabled` from `settings.gitPollingMode`.

## Files Changed (15 files, +184 / -29)

### Schema & Contracts
- **`packages/contracts/src/settings.ts`** — Add `GitPollingMode` literal type (`"all" | "active-session" | "disabled"`), `gitPollingMode` field (default `"all"`), and `gitQuietBackgroundChecks` boolean (default `false`) to `ServerSettings` + `ServerSettingsPatch`

### Server — Git Fetch Control
- **`apps/server/src/git/Layers/GitCore.ts`** (+52 / -14)
  - Add `env` field to `ExecuteGitOptions` interface and forward it through `executeGit` → `execute` → subprocess spawn
  - Import `ServerSettingsService`, yield it in `makeGitCore`
  - `refreshStatusUpstreamIfStale`: early-return when `gitPollingMode === "disabled"`
  - `fetchUpstreamRefForStatus`: read `gitQuietBackgroundChecks`, conditionally set quiet env vars on the fetch subprocess

### Client — Polling Interval Control
- **`apps/web/src/lib/gitReactQuery.ts`** — Add optional `pollingEnabled` param to `gitStatusQueryOptions` and `gitBranchSearchInfiniteQueryOptions`; controls `refetchInterval`, `refetchOnWindowFocus`, `refetchOnReconnect`
- **`apps/web/src/components/Sidebar.tsx`** — Sidebar thread polling enabled only when `gitPollingMode === "all"`
- **`apps/web/src/components/ChatView.tsx`** — Derive `pollingEnabled` from `gitPollingMode !== "disabled"`
- **`apps/web/src/components/DiffPanel.tsx`** — Same pattern
- **`apps/web/src/components/GitActionsControl.tsx`** — Same pattern (added `useSettings` import)
- **`apps/web/src/components/BranchToolbarBranchSelector.tsx`** — Same pattern for both status and branch search queries (added `useSettings` import)

### Settings UI
- **`apps/web/src/components/settings/SettingsPanels.tsx`** (+80)
  - New `GIT_POLLING_MODE_LABELS` constant
  - New "Git Sync" `SettingsSection` between Providers and Advanced with:
    - **Background git polling** — `Select` with three options (All sessions / Active session only / Disabled)
    - **Quiet background fetches** — `Switch` toggle, disabled when polling mode is "Disabled"
  - Both rows have reset buttons and descriptive helper text  
<img width="984" height="252" alt="image" src="https://github.com/user-attachments/assets/4e5fa4ba-2856-49d8-8233-a6c64d196e66" />

### Test Files — New Layer Dependency
Adding `ServerSettingsService` as a dependency of `GitCoreLive` requires providing `ServerSettingsService.layerTest()` in test layer stacks:
- `apps/server/src/git/Layers/GitCore.test.ts`
- `apps/server/src/git/Layers/GitManager.test.ts`
- `apps/server/src/checkpointing/Layers/CheckpointStore.test.ts`
- `apps/server/src/orchestration/Layers/CheckpointReactor.test.ts`
- `apps/server/src/workspace/Layers/WorkspaceEntries.test.ts`
- `apps/server/src/workspace/Layers/WorkspaceFileSystem.test.ts`

## Verification

- **Build**: `npx turbo run build` — all 5 tasks pass
- **Server startup**: `node dist/bin.mjs` — starts cleanly on `:3773`, no errors
- **Runtime**: Verified `Effect.catch` (not `Effect.catchAll`) is the correct API for Effect 4.0 beta



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Git Sync settings to control background polling mode and credential prompts
> - Adds two new server settings: `gitPollingMode` (`all` | `active-session` | `disabled`) and `gitQuietBackgroundChecks` (boolean), configurable via a new Git Sync section in the General Settings panel.
> - When `gitPollingMode` is `disabled`, background upstream status refresh is skipped server-side in `GitCore`, and all client-side git status/branch polling (Sidebar, ChatView, DiffPanel, GitActionsControl, BranchToolbarBranchSelector) is suspended.
> - When `gitQuietBackgroundChecks` is enabled, background git fetches suppress interactive credential prompts by setting `GIT_TERMINAL_PROMPT=0`, `GIT_ASKPASS`, `SSH_ASKPASS` empty, and `GCM_INTERACTIVE=never`.
> - Behavioral Change: `gitPollingMode` defaults to `all` and `gitQuietBackgroundChecks` defaults to `false`, preserving existing behavior for users who have not changed settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a789d30.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->