### PR TITLE
git diff pane + diff qol

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1594,6 +1594,83 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    describe("readWorkingTreeDiff", () => {
+      it.effect("returns an empty diff for a clean repo", () =>
+        Effect.gen(function* () {
+          const tmp = yield* makeTmpDir();
+          yield* initRepoWithCommit(tmp);
+          const diff = yield* (yield* GitCore).readWorkingTreeDiff(tmp);
+          expect(diff).toEqual({ diff: "" });
+        }),
+      );
+
+      it.effect("returns a patch for tracked modifications", () =>
+        Effect.gen(function* () {
+          const tmp = yield* makeTmpDir();
+          yield* initRepoWithCommit(tmp);
+
+          yield* writeTextFile(path.join(tmp, "README.md"), "# test\ntracked change\n");
+
+          const diff = yield* (yield* GitCore).readWorkingTreeDiff(tmp);
+          expect(diff.diff).toContain("diff --git a/README.md b/README.md");
+          expect(diff.diff).toContain("tracked change");
+        }),
+      );
+
+      it.effect("returns a new-file patch for untracked files", () =>
+        Effect.gen(function* () {
+          const tmp = yield* makeTmpDir();
+          yield* initRepoWithCommit(tmp);
+
+          yield* writeTextFile(path.join(tmp, "notes.txt"), "hello\n");
+
+          const diff = yield* (yield* GitCore).readWorkingTreeDiff(tmp);
+          expect(diff.diff).toContain("diff --git a/notes.txt b/notes.txt");
+          expect(diff.diff).toContain("new file mode");
+          expect(diff.diff).toContain("+++ b/notes.txt");
+        }),
+      );
+
+      it.effect("includes combined staged and unstaged changes against HEAD", () =>
+        Effect.gen(function* () {
+          const tmp = yield* makeTmpDir();
+          yield* initRepoWithCommit(tmp);
+
+          yield* writeTextFile(path.join(tmp, "README.md"), "# test\nstaged change\n");
+          yield* git(tmp, ["add", "README.md"]);
+          yield* writeTextFile(
+            path.join(tmp, "README.md"),
+            "# test\nstaged change\nunstaged change\n",
+          );
+
+          const diff = yield* (yield* GitCore).readWorkingTreeDiff(tmp);
+          expect(diff.diff).toContain("diff --git a/README.md b/README.md");
+          expect(diff.diff).toContain("staged change");
+          expect(diff.diff).toContain("unstaged change");
+        }),
+      );
+
+      it.effect("includes staged and untracked changes before the first commit", () =>
+        Effect.gen(function* () {
+          const tmp = yield* makeTmpDir();
+          const core = yield* GitCore;
+          yield* core.initRepo({ cwd: tmp });
+          yield* git(tmp, ["config", "user.email", "test@test.com"]);
+          yield* git(tmp, ["config", "user.name", "Test"]);
+
+          yield* writeTextFile(path.join(tmp, "staged.txt"), "staged\n");
+          yield* writeTextFile(path.join(tmp, "untracked.txt"), "untracked\n");
+          yield* git(tmp, ["add", "staged.txt"]);
+
+          const diff = yield* core.readWorkingTreeDiff(tmp);
+          expect(diff.diff).toContain("diff --git a/staged.txt b/staged.txt");
+          expect(diff.diff).toContain("diff --git a/untracked.txt b/untracked.txt");
+          expect(diff.diff).toContain("+++ b/staged.txt");
+          expect(diff.diff).toContain("+++ b/untracked.txt");
+        }),
+      );
+    });
+
     it.effect("computes ahead count against base branch when no upstream is configured", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -40,6 +40,7 @@ import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
+const LARGE_DIFF_MAX_OUTPUT_BYTES = 5_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
 const PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES = 49_000;
 const RANGE_COMMIT_SUMMARY_MAX_OUTPUT_BYTES = 19_000;
@@ -185,6 +186,13 @@ function parseBranchLine(line: string): { name: string; current: boolean } | nul
     name,
     current: trimmed.startsWith("* "),
   };
+}
+
+function parseNullSeparatedLines(stdout: string): string[] {
+  return stdout
+    .split("\u0000")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
 }
 
 function filterBranchesForListQuery(
@@ -1337,6 +1345,84 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       })),
     );
 
