### PR TITLE
feat: add git working tree diff toggle in diff panel

### DIFF
--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -46,6 +46,7 @@ const PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES = 49_000;
 const RANGE_COMMIT_SUMMARY_MAX_OUTPUT_BYTES = 19_000;
 const RANGE_DIFF_SUMMARY_MAX_OUTPUT_BYTES = 19_000;
 const RANGE_DIFF_PATCH_MAX_OUTPUT_BYTES = 59_000;
+const WORKING_TREE_DIFF_MAX_OUTPUT_BYTES = 512_000;
 const WORKSPACE_FILES_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 const GIT_CHECK_IGNORE_MAX_STDIN_BYTES = 256 * 1024;
 const WORKSPACE_GIT_HARDENED_CONFIG_ARGS = [
@@ -1628,6 +1629,46 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     },
   );
 
+  const readWorkingTreeDiff: GitCoreShape["readWorkingTreeDiff"] = Effect.fn("readWorkingTreeDiff")(
+    function* (cwd) {
+      // Check whether the repository has any commits yet.
+      const hasCommits = yield* executeGit(
+        "GitCore.readWorkingTreeDiff.hasCommits",
+        cwd,
+        ["rev-parse", "HEAD"],
+        { allowNonZeroExit: true, timeoutMs: 5_000, maxOutputBytes: 256 },
+      ).pipe(Effect.map((result) => result.code === 0));
+
+      if (hasCommits) {
+        // Standard case: diff HEAD covers staged + unstaged changes on tracked files.
+        const trackedDiff = yield* runGitStdoutWithOptions(
+          "GitCore.readWorkingTreeDiff.trackedDiff",
+          cwd,
+          ["diff", "HEAD", "--patch", "--minimal", "--no-color"],
+          {
+            maxOutputBytes: WORKING_TREE_DIFF_MAX_OUTPUT_BYTES,
+            truncateOutputAtMaxBytes: true,
+          },
+        );
+
+        return trackedDiff;
+      }
+
+      // No commits yet: show staged changes (initial add).
+      const stagedDiff = yield* runGitStdoutWithOptions(
+        "GitCore.readWorkingTreeDiff.stagedDiff",
+        cwd,
+        ["diff", "--cached", "--patch", "--minimal", "--no-color"],
+        {
+          maxOutputBytes: WORKING_TREE_DIFF_MAX_OUTPUT_BYTES,
+          truncateOutputAtMaxBytes: true,
+        },
+      );
+
+      return stagedDiff;
+    },
+  );
+
   const readConfigValue: GitCoreShape["readConfigValue"] = (cwd, key) =>
     runGitStdout("GitCore.readConfigValue", cwd, ["config", "--get", key], true).pipe(
       Effect.map((stdout) => stdout.trim()),
@@ -2184,6 +2225,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     pushCurrentBranch,
     pullCurrentBranch,
     readRangeContext,
+    readWorkingTreeDiff,
     readConfigValue,
     isInsideWorkTree,
     listWorkspaceFiles,

--- a/apps/server/src/git/Services/GitCore.ts
+++ b/apps/server/src/git/Services/GitCore.ts
@@ -198,6 +198,11 @@ export interface GitCoreShape {
   ) => Effect.Effect<GitRangeContext, GitCommandError>;
 
   /**
+   * Read a unified patch of working tree changes (staged + unstaged) on tracked files against HEAD.
+   */
+  readonly readWorkingTreeDiff: (cwd: string) => Effect.Effect<string, GitCommandError>;
+
+  /**
    * Read a Git config value from the local repository.
    */
   readonly readConfigValue: (

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -882,6 +882,12 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
             git.initRepo(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             { "rpc.aggregate": "git" },
           ),
+        [WS_METHODS.gitWorkingTreeDiff]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.gitWorkingTreeDiff,
+            git.readWorkingTreeDiff(input.cwd).pipe(Effect.map((diff) => ({ diff }))),
+            { "rpc.aggregate": "git" },
+          ),
         [WS_METHODS.terminalOpen]: (input) =>
           observeRpcEffect(WS_METHODS.terminalOpen, terminalManager.open(input), {
             "rpc.aggregate": "terminal",

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -1,6 +1,6 @@
 import { parsePatchFiles } from "@pierre/diffs";
 import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { scopeThreadRef } from "@t3tools/client-runtime";
 import type { TurnId } from "@t3tools/contracts";
@@ -8,6 +8,8 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   Columns2Icon,
+  GitBranchIcon,
+  ListIcon,
   Rows3Icon,
   TextWrapIcon,
 } from "lucide-react";
@@ -22,10 +24,11 @@ import {
 import { openInPreferredEditor } from "../editorPreferences";
 import { useGitStatus } from "~/lib/gitStatusState";
 import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
+import { gitQueryKeys, gitWorkingTreeDiffQueryOptions } from "~/lib/gitReactQuery";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "../localApi";
 import { resolvePathLinkTarget } from "../terminal-links";
-import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import { type DiffScope, parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import { useTheme } from "../hooks/useTheme";
 import { buildPatchCacheKey } from "../lib/diffRendering";
 import { resolveDiffThemeName } from "../lib/diffRendering";
@@ -183,6 +186,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   });
   const diffSearch = useSearch({ strict: false, select: (search) => parseDiffRouteSearch(search) });
   const diffOpen = diffSearch.diff === "1";
+  const diffScope: DiffScope = diffSearch.diffScope ?? "session";
   const activeThreadId = routeThreadRef?.threadId ?? null;
   const activeThread = useStore(
     useMemo(() => createThreadSelectorByRef(routeThreadRef), [routeThreadRef]),
@@ -197,11 +201,23 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       : undefined,
   );
   const activeCwd = activeThread?.worktreePath ?? activeProject?.cwd;
+  const activeEnvironmentId = activeThread?.environmentId ?? null;
+  const queryClient = useQueryClient();
   const gitStatusQuery = useGitStatus({
-    environmentId: activeThread?.environmentId ?? null,
+    environmentId: activeEnvironmentId,
     cwd: activeCwd ?? null,
   });
   const isGitRepo = gitStatusQuery.data?.isRepo ?? true;
+
+  // Invalidate the git working tree diff query whenever git status changes,
+  // so the diff panel stays in sync without polling.
+  const gitStatusData = gitStatusQuery.data;
+  useEffect(() => {
+    if (!activeCwd || !activeEnvironmentId || !gitStatusData) return;
+    void queryClient.invalidateQueries({
+      queryKey: gitQueryKeys.workingTreeDiff(activeEnvironmentId, activeCwd),
+    });
+  }, [queryClient, activeEnvironmentId, activeCwd, gitStatusData]);
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
   const orderedTurnDiffSummaries = useMemo(
@@ -219,7 +235,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     [inferredCheckpointTurnCountByTurnId, turnDiffSummaries],
   );
 
-  const selectedTurnId = diffSearch.diffTurnId ?? null;
+  const selectedTurnId = diffScope === "session" ? (diffSearch.diffTurnId ?? null) : null;
   const selectedFilePath = selectedTurnId !== null ? (diffSearch.diffFilePath ?? null) : null;
   const selectedTurn =
     selectedTurnId === null
@@ -271,6 +287,8 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     }
     return `conversation:${orderedTurnDiffSummaries.map((summary) => summary.turnId).join(",")}`;
   }, [orderedTurnDiffSummaries, selectedTurn]);
