### PR TITLE
feat: Niri-style spatial canvas navigation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "@formkit/auto-animate": "^0.9.0",
     "@lexical/react": "^0.41.0",
     "@pierre/diffs": "^1.1.0-beta.16",
+    "@react-spring/web": "^10.0.3",
     "@t3tools/contracts": "workspace:*",
     "@t3tools/shared": "workspace:*",
     "@tanstack/react-pacer": "^0.19.4",

--- a/apps/web/src/canvasStore.ts
+++ b/apps/web/src/canvasStore.ts
@@ -1,0 +1,391 @@
+/**
+ * Canvas Store — Zustand state for Niri-style spatial canvas navigation.
+ *
+ * Manages the 2D position (project row × thread column), mode switching
+ * (navigate / overview / launcher), column width presets, and per-project
+ * thread pagination cursors.
+ */
+import { type ProjectId, type ThreadId } from "@t3tools/contracts";
+import { create } from "zustand";
+import {
+  COLUMN_WIDTH_PRESETS,
+  DEFAULT_COLUMN_WIDTH_PRESET,
+  type ColumnWidthPreset,
+} from "./lib/springProfiles";
+import { type SidebarThreadSummary, type Project } from "./types";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export type CanvasMode = "navigate" | "overview" | "launcher";
+
+export interface ProjectThreadCursor {
+  loaded: number;
+  hasMore: boolean;
+  loading: boolean;
+}
+
+// ── State ───────────────────────────────────────────────────────────
+
+export interface CanvasState {
+  /** Whether canvas mode is enabled (vs. sidebar mode). */
+  enabled: boolean;
+
+  /** Current canvas mode. */
+  mode: CanvasMode;
+
+  /** Y-axis: focused project row index. */
+  focusedProjectIndex: number;
+
+  /** X-axis: focused thread column index (0 = newest). */
+  focusedThreadIndex: number;
+
+  /** Resolved project ID at the focused row. */
+  focusedProjectId: ProjectId | null;
+
+  /** Resolved thread ID at the focused column. */
+  focusedThreadId: ThreadId | null;
+
+  /** Column width as fraction of viewport width. */
+  columnWidthPreset: ColumnWidthPreset;
+
+  /** Overview mode cursor — project axis. */
+  overviewCursorProject: number;
+
+  /** Overview mode cursor — thread axis. */
+  overviewCursorThread: number;
+
+  /** Launcher search query. */
+  launcherQuery: string;
+
+  /** Launcher selected result index. */
+  launcherSelectedIndex: number;
+
+  /** Per-project thread loading state for "show more" at right edge. */
+  projectThreadCursors: Record<string, ProjectThreadCursor>;
+
+  /** Previous project index for Mod+TAB toggle behavior. */
+  previousProjectIndex: number | null;
+}
+
+const initialState: CanvasState = {
+  enabled: false,
+  mode: "navigate",
+  focusedProjectIndex: 0,
+  focusedThreadIndex: 0,
+  focusedProjectId: null,
+  focusedThreadId: null,
+  columnWidthPreset: DEFAULT_COLUMN_WIDTH_PRESET,
+  overviewCursorProject: 0,
+  overviewCursorThread: 0,
+  launcherQuery: "",
+  launcherSelectedIndex: 0,
+  projectThreadCursors: {},
+  previousProjectIndex: null,
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** External data accessors — set once by CanvasShell on mount. */
+let _getProjects: () => Project[] = () => [];
+let _getThreadsForProject: (projectId: ProjectId | null) => SidebarThreadSummary[] = () => [];
+
+export function setCanvasDataAccessors(
+  getProjects: () => Project[],
+  getThreadsForProject: (projectId: ProjectId | null) => SidebarThreadSummary[],
+): void {
+  _getProjects = getProjects;
+  _getThreadsForProject = getThreadsForProject;
+}
+
+function resolveProjectId(state: CanvasState): ProjectId | null {
+  const projects = _getProjects();
+  return projects[state.focusedProjectIndex]?.id ?? null;
+}
+
+function resolveThreadId(state: CanvasState, projectId: ProjectId | null): ThreadId | null {
+  if (!projectId) return null;
+  const threads = _getThreadsForProject(projectId);
+  return threads[state.focusedThreadIndex]?.id ?? null;
+}
+
+function syncFocusIds(state: CanvasState): Partial<CanvasState> {
+  const projectId = resolveProjectId(state);
+  const threadId = resolveThreadId(state, projectId);
+  if (state.focusedProjectId === projectId && state.focusedThreadId === threadId) {
+    return {};
+  }
+  return { focusedProjectId: projectId, focusedThreadId: threadId };
+}
+
+// ── Store ───────────────────────────────────────────────────────────
+
+export interface CanvasActions {
+  setEnabled: (enabled: boolean) => void;
+
+  // Navigation
+  navigateLeft: () => void;
+  navigateRight: () => void;
+  navigateUp: () => void;
+  navigateDown: () => void;
+  jumpToProject: (targetIndex: number) => void;
+  jumpToThread: (projectId: ProjectId, threadId: ThreadId) => void;
+  togglePreviousProject: () => void;
+
+  // Focus sync (called when external data changes)
+  syncFocus: () => void;
+
+  // Modes
+  toggleOverview: () => void;
+  openLauncher: () => void;
+  closeLauncher: () => void;
+  exitOverlay: () => void;
+
+  // Launcher
+  setLauncherQuery: (query: string) => void;
+  setLauncherSelectedIndex: (index: number) => void;
+
+  // Layout
+  cycleColumnWidth: () => void;
+  setColumnWidthPreset: (preset: ColumnWidthPreset) => void;
+
+  // Pagination
+  setProjectThreadCursor: (projectId: string, cursor: Partial<ProjectThreadCursor>) => void;
+}
+
+export type CanvasStore = CanvasState & CanvasActions;
+
+export const useCanvasStore = create<CanvasStore>((set, get) => ({
+  ...initialState,
+
+  setEnabled: (enabled) => set({ enabled }),
+
+  // ── Navigation ──────────────────────────────────────────────────
+
+  navigateLeft: () => {
+    const { focusedThreadIndex, mode } = get();
+    if (mode !== "navigate") return;
+    if (focusedThreadIndex <= 0) return; // boundary: do nothing
+
+    const nextIndex = focusedThreadIndex - 1;
+    const base = { focusedThreadIndex: nextIndex };
+    const next = { ...get(), ...base };
+    set({ ...base, ...syncFocusIds(next) });
+  },
+
+  navigateRight: () => {
+    const state = get();
+    if (state.mode !== "navigate") return;
+
+    const projectId = state.focusedProjectId;
+    const threads = _getThreadsForProject(projectId);
+
+    if (state.focusedThreadIndex >= threads.length - 1) {
+      // At the edge — try to load more if available
+      if (projectId) {
+        const cursor = state.projectThreadCursors[projectId];
+        if (cursor?.hasMore && !cursor.loading) {
+          // Signal that we want more threads — CanvasShell handles the RPC
+          set({
+            projectThreadCursors: {
+              ...state.projectThreadCursors,
+              [projectId]: { ...cursor, loading: true },
+            },
+          });
+        }
+      }
+      return; // boundary: can't navigate into unloaded content
+    }
+
+    const nextIndex = state.focusedThreadIndex + 1;
+    const base = { focusedThreadIndex: nextIndex };
+    const next = { ...state, ...base };
+    set({ ...base, ...syncFocusIds(next) });
+  },
+
+  navigateUp: () => {
+    const { focusedProjectIndex, mode } = get();
+    if (mode !== "navigate") return;
+    if (focusedProjectIndex <= 0) return; // boundary: do nothing
+
+    const nextIndex = focusedProjectIndex - 1;
+    const base = { focusedProjectIndex: nextIndex, focusedThreadIndex: 0 };
+    const next = { ...get(), ...base };
+    set({
+      ...base,
+      previousProjectIndex: focusedProjectIndex,
+      ...syncFocusIds(next),
+    });
+  },
+
+  navigateDown: () => {
+    const state = get();
+    if (state.mode !== "navigate") return;
+
+    const projects = _getProjects();
+    if (state.focusedProjectIndex >= projects.length - 1) return; // boundary
+
+    const nextIndex = state.focusedProjectIndex + 1;
+    const base = { focusedProjectIndex: nextIndex, focusedThreadIndex: 0 };
+    const next = { ...state, ...base };
+    set({
+      ...base,
+      previousProjectIndex: state.focusedProjectIndex,
+      ...syncFocusIds(next),
+    });
+  },
+
+  jumpToProject: (targetIndex) => {
+    const state = get();
+    const projects = _getProjects();
+    const projectCount = projects.length;
+
+    // If pressing same number and on a non-project row, toggle back
+    if (targetIndex === state.focusedProjectIndex && state.focusedProjectIndex >= projectCount) {
+      if (state.previousProjectIndex !== null) {
+        const base = {
+          focusedProjectIndex: state.previousProjectIndex,
+          previousProjectIndex: state.focusedProjectIndex,
+          focusedThreadIndex: 0,
+        };
+        const next = { ...state, ...base };
+        set({ ...base, ...syncFocusIds(next) });
+        return;
+      }
+    }
+
+    // Clamp to valid range (projectCount = one past last = "new project" row)
+    const resolvedIndex = Math.min(targetIndex, projectCount);
+
+    const base = {
+      previousProjectIndex: state.focusedProjectIndex,
+      focusedProjectIndex: resolvedIndex,
+      focusedThreadIndex: 0,
+    };
+    const next = { ...state, ...base };
+    set({ ...base, ...syncFocusIds(next) });
+  },
+
+  jumpToThread: (projectId, threadId) => {
+    const state = get();
+    const projects = _getProjects();
+    const projectIndex = projects.findIndex((p) => p.id === projectId);
+    if (projectIndex === -1) return;
+
+    const threads = _getThreadsForProject(projectId);
+    const threadIndex = threads.findIndex((t) => t.id === threadId);
+    if (threadIndex === -1) return;
+
+    set({
+      previousProjectIndex: state.focusedProjectIndex,
+      focusedProjectIndex: projectIndex,
+      focusedThreadIndex: threadIndex,
+      focusedProjectId: projectId,
+      focusedThreadId: threadId,
+      mode: "navigate",
+      launcherQuery: "",
+      launcherSelectedIndex: 0,
+    });
+  },
+
+  togglePreviousProject: () => {
+    const state = get();
+    if (state.previousProjectIndex === null) return;
+
+    const base = {
+      focusedProjectIndex: state.previousProjectIndex,
+      previousProjectIndex: state.focusedProjectIndex,
+      focusedThreadIndex: 0,
+    };
+    const next = { ...state, ...base };
+    set({ ...base, ...syncFocusIds(next) });
+  },
+
+  syncFocus: () => {
+    const state = get();
+    const updates = syncFocusIds(state);
+    if (Object.keys(updates).length > 0) {
+      set(updates);
+    }
+  },
+
+  // ── Modes ───────────────────────────────────────────────────────
+
+  toggleOverview: () => {
+    const { mode, focusedProjectIndex, focusedThreadIndex } = get();
+    if (mode === "overview") {
+      set({ mode: "navigate" });
+    } else {
+      set({
+        mode: "overview",
+        overviewCursorProject: focusedProjectIndex,
+        overviewCursorThread: focusedThreadIndex,
+      });
+    }
+  },
+
+  openLauncher: () => {
+    set({ mode: "launcher", launcherQuery: "", launcherSelectedIndex: 0 });
+  },
+
+  closeLauncher: () => {
+    set({ mode: "navigate", launcherQuery: "", launcherSelectedIndex: 0 });
+  },
+
+  exitOverlay: () => {
+    const { mode } = get();
+    if (mode === "launcher") set({ mode: "navigate", launcherQuery: "", launcherSelectedIndex: 0 });
+    else if (mode === "overview") set({ mode: "navigate" });
+  },
+
+  // ── Launcher ────────────────────────────────────────────────────
+
+  setLauncherQuery: (query) => set({ launcherQuery: query, launcherSelectedIndex: 0 }),
+  setLauncherSelectedIndex: (index) => set({ launcherSelectedIndex: index }),
+
+  // ── Layout ──────────────────────────────────────────────────────
+
+  cycleColumnWidth: () => {
+    const { columnWidthPreset } = get();
+    const currentIndex = COLUMN_WIDTH_PRESETS.indexOf(columnWidthPreset);
+    const nextIndex = (currentIndex + 1) % COLUMN_WIDTH_PRESETS.length;
+    set({ columnWidthPreset: COLUMN_WIDTH_PRESETS[nextIndex]! });
+  },
+
+  setColumnWidthPreset: (preset) => set({ columnWidthPreset: preset }),
+
+  // ── Pagination ──────────────────────────────────────────────────
+
+  setProjectThreadCursor: (projectId, cursor) => {
+    const { projectThreadCursors } = get();
+    const existing = projectThreadCursors[projectId] ?? {
+      loaded: 0,
+      hasMore: true,
+      loading: false,
+    };
+    set({
+      projectThreadCursors: {
+        ...projectThreadCursors,
+        [projectId]: { ...existing, ...cursor },
+      },
+    });
+  },
+}));
+
+// ── Selectors ─────────────────────────────────────────────────────
+
+export function selectCanvasEnabled(state: CanvasStore): boolean {
+  return state.enabled;
+}
+
+export function selectCanvasMode(state: CanvasStore): CanvasMode {
+  return state.mode;
+}
+
+export function selectCanvasPosition(state: CanvasStore) {
+  return {
+    projectIndex: state.focusedProjectIndex,
+    threadIndex: state.focusedThreadIndex,
+    projectId: state.focusedProjectId,
+    threadId: state.focusedThreadId,
+  };
+}

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -3,6 +3,9 @@ import { useNavigate } from "@tanstack/react-router";
 
 import ThreadSidebar from "./Sidebar";
 import { Sidebar, SidebarProvider, SidebarRail } from "./ui/sidebar";
+import { CanvasShell } from "./canvas/CanvasShell";
+import { useCanvasStore } from "../canvasStore";
+import { useServerKeybindings } from "../rpc/serverState";
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
 const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
@@ -10,6 +13,8 @@ const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  const canvasEnabled = useCanvasStore((s) => s.enabled);
+  const keybindings = useServerKeybindings();
 
   useEffect(() => {
     const onMenuAction = window.desktopBridge?.onMenuAction;
@@ -26,6 +31,10 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       unsubscribe?.();
     };
   }, [navigate]);
