### PR TITLE
Always show what the agent is doing at every step

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -847,6 +847,50 @@ describe("ProviderRuntimeIngestion", () => {
 
     expect(activity?.summary).toBe("Ran command");
     expect(payload?.detail).toBe("bun run lint");
+    expect(payload?.status).toBe("completed");
+  });
+
+  it("derives persisted command summaries without provider titles", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    harness.emit({
+      type: "item.started",
+      eventId: asEventId("evt-command-started-no-title"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-command-no-title"),
+      itemId: asItemId("item-command-no-title"),
+      payload: {
+        itemType: "command_execution",
+        status: "inProgress",
+        detail: "bun run lint",
+        data: {
+          item: {
+            type: "commandExecution",
+            command: "bun run lint",
+          },
+        },
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.activities.some(
+        (activity: ProviderRuntimeTestActivity) => activity.id === "evt-command-started-no-title",
+      ),
+    );
+    const activity = thread.activities.find(
+      (entry: ProviderRuntimeTestActivity) => entry.id === "evt-command-started-no-title",
+    );
+    const payload =
+      activity?.payload && typeof activity.payload === "object"
+        ? (activity.payload as Record<string, unknown>)
+        : undefined;
+
+    expect(activity?.summary).toBe("Running command");
+    expect(payload?.detail).toBe("bun run lint");
+    expect(payload?.status).toBe("inProgress");
   });
 
   it("uses structured read-file paths when available", async () => {
@@ -2078,6 +2122,61 @@ describe("ProviderRuntimeIngestion", () => {
     expect(finalMessage?.streaming).toBe(false);
   });
 
+  it("finalizes visible streaming assistant messages on turn completion even if runtime segment state is gone", async () => {
+    const harness = await createHarness({ serverSettings: { enableAssistantStreaming: true } });
+    const now = "2026-01-01T00:00:00.000Z";
+    const turnId = asTurnId("turn-orphan-streaming-message");
+    const messageId = asMessageId("assistant:orphan-streaming-message");
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.delta",
+        commandId: CommandId.make("cmd-orphan-streaming-message-delta"),
+        threadId: ThreadId.make("thread-1"),
+        messageId,
+        turnId,
+        delta: "already visible",
+        createdAt: now,
+      }),
+    );
+
+    await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === messageId &&
+          message.turnId === turnId &&
+          message.streaming &&
+          message.text === "already visible",
+      ),
+    );
+
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-complete-orphan-streaming-message"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId,
+      payload: {
+        state: "completed",
+      },
+    });
+
+    const finalThread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === messageId &&
+          message.turnId === turnId &&
+          !message.streaming &&
+          message.text === "already visible",
+      ),
+    );
+    const finalMessage = finalThread.messages.find(
+      (entry: ProviderRuntimeTestMessage) => entry.id === messageId,
+    );
+    expect(finalMessage?.streaming).toBe(false);
+  });
+
   it("spills oversized buffered deltas and still finalizes full assistant text", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
@@ -2421,9 +2520,12 @@ describe("ProviderRuntimeIngestion", () => {
       turnId: asTurnId("turn-9"),
       payload: {
         itemType: "command_execution",
-        status: "in_progress",
+        status: "inProgress",
         title: "Read file",
         detail: "/tmp/file.ts",
+        data: {
+          command: "cat /tmp/file.ts",
+        },
       },
     });
 
@@ -2443,6 +2545,19 @@ describe("ProviderRuntimeIngestion", () => {
         (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.started",
       ),
     ).toBe(true);
+    const startedActivity = thread.activities.find(
+      (activity: ProviderRuntimeTestActivity) => activity.kind === "tool.started",
+    );
+    const payload =
+      startedActivity?.payload && typeof startedActivity.payload === "object"
+        ? (startedActivity.payload as Record<string, unknown>)
+        : undefined;
+    const data =
+      payload?.data && typeof payload.data === "object"
+        ? (payload.data as Record<string, unknown>)
+        : undefined;
+    expect(payload?.status).toBe("inProgress");
+    expect(data?.command).toBe("cat /tmp/file.ts");
   });
 
   it("consumes P1 runtime events into thread metadata, diff checkpoints, and activities", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -16,7 +16,9 @@ import {
   type OrchestrationThread,
   type OrchestrationThreadActivity,
   type ProviderRuntimeEvent,
+  type ToolLifecycleItemType,
 } from "@t3tools/contracts";
+import { deriveToolActivityPresentation } from "@t3tools/shared/toolActivity";
 import * as Cache from "effect/Cache";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
@@ -107,6 +109,28 @@ function hasAssistantMessageForTurn(
   return false;
 }
 
+function assistantMessageIdsForTurn(
+  messages: ReadonlyArray<OrchestrationMessage>,
+  turnId: TurnId,
+  options?: { readonly streamingOnly?: boolean },
+): MessageId[] {
+  const result: MessageId[] = [];
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (!message) {
+      continue;
+    }
+    if (message.role !== "assistant" || message.turnId !== turnId) {
+      continue;
+    }
+    if (options?.streamingOnly === true && !message.streaming) {
+      continue;
+    }
+    result.push(message.id);
+  }
+  return result;
+}
+
 function findMessageById(
   messages: ReadonlyArray<OrchestrationMessage>,
   messageId: MessageId,
@@ -164,6 +188,29 @@ function maxCheckpointTurnCount(
 
 function truncateDetail(value: string, limit = 180): string {
   return value.length > limit ? `${value.slice(0, limit - 3)}...` : value;
+}
+
+function toolLifecyclePresentation(
+  event: Extract<
+    ProviderRuntimeEvent,
+    { type: "item.started" | "item.updated" | "item.completed" }
+  >,
+  fallbackSummary: string,
+) {
+  return deriveToolActivityPresentation({
+    itemType: event.payload.itemType as ToolLifecycleItemType,
+    status: event.payload.status,
+    lifecycle:
+      event.type === "item.started"
+        ? "started"
+        : event.type === "item.updated"
+          ? "updated"
+          : "completed",
+    title: event.payload.title,
+    detail: event.payload.detail,
+    data: event.payload.data,
+    fallbackSummary,
+  });
 }
 
 function normalizeProposedPlanMarkdown(planMarkdown: string | undefined): string | undefined {
@@ -536,17 +583,21 @@ function runtimeEventToActivities(
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];
       }
+      const presentation = toolLifecyclePresentation(event, "Tool updated");
       return [
         {
           id: event.eventId,
           createdAt: event.createdAt,
           tone: "tool",
           kind: "tool.updated",
-          summary: event.payload.title ?? "Tool updated",
+          summary: presentation.summary,
           payload: {
+            ...(event.itemId ? { itemId: event.itemId } : {}),
             itemType: event.payload.itemType,
             ...(event.payload.status ? { status: event.payload.status } : {}),
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...((presentation.detail ?? event.payload.detail)
+              ? { detail: presentation.detail ?? event.payload.detail }
+              : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
@@ -559,16 +610,21 @@ function runtimeEventToActivities(
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];
       }
+      const presentation = toolLifecyclePresentation(event, "Tool");
       return [
         {
           id: event.eventId,
           createdAt: event.createdAt,
           tone: "tool",
           kind: "tool.completed",
-          summary: event.payload.title ?? "Tool",
+          summary: presentation.summary,
           payload: {
+            ...(event.itemId ? { itemId: event.itemId } : {}),
             itemType: event.payload.itemType,
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.status ? { status: event.payload.status } : {}),
+            ...((presentation.detail ?? event.payload.detail)
+              ? { detail: presentation.detail ?? event.payload.detail }
+              : {}),
             ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
@@ -581,16 +637,22 @@ function runtimeEventToActivities(
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];
       }
+      const presentation = toolLifecyclePresentation(event, "Tool started");
       return [
         {
           id: event.eventId,
           createdAt: event.createdAt,
           tone: "tool",
           kind: "tool.started",
-          summary: `${event.payload.title ?? "Tool"} started`,
+          summary: presentation.summary,
           payload: {
+            ...(event.itemId ? { itemId: event.itemId } : {}),
             itemType: event.payload.itemType,
-            ...(event.payload.detail ? { detail: truncateDetail(event.payload.detail) } : {}),
+            ...(event.payload.status ? { status: event.payload.status } : {}),
+            ...((presentation.detail ?? event.payload.detail)
+              ? { detail: presentation.detail ?? event.payload.detail }
+              : {}),
+            ...(event.payload.data !== undefined ? { data: event.payload.data } : {}),
           },
           turnId: toTurnId(event.turnId) ?? null,
           ...maybeSequence,
@@ -905,6 +967,7 @@ const make = Effect.gen(function* () {
     finalDeltaCommandTag: string;
     fallbackText?: string;
     hasProjectedMessage?: boolean;
+    forceComplete?: boolean;
   }) =>
     Effect.gen(function* () {
       const bufferedText = yield* takeBufferedAssistantText(input.messageId);
@@ -928,7 +991,7 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (input.hasProjectedMessage || hasRenderableText) {
+      if (input.forceComplete || input.hasProjectedMessage || hasRenderableText) {
         yield* orchestrationEngine.dispatch({
           type: "thread.message.assistant.complete",
           commandId: yield* providerCommandId(input.event, input.commandTag),
@@ -1450,6 +1513,10 @@ const make = Effect.gen(function* () {
           () => assistantCompletion.messageId,
         );
         const existingAssistantMessage = findMessageById(messages, assistantMessageId);
+        const hasStreamingAssistantMessagesForTurn =
+          turnId !== undefined
+            ? hasAssistantMessageForTurn(messages, turnId, { streamingOnly: true })
+            : false;
         const shouldApplyFallbackCompletionText =
           !existingAssistantMessage || existingAssistantMessage.text.length === 0;
 
@@ -1457,6 +1524,7 @@ const make = Effect.gen(function* () {
           Option.isNone(activeAssistantMessageId) &&
           turnId !== undefined &&
           hasAssistantMessagesForTurn &&
+          !hasStreamingAssistantMessagesForTurn &&
           (assistantCompletion.fallbackText?.trim().length ?? 0) === 0;
 
         if (!shouldSkipRedundantCompletion) {
@@ -1508,8 +1576,16 @@ const make = Effect.gen(function* () {
         const turnId = toTurnId(event.turnId);
         if (turnId) {
           const assistantMessageIds = yield* getAssistantMessageIdsForTurn(thread.id, turnId);
+          const streamingAssistantMessageIds = assistantMessageIdsForTurn(messages, turnId, {
+            streamingOnly: true,
+          });
+          const streamingAssistantMessageIdSet = new Set(streamingAssistantMessageIds);
+          const messageIdsToFinalize = new Set([
+            ...assistantMessageIds,
+            ...streamingAssistantMessageIds,
+          ]);
           yield* Effect.forEach(
-            assistantMessageIds,
+            messageIdsToFinalize,
             (assistantMessageId) =>
               finalizeAssistantMessage({
                 event,
@@ -1520,6 +1596,7 @@ const make = Effect.gen(function* () {
                 commandTag: "assistant-complete-finalize",
                 finalDeltaCommandTag: "assistant-delta-finalize-fallback",
                 hasProjectedMessage: findMessageById(messages, assistantMessageId) !== undefined,
+                forceComplete: streamingAssistantMessageIdSet.has(assistantMessageId),
               }),
             { concurrency: 1 },
           ).pipe(Effect.asVoid);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -236,35 +236,6 @@ function toCanonicalItemType(raw: string | undefined | null): CanonicalItemType 
   return "unknown";
 }
 
-function itemTitle(itemType: CanonicalItemType): string | undefined {
-  switch (itemType) {
-    case "assistant_message":
-      return "Assistant message";
-    case "user_message":
-      return "User message";
-    case "reasoning":
-      return "Reasoning";
-    case "plan":
-      return "Plan";
-    case "command_execution":
-      return "Ran command";
-    case "file_change":
-      return "File change";
-    case "mcp_tool_call":
-      return "MCP tool call";
-    case "dynamic_tool_call":
-      return "Tool call";
-    case "web_search":
-      return "Web search";
-    case "image_view":
-      return "Image view";
-    case "error":
-      return "Error";
-    default:
-      return undefined;
-  }
-}
-
 function itemDetail(item: CodexLifecycleItem): string | undefined {
   const candidates = [
     "command" in item ? item.command : undefined,
@@ -470,14 +441,12 @@ function mapItemLifecycle(
       : lifecycle === "item.completed"
         ? "completed"
         : undefined;
-
   return {
     ...runtimeEventBase(event, canonicalThreadId),
     type: lifecycle,
     payload: {
       itemType,
       ...(status ? { status } : {}),
-      ...(itemTitle(itemType) ? { title: itemTitle(itemType) } : {}),
       ...(detail ? { detail } : {}),
       ...(event.payload !== undefined ? { data: event.payload } : {}),
     },

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -60,6 +60,7 @@ import { selectBootstrapCompleteForActiveEnvironment, useStore } from "../store"
 import { terminalSessionManager } from "../terminalSessionState";
 import { useTerminalUiStateStore } from "../terminalUiStateStore";
 import { useUiStateStore } from "../uiStateStore";
+import { __resetTargetedLocalDispatchForTests } from "./ChatView";
 import { createAuthenticatedSessionHandlers } from "../../test/authHttpHandlers";
 import { BrowserWsRpcHarness, type NormalizedWsRpcRequestBody } from "../../test/wsRpcHarness";
 
@@ -1731,6 +1732,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
       },
     });
     await __resetLocalApiForTests();
+    __resetTargetedLocalDispatchForTests();
     await setViewport(DEFAULT_VIEWPORT);
     localStorage.clear();
     document.body.innerHTML = "";

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -17,7 +17,9 @@ import {
   createLocalDispatchSnapshot,
   deriveComposerSendState,
   hasServerAcknowledgedLocalDispatch,
+  isLocalDispatchRelevantToThread,
   reconcileMountedTerminalThreadIds,
+  resolveLocalDispatchRouteChangeAction,
   resolveSendEnvMode,
   shouldWriteThreadErrorToCurrentServerThread,
   waitForStartedServerThread,
@@ -87,6 +89,64 @@ describe("buildExpiredTerminalContextToastCopy", () => {
       title: "Expired terminal contexts omitted from message",
       description: "Re-add it if you want that terminal output included.",
     });
+  });
+});
+
+describe("resolveLocalDispatchRouteChangeAction", () => {
+  it("resets non-targeted local dispatch state on route changes", () => {
+    expect(
+      resolveLocalDispatchRouteChangeAction({
+        localDispatchTargetThreadId: null,
+        routeThreadId: ThreadId.make("thread-2"),
+      }),
+    ).toBe("reset");
+  });
+
+  it("keeps targeted dispatch visible when landing on the target thread", () => {
+    const targetThreadId = ThreadId.make("thread-2");
+
+    expect(
+      resolveLocalDispatchRouteChangeAction({
+        localDispatchTargetThreadId: targetThreadId,
+        routeThreadId: targetThreadId,
+      }),
+    ).toBe("none");
+  });
+
+  it("clears only view state for a targeted dispatch that belongs to another route", () => {
+    expect(
+      resolveLocalDispatchRouteChangeAction({
+        localDispatchTargetThreadId: ThreadId.make("thread-2"),
+        routeThreadId: ThreadId.make("thread-3"),
+      }),
+    ).toBe("clear-view");
+  });
+});
+
+describe("isLocalDispatchRelevantToThread", () => {
+  it("treats non-targeted dispatch as relevant to the current thread", () => {
+    expect(
+      isLocalDispatchRelevantToThread({
+        localDispatchTargetThreadId: null,
+        activeThreadId: ThreadId.make("thread-1"),
+      }),
+    ).toBe(true);
+  });
+
+  it("treats targeted dispatch as relevant only on the target thread", () => {
+    expect(
+      isLocalDispatchRelevantToThread({
+        localDispatchTargetThreadId: ThreadId.make("thread-2"),
+        activeThreadId: ThreadId.make("thread-2"),
+      }),
+    ).toBe(true);
+
+    expect(
+      isLocalDispatchRelevantToThread({
+        localDispatchTargetThreadId: ThreadId.make("thread-2"),
+        activeThreadId: ThreadId.make("thread-3"),
+      }),
+    ).toBe(false);
   });
 });
 
@@ -449,6 +509,7 @@ describe("waitForStartedServerThread", () => {
 
 describe("hasServerAcknowledgedLocalDispatch", () => {
   const projectId = ProjectId.make("project-1");
+  const threadId = ThreadId.make("thread-1");
   const previousLatestTurn = {
     turnId: TurnId.make("turn-1"),
     state: "completed" as const,
@@ -493,9 +554,79 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(
       hasServerAcknowledgedLocalDispatch({
         localDispatch,
+        threadId,
         phase: "ready",
         latestTurn: previousLatestTurn,
         session: previousSession,
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        threadError: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not clear a targeted dispatch before navigating to the target thread", () => {
+    const targetThreadId = ThreadId.make("thread-2");
+    const localDispatch = createLocalDispatchSnapshot(
+      {
+        id: threadId,
+        environmentId: localEnvironmentId,
+        codexThreadId: null,
+        projectId,
+        title: "Thread",
+        modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+        runtimeMode: "full-access",
+        interactionMode: "default",
+        session: previousSession,
+        messages: [],
+        proposedPlans: [],
+        error: null,
+        createdAt: "2026-03-29T00:00:00.000Z",
+        archivedAt: null,
+        updatedAt: "2026-03-29T00:00:10.000Z",
+        latestTurn: previousLatestTurn,
+        branch: null,
+        worktreePath: null,
+        turnDiffSummaries: [],
+        activities: [],
+      },
+      { targetThreadId },
+    );
+
+    expect(
+      hasServerAcknowledgedLocalDispatch({
+        localDispatch,
+        threadId,
+        phase: "ready",
+        latestTurn: {
+          ...previousLatestTurn,
+          turnId: TurnId.make("turn-2"),
+        },
+        session: {
+          ...previousSession,
+          updatedAt: "2026-03-29T00:00:11.000Z",
+        },
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        threadError: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not clear a targeted dispatch from target thread metadata updates", () => {
+    const targetThreadId = ThreadId.make("thread-2");
+    const localDispatch = createLocalDispatchSnapshot(undefined, { targetThreadId });
+
+    expect(
+      hasServerAcknowledgedLocalDispatch({
+        localDispatch,
+        threadId: targetThreadId,
+        phase: "ready",
+        latestTurn: null,
+        session: {
+          ...previousSession,
+          updatedAt: "2026-03-29T00:00:11.000Z",
+        },
         hasPendingApproval: false,
         hasPendingUserInput: false,
         threadError: null,
@@ -530,6 +661,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(
       hasServerAcknowledgedLocalDispatch({
         localDispatch,
+        threadId,
         phase: "ready",
         latestTurn: {
           ...previousLatestTurn,
@@ -576,6 +708,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(
       hasServerAcknowledgedLocalDispatch({
         localDispatch,
+        threadId,
         phase: "running",
         latestTurn: previousLatestTurn,
         session: {
@@ -619,6 +752,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(
       hasServerAcknowledgedLocalDispatch({
         localDispatch,
+        threadId,
         phase: "running",
         latestTurn: previousLatestTurn,
         session: {
@@ -662,6 +796,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(
       hasServerAcknowledgedLocalDispatch({
         localDispatch,
+        threadId,
         phase: "running",
         latestTurn: {
           ...previousLatestTurn,
@@ -677,6 +812,70 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
           orchestrationStatus: "running",
           activeTurnId: TurnId.make("turn-2"),
           updatedAt: "2026-03-29T00:01:01.000Z",
+        },
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        threadError: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("clears a targeted dispatch once the target thread starts running", () => {
+    const targetThreadId = ThreadId.make("thread-2");
+    const turnId = TurnId.make("turn-2");
+    const localDispatch = createLocalDispatchSnapshot(undefined, { targetThreadId });
+
+    expect(
+      hasServerAcknowledgedLocalDispatch({
+        localDispatch,
+        threadId: targetThreadId,
+        phase: "running",
+        latestTurn: {
+          ...previousLatestTurn,
+          turnId,
+          state: "running",
+          requestedAt: "2026-03-29T00:01:00.000Z",
+          startedAt: "2026-03-29T00:01:01.000Z",
+          completedAt: null,
+        },
+        session: {
+          ...previousSession,
+          status: "running",
+          orchestrationStatus: "running",
+          activeTurnId: turnId,
+          updatedAt: "2026-03-29T00:01:01.000Z",
+        },
+        hasPendingApproval: false,
+        hasPendingUserInput: false,
+        threadError: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("clears a targeted dispatch when the target turn is already settled before running is observed", () => {
+    const targetThreadId = ThreadId.make("thread-2");
+    const turnId = TurnId.make("turn-2");
+    const localDispatch = createLocalDispatchSnapshot(undefined, { targetThreadId });
+
+    expect(
+      hasServerAcknowledgedLocalDispatch({
+        localDispatch,
+        threadId: targetThreadId,
+        phase: "ready",
+        latestTurn: {
+          ...previousLatestTurn,
+          turnId,
+          state: "completed",
+          requestedAt: "2026-03-29T00:01:00.000Z",
+          startedAt: "2026-03-29T00:01:01.000Z",
+          completedAt: "2026-03-29T00:01:30.000Z",
+        },
+        session: {
+          ...previousSession,
+          status: "ready",
+          orchestrationStatus: "idle",
+          activeTurnId: undefined,
+          updatedAt: "2026-03-29T00:01:30.000Z",
         },
         hasPendingApproval: false,
         hasPendingUserInput: false,
@@ -712,6 +911,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
     expect(
       hasServerAcknowledgedLocalDispatch({
         localDispatch,
+        threadId,
         phase: "ready",
         latestTurn: previousLatestTurn,
         session: {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -72,6 +72,28 @@ export function shouldWriteThreadErrorToCurrentServerThread(input: {
   );
 }
 
+export type LocalDispatchRouteChangeAction = "none" | "clear-view" | "reset";
+
+export function resolveLocalDispatchRouteChangeAction(input: {
+  localDispatchTargetThreadId: ThreadId | null;
+  routeThreadId: ThreadId;
+}): LocalDispatchRouteChangeAction {
+  if (input.localDispatchTargetThreadId === null) {
+    return "reset";
+  }
+  return input.localDispatchTargetThreadId === input.routeThreadId ? "none" : "clear-view";
+}
+
+export function isLocalDispatchRelevantToThread(input: {
+  localDispatchTargetThreadId: ThreadId | null;
+  activeThreadId: ThreadId | null;
+}): boolean {
+  return (
+    input.localDispatchTargetThreadId === null ||
+    input.localDispatchTargetThreadId === input.activeThreadId
+  );
+}
+
 export function reconcileMountedTerminalThreadIds(input: {
   currentThreadIds: ReadonlyArray<string>;
   openThreadIds: ReadonlyArray<string>;
@@ -309,6 +331,7 @@ export async function waitForStartedServerThread(
 export interface LocalDispatchSnapshot {
   startedAt: string;
   preparingWorktree: boolean;
+  targetThreadId: ThreadId | null;
   latestTurnTurnId: TurnId | null;
   latestTurnRequestedAt: string | null;
   latestTurnStartedAt: string | null;
@@ -319,13 +342,14 @@ export interface LocalDispatchSnapshot {
 
 export function createLocalDispatchSnapshot(
   activeThread: Thread | undefined,
-  options?: { preparingWorktree?: boolean },
+  options?: { preparingWorktree?: boolean; targetThreadId?: ThreadId | null },
 ): LocalDispatchSnapshot {
   const latestTurn = activeThread?.latestTurn ?? null;
   const session = activeThread?.session ?? null;
   return {
     startedAt: new Date().toISOString(),
     preparingWorktree: Boolean(options?.preparingWorktree),
+    targetThreadId: options?.targetThreadId ?? null,
     latestTurnTurnId: latestTurn?.turnId ?? null,
     latestTurnRequestedAt: latestTurn?.requestedAt ?? null,
     latestTurnStartedAt: latestTurn?.startedAt ?? null,
@@ -337,6 +361,7 @@ export function createLocalDispatchSnapshot(
 
 export function hasServerAcknowledgedLocalDispatch(input: {
   localDispatch: LocalDispatchSnapshot | null;
+  threadId: ThreadId | null;
   phase: SessionPhase;
   latestTurn: Thread["latestTurn"] | null;
   session: Thread["session"] | null;
@@ -345,6 +370,12 @@ export function hasServerAcknowledgedLocalDispatch(input: {
   threadError: string | null | undefined;
 }): boolean {
   if (!input.localDispatch) {
+    return false;
+  }
+  if (
+    input.localDispatch.targetThreadId !== null &&
+    input.threadId !== input.localDispatch.targetThreadId
+  ) {
     return false;
   }
   if (input.hasPendingApproval || input.hasPendingUserInput || Boolean(input.threadError)) {
@@ -374,6 +405,13 @@ export function hasServerAcknowledgedLocalDispatch(input: {
       return false;
     }
     return true;
+  }
+
+  if (input.localDispatch.targetThreadId !== null) {
+    if (latestTurnChanged && latestTurn?.startedAt && latestTurn.completedAt) {
+      return true;
+    }
+    return false;
   }
 
   return (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -171,6 +171,8 @@ import {
   deriveLockedProvider,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
+  isLocalDispatchRelevantToThread,
+  resolveLocalDispatchRouteChangeAction,
   resolveSendEnvMode,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
@@ -363,6 +365,39 @@ interface TerminalLaunchContext {
 
 type PersistentTerminalLaunchContext = Pick<TerminalLaunchContext, "cwd" | "worktreePath">;
 
+const targetedLocalDispatchByThreadId = new Map<string, LocalDispatchSnapshot>();
+
+function readTargetedLocalDispatch(threadId: ThreadId | null): LocalDispatchSnapshot | null {
+  if (threadId === null) {
+    return null;
+  }
+  return targetedLocalDispatchByThreadId.get(threadId) ?? null;
+}
+
+function rememberTargetedLocalDispatch(localDispatch: LocalDispatchSnapshot): void {
+  if (localDispatch.targetThreadId === null) {
+    return;
+  }
+  targetedLocalDispatchByThreadId.set(localDispatch.targetThreadId, localDispatch);
+}
+
+function forgetTargetedLocalDispatch(localDispatch: LocalDispatchSnapshot | null): void {
+  if (localDispatch?.targetThreadId === null || localDispatch === null) {
+    return;
+  }
+  const current = targetedLocalDispatchByThreadId.get(localDispatch.targetThreadId);
+  if (current?.startedAt === localDispatch.startedAt) {
+    targetedLocalDispatchByThreadId.delete(localDispatch.targetThreadId);
+  }
+}
+
+export function __resetTargetedLocalDispatchForTests(): void {
+  if (import.meta.env.PROD) {
+    return;
+  }
+  targetedLocalDispatchByThreadId.clear();
+}
+
 function useLocalDispatchState(input: {
   activeThread: Thread | undefined;
   activeLatestTurn: Thread["latestTurn"] | null;
@@ -371,31 +406,64 @@ function useLocalDispatchState(input: {
   activePendingUserInput: ApprovalRequestId | null;
   threadError: string | null | undefined;
 }) {
-  const [localDispatch, setLocalDispatch] = useState<LocalDispatchSnapshot | null>(null);
+  const activeThreadId = input.activeThread?.id ?? null;
+  const [localDispatch, setLocalDispatch] = useState<LocalDispatchSnapshot | null>(() =>
+    readTargetedLocalDispatch(activeThreadId),
+  );
+  const localDispatchRef = useRef(localDispatch);
+  useEffect(() => {
+    localDispatchRef.current = localDispatch;
+  }, [localDispatch]);
 
   const beginLocalDispatch = useCallback(
-    (options?: { preparingWorktree?: boolean }) => {
+    (options?: { preparingWorktree?: boolean; targetThreadId?: ThreadId | null }) => {
       const preparingWorktree = Boolean(options?.preparingWorktree);
+      const targetThreadId = options?.targetThreadId ?? null;
       setLocalDispatch((current) => {
         if (current) {
-          return current.preparingWorktree === preparingWorktree
-            ? current
-            : { ...current, preparingWorktree };
+          if (
+            current.preparingWorktree === preparingWorktree &&
+            current.targetThreadId === targetThreadId
+          ) {
+            return current;
+          }
+          forgetTargetedLocalDispatch(current);
+          const next = { ...current, preparingWorktree, targetThreadId };
+          rememberTargetedLocalDispatch(next);
+          return next;
         }
-        return createLocalDispatchSnapshot(input.activeThread, options);
+        const next = createLocalDispatchSnapshot(input.activeThread, options);
+        rememberTargetedLocalDispatch(next);
+        return next;
       });
     },
     [input.activeThread],
   );
 
   const resetLocalDispatch = useCallback(() => {
+    forgetTargetedLocalDispatch(localDispatchRef.current);
     setLocalDispatch(null);
   }, []);
+
+  const clearLocalDispatchView = useCallback(() => {
+    setLocalDispatch(null);
+  }, []);
+
+  useEffect(() => {
+    if (localDispatch !== null) {
+      return;
+    }
+    const carriedDispatch = readTargetedLocalDispatch(activeThreadId);
+    if (carriedDispatch !== null) {
+      setLocalDispatch(carriedDispatch);
+    }
+  }, [activeThreadId, localDispatch]);
 
   const serverAcknowledgedLocalDispatch = useMemo(
     () =>
       hasServerAcknowledgedLocalDispatch({
         localDispatch,
+        threadId: activeThreadId,
         phase: input.phase,
         latestTurn: input.activeLatestTurn,
         session: input.activeThread?.session ?? null,
@@ -408,6 +476,7 @@ function useLocalDispatchState(input: {
       input.activePendingApproval,
       input.activePendingUserInput,
       input.activeThread?.session,
+      activeThreadId,
       input.phase,
       input.threadError,
       localDispatch,
@@ -421,12 +490,22 @@ function useLocalDispatchState(input: {
     resetLocalDispatch();
   }, [resetLocalDispatch, serverAcknowledgedLocalDispatch]);
 
+  const localDispatchVisibleOnActiveThread =
+    localDispatch !== null &&
+    isLocalDispatchRelevantToThread({
+      localDispatchTargetThreadId: localDispatch.targetThreadId,
+      activeThreadId,
+    });
+  const visibleLocalDispatch = localDispatchVisibleOnActiveThread ? localDispatch : null;
+
   return {
     beginLocalDispatch,
+    clearLocalDispatchView,
     resetLocalDispatch,
-    localDispatchStartedAt: localDispatch?.startedAt ?? null,
-    isPreparingWorktree: localDispatch?.preparingWorktree ?? false,
-    isSendBusy: localDispatch !== null && !serverAcknowledgedLocalDispatch,
+    localDispatchTargetThreadId: localDispatch?.targetThreadId ?? null,
+    localDispatchStartedAt: visibleLocalDispatch?.startedAt ?? null,
+    isPreparingWorktree: visibleLocalDispatch?.preparingWorktree ?? false,
+    isSendBusy: visibleLocalDispatch !== null && !serverAcknowledgedLocalDispatch,
   };
 }
 
@@ -1549,7 +1628,9 @@ export default function ChatView(props: ChatViewProps) {
   const activePendingApproval = pendingApprovals[0] ?? null;
   const {
     beginLocalDispatch,
+    clearLocalDispatchView,
     resetLocalDispatch,
+    localDispatchTargetThreadId,
     localDispatchStartedAt,
     isPreparingWorktree,
     isSendBusy,
@@ -1561,7 +1642,33 @@ export default function ChatView(props: ChatViewProps) {
     activePendingUserInput: activePendingUserInput?.requestId ?? null,
     threadError: activeThread?.error,
   });
+  const localDispatchTargetThreadIdRef = useRef(localDispatchTargetThreadId);
+  useEffect(() => {
+    localDispatchTargetThreadIdRef.current = localDispatchTargetThreadId;
+  }, [localDispatchTargetThreadId]);
   const isWorking = phase === "running" || isSendBusy || isConnecting || isRevertingCheckpoint;
+  const workingFallbackLabel = isRevertingCheckpoint
+    ? "Reverting checkpoint"
+    : isPreparingWorktree
+      ? "Preparing worktree"
+      : isConnecting
+        ? "Connecting"
+        : isSendBusy
+          ? "Sending"
+          : "Thinking";
+  const workingFallbackPhaseRef = useRef<{ label: string | null; startedAt: string | null }>({
+    label: null,
+    startedAt: null,
+  });
+  if (!isWorking) {
+    workingFallbackPhaseRef.current = { label: null, startedAt: null };
+  } else if (workingFallbackPhaseRef.current.label !== workingFallbackLabel) {
+    workingFallbackPhaseRef.current = {
+      label: workingFallbackLabel,
+      startedAt: new Date().toISOString(),
+    };
+  }
+  const workingFallbackStartedAt = workingFallbackPhaseRef.current.startedAt;
   const activeWorkStartedAt = deriveActiveWorkStartedAt(
     activeLatestTurn,
     activeThread?.session ?? null,
@@ -2572,9 +2679,17 @@ export default function ChatView(props: ChatViewProps) {
       }
       return [];
     });
-    resetLocalDispatch();
+    const localDispatchAction = resolveLocalDispatchRouteChangeAction({
+      localDispatchTargetThreadId: localDispatchTargetThreadIdRef.current,
+      routeThreadId: threadId,
+    });
+    if (localDispatchAction === "reset") {
+      resetLocalDispatch();
+    } else if (localDispatchAction === "clear-view") {
+      clearLocalDispatchView();
+    }
     setExpandedImage(null);
-  }, [draftId, resetLocalDispatch, threadId]);
+  }, [clearLocalDispatchView, draftId, resetLocalDispatch, threadId]);
 
   const closeExpandedImage = useCallback(() => {
     setExpandedImage(null);
@@ -2918,6 +3033,7 @@ export default function ChatView(props: ChatViewProps) {
       isFirstMessage && sendEnvMode === "worktree" && !activeThread.worktreePath
         ? activeThreadBranch
         : null;
+    const localDispatchTargetThreadId = isFirstMessage ? threadIdForSend : null;
 
     // In worktree mode, require an explicit base branch so we don't silently
     // fall back to local execution when branch selection is missing.
@@ -2929,7 +3045,10 @@ export default function ChatView(props: ChatViewProps) {
     }
 
     sendInFlightRef.current = true;
-    beginLocalDispatch({ preparingWorktree: Boolean(baseBranchForWorktree) });
+    beginLocalDispatch({
+      preparingWorktree: Boolean(baseBranchForWorktree),
+      targetThreadId: localDispatchTargetThreadId,
+    });
 
     const composerImagesSnapshot = [...composerImages];
     const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
@@ -3077,7 +3196,7 @@ export default function ChatView(props: ChatViewProps) {
                 : {}),
             }
           : undefined;
-      beginLocalDispatch({ preparingWorktree: false });
+      beginLocalDispatch({ preparingWorktree: false, targetThreadId: localDispatchTargetThreadId });
       await api.orchestration.dispatchCommand({
         type: "thread.turn.start",
         commandId: newCommandId(),
@@ -3497,14 +3616,16 @@ export default function ChatView(props: ChatViewProps) {
     const nextThreadModelSelection: ModelSelection = ctxSelectedModelSelection;
 
     sendInFlightRef.current = true;
-    beginLocalDispatch({ preparingWorktree: false });
-    const finish = () => {
+    beginLocalDispatch({ preparingWorktree: false, targetThreadId: nextThreadId });
+    const finish = (options?: { resetDispatch?: boolean }) => {
       sendInFlightRef.current = false;
-      resetLocalDispatch();
+      if (options?.resetDispatch ?? true) {
+        resetLocalDispatch();
+      }
     };
 
-    await api.orchestration
-      .dispatchCommand({
+    try {
+      await api.orchestration.dispatchCommand({
         type: "thread.create",
         commandId: newCommandId(),
         threadId: nextThreadId,
@@ -3516,63 +3637,56 @@ export default function ChatView(props: ChatViewProps) {
         branch: activeThreadBranch,
         worktreePath: activeThread.worktreePath,
         createdAt,
-      })
-      .then(() => {
-        return api.orchestration.dispatchCommand({
-          type: "thread.turn.start",
+      });
+      await api.orchestration.dispatchCommand({
+        type: "thread.turn.start",
+        commandId: newCommandId(),
+        threadId: nextThreadId,
+        message: {
+          messageId: newMessageId(),
+          role: "user",
+          text: outgoingImplementationPrompt,
+          attachments: [],
+        },
+        modelSelection: ctxSelectedModelSelection,
+        titleSeed: nextThreadTitle,
+        runtimeMode,
+        interactionMode: "default",
+        sourceProposedPlan: {
+          threadId: activeThread.id,
+          planId: activeProposedPlan.id,
+        },
+        createdAt,
+      });
+      await waitForStartedServerThread(scopeThreadRef(activeThread.environmentId, nextThreadId));
+      // Signal that the plan sidebar should open on the new thread when enabled.
+      planSidebarOpenOnNextThreadRef.current = autoOpenPlanSidebar;
+      await navigate({
+        to: "/$environmentId/$threadId",
+        params: {
+          environmentId: activeThread.environmentId,
+          threadId: nextThreadId,
+        },
+      });
+      finish({ resetDispatch: false });
+    } catch (err: unknown) {
+      await api.orchestration
+        .dispatchCommand({
+          type: "thread.delete",
           commandId: newCommandId(),
           threadId: nextThreadId,
-          message: {
-            messageId: newMessageId(),
-            role: "user",
-            text: outgoingImplementationPrompt,
-            attachments: [],
-          },
-          modelSelection: ctxSelectedModelSelection,
-          titleSeed: nextThreadTitle,
-          runtimeMode,
-          interactionMode: "default",
-          sourceProposedPlan: {
-            threadId: activeThread.id,
-            planId: activeProposedPlan.id,
-          },
-          createdAt,
-        });
-      })
-      .then(() => {
-        return waitForStartedServerThread(scopeThreadRef(activeThread.environmentId, nextThreadId));
-      })
-      .then(() => {
-        // Signal that the plan sidebar should open on the new thread when enabled.
-        planSidebarOpenOnNextThreadRef.current = autoOpenPlanSidebar;
-        return navigate({
-          to: "/$environmentId/$threadId",
-          params: {
-            environmentId: activeThread.environmentId,
-            threadId: nextThreadId,
-          },
-        });
-      })
-      .catch(async (err: unknown) => {
-        await api.orchestration
-          .dispatchCommand({
-            type: "thread.delete",
-            commandId: newCommandId(),
-            threadId: nextThreadId,
-          })
-          .catch(() => undefined);
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Could not start implementation thread",
-            description:
-              err instanceof Error
-                ? err.message
-                : "An error occurred while creating the new thread.",
-          }),
-        );
-      })
-      .then(finish, finish);
+        })
+        .catch(() => undefined);
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not start implementation thread",
+          description:
+            err instanceof Error ? err.message : "An error occurred while creating the new thread.",
+        }),
+      );
+      finish();
+    }
   }, [
     activeProject,
     activeProposedPlan,
@@ -3783,6 +3897,8 @@ export default function ChatView(props: ChatViewProps) {
               activeTurnInProgress={isWorking || !latestTurnSettled}
               activeTurnId={activeLatestTurn?.turnId ?? null}
               activeTurnStartedAt={activeWorkStartedAt}
+              workingFallbackLabel={workingFallbackLabel}
+              workingFallbackStartedAt={workingFallbackStartedAt}
               listRef={legendListRef}
               timelineEntries={timelineEntries}
               completionDividerBeforeEntryId={completionDividerBeforeEntryId}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -20,7 +20,7 @@ describe("computeMessageDurationStart", () => {
     expect(result).toEqual(new Map([["a1", "2026-01-01T00:00:05Z"]]));
   });
 
-  it("uses the user message createdAt for the first assistant response", () => {
+  it("uses assistant message createdAt for the segment duration start", () => {
     const result = computeMessageDurationStart([
       { id: "u1", role: "user", createdAt: "2026-01-01T00:00:00Z" },
       {
@@ -34,33 +34,63 @@ describe("computeMessageDurationStart", () => {
     expect(result).toEqual(
       new Map([
         ["u1", "2026-01-01T00:00:00Z"],
-        ["a1", "2026-01-01T00:00:00Z"],
+        ["a1", "2026-01-01T00:00:30Z"],
       ]),
     );
   });
 
-  it("uses the previous assistant completedAt for subsequent assistant responses", () => {
+  it("uses each later assistant message createdAt as its own duration start", () => {
     const result = computeMessageDurationStart([
-      { id: "u1", role: "user", createdAt: "2026-01-01T00:00:00Z" },
+      { id: "u1", role: "user", createdAt: "2026-01-01T00:00:00Z", turnId: "turn-1" as never },
       {
         id: "a1",
         role: "assistant",
         createdAt: "2026-01-01T00:00:30Z",
         completedAt: "2026-01-01T00:00:30Z",
+        turnId: "turn-1" as never,
       },
       {
         id: "a2",
         role: "assistant",
         createdAt: "2026-01-01T00:00:55Z",
         completedAt: "2026-01-01T00:00:55Z",
+        turnId: "turn-2" as never,
       },
     ]);
 
     expect(result).toEqual(
       new Map([
         ["u1", "2026-01-01T00:00:00Z"],
-        ["a1", "2026-01-01T00:00:00Z"],
-        ["a2", "2026-01-01T00:00:30Z"],
+        ["a1", "2026-01-01T00:00:30Z"],
+        ["a2", "2026-01-01T00:00:55Z"],
+      ]),
+    );
+  });
+
+  it("keeps subsequent assistant responses in the same turn on their own createdAt", () => {
+    const result = computeMessageDurationStart([
+      { id: "u1", role: "user", createdAt: "2026-01-01T00:00:00Z", turnId: "turn-1" as never },
+      {
+        id: "a1",
+        role: "assistant",
+        createdAt: "2026-01-01T00:00:30Z",
+        completedAt: "2026-01-01T00:00:30Z",
+        turnId: "turn-1" as never,
+      },
+      {
+        id: "a2",
+        role: "assistant",
+        createdAt: "2026-01-01T00:08:00Z",
+        completedAt: "2026-01-01T00:08:00Z",
+        turnId: "turn-1" as never,
+      },
+    ]);
+
+    expect(result).toEqual(
+      new Map([
+        ["u1", "2026-01-01T00:00:00Z"],
+        ["a1", "2026-01-01T00:00:30Z"],
+        ["a2", "2026-01-01T00:08:00Z"],
       ]),
     );
   });
@@ -80,8 +110,8 @@ describe("computeMessageDurationStart", () => {
     expect(result).toEqual(
       new Map([
         ["u1", "2026-01-01T00:00:00Z"],
-        ["a1", "2026-01-01T00:00:00Z"],
-        ["a2", "2026-01-01T00:00:00Z"],
+        ["a1", "2026-01-01T00:00:30Z"],
+        ["a2", "2026-01-01T00:00:55Z"],
       ]),
     );
   });
@@ -107,9 +137,9 @@ describe("computeMessageDurationStart", () => {
     expect(result).toEqual(
       new Map([
         ["u1", "2026-01-01T00:00:00Z"],
-        ["a1", "2026-01-01T00:00:00Z"],
+        ["a1", "2026-01-01T00:00:30Z"],
         ["u2", "2026-01-01T00:01:00Z"],
-        ["a2", "2026-01-01T00:01:00Z"],
+        ["a2", "2026-01-01T00:01:20Z"],
       ]),
     );
   });
@@ -130,7 +160,7 @@ describe("computeMessageDurationStart", () => {
       new Map([
         ["u1", "2026-01-01T00:00:00Z"],
         ["s1", "2026-01-01T00:00:00Z"],
-        ["a1", "2026-01-01T00:00:00Z"],
+        ["a1", "2026-01-01T00:00:30Z"],
       ]),
     );
   });
@@ -205,6 +235,399 @@ describe("resolveAssistantMessageCopyState", () => {
 });
 
 describe("deriveMessagesTimelineRows", () => {
+  it("labels the working row as waiting before the first active turn output", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Waiting for response",
+      phaseStartedAt: "2026-01-01T00:00:00Z",
+      totalStartedAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("uses the working fallback label before the first active turn output", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      workingFallbackLabel: "Preparing worktree",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Preparing worktree",
+      phaseStartedAt: "2026-01-01T00:00:00Z",
+      totalStartedAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("uses the fallback phase start before the first active turn output", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      workingFallbackLabel: "Thinking",
+      workingFallbackStartedAt: "2026-01-01T00:00:05Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Thinking",
+      phaseStartedAt: "2026-01-01T00:00:05Z",
+      totalStartedAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("ignores older output while waiting for a new turn id", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "assistant-old-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "assistant-old" as never,
+            role: "assistant",
+            text: "Previous response.",
+            turnId: "turn-old" as never,
+            createdAt: "2026-01-01T00:00:00Z",
+            completedAt: "2026-01-01T00:00:02Z",
+            streaming: false,
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnId: null,
+      activeTurnStartedAt: "2026-01-01T00:01:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Waiting for response",
+      phaseStartedAt: "2026-01-01T00:01:00Z",
+      totalStartedAt: "2026-01-01T00:01:00Z",
+    });
+  });
+
+  it("does not derive the working phase from prior output before the current dispatch start", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "assistant-old-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "assistant-old" as never,
+            role: "assistant",
+            text: "Previous response.",
+            turnId: "turn-old" as never,
+            createdAt: "2026-01-01T00:00:00Z",
+            streaming: true,
+          },
+        },
+        {
+          id: "work-old-entry",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:01Z",
+          entry: {
+            id: "work-old",
+            createdAt: "2026-01-01T00:00:01Z",
+            label: "Thinking",
+            tone: "thinking",
+            turnId: "turn-old" as never,
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnId: null,
+      activeTurnStartedAt: "2026-01-01T00:01:00Z",
+      workingFallbackLabel: "Sending",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Sending",
+      phaseStartedAt: "2026-01-01T00:01:00Z",
+      totalStartedAt: "2026-01-01T00:01:00Z",
+    });
+  });
+
+  it("labels the working row as thinking after non-tool work output arrives", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:04Z",
+          entry: {
+            id: "thinking-1",
+            createdAt: "2026-01-01T00:00:04Z",
+            label: "Thinking",
+            tone: "thinking",
+            turnId: "turn-1" as never,
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnId: "turn-1" as never,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Thinking",
+      phaseStartedAt: "2026-01-01T00:00:04Z",
+      totalStartedAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("starts fallback thinking at the first active output instead of the turn start", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "assistant-1-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:09Z",
+          message: {
+            id: "assistant-1" as never,
+            role: "assistant",
+            text: "",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:09Z",
+            streaming: false,
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnId: "turn-1" as never,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Thinking",
+      phaseStartedAt: "2026-01-01T00:00:09Z",
+      totalStartedAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("labels the working row from the active assistant response", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "assistant-1-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:05Z",
+          message: {
+            id: "assistant-1" as never,
+            role: "assistant",
+            text: "Streaming",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:05Z",
+            streaming: true,
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnId: "turn-1" as never,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Responding",
+      phaseStartedAt: "2026-01-01T00:00:05Z",
+      totalStartedAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("labels a single active tool call by its concrete activity", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:10Z",
+          entry: {
+            id: "tool-1",
+            createdAt: "2026-01-01T00:00:10Z",
+            label: "Tool started",
+            tone: "tool",
+            itemType: "web_search",
+            toolStatus: "inProgress",
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Searching web",
+      phaseStartedAt: "2026-01-01T00:00:10Z",
+    });
+  });
+
+  it.each([
+    ["command_execution", "Running command"],
+    ["file_change", "Editing files"],
+    ["mcp_tool_call", "Using MCP tool"],
+    ["dynamic_tool_call", "Using tool"],
+    ["collab_agent_tool_call", "Waiting for subagent"],
+    ["web_search", "Searching web"],
+    ["image_view", "Viewing image"],
+  ] as const)("labels active %s work", (itemType, phaseLabel) => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:10Z",
+          entry: {
+            id: "tool-1",
+            createdAt: "2026-01-01T00:00:10Z",
+            label: "Tool started",
+            tone: "tool",
+            itemType,
+            toolStatus: "inProgress",
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel,
+      phaseStartedAt: "2026-01-01T00:00:10Z",
+    });
+  });
+
+  it("groups concurrent active tool calls", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:10Z",
+          entry: {
+            id: "tool-1",
+            createdAt: "2026-01-01T00:00:10Z",
+            label: "Searching web",
+            tone: "tool",
+            itemType: "web_search",
+            toolStatus: "inProgress",
+          },
+        },
+        {
+          id: "work-2",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:12Z",
+          entry: {
+            id: "tool-2",
+            createdAt: "2026-01-01T00:00:12Z",
+            label: "Viewing image",
+            tone: "tool",
+            itemType: "image_view",
+            toolStatus: "inProgress",
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Running 2 tool calls",
+      phaseStartedAt: "2026-01-01T00:00:10Z",
+    });
+  });
+
+  it("starts thinking after a completed tool at the tool completion time", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "work-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:10Z",
+          entry: {
+            id: "tool-1",
+            createdAt: "2026-01-01T00:00:10Z",
+            updatedAt: "2026-01-01T00:00:18Z",
+            label: "Searched web",
+            tone: "tool",
+            itemType: "web_search",
+            toolStatus: "completed",
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: null,
+      completionSummary: null,
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.at(-1)).toMatchObject({
+      kind: "working",
+      phaseLabel: "Thinking",
+      phaseStartedAt: "2026-01-01T00:00:18Z",
+    });
+  });
+
   it("only enables assistant copy for the terminal assistant message in a turn", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [
@@ -319,6 +742,68 @@ describe("deriveMessagesTimelineRows", () => {
     expect(assistantRows[0]?.completionSummary).toBeNull();
     expect(assistantRows[1]?.assistantCopyStreaming).toBe(true);
     expect(assistantRows[1]?.completionSummary).toBe("done");
+  });
+
+  it("uses the total response boundary for the completed terminal assistant message", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "user-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:00Z",
+          message: {
+            id: "user-1" as never,
+            role: "user",
+            text: "Do it",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:00Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "assistant-one-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:10Z",
+          message: {
+            id: "assistant-one" as never,
+            role: "assistant",
+            text: "First chunk.",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:00:10Z",
+            completedAt: "2026-01-01T00:00:12Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "assistant-two-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:08:00Z",
+          message: {
+            id: "assistant-two" as never,
+            role: "assistant",
+            text: "Final chunk.",
+            turnId: "turn-1" as never,
+            createdAt: "2026-01-01T00:08:00Z",
+            completedAt: "2026-01-01T00:08:03Z",
+            streaming: false,
+          },
+        },
+      ],
+      completionDividerBeforeEntryId: "assistant-two-entry",
+      completionSummary: "Worked for 8m 3s",
+      isWorking: false,
+      activeTurnStartedAt: null,
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    const assistantRows = rows.filter(
+      (row): row is Extract<(typeof rows)[number], { kind: "message" }> =>
+        row.kind === "message" && row.message.role === "assistant",
+    );
+
+    expect(assistantRows[0]?.durationStart).toBe("2026-01-01T00:00:10Z");
+    expect(assistantRows[1]?.durationStart).toBe("2026-01-01T00:00:00Z");
   });
 
   it("projects assistant diff summaries and user revert counts onto the affected rows", () => {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -9,6 +9,7 @@ export interface TimelineDurationMessage {
   id: string;
   role: "user" | "assistant" | "system";
   createdAt: string;
+  turnId?: TurnId | null | undefined;
   completedAt?: string | undefined;
 }
 
@@ -38,7 +39,14 @@ export type MessagesTimelineRow =
       createdAt: string;
       proposedPlan: ProposedPlan;
     }
-  | { kind: "working"; id: string; createdAt: string | null };
+  | {
+      kind: "working";
+      id: string;
+      createdAt: string | null;
+      phaseLabel: string;
+      phaseStartedAt: string | null;
+      totalStartedAt: string | null;
+    };
 
 export interface StableMessagesTimelineRowsState {
   byId: Map<string, MessagesTimelineRow>;
@@ -54,11 +62,16 @@ export function computeMessageDurationStart(
   for (const message of messages) {
     if (message.role === "user") {
       lastBoundary = message.createdAt;
+      result.set(message.id, lastBoundary);
+      continue;
     }
-    result.set(message.id, lastBoundary ?? message.createdAt);
-    if (message.role === "assistant" && message.completedAt) {
-      lastBoundary = message.completedAt;
+
+    if (message.role !== "assistant") {
+      result.set(message.id, lastBoundary ?? message.createdAt);
+      continue;
     }
+
+    result.set(message.id, message.createdAt);
   }
 
   return result;
@@ -110,6 +123,43 @@ function deriveTerminalAssistantMessageIds(timelineEntries: ReadonlyArray<Timeli
   return new Set(lastAssistantMessageIdByResponseKey.values());
 }
 
+function computeTerminalAssistantDurationStart(
+  messages: ReadonlyArray<TimelineDurationMessage>,
+): Map<string, string> {
+  const responseBoundaryByKey = new Map<string, string>();
+  const terminalAssistantIdByKey = new Map<string, string>();
+  let lastBoundary: string | null = null;
+  let nullTurnResponseIndex = 0;
+
+  for (const message of messages) {
+    if (message.role === "user") {
+      lastBoundary = message.createdAt;
+      nullTurnResponseIndex += 1;
+      continue;
+    }
+    if (message.role !== "assistant") {
+      continue;
+    }
+
+    const responseKey = message.turnId
+      ? `turn:${message.turnId}`
+      : `unkeyed:${nullTurnResponseIndex}`;
+    if (!responseBoundaryByKey.has(responseKey)) {
+      responseBoundaryByKey.set(responseKey, lastBoundary ?? message.createdAt);
+    }
+    terminalAssistantIdByKey.set(responseKey, message.id);
+  }
+
+  const result = new Map<string, string>();
+  for (const [responseKey, messageId] of terminalAssistantIdByKey) {
+    const boundary = responseBoundaryByKey.get(responseKey);
+    if (boundary) {
+      result.set(messageId, boundary);
+    }
+  }
+  return result;
+}
+
 export function deriveMessagesTimelineRows(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
   completionDividerBeforeEntryId: string | null;
@@ -118,11 +168,16 @@ export function deriveMessagesTimelineRows(input: {
   activeTurnInProgress?: boolean;
   activeTurnId?: TurnId | null;
   activeTurnStartedAt: string | null;
+  workingFallbackLabel?: string | null;
+  workingFallbackStartedAt?: string | null;
   turnDiffSummaryByAssistantMessageId: ReadonlyMap<MessageId, TurnDiffSummary>;
   revertTurnCountByUserMessageId: ReadonlyMap<MessageId, number>;
 }): MessagesTimelineRow[] {
   const nextRows: MessagesTimelineRow[] = [];
   const durationStartByMessageId = computeMessageDurationStart(
+    input.timelineEntries.flatMap((entry) => (entry.kind === "message" ? [entry.message] : [])),
+  );
+  const terminalDurationStartByMessageId = computeTerminalAssistantDurationStart(
     input.timelineEntries.flatMap((entry) => (entry.kind === "message" ? [entry.message] : [])),
   );
   const terminalAssistantMessageIds = deriveTerminalAssistantMessageIds(input.timelineEntries);
@@ -178,7 +233,14 @@ export function deriveMessagesTimelineRows(input: {
       createdAt: timelineEntry.createdAt,
       message: timelineEntry.message,
       durationStart:
-        durationStartByMessageId.get(timelineEntry.message.id) ?? timelineEntry.message.createdAt,
+        timelineEntry.message.role === "assistant" &&
+        terminalAssistantMessageIds.has(timelineEntry.message.id) &&
+        !timelineEntry.message.streaming
+          ? (terminalDurationStartByMessageId.get(timelineEntry.message.id) ??
+            durationStartByMessageId.get(timelineEntry.message.id) ??
+            timelineEntry.message.createdAt)
+          : (durationStartByMessageId.get(timelineEntry.message.id) ??
+            timelineEntry.message.createdAt),
       showCompletionDivider,
       completionSummary: showCompletionDivider ? (input.completionSummary ?? null) : null,
       showAssistantCopyButton:
@@ -197,14 +259,271 @@ export function deriveMessagesTimelineRows(input: {
   }
 
   if (input.isWorking) {
+    const workingPhase = deriveWorkingPhase({
+      timelineEntries: input.timelineEntries,
+      activeTurnId: input.activeTurnId ?? null,
+      totalStartedAt: input.activeTurnStartedAt,
+      fallbackLabel: input.workingFallbackLabel ?? null,
+      fallbackStartedAt: input.workingFallbackStartedAt ?? null,
+    });
     nextRows.push({
       kind: "working",
       id: "working-indicator-row",
       createdAt: input.activeTurnStartedAt,
+      phaseLabel: workingPhase.label,
+      phaseStartedAt: workingPhase.startedAt,
+      totalStartedAt: input.activeTurnStartedAt,
     });
   }
 
   return nextRows;
+}
+
+function deriveWorkingPhase(input: {
+  timelineEntries: ReadonlyArray<TimelineEntry>;
+  activeTurnId: TurnId | null;
+  totalStartedAt: string | null;
+  fallbackLabel: string | null;
+  fallbackStartedAt: string | null;
+}): { label: string; startedAt: string | null } {
+  const firstOutputAt = firstActiveTurnOutputAt({
+    timelineEntries: input.timelineEntries,
+    activeTurnId: input.activeTurnId,
+    startedAt: input.totalStartedAt,
+  });
+  if (!firstOutputAt) {
+    const hasFallbackLabel = input.fallbackLabel !== null && input.fallbackLabel.trim().length > 0;
+    return {
+      label: input.fallbackLabel ?? "Waiting for response",
+      startedAt: hasFallbackLabel
+        ? (input.fallbackStartedAt ?? input.totalStartedAt)
+        : input.totalStartedAt,
+    };
+  }
+
+  const activeToolEntries = input.timelineEntries.flatMap((entry) =>
+    entry.kind === "work" &&
+    entry.entry.toolStatus === "inProgress" &&
+    isActiveWorkWindowEntry({
+      activeTurnId: input.activeTurnId,
+      startedAt: input.totalStartedAt,
+      turnId: entry.entry.turnId,
+      createdAt: entry.entry.createdAt,
+    })
+      ? [entry.entry]
+      : [],
+  );
+  if (activeToolEntries.length > 1) {
+    return {
+      label: `Running ${activeToolEntries.length.toLocaleString()} tool calls`,
+      startedAt: earliestWorkEntryStart(activeToolEntries),
+    };
+  }
+  if (activeToolEntries.length === 1) {
+    const activeToolEntry = activeToolEntries[0];
+    if (!activeToolEntry) {
+      return { label: input.fallbackLabel ?? "Thinking", startedAt: input.totalStartedAt };
+    }
+    return {
+      label: workingToolPhaseLabel(activeToolEntry),
+      startedAt: activeToolEntry.createdAt,
+    };
+  }
+
+  let current: { label: string; startedAt: string | null } | null = null;
+  const setCurrent = (candidate: { label: string; startedAt: string | null }) => {
+    if (!candidate.startedAt) {
+      if (!current) current = candidate;
+      return;
+    }
+    if (!current?.startedAt || candidate.startedAt.localeCompare(current.startedAt) >= 0) {
+      current = candidate;
+    }
+  };
+
+  for (const entry of input.timelineEntries) {
+    if (entry.kind === "message") {
+      if (
+        entry.message.role === "assistant" &&
+        entry.message.streaming &&
+        isActiveWorkWindowEntry({
+          activeTurnId: input.activeTurnId,
+          startedAt: input.totalStartedAt,
+          turnId: entry.message.turnId,
+          createdAt: entry.message.createdAt,
+        })
+      ) {
+        setCurrent({ label: "Responding", startedAt: entry.message.createdAt });
+      }
+      continue;
+    }
+
+    if (entry.kind !== "work") {
+      continue;
+    }
+    if (
+      !isActiveWorkWindowEntry({
+        activeTurnId: input.activeTurnId,
+        startedAt: input.totalStartedAt,
+        turnId: entry.entry.turnId,
+        createdAt: entry.entry.createdAt,
+      })
+    ) {
+      continue;
+    }
+
+    if (entry.entry.tone === "thinking") {
+      setCurrent({
+        label: workingThinkingPhaseLabel(entry.entry) ?? input.fallbackLabel ?? "Thinking",
+        startedAt: entry.entry.updatedAt ?? entry.entry.createdAt,
+      });
+      continue;
+    }
+
+    if (
+      entry.entry.toolStatus === "completed" ||
+      entry.entry.toolStatus === "failed" ||
+      entry.entry.toolStatus === "declined"
+    ) {
+      setCurrent({
+        label: "Thinking",
+        startedAt: entry.entry.updatedAt ?? entry.entry.createdAt,
+      });
+    }
+  }
+
+  return current ?? { label: input.fallbackLabel ?? "Thinking", startedAt: firstOutputAt };
+}
+
+function isActiveWorkWindowEntry(input: {
+  activeTurnId: TurnId | null;
+  startedAt: string | null;
+  turnId: TurnId | null | undefined;
+  createdAt: string;
+}): boolean {
+  if (input.activeTurnId) {
+    return input.turnId === input.activeTurnId;
+  }
+  if (input.startedAt && input.createdAt.localeCompare(input.startedAt) < 0) {
+    return false;
+  }
+  return true;
+}
+
+function firstActiveTurnOutputAt(input: {
+  timelineEntries: ReadonlyArray<TimelineEntry>;
+  activeTurnId: TurnId | null;
+  startedAt: string | null;
+}): string | null {
+  let firstOutputAt: string | null = null;
+  const collect = (createdAt: string) => {
+    if (!input.activeTurnId && input.startedAt && createdAt.localeCompare(input.startedAt) < 0) {
+      return;
+    }
+    if (!firstOutputAt || createdAt.localeCompare(firstOutputAt) < 0) {
+      firstOutputAt = createdAt;
+    }
+  };
+
+  for (const entry of input.timelineEntries) {
+    if (entry.kind === "message") {
+      if (
+        entry.message.role === "assistant" &&
+        isActiveWorkWindowEntry({
+          activeTurnId: input.activeTurnId,
+          startedAt: input.startedAt,
+          turnId: entry.message.turnId,
+          createdAt: entry.message.createdAt,
+        })
+      ) {
+        collect(entry.message.createdAt);
+      }
+      continue;
+    }
+
+    if (
+      entry.kind === "work" &&
+      isActiveWorkWindowEntry({
+        activeTurnId: input.activeTurnId,
+        startedAt: input.startedAt,
+        turnId: entry.entry.turnId,
+        createdAt: entry.entry.createdAt,
+      })
+    ) {
+      collect(entry.entry.createdAt);
+    }
+  }
+  return firstOutputAt;
+}
+
+function earliestWorkEntryStart(entries: ReadonlyArray<WorkLogEntry>): string | null {
+  let earliest: string | null = null;
+  for (const entry of entries) {
+    if (!earliest || entry.createdAt.localeCompare(earliest) < 0) {
+      earliest = entry.createdAt;
+    }
+  }
+  return earliest;
+}
+
+function workingToolPhaseLabel(entry: WorkLogEntry): string {
+  if (entry.requestKind === "command") return "Awaiting command approval";
+  if (entry.requestKind === "file-read") return "Awaiting file-read approval";
+  if (entry.requestKind === "file-change") return "Awaiting file-change approval";
+  if (entry.command) return "Running command";
+
+  if (entry.itemType) {
+    switch (entry.itemType) {
+      case "command_execution":
+        return "Running command";
+      case "file_change":
+        return "Editing files";
+      case "mcp_tool_call":
+        return "Using MCP tool";
+      case "dynamic_tool_call":
+        return "Using tool";
+      case "collab_agent_tool_call":
+        return "Waiting for subagent";
+      case "web_search":
+        return "Searching web";
+      case "image_view":
+        return "Viewing image";
+      default: {
+        return entry.itemType satisfies never;
+      }
+    }
+  }
+
+  const label = entry.label.trim();
+  if (label.length > 0 && !isGenericWorkingToolLabel(label)) {
+    return label;
+  }
+  return "Awaiting tool call";
+}
+
+function workingThinkingPhaseLabel(entry: WorkLogEntry): string | null {
+  const label = entry.label.trim();
+  if (!label || isGenericThinkingLabel(label)) {
+    return null;
+  }
+  return label;
+}
+
+function isGenericWorkingToolLabel(label: string): boolean {
+  const normalized = label.trim().toLowerCase();
+  return (
+    normalized === "tool" ||
+    normalized === "tool started" ||
+    normalized === "tool updated" ||
+    normalized === "tool call" ||
+    normalized === "dynamic tool call" ||
+    normalized === "mcp tool call"
+  );
+}
+
+function isGenericThinkingLabel(label: string): boolean {
+  const normalized = label.trim().toLowerCase();
+  return normalized === "thinking" || normalized === "task progress" || normalized === "working";
 }
 
 export function computeStableMessagesTimelineRows(
@@ -233,7 +552,12 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
 
   switch (a.kind) {
     case "working":
-      return a.createdAt === (b as typeof a).createdAt;
+      return (
+        a.createdAt === (b as typeof a).createdAt &&
+        a.phaseLabel === (b as typeof a).phaseLabel &&
+        a.phaseStartedAt === (b as typeof a).phaseStartedAt &&
+        a.totalStartedAt === (b as typeof a).totalStartedAt
+      );
 
     case "proposed-plan":
       return a.proposedPlan === (b as typeof a).proposedPlan;

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -231,6 +231,57 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Work log");
   });
 
+  it("renders lifecycle-specific tool call labels with useful metadata", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const startedMarkup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-started",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-started",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Bash",
+              tone: "tool",
+              itemType: "command_execution",
+              command: "bun lint",
+              toolStatus: "inProgress",
+            },
+          },
+        ]}
+      />,
+    );
+    const completedMarkup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-completed",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:29.000Z",
+            entry: {
+              id: "work-completed",
+              createdAt: "2026-03-17T19:12:29.000Z",
+              label: "Bash",
+              tone: "tool",
+              itemType: "command_execution",
+              command: "bun lint",
+              toolStatus: "completed",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(startedMarkup).toContain("Running command");
+    expect(startedMarkup).toContain("bun lint");
+    expect(completedMarkup).toContain("Ran command");
+    expect(completedMarkup).toContain("bun lint");
+  });
+
   it("formats changed file paths from the workspace root", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(
@@ -256,6 +307,37 @@ describe("MessagesTimeline", () => {
 
     expect(markup).toContain("t3code/apps/web/src/session-logic.ts");
     expect(markup).not.toContain("C:/Users/mike/dev-stuff/t3code/apps/web/src/session-logic.ts");
+  });
+
+  it("does not repeat changed file paths in the row heading", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "File change",
+              tone: "tool",
+              itemType: "file_change",
+              detail: "D:/Programme/t3code/apps/web/src/session-logic.ts",
+              changedFiles: ["D:/Programme/t3code/apps/web/src/session-logic.ts"],
+              toolStatus: "completed",
+            },
+          },
+        ]}
+        workspaceRoot="D:/Programme/t3code"
+      />,
+    );
+
+    expect(markup).toContain("Changed files");
+    expect(markup).toContain("t3code/apps/web/src/session-logic.ts");
+    expect(markup).not.toContain("Changed files -");
   });
 
   it("renders review comment contexts as structured cards instead of raw tags", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -340,6 +340,37 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("Changed files -");
   });
 
+  it("keeps changed file detail when it is not the displayed file path", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "File change",
+              tone: "tool",
+              itemType: "file_change",
+              detail: "Updated exports and route wiring",
+              changedFiles: ["D:/Programme/t3code/apps/web/src/session-logic.ts"],
+              toolStatus: "completed",
+            },
+          },
+        ]}
+        workspaceRoot="D:/Programme/t3code"
+      />,
+    );
+
+    expect(markup).toContain("Changed files -");
+    expect(markup).toContain("Updated exports and route wiring");
+    expect(markup).toContain("t3code/apps/web/src/session-logic.ts");
+  });
+
   it("renders review comment contexts as structured cards instead of raw tags", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1157,6 +1157,123 @@ function workEntryIcon(workEntry: TimelineWorkEntry): LucideIcon {
   return workToneIcon(workEntry.tone).icon;
 }
 
+type WorkEntryAction =
+  | "command"
+  | "read"
+  | "file-change"
+  | "web-search"
+  | "image-view"
+  | "mcp-tool"
+  | "collab-agent"
+  | "tool";
+
+function classifyWorkEntryAction(workEntry: TimelineWorkEntry): WorkEntryAction {
+  if (workEntry.requestKind === "command") return "command";
+  if (workEntry.requestKind === "file-read") return "read";
+  if (workEntry.requestKind === "file-change") return "file-change";
+  if (workEntry.itemType === "command_execution" || workEntry.command) return "command";
+  if (workEntry.itemType === "file_change") return "file-change";
+  if (workEntry.itemType === "web_search") return "web-search";
+  if (workEntry.itemType === "image_view") return "image-view";
+  if (workEntry.itemType === "mcp_tool_call") return "mcp-tool";
+  if (workEntry.itemType === "collab_agent_tool_call") return "collab-agent";
+
+  const label = normalizeCompactToolLabel(workEntry.toolTitle ?? workEntry.label).toLowerCase();
+  if (label.includes("command") || label.includes("bash") || label.includes("terminal")) {
+    return "command";
+  }
+  if (label.includes("read") || label.includes("view file")) {
+    return "read";
+  }
+  if (
+    label.includes("edit") ||
+    label.includes("write") ||
+    label.includes("patch") ||
+    label.includes("file change")
+  ) {
+    return "file-change";
+  }
+  if (
+    label.includes("web search") ||
+    label === "search" ||
+    label === "grep" ||
+    label.includes("search web")
+  ) {
+    return "web-search";
+  }
+  return "tool";
+}
+
+function isGenericToolHeading(value: string): boolean {
+  const normalized = normalizeCompactToolLabel(value).toLowerCase();
+  return (
+    normalized === "tool" ||
+    normalized === "tool call" ||
+    normalized === "dynamic tool call" ||
+    normalized === "mcp tool call" ||
+    normalized === "command run" ||
+    normalized === "bash" ||
+    normalized === "terminal" ||
+    normalized === "file change" ||
+    normalized === "web search" ||
+    normalized === "image view"
+  );
+}
+
+function lifecycleHeadingForAction(
+  action: WorkEntryAction,
+  status: NonNullable<TimelineWorkEntry["toolStatus"]>,
+  fallback: string,
+): string {
+  if (status === "failed") {
+    switch (action) {
+      case "command":
+        return "Command failed";
+      case "read":
+        return "Read failed";
+      case "file-change":
+        return "File change failed";
+      case "web-search":
+        return "Web search failed";
+      case "image-view":
+        return "Image view failed";
+      case "mcp-tool":
+        return "MCP tool failed";
+      case "collab-agent":
+        return "Subagent failed";
+      case "tool":
+        return isGenericToolHeading(fallback) ? "Tool failed" : `${fallback} failed`;
+    }
+  }
+
+  if (status === "declined") {
+    return isGenericToolHeading(fallback) ? "Tool declined" : `${fallback} declined`;
+  }
+
+  const completed = status === "completed";
+  switch (action) {
+    case "command":
+      return completed ? "Ran command" : "Running command";
+    case "read":
+      return completed ? "Read file" : "Reading file";
+    case "file-change":
+      return completed ? "Changed files" : "Editing files";
+    case "web-search":
+      return completed ? "Searched web" : "Searching web";
+    case "image-view":
+      return completed ? "Viewed image" : "Viewing image";
+    case "mcp-tool":
+      return completed ? "Used MCP tool" : "Using MCP tool";
+    case "collab-agent":
+      return completed ? "Subagent completed" : "Running subagent";
+    case "tool":
+      if (isGenericToolHeading(fallback)) {
+        return completed ? "Used tool" : "Using tool";
+      }
+      return completed ? `Used ${fallback}` : `Using ${fallback}`;
+  }
+}
+
 function capitalizePhrase(value: string): string {
   const trimmed = value.trim();
   if (trimmed.length === 0) {
@@ -1166,10 +1283,17 @@ function capitalizePhrase(value: string): string {
 }
 
 function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
-  if (!workEntry.toolTitle) {
-    return capitalizePhrase(normalizeCompactToolLabel(workEntry.label));
+  const fallback = capitalizePhrase(
+    normalizeCompactToolLabel(workEntry.toolTitle ?? workEntry.label),
+  );
+  if (!workEntry.toolStatus) {
+    return fallback;
   }
-  return capitalizePhrase(normalizeCompactToolLabel(workEntry.toolTitle));
+  return lifecycleHeadingForAction(
+    classifyWorkEntryAction(workEntry),
+    workEntry.toolStatus,
+    fallback,
+  );
 }
 
 const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
@@ -1180,17 +1304,18 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const iconConfig = workToneIcon(workEntry.tone);
   const EntryIcon = workEntryIcon(workEntry);
   const heading = toolWorkEntryHeading(workEntry);
+  const hasChangedFiles = (workEntry.changedFiles?.length ?? 0) > 0;
   const rawPreview = workEntryPreview(workEntry, workspaceRoot);
   const preview =
-    rawPreview &&
-    normalizeCompactToolLabel(rawPreview).toLowerCase() ===
-      normalizeCompactToolLabel(heading).toLowerCase()
+    hasChangedFiles && !workEntry.command && !workEntry.detail
       ? null
-      : rawPreview;
+      : rawPreview &&
+          normalizeCompactToolLabel(rawPreview).toLowerCase() ===
+            normalizeCompactToolLabel(heading).toLowerCase()
+        ? null
+        : rawPreview;
   const rawCommand = workEntryRawCommand(workEntry);
   const displayText = preview ? `${heading} - ${preview}` : heading;
-  const hasChangedFiles = (workEntry.changedFiles?.length ?? 0) > 0;
-  const previewIsChangedFiles = hasChangedFiles && !workEntry.command && !workEntry.detail;
 
   return (
     <div className="rounded-lg px-1 py-1">
@@ -1268,7 +1393,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           )}
         </div>
       </div>
-      {hasChangedFiles && !previewIsChangedFiles && (
+      {hasChangedFiles && (
         <div className="mt-1 flex flex-wrap gap-1 pl-6">
           {workEntry.changedFiles?.slice(0, 4).map((filePath) => {
             const displayPath = formatWorkspaceRelativePath(filePath, workspaceRoot);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -119,6 +119,8 @@ interface MessagesTimelineProps {
   activeTurnInProgress: boolean;
   activeTurnId?: TurnId | null;
   activeTurnStartedAt: string | null;
+  workingFallbackLabel?: string | null;
+  workingFallbackStartedAt?: string | null;
   listRef: React.RefObject<LegendListRef | null>;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
   completionDividerBeforeEntryId: string | null;
@@ -148,6 +150,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   activeTurnInProgress,
   activeTurnId,
   activeTurnStartedAt,
+  workingFallbackLabel,
+  workingFallbackStartedAt,
   listRef,
   timelineEntries,
   completionDividerBeforeEntryId,
@@ -177,6 +181,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
         activeTurnInProgress,
         activeTurnId: activeTurnId ?? null,
         activeTurnStartedAt,
+        workingFallbackLabel: workingFallbackLabel ?? null,
+        workingFallbackStartedAt: workingFallbackStartedAt ?? null,
         turnDiffSummaryByAssistantMessageId,
         revertTurnCountByUserMessageId,
       }),
@@ -188,6 +194,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       activeTurnInProgress,
       activeTurnId,
       activeTurnStartedAt,
+      workingFallbackLabel,
+      workingFallbackStartedAt,
       turnDiffSummaryByAssistantMessageId,
       revertTurnCountByUserMessageId,
     ],
@@ -526,12 +534,16 @@ function WorkingTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "workin
           <span className="h-1 w-1 rounded-full bg-muted-foreground/30 animate-pulse [animation-delay:400ms]" />
         </span>
         <span>
-          {row.createdAt ? (
+          {row.phaseStartedAt || row.totalStartedAt ? (
             <>
-              Working for <WorkingTimer createdAt={row.createdAt} />
+              <WorkingTimer
+                phaseLabel={row.phaseLabel}
+                phaseStartedAt={row.phaseStartedAt}
+                totalStartedAt={row.totalStartedAt}
+              />
             </>
           ) : (
-            "Working..."
+            `${row.phaseLabel}...`
           )}
         </span>
       </div>
@@ -544,21 +556,33 @@ function WorkingTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "workin
 // does not create a React commit every second while a response is streaming.
 // ---------------------------------------------------------------------------
 
-/** Live "Working for Xs" label. */
-function WorkingTimer({ createdAt }: { createdAt: string }) {
+/** Live current-phase + total elapsed label. */
+function WorkingTimer({
+  phaseLabel,
+  phaseStartedAt,
+  totalStartedAt,
+}: {
+  phaseLabel: string;
+  phaseStartedAt: string | null;
+  totalStartedAt: string | null;
+}) {
   const textRef = useRef<HTMLSpanElement>(null);
-  const initialText = formatWorkingTimerNow(createdAt);
+  const initialText = formatWorkingStatusNow({ phaseLabel, phaseStartedAt, totalStartedAt });
 
   useEffect(() => {
     const updateText = () => {
       if (textRef.current) {
-        textRef.current.textContent = formatWorkingTimerNow(createdAt);
+        textRef.current.textContent = formatWorkingStatusNow({
+          phaseLabel,
+          phaseStartedAt,
+          totalStartedAt,
+        });
       }
     };
     updateText();
     const id = setInterval(updateText, 1000);
     return () => clearInterval(id);
-  }, [createdAt]);
+  }, [phaseLabel, phaseStartedAt, totalStartedAt]);
 
   return <span ref={textRef}>{initialText}</span>;
 }
@@ -1054,6 +1078,25 @@ function formatWorkingTimerNow(startIso: string): string {
   return formatWorkingTimer(startIso, new Date().toISOString()) ?? "0s";
 }
 
+function formatWorkingStatusNow(input: {
+  phaseLabel: string;
+  phaseStartedAt: string | null;
+  totalStartedAt: string | null;
+}): string {
+  const phaseDuration = input.phaseStartedAt ? formatWorkingTimerNow(input.phaseStartedAt) : null;
+  const totalDuration = input.totalStartedAt ? formatWorkingTimerNow(input.totalStartedAt) : null;
+  if (phaseDuration && totalDuration) {
+    return `${input.phaseLabel} for ${phaseDuration} • total ${totalDuration}`;
+  }
+  if (phaseDuration) {
+    return `${input.phaseLabel} for ${phaseDuration}`;
+  }
+  if (totalDuration) {
+    return `${input.phaseLabel} • total ${totalDuration}`;
+  }
+  return `${input.phaseLabel}...`;
+}
+
 function formatLiveMessageMetaNow(
   createdAt: string,
   durationStart: string | null | undefined,
@@ -1120,6 +1163,35 @@ function workEntryPreview(
   return workEntry.changedFiles!.length === 1
     ? displayPath
     : `${displayPath} +${workEntry.changedFiles!.length - 1} more`;
+}
+
+function normalizeChangedFilePreviewLabel(value: string): string {
+  return value.trim().replaceAll("\\", "/").toLowerCase();
+}
+
+function isDuplicateChangedFilesPreview(
+  preview: string | null,
+  changedFiles: readonly string[] | undefined,
+  workspaceRoot: string | undefined,
+): boolean {
+  if (!preview || !changedFiles?.length) return false;
+  const normalizedPreview = normalizeChangedFilePreviewLabel(preview);
+  const duplicateLabels = new Set<string>();
+  for (const filePath of changedFiles) {
+    duplicateLabels.add(normalizeChangedFilePreviewLabel(filePath));
+    duplicateLabels.add(
+      normalizeChangedFilePreviewLabel(formatWorkspaceRelativePath(filePath, workspaceRoot)),
+    );
+  }
+  const [firstPath] = changedFiles;
+  if (firstPath && changedFiles.length > 1) {
+    duplicateLabels.add(
+      normalizeChangedFilePreviewLabel(
+        `${formatWorkspaceRelativePath(firstPath, workspaceRoot)} +${changedFiles.length - 1} more`,
+      ),
+    );
+  }
+  return duplicateLabels.has(normalizedPreview);
 }
 
 function workEntryRawCommand(
@@ -1307,7 +1379,9 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const hasChangedFiles = (workEntry.changedFiles?.length ?? 0) > 0;
   const rawPreview = workEntryPreview(workEntry, workspaceRoot);
   const preview =
-    hasChangedFiles && !workEntry.command && !workEntry.detail
+    hasChangedFiles &&
+    !workEntry.command &&
+    isDuplicateChangedFilesPreview(rawPreview, workEntry.changedFiles, workspaceRoot)
       ? null
       : rawPreview &&
           normalizeCompactToolLabel(rawPreview).toLowerCase() ===

--- a/apps/web/src/filePathDisplay.test.ts
+++ b/apps/web/src/filePathDisplay.test.ts
@@ -38,4 +38,10 @@ describe("formatWorkspaceRelativePath", () => {
       ),
     ).toBe("t3code/apps/web/src/session-logic.ts:501:9");
   });
+
+  it("keeps absolute Windows paths outside the workspace absolute", () => {
+    expect(
+      formatWorkspaceRelativePath("C:/Users/Jens/Pictures/test.png", "D:/Programme/t3code"),
+    ).toBe("C:/Users/Jens/Pictures/test.png");
+  });
 });

--- a/apps/web/src/filePathDisplay.ts
+++ b/apps/web/src/filePathDisplay.ts
@@ -12,6 +12,10 @@ function trimTrailingPathSeparators(path: string): string {
   return path.replace(/[\\/]+$/, "");
 }
 
+function isAbsoluteDisplayPath(path: string): boolean {
+  return path.startsWith("/") || /^[A-Za-z]:\//.test(path);
+}
+
 function basenameOfPath(path: string): string {
   const separatorIndex = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
   return separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path;
@@ -44,7 +48,7 @@ export function formatWorkspaceRelativePath(
     } else if (pathForCompare.startsWith(workspaceWithSeparator)) {
       const relativeSuffix = normalizedPath.slice(normalizedWorkspaceRoot.length + 1);
       displayPath = `${workspaceLabel}/${relativeSuffix}`;
-    } else if (!normalizedPath.startsWith("/")) {
+    } else if (!isAbsoluteDisplayPath(normalizedPath)) {
       const relativePath = stripRelativePrefixes(normalizedPath);
       displayPath = pathForCompare.startsWith(workspaceLabelWithSeparator)
         ? normalizedPath

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -573,24 +573,65 @@ describe("findSidebarProposedPlan", () => {
 });
 
 describe("deriveWorkLogEntries", () => {
-  it("omits tool started entries and keeps completed entries", () => {
+  it("shows started tool entries immediately and collapses completed lifecycle updates", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "tool-complete",
         createdAt: "2026-02-23T00:00:03.000Z",
         summary: "Tool call complete",
         kind: "tool.completed",
+        payload: {
+          itemId: "tool-item-1",
+          itemType: "dynamic_tool_call",
+          status: "completed",
+        },
       }),
       makeActivity({
         id: "tool-start",
         createdAt: "2026-02-23T00:00:02.000Z",
         summary: "Tool call",
         kind: "tool.started",
+        payload: {
+          itemId: "tool-item-1",
+          itemType: "dynamic_tool_call",
+          status: "inProgress",
+        },
       }),
     ];
 
     const entries = deriveWorkLogEntries(activities, undefined);
-    expect(entries.map((entry) => entry.id)).toEqual(["tool-complete"]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "tool-start",
+      createdAt: "2026-02-23T00:00:02.000Z",
+      label: "Tool call complete",
+      itemId: "tool-item-1",
+      itemType: "dynamic_tool_call",
+      toolStatus: "completed",
+    });
+  });
+
+  it("uses runtime warning messages as work log detail", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "runtime-warning",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "runtime.warning",
+        summary: "Runtime warning",
+        tone: "info",
+        payload: {
+          message: "Retrying after provider transport interruption",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "runtime-warning",
+      label: "Runtime warning",
+      detail: "Retrying after provider transport interruption",
+    });
   });
 
   it("omits task.started but shows task.progress and task.completed", () => {
@@ -771,6 +812,34 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.command).toBe("bun run lint");
   });
 
+  it("extracts command text from raw tool input", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-raw-input",
+        kind: "tool.started",
+        summary: "Bash",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          data: {
+            rawInput: {
+              executable: "bash",
+              args: ["-lc", "bun lint"],
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry).toMatchObject({
+      id: "command-tool-raw-input",
+      command: "bun lint",
+      rawCommand: 'bash -lc "bun lint"',
+      toolStatus: "inProgress",
+    });
+  });
+
   it("unwraps PowerShell command wrappers for displayed command text", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -922,6 +991,34 @@ describe("deriveWorkLogEntries", () => {
     ]);
   });
 
+  it("does not treat image view paths as changed files", () => {
+    const imagePath = "C:\\Users\\Jens\\Pictures\\afterimage crimson dash.png";
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "image-view-tool",
+        kind: "tool.completed",
+        summary: "Image view",
+        payload: {
+          itemType: "image_view",
+          detail: imagePath,
+          data: {
+            item: {
+              type: "image",
+              path: imagePath,
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry).toMatchObject({
+      detail: imagePath,
+      itemType: "image_view",
+    });
+    expect(entry?.changedFiles).toBeUndefined();
+  });
+
   it("drops duplicated tool detail when it only repeats the title", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -983,10 +1080,167 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities, undefined);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "grep-complete",
+      id: "grep-update",
       toolTitle: "grep",
       detail: "19 files",
       itemType: "web_search",
+      toolStatus: "completed",
+    });
+  });
+
+  it("uses completed web search URL metadata as the tool detail", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "web-search-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Web search",
+        payload: {
+          itemId: "web-search-item-1",
+          itemType: "web_search",
+          title: "Web search",
+          status: "inProgress",
+          data: {
+            item: {
+              type: "webSearch",
+              query: "",
+              action: {
+                type: "other",
+              },
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "web-search-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Web search",
+        payload: {
+          itemId: "web-search-item-1",
+          itemType: "web_search",
+          title: "Web search",
+          status: "completed",
+          data: {
+            item: {
+              type: "webSearch",
+              query: "fallback query",
+              action: {
+                type: "openPage",
+                url: "https://developers.openai.com/codex/sdk/",
+              },
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "web-search-start",
+      detail: "https://developers.openai.com/codex/sdk/",
+      itemType: "web_search",
+      toolStatus: "completed",
+    });
+  });
+
+  it("does not invent started Codex web search metadata before the query arrives", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "web-search-start-only",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Web search",
+        payload: {
+          itemType: "web_search",
+          title: "Web search",
+          status: "inProgress",
+          data: {
+            item: {
+              type: "webSearch",
+              query: "",
+              action: {
+                type: "other",
+              },
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "web-search-start-only",
+      itemType: "web_search",
+      toolStatus: "inProgress",
+    });
+    expect(entries[0]?.detail).toBeUndefined();
+  });
+
+  it("uses started web search metadata when the provider sends it", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "web-search-start-with-query",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Web search",
+        payload: {
+          itemType: "web_search",
+          title: "Web search",
+          status: "inProgress",
+          data: {
+            item: {
+              type: "webSearch",
+              action: {
+                type: "search",
+                query: "codex app server docs",
+              },
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "web-search-start-with-query",
+      detail: "codex app server docs",
+      itemType: "web_search",
+      toolStatus: "inProgress",
+    });
+  });
+
+  it("uses early raw input metadata for generic tool calls", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "read-start-only",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Read File",
+        payload: {
+          itemType: "dynamic_tool_call",
+          title: "Read File",
+          detail: "Read File",
+          status: "inProgress",
+          data: {
+            rawInput: {
+              file_path: "apps/web/src/session-logic.ts",
+            },
+          },
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "read-start-only",
+      detail: "apps/web/src/session-logic.ts",
+      changedFiles: ["apps/web/src/session-logic.ts"],
+      toolStatus: "inProgress",
     });
   });
 
@@ -1032,10 +1286,11 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities, undefined);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "read-complete",
+      id: "read-update",
       toolTitle: "Read File",
       detail: 'import * as Effect from "effect/Effect"',
       itemType: "dynamic_tool_call",
+      toolStatus: "completed",
     });
   });
 
@@ -1108,9 +1363,10 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities, undefined);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "legacy-read-complete",
+      id: "legacy-read-update",
       toolTitle: "Read File",
       itemType: "dynamic_tool_call",
+      toolStatus: "completed",
     });
     expect(entries[0]?.detail).toBeUndefined();
   });
@@ -1161,13 +1417,14 @@ describe("deriveWorkLogEntries", () => {
 
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
-      id: "tool-complete",
-      createdAt: "2026-02-23T00:00:03.000Z",
+      id: "tool-update-1",
+      createdAt: "2026-02-23T00:00:01.000Z",
       label: "Tool call completed",
       detail: 'Read: {"file_path":"/tmp/app.ts"}',
       command: "sed -n 1,40p /tmp/app.ts",
       itemType: "dynamic_tool_call",
       toolTitle: "Tool call",
+      toolStatus: "completed",
     });
   });
 
@@ -1221,7 +1478,7 @@ describe("deriveWorkLogEntries", () => {
 
     const entries = deriveWorkLogEntries(activities, undefined);
 
-    expect(entries.map((entry) => entry.id)).toEqual(["tool-1-complete", "tool-2-complete"]);
+    expect(entries.map((entry) => entry.id)).toEqual(["tool-1-update", "tool-2-update"]);
   });
 
   it("collapses same-timestamp lifecycle rows even when completed sorts before updated by id", () => {
@@ -1264,7 +1521,8 @@ describe("deriveWorkLogEntries", () => {
     const entries = deriveWorkLogEntries(activities, undefined);
 
     expect(entries).toHaveLength(1);
-    expect(entries[0]?.id).toBe("a-complete-same-timestamp");
+    expect(entries[0]?.id).toBe("z-update-earlier");
+    expect(entries[0]?.toolStatus).toBe("completed");
   });
 });
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1329,7 +1329,7 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.command).toBeUndefined();
   });
 
-  it("collapses legacy completed tool rows that are missing tool metadata", () => {
+  it("does not collapse legacy completed tool rows that are missing lifecycle identity", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "legacy-read-update",
@@ -1361,14 +1361,60 @@ describe("deriveWorkLogEntries", () => {
     ];
 
     const entries = deriveWorkLogEntries(activities, undefined);
-    expect(entries).toHaveLength(1);
+    expect(entries).toHaveLength(2);
     expect(entries[0]).toMatchObject({
       id: "legacy-read-update",
+      toolTitle: "Read File",
+      itemType: "dynamic_tool_call",
+      toolStatus: "inProgress",
+    });
+    expect(entries[1]).toMatchObject({
+      id: "legacy-read-complete",
       toolTitle: "Read File",
       itemType: "dynamic_tool_call",
       toolStatus: "completed",
     });
     expect(entries[0]?.detail).toBeUndefined();
+  });
+
+  it("does not collapse adjacent id-less tool calls with different derived keys", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "first-command-start",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.started",
+        summary: "Running command",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          detail: "bun lint",
+        },
+      }),
+      makeActivity({
+        id: "second-command-start",
+        createdAt: "2026-02-23T00:00:11.000Z",
+        kind: "tool.started",
+        summary: "Running command",
+        payload: {
+          itemType: "command_execution",
+          status: "inProgress",
+          detail: "bun typecheck",
+        },
+      }),
+    ];
+
+    const entries = deriveWorkLogEntries(activities, undefined);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      id: "first-command-start",
+      createdAt: "2026-02-23T00:00:01.000Z",
+      detail: "bun lint",
+    });
+    expect(entries[1]).toMatchObject({
+      id: "second-command-start",
+      createdAt: "2026-02-23T00:00:11.000Z",
+      detail: "bun typecheck",
+    });
   });
 
   it("collapses repeated lifecycle updates for the same tool call into one entry", () => {
@@ -1382,6 +1428,9 @@ describe("deriveWorkLogEntries", () => {
           itemType: "dynamic_tool_call",
           title: "Tool call",
           detail: 'Read: {"file_path":"/tmp/app.ts"}',
+          data: {
+            toolCallId: "tool-read-1",
+          },
         },
       }),
       makeActivity({
@@ -1394,6 +1443,7 @@ describe("deriveWorkLogEntries", () => {
           title: "Tool call",
           detail: 'Read: {"file_path":"/tmp/app.ts"}',
           data: {
+            toolCallId: "tool-read-1",
             item: {
               command: ["sed", "-n", "1,40p", "/tmp/app.ts"],
             },
@@ -1409,6 +1459,9 @@ describe("deriveWorkLogEntries", () => {
           itemType: "dynamic_tool_call",
           title: "Tool call",
           detail: 'Read: {"file_path":"/tmp/app.ts"}',
+          data: {
+            toolCallId: "tool-read-1",
+          },
         },
       }),
     ];

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -58,7 +58,10 @@ export interface WorkLogEntry {
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
   itemType?: ToolLifecycleItemType;
+  itemId?: string;
+  toolStatus?: "inProgress" | "completed" | "failed" | "declined";
   requestKind?: PendingApproval["requestKind"];
+  collapseKey?: string;
 }
 
 interface DerivedWorkLogEntry extends WorkLogEntry {
@@ -485,7 +488,6 @@ export function deriveWorkLogEntries(
   const entries: DerivedWorkLogEntry[] = [];
   for (const activity of ordered) {
     if (latestTurnId && activity.turnId !== latestTurnId) continue;
-    if (activity.kind === "tool.started") continue;
     if (activity.kind === "task.started") continue;
     if (activity.kind === "context-window.updated") continue;
     if (activity.summary === "Checkpoint captured") continue;
@@ -493,7 +495,7 @@ export function deriveWorkLogEntries(
     entries.push(toDerivedWorkLogEntry(activity));
   }
   return collapseDerivedWorkLogEntries(entries).map(
-    ({ activityKind: _activityKind, collapseKey: _collapseKey, ...entry }) => entry,
+    ({ activityKind: _activityKind, ...entry }) => entry,
   );
 }
 
@@ -552,6 +554,8 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     activityKind: activity.kind,
   };
   const itemType = extractWorkLogItemType(payload);
+  const itemId = extractWorkLogItemId(payload);
+  const toolStatus = extractWorkLogToolStatus(payload, activity.kind);
   const requestKind = extractWorkLogRequestKind(payload);
   if (detail) {
     entry.detail = detail;
@@ -571,6 +575,12 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   if (itemType) {
     entry.itemType = itemType;
   }
+  if (itemId) {
+    entry.itemId = itemId;
+  }
+  if (toolStatus) {
+    entry.toolStatus = toolStatus;
+  }
   if (requestKind) {
     entry.requestKind = requestKind;
   }
@@ -588,13 +598,52 @@ function collapseDerivedWorkLogEntries(
   entries: ReadonlyArray<DerivedWorkLogEntry>,
 ): DerivedWorkLogEntry[] {
   const collapsed: DerivedWorkLogEntry[] = [];
+  const openLifecycleRowIndexByCollapseKey = new Map<string, number>();
   for (const entry of entries) {
-    const previous = collapsed.at(-1);
+    const collapseKey = entry.collapseKey;
+    if (collapseKey) {
+      const openIndex = openLifecycleRowIndexByCollapseKey.get(collapseKey);
+      if (openIndex !== undefined) {
+        const previous = collapsed[openIndex];
+        if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
+          collapsed[openIndex] = mergeDerivedWorkLogEntries(previous, entry);
+          if (entry.activityKind === "tool.completed") {
+            openLifecycleRowIndexByCollapseKey.delete(collapseKey);
+          }
+          continue;
+        }
+      }
+    }
+
+    const previousIndex = collapsed.length - 1;
+    const previous = previousIndex >= 0 ? collapsed[previousIndex] : undefined;
     if (previous && shouldCollapseToolLifecycleEntries(previous, entry)) {
-      collapsed[collapsed.length - 1] = mergeDerivedWorkLogEntries(previous, entry);
+      const merged = mergeDerivedWorkLogEntries(previous, entry);
+      collapsed[previousIndex] = merged;
+      if (previous.collapseKey && previous.collapseKey !== merged.collapseKey) {
+        openLifecycleRowIndexByCollapseKey.delete(previous.collapseKey);
+      }
+      if (entry.activityKind === "tool.completed") {
+        if (previous.collapseKey) {
+          openLifecycleRowIndexByCollapseKey.delete(previous.collapseKey);
+        }
+        if (collapseKey) {
+          openLifecycleRowIndexByCollapseKey.delete(collapseKey);
+        }
+      } else if (merged.collapseKey) {
+        openLifecycleRowIndexByCollapseKey.set(merged.collapseKey, previousIndex);
+      }
       continue;
     }
+
     collapsed.push(entry);
+    if (
+      collapseKey &&
+      (entry.activityKind === "tool.started" || entry.activityKind === "tool.updated")
+    ) {
+      openLifecycleRowIndexByCollapseKey.set(collapseKey, collapsed.length - 1);
+      continue;
+    }
   }
   return collapsed;
 }
@@ -603,7 +652,11 @@ function shouldCollapseToolLifecycleEntries(
   previous: DerivedWorkLogEntry,
   next: DerivedWorkLogEntry,
 ): boolean {
-  if (previous.activityKind !== "tool.updated" && previous.activityKind !== "tool.completed") {
+  if (
+    previous.activityKind !== "tool.started" &&
+    previous.activityKind !== "tool.updated" &&
+    previous.activityKind !== "tool.completed"
+  ) {
     return false;
   }
   if (next.activityKind !== "tool.updated" && next.activityKind !== "tool.completed") {
@@ -615,13 +668,19 @@ function shouldCollapseToolLifecycleEntries(
   if (previous.collapseKey !== undefined && previous.collapseKey === next.collapseKey) {
     return true;
   }
-  return (
-    previous.toolCallId !== undefined &&
-    next.toolCallId === undefined &&
-    previous.itemType === next.itemType &&
-    normalizeCompactToolLabel(previous.toolTitle ?? previous.label) ===
-      normalizeCompactToolLabel(next.toolTitle ?? next.label)
-  );
+  if (previous.itemType !== next.itemType) {
+    return false;
+  }
+  if (
+    normalizeToolLifecycleLabelForCollapse(previous.toolTitle ?? previous.label) !==
+    normalizeToolLifecycleLabelForCollapse(next.toolTitle ?? next.label)
+  ) {
+    return false;
+  }
+  if (previous.toolCallId !== undefined) {
+    return next.toolCallId === undefined;
+  }
+  return next.itemId === undefined && next.toolCallId === undefined;
 }
 
 function mergeDerivedWorkLogEntries(
@@ -634,18 +693,22 @@ function mergeDerivedWorkLogEntries(
   const rawCommand = next.rawCommand ?? previous.rawCommand;
   const toolTitle = next.toolTitle ?? previous.toolTitle;
   const itemType = next.itemType ?? previous.itemType;
+  const toolStatus = next.toolStatus ?? previous.toolStatus;
   const requestKind = next.requestKind ?? previous.requestKind;
   const collapseKey = next.collapseKey ?? previous.collapseKey;
   const toolCallId = next.toolCallId ?? previous.toolCallId;
   return {
     ...previous,
     ...next,
+    id: previous.id,
+    createdAt: previous.createdAt,
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),
     ...(changedFiles.length > 0 ? { changedFiles } : {}),
     ...(toolTitle ? { toolTitle } : {}),
     ...(itemType ? { itemType } : {}),
+    ...(toolStatus ? { toolStatus } : {}),
     ...(requestKind ? { requestKind } : {}),
     ...(collapseKey ? { collapseKey } : {}),
     ...(toolCallId ? { toolCallId } : {}),
@@ -664,23 +727,57 @@ function mergeChangedFiles(
 }
 
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {
-  if (entry.activityKind !== "tool.updated" && entry.activityKind !== "tool.completed") {
+  if (
+    entry.activityKind !== "tool.started" &&
+    entry.activityKind !== "tool.updated" &&
+    entry.activityKind !== "tool.completed"
+  ) {
     return undefined;
   }
   if (entry.toolCallId) {
     return `tool:${entry.toolCallId}`;
   }
-  const normalizedLabel = normalizeCompactToolLabel(entry.toolTitle ?? entry.label);
-  const detail = entry.detail?.trim() ?? "";
+  const itemId = entry.itemId?.trim() ?? "";
+  if (itemId.length > 0) {
+    return itemId;
+  }
+  const normalizedLabel = normalizeToolLifecycleLabelForCollapse(entry.toolTitle ?? entry.label);
+  const commandOrDetail = (entry.command ?? entry.detail)?.trim() ?? "";
   const itemType = entry.itemType ?? "";
-  if (normalizedLabel.length === 0 && detail.length === 0 && itemType.length === 0) {
+  if (normalizedLabel.length === 0 && commandOrDetail.length === 0 && itemType.length === 0) {
     return undefined;
   }
-  return [itemType, normalizedLabel, detail].join("\u001f");
+  return [itemType, normalizedLabel, commandOrDetail].join("\u001f");
 }
 
 function normalizeCompactToolLabel(value: string): string {
   return value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
+}
+
+function normalizeToolLifecycleLabelForCollapse(value: string): string {
+  const normalized = normalizeCompactToolLabel(value).toLowerCase();
+  switch (normalized) {
+    case "running command":
+    case "ran command":
+    case "command run":
+    case "bash":
+    case "terminal":
+      return "command";
+    case "editing files":
+    case "changed files":
+    case "file change":
+      return "file-change";
+    case "searching web":
+    case "searched web":
+    case "web search":
+      return "web-search";
+    case "using tool":
+    case "used tool":
+    case "tool call":
+      return "tool";
+    default:
+      return normalized;
+  }
 }
 
 function toLatestProposedPlanState(proposedPlan: ProposedPlan): LatestProposedPlanState {
@@ -851,6 +948,47 @@ function normalizeCommandValue(value: unknown): string | null {
   return formatted ? unwrapKnownShellCommandWrapper(formatted) : null;
 }
 
+function normalizeCommandFromRecord(record: Record<string, unknown> | null): string | null {
+  if (!record) {
+    return null;
+  }
+  const direct =
+    normalizeCommandValue(record.command) ??
+    normalizeCommandValue(record.cmd) ??
+    normalizeCommandValue(record.shellCommand);
+  if (direct) {
+    return direct;
+  }
+  const executable = asTrimmedString(record.executable);
+  const args = normalizeCommandValue(record.args);
+  if (executable && args) {
+    return unwrapKnownShellCommandWrapper(`${formatCommandArrayPart(executable)} ${args}`);
+  }
+  return executable;
+}
+
+function rawCommandFromRecord(
+  record: Record<string, unknown> | null,
+  normalizedCommand: string | null,
+): string | null {
+  if (!record || normalizedCommand === null) {
+    return null;
+  }
+  for (const value of [record.command, record.cmd, record.shellCommand]) {
+    const raw = toRawToolCommand(value, normalizedCommand);
+    if (raw) {
+      return raw;
+    }
+  }
+  const executable = asTrimmedString(record.executable);
+  const args = normalizeCommandValue(record.args);
+  if (!executable) {
+    return null;
+  }
+  const raw = args ? `${formatCommandArrayPart(executable)} ${args}` : executable;
+  return raw === normalizedCommand ? null : raw;
+}
+
 function toRawToolCommand(value: unknown, normalizedCommand: string | null): string | null {
   const formatted = formatCommandValue(value);
   if (!formatted || normalizedCommand === null) {
@@ -867,6 +1005,9 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
   const item = asRecord(data?.item);
   const itemResult = asRecord(item?.result);
   const itemInput = asRecord(item?.input);
+  const dataInput = asRecord(data?.input);
+  const rawInput = asRecord(data?.rawInput);
+  const state = asRecord(data?.state);
   const itemType = asTrimmedString(payload?.itemType);
   const detail = asTrimmedString(payload?.detail);
   const candidates: unknown[] = [
@@ -874,6 +1015,9 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
     itemInput?.command,
     itemResult?.command,
     data?.command,
+    dataInput?.command,
+    rawInput?.command,
+    state?.command,
     itemType === "command_execution" && detail ? stripTrailingExitCode(detail).output : null,
   ];
 
@@ -885,6 +1029,17 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
     return {
       command,
       rawCommand: toRawToolCommand(candidate, command),
+    };
+  }
+
+  for (const record of [dataInput, rawInput, state]) {
+    const command = normalizeCommandFromRecord(record);
+    if (!command) {
+      continue;
+    }
+    return {
+      command,
+      rawCommand: rawCommandFromRecord(record, command),
     };
   }
 
@@ -920,6 +1075,122 @@ function normalizePreviewForComparison(value: string | null | undefined): string
     return null;
   }
   return normalizeCompactToolLabel(normalizeInlinePreview(normalized)).toLowerCase();
+}
+
+function formatStringList(value: unknown): string | null {
+  const direct = asTrimmedString(value);
+  if (direct) {
+    return direct;
+  }
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const values = value
+    .map((entry) => asTrimmedString(entry))
+    .filter((entry): entry is string => entry !== null);
+  return values.length > 0 ? values.join(", ") : null;
+}
+
+function extractSearchPreview(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const action = asRecord(item?.action);
+  const itemInput = asRecord(item?.input);
+  const itemArguments = asRecord(item?.arguments);
+  const rawInput = asRecord(data?.rawInput);
+  const input = asRecord(data?.input);
+  const state = asRecord(data?.state);
+  const stateInput = asRecord(state?.input);
+
+  const actionType = asTrimmedString(action?.type);
+  if (actionType === "findInPage") {
+    const pattern = asTrimmedString(action?.pattern);
+    const url = asTrimmedString(action?.url);
+    if (pattern && url) {
+      return `${pattern} in ${url}`;
+    }
+    return pattern ?? url;
+  }
+  if (actionType === "openPage") {
+    return asTrimmedString(action?.url);
+  }
+
+  const candidates: unknown[] = [];
+  for (const source of [
+    action,
+    item,
+    itemInput,
+    itemArguments,
+    rawInput,
+    input,
+    state,
+    stateInput,
+  ]) {
+    candidates.push(
+      source?.queries,
+      source?.query,
+      source?.pattern,
+      source?.searchTerm,
+      source?.url,
+    );
+  }
+
+  for (const candidate of candidates) {
+    const preview = formatStringList(candidate);
+    if (preview) {
+      return preview;
+    }
+  }
+
+  return null;
+}
+
+function extractEarlyInputPreview(payload: Record<string, unknown> | null): string | null {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const itemInput = asRecord(item?.input);
+  const itemArguments = asRecord(item?.arguments);
+  const rawInput = asRecord(data?.rawInput);
+  const input = asRecord(data?.input);
+  const state = asRecord(data?.state);
+  const stateInput = asRecord(state?.input);
+
+  for (const source of [item, itemInput, itemArguments, rawInput, input, state, stateInput]) {
+    const preview =
+      formatStringList(source?.file_path) ??
+      formatStringList(source?.filePath) ??
+      formatStringList(source?.path) ??
+      formatStringList(source?.relativePath) ??
+      formatStringList(source?.filename) ??
+      formatStringList(source?.url) ??
+      formatStringList(source?.prompt) ??
+      formatStringList(source?.description) ??
+      formatStringList(source?.pattern) ??
+      formatStringList(source?.query) ??
+      formatStringList(source?.searchTerm);
+    if (preview) {
+      return preview;
+    }
+  }
+
+  return null;
+}
+
+function isSearchTool(payload: Record<string, unknown> | null): boolean {
+  const data = asRecord(payload?.data);
+  const kind = asTrimmedString(data?.kind)?.toLowerCase();
+  const itemType = extractWorkLogItemType(payload);
+  const title = asTrimmedString(payload?.title)?.toLowerCase();
+  const toolName = asTrimmedString(data?.toolName ?? data?.tool)?.toLowerCase();
+  return (
+    itemType === "web_search" ||
+    kind === "search" ||
+    title === "web search" ||
+    title === "search" ||
+    title === "grep" ||
+    toolName === "web_search" ||
+    toolName === "websearch"
+  );
 }
 
 function summarizeToolTextOutput(value: string): string | null {
@@ -987,12 +1258,29 @@ function extractToolDetail(
   const normalizedHeading = normalizePreviewForComparison(heading);
   const normalizedDetail = normalizePreviewForComparison(detail);
 
+  if (isSearchTool(payload)) {
+    const searchPreview = extractSearchPreview(payload);
+    if (searchPreview && normalizePreviewForComparison(searchPreview) !== normalizedHeading) {
+      return searchPreview;
+    }
+  }
+
   if (detail && normalizedHeading !== normalizedDetail) {
     return detail;
   }
 
+  const message = asTrimmedString(payload?.message);
+  if (message && normalizePreviewForComparison(message) !== normalizedHeading) {
+    return message;
+  }
+
   if (isCommandToolDetail(payload, heading)) {
     return null;
+  }
+
+  const earlyInputPreview = extractEarlyInputPreview(payload);
+  if (earlyInputPreview && normalizePreviewForComparison(earlyInputPreview) !== normalizedHeading) {
+    return earlyInputPreview;
   }
 
   const rawOutputSummary = summarizeToolRawOutput(payload);
@@ -1032,6 +1320,33 @@ function extractWorkLogItemType(
 ): WorkLogEntry["itemType"] | undefined {
   if (typeof payload?.itemType === "string" && isToolLifecycleItemType(payload.itemType)) {
     return payload.itemType;
+  }
+  return undefined;
+}
+
+function extractWorkLogItemId(payload: Record<string, unknown> | null): string | undefined {
+  return typeof payload?.itemId === "string" && payload.itemId.length > 0
+    ? payload.itemId
+    : undefined;
+}
+
+function extractWorkLogToolStatus(
+  payload: Record<string, unknown> | null,
+  activityKind: OrchestrationThreadActivity["kind"],
+): WorkLogEntry["toolStatus"] | undefined {
+  if (
+    payload?.status === "inProgress" ||
+    payload?.status === "completed" ||
+    payload?.status === "failed" ||
+    payload?.status === "declined"
+  ) {
+    return payload.status;
+  }
+  if (activityKind === "tool.completed") {
+    return "completed";
+  }
+  if (activityKind === "tool.started" || activityKind === "tool.updated") {
+    return "inProgress";
   }
   return undefined;
 }
@@ -1079,6 +1394,7 @@ function collectChangedFiles(value: unknown, target: string[], seen: Set<string>
 
   pushChangedFile(target, seen, record.path);
   pushChangedFile(target, seen, record.filePath);
+  pushChangedFile(target, seen, record.file_path);
   pushChangedFile(target, seen, record.relativePath);
   pushChangedFile(target, seen, record.filename);
   pushChangedFile(target, seen, record.newPath);
@@ -1088,7 +1404,9 @@ function collectChangedFiles(value: unknown, target: string[], seen: Set<string>
     "item",
     "result",
     "input",
+    "rawInput",
     "data",
+    "locations",
     "changes",
     "files",
     "edits",
@@ -1107,6 +1425,9 @@ function collectChangedFiles(value: unknown, target: string[], seen: Set<string>
 }
 
 function extractChangedFiles(payload: Record<string, unknown> | null): string[] {
+  if (extractWorkLogItemType(payload) === "image_view") {
+    return [];
+  }
   const changedFiles: string[] = [];
   const seen = new Set<string>();
   collectChangedFiles(asRecord(payload?.data), changedFiles, seen, 0);

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -50,6 +50,8 @@ export const PROVIDER_OPTIONS: Array<{
 export interface WorkLogEntry {
   id: string;
   createdAt: string;
+  updatedAt?: string;
+  turnId?: TurnId | null;
   label: string;
   detail?: string;
   command?: string;
@@ -544,6 +546,8 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   const entry: DerivedWorkLogEntry = {
     id: activity.id,
     createdAt: activity.createdAt,
+    updatedAt: activity.createdAt,
+    turnId: activity.turnId,
     label: taskLabel || activity.summary,
     tone:
       activity.kind === "task.progress"
@@ -665,22 +669,14 @@ function shouldCollapseToolLifecycleEntries(
   if (previous.activityKind === "tool.completed") {
     return false;
   }
-  if (previous.collapseKey !== undefined && previous.collapseKey === next.collapseKey) {
-    return true;
-  }
-  if (previous.itemType !== next.itemType) {
-    return false;
-  }
-  if (
-    normalizeToolLifecycleLabelForCollapse(previous.toolTitle ?? previous.label) !==
-    normalizeToolLifecycleLabelForCollapse(next.toolTitle ?? next.label)
-  ) {
-    return false;
-  }
-  if (previous.toolCallId !== undefined) {
-    return next.toolCallId === undefined;
-  }
-  return next.itemId === undefined && next.toolCallId === undefined;
+  return haveSameToolLifecycleCollapseKey(previous, next);
+}
+
+function haveSameToolLifecycleCollapseKey(
+  previous: DerivedWorkLogEntry,
+  next: DerivedWorkLogEntry,
+): boolean {
+  return previous.collapseKey !== undefined && previous.collapseKey === next.collapseKey;
 }
 
 function mergeDerivedWorkLogEntries(
@@ -697,11 +693,13 @@ function mergeDerivedWorkLogEntries(
   const requestKind = next.requestKind ?? previous.requestKind;
   const collapseKey = next.collapseKey ?? previous.collapseKey;
   const toolCallId = next.toolCallId ?? previous.toolCallId;
+  const updatedAt = next.updatedAt ?? previous.updatedAt;
   return {
     ...previous,
     ...next,
     id: previous.id,
     createdAt: previous.createdAt,
+    ...(updatedAt ? { updatedAt } : {}),
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),

--- a/packages/shared/src/toolActivity.test.ts
+++ b/packages/shared/src/toolActivity.test.ts
@@ -20,6 +20,45 @@ describe("toolActivity", () => {
     });
   });
 
+  it("uses in-progress phrasing for started command tools", () => {
+    expect(
+      deriveToolActivityPresentation({
+        itemType: "command_execution",
+        status: "inProgress",
+        lifecycle: "started",
+        detail: "bun run lint",
+        data: {
+          command: "bun run lint",
+        },
+        fallbackSummary: "Tool started",
+      }),
+    ).toEqual({
+      summary: "Running command",
+      detail: "bun run lint",
+    });
+  });
+
+  it("uses in-progress phrasing for active web searches", () => {
+    expect(
+      deriveToolActivityPresentation({
+        itemType: "web_search",
+        lifecycle: "started",
+        data: {
+          item: {
+            action: {
+              type: "search",
+              query: "codex app server docs",
+            },
+          },
+        },
+        fallbackSummary: "Tool started",
+      }),
+    ).toEqual({
+      summary: "Searching web",
+      detail: "codex app server docs",
+    });
+  });
+
   it("uses structured file paths for read-file tools when available", () => {
     expect(
       deriveToolActivityPresentation({
@@ -52,6 +91,97 @@ describe("toolActivity", () => {
       }),
     ).toEqual({
       summary: "Read file",
+    });
+  });
+
+  it("uses structured web search metadata for the detail", () => {
+    expect(
+      deriveToolActivityPresentation({
+        itemType: "web_search",
+        title: "Web search",
+        detail: "Web search",
+        data: {
+          item: {
+            action: {
+              type: "openPage",
+              url: "https://developers.openai.com/codex/sdk/",
+            },
+            query: "fallback query",
+          },
+        },
+        fallbackSummary: "Web search",
+      }),
+    ).toEqual({
+      summary: "Searched web",
+      detail: "https://developers.openai.com/codex/sdk/",
+    });
+  });
+
+  it("uses web search action query metadata for the detail", () => {
+    expect(
+      deriveToolActivityPresentation({
+        itemType: "web_search",
+        title: "Web search",
+        detail: "Web search",
+        data: {
+          item: {
+            action: {
+              type: "search",
+              query: "codex app server docs",
+            },
+          },
+        },
+        fallbackSummary: "Web search",
+      }),
+    ).toEqual({
+      summary: "Searched web",
+      detail: "codex app server docs",
+    });
+  });
+
+  it("keeps file-search tool summaries distinct from web searches", () => {
+    expect(
+      deriveToolActivityPresentation({
+        itemType: "dynamic_tool_call",
+        title: "grep",
+        detail: "grep",
+        data: {
+          kind: "search",
+          rawInput: {
+            pattern: "deriveToolActivityPresentation",
+          },
+        },
+        fallbackSummary: "grep",
+      }),
+    ).toEqual({
+      summary: "Searched files",
+      detail: "deriveToolActivityPresentation",
+    });
+  });
+
+  it("keeps lifecycle status in summaries for custom tools", () => {
+    expect(
+      deriveToolActivityPresentation({
+        itemType: "dynamic_tool_call",
+        status: "failed",
+        title: "My Tool",
+        detail: "Failed with exit code 1",
+        fallbackSummary: "Tool",
+      }),
+    ).toEqual({
+      summary: "My Tool failed",
+      detail: "Failed with exit code 1",
+    });
+
+    expect(
+      deriveToolActivityPresentation({
+        itemType: "dynamic_tool_call",
+        status: "declined",
+        title: "My Tool",
+        fallbackSummary: "Tool",
+      }),
+    ).toEqual({
+      summary: "My Tool declined",
     });
   });
 });

--- a/packages/shared/src/toolActivity.ts
+++ b/packages/shared/src/toolActivity.ts
@@ -1,4 +1,4 @@
-import type { ToolLifecycleItemType } from "@t3tools/contracts";
+import type { RuntimeItemStatus, ToolLifecycleItemType } from "@t3tools/contracts";
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === "object" && !Array.isArray(value)
@@ -154,11 +154,62 @@ function isEquivalent(left: string | undefined, right: string | undefined): bool
   return normalizedLeft !== undefined && normalizedLeft === normalizedRight;
 }
 
+function normalizeStringList(value: unknown): string | undefined {
+  const direct = asTrimmedString(value);
+  if (direct) {
+    return direct;
+  }
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const values = value
+    .map((entry) => asTrimmedString(entry))
+    .filter((entry): entry is string => entry !== undefined);
+  return values.length > 0 ? values.join(", ") : undefined;
+}
+
+function extractSearchDetail(data: Record<string, unknown> | undefined): string | undefined {
+  const item = asRecord(data?.item);
+  const action = asRecord(item?.action);
+  const rawInput = asRecord(data?.rawInput);
+  const input = asRecord(data?.input);
+  const actionType = asTrimmedString(action?.type);
+
+  if (actionType === "findInPage") {
+    const pattern = asTrimmedString(action?.pattern);
+    const url = asTrimmedString(action?.url);
+    if (pattern && url) {
+      return `${pattern} in ${url}`;
+    }
+    return pattern ?? url;
+  }
+  if (actionType === "openPage") {
+    return asTrimmedString(action?.url);
+  }
+
+  const candidates = [
+    action?.queries,
+    action?.query,
+    item?.query,
+    rawInput?.query,
+    rawInput?.queries,
+    rawInput?.pattern,
+    rawInput?.searchTerm,
+    rawInput?.url,
+    input?.query,
+    input?.queries,
+    input?.pattern,
+    input?.searchTerm,
+    input?.url,
+  ];
+  return candidates.map(normalizeStringList).find((candidate) => candidate !== undefined);
+}
+
 function classifyToolAction(input: {
   readonly itemType?: ToolLifecycleItemType | null | undefined;
   readonly title?: string | undefined;
   readonly data?: Record<string, unknown> | undefined;
-}): "command" | "read" | "file_change" | "search" | "other" {
+}): "command" | "read" | "file_change" | "file_search" | "web_search" | "image_view" | "other" {
   const itemType = input.itemType ?? undefined;
   const kind = asTrimmedString(input.data?.kind)?.toLowerCase();
   const title = asTrimmedString(input.title)?.toLowerCase();
@@ -177,14 +228,80 @@ function classifyToolAction(input: {
   ) {
     return "file_change";
   }
-  if (itemType === "web_search" || kind === "search" || title === "find" || title === "grep") {
-    return "search";
+  if (itemType === "web_search") {
+    return "web_search";
+  }
+  if (itemType === "image_view") {
+    return "image_view";
+  }
+  if (kind === "search" || title === "find" || title === "grep") {
+    return "file_search";
   }
   return "other";
 }
 
+function lifecyclePhase(input: {
+  readonly status?: RuntimeItemStatus | null | undefined;
+  readonly lifecycle?: "started" | "updated" | "completed" | null | undefined;
+}): "inProgress" | "completed" | "failed" | "declined" {
+  if (input.status === "failed") return "failed";
+  if (input.status === "declined") return "declined";
+  if (input.status === "inProgress") return "inProgress";
+  if (input.lifecycle === "started" || input.lifecycle === "updated") return "inProgress";
+  return "completed";
+}
+
+function lifecycleSummary(input: {
+  readonly action: ReturnType<typeof classifyToolAction>;
+  readonly phase: ReturnType<typeof lifecyclePhase>;
+  readonly fallbackSummary: string;
+  readonly title: string | undefined;
+}): string | undefined {
+  const fallback = input.title ?? input.fallbackSummary;
+  if (input.phase === "failed") {
+    switch (input.action) {
+      case "command":
+        return "Command failed";
+      case "read":
+        return "Read failed";
+      case "file_change":
+        return "File change failed";
+      case "file_search":
+        return "File search failed";
+      case "web_search":
+        return "Web search failed";
+      case "image_view":
+        return "Image view failed";
+      case "other":
+        return fallback === "Tool" ? "Tool failed" : `${fallback} failed`;
+    }
+  }
+  if (input.phase === "declined") {
+    return fallback === "Tool" ? "Tool declined" : `${fallback} declined`;
+  }
+  const completed = input.phase === "completed";
+  switch (input.action) {
+    case "command":
+      return completed ? "Ran command" : "Running command";
+    case "read":
+      return completed ? "Read file" : "Reading file";
+    case "file_change":
+      return completed ? "Changed files" : "Editing files";
+    case "file_search":
+      return completed ? "Searched files" : "Searching files";
+    case "web_search":
+      return completed ? "Searched web" : "Searching web";
+    case "image_view":
+      return completed ? "Viewed image" : "Viewing image";
+    case "other":
+      return undefined;
+  }
+}
+
 export interface ToolActivityPresentationInput {
   readonly itemType?: ToolLifecycleItemType | null | undefined;
+  readonly status?: RuntimeItemStatus | null | undefined;
+  readonly lifecycle?: "started" | "updated" | "completed" | null | undefined;
   readonly title?: string | null | undefined;
   readonly detail?: string | null | undefined;
   readonly data?: unknown;
@@ -210,10 +327,20 @@ export function deriveToolActivityPresentation(
     title,
     data,
   });
+  const phase = lifecyclePhase({
+    status: input.status,
+    lifecycle: input.lifecycle,
+  });
+  const summary = lifecycleSummary({
+    action,
+    phase,
+    fallbackSummary,
+    title,
+  });
 
   if (action === "command") {
     return {
-      summary: "Ran command",
+      summary: summary ?? fallbackSummary,
       ...(command ? { detail: command } : {}),
     };
   }
@@ -221,41 +348,45 @@ export function deriveToolActivityPresentation(
   if (action === "read") {
     if (primaryPath) {
       return {
-        summary: "Read file",
+        summary: summary ?? fallbackSummary,
         detail: primaryPath,
       };
     }
     return {
-      summary: "Read file",
+      summary: summary ?? fallbackSummary,
     };
   }
 
   if (action === "file_change") {
     return {
-      summary: "Changed files",
+      summary: summary ?? fallbackSummary,
       ...(primaryPath ? { detail: primaryPath } : {}),
     };
   }
 
-  if (action === "search") {
-    const query =
-      asTrimmedString(asRecord(data?.rawInput)?.query) ??
-      asTrimmedString(asRecord(data?.rawInput)?.pattern) ??
-      asTrimmedString(asRecord(data?.rawInput)?.searchTerm);
+  if (action === "file_search" || action === "web_search") {
+    const query = extractSearchDetail(data);
     return {
-      summary: "Searched files",
+      summary: summary ?? fallbackSummary,
       ...(query ? { detail: query } : {}),
+    };
+  }
+
+  if (action === "image_view") {
+    return {
+      summary: summary ?? fallbackSummary,
+      ...(primaryPath ? { detail: primaryPath } : {}),
     };
   }
 
   if (detail && !isEquivalent(detail, title) && !isEquivalent(detail, fallbackSummary)) {
     return {
-      summary: title ?? fallbackSummary,
+      summary: summary ?? title ?? fallbackSummary,
       detail,
     };
   }
 
   return {
-    summary: title ?? fallbackSummary,
+    summary: summary ?? title ?? fallbackSummary,
   };
 }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Removed manual `truncateDetail` truncation for agent-sent tool calls. Long output is still visually constrained with CSS ellipsis, and the full value is available on hover.
- Show command details while a command is still running, with support for a different in-progress label.
- Cleaned up some of the state handling.

## Why

- Long commands were being truncated before they reached the UI, which made important details impossible to inspect.
- If the agent starts a long-running or interactive command, the UI previously gave little useful feedback until the command exited or was killed externally. Showing the running command makes that state visible immediately.

## UI Changes

Before this PR:

<img width="1134" height="73" alt="truncated title" src="https://github.com/user-attachments/assets/8e92792d-6ba8-4a0c-8f23-ec9afdd214d7" />

Longer command string visible:

<img width="1125" height="111" alt="unformatted title" src="https://github.com/user-attachments/assets/6ff1ed2e-d9e7-4be2-8389-8721bab6ae58" />

Different label while the command is running:

<img width="538" height="37" alt="running command" src="https://github.com/user-attachments/assets/c7c19a66-957f-47a3-b7bc-975861145bd8" />

Video demonstration:

https://www.youtube.com/watch?v=Ug_mBuv5F5U

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider runtime ingestion, streaming message finalization, and large session/timeline logic; behavior is heavily tested but regressions could affect turn completion or cross-thread send UX.
> 
> **Overview**
> This PR makes **agent activity visible earlier and more specific** end-to-end: runtime ingestion and Codex no longer rely on generic provider titles, and both persisted activities and the work log use shared **`deriveToolActivityPresentation`** for lifecycle-aware labels (e.g. *Running command* vs *Ran command*) plus richer **status**, **itemId**, and **detail** payloads.
> 
> The chat timeline adds a **phase-aware “working” row** (waiting, sending, thinking, responding, per-tool phases) with separate phase and total timers, shows **tool.started** rows that **collapse** into one entry per call, and improves tool/file path display (including paths outside the workspace on Windows).
> 
> **Orchestration** force-completes **streaming assistant messages on turn completion** when segment state is missing. **ChatView** keeps **targeted local dispatch** tied to a thread across navigation until that thread is actually running or settled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f490f5bbd49796a6b9606b68ce652035b2cc896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show real-time phase labels and lifecycle-aware tool headings in the agent timeline
> - The agent working row now shows a live phase label (e.g. 'Running command', 'Responding', 'Thinking') with per-phase and total elapsed timers, replacing a single generic 'Working' spinner.
> - Tool lifecycle events (`tool.started` → `tool.updated` → `tool.completed`) are collapsed into a single timeline entry per tool call, surfacing status immediately on start rather than waiting for completion.
> - Tool headings and previews are now lifecycle-aware: in-progress shows 'Running command', completed shows 'Ran command', failed shows 'Command failed', etc., derived via a shared `deriveToolActivityPresentation` util in [`packages/shared/src/toolActivity.ts`](https://github.com/pingdotgg/t3code/pull/1775/files#diff-3e3d724b5f088f0153670b301f7cd2c063220d2f5bffb6816b4c83abf542e3d6).
> - Redundant preview text is suppressed when changed-file badges already convey the same information; image-view activities no longer produce changed-file entries.
> - Targeted local dispatch now persists per-thread across navigation, so the sending state follows the user to the new thread and clears only when that thread's turn settles.
> - Risk: `classifyToolAction` return values changed from `'search'` to `'file_search'` or `'web_search'`; any callers outside this PR relying on the old `'search'` bucket will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f490f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->