+  const readWorkingTreeDiff: GitCoreShape["readWorkingTreeDiff"] = Effect.fn("readWorkingTreeDiff")(
+    function* (cwd) {
+      const headResult = yield* executeGit(
+        "GitCore.readWorkingTreeDiff.verifyHead",
+        cwd,
+        ["rev-parse", "--verify", "HEAD"],
+        {
+          allowNonZeroExit: true,
+        },
+      );
+      const headExists = headResult.code === 0;
+
+      const trackedPatchSegments = headExists
+        ? [
+            yield* runGitStdoutWithOptions(
+              "GitCore.readWorkingTreeDiff.trackedPatch",
+              cwd,
+              ["diff", "HEAD", "--patch", "--minimal"],
+              {
+                maxOutputBytes: LARGE_DIFF_MAX_OUTPUT_BYTES,
+              },
+            ),
+          ]
+        : yield* Effect.all(
+            [
+              runGitStdoutWithOptions(
+                "GitCore.readWorkingTreeDiff.cachedRootPatch",
+                cwd,
+                ["diff", "--cached", "--patch", "--minimal", "--root"],
+                {
+                  maxOutputBytes: LARGE_DIFF_MAX_OUTPUT_BYTES,
+                },
+              ),
+              runGitStdoutWithOptions(
+                "GitCore.readWorkingTreeDiff.workingTreePatch",
+                cwd,
+                ["diff", "--patch", "--minimal"],
+                {
+                  maxOutputBytes: LARGE_DIFF_MAX_OUTPUT_BYTES,
+                },
+              ),
+            ],
+            { concurrency: "unbounded" },
+          );
+
+      const untrackedPaths = parseNullSeparatedLines(
+        yield* runGitStdout("GitCore.readWorkingTreeDiff.untrackedFiles", cwd, [
+          "ls-files",
+          "--others",
+          "--exclude-standard",
+          "-z",
+        ]),
+      ).toSorted((left, right) => left.localeCompare(right));
+
+      const untrackedPatches = yield* Effect.forEach(
+        untrackedPaths,
+        (relativePath) =>
+          runGitStdoutWithOptions(
+            "GitCore.readWorkingTreeDiff.untrackedPatch",
+            cwd,
+            ["diff", "--no-index", "--patch", "--minimal", "--", "/dev/null", relativePath],
+            {
+              allowNonZeroExit: true,
+              maxOutputBytes: LARGE_DIFF_MAX_OUTPUT_BYTES,
+            },
+          ).pipe(Effect.map((patch) => patch.trim())),
+        { concurrency: "unbounded" },
+      );
+
+      const diff = [...trackedPatchSegments, ...untrackedPatches]
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0)
+        .join("\n\n");
+
+      return { diff };
+    },
+  );
+
   const prepareCommitContext: GitCoreShape["prepareCommitContext"] = Effect.fn(
     "prepareCommitContext",
   )(function* (cwd, filePaths) {
@@ -2127,6 +2213,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
   return {
     execute,
     status,
+    readWorkingTreeDiff,
     statusDetails,
     statusDetailsLocal,
     prepareCommitContext,

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -15,6 +15,7 @@ import type {
   GitCreateBranchResult,
   GitCreateWorktreeInput,
   GitCreateWorktreeResult,
+  GitDiffResult,
   GitInitInput,
   GitListBranchesInput,
   GitListBranchesResult,
@@ -152,6 +153,11 @@ export interface GitCoreShape {
    * Read Git status for a repository.
    */
   readonly status: (input: GitStatusInput) => Effect.Effect<GitStatusResult, GitCommandError>;
+
+  /**
+   * Read a patch for all working tree changes, including untracked files.
+   */
+  readonly readWorkingTreeDiff: (cwd: string) => Effect.Effect<GitDiffResult, GitCommandError>;
 
   /**
    * Read detailed working tree / branch status for a repository.

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -589,6 +589,10 @@ const WsRpcLayer = WsRpcGroup.toLayer(
           ),
           { "rpc.aggregate": "git" },
         ),
+      [WS_METHODS.gitDiff]: (input) =>
+        observeRpcEffect(WS_METHODS.gitDiff, git.readWorkingTreeDiff(input.cwd), {
+          "rpc.aggregate": "git",
+        }),
       [WS_METHODS.gitRunStackedAction]: (input) =>
         observeRpcStream(
           WS_METHODS.gitRunStackedAction,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3877,8 +3877,14 @@ export default function ChatView({ threadId }: ChatViewProps) {
         search: (previous) => {
           const rest = stripDiffSearchParams(previous);
           return filePath
-            ? { ...rest, diff: "1", diffTurnId: turnId, diffFilePath: filePath }
-            : { ...rest, diff: "1", diffTurnId: turnId };
+            ? {
+                ...rest,
+                diff: "1",
+                diffScope: "session",
+                diffTurnId: turnId,
+                diffFilePath: filePath,
+              }
+            : { ...rest, diff: "1", diffScope: "session", diffTurnId: turnId };
         },
       });
     },

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -4,9 +4,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { ThreadId, type TurnId } from "@t3tools/contracts";
 import {
+  ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   Columns2Icon,
+  GitBranchIcon,
+  HistoryIcon,
   Rows3Icon,
   TextWrapIcon,
 } from "lucide-react";
@@ -18,13 +21,11 @@ import {
   useRef,
   useState,
 } from "react";
-import { openInPreferredEditor } from "../editorPreferences";
 import { useGitStatus } from "~/lib/gitStatusState";
+import { gitDiffQueryOptions } from "~/lib/gitReactQuery";
 import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
 import { cn } from "~/lib/utils";
-import { readNativeApi } from "../nativeApi";
-import { resolvePathLinkTarget } from "../terminal-links";
-import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import { parseDiffRouteSearch, stripDiffSearchParams, type DiffScope } from "../diffRouteSearch";
 import { useTheme } from "../hooks/useTheme";
 import { buildPatchCacheKey } from "../lib/diffRendering";
 import { resolveDiffThemeName } from "../lib/diffRendering";
@@ -33,10 +34,18 @@ import { useStore } from "../store";
 import { useSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
+import { VscodeEntryIcon } from "./chat/VscodeEntryIcon";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
 type DiffRenderMode = "stacked" | "split";
 type DiffThemeType = "light" | "dark";
+
+const DIFF_SCOPE_STORAGE_KEY = "t3code:diff-panel-scope";
+const DEFAULT_DIFF_SCOPE: DiffScope = "git";
+
+function getWorkingTreeCollapsedStorageKey(cwd: string): string {
+  return `t3code:diff-panel:git-collapsed:${cwd}`;
+}
 
 const DIFF_PANEL_UNSAFE_CSS = `
 [data-diffs-header],
@@ -153,8 +162,56 @@ function resolveFileDiffPath(fileDiff: FileDiffMetadata): string {
   return raw;
 }
 
+function splitFileDiffPath(filePath: string): { directory: string | null; fileName: string } {
+  const normalizedPath = filePath.replace(/\/+$/, "");
+  const lastSlashIndex = normalizedPath.lastIndexOf("/");
+  if (lastSlashIndex === -1) {
+    return { directory: null, fileName: normalizedPath };
+  }
+  return {
+    directory: normalizedPath.slice(0, lastSlashIndex + 1),
+    fileName: normalizedPath.slice(lastSlashIndex + 1),
+  };
+}
+
 function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {
   return fileDiff.cacheKey ?? `${fileDiff.prevName ?? "none"}:${fileDiff.name}`;
+}
+
+function getFileDiffLineStats(fileDiff: FileDiffMetadata) {
+  return fileDiff.hunks.reduce(
+    (totals, hunk) => ({
+      additions: totals.additions + hunk.additionLines,
+      deletions: totals.deletions + hunk.deletionLines,
+    }),
+    { additions: 0, deletions: 0 },
+  );
+}
+
+function getFileDiffChangeLabel(fileDiff: FileDiffMetadata): string {
+  switch (fileDiff.type) {
+    case "new":
+      return "Added";
+    case "deleted":
+      return "Removed";
+    case "rename-pure":
+      return "Renamed";
+    case "rename-changed":
+      return "Renamed and modified";
+    default:
+      return "Modified";
+  }
+}
+
+function getFileDiffNameClasses(fileDiff: FileDiffMetadata): string {
+  switch (fileDiff.type) {
+    case "new":
+      return "text-emerald-600 dark:text-emerald-400";
+    case "deleted":
+      return "text-rose-600 dark:text-rose-400";
+    default:
+      return "text-foreground";
+  }
 }
 
 interface DiffPanelProps {
@@ -167,6 +224,13 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const navigate = useNavigate();
   const { resolvedTheme } = useTheme();
   const settings = useSettings();
+  const [rememberedDiffScope, setRememberedDiffScope] = useState<DiffScope>(() => {
+    if (typeof window === "undefined") {
+      return DEFAULT_DIFF_SCOPE;
+    }
+    const storedValue = window.localStorage.getItem(DIFF_SCOPE_STORAGE_KEY);
+    return storedValue === "session" || storedValue === "git" ? storedValue : DEFAULT_DIFF_SCOPE;
+  });
   const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("stacked");
   const [diffWordWrap, setDiffWordWrap] = useState(settings.diffWordWrap);
   const patchViewportRef = useRef<HTMLDivElement>(null);
@@ -174,12 +238,15 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const previousDiffOpenRef = useRef(false);
   const [canScrollTurnStripLeft, setCanScrollTurnStripLeft] = useState(false);
   const [canScrollTurnStripRight, setCanScrollTurnStripRight] = useState(false);
+  const [collapsedFileKeys, setCollapsedFileKeys] = useState<Set<string>>(() => new Set());
   const routeThreadId = useParams({
     strict: false,
     select: (params) => (params.threadId ? ThreadId.makeUnsafe(params.threadId) : null),
   });
   const diffSearch = useSearch({ strict: false, select: (search) => parseDiffRouteSearch(search) });
   const diffOpen = diffSearch.diff === "1";
+  const diffScope = diffSearch.diffScope ?? rememberedDiffScope;
+  const isSessionDiffScope = diffScope === "session";
   const activeThreadId = routeThreadId;
   const activeThread = useStore((store) =>
     activeThreadId ? store.threads.find((thread) => thread.id === activeThreadId) : undefined,
@@ -266,24 +333,41 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       fromTurnCount: activeCheckpointRange?.fromTurnCount ?? null,
       toTurnCount: activeCheckpointRange?.toTurnCount ?? null,
       cacheScope: selectedTurn ? `turn:${selectedTurn.turnId}` : conversationCacheScope,
-      enabled: isGitRepo,
+      enabled: isGitRepo && isSessionDiffScope,
     }),
   );
+  const gitDiffQuery = useQuery({
+    ...gitDiffQueryOptions(activeCwd ?? null),
+    enabled: isGitRepo && !isSessionDiffScope && activeCwd !== null,
+  });
   const selectedTurnCheckpointDiff = selectedTurn
     ? activeCheckpointDiffQuery.data?.diff
     : undefined;
   const conversationCheckpointDiff = selectedTurn
     ? undefined
     : activeCheckpointDiffQuery.data?.diff;
-  const isLoadingCheckpointDiff = activeCheckpointDiffQuery.isLoading;
   const checkpointDiffError =
     activeCheckpointDiffQuery.error instanceof Error
       ? activeCheckpointDiffQuery.error.message
       : activeCheckpointDiffQuery.error
         ? "Failed to load checkpoint diff."
         : null;
+  const gitDiffError =
+    gitDiffQuery.error instanceof Error
+      ? gitDiffQuery.error.message
+      : gitDiffQuery.error
+        ? "Failed to load git diff."
+        : null;
 
-  const selectedPatch = selectedTurn ? selectedTurnCheckpointDiff : conversationCheckpointDiff;
+  const selectedPatch = isSessionDiffScope
+    ? selectedTurn
+      ? selectedTurnCheckpointDiff
+      : conversationCheckpointDiff
+    : gitDiffQuery.data?.diff;
+  const activeDiffError = isSessionDiffScope ? checkpointDiffError : gitDiffError;
+  const isLoadingSelectedPatch = isSessionDiffScope
+    ? activeCheckpointDiffQuery.isLoading
+    : gitDiffQuery.isLoading;
   const hasResolvedPatch = typeof selectedPatch === "string";
   const hasNoNetChanges = hasResolvedPatch && selectedPatch.trim().length === 0;
   const renderablePatch = useMemo(
@@ -301,6 +385,24 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       }),
     );
   }, [renderablePatch]);
+  const totalDiffLineStats = useMemo(
+    () =>
+      renderableFiles.reduce(
+        (totals, fileDiff) => {
+          const lineStats = getFileDiffLineStats(fileDiff);
+          return {
+            additions: totals.additions + lineStats.additions,
+            deletions: totals.deletions + lineStats.deletions,
+          };
+        },
+        { additions: 0, deletions: 0 },
+      ),
+    [renderableFiles],
+  );
+
+  const allDiffCardsCollapsed =
+    renderableFiles.length > 0 &&
+    renderableFiles.every((fileDiff) => collapsedFileKeys.has(buildFileDiffRenderKey(fileDiff)));
 
   useEffect(() => {
     if (diffOpen && !previousDiffOpenRef.current) {
@@ -310,25 +412,78 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   }, [diffOpen, settings.diffWordWrap]);
 
   useEffect(() => {
-    if (!selectedFilePath || !patchViewportRef.current) {
+    if (!isSessionDiffScope) {
+      return;
+    }
+    setCollapsedFileKeys(new Set());
+  }, [isSessionDiffScope, selectedPatch]);
+
+  useEffect(() => {
+    if (isSessionDiffScope || typeof window === "undefined") {
+      return;
+    }
+    if (!activeCwd) {
+      setCollapsedFileKeys(new Set());
+      return;
+    }
+
+    const rawValue = window.localStorage.getItem(getWorkingTreeCollapsedStorageKey(activeCwd));
+    if (!rawValue) {
+      setCollapsedFileKeys(new Set());
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(rawValue);
+      if (!Array.isArray(parsed)) {
+        setCollapsedFileKeys(new Set());
+        return;
+      }
+      setCollapsedFileKeys(
+        new Set(parsed.filter((value): value is string => typeof value === "string")),
+      );
+    } catch {
+      setCollapsedFileKeys(new Set());
+    }
+  }, [activeCwd, isSessionDiffScope]);
+
+  useEffect(() => {
+    setRememberedDiffScope(diffScope);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(DIFF_SCOPE_STORAGE_KEY, diffScope);
+    }
+  }, [diffScope]);
+
+  useEffect(() => {
+    if (isSessionDiffScope || typeof window === "undefined" || !activeCwd) {
+      return;
+    }
+    window.localStorage.setItem(
+      getWorkingTreeCollapsedStorageKey(activeCwd),
+      JSON.stringify([...collapsedFileKeys]),
+    );
+  }, [activeCwd, collapsedFileKeys, isSessionDiffScope]);
+
+  useEffect(() => {
+    if (!isSessionDiffScope || !selectedFilePath || !patchViewportRef.current) {
       return;
     }
     const target = Array.from(
       patchViewportRef.current.querySelectorAll<HTMLElement>("[data-diff-file-path]"),
     ).find((element) => element.dataset.diffFilePath === selectedFilePath);
     target?.scrollIntoView({ block: "nearest" });
-  }, [selectedFilePath, renderableFiles]);
+  }, [isSessionDiffScope, selectedFilePath, renderableFiles]);
 
-  const openDiffFileInEditor = useCallback(
-    (filePath: string) => {
-      const api = readNativeApi();
-      if (!api) return;
-      const targetPath = activeCwd ? resolvePathLinkTarget(filePath, activeCwd) : filePath;
-      void openInPreferredEditor(api, targetPath).catch((error) => {
-        console.warn("Failed to open diff file in editor.", error);
+  const selectDiffScope = useCallback(
+    (nextScope: DiffScope) => {
+      if (!activeThread) return;
+      void navigate({
+        to: "/$threadId",
+        params: { threadId: activeThread.id },
+        search: (previous) => ({ ...previous, diff: "1", diffScope: nextScope }),
       });
     },
-    [activeCwd],
+    [activeThread, navigate],
   );
 
   const selectTurn = (turnId: TurnId) => {
@@ -338,7 +493,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       params: { threadId: activeThread.id },
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1", diffTurnId: turnId };
+        return { ...rest, diff: "1", diffScope: "session", diffTurnId: turnId };
       },
     });
   };
@@ -349,7 +504,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       params: { threadId: activeThread.id },
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
+        return { ...rest, diff: "1", diffScope: "session" };
       },
     });
   };
@@ -379,6 +534,30 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     event.preventDefault();
     element.scrollBy({ left: event.deltaY, behavior: "auto" });
   }, []);
+
+  const toggleFileCollapsed = useCallback((fileKey: string) => {
+    setCollapsedFileKeys((previous) => {
+      const next = new Set(previous);
+      if (next.has(fileKey)) {
+        next.delete(fileKey);
+      } else {
+        next.add(fileKey);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAllDiffCards = useCallback(() => {
+    setCollapsedFileKeys((previous) => {
+      const shouldExpandAll = renderableFiles.every((fileDiff) =>
+        previous.has(buildFileDiffRenderKey(fileDiff)),
+      );
+      if (shouldExpandAll) {
+        return new Set();
+      }
+      return new Set(renderableFiles.map((fileDiff) => buildFileDiffRenderKey(fileDiff)));
+    });
+  }, [renderableFiles]);
 
   useEffect(() => {
     const element = turnStripRef.current;
@@ -414,99 +593,137 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     selectedChip?.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "smooth" });
   }, [selectedTurn?.turnId, selectedTurnId]);
 
-  const headerRow = (
-    <>
-      <div className="relative min-w-0 flex-1 [-webkit-app-region:no-drag]">
-        {canScrollTurnStripLeft && (
-          <div className="pointer-events-none absolute inset-y-0 left-8 z-10 w-7 bg-linear-to-r from-card to-transparent" />
+  const headerLead = isSessionDiffScope ? (
+    <div className="relative min-w-0 flex-1 [-webkit-app-region:no-drag]">
+      {canScrollTurnStripLeft && (
+        <div className="pointer-events-none absolute inset-y-0 left-8 z-10 w-7 bg-linear-to-r from-card to-transparent" />
+      )}
+      {canScrollTurnStripRight && (
+        <div className="pointer-events-none absolute inset-y-0 right-8 z-10 w-7 bg-linear-to-l from-card to-transparent" />
+      )}
+      <button
+        type="button"
+        className={cn(
+          "absolute left-0 top-1/2 z-20 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-md border bg-background/90 text-muted-foreground transition-colors",
+          canScrollTurnStripLeft
+            ? "border-border/70 hover:border-border hover:text-foreground"
+            : "cursor-not-allowed border-border/40 text-muted-foreground/40",
         )}
-        {canScrollTurnStripRight && (
-          <div className="pointer-events-none absolute inset-y-0 right-8 z-10 w-7 bg-linear-to-l from-card to-transparent" />
+        onClick={() => scrollTurnStripBy(-180)}
+        disabled={!canScrollTurnStripLeft}
+        aria-label="Scroll turn list left"
+      >
+        <ChevronLeftIcon className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        className={cn(
+          "absolute right-0 top-1/2 z-20 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-md border bg-background/90 text-muted-foreground transition-colors",
+          canScrollTurnStripRight
+            ? "border-border/70 hover:border-border hover:text-foreground"
+            : "cursor-not-allowed border-border/40 text-muted-foreground/40",
         )}
+        onClick={() => scrollTurnStripBy(180)}
+        disabled={!canScrollTurnStripRight}
+        aria-label="Scroll turn list right"
+      >
+        <ChevronRightIcon className="size-3.5" />
+      </button>
+      <div
+        ref={turnStripRef}
+        className="turn-chip-strip flex gap-1 overflow-x-auto px-8 py-0.5"
+        onWheel={onTurnStripWheel}
+      >
         <button
           type="button"
-          className={cn(
-            "absolute left-0 top-1/2 z-20 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-md border bg-background/90 text-muted-foreground transition-colors",
-            canScrollTurnStripLeft
-              ? "border-border/70 hover:border-border hover:text-foreground"
-              : "cursor-not-allowed border-border/40 text-muted-foreground/40",
-          )}
-          onClick={() => scrollTurnStripBy(-180)}
-          disabled={!canScrollTurnStripLeft}
-          aria-label="Scroll turn list left"
+          className="shrink-0 rounded-md"
+          onClick={selectWholeConversation}
+          data-turn-chip-selected={selectedTurnId === null}
         >
-          <ChevronLeftIcon className="size-3.5" />
+          <div
+            className={cn(
+              "rounded-md border px-2 py-1 text-left transition-colors",
+              selectedTurnId === null
+                ? "border-border bg-accent text-accent-foreground"
+                : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80",
+            )}
+          >
+            <div className="text-[10px] leading-tight font-medium">All turns</div>
+          </div>
         </button>
-        <button
-          type="button"
-          className={cn(
-            "absolute right-0 top-1/2 z-20 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-md border bg-background/90 text-muted-foreground transition-colors",
-            canScrollTurnStripRight
-              ? "border-border/70 hover:border-border hover:text-foreground"
-              : "cursor-not-allowed border-border/40 text-muted-foreground/40",
-          )}
-          onClick={() => scrollTurnStripBy(180)}
-          disabled={!canScrollTurnStripRight}
-          aria-label="Scroll turn list right"
-        >
-          <ChevronRightIcon className="size-3.5" />
-        </button>
-        <div
-          ref={turnStripRef}
-          className="turn-chip-strip flex gap-1 overflow-x-auto px-8 py-0.5"
-          onWheel={onTurnStripWheel}
-        >
+        {orderedTurnDiffSummaries.map((summary) => (
           <button
+            key={summary.turnId}
             type="button"
             className="shrink-0 rounded-md"
-            onClick={selectWholeConversation}
-            data-turn-chip-selected={selectedTurnId === null}
+            onClick={() => selectTurn(summary.turnId)}
+            title={summary.turnId}
+            data-turn-chip-selected={summary.turnId === selectedTurn?.turnId}
           >
             <div
               className={cn(
                 "rounded-md border px-2 py-1 text-left transition-colors",
-                selectedTurnId === null
+                summary.turnId === selectedTurn?.turnId
                   ? "border-border bg-accent text-accent-foreground"
                   : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80",
               )}
             >
-              <div className="text-[10px] leading-tight font-medium">All turns</div>
+              <div className="flex items-center gap-1">
+                <span className="text-[10px] leading-tight font-medium">
+                  Turn{" "}
+                  {summary.checkpointTurnCount ??
+                    inferredCheckpointTurnCountByTurnId[summary.turnId] ??
+                    "?"}
+                </span>
+                <span className="text-[9px] leading-tight opacity-70">
+                  {formatShortTimestamp(summary.completedAt, settings.timestampFormat)}
+                </span>
+              </div>
             </div>
           </button>
-          {orderedTurnDiffSummaries.map((summary) => (
-            <button
-              key={summary.turnId}
-              type="button"
-              className="shrink-0 rounded-md"
-              onClick={() => selectTurn(summary.turnId)}
-              title={summary.turnId}
-              data-turn-chip-selected={summary.turnId === selectedTurn?.turnId}
-            >
-              <div
-                className={cn(
-                  "rounded-md border px-2 py-1 text-left transition-colors",
-                  summary.turnId === selectedTurn?.turnId
-                    ? "border-border bg-accent text-accent-foreground"
-                    : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80",
-                )}
-              >
-                <div className="flex items-center gap-1">
-                  <span className="text-[10px] leading-tight font-medium">
-                    Turn{" "}
-                    {summary.checkpointTurnCount ??
-                      inferredCheckpointTurnCountByTurnId[summary.turnId] ??
-                      "?"}
-                  </span>
-                  <span className="text-[9px] leading-tight opacity-70">
-                    {formatShortTimestamp(summary.completedAt, settings.timestampFormat)}
-                  </span>
-                </div>
-              </div>
-            </button>
-          ))}
+        ))}
+      </div>
+    </div>
+  ) : (
+    <div className="min-w-0 flex-1 px-1 [-webkit-app-region:no-drag]">
+      <div className="flex items-center gap-2 overflow-x-auto py-0.5">
+        <div className="shrink-0 rounded-md border border-border bg-accent px-2 py-1 text-left text-[10px] leading-tight font-medium text-accent-foreground">
+          Working Tree
+        </div>
+        <div className="shrink-0 px-0.5 text-[11px] font-medium">
+          <span className="text-emerald-600 dark:text-emerald-400">
+            +{totalDiffLineStats.additions}
+          </span>
+          <span className="px-1" aria-hidden="true" />
+          <span className="text-rose-600 dark:text-rose-400">-{totalDiffLineStats.deletions}</span>
         </div>
       </div>
+    </div>
+  );
+
+  const headerRow = (
+    <>
+      {headerLead}
       <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+        <ToggleGroup
+          className="shrink-0"
+          variant="outline"
+          size="xs"
+          value={[diffScope]}
+          onValueChange={(value) => {
+            const next = value[0];
+            if (next === "session" || next === "git") {
+              selectDiffScope(next);
+            }
+          }}
+        >
+          <Toggle aria-label="Show session diff" title="Show session diff" value="session">
+            <HistoryIcon className="size-3" />
+          </Toggle>
+          <Toggle aria-label="Show full git diff" title="Show full git diff" value="git">
+            <GitBranchIcon className="size-3" />
+          </Toggle>
+        </ToggleGroup>
         <ToggleGroup
           className="shrink-0"
           variant="outline"
@@ -526,6 +743,23 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
             <Columns2Icon className="size-3" />
           </Toggle>
         </ToggleGroup>
+        <Toggle
+          aria-label={allDiffCardsCollapsed ? "Expand all diff cards" : "Collapse all diff cards"}
+          title={allDiffCardsCollapsed ? "Expand all" : "Collapse all"}
+          variant="outline"
+          size="xs"
+          disabled={renderableFiles.length === 0}
+          pressed={allDiffCardsCollapsed}
+          onPressedChange={() => {
+            toggleAllDiffCards();
+          }}
+        >
+          {allDiffCardsCollapsed ? (
+            <ChevronRightIcon className="size-3" />
+          ) : (
+            <ChevronDownIcon className="size-3" />
+          )}
+        </Toggle>
         <Toggle
           aria-label={diffWordWrap ? "Disable diff line wrapping" : "Enable diff line wrapping"}
           title={diffWordWrap ? "Disable line wrapping" : "Enable line wrapping"}
@@ -552,7 +786,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
           Turn diffs are unavailable because this project is not a git repository.
         </div>
-      ) : orderedTurnDiffSummaries.length === 0 ? (
+      ) : isSessionDiffScope && orderedTurnDiffSummaries.length === 0 ? (
         <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
           No completed turns yet.
         </div>
@@ -562,20 +796,26 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
             ref={patchViewportRef}
             className="diff-panel-viewport min-h-0 min-w-0 flex-1 overflow-hidden"
           >
-            {checkpointDiffError && !renderablePatch && (
+            {activeDiffError && !renderablePatch && (
               <div className="px-3">
-                <p className="mb-2 text-[11px] text-red-500/80">{checkpointDiffError}</p>
+                <p className="mb-2 text-[11px] text-red-500/80">{activeDiffError}</p>
               </div>
             )}
             {!renderablePatch ? (
-              isLoadingCheckpointDiff ? (
-                <DiffPanelLoadingState label="Loading checkpoint diff..." />
+              isLoadingSelectedPatch ? (
+                <DiffPanelLoadingState
+                  label={isSessionDiffScope ? "Loading checkpoint diff..." : "Loading git diff..."}
+                />
               ) : (
                 <div className="flex h-full items-center justify-center px-3 py-2 text-xs text-muted-foreground/70">
                   <p>
                     {hasNoNetChanges
-                      ? "No net changes in this selection."
-                      : "No patch available for this selection."}
+                      ? isSessionDiffScope
+                        ? "No net changes in this selection."
+                        : "Git reports no working tree changes."
+                      : !isSessionDiffScope
+                        ? "Git reports no working tree changes."
+                        : "No patch available for this selection."}
                   </p>
                 </div>
               )
@@ -589,36 +829,87 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
               >
                 {renderableFiles.map((fileDiff) => {
                   const filePath = resolveFileDiffPath(fileDiff);
+                  const { directory, fileName } = splitFileDiffPath(filePath);
                   const fileKey = buildFileDiffRenderKey(fileDiff);
                   const themedFileKey = `${fileKey}:${resolvedTheme}`;
+                  const diffBodyId = `diff-card-${themedFileKey.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+                  const isCollapsed = collapsedFileKeys.has(fileKey);
+                  const lineStats = getFileDiffLineStats(fileDiff);
+                  const changeLabel = getFileDiffChangeLabel(fileDiff);
                   return (
-                    <div
+                    <section
                       key={themedFileKey}
                       data-diff-file-path={filePath}
-                      className="diff-render-file mb-2 rounded-md first:mt-2 last:mb-0"
-                      onClickCapture={(event) => {
-                        const nativeEvent = event.nativeEvent as MouseEvent;
-                        const composedPath = nativeEvent.composedPath?.() ?? [];
-                        const clickedHeader = composedPath.some((node) => {
-                          if (!(node instanceof Element)) return false;
-                          return node.hasAttribute("data-title");
-                        });
-                        if (!clickedHeader) return;
-                        openDiffFileInEditor(filePath);
-                      }}
+                      className="diff-render-file mb-1.5 overflow-hidden rounded-md border border-border/70 bg-card/70 shadow-xs first:mt-2 last:mb-0"
                     >
-                      <FileDiff
-                        fileDiff={fileDiff}
-                        options={{
-                          diffStyle: diffRenderMode === "split" ? "split" : "unified",
-                          lineDiffType: "none",
-                          overflow: diffWordWrap ? "wrap" : "scroll",
-                          theme: resolveDiffThemeName(resolvedTheme),
-                          themeType: resolvedTheme as DiffThemeType,
-                          unsafeCSS: DIFF_PANEL_UNSAFE_CSS,
-                        }}
-                      />
-                    </div>
+                      <div className="flex min-h-8 items-center gap-2 px-2.5 py-0.75">
+                        <button
+                          type="button"
+                          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                          onClick={() => toggleFileCollapsed(fileKey)}
+                          aria-expanded={!isCollapsed}
+                          aria-controls={diffBodyId}
+                        >
+                          {isCollapsed ? (
+                            <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
+                          ) : (
+                            <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
+                          )}
+                          <VscodeEntryIcon
+                            pathValue={filePath}
+                            kind="file"
+                            theme={resolvedTheme}
+                            className="size-3.5"
+                          />
+                          <span className="min-w-0 truncate text-[13px] leading-none">
+                            {directory ? (
+                              <>
+                                <span className="text-muted-foreground/80">{directory}</span>
+                                <span
+                                  className={cn("font-medium", getFileDiffNameClasses(fileDiff))}
+                                >
+                                  {fileName}
+                                </span>
+                              </>
+                            ) : (
+                              <span className={cn("font-medium", getFileDiffNameClasses(fileDiff))}>
+                                {fileName}
+                              </span>
+                            )}
+                          </span>
+                        </button>
+                        <div className="flex shrink-0 items-center gap-1.5">
+                          <div
+                            className="flex items-center gap-1.5 px-0.5 text-[11px] font-medium"
+                            title={changeLabel}
+                            aria-label={changeLabel}
+                          >
+                            <span className="text-emerald-600 dark:text-emerald-400">
+                              +{lineStats.additions}
+                            </span>
+                            <span className="text-rose-600 dark:text-rose-400">
+                              -{lineStats.deletions}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      {!isCollapsed && (
+                        <div id={diffBodyId} className="border-t border-border/60 bg-background/20">
+                          <FileDiff
+                            fileDiff={fileDiff}
+                            options={{
+                              diffStyle: diffRenderMode === "split" ? "split" : "unified",
+                              disableFileHeader: true,
+                              lineDiffType: "none",
+                              overflow: diffWordWrap ? "wrap" : "scroll",
+                              theme: resolveDiffThemeName(resolvedTheme),
+                              themeType: resolvedTheme as DiffThemeType,
+                              unsafeCSS: DIFF_PANEL_UNSAFE_CSS,
+                            }}
+                          />
+                        </div>
+                      )}
+                    </section>
                   );
                 })}
               </Virtualizer>

--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -6,12 +6,14 @@ describe("parseDiffRouteSearch", () => {
   it("parses valid diff search values", () => {
     const parsed = parseDiffRouteSearch({
       diff: "1",
+      diffScope: "git",
       diffTurnId: "turn-1",
       diffFilePath: "src/app.ts",
     });
 
     expect(parsed).toEqual({
       diff: "1",
+      diffScope: "git",
       diffTurnId: "turn-1",
       diffFilePath: "src/app.ts",
     });
@@ -69,6 +71,43 @@ describe("parseDiffRouteSearch", () => {
 
     expect(parsed).toEqual({
       diff: "1",
+    });
+  });
+
+  it("leaves diff scope unset when absent", () => {
+    expect(
+      parseDiffRouteSearch({
+        diff: "1",
+      }),
+    ).toEqual({
+      diff: "1",
+    });
+  });
+
+  it("drops invalid diff scope values", () => {
+    expect(
+      parseDiffRouteSearch({
+        diff: "1",
+        diffScope: "workspace",
+      }),
+    ).toEqual({
+      diff: "1",
+    });
+  });
+
+  it("preserves turn and file state in git diff scope", () => {
+    expect(
+      parseDiffRouteSearch({
+        diff: "1",
+        diffScope: "git",
+        diffTurnId: "turn-1",
+        diffFilePath: "src/app.ts",
+      }),
+    ).toEqual({
+      diff: "1",
+      diffScope: "git",
+      diffTurnId: "turn-1",
+      diffFilePath: "src/app.ts",
     });
   });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -1,7 +1,10 @@
 import { TurnId } from "@t3tools/contracts";
 
+export type DiffScope = "session" | "git";
+
 export interface DiffRouteSearch {
   diff?: "1" | undefined;
+  diffScope?: DiffScope | undefined;
   diffTurnId?: TurnId | undefined;
   diffFilePath?: string | undefined;
 }
@@ -20,19 +23,29 @@ function normalizeSearchString(value: unknown): string | undefined {
 
 export function stripDiffSearchParams<T extends Record<string, unknown>>(
   params: T,
-): Omit<T, "diff" | "diffTurnId" | "diffFilePath"> {
-  const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, ...rest } = params;
-  return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
+): Omit<T, "diff" | "diffScope" | "diffTurnId" | "diffFilePath"> {
+  const {
+    diff: _diff,
+    diffScope: _diffScope,
+    diffTurnId: _diffTurnId,
+    diffFilePath: _diffFilePath,
+    ...rest
+  } = params;
+  return rest as Omit<T, "diff" | "diffScope" | "diffTurnId" | "diffFilePath">;
 }
 
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
   const diff = isDiffOpenValue(search.diff) ? "1" : undefined;
+  const diffScopeRaw = diff ? normalizeSearchString(search.diffScope) : undefined;
+  const diffScope: DiffScope | undefined =
+    diffScopeRaw === "git" || diffScopeRaw === "session" ? diffScopeRaw : undefined;
   const diffTurnIdRaw = diff ? normalizeSearchString(search.diffTurnId) : undefined;
   const diffTurnId = diffTurnIdRaw ? TurnId.makeUnsafe(diffTurnIdRaw) : undefined;
   const diffFilePath = diff && diffTurnId ? normalizeSearchString(search.diffFilePath) : undefined;
 
   return {
     ...(diff ? { diff } : {}),
+    ...(diffScope ? { diffScope } : {}),
     ...(diffTurnId ? { diffTurnId } : {}),
     ...(diffFilePath ? { diffFilePath } : {}),
   };

--- a/apps/web/src/lib/gitReactQuery.test.ts
+++ b/apps/web/src/lib/gitReactQuery.test.ts
@@ -14,9 +14,11 @@ import type { GitListBranchesResult } from "@t3tools/contracts";
 
 import {
   gitBranchSearchInfiniteQueryOptions,
+  gitDiffQueryOptions,
   gitMutationKeys,
   gitPreparePullRequestThreadMutationOptions,
   gitPullMutationOptions,
+  gitQueryKeys,
   gitRunStackedActionMutationOptions,
   invalidateGitQueries,
 } from "./gitReactQuery";
@@ -33,6 +35,12 @@ const BRANCH_SEARCH_RESULT: InfiniteData<GitListBranchesResult, number> = {
   pages: [BRANCH_QUERY_RESULT],
   pageParams: [0],
 };
+
+describe("gitQueryKeys", () => {
+  it("scopes diff keys by cwd", () => {
+    expect(gitQueryKeys.diff("/repo/a")).not.toEqual(gitQueryKeys.diff("/repo/b"));
+  });
+});
 
 describe("gitMutationKeys", () => {
   it("scopes stacked action keys by cwd", () => {
@@ -114,5 +122,12 @@ describe("invalidateGitQueries", () => {
         }).queryKey,
       )?.isInvalidated,
     ).toBe(false);
+  });
+});
+
+describe("git query options", () => {
+  it("attaches cwd-scoped query key for diff", () => {
+    const options = gitDiffQueryOptions("/repo/a");
+    expect(options.queryKey).toEqual(gitQueryKeys.diff("/repo/a"));
   });
 });

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -12,12 +12,15 @@ import {
 import { ensureNativeApi } from "../nativeApi";
 import { getWsRpcClient } from "../wsRpcClient";
 
+const GIT_STATUS_STALE_TIME_MS = 5_000;
+const GIT_STATUS_REFETCH_INTERVAL_MS = 15_000;
 const GIT_BRANCHES_STALE_TIME_MS = 15_000;
 const GIT_BRANCHES_REFETCH_INTERVAL_MS = 60_000;
 const GIT_BRANCHES_PAGE_SIZE = 100;
 
 export const gitQueryKeys = {
   all: ["git"] as const,
+  diff: (cwd: string | null) => ["git", "diff", cwd] as const,
   branches: (cwd: string | null) => ["git", "branches", cwd] as const,
   branchSearch: (cwd: string | null, query: string) =>
     ["git", "branches", cwd, "search", query] as const,
@@ -47,6 +50,22 @@ function invalidateGitBranchQueries(queryClient: QueryClient, cwd: string | null
   }
 
   return queryClient.invalidateQueries({ queryKey: gitQueryKeys.branches(cwd) });
+}
+
+export function gitDiffQueryOptions(cwd: string | null) {
+  return queryOptions({
+    queryKey: gitQueryKeys.diff(cwd),
+    queryFn: async () => {
+      const api = ensureNativeApi();
+      if (!cwd) throw new Error("Git diff is unavailable.");
+      return api.git.diff({ cwd });
+    },
+    enabled: cwd !== null,
+    staleTime: GIT_STATUS_STALE_TIME_MS,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: GIT_STATUS_REFETCH_INTERVAL_MS,
+  });
 }
 
 export function gitBranchSearchInfiniteQueryOptions(input: {

--- a/apps/web/src/wsNativeApi.test.ts
+++ b/apps/web/src/wsNativeApi.test.ts
@@ -56,6 +56,7 @@ const rpcClientMock = {
   },
   git: {
     pull: vi.fn(),
+    diff: vi.fn(),
     refreshStatus: vi.fn(),
     onStatus: vi.fn((input: { cwd: string }, listener: (event: GitStatusResult) => void) =>
       registerListener(gitStatusListeners, listener),
@@ -340,6 +341,16 @@ describe("wsNativeApi", () => {
       relativePath: "plan.md",
       contents: "# Plan\n",
     });
+  });
+
+  it("forwards git diff requests directly to the RPC client", async () => {
+    rpcClientMock.git.diff.mockResolvedValue({ diff: "patch" });
+    const { createWsNativeApi } = await import("./wsNativeApi");
+
+    const api = createWsNativeApi();
+    await api.git.diff({ cwd: "/repo" });
+
+    expect(rpcClientMock.git.diff).toHaveBeenCalledWith({ cwd: "/repo" });
   });
 
   it("forwards full-thread diff requests to the orchestration RPC", async () => {

--- a/apps/web/src/wsNativeApi.ts
+++ b/apps/web/src/wsNativeApi.ts
@@ -69,6 +69,7 @@ export function createWsNativeApi(): NativeApi {
     },
     git: {
       pull: rpcClient.git.pull,
+      diff: rpcClient.git.diff,
       refreshStatus: rpcClient.git.refreshStatus,
       onStatus: (input, callback, options) => rpcClient.git.onStatus(input, callback, options),
       listBranches: rpcClient.git.listBranches,

--- a/apps/web/src/wsRpcClient.ts
+++ b/apps/web/src/wsRpcClient.ts
@@ -1,5 +1,6 @@
 import {
   type GitActionProgressEvent,
+  type GitDiffResult,
   type GitRunStackedActionInput,
   type GitRunStackedActionResult,
   type GitStatusResult,
@@ -67,6 +68,7 @@ export interface WsRpcClient {
   };
   readonly git: {
     readonly pull: RpcUnaryMethod<typeof WS_METHODS.gitPull>;
+    readonly diff: (input: { cwd: string }) => Promise<GitDiffResult>;
     readonly refreshStatus: RpcUnaryMethod<typeof WS_METHODS.gitRefreshStatus>;
     readonly onStatus: (
       input: RpcInput<typeof WS_METHODS.subscribeGitStatus>,
@@ -157,6 +159,7 @@ export function createWsRpcClient(transport = new WsTransport()): WsRpcClient {
     },
     git: {
       pull: (input) => transport.request((client) => client[WS_METHODS.gitPull](input)),
+      diff: (input) => transport.request((client) => client[WS_METHODS.gitDiff](input)),
       refreshStatus: (input) =>
         transport.request((client) => client[WS_METHODS.gitRefreshStatus](input)),
       onStatus: (input, listener, options) => {

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -115,6 +115,11 @@ export const GitPullInput = Schema.Struct({
 });
 export type GitPullInput = typeof GitPullInput.Type;
 
+export const GitDiffInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+});
+export type GitDiffInput = typeof GitDiffInput.Type;
+
 export const GitRunStackedActionInput = Schema.Struct({
   actionId: TrimmedNonEmptyStringSchema,
   cwd: TrimmedNonEmptyStringSchema,
@@ -319,6 +324,11 @@ export const GitPullResult = Schema.Struct({
   upstreamBranch: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
 });
 export type GitPullResult = typeof GitPullResult.Type;
+
+export const GitDiffResult = Schema.Struct({
+  diff: Schema.String,
+});
+export type GitDiffResult = typeof GitDiffResult.Type;
 
 // RPC / domain errors
 export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()("GitCommandError", {

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -2,6 +2,8 @@ import type {
   GitCheckoutInput,
   GitCheckoutResult,
   GitCreateBranchInput,
+  GitDiffInput,
+  GitDiffResult,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
   GitPullRequestRefInput,
@@ -167,6 +169,7 @@ export interface NativeApi {
         onResubscribe?: () => void;
       },
     ) => () => void;
+    diff: (input: GitDiffInput) => Promise<GitDiffResult>;
   };
   contextMenu: {
     show: <T extends string>(

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -12,6 +12,8 @@ import {
   GitCreateBranchResult,
   GitCreateWorktreeInput,
   GitCreateWorktreeResult,
+  GitDiffInput,
+  GitDiffResult,
   GitInitInput,
   GitListBranchesInput,
   GitListBranchesResult,
@@ -86,6 +88,7 @@ export const WS_METHODS = {
 
   // Git methods
   gitPull: "git.pull",
+  gitDiff: "git.diff",
   gitRefreshStatus: "git.refreshStatus",
   gitRunStackedAction: "git.runStackedAction",
   gitListBranches: "git.listBranches",
@@ -176,6 +179,12 @@ export const WsSubscribeGitStatusRpc = Rpc.make(WS_METHODS.subscribeGitStatus, {
 export const WsGitPullRpc = Rpc.make(WS_METHODS.gitPull, {
   payload: GitPullInput,
   success: GitPullResult,
+  error: GitCommandError,
+});
+
+export const WsGitDiffRpc = Rpc.make(WS_METHODS.gitDiff, {
+  payload: GitDiffInput,
+  success: GitDiffResult,
   error: GitCommandError,
 });
 
@@ -345,6 +354,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsShellOpenInEditorRpc,
   WsSubscribeGitStatusRpc,
   WsGitPullRpc,
+  WsGitDiffRpc,
   WsGitRefreshStatusRpc,
   WsGitRunStackedActionRpc,
   WsGitResolvePullRequestRpc,


### PR DESCRIPTION
Addresses #1590 and #1122

## What Changed

- added diff toggle button that switches between session/turn diffs and full git worktree diff
- diff QoL (applied to both git and session/turn diff views)
  - added ability to expand/collapse individual file diff cards
  - added button to expand/collapse all
  - made file diff card headers smaller/more compact
  - removed icons for added/remove/changed file status, opting for coloring the file name instead (de-cluttering the card headers)  

## Why

I will often use agents in combination with manual changes or with other agents. When I do this, I need the ability to review the changes to the branch holistically. T3 Code's diff UI is actually quite pleasant to read, and thus I wanted to have the ability to review the entire branch's changes from the primary UI I use in development. I find that this is critical when using a generative tooling like T3 Code for real production workflows that will affect real users. 

## UI Changes

**Diff pane buttons**

before:
<img width="92" height="36" alt="image" src="https://github.com/user-attachments/assets/01d2d2f4-9b98-45bc-887a-119e3bb28a05" />

after:
<img width="181" height="58" alt="image" src="https://github.com/user-attachments/assets/f94112aa-7fcc-4df9-bd69-938a944d221c" />
(red: git/session toggle, blue: expand/collapse all)

**Smaller diff card headers**

before:
(tbd, I dont have the ability to create session diffs on this laptop)

after:
<img width="1218" height="248" alt="image" src="https://github.com/user-attachments/assets/377e8e16-4ee8-4771-894b-91321c3148ba" />

## Checklist

- [ ] This PR is small and focused
  - unfortunately no, this PR contains multiple separate changes, I am keeping it as a draft for reference to help move various conversations along. If the code for specific features looks OK, I will happily slice the PR into multiple feature-specific PRs  
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git working tree diff pane with session/git scope toggle to DiffPanel
> - Adds a `readWorkingTreeDiff` method to `GitCore` that generates a unified patch covering tracked, staged, unstaged, and untracked changes, handling repos with or without an initial commit.
> - Exposes the diff over WebSocket via a new `git.diff` RPC method, wired through contracts, transport, and native API layers.
> - Updates [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/1801/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) with a toggle between 'session' and 'git' diff scopes, per-file collapse/expand controls with add/delete counts, and persisted state in localStorage.
> - Adds `diffScope` to the diff route URL search params; `ChatView` now sets `diffScope: "session"` when opening a turn diff.
> - Behavioral Change: DiffPanel no longer opens files in the editor when clicking a file header.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 218fee3. 15 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->