### PR TITLE
Use Codex defaults for custom model capabilities

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -32,6 +32,7 @@ import {
   spawnAndCollect,
   type CommandResult,
 } from "../providerSnapshot";
+import { DEFAULT_CODEX_MODEL_CAPABILITIES } from "@t3tools/shared/model";
 import { makeManagedServerProvider } from "../makeManagedServerProvider";
 import {
   formatCodexCliUpgradeMessage,
@@ -159,13 +160,8 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
 export function getCodexModelCapabilities(model: string | null | undefined): ModelCapabilities {
   const slug = model?.trim();
   return (
-    BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ?? {
-      reasoningEffortLevels: [],
-      supportsFastMode: false,
-      supportsThinkingToggle: false,
-      contextWindowOptions: [],
-      promptInjectedEffortLevels: [],
-    }
+    BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
+    DEFAULT_CODEX_MODEL_CAPABILITIES
   );
 }
 
@@ -339,7 +335,12 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     Effect.map((settings) => settings.providers.codex),
   );
   const checkedAt = new Date().toISOString();
-  const models = providerModelsFromSettings(BUILT_IN_MODELS, PROVIDER, codexSettings.customModels);
+  const models = providerModelsFromSettings(
+    BUILT_IN_MODELS,
+    PROVIDER,
+    codexSettings.customModels,
+    DEFAULT_CODEX_MODEL_CAPABILITIES,
+  );
 
   if (!codexSettings.enabled) {
     return buildServerProvider({

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -220,6 +220,41 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
         ),
       );
 
+      it.effect("adds standard codex capabilities to custom codex models", () =>
+        Effect.gen(function* () {
+          yield* withTempCodexHome();
+          const serverSettingsLayer = ServerSettingsService.layerTest({
+            providers: {
+              codex: {
+                customModels: ["custom-codex-model"],
+              },
+            },
+          });
+
+          const status = yield* checkCodexProviderStatus().pipe(
+            Effect.provide(serverSettingsLayer),
+          );
+          const customModel = status.models.find((model) => model.slug === "custom-codex-model");
+
+          assert.ok(customModel);
+          assert.strictEqual(customModel.isCustom, true);
+          assert.deepStrictEqual(
+            customModel.capabilities?.reasoningEffortLevels.map((level) => level.value),
+            ["xhigh", "high", "medium", "low"],
+          );
+          assert.strictEqual(customModel.capabilities?.supportsFastMode, true);
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
+              if (joined === "login status") return { stdout: "Logged in\n", stderr: "", code: 0 };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("hides spark from codex models for unsupported chatgpt plans", () =>
         Effect.gen(function* () {
           yield* withTempCodexHome();

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -1,4 +1,5 @@
 import type {
+  ModelCapabilities,
   ServerProvider,
   ServerProviderAuth,
   ServerProviderModel,
@@ -102,6 +103,7 @@ export function providerModelsFromSettings(
   builtInModels: ReadonlyArray<ServerProviderModel>,
   provider: ServerProvider["provider"],
   customModels: ReadonlyArray<string>,
+  defaultCustomCapabilities: ModelCapabilities | null = null,
 ): ReadonlyArray<ServerProviderModel> {
   const resolvedBuiltInModels = [...builtInModels];
   const seen = new Set(resolvedBuiltInModels.map((model) => model.slug));
@@ -117,7 +119,7 @@ export function providerModelsFromSettings(
       slug: normalized,
       name: normalized,
       isCustom: true,
-      capabilities: null,
+      capabilities: defaultCustomCapabilities,
     });
   }
 

--- a/apps/web/src/components/chat/TraitsPicker.browser.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.browser.tsx
@@ -477,6 +477,23 @@ describe("TraitsPicker (Codex)", () => {
     });
   });
 
+  it("shows default effort options for custom codex models without capabilities", async () => {
+    await using _ = await mountCodexPicker({
+      model: "custom-codex-model",
+      options: { reasoningEffort: "low" },
+    });
+
+    await page.getByRole("button").click();
+
+    await vi.waitFor(() => {
+      const text = document.body.textContent ?? "";
+      expect(text).toContain("Extra High");
+      expect(text).toContain("High");
+      expect(text).toContain("Medium");
+      expect(text).toContain("Low");
+    });
+  });
+
   it("persists sticky codex model options when traits change", async () => {
     await using _ = await mountCodexPicker({
       options: { fastMode: false },

--- a/apps/web/src/components/chat/composerProviderRegistry.test.tsx
+++ b/apps/web/src/components/chat/composerProviderRegistry.test.tsx
@@ -149,6 +149,36 @@ describe("getComposerProviderState", () => {
     });
   });
 
+  it("uses standard codex defaults for custom codex models without capabilities", () => {
+    const state = getComposerProviderState({
+      provider: "codex",
+      model: "custom-codex-model",
+      models: [
+        ...CODEX_MODELS,
+        {
+          slug: "custom-codex-model",
+          name: "custom-codex-model",
+          isCustom: true,
+          capabilities: null,
+        },
+      ],
+      prompt: "",
+      modelOptions: {
+        codex: {
+          reasoningEffort: "low",
+        },
+      },
+    });
+
+    expect(state).toEqual({
+      provider: "codex",
+      promptEffort: "low",
+      modelOptionsForDispatch: {
+        reasoningEffort: "low",
+      },
+    });
+  });
+
   it("preserves codex fast mode when it is the only active option", () => {
     const state = getComposerProviderState({
       provider: "codex",

--- a/apps/web/src/providerModels.ts
+++ b/apps/web/src/providerModels.ts
@@ -5,7 +5,7 @@ import {
   type ServerProvider,
   type ServerProviderModel,
 } from "@t3tools/contracts";
-import { normalizeModelSlug } from "@t3tools/shared/model";
+import { DEFAULT_CODEX_MODEL_CAPABILITIES, normalizeModelSlug } from "@t3tools/shared/model";
 
 const EMPTY_CAPABILITIES: ModelCapabilities = {
   reasoningEffortLevels: [],
@@ -53,7 +53,10 @@ export function getProviderModelCapabilities(
   provider: ProviderKind,
 ): ModelCapabilities {
   const slug = normalizeModelSlug(model, provider);
-  return models.find((candidate) => candidate.slug === slug)?.capabilities ?? EMPTY_CAPABILITIES;
+  const capabilities = models.find((candidate) => candidate.slug === slug)?.capabilities;
+  return (
+    capabilities ?? (provider === "codex" ? DEFAULT_CODEX_MODEL_CAPABILITIES : EMPTY_CAPABILITIES)
+  );
 }
 
 export function getDefaultServerModel(

--- a/packages/shared/src/model.ts
+++ b/packages/shared/src/model.ts
@@ -14,6 +14,19 @@ export interface SelectableModelOption {
   name: string;
 }
 
+export const DEFAULT_CODEX_MODEL_CAPABILITIES: ModelCapabilities = {
+  reasoningEffortLevels: [
+    { value: "xhigh", label: "Extra High" },
+    { value: "high", label: "High", isDefault: true },
+    { value: "medium", label: "Medium" },
+    { value: "low", label: "Low" },
+  ],
+  supportsFastMode: true,
+  supportsThinkingToggle: false,
+  contextWindowOptions: [],
+  promptInjectedEffortLevels: [],
+};
+
 // ── Effort helpers ────────────────────────────────────────────────────
 
 /** Check whether a capabilities object includes a given effort value. */


### PR DESCRIPTION
## Summary
- Standardized Codex custom-model behavior on the shared Codex defaults instead of leaving capabilities empty.
- Propagated the default Codex capability set through server model resolution and web-side model capability lookups.
- Added coverage to verify custom Codex models expose the expected effort options and preserve dispatch behavior.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- Not run: `bun run test`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use Codex defaults for custom model capabilities
> - Adds `DEFAULT_CODEX_MODEL_CAPABILITIES` constant in [`packages/shared/src/model.ts`](https://github.com/pingdotgg/t3code/pull/1792/files#diff-6319cd97b4ed5842958c7fbc93b4ed733efa158c2b1ad15c1d54bcddea713505) defining standard Codex capabilities: effort levels (xhigh, high, medium, low), fast mode support, and no thinking toggle.
> - Updates [`getCodexModelCapabilities`](https://github.com/pingdotgg/t3code/pull/1792/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) to return these defaults when a model slug is not found, instead of returning empty/null capabilities.
> - Updates [`providerModelsFromSettings`](https://github.com/pingdotgg/t3code/pull/1792/files#diff-62373f674410fb63637739f0efeb07b9ef79b579393ae2adf51567de0b812b26) to accept an optional `defaultCustomCapabilities` parameter, so custom Codex models are created with standard capabilities rather than null.
> - Updates [`getProviderModelCapabilities`](https://github.com/pingdotgg/t3code/pull/1792/files#diff-aae3d964ea760fa1047227e41883ae0577a1676fb25c3f549a31c75ef72319c4) on the web side to fall back to `DEFAULT_CODEX_MODEL_CAPABILITIES` for Codex provider models that have no explicit capabilities.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4db64af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->