### PR TITLE
feat: implement more friendly updater errors

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -30,6 +30,7 @@ import { NetService } from "@t3tools/shared/Net";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { parsePersistedServerObservabilitySettings } from "@t3tools/shared/serverSettings";
 import { showDesktopConfirmDialog } from "./confirmDialog";
+import { normalizeDesktopUpdateError } from "./updateErrors";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
 import {
@@ -806,11 +807,16 @@ async function checkForUpdates(reason: string): Promise<boolean> {
     await autoUpdater.checkForUpdates();
     return true;
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const normalizedError = normalizeDesktopUpdateError(error, "check");
     setUpdateState(
-      reduceDesktopUpdateStateOnCheckFailure(updateState, message, new Date().toISOString()),
+      reduceDesktopUpdateStateOnCheckFailure(
+        updateState,
+        normalizedError.message,
+        new Date().toISOString(),
+        normalizedError.toastAction,
+      ),
     );
-    console.error(`[desktop-updater] Failed to check for updates: ${message}`);
+    console.error(`[desktop-updater] Failed to check for updates: ${normalizedError.rawMessage}`);
     return true;
   } finally {
     updateCheckInFlight = false;
@@ -830,9 +836,15 @@ async function downloadAvailableUpdate(): Promise<{ accepted: boolean; completed
     await autoUpdater.downloadUpdate();
     return { accepted: true, completed: true };
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    setUpdateState(reduceDesktopUpdateStateOnDownloadFailure(updateState, message));
-    console.error(`[desktop-updater] Failed to download update: ${message}`);
+    const normalizedError = normalizeDesktopUpdateError(error, "download");
+    setUpdateState(
+      reduceDesktopUpdateStateOnDownloadFailure(
+        updateState,
+        normalizedError.message,
+        normalizedError.toastAction,
+      ),
+    );
+    console.error(`[desktop-updater] Failed to download update: ${normalizedError.rawMessage}`);
     return { accepted: true, completed: false };
   } finally {
     updateDownloadInFlight = false;
@@ -859,11 +871,17 @@ async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed
     autoUpdater.quitAndInstall(true, true);
     return { accepted: true, completed: false };
   } catch (error: unknown) {
-    const message = formatErrorMessage(error);
+    const normalizedError = normalizeDesktopUpdateError(error, "install");
     updateInstallInFlight = false;
     isQuitting = false;
-    setUpdateState(reduceDesktopUpdateStateOnInstallFailure(updateState, message));
-    console.error(`[desktop-updater] Failed to install update: ${message}`);
+    setUpdateState(
+      reduceDesktopUpdateStateOnInstallFailure(
+        updateState,
+        normalizedError.message,
+        normalizedError.toastAction,
+      ),
+    );
+    console.error(`[desktop-updater] Failed to install update: ${normalizedError.rawMessage}`);
     return { accepted: true, completed: false };
   }
 }
@@ -939,25 +957,33 @@ function configureAutoUpdater(): void {
     console.info("[desktop-updater] No updates available.");
   });
   autoUpdater.on("error", (error) => {
-    const message = formatErrorMessage(error);
+    const errorContext = resolveUpdaterErrorContext();
+    const normalizedError = normalizeDesktopUpdateError(error, errorContext);
     if (updateInstallInFlight) {
       updateInstallInFlight = false;
       isQuitting = false;
-      setUpdateState(reduceDesktopUpdateStateOnInstallFailure(updateState, message));
-      console.error(`[desktop-updater] Updater error: ${message}`);
+      setUpdateState(
+        reduceDesktopUpdateStateOnInstallFailure(
+          updateState,
+          normalizedError.message,
+          normalizedError.toastAction,
+        ),
+      );
+      console.error(`[desktop-updater] Updater error: ${normalizedError.rawMessage}`);
       return;
     }
     if (!updateCheckInFlight && !updateDownloadInFlight) {
       setUpdateState({
         status: "error",
-        message,
+        message: normalizedError.message,
         checkedAt: new Date().toISOString(),
         downloadPercent: null,
-        errorContext: resolveUpdaterErrorContext(),
+        errorContext,
         canRetry: updateState.availableVersion !== null || updateState.downloadedVersion !== null,
+        toastAction: normalizedError.toastAction,
       });
     }
-    console.error(`[desktop-updater] Updater error: ${message}`);
+    console.error(`[desktop-updater] Updater error: ${normalizedError.rawMessage}`);
   });
   autoUpdater.on("download-progress", (progress) => {
     const percent = Math.floor(progress.percent);

--- a/apps/desktop/src/updateErrors.test.ts
+++ b/apps/desktop/src/updateErrors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeDesktopUpdateError } from "./updateErrors";
+
+describe("normalizeDesktopUpdateError", () => {
+  it("maps network-style check errors to a friendly message", () => {
+    expect(normalizeDesktopUpdateError(new Error("net::ERR_CONNECTION_REFUSED"), "check")).toEqual({
+      message: "Couldn't reach the update server. Check your connection and try again.",
+      rawMessage: "net::ERR_CONNECTION_REFUSED",
+      toastAction: null,
+    });
+  });
+
+  it("maps checksum download failures to a retryable message", () => {
+    expect(
+      normalizeDesktopUpdateError(
+        new Error("sha512 checksum mismatch, expected abc but got def"),
+        "download",
+      ),
+    ).toEqual({
+      message: "The downloaded update could not be verified. Try downloading it again.",
+      rawMessage: "sha512 checksum mismatch, expected abc but got def",
+      toastAction: {
+        kind: "desktop-update.retry-download",
+        label: "Retry download",
+      },
+    });
+  });
+
+  it("falls back to the raw message when it is already useful", () => {
+    expect(
+      normalizeDesktopUpdateError(new Error("Release feed returned malformed JSON"), "check"),
+    ).toEqual({
+      message: "Release feed returned malformed JSON",
+      rawMessage: "Release feed returned malformed JSON",
+      toastAction: null,
+    });
+  });
+});

--- a/apps/desktop/src/updateErrors.ts
+++ b/apps/desktop/src/updateErrors.ts
@@ -1,0 +1,76 @@
+import type { DesktopToastAction, DesktopUpdateState } from "@t3tools/contracts";
+
+type DesktopUpdateErrorContext = DesktopUpdateState["errorContext"];
+
+const RETRY_DOWNLOAD_TOAST_ACTION: DesktopToastAction = {
+  kind: "desktop-update.retry-download",
+  label: "Retry download",
+};
+
+const NETWORK_ERROR_PATTERN =
+  /\b(EAI_AGAIN|ECONNABORTED|ECONNREFUSED|ECONNRESET|ENETUNREACH|ENOTFOUND|ERR_CONNECTION_(?:CLOSED|REFUSED|RESET|TIMED_OUT)|ERR_INTERNET_DISCONNECTED|ERR_NAME_NOT_RESOLVED|ETIMEDOUT|socket hang up)\b/i;
+const CHECKSUM_ERROR_PATTERN =
+  /\b(checksum|sha(?:256|512)?|hash)\b.*\b(mismatch|invalid|failed|different)\b|\b(mismatch|invalid|failed|different)\b.*\b(checksum|sha(?:256|512)?|hash)\b/i;
+
+function formatDesktopUpdateRawError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function getFallbackDesktopUpdateErrorMessage(context: DesktopUpdateErrorContext): string {
+  if (context === "check") return "Couldn't check for updates.";
+  if (context === "download") return "Couldn't download the update.";
+  if (context === "install") return "Couldn't install the update.";
+  return "Update failed.";
+}
+
+function isNetworkErrorMessage(message: string): boolean {
+  return NETWORK_ERROR_PATTERN.test(message);
+}
+
+function isChecksumErrorMessage(message: string): boolean {
+  return CHECKSUM_ERROR_PATTERN.test(message);
+}
+
+export function normalizeDesktopUpdateError(
+  error: unknown,
+  context: DesktopUpdateErrorContext,
+): {
+  message: string;
+  rawMessage: string;
+  toastAction: DesktopToastAction | null;
+} {
+  const rawMessage = formatDesktopUpdateRawError(error).trim();
+
+  if (context === "download" && isChecksumErrorMessage(rawMessage)) {
+    return {
+      message: "The downloaded update could not be verified. Try downloading it again.",
+      rawMessage,
+      toastAction: RETRY_DOWNLOAD_TOAST_ACTION,
+    };
+  }
+
+  if (isNetworkErrorMessage(rawMessage)) {
+    if (context === "download") {
+      return {
+        message:
+          "Couldn't download the update because the update server is unavailable. Try again in a moment.",
+        rawMessage,
+        toastAction: null,
+      };
+    }
+    return {
+      message: "Couldn't reach the update server. Check your connection and try again.",
+      rawMessage,
+      toastAction: null,
+    };
+  }
+
+  return {
+    message: rawMessage.length > 0 ? rawMessage : getFallbackDesktopUpdateErrorMessage(context),
+    rawMessage,
+    toastAction: null,
+  };
+}

--- a/apps/desktop/src/updateMachine.test.ts
+++ b/apps/desktop/src/updateMachine.test.ts
@@ -53,6 +53,7 @@ describe("updateMachine", () => {
     expect(state.status).toBe("error");
     expect(state.errorContext).toBe("check");
     expect(state.canRetry).toBe(true);
+    expect(state.toastAction).toBeNull();
   });
 
   it("preserves available version on download failure for retry", () => {
@@ -65,12 +66,20 @@ describe("updateMachine", () => {
         downloadPercent: 43,
       },
       "checksum mismatch",
+      {
+        kind: "desktop-update.retry-download",
+        label: "Retry download",
+      },
     );
 
     expect(state.status).toBe("available");
     expect(state.availableVersion).toBe("1.1.0");
     expect(state.errorContext).toBe("download");
     expect(state.canRetry).toBe(true);
+    expect(state.toastAction).toEqual({
+      kind: "desktop-update.retry-download",
+      label: "Retry download",
+    });
   });
 
   it("transitions to downloaded and then preserves install retry state", () => {
@@ -133,7 +142,9 @@ describe("updateMachine", () => {
     expect(available.status).toBe("available");
     expect(downloading.status).toBe("downloading");
     expect(downloading.downloadPercent).toBe(0);
+    expect(downloading.toastAction).toBeNull();
     expect(progress.downloadPercent).toBe(55.5);
     expect(progress.errorContext).toBeNull();
+    expect(progress.toastAction).toBeNull();
   });
 });

--- a/apps/desktop/src/updateMachine.ts
+++ b/apps/desktop/src/updateMachine.ts
@@ -1,4 +1,8 @@
-import type { DesktopRuntimeInfo, DesktopUpdateState } from "@t3tools/contracts";
+import type {
+  DesktopRuntimeInfo,
+  DesktopToastAction,
+  DesktopUpdateState,
+} from "@t3tools/contracts";
 
 import { getCanRetryAfterDownloadFailure, nextStatusAfterDownloadFailure } from "./updateState";
 
@@ -20,6 +24,7 @@ export function createInitialDesktopUpdateState(
     message: null,
     errorContext: null,
     canRetry: false,
+    toastAction: null,
   };
 }
 