+
+  // --- Session (checkpoint) diff query ---
   const activeCheckpointDiffQuery = useQuery(
     checkpointDiffQueryOptions({
       environmentId: activeThread?.environmentId ?? null,
@@ -278,29 +296,45 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       fromTurnCount: activeCheckpointRange?.fromTurnCount ?? null,
       toTurnCount: activeCheckpointRange?.toTurnCount ?? null,
       cacheScope: selectedTurn ? `turn:${selectedTurn.turnId}` : conversationCacheScope,
-      enabled: isGitRepo,
+      enabled: isGitRepo && diffScope === "session",
     }),
   );
-  const selectedTurnCheckpointDiff = selectedTurn
-    ? activeCheckpointDiffQuery.data?.diff
-    : undefined;
-  const conversationCheckpointDiff = selectedTurn
-    ? undefined
-    : activeCheckpointDiffQuery.data?.diff;
-  const isLoadingCheckpointDiff = activeCheckpointDiffQuery.isLoading;
-  const checkpointDiffError =
-    activeCheckpointDiffQuery.error instanceof Error
-      ? activeCheckpointDiffQuery.error.message
-      : activeCheckpointDiffQuery.error
-        ? "Failed to load checkpoint diff."
-        : null;
 
-  const selectedPatch = selectedTurn ? selectedTurnCheckpointDiff : conversationCheckpointDiff;
+  // --- Git working tree diff query ---
+  const gitDiffQuery = useQuery(
+    gitWorkingTreeDiffQueryOptions({
+      environmentId: activeEnvironmentId,
+      cwd: activeCwd ?? null,
+      enabled: isGitRepo && diffScope === "git",
+    }),
+  );
+
+  // --- Derive active patch based on scope ---
+  const sessionPatch = selectedTurn
+    ? activeCheckpointDiffQuery.data?.diff
+    : activeCheckpointDiffQuery.data?.diff;
+  const gitPatch = gitDiffQuery.data?.diff;
+  const selectedPatch = diffScope === "git" ? gitPatch : sessionPatch;
+  const isLoadingPatch =
+    diffScope === "git" ? gitDiffQuery.isLoading : activeCheckpointDiffQuery.isLoading;
+  const patchError =
+    diffScope === "git"
+      ? gitDiffQuery.error instanceof Error
+        ? gitDiffQuery.error.message
+        : gitDiffQuery.error
+          ? "Failed to load git diff."
+          : null
+      : activeCheckpointDiffQuery.error instanceof Error
+        ? activeCheckpointDiffQuery.error.message
+        : activeCheckpointDiffQuery.error
+          ? "Failed to load checkpoint diff."
+          : null;
+
   const hasResolvedPatch = typeof selectedPatch === "string";
   const hasNoNetChanges = hasResolvedPatch && selectedPatch.trim().length === 0;
   const renderablePatch = useMemo(
-    () => getRenderablePatch(selectedPatch, `diff-panel:${resolvedTheme}`),
-    [resolvedTheme, selectedPatch],
+    () => getRenderablePatch(selectedPatch, `diff-panel:${resolvedTheme}:${diffScope}`),
+    [resolvedTheme, selectedPatch, diffScope],
   );
   const renderableFiles = useMemo(() => {
     if (!renderablePatch || renderablePatch.kind !== "files") {
@@ -343,6 +377,21 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     [activeCwd],
   );
 
+  const setDiffScope = useCallback(
+    (scope: DiffScope) => {
+      if (!activeThread) return;
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
+        search: (previous) => {
+          const rest = stripDiffSearchParams(previous);
+          return { ...rest, diff: "1", diffScope: scope };
+        },
+      });
+    },
+    [activeThread, navigate],
+  );
+
   const selectTurn = (turnId: TurnId) => {
     if (!activeThread) return;
     void navigate({
@@ -350,7 +399,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1", diffTurnId: turnId };
+        return { ...rest, diff: "1", diffTurnId: turnId, diffScope: "session" };
       },
     });
   };
