### PR TITLE
fix: use different bundle ID for dev runner

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -18,7 +18,7 @@ import { fileURLToPath } from "node:url";
 
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
 const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
-const APP_BUNDLE_ID = "com.t3tools.t3code";
+const APP_BUNDLE_ID = isDevelopment ? "com.t3tools.t3code.dev" : "com.t3tools.t3code";
 const LAUNCHER_VERSION = 1;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## What Changed

This just makes our dev runner use a different bundle ID.

## Why

macOS expects different apps to have different bundle IDs. When we break this expectation, that may lead to bad side effects. It's hard to say specifically, as the OS likely makes a multitude of decisions based on this in all different areas. Ultimately, we just don't want macOS to confuse our dev runner for our built app or visa versa.

## UI Changes

N/A

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] ~I included before/after screenshots for any UI changes~
- [x] ~I included a video for animation/interaction changes~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the macOS `CFBundleIdentifier` used by the dev launcher to avoid OS-level app identity collisions; runtime behavior should be unaffected aside from app identity.
> 
> **Overview**
> Updates the desktop Electron launcher to use a **different macOS bundle ID in development** (`com.t3tools.t3code.dev`) while keeping the production bundle ID unchanged.
> 
> This prevents macOS from treating the dev runner and built app as the same application (and avoids related caching/registration side effects) when patching `Info.plist` during launcher build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 862f65cc969b232e992d7217b0946cdcb55bb388. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use a separate bundle ID for the dev Electron runner
> In [electron-launcher.mjs](https://github.com/pingdotgg/t3code/pull/1806/files#diff-8a117bf8144a87af3b3928053a08e442ffe3b14884df08757b77d55907d596b4), `APP_BUNDLE_ID` is now set to `com.t3tools.t3code.dev` in development mode and `com.t3tools.t3code` in production. This prevents the dev runner from conflicting with the production app on macOS.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 862f65c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->