@@ -35,6 +40,7 @@ export function reduceDesktopUpdateStateOnCheckStart(
     downloadPercent: null,
     errorContext: null,
     canRetry: false,
+    toastAction: null,
   };
 }
 
@@ -42,6 +48,7 @@ export function reduceDesktopUpdateStateOnCheckFailure(
   state: DesktopUpdateState,
   message: string,
   checkedAt: string,
+  toastAction: DesktopToastAction | null = null,
 ): DesktopUpdateState {
   return {
     ...state,
@@ -51,6 +58,7 @@ export function reduceDesktopUpdateStateOnCheckFailure(
     downloadPercent: null,
     errorContext: "check",
     canRetry: true,
+    toastAction,
   };
 }
 
@@ -69,6 +77,7 @@ export function reduceDesktopUpdateStateOnUpdateAvailable(
     message: null,
     errorContext: null,
     canRetry: false,
+    toastAction: null,
   };
 }
 
@@ -86,6 +95,7 @@ export function reduceDesktopUpdateStateOnNoUpdate(
     message: null,
     errorContext: null,
     canRetry: false,
+    toastAction: null,
   };
 }
 
@@ -99,12 +109,14 @@ export function reduceDesktopUpdateStateOnDownloadStart(
     message: null,
     errorContext: null,
     canRetry: false,
+    toastAction: null,
   };
 }
 
 export function reduceDesktopUpdateStateOnDownloadFailure(
   state: DesktopUpdateState,
   message: string,
+  toastAction: DesktopToastAction | null = null,
 ): DesktopUpdateState {
   return {
     ...state,
@@ -113,6 +125,7 @@ export function reduceDesktopUpdateStateOnDownloadFailure(
     downloadPercent: null,
     errorContext: "download",
     canRetry: getCanRetryAfterDownloadFailure(state),
+    toastAction,
   };
 }
 
@@ -127,6 +140,7 @@ export function reduceDesktopUpdateStateOnDownloadProgress(
     message: null,
     errorContext: null,
     canRetry: false,
+    toastAction: null,
   };
 }
 
