### PR TITLE
fix: quote editor launch args on Windows to support paths with spaces

### DIFF
--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -293,11 +293,16 @@ export const launchDetached = (launch: EditorLaunch) =>
     yield* Effect.callback<void, OpenError>((resume) => {
       let child;
       try {
-        child = spawn(launch.command, [...launch.args], {
-          detached: true,
-          stdio: "ignore",
-          shell: process.platform === "win32",
-        });
+        const isWin32 = process.platform === "win32";
+        child = spawn(
+          launch.command,
+          isWin32 ? launch.args.map((a) => `"${a}"`) : [...launch.args],
+          {
+            detached: true,
+            stdio: "ignore",
+            shell: isWin32,
+          },
+        );
       } catch (error) {
         return resume(
           Effect.fail(new OpenError({ message: "failed to spawn detached process", cause: error })),


### PR DESCRIPTION
## Summary

Fixes #1804

"Open in Editor" breaks on Windows when the project path contains spaces (e.g. `C:\bug showcase`). The editor receives each space-separated word as a separate argument, opening multiple file tabs instead of the project folder.

**Root cause:** `launchDetached` in `apps/server/src/open.ts` uses `shell: true` on Windows so editor commands are resolved via `PATH`. When Node's `spawn` passes args through the shell, unquoted spaces in paths are treated as argument separators.

**Fix:** Wrap each argument in double quotes on Windows before passing to `spawn()`, so the shell keeps paths with spaces intact. Non-Windows platforms are unchanged (they don't use `shell: true`).

## Test plan

- [ ] On Windows, create a project at a path with spaces (e.g. `C:\Users\test\My Projects\app`)
- [ ] Click "Open in Editor" → editor should open the folder, not individual word-tabs
- [ ] Verify paths without spaces still work as before on Windows
- [x] Verify no behavior change on macOS/Linux

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix editor launch args quoting on Windows to support paths with spaces
> In [open.ts](https://github.com/pingdotgg/t3code/pull/1805/files#diff-67f3655f84064d89de7cec58f5e8d2b9d406dd21986dcefc77c335e3036b65be), each argument passed to the detached editor process is now wrapped in double quotes when running on Windows, fixing failures when paths contain spaces. Non-Windows behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f993c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->