### PR TITLE
security: add HTTP security headers, CSP, and core dump gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ apps/web/playwright-report
 apps/web/src/components/__screenshots__
 .vitest-*
 __screenshots__/
+core.*
 .tanstack

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,5 +1,5 @@
 import { Effect, Layer } from "effect";
-import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
+import { FetchHttpClient, HttpRouter, HttpServer, HttpServerResponse } from "effect/unstable/http";
 
 import { ServerConfig } from "./config";
 import {
@@ -216,6 +216,17 @@ export const makeRoutesLayer = Layer.mergeAll(
   websocketRpcRouteLayer,
 );
 
+/** Middleware that appends standard security headers to every HTTP response. */
+const securityHeadersMiddleware = HttpRouter.middleware(
+  (httpApp) =>
+    Effect.map(httpApp, (response) =>
+      HttpServerResponse.setHeaders(response, {
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "DENY",
+      }),
+    ),
+);
+
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {
     const config = yield* ServerConfig;
@@ -234,6 +245,7 @@ export const makeServerLayer = Layer.unwrap(
       HttpRouter.serve(makeRoutesLayer, {
         disableLogger: !config.logWebSocketEvents,
       }),
+      securityHeadersMiddleware.layer,
       httpListeningLayer,
     );
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' ws: wss: http://localhost:* http://127.0.0.1:* https://fonts.googleapis.com https://fonts.gstatic.com; frame-ancestors 'none'; base-uri 'self';"
+    />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Security Hardening

This PR addresses several findings from a security audit of the codebase.

### Changes

1. **HTTP Security Headers** (`apps/server/src/server.ts`)
   - Added `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` to all HTTP responses via an Effect `HttpRouter.middleware`
   - Prevents MIME-type sniffing attacks and clickjacking

2. **Content Security Policy** (`apps/web/index.html`)
   - Added CSP meta tag restricting script sources, connection targets, and frame ancestors
   - Uses `wasm-unsafe-eval` for Shiki syntax highlighting compatibility (WebAssembly)
   - Allows font loading from Google Fonts and WebSocket connections to localhost

3. **Gitignore Core Dumps** (`.gitignore`)
   - Added `core.*` pattern to prevent accidental commits of core dump files
   - Core dumps can contain sensitive data (env vars, tokens, memory contents)

### Type-checked
All changes pass `tsc --noEmit` with zero new errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk hardening changes; main risk is inadvertently breaking browser resource loading or WebSocket/dev connections due to the new CSP.
> 
> **Overview**
> Adds basic security hardening across server and web.
> 
> The server now applies a global `HttpRouter` middleware that sets `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` on all HTTP responses. The web app adds a `Content-Security-Policy` meta tag restricting scripts/styles/fonts/images and allowed connection targets (including localhost/ws), and `.gitignore` now excludes `core.*` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0dd0c548f609e1f423e5eae57e46751d7353593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add HTTP security headers and Content Security Policy to server and web app
> - Adds a middleware in [server.ts](https://github.com/pingdotgg/t3code/pull/1782/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) that sets `x-content-type-options: nosniff` and `x-frame-options: DENY` on all HTTP responses.
> - Adds a CSP meta tag to [index.html](https://github.com/pingdotgg/t3code/pull/1782/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f) restricting resource origins, disallowing framing via `frame-ancestors 'none'`, and permitting WebAssembly via `wasm-unsafe-eval`.
> - Adds `core.*` to [.gitignore](https://github.com/pingdotgg/t3code/pull/1782/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) to exclude core dump files from the repository.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0dd0c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->