### PR TITLE
Add OS notifications for turn completions

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -46,6 +46,7 @@ import {
   resolveAppModelSelectionState,
 } from "../../modelSelection";
 import { ensureNativeApi, readNativeApi } from "../../nativeApi";
+import { requestNotificationPermission } from "../../turnCompletionNotifier";
 import { useStore } from "../../store";
 import { formatRelativeTime, formatRelativeTimeLabel } from "../../timestampFormat";
 import { cn } from "../../lib/utils";
@@ -469,6 +470,10 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
+      ...(settings.enableTurnCompletionNotifications !==
+      DEFAULT_UNIFIED_SETTINGS.enableTurnCompletionNotifications
+        ? ["Turn completion notifications"]
+        : []),
       ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
         : []),
@@ -489,6 +494,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.defaultThreadEnvMode,
       settings.diffWordWrap,
       settings.enableAssistantStreaming,
+      settings.enableTurnCompletionNotifications,
       settings.timestampFormat,
       theme,
     ],
@@ -927,8 +933,8 @@ export function GeneralSettingsPanel() {
               checked={settings.enableTurnCompletionNotifications}
               onCheckedChange={(checked) => {
                 const enabled = Boolean(checked);
-                if (enabled && "Notification" in window && Notification.permission === "default") {
-                  void Notification.requestPermission();
+                if (enabled) {
+                  void requestNotificationPermission();
                 }
                 updateSettings({ enableTurnCompletionNotifications: enabled });
               }}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -906,6 +906,38 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          title="Turn completion notifications"
+          description="Show an OS notification when a turn finishes while the tab is in the background."
+          resetAction={
+            settings.enableTurnCompletionNotifications !==
+            DEFAULT_UNIFIED_SETTINGS.enableTurnCompletionNotifications ? (
+              <SettingResetButton
+                label="turn completion notifications"
+                onClick={() =>
+                  updateSettings({
+                    enableTurnCompletionNotifications:
+                      DEFAULT_UNIFIED_SETTINGS.enableTurnCompletionNotifications,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.enableTurnCompletionNotifications}
+              onCheckedChange={(checked) => {
+                const enabled = Boolean(checked);
+                if (enabled && "Notification" in window && Notification.permission === "default") {
+                  void Notification.requestPermission();
+                }
+                updateSettings({ enableTurnCompletionNotifications: enabled });
+              }}
+              aria-label="Enable turn completion notifications"
+            />
+          }
+        />
+
+        <SettingsRow
           title="New threads"
           description="Pick the default workspace mode for newly created draft threads."
           resetAction={

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -48,6 +48,13 @@ import { collectActiveTerminalThreadIds } from "../lib/terminalStateCleanup";
 import { deriveOrchestrationBatchEffects } from "../orchestrationEventEffects";
 import { createOrchestrationRecoveryCoordinator } from "../orchestrationRecovery";
 import { deriveReplayRetryDecision } from "../orchestrationRecovery";
+import {
+  extractTurnCompletions,
+  resetRunningThreadTracker,
+  seedRunningThreads,
+  showTurnCompletionNotification,
+} from "../turnCompletionNotifier";
+import { useSettings } from "../hooks/useSettings";
 import { getWsRpcClient } from "~/wsRpcClient";
 
 export const Route = createRootRouteWithContext<{
@@ -229,6 +236,11 @@ function EventRouter() {
   const bootstrapFromSnapshotRef = useRef<() => Promise<void>>(async () => undefined);
   const serverConfig = useServerConfig();
 
+  // Turn-completion OS notifications
+  const { enableTurnCompletionNotifications } = useSettings();
+  const notificationsEnabledRef = useRef(enableTurnCompletionNotifications);
+  notificationsEnabledRef.current = enableTurnCompletionNotifications;
+
   const handleWelcome = useEffectEvent((payload: ServerLifecycleWelcomePayload | null) => {
     if (!payload) return;
 
@@ -338,6 +350,10 @@ function EventRouter() {
         })),
       );
       clearPromotedDraftThreads(threads.map((thread) => thread.id));
+      // Seed the turn-completion tracker so we detect transitions that
+      // started before our event subscription (e.g. a running turn
+      // present in the snapshot after a page refresh).
+      seedRunningThreads(threads);
       const draftThreadIds = Object.keys(
         useComposerDraftStore.getState().draftThreadsByThreadId,
       ) as ThreadId[];
@@ -375,6 +391,17 @@ function EventRouter() {
       if (nextEvents.length === 0) {
         return;
       }
+
+      // Extract turn-completion transitions *before* the store update so
+      // the running-thread tracker sees the pre-update session state. Thread
+      // and project titles are read from the current store for display.
+      const turnCompletions = notificationsEnabledRef.current
+        ? extractTurnCompletions(
+            nextEvents,
+            (id) => useStore.getState().threads.find((t) => t.id === id),
+            (id) => useStore.getState().projects.find((p) => p.id === id),
+          )
+        : [];
 
       const batchEffects = deriveOrchestrationBatchEffects(nextEvents);
       const uiEvents = coalesceOrchestrationUiEvents(nextEvents);
@@ -417,6 +444,22 @@ function EventRouter() {
       }
       for (const threadId of batchEffects.removeTerminalStateThreadIds) {
         removeTerminalState(threadId);
+      }
+
+      // Fire OS notifications for completed turns (deferred to end so store
+      // updates are already applied if the user clicks through).  Falls
+      // back to an in-app toast when the tab is focused or when the
+      // browser blocked the OS notification.
+      for (const completion of turnCompletions) {
+        const { title, body, osNotificationSent } = showTurnCompletionNotification(completion);
+        if (!osNotificationSent) {
+          toastManager.add({
+            type: completion.status === "error" ? "error" : "success",
+            title,
+            description: body,
+            data: { threadId: completion.threadId, dismissAfterVisibleMs: 5_000 },
+          });
+        }
       }
     };
     const flushPendingDomainEvents = () => {
@@ -568,6 +611,7 @@ function EventRouter() {
       flushPendingDomainEventsScheduled = false;
       pendingDomainEvents.length = 0;
       queryInvalidationThrottler.cancel();
+      resetRunningThreadTracker();
       unsubDomainEvent();
       unsubTerminalEvent();
     };

--- a/apps/web/src/turnCompletionNotifier.ts
+++ b/apps/web/src/turnCompletionNotifier.ts
@@ -1,0 +1,188 @@
+/**
+ * OS-level notifications for turn completions.
+ *
+ * Tracks which threads are currently "running" and fires a browser
+ * Notification when a thread transitions out of the running state
+ * (i.e. the agent finished, was interrupted, errored, or was stopped).
+ *
+ * Notifications are only shown when the tab is not focused so the user
+ * gets an ambient signal without being disrupted while actively watching.
+ */
+import type { OrchestrationEvent, OrchestrationSessionStatus, ThreadId } from "@t3tools/contracts";
+import type { Thread, Project } from "./types";
+
+// ── Running-thread tracker ──────────────────────────────────────────
+
+const runningThreadIds = new Set<ThreadId>();
+
+export function resetRunningThreadTracker(): void {
+  runningThreadIds.clear();
+}
+
+/**
+ * Seed the tracker with threads that are already running in the store.
+ * Call after snapshot bootstrap so we can detect transitions that
+ * started before the current event subscription.
+ */
+export function seedRunningThreads(threads: readonly Thread[]): void {
+  for (const thread of threads) {
+    if (thread.session?.orchestrationStatus === "running") {
+      runningThreadIds.add(thread.id);
+    }
+  }
+}
+
+// ── Permission helpers ──────────────────────────────────────────────
+
+export function notificationsSupported(): boolean {
+  return typeof window !== "undefined" && "Notification" in window;
+}
+
+export function requestNotificationPermission(): Promise<NotificationPermission> {
+  if (!notificationsSupported()) {
+    return Promise.resolve("denied" as NotificationPermission);
+  }
+  if (Notification.permission !== "default") {
+    return Promise.resolve(Notification.permission);
+  }
+  return Notification.requestPermission();
+}
+
+// ── Notification body derivation ────────────────────────────────────
+
+interface TurnCompletionInfo {
+  threadId: ThreadId;
+  threadTitle: string;
+  projectName: string | null;
+  status: OrchestrationSessionStatus;
+}
+
+const STATUS_LABELS: Partial<Record<OrchestrationSessionStatus, string>> = {
+  idle: "completed",
+  ready: "completed",
+  interrupted: "interrupted",
+  stopped: "stopped",
+  error: "failed",
+};
+
+/**
+ * Scans an event batch for `thread.session-set` transitions that signal
+ * a thread leaving the "running" state. Returns one entry per such
+ * transition, enriched with thread/project metadata from the store.
+ *
+ * Detection uses two sources:
+ *  1. The in-memory `runningThreadIds` set (populated from earlier event
+ *     batches and snapshot seeding).
+ *  2. The store's current `orchestrationStatus` for the thread (covers
+ *     cases where the running state was set before we started tracking,
+ *     e.g. snapshot bootstrap or same-batch transitions).
+ */
+export function extractTurnCompletions(
+  events: readonly OrchestrationEvent[],
+  getThread: (id: ThreadId) => Thread | undefined,
+  getProject: (id: string) => Project | undefined,
+): TurnCompletionInfo[] {
+  const completions: TurnCompletionInfo[] = [];
+
+  for (const event of events) {
+    if (event.type !== "thread.session-set") {
+      continue;
+    }
+
+    const { threadId } = event.payload;
+    const status = event.payload.session.status;
+
+    if (status === "running") {
+      runningThreadIds.add(threadId);
+      continue;
+    }
+
+    // "starting" is a transient pre-run state — never a completion.
+    if (status === "starting") {
+      continue;
+    }
+
+    // Check both the in-memory tracker AND the store's current state so
+    // we catch transitions that started before our subscription (e.g.
+    // snapshot-bootstrapped sessions or page refreshes).
+    const wasRunning =
+      runningThreadIds.has(threadId) ||
+      getThread(threadId)?.session?.orchestrationStatus === "running";
+
+    if (!wasRunning) {
+      continue;
+    }
+    runningThreadIds.delete(threadId);
+
+    const thread = getThread(threadId);
+    const project = thread ? getProject(thread.projectId) : undefined;
+
+    completions.push({
+      threadId,
+      threadTitle: thread?.title ?? "Thread",
+      projectName: project?.name ?? null,
+      status,
+    });
+  }
+
+  return completions;
+}
+
+// ── Notification dispatch ───────────────────────────────────────────
+
+function buildNotificationContent(info: TurnCompletionInfo): { title: string; body: string } {
+  const statusLabel = STATUS_LABELS[info.status] ?? info.status;
+  return {
+    title: `Turn ${statusLabel}`,
+    body: info.projectName ? `${info.threadTitle} — ${info.projectName}` : info.threadTitle,
+  };
+}
+
+/**
+ * Whether the user is actively looking at the page.
+ *
+ * Uses `document.hasFocus()` (detects if the browser window has OS-level
+ * focus) combined with `document.hidden` (detects if the tab is visible).
+ * This correctly identifies the case where the tab is visible but the
+ * user switched to a different application window.
+ */
+function isPageActivelyFocused(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.hasFocus() && !document.hidden;
+}
+
+/**
+ * Fires an OS-level notification when the user is not actively focused
+ * on the page, and returns the content so the caller can fall back to
+ * an in-app toast when the page is focused or the OS channel is
+ * unavailable.
+ */
+export function showTurnCompletionNotification(info: TurnCompletionInfo): {
+  title: string;
+  body: string;
+  osNotificationSent: boolean;
+} {
+  const content = buildNotificationContent(info);
+
+  if (
+    isPageActivelyFocused() ||
+    !notificationsSupported() ||
+    Notification.permission !== "granted"
+  ) {
+    return { ...content, osNotificationSent: false };
+  }
+
+  try {
+    // eslint-disable-next-line no-new -- Notification is intentionally fire-and-forget.
+    new Notification(content.title, {
+      body: content.body,
+      tag: `t3-turn-${info.threadId}`,
+      icon: "/favicon.svg",
+    });
+    return { ...content, osNotificationSent: true };
+  } catch {
+    // Notification constructor can throw in restricted contexts (e.g. some
+    // sandboxed iframes). Fall back to in-app toast via caller.
+    return { ...content, osNotificationSent: false };
+  }
+}

--- a/apps/web/src/turnCompletionNotifier.ts
+++ b/apps/web/src/turnCompletionNotifier.ts
@@ -20,11 +20,13 @@ export function resetRunningThreadTracker(): void {
 }
 
 /**
- * Seed the tracker with threads that are already running in the store.
- * Call after snapshot bootstrap so we can detect transitions that
- * started before the current event subscription.
+ * Replace the tracker with threads that are running in the given snapshot.
+ * Call after each snapshot sync (bootstrap / recovery) so the set matches
+ * server state and stale IDs from before a disconnect cannot produce false
+ * completion transitions.
  */
 export function seedRunningThreads(threads: readonly Thread[]): void {
+  runningThreadIds.clear();
   for (const thread of threads) {
     if (thread.session?.orchestrationStatus === "running") {
       runningThreadIds.add(thread.id);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -27,6 +27,7 @@ export const ClientSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(() => true)),
   diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
+  enableTurnCompletionNotifications: Schema.Boolean.pipe(Schema.withDecodingDefault(() => false)),
   sidebarProjectSortOrder: SidebarProjectSortOrder.pipe(
     Schema.withDecodingDefault(() => DEFAULT_SIDEBAR_PROJECT_SORT_ORDER),
   ),


### PR DESCRIPTION
- New setting to enable/disable notifications when turns finish
- Tracker detects thread state transitions (running → idle/error/stopped)
- Notifications only show when tab is unfocused; fallback to in-app toast when focused
- Handles permission requests and restricted contexts gracefully

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Added system-level (OS) notifications that fire when a turn finishes and the
user is not actively focused on the app. Includes a toggle in Settings → General.

- New `enableTurnCompletionNotifications` client setting (off by default)
- Tracks thread session transitions (running → idle/ready/error/stopped/interrupted)
- Fires native OS notification via the Notification API when the page loses focus
- Falls back to an in-app toast when the tab is actively focused
- Automatically prompts for browser notification permission when toggled on
- Seeds tracker from snapshot so page refreshes mid-turn still detect completion


## Why

When running long agent tasks, users often switch to another app (terminal, IDE, 
browser tab) while waiting. There was no way to know the turn finished without 
manually checking back. This adds an ambient signal through the OS notification 
system so the user gets notified wherever they are — same as any other desktop 
notification on their system (Linux, macOS, Windows).


## UI Change
Notification setting 

<img width="1366" height="768" alt="after" src="https://github.com/user-attachments/assets/2f154dbd-eb9c-4de6-bd37-93b946c830d5" />


video record for the notification trigger

[Screencast_٢٠٢٦٠٤٠٦_١٢٠٩١٨.webm](https://github.com/user-attachments/assets/2749ccb3-e721-458f-84d9-b7fa8c78bcbb)



## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client setting and hooks notification logic into the root orchestration event pipeline; behavior depends on browser Notification permissions/focus detection and could introduce noisy or missed notifications if tracking is wrong.
> 
> **Overview**
> Adds opt-in **OS-level notifications** when an orchestration turn completes, driven by a new `enableTurnCompletionNotifications` client setting (default off).
> 
> Introduces `turnCompletionNotifier.ts` to track running threads from snapshots and `thread.session-set` events, request notification permission, and emit browser `Notification`s only when the page isn’t actively focused (with graceful fallback).
> 
> Wires the notifier into `__root.tsx`’s event-batch processing to detect running→non-running transitions and either show an OS notification or fall back to an in-app toast; also adds a Settings toggle (with reset support) that prompts for permission when enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08b67ff8eaba6ab454364fb65830945974fbc6ac. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OS notifications for thread turn completions
> - Adds a new `enableTurnCompletionNotifications` boolean to [settings.ts](https://github.com/pingdotgg/t3code/pull/1780/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) (default `false`) and a toggle in the General Settings panel that requests browser Notification permission on enable.
> - Adds [turnCompletionNotifier.ts](https://github.com/pingdotgg/t3code/pull/1780/files#diff-183bfc627562e08d69b60774bcc51e34b361b578990eaf090a3ad307729cb2f2) with utilities to track running threads, detect turn-completion transitions from event batches, and fire OS notifications when the page is not focused.
> - The event router in [__root.tsx](https://github.com/pingdotgg/t3code/pull/1780/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) calls these utilities on each event batch, falling back to in-app toasts when OS notifications are unavailable or permission is denied.
> - Behavioral Change: enabling the setting will trigger a browser permission prompt; OS notifications are only sent when the page is not focused.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08b67ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->