@@ -361,7 +410,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
+        return { ...rest, diff: "1", diffScope: "session" };
       },
     });
   };
@@ -429,97 +478,127 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const headerRow = (
     <>
       <div className="relative min-w-0 flex-1 [-webkit-app-region:no-drag]">
-        <button
-          type="button"
-          className={cn(
-            "absolute left-0 top-1/2 z-20 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-md border bg-background/90 text-muted-foreground transition-colors",
-            canScrollTurnStripLeft
-              ? "border-border/70 hover:border-border hover:text-foreground"
-              : "cursor-not-allowed border-border/40 text-muted-foreground/40",
-          )}
-          onClick={() => scrollTurnStripBy(-180)}
-          disabled={!canScrollTurnStripLeft}
-          aria-label="Scroll turn list left"
-        >
-          <ChevronLeftIcon className="size-3.5" />
-        </button>
-        <button
-          type="button"
-          className={cn(
-            "absolute right-0 top-1/2 z-20 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-md border bg-background/90 text-muted-foreground transition-colors",
-            canScrollTurnStripRight
-              ? "border-border/70 hover:border-border hover:text-foreground"
-              : "cursor-not-allowed border-border/40 text-muted-foreground/40",
-          )}
-          onClick={() => scrollTurnStripBy(180)}
-          disabled={!canScrollTurnStripRight}
-          aria-label="Scroll turn list right"
-        >
-          <ChevronRightIcon className="size-3.5" />
-        </button>
-        <div
-          ref={turnStripRef}
-          className="turn-chip-strip flex gap-1 overflow-x-auto px-8 py-0.5"
-          style={
-            canScrollTurnStripLeft || canScrollTurnStripRight
-              ? {
-                  maskImage: `linear-gradient(to right, ${canScrollTurnStripLeft ? "transparent 24px, black 72px" : "black"}, ${canScrollTurnStripRight ? "black calc(100% - 72px), transparent calc(100% - 24px)" : "black"})`,
-                }
-              : undefined
-          }
-          onWheel={onTurnStripWheel}
-        >
-          <button
-            type="button"
-            className="shrink-0 rounded-md"
-            onClick={selectWholeConversation}
-            data-turn-chip-selected={selectedTurnId === null}
-          >
-            <div
-              className={cn(
-                "rounded-md border px-2 py-1 text-left transition-colors",
-                selectedTurnId === null
-                  ? "border-border bg-accent text-accent-foreground"
-                  : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80",
-              )}
-            >
-              <div className="text-[10px] leading-tight font-medium">All turns</div>
-            </div>
-          </button>
-          {orderedTurnDiffSummaries.map((summary) => (
+        {diffScope === "session" && (
+          <>
             <button
-              key={summary.turnId}
               type="button"
-              className="shrink-0 rounded-md"
-              onClick={() => selectTurn(summary.turnId)}
-              title={summary.turnId}
-              data-turn-chip-selected={summary.turnId === selectedTurn?.turnId}
+              className={cn(
+                "absolute left-0 top-1/2 z-20 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-md border bg-background/90 text-muted-foreground transition-colors",
+                canScrollTurnStripLeft
+                  ? "border-border/70 hover:border-border hover:text-foreground"
+                  : "cursor-not-allowed border-border/40 text-muted-foreground/40",
+              )}
+              onClick={() => scrollTurnStripBy(-180)}
+              disabled={!canScrollTurnStripLeft}
+              aria-label="Scroll turn list left"
             >
-              <div
-                className={cn(
-                  "rounded-md border px-2 py-1 text-left transition-colors",
-                  summary.turnId === selectedTurn?.turnId
-                    ? "border-border bg-accent text-accent-foreground"
-                    : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80",
-                )}
-              >
-                <div className="flex items-center gap-1">
-                  <span className="text-[10px] leading-tight font-medium">
-                    Turn{" "}
-                    {summary.checkpointTurnCount ??
-                      inferredCheckpointTurnCountByTurnId[summary.turnId] ??
-                      "?"}
-                  </span>
-                  <span className="text-[9px] leading-tight opacity-70">
-                    {formatShortTimestamp(summary.completedAt, settings.timestampFormat)}
-                  </span>
-                </div>
-              </div>
+              <ChevronLeftIcon className="size-3.5" />
             </button>
-          ))}
-        </div>
+            <button
+              type="button"
+              className={cn(
+                "absolute right-0 top-1/2 z-20 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-md border bg-background/90 text-muted-foreground transition-colors",
+                canScrollTurnStripRight
+                  ? "border-border/70 hover:border-border hover:text-foreground"
+                  : "cursor-not-allowed border-border/40 text-muted-foreground/40",
+              )}
+              onClick={() => scrollTurnStripBy(180)}
+              disabled={!canScrollTurnStripRight}
+              aria-label="Scroll turn list right"
+            >
+              <ChevronRightIcon className="size-3.5" />
+            </button>
+            <div
+              ref={turnStripRef}
+              className="turn-chip-strip flex gap-1 overflow-x-auto px-8 py-0.5"
+              style={
+                canScrollTurnStripLeft || canScrollTurnStripRight
+                  ? {
+                      maskImage: `linear-gradient(to right, ${canScrollTurnStripLeft ? "transparent 24px, black 72px" : "black"}, ${canScrollTurnStripRight ? "black calc(100% - 72px), transparent calc(100% - 24px)" : "black"})`,
+                    }
+                  : undefined
+              }
+              onWheel={onTurnStripWheel}
+            >
+              <button
+                type="button"
+                className="shrink-0 rounded-md"
+                onClick={selectWholeConversation}
+                data-turn-chip-selected={selectedTurnId === null}
+              >
+                <div
+                  className={cn(
+                    "rounded-md border px-2 py-1 text-left transition-colors",
+                    selectedTurnId === null
+                      ? "border-border bg-accent text-accent-foreground"
+                      : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80",
+                  )}
+                >
+                  <div className="text-[10px] leading-tight font-medium">All turns</div>
+                </div>
+              </button>
+              {orderedTurnDiffSummaries.map((summary) => (
+                <button
+                  key={summary.turnId}
+                  type="button"
+                  className="shrink-0 rounded-md"
+                  onClick={() => selectTurn(summary.turnId)}
+                  title={summary.turnId}
+                  data-turn-chip-selected={summary.turnId === selectedTurn?.turnId}
+                >
+                  <div
+                    className={cn(
+                      "rounded-md border px-2 py-1 text-left transition-colors",
+                      summary.turnId === selectedTurn?.turnId
+                        ? "border-border bg-accent text-accent-foreground"
+                        : "border-border/70 bg-background/70 text-muted-foreground/80 hover:border-border hover:text-foreground/80",
+                    )}
+                  >
+                    <div className="flex items-center gap-1">
+                      <span className="text-[10px] leading-tight font-medium">
+                        Turn{" "}
+                        {summary.checkpointTurnCount ??
+                          inferredCheckpointTurnCountByTurnId[summary.turnId] ??
+                          "?"}
+                      </span>
+                      <span className="text-[9px] leading-tight opacity-70">
+                        {formatShortTimestamp(summary.completedAt, settings.timestampFormat)}
+                      </span>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+        {diffScope === "git" && (
+          <div className="flex items-center px-2 py-1">
+            <span className="text-[10px] leading-tight font-medium text-muted-foreground">
+              Working tree changes
+            </span>
+          </div>
+        )}
       </div>
       <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+        <ToggleGroup
+          className="shrink-0"
+          variant="outline"
+          size="xs"
+          value={[diffScope]}
+          onValueChange={(value) => {
+            const next = value[0];
+            if (next === "session" || next === "git") {
+              setDiffScope(next);
+            }
+          }}
+        >
+          <Toggle aria-label="Session turn diffs" title="Session turn diffs" value="session">
+            <ListIcon className="size-3" />
+          </Toggle>
+          <Toggle aria-label="Git working tree diff" title="Git working tree diff" value="git">
+            <GitBranchIcon className="size-3" />
+          </Toggle>
+        </ToggleGroup>
         <ToggleGroup
           className="shrink-0"
           variant="outline"
@@ -555,19 +634,28 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     </>
   );
 
+  const emptyStateMessage =
+    diffScope === "git" ? "No working tree changes." : "No completed turns yet.";
+  const loadingLabel = diffScope === "git" ? "Loading git diff..." : "Loading checkpoint diff...";
+  const noChangesLabel =
+    diffScope === "git" ? "No working tree changes." : "No net changes in this selection.";
+  const noPatchLabel =
+    diffScope === "git" ? "No working tree changes." : "No patch available for this selection.";
+  const showEmptySessionState = diffScope === "session" && orderedTurnDiffSummaries.length === 0;
+
   return (
     <DiffPanelShell mode={mode} header={headerRow}>
       {!activeThread ? (
         <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
-          Select a thread to inspect turn diffs.
+          Select a thread to inspect diffs.
         </div>
       ) : !isGitRepo ? (
         <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
-          Turn diffs are unavailable because this project is not a git repository.
+          Diffs are unavailable because this project is not a git repository.
         </div>
-      ) : orderedTurnDiffSummaries.length === 0 ? (
+      ) : showEmptySessionState ? (
         <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
-          No completed turns yet.
+          {emptyStateMessage}
         </div>
       ) : (
         <>
@@ -575,21 +663,17 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
             ref={patchViewportRef}
             className="diff-panel-viewport min-h-0 min-w-0 flex-1 overflow-hidden"
           >
-            {checkpointDiffError && !renderablePatch && (
+            {patchError && !renderablePatch && (
               <div className="px-3">
-                <p className="mb-2 text-[11px] text-red-500/80">{checkpointDiffError}</p>
+                <p className="mb-2 text-[11px] text-red-500/80">{patchError}</p>
               </div>
             )}
             {!renderablePatch ? (
-              isLoadingCheckpointDiff ? (
-                <DiffPanelLoadingState label="Loading checkpoint diff..." />
+              isLoadingPatch ? (
+                <DiffPanelLoadingState label={loadingLabel} />
               ) : (
                 <div className="flex h-full items-center justify-center px-3 py-2 text-xs text-muted-foreground/70">
-                  <p>
-                    {hasNoNetChanges
-                      ? "No net changes in this selection."
-                      : "No patch available for this selection."}
-                  </p>
+                  <p>{hasNoNetChanges ? noChangesLabel : noPatchLabel}</p>
                 </div>
               )
             ) : renderablePatch.kind === "files" ? (

--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -71,4 +71,46 @@ describe("parseDiffRouteSearch", () => {
       diff: "1",
     });
   });
+
+  it("parses diffScope when diff is open", () => {
+    expect(
+      parseDiffRouteSearch({
+        diff: "1",
+        diffScope: "git",
+      }),
+    ).toEqual({
+      diff: "1",
+      diffScope: "git",
+    });
+
+    expect(
+      parseDiffRouteSearch({
+        diff: "1",
+        diffScope: "session",
+      }),
+    ).toEqual({
+      diff: "1",
+      diffScope: "session",
+    });
+  });
+
+  it("drops diffScope when diff is closed", () => {
+    expect(
+      parseDiffRouteSearch({
+        diff: "0",
+        diffScope: "git",
+      }),
+    ).toEqual({});
+  });
+
+  it("drops invalid diffScope values", () => {
+    expect(
+      parseDiffRouteSearch({
+        diff: "1",
+        diffScope: "invalid",
+      }),
+    ).toEqual({
+      diff: "1",
+    });
+  });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -1,9 +1,12 @@
 import { TurnId } from "@t3tools/contracts";
 
+export type DiffScope = "session" | "git";
+
 export interface DiffRouteSearch {
   diff?: "1" | undefined;
   diffTurnId?: TurnId | undefined;
   diffFilePath?: string | undefined;
+  diffScope?: DiffScope | undefined;
 }
 
 function isDiffOpenValue(value: unknown): boolean {
@@ -18,11 +21,21 @@ function normalizeSearchString(value: unknown): string | undefined {
   return normalized.length > 0 ? normalized : undefined;
 }
 
+function isDiffScope(value: unknown): value is DiffScope {
+  return value === "session" || value === "git";
+}
+
 export function stripDiffSearchParams<T extends Record<string, unknown>>(
   params: T,
-): Omit<T, "diff" | "diffTurnId" | "diffFilePath"> {
-  const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, ...rest } = params;
-  return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
+): Omit<T, "diff" | "diffTurnId" | "diffFilePath" | "diffScope"> {
+  const {
+    diff: _diff,
+    diffTurnId: _diffTurnId,
+    diffFilePath: _diffFilePath,
+    diffScope: _diffScope,
+    ...rest
+  } = params;
+  return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath" | "diffScope">;
 }
 
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
@@ -30,10 +43,12 @@ export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRoute
   const diffTurnIdRaw = diff ? normalizeSearchString(search.diffTurnId) : undefined;
   const diffTurnId = diffTurnIdRaw ? TurnId.make(diffTurnIdRaw) : undefined;
   const diffFilePath = diff && diffTurnId ? normalizeSearchString(search.diffFilePath) : undefined;
+  const diffScope = diff && isDiffScope(search.diffScope) ? search.diffScope : undefined;
 
   return {
     ...(diff ? { diff } : {}),
     ...(diffTurnId ? { diffTurnId } : {}),
     ...(diffFilePath ? { diffFilePath } : {}),
+    ...(diffScope ? { diffScope } : {}),
   };
 }

--- a/apps/web/src/environmentApi.ts
+++ b/apps/web/src/environmentApi.ts
@@ -33,6 +33,7 @@ export function createEnvironmentApi(rpcClient: WsRpcClient): EnvironmentApi {
       createBranch: rpcClient.git.createBranch,
       checkout: rpcClient.git.checkout,
       init: rpcClient.git.init,
+      workingTreeDiff: rpcClient.git.workingTreeDiff,
       resolvePullRequest: rpcClient.git.resolvePullRequest,
       preparePullRequestThread: rpcClient.git.preparePullRequestThread,
     },

--- a/apps/web/src/lib/gitReactQuery.ts
+++ b/apps/web/src/lib/gitReactQuery.ts
@@ -23,6 +23,8 @@ export const gitQueryKeys = {
     ["git", "branches", environmentId ?? null, cwd] as const,
   branchSearch: (environmentId: EnvironmentId | null, cwd: string | null, query: string) =>
     ["git", "branches", environmentId ?? null, cwd, "search", query] as const,
+  workingTreeDiff: (environmentId: EnvironmentId | null, cwd: string | null) =>
+    ["git", "workingTreeDiff", environmentId ?? null, cwd] as const,
 };
 
 export const gitMutationKeys = {
@@ -253,6 +255,26 @@ export function gitRemoveWorktreeMutationOptions(input: {
     onSuccess: async () => {
       await invalidateGitQueries(input.queryClient, { environmentId: input.environmentId });
     },
+  });
+}
+
+export function gitWorkingTreeDiffQueryOptions(input: {
+  environmentId: EnvironmentId | null;
+  cwd: string | null;
+  enabled?: boolean;
+}) {
+  return queryOptions({
+    queryKey: gitQueryKeys.workingTreeDiff(input.environmentId, input.cwd),
+    queryFn: async () => {
+      if (!input.cwd || !input.environmentId) {
+        throw new Error("Git working tree diff is unavailable.");
+      }
+      const api = ensureEnvironmentApi(input.environmentId);
+      return api.git.workingTreeDiff({ cwd: input.cwd });
+    },
+    enabled: input.environmentId !== null && input.cwd !== null && (input.enabled ?? true),
+    staleTime: 0,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/apps/web/src/rpc/wsRpcClient.ts
+++ b/apps/web/src/rpc/wsRpcClient.ts
@@ -95,6 +95,7 @@ export interface WsRpcClient {
     readonly createBranch: RpcUnaryMethod<typeof WS_METHODS.gitCreateBranch>;
     readonly checkout: RpcUnaryMethod<typeof WS_METHODS.gitCheckout>;
     readonly init: RpcUnaryMethod<typeof WS_METHODS.gitInit>;
+    readonly workingTreeDiff: RpcUnaryMethod<typeof WS_METHODS.gitWorkingTreeDiff>;
     readonly resolvePullRequest: RpcUnaryMethod<typeof WS_METHODS.gitResolvePullRequest>;
     readonly preparePullRequestThread: RpcUnaryMethod<
       typeof WS_METHODS.gitPreparePullRequestThread
@@ -199,6 +200,8 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
         transport.request((client) => client[WS_METHODS.gitCreateBranch](input)),
       checkout: (input) => transport.request((client) => client[WS_METHODS.gitCheckout](input)),
       init: (input) => transport.request((client) => client[WS_METHODS.gitInit](input)),
+      workingTreeDiff: (input) =>
+        transport.request((client) => client[WS_METHODS.gitWorkingTreeDiff](input)),
       resolvePullRequest: (input) =>
         transport.request((client) => client[WS_METHODS.gitResolvePullRequest](input)),
       preparePullRequestThread: (input) =>

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -105,6 +105,16 @@ export type GitResolvedPullRequest = typeof GitResolvedPullRequest.Type;
 
 // RPC Inputs
 
+export const GitWorkingTreeDiffInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+});
+export type GitWorkingTreeDiffInput = typeof GitWorkingTreeDiffInput.Type;
+
+export const GitWorkingTreeDiffResult = Schema.Struct({
+  diff: Schema.String,
+});
+export type GitWorkingTreeDiffResult = typeof GitWorkingTreeDiffResult.Type;
+
 export const GitStatusInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
 });

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -17,6 +17,8 @@ import type {
   GitStatusInput,
   GitStatusResult,
   GitCreateBranchResult,
+  GitWorkingTreeDiffInput,
+  GitWorkingTreeDiffResult,
 } from "./git";
 import type { FilesystemBrowseInput, FilesystemBrowseResult } from "./filesystem";
 import type {
@@ -258,6 +260,7 @@ export interface EnvironmentApi {
     preparePullRequestThread: (
       input: GitPreparePullRequestThreadInput,
     ) => Promise<GitPreparePullRequestThreadResult>;
+    workingTreeDiff: (input: GitWorkingTreeDiffInput) => Promise<GitWorkingTreeDiffResult>;
     pull: (input: GitPullInput) => Promise<GitPullResult>;
     refreshStatus: (input: GitStatusInput) => Promise<GitStatusResult>;
     onStatus: (

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -29,6 +29,8 @@ import {
   GitStatusInput,
   GitStatusResult,
   GitStatusStreamEvent,
+  GitWorkingTreeDiffInput,
+  GitWorkingTreeDiffResult,
 } from "./git";
 import { KeybindingsConfigError } from "./keybindings";
 import {
@@ -97,6 +99,7 @@ export const WS_METHODS = {
   gitCreateBranch: "git.createBranch",
   gitCheckout: "git.checkout",
   gitInit: "git.init",
+  gitWorkingTreeDiff: "git.workingTreeDiff",
   gitResolvePullRequest: "git.resolvePullRequest",
   gitPreparePullRequestThread: "git.preparePullRequestThread",
 
@@ -247,6 +250,12 @@ export const WsGitInitRpc = Rpc.make(WS_METHODS.gitInit, {
   error: GitCommandError,
 });
 
+export const WsGitWorkingTreeDiffRpc = Rpc.make(WS_METHODS.gitWorkingTreeDiff, {
+  payload: GitWorkingTreeDiffInput,
+  success: GitWorkingTreeDiffResult,
+  error: GitCommandError,
+});
+
 export const WsTerminalOpenRpc = Rpc.make(WS_METHODS.terminalOpen, {
   payload: TerminalOpenInput,
   success: TerminalSessionSnapshot,
@@ -373,6 +382,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsGitCreateBranchRpc,
   WsGitCheckoutRpc,
   WsGitInitRpc,
+  WsGitWorkingTreeDiffRpc,
   WsTerminalOpenRpc,
   WsTerminalWriteRpc,
   WsTerminalResizeRpc,


### PR DESCRIPTION
Closes #1590

## Summary

Adds a toggle in the diff panel header that switches between two modes:

- **Session mode** (default) — existing checkpoint-based turn-by-turn diffs, unchanged behavior.
- **Git mode** — live `git diff HEAD` output showing all staged + unstaged changes on tracked files.

This gives visibility into changes made outside the agent (manual edits, IDE refactors, other tools) and provides a reliability fallback when checkpoint-based diffs are incomplete or unavailable.

## What changed

**Contracts (`packages/contracts`)**
- Added `GitWorkingTreeDiffInput` / `GitWorkingTreeDiffResult` schemas in `git.ts`
- Added `git.workingTreeDiff` RPC method definition in `rpc.ts`
- Added `workingTreeDiff` to the `NativeApi.git` interface in `ipc.ts`

**Server (`apps/server`)**
- Added `readWorkingTreeDiff` to the `GitCoreShape` service interface
- Implemented it in the GitCore layer: runs `git diff HEAD --patch --minimal --no-color`, with a fallback to `git diff --cached` for repos with no commits yet. Output capped at 512KB with truncation.
- Wired the `git.workingTreeDiff` RPC handler in `ws.ts`

**Web (`apps/web`)**
- Added `gitWorkingTreeDiffQueryOptions` React Query helper in `gitReactQuery.ts`
- Added `workingTreeDiff` to the RPC client and NativeApi wiring
- Added `diffScope: "session" | "git"` URL search param in `diffRouteSearch.ts`
- Updated `DiffPanel.tsx`:
  - New session/git toggle group in the header (list icon / git branch icon), placed before the existing stacked/split toggle
  - In session mode: existing turn chip strip (unchanged)
  - In git mode: turn strip hidden, replaced with a "Working tree changes" label
  - Both modes share the same diff renderer, word-wrap, and stacked/split controls
  - **Live refresh**: the git diff query is automatically invalidated whenever the existing git status subscription detects working tree changes — no polling needed

**Tests**
- Added 3 test cases for `diffScope` parsing in `diffRouteSearch.test.ts`

## UI

<img width="1212" height="892" alt="image" src="https://github.com/user-attachments/assets/672a68e9-978d-4e4b-8c9b-b11f6d4f2c4b" />

## Design decisions

- **Refresh strategy**: piggybacks on the existing `subscribeGitStatus` stream. When the server broadcasts a git status change, the diff query is invalidated and refetches. Zero polling overhead.
- **Output cap**: 512KB max patch output, truncated with `[truncated]` marker. Larger than `readRangeContext`'s 59KB cap since working tree diffs tend to be bigger, but still bounded.
- **No-commit repos**: falls back to `git diff --cached` to handle initial-add scenarios gracefully.
- **Tracked files only**: `git diff HEAD` covers staged + unstaged changes on tracked files. Untracked files are excluded (consistent with checkpoint diffs).
- **URL-persisted scope**: `diffScope` is stored in the URL search params so the mode survives navigation and can be deep-linked.

## Test plan

- [x] Open diff panel → verify session mode works exactly as before (turn chips, all turns, per-turn diffs)
- [x] Toggle to git mode → verify working tree diff appears
- [x] Make a manual file edit → verify git diff panel updates automatically (via status subscription)
- [x] Run an agent turn → verify git diff updates as changes are written
- [x] Toggle back to session mode → verify turn diffs are still intact
- [x] Test on a repo with no commits → verify no crash (cached diff fallback)
- [x] Test stacked/split and word-wrap toggles work in both modes
- [x] Verify `diffScope=git` persists in URL across navigation

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add git working tree diff toggle to the diff panel
> - Adds a scope toggle (session / git) to the diff panel in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/1809/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3), letting users switch between checkpoint diffs and the current working tree diff.
> - The working tree diff is fetched via a new `git.workingTreeDiff` WebSocket RPC endpoint, backed by `readWorkingTreeDiff` in [GitCore.ts](https://github.com/pingdotgg/t3code/pull/1809/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865), which runs `git diff HEAD` or `git diff --cached` depending on whether commits exist.
> - Output is truncated at 512 KB (`WORKING_TREE_DIFF_MAX_OUTPUT_BYTES`). The diff is automatically re-fetched on git status changes.
> - The selected scope is encoded in the URL via a new `diffScope` search param, parsed and validated in [diffRouteSearch.ts](https://github.com/pingdotgg/t3code/pull/1809/files#diff-625b76b0ee5e0cd241579df3eec55eaf0d42a2403fe980a4f5dfffa6af912f8f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a17b919.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->