+
+  if (canvasEnabled) {
+    return <CanvasShell keybindings={keybindings} />;
+  }
 
   return (
     <SidebarProvider defaultOpen>

--- a/apps/web/src/components/ChatContent.tsx
+++ b/apps/web/src/components/ChatContent.tsx
@@ -1,0 +1,11 @@
+/**
+ * ChatContent — Route-independent chat renderer.
+ *
+ * Re-exports ChatView so the canvas can render thread content
+ * without depending on TanStack Router route params.
+ *
+ * ChatView already accepts only `threadId` as a prop and fetches
+ * all other data from Zustand stores, so no additional wrapping
+ * is needed.
+ */
+export { default as ChatContent } from "./ChatView";

--- a/apps/web/src/components/canvas/CanvasBreadcrumb.tsx
+++ b/apps/web/src/components/canvas/CanvasBreadcrumb.tsx
@@ -1,0 +1,42 @@
+/**
+ * CanvasBreadcrumb — Position indicator for the canvas header.
+ *
+ * Shows: [Project Name] > [Thread Title]  (3/12 threads)
+ */
+import { memo } from "react";
+import { useCanvasStore } from "../../canvasStore";
+import { useStore } from "../../store";
+import { type SidebarThreadSummary } from "../../types";
+
+export const CanvasBreadcrumb = memo(function CanvasBreadcrumb() {
+  const focusedProjectId = useCanvasStore((s) => s.focusedProjectId);
+  const focusedThreadId = useCanvasStore((s) => s.focusedThreadId);
+  const focusedThreadIndex = useCanvasStore((s) => s.focusedThreadIndex);
+
+  const project = useStore((s) => s.projects.find((p) => p.id === focusedProjectId));
+  const threadSummary: SidebarThreadSummary | undefined = useStore((s) =>
+    focusedThreadId ? s.sidebarThreadsById[focusedThreadId] : undefined,
+  );
+  const threadCount = useStore((s) =>
+    focusedProjectId ? (s.threadIdsByProjectId[focusedProjectId]?.length ?? 0) : 0,
+  );
+
+  if (!project) return null;
+
+  return (
+    <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <span className="font-medium text-foreground">{project.name}</span>
+      {threadSummary && (
+        <>
+          <span className="text-muted-foreground/50">&rsaquo;</span>
+          <span className="max-w-[200px] truncate">{threadSummary.title || "New thread"}</span>
+        </>
+      )}
+      {threadCount > 0 && (
+        <span className="ml-1 text-xs text-muted-foreground/70">
+          ({focusedThreadIndex + 1}/{threadCount})
+        </span>
+      )}
+    </div>
+  );
+});

--- a/apps/web/src/components/canvas/CanvasColumn.tsx
+++ b/apps/web/src/components/canvas/CanvasColumn.tsx
@@ -1,0 +1,67 @@
+/**
+ * CanvasColumn — A single thread column in the canvas.
+ *
+ * Renders either:
+ *   - ActiveColumn: full ChatContent for the focused thread
+ *   - PreviewColumn: compact PreviewCard for adjacent threads
+ *   - SentinelColumn: loading trigger at the right edge
+ */
+import { memo } from "react";
+import { type ProjectId, type ThreadId } from "@t3tools/contracts";
+import { type SidebarThreadSummary } from "../../types";
+import { ChatContent } from "../ChatContent";
+import { PreviewCard } from "./PreviewCard";
+import { COLUMN_GAP, PREVIEW_COLUMN_WIDTH } from "../../lib/springProfiles";
+
+export type ColumnRole = "active" | "preview" | "sentinel";
+
+export interface CanvasColumnProps {
+  thread: SidebarThreadSummary | null;
+  role: ColumnRole;
+  activeColumnWidth: number;
+  lastVisitedAt: string | undefined;
+  isFocused: boolean;
+  onSelectThread: (projectId: ProjectId, threadId: ThreadId) => void;
+}
+
+export const CanvasColumn = memo(function CanvasColumn({
+  thread,
+  role,
+  activeColumnWidth,
+  lastVisitedAt,
+  isFocused,
+  onSelectThread,
+}: CanvasColumnProps) {
+  const width = role === "active" ? activeColumnWidth : PREVIEW_COLUMN_WIDTH;
+
+  return (
+    <div
+      className="relative shrink-0 overflow-hidden"
+      style={{
+        width,
+        marginRight: COLUMN_GAP,
+      }}
+    >
+      {role === "active" && thread && (
+        <div className="h-full w-full">
+          <ChatContent threadId={thread.id} />
+        </div>
+      )}
+
+      {role === "preview" && thread && (
+        <PreviewCard
+          thread={thread}
+          lastVisitedAt={lastVisitedAt}
+          isFocused={isFocused}
+          onSelect={onSelectThread}
+        />
+      )}
+
+      {role === "sentinel" && (
+        <div className="flex h-full w-[280px] items-center justify-center rounded-lg border border-dashed border-border/50">
+          <span className="text-sm text-muted-foreground">Loading more...</span>
+        </div>
+      )}
+    </div>
+  );
+});

--- a/apps/web/src/components/canvas/CanvasLauncher.tsx
+++ b/apps/web/src/components/canvas/CanvasLauncher.tsx
@@ -1,0 +1,239 @@
+/**
+ * CanvasLauncher — Fuzzy search overlay for projects and threads.
+ *
+ * Activated by Mod+Space. Shows recent threads by default,
+ * fuzzy-searches across all projects and threads when query is entered.
+ */
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { type ProjectId, type ThreadId } from "@t3tools/contracts";
+import { animated, useSpring } from "@react-spring/web";
+import { useCanvasStore } from "../../canvasStore";
+import { useStore } from "../../store";
+import { type SidebarThreadSummary } from "../../types";
+import { SPRING_PROFILES } from "../../lib/springProfiles";
+import { cn } from "../../lib/utils";
+
+interface SearchResult {
+  type: "project" | "thread";
+  projectId: ProjectId;
+  threadId: ThreadId | null;
+  projectName: string;
+  threadTitle: string | null;
+  score: number;
+}
+
+export const CanvasLauncher = memo(function CanvasLauncher() {
+  const mode = useCanvasStore((s) => s.mode);
+  const query = useCanvasStore((s) => s.launcherQuery);
+  const selectedIndex = useCanvasStore((s) => s.launcherSelectedIndex);
+  const setQuery = useCanvasStore((s) => s.setLauncherQuery);
+  const setSelectedIndex = useCanvasStore((s) => s.setLauncherSelectedIndex);
+  const closeLauncher = useCanvasStore((s) => s.closeLauncher);
+  const jumpToThread = useCanvasStore((s) => s.jumpToThread);
+
+  const projects = useStore((s) => s.projects);
+  const sidebarThreadsById = useStore((s) => s.sidebarThreadsById);
+  const threadIdsByProjectId = useStore((s) => s.threadIdsByProjectId);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Build search results
+  const results: SearchResult[] = useMemo(() => {
+    if (!query.trim()) {
+      // Default: show recent threads across all projects
+      const allThreads: (SidebarThreadSummary & { projectName: string })[] = [];
+      for (const project of projects) {
+        const threadIds = threadIdsByProjectId[project.id] ?? [];
+        for (const id of threadIds) {
+          const thread = sidebarThreadsById[id];
+          if (thread && !thread.archivedAt) {
+            allThreads.push({ ...thread, projectName: project.name });
+          }
+        }
+      }
+      // Sort by creation date (newest first)
+      allThreads.sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt));
+      return allThreads.slice(0, 20).map((t) => ({
+        type: "thread" as const,
+        projectId: t.projectId,
+        threadId: t.id,
+        projectName: t.projectName,
+        threadTitle: t.title,
+        score: 1,
+      }));
+    }
+
+    // Fuzzy search
+    const lowerQuery = query.toLowerCase();
+    const scored: SearchResult[] = [];
+
+    for (const project of projects) {
+      const projectScore = fuzzyScore(project.name, lowerQuery);
+      if (projectScore > 0) {
+        scored.push({
+          type: "project",
+          projectId: project.id,
+          threadId: null,
+          projectName: project.name,
+          threadTitle: null,
+          score: projectScore,
+        });
+      }
+
+      const threadIds = threadIdsByProjectId[project.id] ?? [];
+      for (const id of threadIds) {
+        const thread = sidebarThreadsById[id];
+        if (!thread || thread.archivedAt) continue;
+        const titleScore = fuzzyScore(thread.title, lowerQuery);
+        if (titleScore > 0) {
+          scored.push({
+            type: "thread",
+            projectId: project.id,
+            threadId: thread.id,
+            projectName: project.name,
+            threadTitle: thread.title,
+            score: titleScore,
+          });
+        }
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, 30);
+  }, [query, projects, threadIdsByProjectId, sidebarThreadsById]);
+
+  // Focus input on open
+  useEffect(() => {
+    if (mode === "launcher") {
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [mode]);
+
+  const handleSelect = useCallback(
+    (result: SearchResult) => {
+      if (result.type === "thread" && result.threadId) {
+        jumpToThread(result.projectId, result.threadId);
+      } else if (result.type === "project") {
+        // Jump to first thread of the project
+        const threadIds = threadIdsByProjectId[result.projectId] ?? [];
+        const firstThread = threadIds[0] ? sidebarThreadsById[threadIds[0]] : null;
+        if (firstThread) {
+          jumpToThread(result.projectId, firstThread.id);
+        }
+      }
+    },
+    [jumpToThread, threadIdsByProjectId, sidebarThreadsById],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          setSelectedIndex(Math.min(selectedIndex + 1, results.length - 1));
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          setSelectedIndex(Math.max(selectedIndex - 1, 0));
+          break;
+        case "Enter": {
+          event.preventDefault();
+          const selected = results[selectedIndex];
+          if (selected) handleSelect(selected);
+          break;
+        }
+        case "Escape":
+          event.preventDefault();
+          closeLauncher();
+          break;
+      }
+    },
+    [selectedIndex, results, handleSelect, closeLauncher, setSelectedIndex],
+  );
+
+  const springs = useSpring({
+    opacity: mode === "launcher" ? 1 : 0,
+    y: mode === "launcher" ? 0 : -20,
+    config: SPRING_PROFILES.cardReveal,
+  });
+
+  if (mode !== "launcher") return null;
+
+  return (
+    <animated.div
+      className="absolute inset-0 z-50 flex items-start justify-center bg-background/80 pt-[15vh] backdrop-blur-sm"
+      style={{ opacity: springs.opacity }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) closeLauncher();
+      }}
+    >
+      <animated.div
+        className="w-full max-w-lg overflow-hidden rounded-xl border border-border bg-card shadow-2xl"
+        style={{ transform: springs.y.to((y) => `translateY(${y}px)`) }}
+      >
+        {/* Search input */}
+        <div className="border-b border-border px-4 py-3">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search projects and threads..."
+            className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+
+        {/* Results */}
+        <div className="max-h-[50vh] overflow-y-auto">
+          {results.length === 0 && query.trim() && (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No results found
+            </div>
+          )}
+
+          {results.map((result, index) => (
+            <button
+              key={`${result.projectId}-${result.threadId ?? "project"}`}
+              type="button"
+              className={cn(
+                "flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors",
+                index === selectedIndex ? "bg-accent" : "hover:bg-accent/50",
+              )}
+              onClick={() => handleSelect(result)}
+              onMouseEnter={() => setSelectedIndex(index)}
+            >
+              <span className="flex size-6 shrink-0 items-center justify-center rounded text-xs">
+                {result.type === "project" ? "P" : "T"}
+              </span>
+              <div className="min-w-0 flex-1">
+                <div className="truncate text-sm text-foreground">
+                  {result.type === "thread"
+                    ? result.threadTitle || "New thread"
+                    : result.projectName}
+                </div>
+                {result.type === "thread" && (
+                  <div className="truncate text-xs text-muted-foreground">{result.projectName}</div>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      </animated.div>
+    </animated.div>
+  );
+});
+
+/** Simple fuzzy matching score. Returns 0 for no match. */
+function fuzzyScore(text: string, query: string): number {
+  const lower = text.toLowerCase();
+  if (lower === query) return 2; // exact match
+  if (lower.includes(query)) return 1; // substring match
+
+  // Character-by-character fuzzy
+  let qi = 0;
+  for (let ti = 0; ti < lower.length && qi < query.length; ti++) {
+    if (lower[ti] === query[qi]) qi++;
+  }
+  return qi === query.length ? 0.5 : 0;
+}

--- a/apps/web/src/components/canvas/CanvasOverview.tsx
+++ b/apps/web/src/components/canvas/CanvasOverview.tsx
@@ -1,0 +1,113 @@
+/**
+ * CanvasOverview — Bird's-eye overview of all projects and threads.
+ *
+ * Shows all project rows with miniature thread cards.
+ * Supports HJKL/arrow navigation and click-to-focus.
+ */
+import { memo, useCallback, useMemo } from "react";
+import { type ProjectId, type ThreadId } from "@t3tools/contracts";
+import { animated, useSpring } from "@react-spring/web";
+import { useCanvasStore } from "../../canvasStore";
+import { useStore } from "../../store";
+import { type SidebarThreadSummary, type Project } from "../../types";
+import { SPRING_PROFILES } from "../../lib/springProfiles";
+import { cn } from "../../lib/utils";
+
+interface OverviewProjectRow {
+  project: Project;
+  threads: SidebarThreadSummary[];
+}
+
+export const CanvasOverview = memo(function CanvasOverview() {
+  const mode = useCanvasStore((s) => s.mode);
+  const overviewCursorProject = useCanvasStore((s) => s.overviewCursorProject);
+  const overviewCursorThread = useCanvasStore((s) => s.overviewCursorThread);
+
+  const projects = useStore((s) => s.projects);
+  const sidebarThreadsById = useStore((s) => s.sidebarThreadsById);
+  const threadIdsByProjectId = useStore((s) => s.threadIdsByProjectId);
+
+  const rows: OverviewProjectRow[] = useMemo(() => {
+    return projects.map((project) => {
+      const threadIds = threadIdsByProjectId[project.id] ?? [];
+      const threads = threadIds
+        .map((id) => sidebarThreadsById[id])
+        .filter((t): t is SidebarThreadSummary => t != null && t.archivedAt == null);
+      return { project, threads };
+    });
+  }, [projects, threadIdsByProjectId, sidebarThreadsById]);
+
+  const jumpToThread = useCanvasStore((s) => s.jumpToThread);
+
+  const handleCardClick = useCallback(
+    (projectId: ProjectId, threadId: ThreadId) => {
+      jumpToThread(projectId, threadId);
+    },
+    [jumpToThread],
+  );
+
+  const springs = useSpring({
+    opacity: mode === "overview" ? 1 : 0,
+    scale: mode === "overview" ? 1 : 0.95,
+    config: SPRING_PROFILES.overview,
+  });
+
+  if (mode !== "overview") return null;
+
+  return (
+    <animated.div
+      className="absolute inset-0 z-50 overflow-auto bg-background/95 backdrop-blur-sm"
+      style={{
+        opacity: springs.opacity,
+        transform: springs.scale.to((s) => `scale(${s})`),
+      }}
+    >
+      <div className="mx-auto max-w-7xl p-6">
+        <h2 className="mb-6 text-lg font-semibold text-foreground">Overview</h2>
+
+        <div className="flex flex-col gap-4">
+          {rows.map((row, projectIndex) => (
+            <div key={row.project.id} className="flex flex-col gap-2">
+              {/* Project label */}
+              <h3 className="text-sm font-medium text-muted-foreground">{row.project.name}</h3>
+
+              {/* Thread cards */}
+              <div className="flex gap-2 overflow-x-auto pb-2">
+                {row.threads.length === 0 && (
+                  <div className="flex h-20 w-40 items-center justify-center rounded-md border border-dashed border-border/50 text-xs text-muted-foreground">
+                    No threads
+                  </div>
+                )}
+                {row.threads.map((thread, threadIndex) => {
+                  const isCursor =
+                    projectIndex === overviewCursorProject && threadIndex === overviewCursorThread;
+
+                  return (
+                    <button
+                      key={thread.id}
+                      type="button"
+                      onClick={() => handleCardClick(row.project.id, thread.id)}
+                      className={cn(
+                        "flex h-20 w-40 shrink-0 flex-col gap-1 rounded-md border bg-card p-2 text-left transition-all",
+                        isCursor
+                          ? "border-primary ring-2 ring-primary/30"
+                          : "border-border hover:border-border/80",
+                      )}
+                    >
+                      <span className="truncate text-xs font-medium text-foreground">
+                        {thread.title || "New thread"}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground">
+                        {thread.session?.status === "running" ? "Working" : "Idle"}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </animated.div>
+  );
+});

--- a/apps/web/src/components/canvas/CanvasRow.tsx
+++ b/apps/web/src/components/canvas/CanvasRow.tsx
@@ -1,0 +1,118 @@
+/**
+ * CanvasRow — A horizontal strip of thread columns for a single project.
+ *
+ * Uses TanStack Virtual for horizontal virtualization.
+ * Threads are ordered newest (left, index 0) → oldest (right).
+ */
+import { memo, useCallback, useRef } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { type ProjectId, type ThreadId } from "@t3tools/contracts";
+import { type SidebarThreadSummary } from "../../types";
+import { CanvasColumn, type ColumnRole } from "./CanvasColumn";
+import { COLUMN_GAP, PREVIEW_COLUMN_WIDTH } from "../../lib/springProfiles";
+
+export interface CanvasRowProps {
+  projectId: ProjectId;
+  projectName: string;
+  threads: SidebarThreadSummary[];
+  focusedThreadIndex: number;
+  isFocusedRow: boolean;
+  activeColumnWidth: number;
+  viewportWidth: number;
+  threadLastVisitedAtById: Record<string, string>;
+  hasMore: boolean;
+  onSelectThread: (projectId: ProjectId, threadId: ThreadId) => void;
+}
+
+export const CanvasRow = memo(function CanvasRow({
+  projectId: _projectId,
+  projectName,
+  threads,
+  focusedThreadIndex,
+  isFocusedRow,
+  activeColumnWidth,
+  viewportWidth,
+  threadLastVisitedAtById,
+  hasMore,
+  onSelectThread,
+}: CanvasRowProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Total items: threads + sentinel (if hasMore)
+  const itemCount = threads.length + (hasMore ? 1 : 0);
+
+  const estimateSize = useCallback(
+    (index: number) => {
+      if (isFocusedRow && index === focusedThreadIndex) {
+        return activeColumnWidth + COLUMN_GAP;
+      }
+      return PREVIEW_COLUMN_WIDTH + COLUMN_GAP;
+    },
+    [isFocusedRow, focusedThreadIndex, activeColumnWidth],
+  );
+
+  const virtualizer = useVirtualizer({
+    count: itemCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize,
+    horizontal: true,
+    overscan: 2,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  return (
+    <div className="relative h-full w-full">
+      {/* Sticky project label */}
+      <div className="pointer-events-none absolute left-3 top-3 z-10">
+        <span className="rounded bg-card/90 px-2 py-1 text-xs font-semibold text-muted-foreground shadow-sm backdrop-blur-sm">
+          {projectName}
+        </span>
+      </div>
+
+      {/* Horizontal scroll container */}
+      <div
+        ref={scrollRef}
+        className="h-full w-full overflow-x-hidden overflow-y-hidden"
+        style={{ width: viewportWidth }}
+      >
+        <div className="relative flex h-full" style={{ width: virtualizer.getTotalSize() }}>
+          {virtualItems.map((virtualItem) => {
+            const index = virtualItem.index;
+            const isSentinel = index >= threads.length;
+            const thread = isSentinel ? null : (threads[index] ?? null);
+
+            let role: ColumnRole;
+            if (isSentinel) {
+              role = "sentinel";
+            } else if (isFocusedRow && index === focusedThreadIndex) {
+              role = "active";
+            } else {
+              role = "preview";
+            }
+
+            return (
+              <div
+                key={isSentinel ? "sentinel" : (thread?.id ?? index)}
+                className="absolute left-0 top-0 h-full"
+                style={{
+                  width: virtualItem.size,
+                  transform: `translateX(${virtualItem.start}px)`,
+                }}
+              >
+                <CanvasColumn
+                  thread={thread}
+                  role={role}
+                  activeColumnWidth={activeColumnWidth}
+                  lastVisitedAt={thread ? threadLastVisitedAtById[thread.id] : undefined}
+                  isFocused={isFocusedRow && index === focusedThreadIndex}
+                  onSelectThread={onSelectThread}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/components/canvas/CanvasShell.tsx
+++ b/apps/web/src/components/canvas/CanvasShell.tsx
@@ -1,0 +1,198 @@
+/**
+ * CanvasShell — Main canvas container for Niri-style spatial navigation.
+ *
+ * Replaces the sidebar layout when canvas mode is enabled.
+ * Manages:
+ *   - Spring-animated 2D viewport (translate3d + scale)
+ *   - Vertical virtualization of project rows
+ *   - Horizontal virtualization of thread columns per row
+ *   - Overview and Launcher overlays
+ *   - Keyboard and mouse/trackpad navigation
+ */
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { animated, useSpring } from "@react-spring/web";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { type ProjectId, type ThreadId, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import { useCanvasStore, setCanvasDataAccessors } from "../../canvasStore";
+import { useStore } from "../../store";
+import { useUiStateStore } from "../../uiStateStore";
+import { SPRING_PROFILES, COLUMN_GAP, PREVIEW_COLUMN_WIDTH } from "../../lib/springProfiles";
+import { sortThreadsForSidebar } from "../Sidebar.logic";
+import { type SidebarThreadSummary } from "../../types";
+import { CanvasRow } from "./CanvasRow";
+import { CanvasOverview } from "./CanvasOverview";
+import { CanvasLauncher } from "./CanvasLauncher";
+import { CanvasBreadcrumb } from "./CanvasBreadcrumb";
+import { useCanvasNavigation } from "../../hooks/useCanvasNavigation";
+
+interface CanvasShellProps {
+  keybindings: ResolvedKeybindingsConfig;
+}
+
+export function CanvasShell({ keybindings }: CanvasShellProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  // ── Store subscriptions ──────────────────────────────────────────
+
+  const projects = useStore((s) => s.projects);
+  const sidebarThreadsById = useStore((s) => s.sidebarThreadsById);
+  const threadIdsByProjectId = useStore((s) => s.threadIdsByProjectId);
+  const threadLastVisitedAtById = useUiStateStore((s) => s.threadLastVisitedAtById);
+
+  const focusedProjectIndex = useCanvasStore((s) => s.focusedProjectIndex);
+  const focusedThreadIndex = useCanvasStore((s) => s.focusedThreadIndex);
+  const columnWidthPreset = useCanvasStore((s) => s.columnWidthPreset);
+  const projectThreadCursors = useCanvasStore((s) => s.projectThreadCursors);
+
+  // ── Computed layout ──────────────────────────────────────────────
+
+  const viewportWidth = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 720;
+  const activeColumnWidth = Math.floor(viewportWidth * columnWidthPreset);
+
+  // ── Thread data accessor ─────────────────────────────────────────
+
+  const getThreadsForProject = useCallback(
+    (projectId: ProjectId | null): SidebarThreadSummary[] => {
+      if (!projectId) return [];
+      const threadIds = threadIdsByProjectId[projectId] ?? [];
+      const threads = threadIds
+        .map((id) => sidebarThreadsById[id])
+        .filter((t): t is SidebarThreadSummary => t != null && t.archivedAt == null);
+      return sortThreadsForSidebar(threads, "updated_at");
+    },
+    [threadIdsByProjectId, sidebarThreadsById],
+  );
+
+  const getProjects = useCallback(() => projects, [projects]);
+
+  // Register data accessors for the canvas store
+  useEffect(() => {
+    setCanvasDataAccessors(getProjects, getThreadsForProject);
+  }, [getProjects, getThreadsForProject]);
+
+  // Sync focus IDs when data changes
+  useEffect(() => {
+    useCanvasStore.getState().syncFocus();
+  }, [projects, threadIdsByProjectId, sidebarThreadsById]);
+
+  // ── Spring animation ─────────────────────────────────────────────
+
+  // Compute target position based on focused indices
+  const targetX = useMemo(() => {
+    // Before the focused thread, all columns are preview width
+    let x = 0;
+    for (let i = 0; i < focusedThreadIndex; i++) {
+      x += PREVIEW_COLUMN_WIDTH + COLUMN_GAP;
+    }
+    return -x;
+  }, [focusedThreadIndex]);
+
+  const targetY = useMemo(() => {
+    return -(focusedProjectIndex * viewportHeight);
+  }, [focusedProjectIndex, viewportHeight]);
+
+  const [springs, api] = useSpring(() => ({
+    x: targetX,
+    y: targetY,
+    scale: 1,
+    config: SPRING_PROFILES.horizontalNav,
+  }));
+
+  // Animate to new position when focus changes
+  useEffect(() => {
+    api.start({
+      x: targetX,
+      config: SPRING_PROFILES.horizontalNav,
+    });
+  }, [targetX, api]);
+
+  useEffect(() => {
+    api.start({
+      y: targetY,
+      config: SPRING_PROFILES.verticalNav,
+    });
+  }, [targetY, api]);
+
+  // ── Vertical virtualizer (project rows) ──────────────────────────
+
+  const rowVirtualizer = useVirtualizer({
+    count: projects.length,
+    getScrollElement: () => viewportRef.current,
+    estimateSize: () => viewportHeight,
+    overscan: 1,
+  });
+
+  // ── Thread selection handler ──────────────────────────────────────
+
+  const handleSelectThread = useCallback((projectId: ProjectId, threadId: ThreadId) => {
+    useCanvasStore.getState().jumpToThread(projectId, threadId);
+  }, []);
+
+  // ── Keyboard navigation ──────────────────────────────────────────
+
+  useCanvasNavigation({ keybindings });
+
+  // ── Render ────────────────────────────────────────────────────────
+
+  const virtualRows = rowVirtualizer.getVirtualItems();
+
+  return (
+    <div className="relative h-dvh w-full overflow-hidden bg-background">
+      {/* Breadcrumb header */}
+      <div className="absolute left-0 right-0 top-0 z-30 flex h-12 items-center border-b border-border bg-card/95 px-4 backdrop-blur-sm">
+        <CanvasBreadcrumb />
+      </div>
+
+      {/* Canvas viewport */}
+      <div ref={viewportRef} className="h-full w-full overflow-hidden pt-12">
+        <animated.div
+          className="relative h-full"
+          style={{
+            transform: springs.x.to((x) => `translate3d(${x}px, 0, 0)`),
+          }}
+        >
+          {/* Render project rows */}
+          <div className="relative" style={{ height: rowVirtualizer.getTotalSize() }}>
+            {virtualRows.map((virtualRow) => {
+              const project = projects[virtualRow.index];
+              if (!project) return null;
+
+              const threads = getThreadsForProject(project.id);
+              const isFocusedRow = virtualRow.index === focusedProjectIndex;
+              const cursor = projectThreadCursors[project.id];
+
+              return (
+                <div
+                  key={project.id}
+                  className="absolute left-0 top-0 w-full"
+                  style={{
+                    height: virtualRow.size,
+                    transform: `translateY(${virtualRow.start}px)`,
+                  }}
+                >
+                  <CanvasRow
+                    projectId={project.id}
+                    projectName={project.name}
+                    threads={threads}
+                    focusedThreadIndex={isFocusedRow ? focusedThreadIndex : -1}
+                    isFocusedRow={isFocusedRow}
+                    activeColumnWidth={activeColumnWidth}
+                    viewportWidth={viewportWidth}
+                    threadLastVisitedAtById={threadLastVisitedAtById}
+                    hasMore={cursor?.hasMore ?? false}
+                    onSelectThread={handleSelectThread}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </animated.div>
+      </div>
+
+      {/* Overlays */}
+      <CanvasOverview />
+      <CanvasLauncher />
+    </div>
+  );
+}

--- a/apps/web/src/components/canvas/PreviewCard.tsx
+++ b/apps/web/src/components/canvas/PreviewCard.tsx
@@ -1,0 +1,98 @@
+/**
+ * PreviewCard — Compact thread preview for non-focused canvas columns.
+ *
+ * Shows thread title, status indicator, last message preview, and timestamp.
+ * Reuses SidebarThreadSummary data from the main Zustand store.
+ */
+import { memo, useCallback } from "react";
+import { type ThreadId, type ProjectId } from "@t3tools/contracts";
+import { type SidebarThreadSummary } from "../../types";
+import { resolveThreadStatusPill, type ThreadStatusPill } from "../Sidebar.logic";
+import { cn } from "../../lib/utils";
+
+export interface PreviewCardProps {
+  thread: SidebarThreadSummary;
+  lastVisitedAt: string | undefined;
+  isFocused: boolean;
+  onSelect: (projectId: ProjectId, threadId: ThreadId) => void;
+}
+
+export const PreviewCard = memo(function PreviewCard({
+  thread,
+  lastVisitedAt,
+  isFocused,
+  onSelect,
+}: PreviewCardProps) {
+  const statusPill = resolveThreadStatusPill({ thread: { ...thread, lastVisitedAt } });
+
+  const handleClick = useCallback(() => {
+    onSelect(thread.projectId, thread.id);
+  }, [onSelect, thread.projectId, thread.id]);
+
+  const relativeTime = getRelativeTime(thread.createdAt);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        "flex h-full w-[280px] shrink-0 cursor-pointer flex-col gap-2 overflow-hidden rounded-lg border bg-card p-3 text-left transition-colors",
+        "contain-content",
+        isFocused
+          ? "border-primary/50 ring-1 ring-primary/30"
+          : "border-border hover:border-border/80",
+      )}
+      style={{
+        contentVisibility: "auto",
+        containIntrinsicSize: "280px 100%",
+      }}
+    >
+      {/* Header: title + status */}
+      <div className="flex items-center gap-2">
+        <h3 className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+          {thread.title || "New thread"}
+        </h3>
+        {statusPill && <StatusDot pill={statusPill} />}
+      </div>
+
+      {/* Timestamp */}
+      <span className="text-xs text-muted-foreground">{relativeTime}</span>
+
+      {/* Branch indicator */}
+      {thread.branch && (
+        <span className="truncate text-xs text-muted-foreground/70">
+          <span className="font-mono">{thread.branch}</span>
+        </span>
+      )}
+    </button>
+  );
+});
+
+function StatusDot({ pill }: { pill: ThreadStatusPill }) {
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      <span
+        className={cn(
+          "inline-block size-2 rounded-full",
+          pill.dotClass,
+          pill.pulse && "animate-pulse",
+        )}
+      />
+      <span className={cn("text-[10px] font-medium", pill.colorClass)}>{pill.label}</span>
+    </span>
+  );
+}
+
+function getRelativeTime(isoDate: string): string {
+  const ms = Date.now() - Date.parse(isoDate);
+  if (Number.isNaN(ms) || ms < 0) return "just now";
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(isoDate).toLocaleDateString();
+}

--- a/apps/web/src/hooks/useCanvasNavigation.ts
+++ b/apps/web/src/hooks/useCanvasNavigation.ts
@@ -1,0 +1,159 @@
+/**
+ * useCanvasNavigation — Keyboard + mouse/trackpad handler for canvas mode.
+ *
+ * Intercepts key events and dispatches to canvas store actions.
+ * Only active when canvas mode is enabled.
+ */
+import { useCallback, useEffect } from "react";
+import { type ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import { useCanvasStore } from "../canvasStore";
+import {
+  resolveShortcutCommand,
+  isCanvasCommand,
+  canvasJumpProjectIndexFromCommand,
+} from "../keybindings";
+
+export interface UseCanvasNavigationOptions {
+  keybindings: ResolvedKeybindingsConfig;
+  platform?: string;
+}
+
+function handleOverviewKeyDown(event: KeyboardEvent): void {
+  const key = event.key.toLowerCase();
+  const store = useCanvasStore.getState();
+
+  let handled = true;
+  switch (key) {
+    case "h":
+    case "arrowleft":
+      store.navigateLeft();
+      break;
+    case "l":
+    case "arrowright":
+      store.navigateRight();
+      break;
+    case "k":
+    case "arrowup":
+      store.navigateUp();
+      break;
+    case "j":
+    case "arrowdown":
+      store.navigateDown();
+      break;
+    case "enter":
+      store.toggleOverview(); // Exit overview, navigate to cursor position
+      break;
+    case "escape":
+      store.toggleOverview(); // Exit overview without changing focus
+      break;
+    default:
+      handled = false;
+  }
+
+  if (handled) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+}
+
+export function useCanvasNavigation({ keybindings, platform }: UseCanvasNavigationOptions): void {
+  const enabled = useCanvasStore((s) => s.enabled);
+  const mode = useCanvasStore((s) => s.mode);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!enabled) return;
+
+      // In launcher mode, let the launcher handle its own keyboard events
+      if (mode === "launcher") return;
+
+      // In overview mode, handle HJKL/arrows for cursor movement
+      if (mode === "overview") {
+        handleOverviewKeyDown(event);
+        return;
+      }
+
+      // Navigate mode — resolve command from keybindings
+      const options = platform ? { platform } : undefined;
+      const command = resolveShortcutCommand(event, keybindings, options);
+      if (!command || !isCanvasCommand(command)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const store = useCanvasStore.getState();
+
+      switch (command) {
+        case "canvas.focusLeft":
+          store.navigateLeft();
+          break;
+        case "canvas.focusRight":
+          store.navigateRight();
+          break;
+        case "canvas.focusUp":
+          store.navigateUp();
+          break;
+        case "canvas.focusDown":
+          store.navigateDown();
+          break;
+        case "canvas.toggleOverview":
+          store.toggleOverview();
+          break;
+        case "canvas.openLauncher":
+          store.openLauncher();
+          break;
+        case "canvas.cycleWidth":
+          store.cycleColumnWidth();
+          break;
+        case "canvas.togglePrevious":
+          store.togglePreviousProject();
+          break;
+        default: {
+          // Check if it's a jump-to-project command
+          const jumpIndex = canvasJumpProjectIndexFromCommand(command);
+          if (jumpIndex !== null) {
+            store.jumpToProject(jumpIndex);
+          }
+          break;
+        }
+      }
+    },
+    [enabled, mode, keybindings, platform],
+  );
+
+  // Wheel handler for Mod+Scroll navigation
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      if (!enabled || mode !== "navigate") return;
+
+      const isMod = event.metaKey || event.ctrlKey;
+      if (!isMod) return;
+
+      event.preventDefault();
+      const store = useCanvasStore.getState();
+
+      if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+        // Vertical scroll → navigate projects
+        if (event.deltaY < 0) store.navigateUp();
+        else store.navigateDown();
+      } else {
+        // Horizontal scroll → navigate threads
+        if (event.deltaX < 0) store.navigateLeft();
+        else store.navigateRight();
+      }
+    },
+    [enabled, mode],
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    window.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
+      window.removeEventListener("wheel", handleWheel);
+    };
+  }, [enabled, handleKeyDown, handleWheel]);
+}

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -5,6 +5,9 @@ import {
   type ResolvedKeybindingsConfig,
   THREAD_JUMP_KEYBINDING_COMMANDS,
   type ThreadJumpKeybindingCommand,
+  CANVAS_JUMP_PROJECT_COMMANDS,
+  type CanvasJumpProjectCommand,
+  type CanvasKeybindingCommand,
 } from "@t3tools/contracts";
 import { isMacPlatform } from "./lib/utils";
 
@@ -368,6 +371,81 @@ export function isTerminalClearShortcut(
     !event.altKey &&
     !event.shiftKey
   );
+}
+
+// ── Canvas shortcut helpers ──────────────────────────────────────────
+
+export function isCanvasCommand(command: string | null): command is CanvasKeybindingCommand {
+  return command !== null && command.startsWith("canvas.");
+}
+
+export function isCanvasFocusLeftShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "canvas.focusLeft", options);
+}
+
+export function isCanvasFocusRightShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "canvas.focusRight", options);
+}
+
+export function isCanvasFocusUpShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "canvas.focusUp", options);
+}
+
+export function isCanvasFocusDownShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "canvas.focusDown", options);
+}
+
+export function isCanvasToggleOverviewShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "canvas.toggleOverview", options);
+}
+
+export function isCanvasOpenLauncherShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "canvas.openLauncher", options);
+}
+
+export function isCanvasCycleWidthShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "canvas.cycleWidth", options);
+}
+
+export function isCanvasTogglePreviousShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "canvas.togglePrevious", options);
+}
+
+export function canvasJumpProjectIndexFromCommand(command: string): number | null {
+  const index = CANVAS_JUMP_PROJECT_COMMANDS.indexOf(command as CanvasJumpProjectCommand);
+  return index === -1 ? null : index;
 }
 
 export function terminalNavigationShortcutData(

--- a/apps/web/src/lib/springProfiles.ts
+++ b/apps/web/src/lib/springProfiles.ts
@@ -1,0 +1,40 @@
+/**
+ * Spring animation profiles for Niri-style spatial canvas navigation.
+ *
+ * Values are tuned to match the user's Niri compositor config:
+ *   - damping-ratio = 1.0 (critical damping — no overshoot)
+ *   - stiffness ~900–1000
+ *
+ * react-spring maps: tension ≈ stiffness, friction ≈ 2 * sqrt(stiffness) for critical damping.
+ */
+export const SPRING_PROFILES = {
+  /** Horizontal thread-to-thread navigation (stiffness≈900, critical damping) */
+  horizontalNav: { tension: 350, friction: 26, clamp: true },
+
+  /** Vertical project-to-project navigation (stiffness≈1000, critical damping) */
+  verticalNav: { tension: 400, friction: 28, clamp: true },
+
+  /** Overview zoom in/out (stiffness≈900, allows slight settle) */
+  overview: { tension: 350, friction: 26 },
+
+  /** Preview card reveal (~200ms equivalent, clamped) */
+  cardReveal: { tension: 400, friction: 30, clamp: true },
+
+  /** Preview card dismiss (~200ms equivalent, clamped) */
+  cardDismiss: { tension: 300, friction: 28, clamp: true },
+} as const;
+
+export type SpringProfile = keyof typeof SPRING_PROFILES;
+
+/** Gap between columns in pixels (matches Niri's 5px gaps config) */
+export const COLUMN_GAP = 5;
+
+/** Preview card width in pixels */
+export const PREVIEW_COLUMN_WIDTH = 280;
+
+/** Available column width presets as fractions of viewport width */
+export const COLUMN_WIDTH_PRESETS = [1 / 3, 1 / 2, 2 / 3, 1.0] as const;
+export type ColumnWidthPreset = (typeof COLUMN_WIDTH_PRESETS)[number];
+
+/** Default column width preset */
+export const DEFAULT_COLUMN_WIDTH_PRESET: ColumnWidthPreset = 2 / 3;

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -19,6 +19,8 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 interface PersistedUiState {
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
+  canvasEnabled?: boolean;
+  canvasColumnWidthPreset?: number;
 }
 
 export interface UiProjectState {

--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,7 @@
         "@formkit/auto-animate": "^0.9.0",
         "@lexical/react": "^0.41.0",
         "@pierre/diffs": "^1.1.0-beta.16",
+        "@react-spring/web": "^10.0.3",
         "@t3tools/contracts": "workspace:*",
         "@t3tools/shared": "workspace:*",
         "@tanstack/react-pacer": "^0.19.4",
@@ -598,6 +599,18 @@
     "@preact/signals-core": ["@preact/signals-core@1.14.0", "", {}, "sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
+
+    "@react-spring/animated": ["@react-spring/animated@10.0.3", "", { "dependencies": { "@react-spring/shared": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-7MrxADV3vaUADn2V9iYhaIL6iOWRx9nCJjYrsk2AHD2kwPr6fg7Pt0v+deX5RnCDmCKNnD6W5fasiyM8D+wzJQ=="],
+
+    "@react-spring/core": ["@react-spring/core@10.0.3", "", { "dependencies": { "@react-spring/animated": "~10.0.3", "@react-spring/shared": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-D4DwNO68oohDf/0HG2G0Uragzb9IA1oXblxrd6MZAcBcUQG2EHUWXewjdECMPLNmQvlYVyyBRH6gPxXM5DX7DQ=="],
+
+    "@react-spring/rafz": ["@react-spring/rafz@10.0.3", "", {}, "sha512-Ri2/xqt8OnQ2iFKkxKMSF4Nqv0LSWnxXT4jXFzBDsHgeeH/cHxTLupAWUwmV9hAGgmEhBmh5aONtj3J6R/18wg=="],
+
+    "@react-spring/shared": ["@react-spring/shared@10.0.3", "", { "dependencies": { "@react-spring/rafz": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-geCal66nrkaQzUVhPkGomylo+Jpd5VPK8tPMEDevQEfNSWAQP15swHm+MCRG4wVQrQlTi9lOzKzpRoTL3CA84Q=="],
+
+    "@react-spring/types": ["@react-spring/types@10.0.3", "", {}, "sha512-H5Ixkd2OuSIgHtxuHLTt7aJYfhMXKXT/rK32HPD/kSrOB6q6ooeiWAXkBy7L8F3ZxdkBb9ini9zP9UwnEFzWgQ=="],
+
+    "@react-spring/web": ["@react-spring/web@10.0.3", "", { "dependencies": { "@react-spring/animated": "~10.0.3", "@react-spring/core": "~10.0.3", "@react-spring/shared": "~10.0.3", "@react-spring/types": "~10.0.3" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ndU+kWY81rHsT7gTFtCJ6mrVhaJ6grFmgTnENipzmKqot4HGf5smPNK+cZZJqoGeDsj9ZsiWPW4geT/NyD484A=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.3", "", { "os": "android", "cpu": "arm64" }, "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ=="],
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -27,6 +27,40 @@ export const THREAD_KEYBINDING_COMMANDS = [
 ] as const;
 export type ThreadKeybindingCommand = (typeof THREAD_KEYBINDING_COMMANDS)[number];
 
+export const CANVAS_KEYBINDING_COMMANDS = [
+  "canvas.focusLeft",
+  "canvas.focusRight",
+  "canvas.focusUp",
+  "canvas.focusDown",
+  "canvas.toggleOverview",
+  "canvas.openLauncher",
+  "canvas.cycleWidth",
+  "canvas.jumpProject.1",
+  "canvas.jumpProject.2",
+  "canvas.jumpProject.3",
+  "canvas.jumpProject.4",
+  "canvas.jumpProject.5",
+  "canvas.jumpProject.6",
+  "canvas.jumpProject.7",
+  "canvas.jumpProject.8",
+  "canvas.jumpProject.9",
+  "canvas.togglePrevious",
+] as const;
+export type CanvasKeybindingCommand = (typeof CANVAS_KEYBINDING_COMMANDS)[number];
+
+export const CANVAS_JUMP_PROJECT_COMMANDS = [
+  "canvas.jumpProject.1",
+  "canvas.jumpProject.2",
+  "canvas.jumpProject.3",
+  "canvas.jumpProject.4",
+  "canvas.jumpProject.5",
+  "canvas.jumpProject.6",
+  "canvas.jumpProject.7",
+  "canvas.jumpProject.8",
+  "canvas.jumpProject.9",
+] as const;
+export type CanvasJumpProjectCommand = (typeof CANVAS_JUMP_PROJECT_COMMANDS)[number];
+
 const STATIC_KEYBINDING_COMMANDS = [
   "terminal.toggle",
   "terminal.split",
@@ -37,6 +71,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "chat.newLocal",
   "editor.openFavorite",
   ...THREAD_KEYBINDING_COMMANDS,
+  ...CANVAS_KEYBINDING_COMMANDS,
 ] as const;
 
 export const SCRIPT_RUN_COMMAND_PATTERN = Schema.TemplateLiteral([


### PR DESCRIPTION
## Summary
- Add a 2D spatial canvas UI as an alternative to the sidebar layout, inspired by the [Niri](https://github.com/YaLTeR/niri) scrollable tiling Wayland compositor
- Projects are arranged vertically (rows), threads horizontally (columns) with spring-animated navigation, TanStack Virtual scrolling, fuzzy launcher (Mod+Space), and bird's-eye overview mode
- New Zustand store (`canvasStore`) manages 2D position, mode switching (navigate/overview/launcher), column width presets, and per-project thread pagination cursors
- Keybinding contracts extended with canvas-specific bindings (HJKL navigation, number-jump, column width cycling, overview/launcher toggles)

### New files
| File | Purpose |
|------|---------|
| `canvasStore.ts` | Zustand state for canvas position, modes, pagination |
| `CanvasShell.tsx` | Main container — spring viewport, vertical virtualization |
| `CanvasRow.tsx` | Horizontal virtualized thread strip per project |
| `CanvasColumn.tsx` | Active/preview/sentinel column renderer |
| `CanvasOverview.tsx` | Bird's-eye grid of all projects × threads |
| `CanvasLauncher.tsx` | Mod+Space fuzzy search overlay |
| `CanvasBreadcrumb.tsx` | Header position indicator |
| `PreviewCard.tsx` | Compact thread preview with status |
| `useCanvasNavigation.ts` | Keyboard handler (HJKL, arrows, numbers) |
| `springProfiles.ts` | Shared spring configs and column width presets |
| `ChatContent.tsx` | Route-independent ChatView re-export for canvas |

## Test plan
- [ ] Toggle canvas mode on — verify sidebar is replaced by canvas shell
- [ ] Navigate between projects (Up/Down or K/J) and threads (Left/Right or H/L)
- [ ] Open overview mode (Mod+O) — verify bird's-eye grid renders all projects
- [ ] Open launcher (Mod+Space) — verify fuzzy search finds projects and threads
- [ ] Cycle column widths (Mod+]) — verify active column resizes
- [ ] Verify `bun fmt`, `bun lint`, and `bun typecheck` all pass ✅
- [ ] Verify no regressions in sidebar mode when canvas is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new alternate navigation surface (canvas/overview/launcher) and global keyboard/wheel handlers, which could affect interaction behavior and performance across the app when enabled.
> 
> **Overview**
> Adds an optional **2D “canvas” navigation mode** that replaces the existing sidebar layout when `useCanvasStore().enabled` is true, rendering projects as vertical rows and threads as horizontal columns with virtualization and spring-animated transitions.
> 
> Introduces a new `canvasStore` to manage focus position, modes (`navigate`/`overview`/`launcher), column width presets, and per-project pagination cursors, plus new UI pieces for breadcrumb header, preview cards, overview grid, and a fuzzy-search launcher overlay.
> 
> Extends keybinding contracts and client keybinding helpers to support `canvas.*` commands (directional movement, overview/launcher toggles, width cycling, project number-jump, previous-project toggle) and adds `@react-spring/web` plus shared `springProfiles` for animation tuning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6940eae5a1417b18cbe898d7e6e15cc8e97b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Niri-style spatial canvas navigation for browsing projects and threads
> - Introduces a full 2D canvas interface as an alternative to the sidebar layout, rendered by [`CanvasShell`](https://github.com/pingdotgg/t3code/pull/1764/files#diff-d71828c9f162a269c78ce2865922aaa409e4a46cd731177190ca25c8c5c015e4) when `canvasEnabled` is set in persisted UI state.
> - Projects are displayed as horizontally virtualized rows ([`CanvasRow`](https://github.com/pingdotgg/t3code/pull/1764/files#diff-ae9b1890c3ce0f6003ead61d98231e0c22588f8529d47c807dd87a1051eea1cb)); the focused thread shows full chat content while adjacent threads show compact [`PreviewCard`](https://github.com/pingdotgg/t3code/pull/1764/files#diff-4702f8bc7afa4dd5615b286a979998a412deb99a64865392db404f70356cc67b) previews.
> - Navigation is driven by keyboard shortcuts and Mod+scroll, managed in [`canvasStore`](https://github.com/pingdotgg/t3code/pull/1764/files#diff-5963ff989e9ad84ccaf988b4b093b17a96f672aee56063b7c3b04741376164ba) and [`useCanvasNavigation`](https://github.com/pingdotgg/t3code/pull/1764/files#diff-96b76cd10619cbe79838425bf5e14fad05c6efa9bc7b0df70fc944625d6cc68f), with new canvas commands added to the keybindings contract.
> - Two overlays are included: a bird's-eye [`CanvasOverview`](https://github.com/pingdotgg/t3code/pull/1764/files#diff-14951071ad3f61cb2cc71c9aec45ac8e7cc8bf928d3cb83db30612a1a98ecec3) and a fuzzy-search [`CanvasLauncher`](https://github.com/pingdotgg/t3code/pull/1764/files#diff-78f0651cefca09771fe641eb40d148c93bb94f1ee6a1234325ddae964051d431) for jumping to any thread or project.
> - Adds `@react-spring/web` for animated position transitions; layout constants and spring profiles are defined in [`springProfiles.ts`](https://github.com/pingdotgg/t3code/pull/1764/files#diff-11a93e36875a0efc25554864979604d2ed773ebca5ff3ff35ac1eccdc05b9cf2).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7c6940e. 15 files reviewed, 7 issues evaluated, 2 issues filtered, 5 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/canvas/CanvasBreadcrumb.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 21](https://github.com/pingdotgg/t3code/blob/7c6940eae5a1417b18cbe898d7e6e15cc8e97b46/apps/web/src/components/canvas/CanvasBreadcrumb.tsx#L21): Thread count mismatch in breadcrumb display. `threadCount` at line 21 uses `threadIdsByProjectId[focusedProjectId]?.length` which includes ALL threads (including archived), but `focusedThreadIndex` is an index into the filtered list (non-archived only) from `getThreadsForProject`. This causes misleading position indicators like "(3/5)" when the user is at the last of 3 visible threads but there are 2 archived threads counted in the total. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/components/canvas/CanvasShell.tsx — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 120](https://github.com/pingdotgg/t3code/blob/7c6940eae5a1417b18cbe898d7e6e15cc8e97b46/apps/web/src/components/canvas/CanvasShell.tsx#L120): The `rowVirtualizer` is configured with `count: projects.length`, but `canvasStore.jumpToProject()` allows `focusedProjectIndex` to be set to `projects.length` (for a "new project" row per the store's comment). When the user navigates to this index, the spring animation scrolls the viewport to row `projects.length`, but the virtualizer only renders indices 0 to `projects.length - 1`, leaving empty space with no rendered row. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->