### PR TITLE
Rename "Chat" to "Build" in interaction mode toggle

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -866,7 +866,7 @@ async function expectComposerActionsContained(): Promise<void> {
 }
 
 async function waitForInteractionModeButton(
-  expectedLabel: "Code" | "Plan",
+  expectedLabel: "Build" | "Plan",
 ): Promise<HTMLButtonElement> {
   return waitForElement(
     () =>
@@ -2096,7 +2096,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
-      const initialModeButton = await waitForInteractionModeButton("Code");
+      const initialModeButton = await waitForInteractionModeButton("Build");
       expect(initialModeButton.title).toContain("enter plan mode");
 
       window.dispatchEvent(
@@ -2109,7 +2109,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
       await waitForLayout();
 
-      expect((await waitForInteractionModeButton("Code")).title).toContain("enter plan mode");
+      expect((await waitForInteractionModeButton("Build")).title).toContain("enter plan mode");
 
       const composerEditor = await waitForComposerEditor();
       composerEditor.focus();
@@ -2125,7 +2125,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       await vi.waitFor(
         async () => {
           expect((await waitForInteractionModeButton("Plan")).title).toContain(
-            "return to normal code mode",
+            "return to normal build mode",
           );
         },
         { timeout: 8_000, interval: 16 },
@@ -2142,7 +2142,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       await vi.waitFor(
         async () => {
-          expect((await waitForInteractionModeButton("Code")).title).toContain("enter plan mode");
+          expect((await waitForInteractionModeButton("Build")).title).toContain("enter plan mode");
         },
         { timeout: 8_000, interval: 16 },
       );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1476,7 +1476,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
           type: "slash-command",
           command: "default",
           label: "/default",
-          description: "Switch this thread back to normal code mode",
+          description: "Switch this thread back to normal build mode",
         },
       ] satisfies ReadonlyArray<Extract<ComposerCommandItem, { type: "slash-command" }>>;
       const query = composerTrigger.query.trim().toLowerCase();
@@ -4029,7 +4029,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
             <form
               ref={composerFormRef}
               onSubmit={onSend}
-              className="mx-auto w-full min-w-0 max-w-[52rem]"
+              className="mx-auto w-full min-w-0 max-w-208"
               data-chat-composer-form="true"
             >
               <div
@@ -4284,13 +4284,13 @@ export default function ChatView({ threadId }: ChatViewProps) {
                               onClick={toggleInteractionMode}
                               title={
                                 interactionMode === "plan"
-                                  ? "Plan mode — click to return to normal code mode"
+                                  ? "Plan mode — click to return to normal build mode"
                                   : "Default mode — click to enter plan mode"
                               }
                             >
                               <BotIcon />
                               <span className="sr-only sm:not-sr-only">
-                                {interactionMode === "plan" ? "Plan" : "Code"}
+                                {interactionMode === "plan" ? "Plan" : "Build"}
                               </span>
                             </Button>
 


### PR DESCRIPTION
## What changed
Renamed the interaction mode toggle label from "Chat" to "Code" (the non-plan default mode). Updated the corresponding browser test assertions.

## Why
T3 Code is a coding agent app, not a chatbot. The default mode label should reflect what the tool actually does — execute code, edit files, and run commands. "Chat" undersells the capability and is misleading.

## Before / After
Before:
<img width="849" height="161" alt="CleanShot 2026-04-05 at 22 18 21" src="https://github.com/user-attachments/assets/d9ce0c5d-2c57-41b9-a1ce-c17f47e7578c" />

After:
<img width="849" height="161" alt="CleanShot 2026-04-05 at 22 18 57" src="https://github.com/user-attachments/assets/b20e631e-9319-498c-878f-2d02f6124551" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: text/label tweaks plus a small layout width class change, with browser tests updated accordingly.
> 
> **Overview**
> Renames the default (non-plan) interaction mode from **“Chat” to “Build”** across the composer UI, including the toggle button label/tooltip text and the `/default` slash-command description.
> 
> Updates the `ChatView.browser.tsx` interaction-mode hotkey test to assert against the new label and tooltip copy, and slightly widens the composer form by changing its max-width class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bddd7ddc173a97fe1200f1632ccd010a7bceac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename 'Chat' to 'Build' in interaction mode toggle
> Updates the default interaction mode label from 'Chat' to 'Build' in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1769/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), including the toggle button label, tooltip text, and `/default` slash command description. Also changes the composer form max-width from `max-w-[52rem]` to `max-w-208`. Browser tests are updated to match the new 'Build' label and tooltip text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bddd7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