@@ -143,12 +157,14 @@ export function reduceDesktopUpdateStateOnDownloadComplete(
     message: null,
     errorContext: null,
     canRetry: true,
+    toastAction: null,
   };
 }
 
 export function reduceDesktopUpdateStateOnInstallFailure(
   state: DesktopUpdateState,
   message: string,
+  toastAction: DesktopToastAction | null = null,
 ): DesktopUpdateState {
   return {
     ...state,
@@ -156,5 +172,6 @@ export function reduceDesktopUpdateStateOnInstallFailure(
     message,
     errorContext: "install",
     canRetry: true,
+    toastAction,
   };
 }

--- a/apps/desktop/src/updateState.test.ts
+++ b/apps/desktop/src/updateState.test.ts
@@ -22,6 +22,7 @@ const baseState: DesktopUpdateState = {
   message: null,
   errorContext: null,
   canRetry: false,
+  toastAction: null,
 };
 
 describe("shouldBroadcastDownloadProgress", () => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -81,13 +81,16 @@ import { formatRelativeTimeLabel } from "../timestampFormat";
 import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
 import {
   getArm64IntelBuildWarningDescription,
-  getDesktopUpdateActionError,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
-  shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
+import {
+  toastDesktopUpdateDownloadResult,
+  toastDesktopUpdateInstallResult,
+  toastDesktopUpdateUnexpectedError,
+} from "./desktopUpdateToast";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Menu, MenuGroup, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
@@ -1893,28 +1896,10 @@ export default function Sidebar() {
       void bridge
         .downloadUpdate()
         .then((result) => {
-          if (result.completed) {
-            toastManager.add({
-              type: "success",
-              title: "Update downloaded",
-              description: "Restart the app from the update button to install it.",
-            });
-          }
-          if (!shouldToastDesktopUpdateActionResult(result)) return;
-          const actionError = getDesktopUpdateActionError(result);
-          if (!actionError) return;
-          toastManager.add({
-            type: "error",
-            title: "Could not download update",
-            description: actionError,
-          });
+          toastDesktopUpdateDownloadResult(result);
         })
         .catch((error) => {
-          toastManager.add({
-            type: "error",
-            title: "Could not start update download",
-            description: error instanceof Error ? error.message : "An unexpected error occurred.",
-          });
+          toastDesktopUpdateUnexpectedError("download", error);
         });
       return;
     }
@@ -1927,21 +1912,10 @@ export default function Sidebar() {
       void bridge
         .installUpdate()
         .then((result) => {
-          if (!shouldToastDesktopUpdateActionResult(result)) return;
-          const actionError = getDesktopUpdateActionError(result);
-          if (!actionError) return;
-          toastManager.add({
-            type: "error",
-            title: "Could not install update",
-            description: actionError,
-          });
+          toastDesktopUpdateInstallResult(result);
         })
         .catch((error) => {
-          toastManager.add({
-            type: "error",
-            title: "Could not install update",
-            description: error instanceof Error ? error.message : "An unexpected error occurred.",
-          });
+          toastDesktopUpdateUnexpectedError("install", error);
         });
     }
   }, [desktopUpdateButtonAction, desktopUpdateButtonDisabled, desktopUpdateState]);

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -28,6 +28,7 @@ const baseState: DesktopUpdateState = {
   message: null,
   errorContext: null,
   canRetry: false,
+  toastAction: null,
 };
 
 describe("desktop update button state", () => {

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -94,11 +94,6 @@ export function shouldToastDesktopUpdateActionResult(result: DesktopUpdateAction
   return getDesktopUpdateActionError(result) !== null;
 }
 
-export function shouldHighlightDesktopUpdateError(state: DesktopUpdateState | null): boolean {
-  if (!state || state.status !== "error") return false;
-  return state.errorContext === "download" || state.errorContext === "install";
-}
-
 export function canCheckForUpdate(state: DesktopUpdateState | null): boolean {
   if (!state || !state.enabled) return false;
   return (

--- a/apps/web/src/components/desktopUpdateToast.ts
+++ b/apps/web/src/components/desktopUpdateToast.ts
@@ -1,0 +1,116 @@
+import type {
+  DesktopToastAction,
+  DesktopUpdateActionResult,
+  DesktopUpdateCheckResult,
+} from "@t3tools/contracts";
+import { getDesktopUpdateActionError } from "./desktopUpdate.logic";
+import { toastManager } from "./ui/toast";
+
+function formatUnexpectedDesktopUpdateError(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function getDesktopUpdateActionErrorToastAction(
+  action: DesktopToastAction | null,
+): { children: string; onClick: () => void } | undefined {
+  if (!action) return undefined;
+  return {
+    children: action.label,
+    onClick: () => {
+      void runDesktopToastAction(action);
+    },
+  };
+}
+
+function showDesktopUpdateDownloadResultToast(result: DesktopUpdateActionResult): void {
+  if (result.completed) {
+    toastManager.add({
+      type: "success",
+      title: "Update downloaded",
+      description: "Restart the app from the update button to install it.",
+    });
+  }
+
+  const actionError = getDesktopUpdateActionError(result);
+  if (!actionError) return;
+  toastManager.add({
+    type: "error",
+    title: "Could not download update",
+    description: actionError,
+    actionProps: getDesktopUpdateActionErrorToastAction(result.state.toastAction),
+  });
+}
+
+function showDesktopUpdateInstallResultToast(result: DesktopUpdateActionResult): void {
+  const actionError = getDesktopUpdateActionError(result);
+  if (!actionError) return;
+  toastManager.add({
+    type: "error",
+    title: "Could not install update",
+    description: actionError,
+    actionProps: getDesktopUpdateActionErrorToastAction(result.state.toastAction),
+  });
+}
+
+async function runDesktopToastAction(action: DesktopToastAction): Promise<void> {
+  const bridge = window.desktopBridge;
+  if (!bridge) return;
+
+  switch (action.kind) {
+    case "desktop-update.retry-download": {
+      try {
+        const result = await bridge.downloadUpdate();
+        showDesktopUpdateDownloadResultToast(result);
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Could not start update download",
+          description: formatUnexpectedDesktopUpdateError(error, "An unexpected error occurred."),
+        });
+      }
+      return;
+    }
+  }
+}
+
+export function toastDesktopUpdateDownloadResult(result: DesktopUpdateActionResult): void {
+  showDesktopUpdateDownloadResultToast(result);
+}
+
+export function toastDesktopUpdateInstallResult(result: DesktopUpdateActionResult): void {
+  showDesktopUpdateInstallResultToast(result);
+}
+
+export function toastDesktopUpdateCheckFailure(result: DesktopUpdateCheckResult): void {
+  if (result.checked) return;
+  toastManager.add({
+    type: "error",
+    title: "Could not check for updates",
+    description: result.state.message ?? "Automatic updates are not available in this build.",
+    actionProps: getDesktopUpdateActionErrorToastAction(result.state.toastAction),
+  });
+}
+
+export function toastDesktopUpdateUnexpectedError(
+  phase: "check" | "download" | "install",
+  error: unknown,
+): void {
+  const titles: Record<"check" | "download" | "install", string> = {
+    check: "Could not check for updates",
+    download: "Could not start update download",
+    install: "Could not install update",
+  };
+  const fallbacks: Record<"check" | "download" | "install", string> = {
+    check: "Update check failed.",
+    download: "An unexpected error occurred.",
+    install: "An unexpected error occurred.",
+  };
+  toastManager.add({
+    type: "error",
+    title: titles[phase],
+    description: formatUnexpectedDesktopUpdateError(error, fallbacks[phase]),
+  });
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -29,6 +29,12 @@ import {
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
 } from "../../components/desktopUpdate.logic";
+import {
+  toastDesktopUpdateCheckFailure,
+  toastDesktopUpdateDownloadResult,
+  toastDesktopUpdateInstallResult,
+  toastDesktopUpdateUnexpectedError,
+} from "../../components/desktopUpdateToast";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { TraitsPicker } from "../chat/TraitsPicker";
 import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
@@ -341,13 +347,10 @@ function AboutVersionSection() {
         .downloadUpdate()
         .then((result) => {
           setDesktopUpdateStateQueryData(queryClient, result.state);
+          toastDesktopUpdateDownloadResult(result);
         })
         .catch((error: unknown) => {
-          toastManager.add({
-            type: "error",
-            title: "Could not download update",
-            description: error instanceof Error ? error.message : "Download failed.",
-          });
+          toastDesktopUpdateUnexpectedError("download", error);
         });
       return;
     }
@@ -363,13 +366,10 @@ function AboutVersionSection() {
         .installUpdate()
         .then((result) => {
           setDesktopUpdateStateQueryData(queryClient, result.state);
+          toastDesktopUpdateInstallResult(result);
         })
         .catch((error: unknown) => {
-          toastManager.add({
-            type: "error",
-            title: "Could not install update",
-            description: error instanceof Error ? error.message : "Install failed.",
-          });
+          toastDesktopUpdateUnexpectedError("install", error);
         });
       return;
     }
@@ -379,21 +379,10 @@ function AboutVersionSection() {
       .checkForUpdate()
       .then((result) => {
         setDesktopUpdateStateQueryData(queryClient, result.state);
-        if (!result.checked) {
-          toastManager.add({
-            type: "error",
-            title: "Could not check for updates",
-            description:
-              result.state.message ?? "Automatic updates are not available in this build.",
-          });
-        }
+        toastDesktopUpdateCheckFailure(result);
       })
       .catch((error: unknown) => {
-        toastManager.add({
-          type: "error",
-          title: "Could not check for updates",
-          description: error instanceof Error ? error.message : "Update check failed.",
-        });
+        toastDesktopUpdateUnexpectedError("check", error);
       });
   }, [queryClient, updateState]);
 

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -6,18 +6,20 @@ import {
   setDesktopUpdateStateQueryData,
   useDesktopUpdateState,
 } from "../../lib/desktopUpdateReactQuery";
-import { toastManager } from "../ui/toast";
 import {
   getArm64IntelBuildWarningDescription,
-  getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
   shouldShowDesktopUpdateButton,
-  shouldToastDesktopUpdateActionResult,
 } from "../desktopUpdate.logic";
+import {
+  toastDesktopUpdateDownloadResult,
+  toastDesktopUpdateInstallResult,
+  toastDesktopUpdateUnexpectedError,
+} from "../desktopUpdateToast";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
@@ -45,28 +47,10 @@ export function SidebarUpdatePill() {
         .downloadUpdate()
         .then((result) => {
           setDesktopUpdateStateQueryData(queryClient, result.state);
-          if (result.completed) {
-            toastManager.add({
-              type: "success",
-              title: "Update downloaded",
-              description: "Restart the app from the update button to install it.",
-            });
-          }
-          if (!shouldToastDesktopUpdateActionResult(result)) return;
-          const actionError = getDesktopUpdateActionError(result);
-          if (!actionError) return;
-          toastManager.add({
-            type: "error",
-            title: "Could not download update",
-            description: actionError,
-          });
+          toastDesktopUpdateDownloadResult(result);
         })
         .catch((error) => {
-          toastManager.add({
-            type: "error",
-            title: "Could not start update download",
-            description: error instanceof Error ? error.message : "An unexpected error occurred.",
-          });
+          toastDesktopUpdateUnexpectedError("download", error);
         });
       return;
     }
@@ -78,21 +62,10 @@ export function SidebarUpdatePill() {
         .installUpdate()
         .then((result) => {
           setDesktopUpdateStateQueryData(queryClient, result.state);
-          if (!shouldToastDesktopUpdateActionResult(result)) return;
-          const actionError = getDesktopUpdateActionError(result);
-          if (!actionError) return;
-          toastManager.add({
-            type: "error",
-            title: "Could not install update",
-            description: actionError,
-          });
+          toastDesktopUpdateInstallResult(result);
         })
         .catch((error) => {
-          toastManager.add({
-            type: "error",
-            title: "Could not install update",
-            description: error instanceof Error ? error.message : "An unexpected error occurred.",
-          });
+          toastDesktopUpdateUnexpectedError("install", error);
         });
     }
   }, [action, disabled, queryClient, state]);

--- a/apps/web/src/lib/desktopUpdateReactQuery.test.ts
+++ b/apps/web/src/lib/desktopUpdateReactQuery.test.ts
@@ -21,6 +21,7 @@ const baseState: DesktopUpdateState = {
   message: null,
   errorContext: null,
   canRetry: false,
+  toastAction: null,
 };
 
 describe("desktopUpdateStateQueryOptions", () => {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -67,6 +67,11 @@ export type DesktopUpdateStatus =
   | "downloaded"
   | "error";
 
+export type DesktopToastAction = {
+  kind: "desktop-update.retry-download";
+  label: string;
+};
+
 export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
 
@@ -90,6 +95,7 @@ export interface DesktopUpdateState {
   message: string | null;
   errorContext: "check" | "download" | "install" | null;
   canRetry: boolean;
+  toastAction: DesktopToastAction | null;
 }
 
 export interface DesktopUpdateActionResult {


### PR DESCRIPTION
## What Changed

This condenses all our copied update state toasts to a single file, and also allows us to add action buttons to the toast from the Electron main process (over IPC). This makes the code more DRY and also gives users updating a more friendly experience when something goes wrong.

## Why

Our update error toasts are unfriendly.

Example: https://x.com/asvirts/status/2040604365040300485

## UI Changes

This is an example I made with our mock update server explicitly serving the wrong checksum. That's why it always fails. But you can see the "retry download" button works.

https://github.com/user-attachments/assets/4a594bc8-2218-42da-8fca-78b48d6336b9

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included ~before/~after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the desktop auto-update error pipeline end-to-end (Electron main process, IPC contracts, and multiple UI entry points), so regressions could affect update flows and user messaging. Logic is mostly additive and covered by new tests, but it touches a user-critical path.
> 
> **Overview**
> Improves desktop auto-update UX by **normalizing updater errors into user-friendly messages** and optionally attaching a **toast action** (e.g. *Retry download*) returned from the Electron main process.
> 
> Adds `DesktopToastAction` and a `toastAction` field to `DesktopUpdateState`, propagates it through update state reducers, and wires `main.ts` to use `normalizeDesktopUpdateError()` for check/download/install failures and updater `error` events.
> 
> Centralizes web UI update toasts into `desktopUpdateToast.ts` and replaces duplicated inline toast logic in `Sidebar`, `SidebarUpdatePill`, and `SettingsPanels`, including support for action buttons that trigger the corresponding `window.desktopBridge` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fb506aa81fbc308245cd96389e39e7aa1b0426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add user-friendly error messages and retry toast actions to the desktop updater
> - Introduces `normalizeDesktopUpdateError` in [updateErrors.ts](https://github.com/pingdotgg/t3code/pull/1770/files#diff-578c7f6faadec2cb9ca81bf49226f034aa7d90ce615eb32a69a338ff78d6bb57) to classify raw updater errors (network, checksum/hash mismatch, etc.) into structured objects with a user-facing message, raw message for logging, and an optional `DesktopToastAction`.
> - Extends `DesktopUpdateState` in [ipc.ts](https://github.com/pingdotgg/t3code/pull/1770/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a) with a `toastAction` field, and updates all state reducers in [updateMachine.ts](https://github.com/pingdotgg/t3code/pull/1770/files#diff-f9b783949eb3daed6a190b2a507f117bcd1621cdf688330917a98de0df8ace61) to carry or clear this field across update lifecycle transitions.
> - Centralizes update toast logic into [desktopUpdateToast.ts](https://github.com/pingdotgg/t3code/pull/1770/files#diff-6d7097e167f3a0a385152ace62d2bd2b00d6ebdd0530b9cf9e22448f97685d77), replacing inline toast calls in `Sidebar`, `SidebarUpdatePill`, and `AboutVersionSection` with shared helpers that surface action buttons (e.g. retry download) when `toastAction` is present.
> - On a checksum download failure, users now see a toast with a "Retry Download" button that re-triggers `bridge.downloadUpdate()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3fb506.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->