### PR TITLE
Add project rename support in the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -267,8 +267,9 @@ interface SidebarThreadRowProps {
   renamingThreadId: ThreadId | null;
   renamingTitle: string;
   setRenamingTitle: (title: string) => void;
-  renamingInputRef: MutableRefObject<HTMLInputElement | null>;
-  renamingCommittedRef: MutableRefObject<boolean>;
+  onRenamingInputMount: (element: HTMLInputElement | null) => void;
+  hasRenameCommitted: () => boolean;
+  markRenameCommitted: () => void;
   confirmingArchiveThreadId: ThreadId | null;
   setConfirmingArchiveThreadId: Dispatch<SetStateAction<ThreadId | null>>;
   confirmArchiveButtonRefs: MutableRefObject<Map<ThreadId, HTMLButtonElement>>;
@@ -400,13 +401,7 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
           {threadStatus && <ThreadStatusLabel status={threadStatus} />}
           {props.renamingThreadId === thread.id ? (
             <input
-              ref={(element) => {
-                if (element && props.renamingInputRef.current !== element) {
-                  props.renamingInputRef.current = element;
-                  element.focus();
-                  element.select();
-                }
-              }}
+              ref={props.onRenamingInputMount}
               className="min-w-0 flex-1 truncate text-xs bg-transparent outline-none border border-ring rounded px-0.5"
               value={props.renamingTitle}
               onChange={(event) => props.setRenamingTitle(event.target.value)}
@@ -414,16 +409,16 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
                 event.stopPropagation();
                 if (event.key === "Enter") {
                   event.preventDefault();
-                  props.renamingCommittedRef.current = true;
+                  props.markRenameCommitted();
                   void props.commitRename(thread.id, props.renamingTitle, thread.title);
                 } else if (event.key === "Escape") {
                   event.preventDefault();
-                  props.renamingCommittedRef.current = true;
+                  props.markRenameCommitted();
                   props.cancelRename();
                 }
               }}
               onBlur={() => {
-                if (!props.renamingCommittedRef.current) {
+                if (!props.hasRenameCommitted()) {
                   void props.commitRename(thread.id, props.renamingTitle, thread.title);
                 }
               }}
@@ -718,6 +713,8 @@ export default function Sidebar() {
   const [isAddingProject, setIsAddingProject] = useState(false);
   const [addProjectError, setAddProjectError] = useState<string | null>(null);
   const addProjectInputRef = useRef<HTMLInputElement | null>(null);
+  const [renamingProjectId, setRenamingProjectId] = useState<ProjectId | null>(null);
+  const [renamingProjectTitle, setRenamingProjectTitle] = useState("");
   const [renamingThreadId, setRenamingThreadId] = useState<ThreadId | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
   const [confirmingArchiveThreadId, setConfirmingArchiveThreadId] = useState<ThreadId | null>(null);
@@ -725,6 +722,8 @@ export default function Sidebar() {
     ReadonlySet<ProjectId>
   >(() => new Set());
   const { showThreadJumpHints, updateThreadJumpHintsVisibility } = useThreadJumpHintVisibility();
+  const projectRenamingCommittedRef = useRef(false);
+  const projectRenamingInputRef = useRef<HTMLInputElement | null>(null);
   const renamingCommittedRef = useRef(false);
   const renamingInputRef = useRef<HTMLInputElement | null>(null);
   const confirmArchiveButtonRefs = useRef(new Map<ThreadId, HTMLButtonElement>());
@@ -937,6 +936,28 @@ export default function Sidebar() {
     renamingInputRef.current = null;
   }, []);
 
+  const handleRenamingInputMount = useCallback((element: HTMLInputElement | null) => {
+    if (element && renamingInputRef.current !== element) {
+      renamingInputRef.current = element;
+      element.focus();
+      element.select();
+      return;
+    }
+    if (element === null && renamingInputRef.current !== null) {
+      renamingInputRef.current = null;
+    }
+  }, []);
+
+  const hasRenameCommitted = useCallback(() => renamingCommittedRef.current, []);
+  const markRenameCommitted = useCallback(() => {
+    renamingCommittedRef.current = true;
+  }, []);
+
+  const cancelProjectRename = useCallback(() => {
+    setRenamingProjectId(null);
+    projectRenamingInputRef.current = null;
+  }, []);
+
   const commitRename = useCallback(
     async (threadId: ThreadId, newTitle: string, originalTitle: string) => {
       const finishRename = () => {
@@ -976,6 +997,53 @@ export default function Sidebar() {
         toastManager.add({
           type: "error",
           title: "Failed to rename thread",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
+      }
+      finishRename();
+    },
+    [],
+  );
+
+  const commitProjectRename = useCallback(
+    async (projectId: ProjectId, newTitle: string, originalTitle: string) => {
+      const finishRename = () => {
+        setRenamingProjectId((current) => {
+          if (current !== projectId) return current;
+          projectRenamingInputRef.current = null;
+          return null;
+        });
+      };
+
+      const trimmed = newTitle.trim();
+      if (trimmed.length === 0) {
+        toastManager.add({
+          type: "warning",
+          title: "Project title cannot be empty",
+        });
+        finishRename();
+        return;
+      }
+      if (trimmed === originalTitle) {
+        finishRename();
+        return;
+      }
+      const api = readNativeApi();
+      if (!api) {
+        finishRename();
+        return;
+      }
+      try {
+        await api.orchestration.dispatchCommand({
+          type: "project.meta.update",
+          commandId: newCommandId(),
+          projectId,
+          title: trimmed,
+        });
+      } catch (error) {
+        toastManager.add({
+          type: "error",
+          title: "Failed to rename project",
           description: error instanceof Error ? error.message : "An error occurred.",
         });
       }
@@ -1040,6 +1108,8 @@ export default function Sidebar() {
       );
 
       if (clicked === "rename") {
+        setRenamingProjectId(null);
+        projectRenamingInputRef.current = null;
         setRenamingThreadId(threadId);
         setRenamingTitle(thread.title);
         renamingCommittedRef.current = false;
@@ -1206,11 +1276,20 @@ export default function Sidebar() {
 
       const clicked = await api.contextMenu.show(
         [
+          { id: "rename", label: "Rename project" },
           { id: "copy-path", label: "Copy Project Path" },
           { id: "delete", label: "Remove project", destructive: true },
         ],
         position,
       );
+      if (clicked === "rename") {
+        setRenamingThreadId(null);
+        renamingInputRef.current = null;
+        setRenamingProjectId(projectId);
+        setRenamingProjectTitle(project.name);
+        projectRenamingCommittedRef.current = false;
+        return;
+      }
       if (clicked === "copy-path") {
         copyPathToClipboard(project.cwd, { path: project.cwd });
         return;
@@ -1602,9 +1681,43 @@ export default function Sidebar() {
               />
             )}
             <ProjectFavicon cwd={project.cwd} />
-            <span className="flex-1 truncate text-xs font-medium text-foreground/90">
-              {project.name}
-            </span>
+            {renamingProjectId === project.id ? (
+              <input
+                ref={(element) => {
+                  if (element && projectRenamingInputRef.current !== element) {
+                    projectRenamingInputRef.current = element;
+                    element.focus();
+                    element.select();
+                  }
+                }}
+                className="min-w-0 flex-1 truncate rounded border border-ring bg-transparent px-0.5 text-xs font-medium text-foreground/90 outline-none"
+                value={renamingProjectTitle}
+                onChange={(event) => setRenamingProjectTitle(event.target.value)}
+                onKeyDown={(event) => {
+                  event.stopPropagation();
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    projectRenamingCommittedRef.current = true;
+                    void commitProjectRename(project.id, renamingProjectTitle, project.name);
+                  } else if (event.key === "Escape") {
+                    event.preventDefault();
+                    projectRenamingCommittedRef.current = true;
+                    cancelProjectRename();
+                  }
+                }}
+                onBlur={() => {
+                  if (!projectRenamingCommittedRef.current) {
+                    void commitProjectRename(project.id, renamingProjectTitle, project.name);
+                  }
+                }}
+                onClick={(event) => event.stopPropagation()}
+                onPointerDown={(event) => event.stopPropagation()}
+              />
+            ) : (
+              <span className="flex-1 truncate text-xs font-medium text-foreground/90">
+                {project.name}
+              </span>
+            )}
           </SidebarMenuButton>
           <Tooltip>
             <TooltipTrigger
@@ -1693,8 +1806,9 @@ export default function Sidebar() {
                 renamingThreadId={renamingThreadId}
                 renamingTitle={renamingTitle}
                 setRenamingTitle={setRenamingTitle}
-                renamingInputRef={renamingInputRef}
-                renamingCommittedRef={renamingCommittedRef}
+                onRenamingInputMount={handleRenamingInputMount}
+                hasRenameCommitted={hasRenameCommitted}
+                markRenameCommitted={markRenameCommitted}
                 confirmingArchiveThreadId={confirmingArchiveThreadId}
                 setConfirmingArchiveThreadId={setConfirmingArchiveThreadId}
                 confirmArchiveButtonRefs={confirmArchiveButtonRefs}

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -328,6 +328,27 @@ describe("incremental orchestration updates", () => {
     expect(next.bootstrapComplete).toBe(false);
   });
 
+  it("updates the existing project title when project.meta-updated arrives", () => {
+    const projectId = ProjectId.makeUnsafe("project-1");
+    const state = makeState(
+      makeThread({
+        projectId,
+      }),
+    );
+
+    const next = applyOrchestrationEvent(
+      state,
+      makeEvent("project.meta-updated", {
+        projectId,
+        title: "Renamed Project",
+        updatedAt: "2026-02-27T00:00:01.000Z",
+      }),
+    );
+
+    expect(next.projects[0]?.name).toBe("Renamed Project");
+    expect(next.projects[0]?.updatedAt).toBe("2026-02-27T00:00:01.000Z");
+  });
+
   it("preserves state identity for no-op project and thread deletes", () => {
     const thread = makeThread();
     const state = makeState(thread);


### PR DESCRIPTION
Closes #1370 

<img width="734" height="352" alt="CleanShot 2026-04-06 at 16 03 39@2x" src="https://github.com/user-attachments/assets/23a8045c-c125-4be0-adc4-0282a627973d" />
<img width="756" height="372" alt="CleanShot 2026-04-06 at 16 03 42@2x" src="https://github.com/user-attachments/assets/c97827d1-b4fc-4a7c-b1e1-08266b175f47" />


## Summary
- Adds inline project rename support from the sidebar project row context menu.
- Commits project title changes through `project.meta.update` and clears rename state on blur, Enter, or Escape.
- Updates orchestration store coverage so `project.meta-updated` refreshes the existing project name and timestamp.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state changes that add a new `project.meta.update` command dispatch path; main risk is minor rename-state edge cases (blur/escape/enter) affecting sidebar interactions.
> 
> **Overview**
> Adds inline **project rename** in the sidebar: a new "Rename project" context-menu action swaps the project title for an input, then commits on Enter/blur (or cancels on Escape) by dispatching `project.meta.update`.
> 
> Refactors thread renaming to pass explicit callbacks (`onRenamingInputMount`, `hasRenameCommitted`, `markRenameCommitted`) instead of exposing mutable refs, and ensures starting a rename clears any active rename state for the other entity (project vs thread).
> 
> Extends store tests to cover `project.meta-updated` updating an existing project’s `name` and `updatedAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe56ef0dd2ab27b6c5ee450c19794ace7ae8f464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add inline project rename support in the sidebar
> - Adds a 'Rename project' option to the project context menu in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1798/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), replacing the static project name with an inline input when active.
> - On Enter or blur, dispatches a `project.meta.update` command via the native API; on Escape, cancels without saving. Shows a toast on error.
> - Starting a project rename cancels any active thread rename, and vice versa.
> - Refactors thread rename props in `SidebarThreadRow` from ref-based to function-based (`onRenamingInputMount`, `hasRenameCommitted`, `markRenameCommitted`).
> - Adds a test in [store.test.ts](https://github.com/pingdotgg/t3code/pull/1798/files#diff-da5bb58321c36f9d05fab4094aeab97a54cb8eb30f13d85a80ab85bbbd7f3405) verifying that `project.meta-updated` events correctly update project title and `updatedAt` in state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe56ef0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->