### PR TITLE
fix(web): prevent number-key shortcuts from hijacking input in focused editor

### DIFF
--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -98,7 +98,10 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
       if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
         return;
       }
-      if (target instanceof HTMLElement && target.closest('[contenteditable="true"]')) {
+      if (
+        target instanceof HTMLElement &&
+        target.closest('[contenteditable]:not([contenteditable="false"])')
+      ) {
         return;
       }
       const digit = Number.parseInt(event.key, 10);

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -98,7 +98,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
       if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
         return;
       }
-      if (target instanceof HTMLElement && target.isContentEditable) {
+      if (target instanceof HTMLElement && target.closest('[contenteditable="true"]')) {
         return;
       }
       const digit = Number.parseInt(event.key, 10);


### PR DESCRIPTION
## Summary

Fixes #1794

When the AI presents a question with numbered options, a global `keydown` handler on `document` lets users press `1`–`9` to quick-select an option. The handler guards against firing inside editable elements by checking `event.target`:

```ts
if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) return;
if (target instanceof HTMLElement && target.isContentEditable) return;
```

The main composer is a **Lexical editor** (`ComposerPromptEditor`), which renders a `<div contenteditable="true">` containing nested child elements — including `ComposerMentionNode` decorations that explicitly set `contentEditable = "false"`. When the keydown `event.target` resolves to one of these nested children, `target.isContentEditable` returns `false` (because `isContentEditable` respects the nearest `contenteditable` attribute in the ancestor chain, including intervening `contenteditable="false"` nodes). The guard fails and the number key triggers option selection instead of typing into the editor.

### Fix

Replace `target.isContentEditable` with `target.closest('[contenteditable]:not([contenteditable="false"])')`. This walks up the DOM tree looking for any ancestor with a `contenteditable` attribute that isn't explicitly `"false"`, covering all valid editable states (`"true"`, `""`, `"plaintext-only"`) while still correctly skipping past Lexical's `contenteditable="false"` mention decoration nodes to find the editor root.

```diff
- if (target instanceof HTMLElement && target.isContentEditable) {
+ if (
+   target instanceof HTMLElement &&
+   target.closest('[contenteditable]:not([contenteditable="false"])')
+ ) {
```

## Test plan

- [x] Open a session and trigger an AI question with numbered options
- [x] Click into the composer editor and type number keys (`1`, `2`, `3`) — they appear as text in the editor, not select options
- [x] Click outside the editor and press number keys — they select options as before
- [x] Verify option buttons are still clickable