### PR TITLE
Add provider icons to sidebar thread rows

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -219,7 +219,9 @@ function createSnapshotForTargetUser(options: {
   targetText: string;
   targetAttachmentCount?: number;
   sessionStatus?: OrchestrationSessionStatus;
+  provider?: "codex" | "claudeAgent";
 }): OrchestrationReadModel {
+  const provider = options.provider ?? "codex";
   const messages: Array<OrchestrationReadModel["threads"][number]["messages"][number]> = [];
 
   for (let index = 0; index < 22; index += 1) {
@@ -278,8 +280,8 @@ function createSnapshotForTargetUser(options: {
         projectId: PROJECT_ID,
         title: "Browser test thread",
         modelSelection: {
-          provider: "codex",
-          model: "gpt-5",
+          provider,
+          model: provider === "claudeAgent" ? "claude-sonnet-4-6" : "gpt-5",
         },
         interactionMode: "default",
         runtimeMode: "full-access",
@@ -297,7 +299,7 @@ function createSnapshotForTargetUser(options: {
         session: {
           threadId: THREAD_ID,
           status: options.sessionStatus ?? "ready",
-          providerName: "codex",
+          providerName: provider,
           runtimeMode: "full-access",
           activeTurnId: null,
           lastError: null,
@@ -2393,6 +2395,44 @@ describe("ChatView timeline estimator parity (full app)", () => {
         },
         { timeout: 4_000, interval: 16 },
       );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("renders the provider icon next to the sidebar thread title", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-provider-icon-test" as MessageId,
+        targetText: "provider icon target",
+        provider: "claudeAgent",
+      }),
+      configureFixture: (fixture) => {
+        fixture.serverConfig = {
+          ...fixture.serverConfig,
+          providers: [
+            ...fixture.serverConfig.providers,
+            {
+              provider: "claudeAgent",
+              enabled: true,
+              installed: true,
+              version: "1.0.0",
+              status: "ready",
+              auth: { status: "authenticated" },
+              checkedAt: NOW_ISO,
+              models: [],
+            },
+          ],
+        };
+      },
+    });
+
+    try {
+      const providerIcon = page.getByTestId(`thread-provider-icon-${THREAD_ID}`);
+
+      await expect.element(providerIcon).toBeInTheDocument();
+      await expect.element(providerIcon).toHaveAttribute("aria-label", "Claude thread");
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -8,6 +8,7 @@ import {
   type OrchestrationEvent,
   type OrchestrationReadModel,
   type ProjectId,
+  type ProviderKind,
   type ServerConfig,
   type ServerLifecycleWelcomePayload,
   type ThreadId,
@@ -219,7 +220,7 @@ function createSnapshotForTargetUser(options: {
   targetText: string;
   targetAttachmentCount?: number;
   sessionStatus?: OrchestrationSessionStatus;
-  provider?: "codex" | "claudeAgent";
+  provider?: ProviderKind;
 }): OrchestrationReadModel {
   const provider = options.provider ?? "codex";
   const messages: Array<OrchestrationReadModel["threads"][number]["messages"][number]> = [];

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -130,6 +130,11 @@ import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
 import { useServerKeybindings } from "../rpc/serverState";
 import { useSidebarThreadSummaryById } from "../storeSelectors";
 import type { Project } from "../types";
+import {
+  PROVIDER_ICON_BY_KIND,
+  providerDisplayLabel,
+  providerIconClassName,
+} from "../providerPresentation";
 const THREAD_PREVIEW_LIMIT = 6;
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
@@ -253,6 +258,26 @@ function resolveThreadPr(
   }
 
   return gitStatus.pr ?? null;
+}
+
+function ThreadProviderIcon(props: { provider: "codex" | "claudeAgent"; threadId: ThreadId }) {
+  const ProviderIcon = PROVIDER_ICON_BY_KIND[props.provider];
+  const label = `${providerDisplayLabel(props.provider)} thread`;
+
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      data-testid={`thread-provider-icon-${props.threadId}`}
+      className="inline-flex size-3 shrink-0 items-center justify-center"
+    >
+      <ProviderIcon
+        aria-hidden="true"
+        className={`size-3 ${providerIconClassName(props.provider, "text-muted-foreground/70")}`}
+      />
+    </span>
+  );
 }
 
 interface SidebarThreadRowProps {
@@ -399,6 +424,7 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
             </Tooltip>
           )}
           {threadStatus && <ThreadStatusLabel status={threadStatus} />}
+          <ThreadProviderIcon provider={thread.provider} threadId={thread.id} />
           {props.renamingThreadId === thread.id ? (
             <input
               ref={props.onRenamingInputMount}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -46,6 +46,8 @@ import {
   DEFAULT_MODEL_BY_PROVIDER,
   type DesktopUpdateState,
   ProjectId,
+  type ProviderKind,
+  PROVIDER_DISPLAY_NAMES,
   ThreadId,
   type GitStatusResult,
 } from "@t3tools/contracts";
@@ -130,11 +132,7 @@ import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
 import { useServerKeybindings } from "../rpc/serverState";
 import { useSidebarThreadSummaryById } from "../storeSelectors";
 import type { Project } from "../types";
-import {
-  PROVIDER_ICON_BY_KIND,
-  providerDisplayLabel,
-  providerIconClassName,
-} from "../providerPresentation";
+import { PROVIDER_ICON_BY_KIND, providerIconClassName } from "../providerPresentation";
 const THREAD_PREVIEW_LIMIT = 6;
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
@@ -260,9 +258,9 @@ function resolveThreadPr(
   return gitStatus.pr ?? null;
 }
 
-function ThreadProviderIcon(props: { provider: "codex" | "claudeAgent"; threadId: ThreadId }) {
+function ThreadProviderIcon(props: { provider: ProviderKind; threadId: ThreadId }) {
   const ProviderIcon = PROVIDER_ICON_BY_KIND[props.provider];
-  const label = `${providerDisplayLabel(props.provider)} thread`;
+  const label = `${PROVIDER_DISPLAY_NAMES[props.provider]} thread`;
 
   return (
     <span

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -2,7 +2,7 @@ import { type ProviderKind, type ServerProvider } from "@t3tools/contracts";
 import { resolveSelectableModel } from "@t3tools/shared/model";
 import { memo, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
-import { type ProviderPickerKind, PROVIDER_OPTIONS } from "../../session-logic";
+import { PROVIDER_OPTIONS } from "../../session-logic";
 import { ChevronDownIcon } from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
 import {
@@ -18,9 +18,10 @@ import {
   MenuSubTrigger,
   MenuTrigger,
 } from "../ui/menu";
-import { ClaudeAI, CursorIcon, Gemini, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { Gemini, OpenCodeIcon } from "../Icons";
 import { cn } from "~/lib/utils";
 import { getProviderSnapshot } from "../../providerModels";
+import { PROVIDER_ICON_BY_KIND, providerIconClassName } from "../../providerPresentation";
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {
   value: ProviderKind;
@@ -30,25 +31,12 @@ function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): o
   return option.available;
 }
 
-const PROVIDER_ICON_BY_PROVIDER: Record<ProviderPickerKind, Icon> = {
-  codex: OpenAI,
-  claudeAgent: ClaudeAI,
-  cursor: CursorIcon,
-};
-
 export const AVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter(isAvailableProviderOption);
 const UNAVAILABLE_PROVIDER_OPTIONS = PROVIDER_OPTIONS.filter((option) => !option.available);
 const COMING_SOON_PROVIDER_OPTIONS = [
   { id: "opencode", label: "OpenCode", icon: OpenCodeIcon },
   { id: "gemini", label: "Gemini", icon: Gemini },
 ] as const;
-
-function providerIconClassName(
-  provider: ProviderKind | ProviderPickerKind,
-  fallbackClassName: string,
-): string {
-  return provider === "claudeAgent" ? "text-[#d97757]" : fallbackClassName;
-}
 
 export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   provider: ProviderKind;
@@ -68,7 +56,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   const selectedProviderOptions = props.modelOptionsByProvider[activeProvider];
   const selectedModelLabel =
     selectedProviderOptions.find((option) => option.slug === props.model)?.name ?? props.model;
-  const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[activeProvider];
+  const ProviderIcon = PROVIDER_ICON_BY_KIND[activeProvider];
   const handleModelChange = (provider: ProviderKind, value: string) => {
     if (props.disabled) return;
     if (!value) return;
@@ -147,7 +135,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
         ) : (
           <>
             {AVAILABLE_PROVIDER_OPTIONS.map((option) => {
-              const OptionIcon = PROVIDER_ICON_BY_PROVIDER[option.value];
+              const OptionIcon = PROVIDER_ICON_BY_KIND[option.value];
               const liveProvider = props.providers
                 ? getProviderSnapshot(props.providers, option.value)
                 : undefined;
@@ -208,7 +196,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
             })}
             {UNAVAILABLE_PROVIDER_OPTIONS.length > 0 && <MenuDivider />}
             {UNAVAILABLE_PROVIDER_OPTIONS.map((option) => {
-              const OptionIcon = PROVIDER_ICON_BY_PROVIDER[option.value];
+              const OptionIcon = PROVIDER_ICON_BY_KIND[option.value];
               return (
                 <MenuItem key={option.value} disabled>
                   <OptionIcon

--- a/apps/web/src/providerPresentation.ts
+++ b/apps/web/src/providerPresentation.ts
@@ -1,4 +1,3 @@
-import { type ProviderKind } from "@t3tools/contracts";
 import { type ProviderPickerKind } from "./session-logic";
 import { type Icon, ClaudeAI, CursorIcon, OpenAI } from "./components/Icons";
 
@@ -8,12 +7,8 @@ export const PROVIDER_ICON_BY_KIND: Record<ProviderPickerKind, Icon> = {
   cursor: CursorIcon,
 };
 
-export function providerDisplayLabel(provider: ProviderKind): string {
-  return provider === "claudeAgent" ? "Claude" : "Codex";
-}
-
 export function providerIconClassName(
-  provider: ProviderKind | ProviderPickerKind,
+  provider: ProviderPickerKind,
   fallbackClassName: string,
 ): string {
   return provider === "claudeAgent" ? "text-[#d97757]" : fallbackClassName;

--- a/apps/web/src/providerPresentation.ts
+++ b/apps/web/src/providerPresentation.ts
@@ -1,0 +1,20 @@
+import { type ProviderKind } from "@t3tools/contracts";
+import { type ProviderPickerKind } from "./session-logic";
+import { type Icon, ClaudeAI, CursorIcon, OpenAI } from "./components/Icons";
+
+export const PROVIDER_ICON_BY_KIND: Record<ProviderPickerKind, Icon> = {
+  codex: OpenAI,
+  claudeAgent: ClaudeAI,
+  cursor: CursorIcon,
+};
+
+export function providerDisplayLabel(provider: ProviderKind): string {
+  return provider === "claudeAgent" ? "Claude" : "Codex";
+}
+
+export function providerIconClassName(
+  provider: ProviderKind | ProviderPickerKind,
+  fallbackClassName: string,
+): string {
+  return provider === "claudeAgent" ? "text-[#d97757]" : fallbackClassName;
+}

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -194,6 +194,23 @@ describe("store read model sync", () => {
     expect(next.threads[0]?.modelSelection.model).toBe("claude-opus-4-6");
   });
 
+  it("captures the sidebar provider from the thread model selection", () => {
+    const initialState = makeState(makeThread());
+    const readModel = makeReadModel(
+      makeReadModelThread({
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-6",
+        },
+        session: null,
+      }),
+    );
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.sidebarThreadsById[ThreadId.makeUnsafe("thread-1")]?.provider).toBe("claudeAgent");
+  });
+
   it("resolves claude aliases when session provider is claudeAgent", () => {
     const initialState = makeState(makeThread());
     const readModel = makeReadModel(
@@ -569,6 +586,25 @@ describe("incremental orchestration updates", () => {
     expect(next.threads[0]?.session?.status).toBe("running");
     expect(next.threads[0]?.latestTurn?.state).toBe("completed");
     expect(next.threads[0]?.messages).toHaveLength(1);
+  });
+
+  it("updates the sidebar provider when thread model selection changes", () => {
+    const state = makeState(makeThread());
+
+    const next = applyOrchestrationEvent(
+      state,
+      makeEvent("thread.meta-updated", {
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-6",
+        },
+        updatedAt: "2026-02-27T00:00:02.000Z",
+      }),
+    );
+
+    expect(next.threads[0]?.modelSelection.provider).toBe("claudeAgent");
+    expect(next.sidebarThreadsById[ThreadId.makeUnsafe("thread-1")]?.provider).toBe("claudeAgent");
   });
 
   it("does not regress latestTurn when an older turn diff completes late", () => {

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -215,6 +215,7 @@ function buildSidebarThreadSummary(thread: Thread): SidebarThreadSummary {
     id: thread.id,
     projectId: thread.projectId,
     title: thread.title,
+    provider: thread.modelSelection.provider,
     interactionMode: thread.interactionMode,
     session: thread.session,
     createdAt: thread.createdAt,
@@ -241,6 +242,7 @@ function sidebarThreadSummariesEqual(
     left.id === right.id &&
     left.projectId === right.projectId &&
     left.title === right.title &&
+    left.provider === right.provider &&
     left.interactionMode === right.interactionMode &&
     left.session === right.session &&
     left.createdAt === right.createdAt &&

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -115,6 +115,7 @@ export interface SidebarThreadSummary {
   id: ThreadId;
   projectId: ProjectId;
   title: string;
+  provider: ProviderKind;
   interactionMode: ProviderInteractionMode;
   session: ThreadSession | null;
   createdAt: string;


### PR DESCRIPTION
Closes #1813

## What Changed

- Added provider icons beside sidebar thread titles so Codex and Claude threads are visually distinguishable at a glance.
- Extended the normalized sidebar thread summary to retain the thread provider, so the sidebar can render the icon without reaching back into full thread state.
- Extracted shared provider icon presentation logic so the sidebar and model picker use the same icon/color mapping.
- Added store and browser regression coverage for provider propagation and sidebar icon rendering.

## Why

The issue asks for a quick visual way to sort conversations by harness. The sidebar already renders thread-specific metadata from normalized store summaries, so carrying the provider into that summary keeps the change small, avoids duplicating lookup logic in each row, and matches the direction of recent merged sidebar work.

## UI Changes

- Sidebar thread rows now show the provider icon immediately before the thread title.

## Testing

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test -- src/store.test.ts`
- `bun run test:browser -- src/components/ChatView.browser.tsx`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
<img width="247" height="181" alt="image" src="https://github.com/user-attachments/assets/76f42cbe-97a5-43df-9f8a-866993147e1d" />

- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change that adds a new `provider` field to the sidebar thread summary and uses it for rendering; main risk is minor UI regression or missed updates if provider data is absent/mismatched.
> 
> **Overview**
> Adds a provider icon next to each sidebar thread title, using shared icon/color mapping and accessible labels (via new `ThreadProviderIcon`).
> 
> Extends the normalized `SidebarThreadSummary` to include the thread’s `modelSelection.provider` and updates equality checks so sidebar rows re-render when the provider changes.
> 
> Refactors provider icon presentation into `providerPresentation.ts` and updates the model picker and browser/store tests to cover provider propagation and icon rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85db0173128240374267b074e8d7471f255265f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider icons to sidebar thread rows
> - Introduces a `ThreadProviderIcon` component in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1814/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) that renders a provider-specific icon next to each thread title, with accessible `aria-label` and `data-testid` attributes.
> - Adds `provider` to the `SidebarThreadSummary` type and populates it from `thread.modelSelection.provider` in `buildSidebarThreadSummary`; `sidebarThreadSummariesEqual` now includes `provider` in its equality check so UI updates propagate on provider changes.
> - Extracts shared `PROVIDER_ICON_BY_KIND` and `providerIconClassName` into [providerPresentation.ts](https://github.com/pingdotgg/t3code/pull/1814/files#diff-b245f07ee6471f32a196bb163d2082a003a4b7fc0f4dd0efa272ec1d2601319b), replacing duplicated local mappings in `ProviderModelPicker`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85db017.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->