### PR TITLE
feat: added terminal docking to right

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -24,6 +24,31 @@ const LAUNCHER_VERSION = 1;
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const desktopDir = resolve(__dirname, "..");
 
+function ensureElectronInstalled(require) {
+  const electronPackageJsonPath = require.resolve("electron/package.json");
+  const electronPackageDir = dirname(electronPackageJsonPath);
+  const electronPathFile = join(electronPackageDir, "path.txt");
+
+  if (existsSync(electronPathFile)) {
+    return;
+  }
+
+  const installScriptPath = join(electronPackageDir, "install.js");
+  const installResult = spawnSync("node", [installScriptPath], {
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (installResult.status !== 0 || !existsSync(electronPathFile)) {
+    const detail = installResult.error?.message
+      ? ` ${installResult.error.message}`
+      : installResult.status === null
+        ? ""
+        : ` (exit ${installResult.status})`;
+    throw new Error(`Failed to install Electron runtime automatically.${detail}`.trim());
+  }
+}
+
 function setPlistString(plistPath, key, value) {
   const replaceResult = spawnSync("plutil", ["-replace", key, "-string", value, plistPath], {
     encoding: "utf8",
@@ -134,7 +159,18 @@ function buildMacLauncher(electronBinaryPath) {
 
 export function resolveElectronPath() {
   const require = createRequire(import.meta.url);
-  const electronBinaryPath = require("electron");
+
+  let electronBinaryPath;
+  try {
+    electronBinaryPath = require("electron");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Electron failed to install correctly")) {
+      throw error;
+    }
+    ensureElectronInstalled(require);
+    electronBinaryPath = require("electron");
+  }
 
   if (process.platform !== "darwin") {
     return electronBinaryPath;

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1404,6 +1404,8 @@ describe("ChatView timeline estimator parity (full app)", () => {
         [THREAD_ID]: {
           terminalOpen: true,
           terminalHeight: 280,
+          terminalWidth: 420,
+          terminalDock: "bottom",
           terminalIds: ["default"],
           runningTerminalIds: [],
           activeTerminalId: "default",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -77,6 +77,7 @@ import {
   DEFAULT_RUNTIME_MODE,
   DEFAULT_THREAD_TERMINAL_ID,
   MAX_TERMINALS_PER_GROUP,
+  type ThreadTerminalDock,
   type ChatMessage,
   type SessionPhase,
   type Thread,
@@ -437,6 +438,8 @@ function PersistentThreadTerminalDrawer({
     selectThreadTerminalState(state.terminalStateByThreadId, threadId),
   );
   const storeSetTerminalHeight = useTerminalStateStore((state) => state.setTerminalHeight);
+  const storeSetTerminalWidth = useTerminalStateStore((state) => state.setTerminalWidth);
+  const storeSetTerminalDock = useTerminalStateStore((state) => state.setTerminalDock);
   const storeSplitTerminal = useTerminalStateStore((state) => state.splitTerminal);
   const storeNewTerminal = useTerminalStateStore((state) => state.newTerminal);
   const storeSetActiveTerminal = useTerminalStateStore((state) => state.setActiveTerminal);
@@ -483,6 +486,18 @@ function PersistentThreadTerminalDrawer({
       storeSetTerminalHeight(threadId, height);
     },
     [storeSetTerminalHeight, threadId],
+  );
+  const setTerminalWidth = useCallback(
+    (width: number) => {
+      storeSetTerminalWidth(threadId, width);
+    },
+    [storeSetTerminalWidth, threadId],
+  );
+  const setTerminalDock = useCallback(
+    (dock: ThreadTerminalDock) => {
+      storeSetTerminalDock(threadId, dock);
+    },
+    [storeSetTerminalDock, threadId],
   );
 
   const splitTerminal = useCallback(() => {
@@ -554,7 +569,9 @@ function PersistentThreadTerminalDrawer({
         worktreePath={effectiveWorktreePath}
         runtimeEnv={runtimeEnv}
         visible={visible}
+        dock={terminalState.terminalDock}
         height={terminalState.terminalHeight}
+        width={terminalState.terminalWidth}
         terminalIds={terminalState.terminalIds}
         activeTerminalId={terminalState.activeTerminalId}
         terminalGroups={terminalState.terminalGroups}
@@ -567,7 +584,9 @@ function PersistentThreadTerminalDrawer({
         closeShortcutLabel={visible ? closeShortcutLabel : undefined}
         onActiveTerminalChange={activateTerminal}
         onCloseTerminal={closeTerminal}
+        onDockChange={setTerminalDock}
         onHeightChange={setTerminalHeight}
+        onWidthChange={setTerminalWidth}
         onAddTerminalContext={handleAddTerminalContext}
       />
     </div>
@@ -740,8 +759,10 @@ export default function ChatView({ threadId }: ChatViewProps) {
   );
   const openTerminalThreadIds = useMemo(
     () =>
-      Object.entries(terminalStateByThreadId).flatMap(([nextThreadId, nextTerminalState]) =>
-        nextTerminalState.terminalOpen ? [nextThreadId as ThreadId] : [],
+      Object.keys(terminalStateByThreadId).flatMap((nextThreadId) =>
+        selectThreadTerminalState(terminalStateByThreadId, nextThreadId as ThreadId).terminalOpen
+          ? [nextThreadId as ThreadId]
+          : [],
       ),
     [terminalStateByThreadId],
   );
@@ -764,6 +785,24 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [draftThreadsByThreadId],
   );
   const [mountedTerminalThreadIds, setMountedTerminalThreadIds] = useState<ThreadId[]>([]);
+  const rightDockedMountedTerminalThreadIds = useMemo(
+    () =>
+      mountedTerminalThreadIds.filter(
+        (mountedThreadId) =>
+          selectThreadTerminalState(terminalStateByThreadId, mountedThreadId).terminalDock ===
+          "right",
+      ),
+    [mountedTerminalThreadIds, terminalStateByThreadId],
+  );
+  const bottomDockedMountedTerminalThreadIds = useMemo(
+    () =>
+      mountedTerminalThreadIds.filter(
+        (mountedThreadId) =>
+          selectThreadTerminalState(terminalStateByThreadId, mountedThreadId).terminalDock !==
+          "right",
+      ),
+    [mountedTerminalThreadIds, terminalStateByThreadId],
+  );
 
   const setPrompt = useCallback(
     (nextPrompt: string) => {
@@ -3891,6 +3930,21 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
     void onRevertToTurnCount(targetTurnCount);
   };
+  const renderPersistentTerminalDrawer = (mountedThreadId: ThreadId) => (
+    <PersistentThreadTerminalDrawer
+      key={mountedThreadId}
+      threadId={mountedThreadId}
+      visible={mountedThreadId === activeThreadId && terminalState.terminalOpen}
+      launchContext={
+        mountedThreadId === activeThreadId ? (activeTerminalLaunchContext ?? null) : null
+      }
+      focusRequestId={mountedThreadId === activeThreadId ? terminalFocusRequestId : 0}
+      splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
+      newShortcutLabel={newTerminalShortcutLabel ?? undefined}
+      closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
+      onAddTerminalContext={addTerminalContextToDraft}
+    />
+  );
 
   // Empty state: no active thread
   if (!activeThread) {
@@ -4451,24 +4505,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
             }}
           />
         ) : null}
+
+        {rightDockedMountedTerminalThreadIds.map(renderPersistentTerminalDrawer)}
       </div>
       {/* end horizontal flex container */}
 
-      {mountedTerminalThreadIds.map((mountedThreadId) => (
-        <PersistentThreadTerminalDrawer
-          key={mountedThreadId}
-          threadId={mountedThreadId}
-          visible={mountedThreadId === activeThreadId && terminalState.terminalOpen}
-          launchContext={
-            mountedThreadId === activeThreadId ? (activeTerminalLaunchContext ?? null) : null
-          }
-          focusRequestId={mountedThreadId === activeThreadId ? terminalFocusRequestId : 0}
-          splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
-          newShortcutLabel={newTerminalShortcutLabel ?? undefined}
-          closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
-          onAddTerminalContext={addTerminalContextToDraft}
-        />
-      ))}
+      {bottomDockedMountedTerminalThreadIds.map(renderPersistentTerminalDrawer)}
 
       {expandedImage && expandedImageItem && (
         <div

--- a/apps/web/src/components/ThreadTerminalDrawer.test.ts
+++ b/apps/web/src/components/ThreadTerminalDrawer.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  clampTerminalDockWidth,
   resolveTerminalSelectionActionPosition,
+  resolveTerminalSplitGridStyle,
   selectPendingTerminalEventEntries,
   selectTerminalEventEntriesAfterSnapshot,
   shouldHandleTerminalSelectionMouseUp,
@@ -67,6 +69,21 @@ describe("resolveTerminalSelectionActionPosition", () => {
     expect(terminalSelectionActionDelayForClickCount(1)).toBe(0);
     expect(terminalSelectionActionDelayForClickCount(2)).toBe(260);
     expect(terminalSelectionActionDelayForClickCount(3)).toBe(260);
+  });
+
+  it("clamps right-docked terminal widths to the supported range", () => {
+    expect(clampTerminalDockWidth(120, 1_000)).toBe(320);
+    expect(clampTerminalDockWidth(640, 1_000)).toBe(600);
+    expect(clampTerminalDockWidth(480, 1_000)).toBe(480);
+  });
+
+  it("switches split terminals to rows when docked on the right", () => {
+    expect(resolveTerminalSplitGridStyle("bottom", 3)).toEqual({
+      gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+    });
+    expect(resolveTerminalSplitGridStyle("right", 3)).toEqual({
+      gridTemplateRows: "repeat(3, minmax(0, 1fr))",
+    });
   });
 
   it("only handles mouseup when the selection gesture started in the terminal", () => {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -310,7 +310,6 @@ function TerminalViewport({
     });
     terminal.loadAddon(fitAddon);
     terminal.open(mount);
-    fitAddon.fit();
 
     terminalRef.current = terminal;
     fitAddonRef.current = fitAddon;
@@ -672,25 +671,6 @@ function TerminalViewport({
       }
     };
 
-    const fitTimer = window.setTimeout(() => {
-      const activeTerminal = terminalRef.current;
-      const activeFitAddon = fitAddonRef.current;
-      if (!activeTerminal || !activeFitAddon) return;
-      const wasAtBottom =
-        activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
-      activeFitAddon.fit();
-      if (wasAtBottom) {
-        activeTerminal.scrollToBottom();
-      }
-      void api.terminal
-        .resize({
-          threadId,
-          terminalId,
-          cols: activeTerminal.cols,
-          rows: activeTerminal.rows,
-        })
-        .catch(() => undefined);
-    }, 30);
     void openTerminal();
 
     return () => {
@@ -698,7 +678,6 @@ function TerminalViewport({
       terminalHydratedRef.current = false;
       lastAppliedTerminalEventIdRef.current = 0;
       unsubscribeTerminalEvents();
-      window.clearTimeout(fitTimer);
       inputDisposable.dispose();
       selectionDisposable.dispose();
       terminalLinksDisposable.dispose();
@@ -1206,63 +1185,43 @@ export default function ThreadTerminalDrawer({
       <div className="min-h-0 w-full flex-1">
         <div className={`flex h-full min-h-0 ${hasTerminalSidebar ? "gap-1.5" : ""}`}>
           <div className="min-w-0 flex-1">
-            {isSplitView ? (
-              <div
-                className="grid h-full w-full min-w-0 gap-0 overflow-hidden"
-                style={splitGridStyle}
-              >
-                {visibleTerminalIds.map((terminalId) => (
-                  <div
-                    key={terminalId}
-                    className={`${splitPaneClassName} ${
-                      terminalId === resolvedActiveTerminalId ? "border-border" : "border-border/70"
-                    }`}
-                    onMouseDown={() => {
-                      if (terminalId !== resolvedActiveTerminalId) {
-                        onActiveTerminalChange(terminalId);
-                      }
-                    }}
-                  >
-                    <div className="h-full p-1">
-                      <TerminalViewport
-                        threadId={threadId}
-                        terminalId={terminalId}
-                        terminalLabel={terminalLabelById.get(terminalId) ?? "Terminal"}
-                        cwd={cwd}
-                        {...(worktreePath !== undefined ? { worktreePath } : {})}
-                        {...(runtimeEnv ? { runtimeEnv } : {})}
-                        onSessionExited={() => onCloseTerminal(terminalId)}
-                        onAddTerminalContext={onAddTerminalContext}
-                        focusRequestId={focusRequestId}
-                        autoFocus={terminalId === resolvedActiveTerminalId}
-                        resizeEpoch={resizeEpoch}
-                        dock={dock}
-                        resizeMeasure={resizeMeasure}
-                      />
-                    </div>
+            <div
+              className="grid h-full w-full min-w-0 gap-0 overflow-hidden"
+              style={splitGridStyle}
+            >
+              {visibleTerminalIds.map((terminalId) => (
+                <div
+                  key={terminalId}
+                  className={`${isSplitView ? splitPaneClassName : ""} ${
+                    terminalId === resolvedActiveTerminalId ? "border-border" : "border-border/70"
+                  }`}
+                  onMouseDown={() => {
+                    if (terminalId !== resolvedActiveTerminalId) {
+                      onActiveTerminalChange(terminalId);
+                    }
+                  }}
+                >
+                  <div className="h-full p-1">
+                    <TerminalViewport
+                      key={terminalId}
+                      threadId={threadId}
+                      terminalId={terminalId}
+                      terminalLabel={terminalLabelById.get(terminalId) ?? "Terminal"}
+                      cwd={cwd}
+                      {...(worktreePath !== undefined ? { worktreePath } : {})}
+                      {...(runtimeEnv ? { runtimeEnv } : {})}
+                      onSessionExited={() => onCloseTerminal(terminalId)}
+                      onAddTerminalContext={onAddTerminalContext}
+                      focusRequestId={focusRequestId}
+                      autoFocus={terminalId === resolvedActiveTerminalId}
+                      resizeEpoch={resizeEpoch}
+                      dock={dock}
+                      resizeMeasure={resizeMeasure}
+                    />
                   </div>
-                ))}
-              </div>
-            ) : (
-              <div className="h-full p-1">
-                <TerminalViewport
-                  key={resolvedActiveTerminalId}
-                  threadId={threadId}
-                  terminalId={resolvedActiveTerminalId}
-                  terminalLabel={terminalLabelById.get(resolvedActiveTerminalId) ?? "Terminal"}
-                  cwd={cwd}
-                  {...(worktreePath !== undefined ? { worktreePath } : {})}
-                  {...(runtimeEnv ? { runtimeEnv } : {})}
-                  onSessionExited={() => onCloseTerminal(resolvedActiveTerminalId)}
-                  onAddTerminalContext={onAddTerminalContext}
-                  focusRequestId={focusRequestId}
-                  autoFocus
-                  resizeEpoch={resizeEpoch}
-                  dock={dock}
-                  resizeMeasure={resizeMeasure}
-                />
-              </div>
-            )}
+                </div>
+              ))}
+            </div>
           </div>
 
           {hasTerminalSidebar && (

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1,5 +1,13 @@
 import { FitAddon } from "@xterm/addon-fit";
-import { Plus, SquareSplitHorizontal, TerminalSquare, Trash2, XIcon } from "lucide-react";
+import {
+  PanelBottomOpenIcon,
+  PanelRightOpenIcon,
+  Plus,
+  SquareSplitHorizontal,
+  TerminalSquare,
+  Trash2,
+  XIcon,
+} from "lucide-react";
 import {
   type TerminalEvent,
   type TerminalSessionSnapshot,
@@ -26,9 +34,12 @@ import {
 } from "../terminal-links";
 import { isTerminalClearShortcut, terminalNavigationShortcutData } from "../keybindings";
 import {
+  DEFAULT_THREAD_TERMINAL_DOCK,
   DEFAULT_THREAD_TERMINAL_HEIGHT,
   DEFAULT_THREAD_TERMINAL_ID,
+  DEFAULT_THREAD_TERMINAL_WIDTH,
   MAX_TERMINALS_PER_GROUP,
+  type ThreadTerminalDock,
   type ThreadTerminalGroup,
 } from "../types";
 import { readNativeApi } from "~/nativeApi";
@@ -36,6 +47,8 @@ import { selectTerminalEventEntries, useTerminalStateStore } from "../terminalSt
 
 const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
+const MIN_DRAWER_WIDTH = 320;
+const MAX_DRAWER_WIDTH_RATIO = 0.6;
 const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
 
 function maxDrawerHeight(): number {
@@ -47,6 +60,19 @@ function clampDrawerHeight(height: number): number {
   const safeHeight = Number.isFinite(height) ? height : DEFAULT_THREAD_TERMINAL_HEIGHT;
   const maxHeight = maxDrawerHeight();
   return Math.min(Math.max(Math.round(safeHeight), MIN_DRAWER_HEIGHT), maxHeight);
+}
+
+function maxDrawerWidth(viewportWidth?: number): number {
+  const resolvedViewportWidth =
+    viewportWidth ??
+    (typeof window === "undefined" ? DEFAULT_THREAD_TERMINAL_WIDTH : window.innerWidth);
+  return Math.max(MIN_DRAWER_WIDTH, Math.floor(resolvedViewportWidth * MAX_DRAWER_WIDTH_RATIO));
+}
+
+export function clampTerminalDockWidth(width: number, viewportWidth?: number): number {
+  const safeWidth = Number.isFinite(width) ? width : DEFAULT_THREAD_TERMINAL_WIDTH;
+  const maxWidth = maxDrawerWidth(viewportWidth);
+  return Math.min(Math.max(Math.round(safeWidth), MIN_DRAWER_WIDTH), maxWidth);
 }
 
 function writeSystemMessage(terminal: Terminal, message: string): void {
@@ -72,6 +98,16 @@ export function selectPendingTerminalEventEntries(
   lastAppliedTerminalEventId: number,
 ): ReadonlyArray<{ id: number; event: TerminalEvent }> {
   return entries.filter((entry) => entry.id > lastAppliedTerminalEventId);
+}
+
+export function resolveTerminalSplitGridStyle(
+  dock: ThreadTerminalDock,
+  visibleTerminalCount: number,
+): { gridTemplateColumns?: string; gridTemplateRows?: string } {
+  const count = Math.max(1, Math.round(visibleTerminalCount));
+  return dock === "right"
+    ? { gridTemplateRows: `repeat(${count}, minmax(0, 1fr))` }
+    : { gridTemplateColumns: `repeat(${count}, minmax(0, 1fr))` };
 }
 
 function terminalThemeFromApp(): ITheme {
@@ -219,7 +255,8 @@ interface TerminalViewportProps {
   focusRequestId: number;
   autoFocus: boolean;
   resizeEpoch: number;
-  drawerHeight: number;
+  dock: ThreadTerminalDock;
+  resizeMeasure: number;
 }
 
 function TerminalViewport({
@@ -234,7 +271,8 @@ function TerminalViewport({
   focusRequestId,
   autoFocus,
   resizeEpoch,
-  drawerHeight,
+  dock,
+  resizeMeasure,
 }: TerminalViewportProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
@@ -714,7 +752,7 @@ function TerminalViewport({
     return () => {
       window.cancelAnimationFrame(frame);
     };
-  }, [drawerHeight, resizeEpoch, terminalId, threadId]);
+  }, [dock, resizeEpoch, resizeMeasure, terminalId, threadId]);
   return (
     <div ref={containerRef} className="relative h-full w-full overflow-hidden rounded-[4px]" />
   );
@@ -726,7 +764,9 @@ interface ThreadTerminalDrawerProps {
   worktreePath?: string | null;
   runtimeEnv?: Record<string, string>;
   visible?: boolean;
+  dock: ThreadTerminalDock;
   height: number;
+  width: number;
   terminalIds: string[];
   activeTerminalId: string;
   terminalGroups: ThreadTerminalGroup[];
@@ -739,7 +779,9 @@ interface ThreadTerminalDrawerProps {
   closeShortcutLabel?: string | undefined;
   onActiveTerminalChange: (terminalId: string) => void;
   onCloseTerminal: (terminalId: string) => void;
+  onDockChange: (dock: ThreadTerminalDock) => void;
   onHeightChange: (height: number) => void;
+  onWidthChange: (width: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
 }
 
@@ -778,7 +820,9 @@ export default function ThreadTerminalDrawer({
   worktreePath,
   runtimeEnv,
   visible = true,
+  dock = DEFAULT_THREAD_TERMINAL_DOCK,
   height,
+  width,
   terminalIds,
   activeTerminalId,
   terminalGroups,
@@ -791,18 +835,25 @@ export default function ThreadTerminalDrawer({
   closeShortcutLabel,
   onActiveTerminalChange,
   onCloseTerminal,
+  onDockChange,
   onHeightChange,
+  onWidthChange,
   onAddTerminalContext,
 }: ThreadTerminalDrawerProps) {
   const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height));
+  const [drawerWidth, setDrawerWidth] = useState(() => clampTerminalDockWidth(width));
   const [resizeEpoch, setResizeEpoch] = useState(0);
   const drawerHeightRef = useRef(drawerHeight);
+  const drawerWidthRef = useRef(drawerWidth);
   const lastSyncedHeightRef = useRef(clampDrawerHeight(height));
+  const lastSyncedWidthRef = useRef(clampTerminalDockWidth(width));
   const onHeightChangeRef = useRef(onHeightChange);
+  const onWidthChangeRef = useRef(onWidthChange);
   const resizeStateRef = useRef<{
     pointerId: number;
+    startX: number;
     startY: number;
-    startHeight: number;
+    startSize: number;
   } | null>(null);
   const didResizeDuringDragRef = useRef(false);
 
@@ -911,16 +962,27 @@ export default function ThreadTerminalDrawer({
     : splitShortcutLabel
       ? `Split Terminal (${splitShortcutLabel})`
       : "Split Terminal";
+  const dockTerminalActionLabel = dock === "right" ? "Dock Terminal Below" : "Dock Terminal Right";
+  const DockTerminalActionIcon = dock === "right" ? PanelBottomOpenIcon : PanelRightOpenIcon;
   const newTerminalActionLabel = newShortcutLabel
     ? `New Terminal (${newShortcutLabel})`
     : "New Terminal";
   const closeTerminalActionLabel = closeShortcutLabel
     ? `Close Terminal (${closeShortcutLabel})`
     : "Close Terminal";
+  const resizeMeasure = dock === "right" ? drawerWidth : drawerHeight;
+  const splitGridStyle = resolveTerminalSplitGridStyle(dock, visibleTerminalIds.length);
+  const splitPaneClassName =
+    dock === "right"
+      ? "min-h-0 min-w-0 border-t first:border-t-0"
+      : "min-h-0 min-w-0 border-l first:border-l-0";
   const onSplitTerminalAction = useCallback(() => {
     if (hasReachedSplitLimit) return;
     onSplitTerminal();
   }, [hasReachedSplitLimit, onSplitTerminal]);
+  const onToggleDock = useCallback(() => {
+    onDockChange(dock === "right" ? "bottom" : "right");
+  }, [dock, onDockChange]);
   const onNewTerminalAction = useCallback(() => {
     onNewTerminal();
   }, [onNewTerminal]);
@@ -930,14 +992,29 @@ export default function ThreadTerminalDrawer({
   }, [onHeightChange]);
 
   useEffect(() => {
+    onWidthChangeRef.current = onWidthChange;
+  }, [onWidthChange]);
+
+  useEffect(() => {
     drawerHeightRef.current = drawerHeight;
   }, [drawerHeight]);
+
+  useEffect(() => {
+    drawerWidthRef.current = drawerWidth;
+  }, [drawerWidth]);
 
   const syncHeight = useCallback((nextHeight: number) => {
     const clampedHeight = clampDrawerHeight(nextHeight);
     if (lastSyncedHeightRef.current === clampedHeight) return;
     lastSyncedHeightRef.current = clampedHeight;
     onHeightChangeRef.current(clampedHeight);
+  }, []);
+
+  const syncWidth = useCallback((nextWidth: number) => {
+    const clampedWidth = clampTerminalDockWidth(nextWidth);
+    if (lastSyncedWidthRef.current === clampedWidth) return;
+    lastSyncedWidthRef.current = clampedWidth;
+    onWidthChangeRef.current(clampedWidth);
   }, []);
 
   useEffect(() => {
@@ -947,32 +1024,60 @@ export default function ThreadTerminalDrawer({
     lastSyncedHeightRef.current = clampedHeight;
   }, [height, threadId]);
 
-  const handleResizePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.button !== 0) return;
-    event.preventDefault();
-    event.currentTarget.setPointerCapture(event.pointerId);
-    didResizeDuringDragRef.current = false;
-    resizeStateRef.current = {
-      pointerId: event.pointerId,
-      startY: event.clientY,
-      startHeight: drawerHeightRef.current,
-    };
-  }, []);
+  useEffect(() => {
+    const clampedWidth = clampTerminalDockWidth(width);
+    setDrawerWidth(clampedWidth);
+    drawerWidthRef.current = clampedWidth;
+    lastSyncedWidthRef.current = clampedWidth;
+  }, [threadId, width]);
 
-  const handleResizePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    const resizeState = resizeStateRef.current;
-    if (!resizeState || resizeState.pointerId !== event.pointerId) return;
-    event.preventDefault();
-    const clampedHeight = clampDrawerHeight(
-      resizeState.startHeight + (resizeState.startY - event.clientY),
-    );
-    if (clampedHeight === drawerHeightRef.current) {
-      return;
-    }
-    didResizeDuringDragRef.current = true;
-    drawerHeightRef.current = clampedHeight;
-    setDrawerHeight(clampedHeight);
-  }, []);
+  const handleResizePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      didResizeDuringDragRef.current = false;
+      resizeStateRef.current = {
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        startSize: dock === "right" ? drawerWidthRef.current : drawerHeightRef.current,
+      };
+    },
+    [dock],
+  );
+
+  const handleResizePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const resizeState = resizeStateRef.current;
+      if (!resizeState || resizeState.pointerId !== event.pointerId) return;
+      event.preventDefault();
+
+      if (dock === "right") {
+        const clampedWidth = clampTerminalDockWidth(
+          resizeState.startSize + (resizeState.startX - event.clientX),
+        );
+        if (clampedWidth === drawerWidthRef.current) {
+          return;
+        }
+        didResizeDuringDragRef.current = true;
+        drawerWidthRef.current = clampedWidth;
+        setDrawerWidth(clampedWidth);
+        return;
+      }
+
+      const clampedHeight = clampDrawerHeight(
+        resizeState.startSize + (resizeState.startY - event.clientY),
+      );
+      if (clampedHeight === drawerHeightRef.current) {
+        return;
+      }
+      didResizeDuringDragRef.current = true;
+      drawerHeightRef.current = clampedHeight;
+      setDrawerHeight(clampedHeight);
+    },
+    [dock],
+  );
 
   const handleResizePointerEnd = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -985,10 +1090,14 @@ export default function ThreadTerminalDrawer({
       if (!didResizeDuringDragRef.current) {
         return;
       }
-      syncHeight(drawerHeightRef.current);
+      if (dock === "right") {
+        syncWidth(drawerWidthRef.current);
+      } else {
+        syncHeight(drawerHeightRef.current);
+      }
       setResizeEpoch((value) => value + 1);
     },
-    [syncHeight],
+    [dock, syncHeight, syncWidth],
   );
 
   useEffect(() => {
@@ -998,13 +1107,18 @@ export default function ThreadTerminalDrawer({
 
     const onWindowResize = () => {
       const clampedHeight = clampDrawerHeight(drawerHeightRef.current);
-      const changed = clampedHeight !== drawerHeightRef.current;
-      if (changed) {
+      const clampedWidth = clampTerminalDockWidth(drawerWidthRef.current);
+      if (clampedHeight !== drawerHeightRef.current) {
         setDrawerHeight(clampedHeight);
         drawerHeightRef.current = clampedHeight;
       }
+      if (clampedWidth !== drawerWidthRef.current) {
+        setDrawerWidth(clampedWidth);
+        drawerWidthRef.current = clampedWidth;
+      }
       if (!resizeStateRef.current) {
         syncHeight(clampedHeight);
+        syncWidth(clampedWidth);
       }
       setResizeEpoch((value) => value + 1);
     };
@@ -1012,28 +1126,35 @@ export default function ThreadTerminalDrawer({
     return () => {
       window.removeEventListener("resize", onWindowResize);
     };
-  }, [syncHeight, visible]);
+  }, [syncHeight, syncWidth, visible]);
 
   useEffect(() => {
     if (!visible) {
       return;
     }
     setResizeEpoch((value) => value + 1);
-  }, [visible]);
+  }, [dock, visible]);
 
   useEffect(() => {
     return () => {
       syncHeight(drawerHeightRef.current);
+      syncWidth(drawerWidthRef.current);
     };
-  }, [syncHeight]);
+  }, [syncHeight, syncWidth]);
 
   return (
     <aside
-      className="thread-terminal-drawer relative flex min-w-0 shrink-0 flex-col overflow-hidden border-t border-border/80 bg-background"
-      style={{ height: `${drawerHeight}px` }}
+      className={`thread-terminal-drawer relative flex min-h-0 min-w-0 shrink-0 flex-col overflow-hidden bg-background ${
+        dock === "right" ? "h-full border-l border-border/80" : "border-t border-border/80"
+      }`}
+      style={dock === "right" ? { width: `${drawerWidth}px` } : { height: `${drawerHeight}px` }}
     >
       <div
-        className="absolute inset-x-0 top-0 z-20 h-1.5 cursor-row-resize"
+        className={
+          dock === "right"
+            ? "absolute inset-y-0 left-0 z-20 w-1.5 cursor-col-resize"
+            : "absolute inset-x-0 top-0 z-20 h-1.5 cursor-row-resize"
+        }
         onPointerDown={handleResizePointerDown}
         onPointerMove={handleResizePointerMove}
         onPointerUp={handleResizePointerEnd}
@@ -1053,6 +1174,14 @@ export default function ThreadTerminalDrawer({
               label={splitTerminalActionLabel}
             >
               <SquareSplitHorizontal className="size-3.25" />
+            </TerminalActionButton>
+            <div className="h-4 w-px bg-border/80" />
+            <TerminalActionButton
+              className="p-1 text-foreground/90 transition-colors hover:bg-accent"
+              onClick={onToggleDock}
+              label={dockTerminalActionLabel}
+            >
+              <DockTerminalActionIcon className="size-3.25" />
             </TerminalActionButton>
             <div className="h-4 w-px bg-border/80" />
             <TerminalActionButton
@@ -1080,14 +1209,12 @@ export default function ThreadTerminalDrawer({
             {isSplitView ? (
               <div
                 className="grid h-full w-full min-w-0 gap-0 overflow-hidden"
-                style={{
-                  gridTemplateColumns: `repeat(${visibleTerminalIds.length}, minmax(0, 1fr))`,
-                }}
+                style={splitGridStyle}
               >
                 {visibleTerminalIds.map((terminalId) => (
                   <div
                     key={terminalId}
-                    className={`min-h-0 min-w-0 border-l first:border-l-0 ${
+                    className={`${splitPaneClassName} ${
                       terminalId === resolvedActiveTerminalId ? "border-border" : "border-border/70"
                     }`}
                     onMouseDown={() => {
@@ -1109,7 +1236,8 @@ export default function ThreadTerminalDrawer({
                         focusRequestId={focusRequestId}
                         autoFocus={terminalId === resolvedActiveTerminalId}
                         resizeEpoch={resizeEpoch}
-                        drawerHeight={drawerHeight}
+                        dock={dock}
+                        resizeMeasure={resizeMeasure}
                       />
                     </div>
                   </div>
@@ -1130,7 +1258,8 @@ export default function ThreadTerminalDrawer({
                   focusRequestId={focusRequestId}
                   autoFocus
                   resizeEpoch={resizeEpoch}
-                  drawerHeight={drawerHeight}
+                  dock={dock}
+                  resizeMeasure={resizeMeasure}
                 />
               </div>
             )}
@@ -1150,6 +1279,13 @@ export default function ThreadTerminalDrawer({
                     label={splitTerminalActionLabel}
                   >
                     <SquareSplitHorizontal className="size-3.25" />
+                  </TerminalActionButton>
+                  <TerminalActionButton
+                    className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"
+                    onClick={onToggleDock}
+                    label={dockTerminalActionLabel}
+                  >
+                    <DockTerminalActionIcon className="size-3.25" />
                   </TerminalActionButton>
                   <TerminalActionButton
                     className="inline-flex h-full items-center border-l border-border/70 px-1 text-foreground/90 transition-colors hover:bg-accent/70"

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -285,6 +285,7 @@ function TerminalViewport({
   const selectionActionTimerRef = useRef<number | null>(null);
   const lastAppliedTerminalEventIdRef = useRef(0);
   const terminalHydratedRef = useRef(false);
+  const lastSyncedTerminalSizeRef = useRef<{ cols: number; rows: number } | null>(null);
   const handleSessionExited = useEffectEvent(() => {
     onSessionExited();
   });
@@ -632,13 +633,16 @@ function TerminalViewport({
         const activeFitAddon = fitAddonRef.current;
         if (!activeTerminal || !activeFitAddon) return;
         activeFitAddon.fit();
+        const cols = activeTerminal.cols;
+        const rows = activeTerminal.rows;
+        lastSyncedTerminalSizeRef.current = { cols, rows };
         const snapshot = await api.terminal.open({
           threadId,
           terminalId,
           cwd,
           ...(worktreePath !== undefined ? { worktreePath } : {}),
-          cols: activeTerminal.cols,
-          rows: activeTerminal.rows,
+          cols,
+          rows,
           ...(runtimeEnv ? { env: runtimeEnv } : {}),
         });
         if (disposed) return;
@@ -677,6 +681,7 @@ function TerminalViewport({
       disposed = true;
       terminalHydratedRef.current = false;
       lastAppliedTerminalEventIdRef.current = 0;
+      lastSyncedTerminalSizeRef.current = null;
       unsubscribeTerminalEvents();
       inputDisposable.dispose();
       selectionDisposable.dispose();
@@ -712,19 +717,26 @@ function TerminalViewport({
     const api = readNativeApi();
     const terminal = terminalRef.current;
     const fitAddon = fitAddonRef.current;
-    if (!api || !terminal || !fitAddon) return;
+    if (!api || !terminal || !fitAddon || !terminalHydratedRef.current) return;
     const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
     const frame = window.requestAnimationFrame(() => {
       fitAddon.fit();
       if (wasAtBottom) {
         terminal.scrollToBottom();
       }
+      const cols = terminal.cols;
+      const rows = terminal.rows;
+      const lastSyncedSize = lastSyncedTerminalSizeRef.current;
+      if (lastSyncedSize && lastSyncedSize.cols === cols && lastSyncedSize.rows === rows) {
+        return;
+      }
+      lastSyncedTerminalSizeRef.current = { cols, rows };
       void api.terminal
         .resize({
           threadId,
           terminalId,
-          cols: terminal.cols,
-          rows: terminal.rows,
+          cols,
+          rows,
         })
         .catch(() => undefined);
     });
@@ -1085,19 +1097,24 @@ export default function ThreadTerminalDrawer({
     }
 
     const onWindowResize = () => {
-      const clampedHeight = clampDrawerHeight(drawerHeightRef.current);
-      const clampedWidth = clampTerminalDockWidth(drawerWidthRef.current);
-      if (clampedHeight !== drawerHeightRef.current) {
-        setDrawerHeight(clampedHeight);
-        drawerHeightRef.current = clampedHeight;
-      }
-      if (clampedWidth !== drawerWidthRef.current) {
-        setDrawerWidth(clampedWidth);
-        drawerWidthRef.current = clampedWidth;
-      }
-      if (!resizeStateRef.current) {
-        syncHeight(clampedHeight);
-        syncWidth(clampedWidth);
+      if (dock === "right") {
+        const clampedWidth = clampTerminalDockWidth(drawerWidthRef.current);
+        if (clampedWidth !== drawerWidthRef.current) {
+          setDrawerWidth(clampedWidth);
+          drawerWidthRef.current = clampedWidth;
+        }
+        if (!resizeStateRef.current) {
+          syncWidth(clampedWidth);
+        }
+      } else {
+        const clampedHeight = clampDrawerHeight(drawerHeightRef.current);
+        if (clampedHeight !== drawerHeightRef.current) {
+          setDrawerHeight(clampedHeight);
+          drawerHeightRef.current = clampedHeight;
+        }
+        if (!resizeStateRef.current) {
+          syncHeight(clampedHeight);
+        }
       }
       setResizeEpoch((value) => value + 1);
     };
@@ -1105,7 +1122,7 @@ export default function ThreadTerminalDrawer({
     return () => {
       window.removeEventListener("resize", onWindowResize);
     };
-  }, [syncHeight, syncWidth, visible]);
+  }, [dock, syncHeight, syncWidth, visible]);
 
   useEffect(() => {
     if (!visible) {

--- a/apps/web/src/terminalStateStore.test.ts
+++ b/apps/web/src/terminalStateStore.test.ts
@@ -71,6 +71,8 @@ describe("terminalStateStore actions", () => {
     expect(terminalState).toEqual({
       terminalOpen: false,
       terminalHeight: 280,
+      terminalWidth: 420,
+      terminalDock: "bottom",
       terminalIds: ["default"],
       runningTerminalIds: [],
       activeTerminalId: "default",
@@ -94,6 +96,37 @@ describe("terminalStateStore actions", () => {
     expect(terminalState.terminalGroups).toEqual([
       { id: "group-default", terminalIds: ["default", "terminal-2"] },
     ]);
+  });
+
+  it("tracks right-docked terminal sizing per thread", () => {
+    const store = useTerminalStateStore.getState();
+    store.setTerminalDock(THREAD_ID, "right");
+    store.setTerminalWidth(THREAD_ID, 512);
+
+    const terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadId,
+      THREAD_ID,
+    );
+    expect(terminalState.terminalDock).toBe("right");
+    expect(terminalState.terminalWidth).toBe(512);
+  });
+
+  it("normalizes legacy terminal state snapshots without dock metadata", () => {
+    const legacyTerminalStateByThreadId = {
+      [THREAD_ID]: {
+        terminalOpen: true,
+        terminalHeight: 320,
+        terminalIds: ["default"],
+        runningTerminalIds: [],
+        activeTerminalId: "default",
+        terminalGroups: [{ id: "group-default", terminalIds: ["default"] }],
+        activeTerminalGroupId: "group-default",
+      },
+    } as unknown as ReturnType<typeof useTerminalStateStore.getState>["terminalStateByThreadId"];
+
+    const terminalState = selectThreadTerminalState(legacyTerminalStateByThreadId, THREAD_ID);
+    expect(terminalState.terminalDock).toBe("bottom");
+    expect(terminalState.terminalWidth).toBe(420);
   });
 
   it("caps splits at four terminals per group", () => {

--- a/apps/web/src/terminalStateStore.test.ts
+++ b/apps/web/src/terminalStateStore.test.ts
@@ -227,7 +227,7 @@ describe("terminalStateStore actions", () => {
     ).toEqual([]);
   });
 
-  it("resets to default and clears persisted entry when closing the last terminal", () => {
+  it("resets to default and clears persisted entry when closing the last terminal with default layout", () => {
     const store = useTerminalStateStore.getState();
     store.closeTerminal(THREAD_ID, "default");
 
@@ -236,6 +236,22 @@ describe("terminalStateStore actions", () => {
       selectThreadTerminalState(useTerminalStateStore.getState().terminalStateByThreadId, THREAD_ID)
         .terminalIds,
     ).toEqual(["default"]);
+  });
+
+  it("preserves dock and sizing preferences when closing the last terminal", () => {
+    const store = useTerminalStateStore.getState();
+    store.setTerminalDock(THREAD_ID, "right");
+    store.setTerminalWidth(THREAD_ID, 540);
+    store.closeTerminal(THREAD_ID, "default");
+
+    const terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadId,
+      THREAD_ID,
+    );
+    expect(terminalState.terminalOpen).toBe(false);
+    expect(terminalState.terminalDock).toBe("right");
+    expect(terminalState.terminalWidth).toBe(540);
+    expect(terminalState.terminalIds).toEqual(["default"]);
   });
 
   it("keeps a valid active terminal after closing an active split terminal", () => {

--- a/apps/web/src/terminalStateStore.ts
+++ b/apps/web/src/terminalStateStore.ts
@@ -461,7 +461,22 @@ function closeThreadTerminal(state: ThreadTerminalState, terminalId: string): Th
 
   const remainingTerminalIds = normalized.terminalIds.filter((id) => id !== terminalId);
   if (remainingTerminalIds.length === 0) {
-    return createDefaultThreadTerminalState();
+    return normalizeThreadTerminalState({
+      terminalOpen: false,
+      terminalHeight: normalized.terminalHeight,
+      terminalWidth: normalized.terminalWidth,
+      terminalDock: normalized.terminalDock,
+      terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+      runningTerminalIds: [],
+      activeTerminalId: DEFAULT_THREAD_TERMINAL_ID,
+      terminalGroups: [
+        {
+          id: fallbackGroupId(DEFAULT_THREAD_TERMINAL_ID),
+          terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
+        },
+      ],
+      activeTerminalGroupId: fallbackGroupId(DEFAULT_THREAD_TERMINAL_ID),
+    });
   }
 
   const closedTerminalIndex = normalized.terminalIds.indexOf(terminalId);

--- a/apps/web/src/terminalStateStore.ts
+++ b/apps/web/src/terminalStateStore.ts
@@ -11,15 +11,20 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { resolveStorage } from "./lib/storage";
 import { terminalRunningSubprocessFromEvent } from "./terminalActivity";
 import {
+  DEFAULT_THREAD_TERMINAL_DOCK,
   DEFAULT_THREAD_TERMINAL_HEIGHT,
   DEFAULT_THREAD_TERMINAL_ID,
+  DEFAULT_THREAD_TERMINAL_WIDTH,
   MAX_TERMINALS_PER_GROUP,
+  type ThreadTerminalDock,
   type ThreadTerminalGroup,
 } from "./types";
 
 interface ThreadTerminalState {
   terminalOpen: boolean;
   terminalHeight: number;
+  terminalWidth: number;
+  terminalDock: ThreadTerminalDock;
   terminalIds: string[];
   runningTerminalIds: string[];
   activeTerminalId: string;
@@ -38,6 +43,7 @@ export interface TerminalEventEntry {
 }
 
 const TERMINAL_STATE_STORAGE_KEY = "t3code:terminal-state:v1";
+const TERMINAL_STATE_STORAGE_VERSION = 2;
 const EMPTY_TERMINAL_EVENT_ENTRIES: ReadonlyArray<TerminalEventEntry> = [];
 const MAX_TERMINAL_EVENT_BUFFER = 200;
 
@@ -160,6 +166,8 @@ function threadTerminalStateEqual(left: ThreadTerminalState, right: ThreadTermin
   return (
     left.terminalOpen === right.terminalOpen &&
     left.terminalHeight === right.terminalHeight &&
+    left.terminalWidth === right.terminalWidth &&
+    left.terminalDock === right.terminalDock &&
     left.activeTerminalId === right.activeTerminalId &&
     left.activeTerminalGroupId === right.activeTerminalGroupId &&
     arraysEqual(left.terminalIds, right.terminalIds) &&
@@ -171,6 +179,8 @@ function threadTerminalStateEqual(left: ThreadTerminalState, right: ThreadTermin
 const DEFAULT_THREAD_TERMINAL_STATE: ThreadTerminalState = Object.freeze({
   terminalOpen: false,
   terminalHeight: DEFAULT_THREAD_TERMINAL_HEIGHT,
+  terminalWidth: DEFAULT_THREAD_TERMINAL_WIDTH,
+  terminalDock: DEFAULT_THREAD_TERMINAL_DOCK,
   terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
   runningTerminalIds: [],
   activeTerminalId: DEFAULT_THREAD_TERMINAL_ID,
@@ -218,6 +228,11 @@ function normalizeThreadTerminalState(state: ThreadTerminalState): ThreadTermina
       Number.isFinite(state.terminalHeight) && state.terminalHeight > 0
         ? state.terminalHeight
         : DEFAULT_THREAD_TERMINAL_HEIGHT,
+    terminalWidth:
+      Number.isFinite(state.terminalWidth) && state.terminalWidth > 0
+        ? state.terminalWidth
+        : DEFAULT_THREAD_TERMINAL_WIDTH,
+    terminalDock: state.terminalDock === "right" ? "right" : DEFAULT_THREAD_TERMINAL_DOCK,
     terminalIds: nextTerminalIds,
     runningTerminalIds,
     activeTerminalId,
@@ -387,6 +402,25 @@ function setThreadTerminalHeight(state: ThreadTerminalState, height: number): Th
   return { ...normalized, terminalHeight: height };
 }
 
+function setThreadTerminalWidth(state: ThreadTerminalState, width: number): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (!Number.isFinite(width) || width <= 0 || normalized.terminalWidth === width) {
+    return normalized;
+  }
+  return { ...normalized, terminalWidth: width };
+}
+
+function setThreadTerminalDock(
+  state: ThreadTerminalState,
+  dock: ThreadTerminalDock,
+): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (normalized.terminalDock === dock) {
+    return normalized;
+  }
+  return { ...normalized, terminalDock: dock };
+}
+
 function splitThreadTerminal(state: ThreadTerminalState, terminalId: string): ThreadTerminalState {
   return upsertTerminalIntoGroups(state, terminalId, "split");
 }
@@ -453,6 +487,8 @@ function closeThreadTerminal(state: ThreadTerminalState, terminalId: string): Th
   return normalizeThreadTerminalState({
     terminalOpen: normalized.terminalOpen,
     terminalHeight: normalized.terminalHeight,
+    terminalWidth: normalized.terminalWidth,
+    terminalDock: normalized.terminalDock,
     terminalIds: remainingTerminalIds,
     runningTerminalIds: normalized.runningTerminalIds.filter((id) => id !== terminalId),
     activeTerminalId: nextActiveTerminalId,
@@ -490,7 +526,8 @@ export function selectThreadTerminalState(
   if (threadId.length === 0) {
     return getDefaultThreadTerminalState();
   }
-  return terminalStateByThreadId[threadId] ?? getDefaultThreadTerminalState();
+  const state = terminalStateByThreadId[threadId];
+  return state ? normalizeThreadTerminalState(state) : getDefaultThreadTerminalState();
 }
 
 function updateTerminalStateByThreadId(
@@ -543,6 +580,8 @@ interface TerminalStateStoreState {
   nextTerminalEventId: number;
   setTerminalOpen: (threadId: ThreadId, open: boolean) => void;
   setTerminalHeight: (threadId: ThreadId, height: number) => void;
+  setTerminalWidth: (threadId: ThreadId, width: number) => void;
+  setTerminalDock: (threadId: ThreadId, dock: ThreadTerminalDock) => void;
   splitTerminal: (threadId: ThreadId, terminalId: string) => void;
   newTerminal: (threadId: ThreadId, terminalId: string) => void;
   ensureTerminal: (
@@ -597,6 +636,10 @@ export const useTerminalStateStore = create<TerminalStateStoreState>()(
           updateTerminal(threadId, (state) => setThreadTerminalOpen(state, open)),
         setTerminalHeight: (threadId, height) =>
           updateTerminal(threadId, (state) => setThreadTerminalHeight(state, height)),
+        setTerminalWidth: (threadId, width) =>
+          updateTerminal(threadId, (state) => setThreadTerminalWidth(state, width)),
+        setTerminalDock: (threadId, dock) =>
+          updateTerminal(threadId, (state) => setThreadTerminalDock(state, dock)),
         splitTerminal: (threadId, terminalId) =>
           updateTerminal(threadId, (state) => splitThreadTerminal(state, terminalId)),
         newTerminal: (threadId, terminalId) =>
@@ -799,8 +842,28 @@ export const useTerminalStateStore = create<TerminalStateStoreState>()(
     },
     {
       name: TERMINAL_STATE_STORAGE_KEY,
-      version: 1,
+      version: TERMINAL_STATE_STORAGE_VERSION,
       storage: createJSONStorage(createTerminalStateStorage),
+      migrate: (persistedState) => {
+        if (!persistedState || typeof persistedState !== "object") {
+          return { terminalStateByThreadId: {} };
+        }
+
+        const state = persistedState as {
+          terminalStateByThreadId?: Record<ThreadId, ThreadTerminalState>;
+        };
+        const terminalStateByThreadId = Object.fromEntries(
+          Object.entries(state.terminalStateByThreadId ?? {}).map(([threadId, terminalState]) => [
+            threadId,
+            normalizeThreadTerminalState(terminalState),
+          ]),
+        ) as Record<ThreadId, ThreadTerminalState>;
+
+        return {
+          ...state,
+          terminalStateByThreadId,
+        };
+      },
       partialize: (state) => ({
         terminalStateByThreadId: state.terminalStateByThreadId,
       }),

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -20,9 +20,12 @@ export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
 
 export const DEFAULT_INTERACTION_MODE: ProviderInteractionMode = "default";
 export const DEFAULT_THREAD_TERMINAL_HEIGHT = 280;
+export const DEFAULT_THREAD_TERMINAL_WIDTH = 420;
 export const DEFAULT_THREAD_TERMINAL_ID = "default";
+export const DEFAULT_THREAD_TERMINAL_DOCK = "bottom" as const;
 export const MAX_TERMINALS_PER_GROUP = 4;
 export type ProjectScript = ContractProjectScript;
+export type ThreadTerminalDock = "bottom" | "right";
 
 export interface ThreadTerminalGroup {
   id: string;

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     ]
   },
   "trustedDependencies": [
+    "electron",
     "node-pty"
   ]
 }


### PR DESCRIPTION
## What Changed

 - Added a terminal dock toggle button next to the existing split terminal action in the thread terminal toolbar.
 - Terminals can now be docked either:
     - below the chat view, or
     - on the right side of the chat view.
- Terminal dock position and right-dock width are persisted per thread.

## Why

- The terminal could previously only be docked below the chat view, which limited layout flexibility and made it harder to use alongside the conversation in wider desktop layouts.
- The change fixes that by allowing the terminal to be docked to the right. 
- Also, the dock state persists, so users won't have to manually do it every time they open the app. 

## UI Changes

Terminal Docked to the right: 
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/6059101f-6185-4736-bc18-8f6aebaa1bac" />

Works when the app is minimised as well: 
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/8f196219-b38e-490a-ab91-a70499cb492e" />

Redocking back to below the chat: 
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/8f196219-b38e-490a-ab91-a70499cb492e" />

Small Video showing the full change: 
https://github.com/user-attachments/assets/3a6f0f84-5040-4dd1-b139-7c2e94650050

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/state changes: introduces persisted terminal dock/width with a storage migration and alters terminal resize/open behavior, which could regress layout or terminal sizing across existing users.
> 
> **Overview**
> Adds a *dock toggle* to the thread terminal drawer so terminals can be displayed either **below** the chat view or **docked to the right**, including right-side resize handling and updated split-pane layout when docked right.
> 
> Persists the new per-thread `terminalDock` and `terminalWidth` in the terminal Zustand store (with a storage version bump + migration/normalization), updates `ChatView` to render right-docked drawers alongside the main content while keeping bottom-docked drawers below, and extends tests to cover dock/width behavior.
> 
> Additionally, the desktop `electron-launcher` now attempts to automatically run Electron’s `install.js` when `require('electron')` fails with the known “failed to install correctly” error, and `package.json` marks `electron` as a trusted dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f328b1dc6a6c662c1f42da98ba8a0d2a8ed5cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add right-side docking to the terminal drawer
> - Adds a dock toggle button to `ThreadTerminalDrawer` so users can switch the terminal between bottom and right-side docking.
> - Introduces `terminalDock` and `terminalWidth` to `ThreadTerminalState`, persisted per thread and migrated from legacy snapshots. Closing the last terminal now preserves dock/size preferences.
> - `ChatView` partitions mounted terminal drawers by dock position and renders right-docked terminals alongside the main layout, bottom-docked terminals below.
> - Adds `clampTerminalDockWidth` and `resolveTerminalSplitGridStyle` helpers to constrain right-dock widths and switch split-terminal grid orientation based on dock side.
> - Behavioral Change: `selectThreadTerminalState` now normalizes returned state, which may differ from raw persisted values for older stored states.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f328b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->