### PR TITLE
[codex] Add thread loop scheduling and restart recovery

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1104,10 +1104,14 @@ function stopBackend(): void {
   if (!child) return;
 
   if (child.exitCode === null && child.signalCode === null) {
+    writeDesktopLogHeader(`stopping backend pid=${child.pid ?? "unknown"} via SIGTERM`);
     expectedBackendExitChildren.add(child);
     child.kill("SIGTERM");
     setTimeout(() => {
       if (child.exitCode === null && child.signalCode === null) {
+        writeDesktopLogHeader(
+          `backend pid=${child.pid ?? "unknown"} did not exit after SIGTERM; sending SIGKILL`,
+        );
         child.kill("SIGKILL");
       }
     }, 2_000).unref();

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1104,14 +1104,10 @@ function stopBackend(): void {
   if (!child) return;
 
   if (child.exitCode === null && child.signalCode === null) {
-    writeDesktopLogHeader(`stopping backend pid=${child.pid ?? "unknown"} via SIGTERM`);
     expectedBackendExitChildren.add(child);
     child.kill("SIGTERM");
     setTimeout(() => {
       if (child.exitCode === null && child.signalCode === null) {
-        writeDesktopLogHeader(
-          `backend pid=${child.pid ?? "unknown"} did not exit after SIGTERM; sending SIGKILL`,
-        );
         child.kill("SIGKILL");
       }
     }, 2_000).unref();

--- a/apps/server/integration/OrchestrationEngineHarness.integration.ts
+++ b/apps/server/integration/OrchestrationEngineHarness.integration.ts
@@ -58,6 +58,7 @@ import {
 } from "../src/orchestration/Services/OrchestrationEngine.ts";
 import { OrchestrationReactor } from "../src/orchestration/Services/OrchestrationReactor.ts";
 import { ProjectionSnapshotQuery } from "../src/orchestration/Services/ProjectionSnapshotQuery.ts";
+import { ThreadLoopScheduler } from "../src/orchestration/Services/ThreadLoopScheduler.ts";
 import {
   RuntimeReceiptBus,
   type OrchestrationRuntimeReceipt,
@@ -333,6 +334,11 @@ export const makeOrchestrationIntegrationHarness = (
       Layer.provideMerge(runtimeIngestionLayer),
       Layer.provideMerge(providerCommandReactorLayer),
       Layer.provideMerge(checkpointReactorLayer),
+      Layer.provideMerge(
+        Layer.succeed(ThreadLoopScheduler, {
+          start: () => Effect.void,
+        }),
+      ),
     );
     const layer = Layer.empty.pipe(
       Layer.provideMerge(runtimeServicesLayer),

--- a/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/CheckpointReactor.test.ts
@@ -424,6 +424,83 @@ describe("CheckpointReactor", () => {
     ).toBe("v2\n");
   });
 
+  it("still captures turn completion after activeTurnId is sanitized before completion", async () => {
+    const harness = await createHarness({ seedFilesystemCheckpoints: false });
+    const createdAt = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-running-before-sanitize"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: asTurnId("turn-sanitized-before-checkpoint"),
+          lastError: null,
+          updatedAt: createdAt,
+        },
+        createdAt,
+      }),
+    );
+
+    harness.provider.emit({
+      type: "turn.started",
+      eventId: EventId.makeUnsafe("evt-turn-started-sanitized-before-checkpoint"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-sanitized-before-checkpoint"),
+    });
+    await waitForGitRefExists(
+      harness.cwd,
+      checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 0),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-set-ready-after-sanitize"),
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        session: {
+          threadId: ThreadId.makeUnsafe("thread-1"),
+          status: "ready",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: null,
+          lastError: null,
+          updatedAt: new Date().toISOString(),
+        },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
+    fs.writeFileSync(path.join(harness.cwd, "README.md"), "v2\n", "utf8");
+    harness.provider.emit({
+      type: "turn.completed",
+      eventId: EventId.makeUnsafe("evt-turn-completed-sanitized-before-checkpoint"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: ThreadId.makeUnsafe("thread-1"),
+      turnId: asTurnId("turn-sanitized-before-checkpoint"),
+      payload: { state: "completed" },
+    });
+
+    await waitForEvent(harness.engine, (event) => event.type === "thread.turn-diff-completed");
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.latestTurn?.turnId === "turn-sanitized-before-checkpoint" &&
+        entry.checkpoints.length === 1,
+    );
+    expect(thread.checkpoints[0]?.checkpointTurnCount).toBe(1);
+    expect(
+      gitRefExists(harness.cwd, checkpointRefForThreadTurn(ThreadId.makeUnsafe("thread-1"), 1)),
+    ).toBe(true);
+  });
+
   it("ignores auxiliary thread turn completion while primary turn is active", async () => {
     const harness = await createHarness({ seedFilesystemCheckpoints: false });
     const createdAt = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.test.ts
@@ -5,6 +5,7 @@ import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
 import { OrchestrationReactor } from "../Services/OrchestrationReactor.ts";
+import { ThreadLoopScheduler } from "../Services/ThreadLoopScheduler.ts";
 import { makeOrchestrationReactor } from "./OrchestrationReactor.ts";
 
 describe("OrchestrationReactor", () => {
@@ -49,6 +50,14 @@ describe("OrchestrationReactor", () => {
             drain: Effect.void,
           }),
         ),
+        Layer.provideMerge(
+          Layer.succeed(ThreadLoopScheduler, {
+            start: () => {
+              started.push("thread-loop-scheduler");
+              return Effect.void;
+            },
+          }),
+        ),
       ),
     );
 
@@ -60,6 +69,7 @@ describe("OrchestrationReactor", () => {
       "provider-runtime-ingestion",
       "provider-command-reactor",
       "checkpoint-reactor",
+      "thread-loop-scheduler",
     ]);
 
     await Effect.runPromise(Scope.close(scope, Exit.void));

--- a/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationReactor.ts
@@ -7,16 +7,19 @@ import {
 import { CheckpointReactor } from "../Services/CheckpointReactor.ts";
 import { ProviderCommandReactor } from "../Services/ProviderCommandReactor.ts";
 import { ProviderRuntimeIngestionService } from "../Services/ProviderRuntimeIngestion.ts";
+import { ThreadLoopScheduler } from "../Services/ThreadLoopScheduler.ts";
 
 export const makeOrchestrationReactor = Effect.gen(function* () {
   const providerRuntimeIngestion = yield* ProviderRuntimeIngestionService;
   const providerCommandReactor = yield* ProviderCommandReactor;
   const checkpointReactor = yield* CheckpointReactor;
+  const threadLoopScheduler = yield* ThreadLoopScheduler;
 
   const start: OrchestrationReactorShape["start"] = Effect.fn("start")(function* () {
     yield* providerRuntimeIngestion.start();
     yield* providerCommandReactor.start();
     yield* checkpointReactor.start();
+    yield* threadLoopScheduler.start();
   });
 
   return {

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -23,6 +23,10 @@ import {
 } from "../../persistence/Services/ProjectionThreadProposedPlans.ts";
 import { ProjectionThreadSessionRepository } from "../../persistence/Services/ProjectionThreadSessions.ts";
 import {
+  ProjectionThreadLoopRepository,
+  type ProjectionThreadLoop,
+} from "../../persistence/Services/ProjectionThreadLoops.ts";
+import {
   type ProjectionTurn,
   ProjectionTurnRepository,
 } from "../../persistence/Services/ProjectionTurns.ts";
@@ -34,6 +38,7 @@ import { ProjectionThreadActivityRepositoryLive } from "../../persistence/Layers
 import { ProjectionThreadMessageRepositoryLive } from "../../persistence/Layers/ProjectionThreadMessages.ts";
 import { ProjectionThreadProposedPlanRepositoryLive } from "../../persistence/Layers/ProjectionThreadProposedPlans.ts";
 import { ProjectionThreadSessionRepositoryLive } from "../../persistence/Layers/ProjectionThreadSessions.ts";
+import { ProjectionThreadLoopRepositoryLive } from "../../persistence/Layers/ProjectionThreadLoops.ts";
 import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
 import { ProjectionThreadRepositoryLive } from "../../persistence/Layers/ProjectionThreads.ts";
 import { ServerConfig } from "../../config.ts";
@@ -55,6 +60,7 @@ export const ORCHESTRATION_PROJECTOR_NAMES = {
   threadProposedPlans: "projection.thread-proposed-plans",
   threadActivities: "projection.thread-activities",
   threadSessions: "projection.thread-sessions",
+  threadLoops: "projection.thread-loops",
   threadTurns: "projection.thread-turns",
   checkpoints: "projection.checkpoints",
   pendingApprovals: "projection.pending-approvals",
@@ -366,6 +372,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
     const projectionThreadProposedPlanRepository = yield* ProjectionThreadProposedPlanRepository;
     const projectionThreadActivityRepository = yield* ProjectionThreadActivityRepository;
     const projectionThreadSessionRepository = yield* ProjectionThreadSessionRepository;
+    const projectionThreadLoopRepository = yield* ProjectionThreadLoopRepository;
     const projectionTurnRepository = yield* ProjectionTurnRepository;
     const projectionPendingApprovalRepository = yield* ProjectionPendingApprovalRepository;
 
@@ -817,6 +824,38 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
       });
     });
 
+    const applyThreadLoopsProjection: ProjectorDefinition["apply"] = Effect.fn(
+      "applyThreadLoopsProjection",
+    )(function* (event, _attachmentSideEffects) {
+      switch (event.type) {
+        case "thread.loop-upserted": {
+          const row: ProjectionThreadLoop = {
+            threadId: event.payload.threadId,
+            enabled: event.payload.loop.enabled,
+            prompt: event.payload.loop.prompt,
+            intervalMinutes: event.payload.loop.intervalMinutes,
+            nextRunAt: event.payload.loop.nextRunAt,
+            lastRunAt: event.payload.loop.lastRunAt,
+            lastError: event.payload.loop.lastError,
+            createdAt: event.payload.loop.createdAt,
+            updatedAt: event.payload.loop.updatedAt,
+          };
+          yield* projectionThreadLoopRepository.upsert(row);
+          return;
+        }
+
+        case "thread.loop-deleted":
+        case "thread.deleted":
+          yield* projectionThreadLoopRepository.deleteByThreadId({
+            threadId: event.payload.threadId,
+          });
+          return;
+
+        default:
+          return;
+      }
+    });
+
     const applyThreadTurnsProjection: ProjectorDefinition["apply"] = Effect.fn(
       "applyThreadTurnsProjection",
     )(function* (event, _attachmentSideEffects) {
@@ -1185,6 +1224,10 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         apply: applyThreadSessionsProjection,
       },
       {
+        name: ORCHESTRATION_PROJECTOR_NAMES.threadLoops,
+        apply: applyThreadLoopsProjection,
+      },
+      {
         name: ORCHESTRATION_PROJECTOR_NAMES.threadTurns,
         apply: applyThreadTurnsProjection,
       },
@@ -1300,6 +1343,7 @@ export const OrchestrationProjectionPipelineLive = Layer.effect(
   Layer.provideMerge(ProjectionThreadProposedPlanRepositoryLive),
   Layer.provideMerge(ProjectionThreadActivityRepositoryLive),
   Layer.provideMerge(ProjectionThreadSessionRepositoryLive),
+  Layer.provideMerge(ProjectionThreadLoopRepositoryLive),
   Layer.provideMerge(ProjectionTurnRepositoryLive),
   Layer.provideMerge(ProjectionPendingApprovalRepositoryLive),
   Layer.provideMerge(ProjectionStateRepositoryLive),

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -374,6 +374,213 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
     }),
   );
 
+  it.effect("sanitizes impossible session snapshots during boot hydration", () =>
+    Effect.gen(function* () {
+      const snapshotQuery = yield* ProjectionSnapshotQuery;
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* sql`DELETE FROM projection_projects`;
+      yield* sql`DELETE FROM projection_threads`;
+      yield* sql`DELETE FROM projection_thread_sessions`;
+      yield* sql`DELETE FROM projection_state`;
+
+      yield* sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model_selection_json,
+          scripts_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (
+          'project-sanitize',
+          'Project Sanitize',
+          '/tmp/project-sanitize',
+          '{"provider":"codex","model":"gpt-5-codex"}',
+          '[]',
+          '2026-03-01T00:00:00.000Z',
+          '2026-03-01T00:00:01.000Z',
+          NULL
+        )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_threads (
+          thread_id,
+          project_id,
+          title,
+          model_selection_json,
+          runtime_mode,
+          interaction_mode,
+          branch,
+          worktree_path,
+          latest_turn_id,
+          created_at,
+          updated_at,
+          archived_at,
+          deleted_at
+        )
+        VALUES
+          (
+            'thread-ready',
+            'project-sanitize',
+            'Thread Ready',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'approval-required',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            '2026-03-01T00:00:02.000Z',
+            '2026-03-01T00:00:03.000Z',
+            NULL,
+            NULL
+          ),
+          (
+            'thread-stopped',
+            'project-sanitize',
+            'Thread Stopped',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'approval-required',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            '2026-03-01T00:00:04.000Z',
+            '2026-03-01T00:00:05.000Z',
+            NULL,
+            NULL
+          ),
+          (
+            'thread-interrupted',
+            'project-sanitize',
+            'Thread Interrupted',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'approval-required',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            '2026-03-01T00:00:06.000Z',
+            '2026-03-01T00:00:07.000Z',
+            NULL,
+            NULL
+          ),
+          (
+            'thread-error',
+            'project-sanitize',
+            'Thread Error',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'approval-required',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            '2026-03-01T00:00:08.000Z',
+            '2026-03-01T00:00:09.000Z',
+            NULL,
+            NULL
+          ),
+          (
+            'thread-running',
+            'project-sanitize',
+            'Thread Running',
+            '{"provider":"codex","model":"gpt-5-codex"}',
+            'approval-required',
+            'default',
+            NULL,
+            NULL,
+            NULL,
+            '2026-03-01T00:00:10.000Z',
+            '2026-03-01T00:00:11.000Z',
+            NULL,
+            NULL
+          )
+      `;
+
+      yield* sql`
+        INSERT INTO projection_thread_sessions (
+          thread_id,
+          status,
+          provider_name,
+          runtime_mode,
+          active_turn_id,
+          last_error,
+          updated_at
+        )
+        VALUES
+          (
+            'thread-ready',
+            'ready',
+            'codex',
+            'approval-required',
+            'turn-zombie-ready',
+            NULL,
+            '2026-03-01T00:01:00.000Z'
+          ),
+          (
+            'thread-stopped',
+            'stopped',
+            'codex',
+            'approval-required',
+            'turn-zombie-stopped',
+            NULL,
+            '2026-03-01T00:01:01.000Z'
+          ),
+          (
+            'thread-interrupted',
+            'interrupted',
+            'codex',
+            'approval-required',
+            'turn-zombie-interrupted',
+            NULL,
+            '2026-03-01T00:01:02.000Z'
+          ),
+          (
+            'thread-error',
+            'error',
+            'codex',
+            'approval-required',
+            'turn-zombie-error',
+            'provider crashed',
+            '2026-03-01T00:01:03.000Z'
+          ),
+          (
+            'thread-running',
+            'running',
+            'codex',
+            'approval-required',
+            'turn-live',
+            NULL,
+            '2026-03-01T00:01:04.000Z'
+          )
+      `;
+
+      const snapshot = yield* snapshotQuery.getSnapshot();
+      const sessionByThreadId = new Map(
+        snapshot.threads.map((thread) => [thread.id, thread.session] as const),
+      );
+
+      assert.equal(sessionByThreadId.get(ThreadId.makeUnsafe("thread-ready"))?.activeTurnId, null);
+      assert.equal(
+        sessionByThreadId.get(ThreadId.makeUnsafe("thread-stopped"))?.activeTurnId,
+        null,
+      );
+      assert.equal(
+        sessionByThreadId.get(ThreadId.makeUnsafe("thread-interrupted"))?.activeTurnId,
+        null,
+      );
+      assert.equal(sessionByThreadId.get(ThreadId.makeUnsafe("thread-error"))?.activeTurnId, null);
+      assert.equal(
+        sessionByThreadId.get(ThreadId.makeUnsafe("thread-running"))?.activeTurnId,
+        asTurnId("turn-live"),
+      );
+    }),
+  );
+
   it.effect(
     "reads targeted project, thread, and count queries without hydrating the full snapshot",
     () =>

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -174,6 +174,31 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
       `;
 
       yield* sql`
+        INSERT INTO projection_thread_loops (
+          thread_id,
+          enabled,
+          prompt,
+          interval_minutes,
+          next_run_at,
+          last_run_at,
+          last_error,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          'thread-1',
+          1,
+          'Check the inbox',
+          5,
+          '2026-02-24T00:10:00.000Z',
+          NULL,
+          NULL,
+          '2026-02-24T00:00:07.500Z',
+          '2026-02-24T00:00:07.500Z'
+        )
+      `;
+
+      yield* sql`
         INSERT INTO projection_turns (
           thread_id,
           turn_id,
@@ -333,6 +358,16 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
             activeTurnId: asTurnId("turn-1"),
             lastError: null,
             updatedAt: "2026-02-24T00:00:07.000Z",
+          },
+          loop: {
+            enabled: true,
+            prompt: "Check the inbox",
+            intervalMinutes: 5,
+            nextRunAt: "2026-02-24T00:10:00.000Z",
+            lastRunAt: null,
+            lastError: null,
+            createdAt: "2026-02-24T00:00:07.500Z",
+            updatedAt: "2026-02-24T00:00:07.500Z",
           },
         },
       ]);

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.test.ts
@@ -352,10 +352,10 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           ],
           session: {
             threadId: ThreadId.makeUnsafe("thread-1"),
-            status: "running",
+            status: "interrupted",
             providerName: "codex",
             runtimeMode: "approval-required",
-            activeTurnId: asTurnId("turn-1"),
+            activeTurnId: null,
             lastError: null,
             updatedAt: "2026-02-24T00:00:07.000Z",
           },
@@ -559,24 +559,75 @@ projectionSnapshotLayer("ProjectionSnapshotQuery", (it) => {
           )
       `;
 
-      const snapshot = yield* snapshotQuery.getSnapshot();
-      const sessionByThreadId = new Map(
-        snapshot.threads.map((thread) => [thread.id, thread.session] as const),
-      );
+      yield* sql`
+        INSERT INTO projection_turns (
+          thread_id,
+          turn_id,
+          pending_message_id,
+          source_proposed_plan_thread_id,
+          source_proposed_plan_id,
+          assistant_message_id,
+          state,
+          requested_at,
+          started_at,
+          completed_at,
+          checkpoint_turn_count,
+          checkpoint_ref,
+          checkpoint_status,
+          checkpoint_files_json
+        )
+        VALUES (
+          'thread-running',
+          'turn-live',
+          NULL,
+          NULL,
+          NULL,
+          NULL,
+          'running',
+          '2026-03-01T00:01:04.000Z',
+          '2026-03-01T00:01:04.000Z',
+          NULL,
+          NULL,
+          NULL,
+          NULL,
+          '[]'
+        )
+      `;
 
-      assert.equal(sessionByThreadId.get(ThreadId.makeUnsafe("thread-ready"))?.activeTurnId, null);
+      const snapshot = yield* snapshotQuery.getSnapshot();
+      const threadById = new Map(snapshot.threads.map((thread) => [thread.id, thread] as const));
+
       assert.equal(
-        sessionByThreadId.get(ThreadId.makeUnsafe("thread-stopped"))?.activeTurnId,
+        threadById.get(ThreadId.makeUnsafe("thread-ready"))?.session?.activeTurnId,
         null,
       );
       assert.equal(
-        sessionByThreadId.get(ThreadId.makeUnsafe("thread-interrupted"))?.activeTurnId,
+        threadById.get(ThreadId.makeUnsafe("thread-stopped"))?.session?.activeTurnId,
         null,
       );
-      assert.equal(sessionByThreadId.get(ThreadId.makeUnsafe("thread-error"))?.activeTurnId, null);
       assert.equal(
-        sessionByThreadId.get(ThreadId.makeUnsafe("thread-running"))?.activeTurnId,
-        asTurnId("turn-live"),
+        threadById.get(ThreadId.makeUnsafe("thread-interrupted"))?.session?.activeTurnId,
+        null,
+      );
+      assert.equal(
+        threadById.get(ThreadId.makeUnsafe("thread-error"))?.session?.activeTurnId,
+        null,
+      );
+      assert.equal(
+        threadById.get(ThreadId.makeUnsafe("thread-running"))?.session?.status,
+        "interrupted",
+      );
+      assert.equal(
+        threadById.get(ThreadId.makeUnsafe("thread-running"))?.session?.activeTurnId,
+        null,
+      );
+      assert.equal(
+        threadById.get(ThreadId.makeUnsafe("thread-running"))?.latestTurn?.state,
+        "interrupted",
+      );
+      assert.equal(
+        threadById.get(ThreadId.makeUnsafe("thread-running"))?.latestTurn?.completedAt,
+        "2026-03-01T00:01:04.000Z",
       );
     }),
   );

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -47,7 +47,7 @@ import {
   type ProjectionThreadCheckpointContext,
   type ProjectionSnapshotQueryShape,
 } from "../Services/ProjectionSnapshotQuery.ts";
-import { sanitizeSessionActiveTurn } from "../sessionState.ts";
+import { sanitizeBootLatestTurnState, sanitizeBootSessionState } from "../sessionState.ts";
 
 const decodeReadModel = Schema.decodeUnknownEffect(OrchestrationReadModel);
 const ProjectionProjectDbRowSchema = ProjectionProject.mapFields(
@@ -172,6 +172,7 @@ function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: st
 
 const makeProjectionSnapshotQuery = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
+  const processStartedAt = new Date().toISOString();
 
   const listProjectRows = SqlSchema.findAll({
     Request: Schema.Void,
@@ -685,16 +686,32 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             updatedAt = maxIso(updatedAt, row.updatedAt);
             sessionsByThread.set(
               row.threadId,
-              sanitizeSessionActiveTurn({
-                threadId: row.threadId,
-                status: row.status,
-                providerName: row.providerName,
-                runtimeMode: row.runtimeMode,
-                activeTurnId: row.activeTurnId,
-                lastError: row.lastError,
-                updatedAt: row.updatedAt,
-              }),
+              sanitizeBootSessionState(
+                {
+                  threadId: row.threadId,
+                  status: row.status,
+                  providerName: row.providerName,
+                  runtimeMode: row.runtimeMode,
+                  activeTurnId: row.activeTurnId,
+                  lastError: row.lastError,
+                  updatedAt: row.updatedAt,
+                },
+                processStartedAt,
+              ),
             );
+          }
+
+          for (const [threadId, latestTurn] of latestTurnByThread.entries()) {
+            const session = sessionsByThread.get(threadId) ?? null;
+            const sanitizedLatestTurn = sanitizeBootLatestTurnState(
+              latestTurn,
+              session,
+              processStartedAt,
+            );
+            latestTurnByThread.set(threadId, sanitizedLatestTurn);
+            if (sanitizedLatestTurn.completedAt !== null) {
+              updatedAt = maxIso(updatedAt, sanitizedLatestTurn.completedAt);
+            }
           }
 
           for (const row of threadLoopRows) {

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -16,6 +16,7 @@ import {
   type OrchestrationSession,
   type OrchestrationThread,
   type OrchestrationThreadActivity,
+  type ThreadLoop,
   ModelSelection,
   ProjectId,
   ThreadId,
@@ -37,6 +38,7 @@ import { ProjectionThreadActivity } from "../../persistence/Services/ProjectionT
 import { ProjectionThreadMessage } from "../../persistence/Services/ProjectionThreadMessages.ts";
 import { ProjectionThreadProposedPlan } from "../../persistence/Services/ProjectionThreadProposedPlans.ts";
 import { ProjectionThreadSession } from "../../persistence/Services/ProjectionThreadSessions.ts";
+import { ProjectionThreadLoop } from "../../persistence/Services/ProjectionThreadLoops.ts";
 import { ProjectionThread } from "../../persistence/Services/ProjectionThreads.ts";
 import { ORCHESTRATION_PROJECTOR_NAMES } from "./ProjectionPipeline.ts";
 import {
@@ -72,6 +74,11 @@ const ProjectionThreadActivityDbRowSchema = ProjectionThreadActivity.mapFields(
   }),
 );
 const ProjectionThreadSessionDbRowSchema = ProjectionThreadSession;
+const ProjectionThreadLoopDbRowSchema = ProjectionThreadLoop.mapFields(
+  Struct.assign({
+    enabled: Schema.Number,
+  }),
+);
 const ProjectionCheckpointDbRowSchema = ProjectionCheckpoint.mapFields(
   Struct.assign({
     files: Schema.fromJsonString(Schema.Array(OrchestrationCheckpointFile)),
@@ -120,6 +127,7 @@ const REQUIRED_SNAPSHOT_PROJECTORS = [
   ORCHESTRATION_PROJECTOR_NAMES.threadProposedPlans,
   ORCHESTRATION_PROJECTOR_NAMES.threadActivities,
   ORCHESTRATION_PROJECTOR_NAMES.threadSessions,
+  ORCHESTRATION_PROJECTOR_NAMES.threadLoops,
   ORCHESTRATION_PROJECTOR_NAMES.checkpoints,
 ] as const;
 
@@ -203,6 +211,26 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           archived_at AS "archivedAt",
           deleted_at AS "deletedAt"
         FROM projection_threads
+        ORDER BY created_at ASC, thread_id ASC
+      `,
+  });
+
+  const listThreadLoopRows = SqlSchema.findAll({
+    Request: Schema.Void,
+    Result: ProjectionThreadLoopDbRowSchema,
+    execute: () =>
+      sql`
+        SELECT
+          thread_id AS "threadId",
+          enabled,
+          prompt,
+          interval_minutes AS "intervalMinutes",
+          next_run_at AS "nextRunAt",
+          last_run_at AS "lastRunAt",
+          last_error AS "lastError",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM projection_thread_loops
         ORDER BY created_at ASC, thread_id ASC
       `,
   });
@@ -440,6 +468,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           const [
             projectRows,
             threadRows,
+            threadLoopRows,
             messageRows,
             proposedPlanRows,
             activityRows,
@@ -461,6 +490,14 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
                 toPersistenceSqlOrDecodeError(
                   "ProjectionSnapshotQuery.getSnapshot:listThreads:query",
                   "ProjectionSnapshotQuery.getSnapshot:listThreads:decodeRows",
+                ),
+              ),
+            ),
+            listThreadLoopRows(undefined).pipe(
+              Effect.mapError(
+                toPersistenceSqlOrDecodeError(
+                  "ProjectionSnapshotQuery.getSnapshot:listThreadLoops:query",
+                  "ProjectionSnapshotQuery.getSnapshot:listThreadLoops:decodeRows",
                 ),
               ),
             ),
@@ -527,6 +564,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
           const activitiesByThread = new Map<string, Array<OrchestrationThreadActivity>>();
           const checkpointsByThread = new Map<string, Array<OrchestrationCheckpointSummary>>();
           const sessionsByThread = new Map<string, OrchestrationSession>();
+          const loopsByThread = new Map<string, ThreadLoop>();
           const latestTurnByThread = new Map<string, OrchestrationLatestTurn>();
 
           let updatedAt: string | null = null;
@@ -535,6 +573,9 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             updatedAt = maxIso(updatedAt, row.updatedAt);
           }
           for (const row of threadRows) {
+            updatedAt = maxIso(updatedAt, row.updatedAt);
+          }
+          for (const row of threadLoopRows) {
             updatedAt = maxIso(updatedAt, row.updatedAt);
           }
           for (const row of stateRows) {
@@ -652,6 +693,19 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             });
           }
 
+          for (const row of threadLoopRows) {
+            loopsByThread.set(row.threadId, {
+              enabled: row.enabled === 1,
+              prompt: row.prompt,
+              intervalMinutes: row.intervalMinutes,
+              nextRunAt: row.nextRunAt,
+              lastRunAt: row.lastRunAt,
+              lastError: row.lastError,
+              createdAt: row.createdAt,
+              updatedAt: row.updatedAt,
+            });
+          }
+
           const projects: ReadonlyArray<OrchestrationProject> = projectRows.map((row) => ({
             id: row.projectId,
             title: row.title,
@@ -682,6 +736,7 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
             activities: activitiesByThread.get(row.threadId) ?? [],
             checkpoints: checkpointsByThread.get(row.threadId) ?? [],
             session: sessionsByThread.get(row.threadId) ?? null,
+            loop: loopsByThread.get(row.threadId) ?? null,
           }));
 
           const snapshot = {

--- a/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionSnapshotQuery.ts
@@ -47,6 +47,7 @@ import {
   type ProjectionThreadCheckpointContext,
   type ProjectionSnapshotQueryShape,
 } from "../Services/ProjectionSnapshotQuery.ts";
+import { sanitizeSessionActiveTurn } from "../sessionState.ts";
 
 const decodeReadModel = Schema.decodeUnknownEffect(OrchestrationReadModel);
 const ProjectionProjectDbRowSchema = ProjectionProject.mapFields(
@@ -682,15 +683,18 @@ const makeProjectionSnapshotQuery = Effect.gen(function* () {
 
           for (const row of sessionRows) {
             updatedAt = maxIso(updatedAt, row.updatedAt);
-            sessionsByThread.set(row.threadId, {
-              threadId: row.threadId,
-              status: row.status,
-              providerName: row.providerName,
-              runtimeMode: row.runtimeMode,
-              activeTurnId: row.activeTurnId,
-              lastError: row.lastError,
-              updatedAt: row.updatedAt,
-            });
+            sessionsByThread.set(
+              row.threadId,
+              sanitizeSessionActiveTurn({
+                threadId: row.threadId,
+                status: row.status,
+                providerName: row.providerName,
+                runtimeMode: row.runtimeMode,
+                activeTurnId: row.activeTurnId,
+                lastError: row.lastError,
+                updatedAt: row.updatedAt,
+              }),
+            );
           }
 
           for (const row of threadLoopRows) {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -353,6 +353,25 @@ describe("ProviderRuntimeIngestion", () => {
     expect(thread.session?.status).toBe("running");
     expect(thread.session?.lastError).toBeNull();
 
+    const seededTurnId = asTurnId("turn-zombie-session");
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.set",
+        commandId: CommandId.makeUnsafe("cmd-session-seed-zombie-turn"),
+        threadId: asThreadId("thread-1"),
+        session: {
+          threadId: asThreadId("thread-1"),
+          status: "running",
+          providerName: "codex",
+          runtimeMode: "approval-required",
+          activeTurnId: seededTurnId,
+          updatedAt: new Date().toISOString(),
+          lastError: null,
+        },
+        createdAt: new Date().toISOString(),
+      }),
+    );
+
     harness.emit({
       type: "session.state.changed",
       eventId: asEventId("evt-session-state-error"),
@@ -398,6 +417,27 @@ describe("ProviderRuntimeIngestion", () => {
 
     harness.emit({
       type: "session.state.changed",
+      eventId: asEventId("evt-session-state-interrupted"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: new Date().toISOString(),
+      payload: {
+        state: "interrupted",
+      },
+    });
+
+    thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.session?.status === "interrupted" &&
+        entry.session?.activeTurnId === null &&
+        entry.session?.lastError === "provider crashed",
+    );
+    expect(thread.session?.status).toBe("interrupted");
+    expect(thread.session?.lastError).toBe("provider crashed");
+
+    harness.emit({
+      type: "session.state.changed",
       eventId: asEventId("evt-session-state-ready"),
       provider: "codex",
       threadId: asThreadId("thread-1"),
@@ -416,6 +456,89 @@ describe("ProviderRuntimeIngestion", () => {
     );
     expect(thread.session?.status).toBe("ready");
     expect(thread.session?.lastError).toBeNull();
+  });
+
+  it("clears active turn and buffered state when a turn is aborted", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-aborted"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-aborted"),
+      payload: {},
+    });
+
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" && thread.session?.activeTurnId === "turn-aborted",
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-aborted"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-aborted"),
+      itemId: asItemId("item-aborted"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "ghost text",
+      },
+    });
+    harness.emit({
+      type: "turn.proposed.delta",
+      eventId: asEventId("evt-plan-delta-aborted"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-aborted"),
+      payload: {
+        delta: "# Ghost plan",
+      },
+    });
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-aborted"),
+      payload: {
+        reason: "User interrupted",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.session?.status === "interrupted" &&
+        entry.session?.activeTurnId === null &&
+        !entry.messages.some(
+          (message: ProviderRuntimeTestMessage) => message.id === "assistant:item-aborted",
+        ) &&
+        !entry.proposedPlans.some(
+          (plan: ProviderRuntimeTestProposedPlan) => plan.id === "plan:thread-1:turn:turn-aborted",
+        ),
+    );
+
+    expect(thread.session?.status).toBe("interrupted");
+    expect(thread.session?.activeTurnId).toBeNull();
+    expect(
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) => message.id === "assistant:item-aborted",
+      ),
+    ).toBe(false);
+    expect(
+      thread.proposedPlans.some(
+        (plan: ProviderRuntimeTestProposedPlan) => plan.id === "plan:thread-1:turn:turn-aborted",
+      ),
+    ).toBe(false);
   });
 
   it("does not clear active turn when session/thread started arrives mid-turn", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -541,6 +541,101 @@ describe("ProviderRuntimeIngestion", () => {
     ).toBe(false);
   });
 
+  it("does not clear active turn buffers when a different turn is aborted", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-live-turn"),
+      provider: "codex",
+      threadId: asThreadId("thread-1"),
+      createdAt: now,
+      turnId: asTurnId("turn-live"),
+      payload: {},
+    });
+
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" && thread.session?.activeTurnId === "turn-live",
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-live-turn"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-live"),
+      itemId: asItemId("item-live"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "live text",
+      },
+    });
+    harness.emit({
+      type: "turn.proposed.delta",
+      eventId: asEventId("evt-plan-delta-live-turn"),
+      provider: "codex",
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-live"),
+      payload: {
+        delta: "# Live plan",
+      },
+    });
+
+    harness.emit({
+      type: "turn.aborted",
+      eventId: asEventId("evt-turn-aborted-stale"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-stale"),
+      payload: {
+        reason: "Stale abort",
+      },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-live-turn"),
+      provider: "codex",
+      createdAt: new Date().toISOString(),
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-live"),
+      payload: {
+        state: "completed",
+      },
+    });
+
+    const thread = await waitForThread(
+      harness.engine,
+      (entry) =>
+        entry.session?.status === "ready" &&
+        entry.session?.activeTurnId === null &&
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) => message.id === "assistant:item-live",
+        ) &&
+        entry.proposedPlans.some(
+          (plan: ProviderRuntimeTestProposedPlan) => plan.id === "plan:thread-1:turn:turn-live",
+        ),
+    );
+
+    expect(thread.session?.status).toBe("ready");
+    expect(thread.session?.activeTurnId).toBeNull();
+    expect(
+      thread.messages.some(
+        (message: ProviderRuntimeTestMessage) => message.id === "assistant:item-live",
+      ),
+    ).toBe(true);
+    expect(
+      thread.proposedPlans.some(
+        (plan: ProviderRuntimeTestProposedPlan) => plan.id === "plan:thread-1:turn:turn-live",
+      ),
+    ).toBe(true);
+  });
+
   it("does not clear active turn when session/thread started arrives mid-turn", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -27,6 +27,7 @@ import {
   type ProviderRuntimeIngestionShape,
 } from "../Services/ProviderRuntimeIngestion.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { sessionStatusAllowsActiveTurn } from "../sessionState.ts";
 
 const providerTurnKey = (threadId: ThreadId, turnId: TurnId) => `${threadId}:${turnId}`;
 const providerCommandId = (event: ProviderRuntimeEvent, tag: string): CommandId =>
@@ -139,6 +140,12 @@ function orchestrationSessionStatusFromRuntimeState(
     case "error":
       return "error";
   }
+}
+
+function shouldClearTurnStateForRuntimeSessionStatus(
+  status: "starting" | "running" | "ready" | "interrupted" | "stopped" | "error",
+): boolean {
+  return !sessionStatusAllowsActiveTurn(status);
 }
 
 function requestKindFromCanonicalRequestType(
@@ -899,6 +906,7 @@ const make = Effect.fn("make")(function* () {
           return true;
         case "turn.started":
           return !conflictsWithActiveTurn;
+        case "turn.aborted":
         case "turn.completed":
           if (conflictsWithActiveTurn || missingTurnForActiveTurn) {
             return false;
@@ -924,14 +932,9 @@ const make = Effect.fn("make")(function* () {
       event.type === "session.exited" ||
       event.type === "thread.started" ||
       event.type === "turn.started" ||
+      event.type === "turn.aborted" ||
       event.type === "turn.completed"
     ) {
-      const nextActiveTurnId =
-        event.type === "turn.started"
-          ? (eventTurnId ?? null)
-          : event.type === "turn.completed" || event.type === "session.exited"
-            ? null
-            : activeTurnId;
       const status = (() => {
         switch (event.type) {
           case "session.state.changed":
@@ -940,6 +943,8 @@ const make = Effect.fn("make")(function* () {
             return "running";
           case "session.exited":
             return "stopped";
+          case "turn.aborted":
+            return "interrupted";
           case "turn.completed":
             return normalizeRuntimeTurnState(event.payload.state) === "failed" ? "error" : "ready";
           case "session.started":
@@ -949,6 +954,12 @@ const make = Effect.fn("make")(function* () {
             return activeTurnId !== null ? "running" : "ready";
         }
       })();
+      const nextActiveTurnId =
+        event.type === "turn.started"
+          ? (eventTurnId ?? null)
+          : shouldClearTurnStateForRuntimeSessionStatus(status)
+            ? null
+            : activeTurnId;
       const lastError =
         event.type === "session.state.changed" && event.payload.state === "error"
           ? (event.payload.reason ?? thread.session?.lastError ?? "Provider session error")
@@ -1137,7 +1148,16 @@ const make = Effect.fn("make")(function* () {
       }
     }
 
-    if (event.type === "session.exited") {
+    const shouldClearTurnState =
+      event.type === "turn.completed" ||
+      event.type === "turn.aborted" ||
+      event.type === "session.exited" ||
+      (event.type === "session.state.changed" &&
+        shouldClearTurnStateForRuntimeSessionStatus(
+          orchestrationSessionStatusFromRuntimeState(event.payload.state),
+        ));
+
+    if (shouldClearTurnState) {
       yield* clearTurnStateForSession(thread.id);
     }
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1149,13 +1149,14 @@ const make = Effect.fn("make")(function* () {
     }
 
     const shouldClearTurnState =
-      event.type === "turn.completed" ||
-      event.type === "turn.aborted" ||
-      event.type === "session.exited" ||
-      (event.type === "session.state.changed" &&
-        shouldClearTurnStateForRuntimeSessionStatus(
-          orchestrationSessionStatusFromRuntimeState(event.payload.state),
-        ));
+      shouldApplyThreadLifecycle &&
+      (event.type === "turn.completed" ||
+        event.type === "turn.aborted" ||
+        event.type === "session.exited" ||
+        (event.type === "session.state.changed" &&
+          shouldClearTurnStateForRuntimeSessionStatus(
+            orchestrationSessionStatusFromRuntimeState(event.payload.state),
+          )));
 
     if (shouldClearTurnState) {
       yield* clearTurnStateForSession(thread.id);

--- a/apps/server/src/orchestration/Layers/ThreadLoopScheduler.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadLoopScheduler.test.ts
@@ -257,7 +257,12 @@ describe("ThreadLoopScheduler", () => {
     const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
     assert.isTrue(commands.some((command) => command.type === "thread.turn.start"));
     assert.isTrue(
-      commands.some((command) => command.type === "thread.loop.sync" && "patch" in command),
+      commands.some(
+        (command) =>
+          command.type === "thread.loop.sync" &&
+          command.patch.nextRunAt !== undefined &&
+          typeof command.patch.lastRunAt === "string",
+      ),
     );
   });
 
@@ -278,6 +283,14 @@ describe("ThreadLoopScheduler", () => {
 
     const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
     assert.isFalse(commands.some((command) => command.type === "thread.turn.start"));
+    assert.isTrue(
+      commands.some(
+        (command) =>
+          command.type === "thread.loop.sync" &&
+          command.patch.nextRunAt !== undefined &&
+          command.patch.lastRunAt === undefined,
+      ),
+    );
     assert.isTrue(
       commands.some(
         (command) =>

--- a/apps/server/src/orchestration/Layers/ThreadLoopScheduler.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadLoopScheduler.test.ts
@@ -1,3 +1,7 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { assert } from "@effect/vitest";
 import {
   CommandId,
@@ -10,12 +14,21 @@ import {
   type OrchestrationReadModel,
 } from "@t3tools/contracts";
 import { Effect, Exit, Layer, ManagedRuntime, PubSub, Ref, Scope, Stream } from "effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
 import { afterEach, describe, it } from "vitest";
 
+import { ServerConfig } from "../../config.ts";
+import { OrchestrationCommandReceiptRepositoryLive } from "../../persistence/Layers/OrchestrationCommandReceipts.ts";
+import { OrchestrationEventStoreLive } from "../../persistence/Layers/OrchestrationEventStore.ts";
+import { layerConfig as SqlitePersistenceLive } from "../../persistence/Layers/Sqlite.ts";
 import { ProjectionThreadLoopRepository } from "../../persistence/Services/ProjectionThreadLoops.ts";
+import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
+import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
+import { OrchestrationProjectionSnapshotQueryLive } from "./ProjectionSnapshotQuery.ts";
 import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
 import { ThreadLoopScheduler } from "../Services/ThreadLoopScheduler.ts";
-import { makeThreadLoopScheduler } from "./ThreadLoopScheduler.ts";
+import { makeThreadLoopScheduler, ThreadLoopSchedulerLive } from "./ThreadLoopScheduler.ts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 
 const asThreadId = (value: string) => ThreadId.makeUnsafe(value);
 const asProjectId = (value: string) => ProjectId.makeUnsafe(value);
@@ -56,7 +69,7 @@ describe("ThreadLoopScheduler", () => {
   });
 
   async function createHarness(input: {
-    sessionStatus: "ready" | "running";
+    sessionStatus: "ready" | "running" | "interrupted" | "stopped" | "error";
     activeTurnId: string | null;
   }) {
     const commandsRef = Effect.runSync(Ref.make<Array<OrchestrationCommand>>([]));
@@ -266,6 +279,28 @@ describe("ThreadLoopScheduler", () => {
     );
   });
 
+  it("does not treat ready plus a zombie active turn as busy", async () => {
+    const harness = await createHarness({
+      sessionStatus: "ready",
+      activeTurnId: "turn-zombie-ready",
+    });
+
+    await waitFor(async () => {
+      const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+      return commands.some((command) => command.type === "thread.turn.start");
+    });
+
+    const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+    assert.isTrue(commands.some((command) => command.type === "thread.turn.start"));
+    assert.isFalse(
+      commands.some(
+        (command) =>
+          command.type === "thread.activity.append" &&
+          command.activity.kind === "loop.tick.skipped",
+      ),
+    );
+  });
+
   it("skips a due loop while the thread is busy", async () => {
     const harness = await createHarness({
       sessionStatus: "running",
@@ -292,6 +327,28 @@ describe("ThreadLoopScheduler", () => {
       ),
     );
     assert.isTrue(
+      commands.some(
+        (command) =>
+          command.type === "thread.activity.append" &&
+          command.activity.kind === "loop.tick.skipped",
+      ),
+    );
+  });
+
+  it("does not treat terminal zombie sessions as busy", async () => {
+    const harness = await createHarness({
+      sessionStatus: "error",
+      activeTurnId: "turn-zombie-error",
+    });
+
+    await waitFor(async () => {
+      const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+      return commands.some((command) => command.type === "thread.turn.start");
+    });
+
+    const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+    assert.isTrue(commands.some((command) => command.type === "thread.turn.start"));
+    assert.isFalse(
       commands.some(
         (command) =>
           command.type === "thread.activity.append" &&
@@ -347,5 +404,188 @@ describe("ThreadLoopScheduler", () => {
           command.patch.nextRunAt === null,
       ),
     );
+  });
+
+  it("recovers a dirty boot snapshot and resumes due loops after restart", async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-thread-loop-restart-"));
+    const makeServerConfigLayer = () => ServerConfig.layerTest(process.cwd(), baseDir);
+    const makeSchedulerRuntime = () => {
+      const serverConfigLayer = makeServerConfigLayer();
+      const sqliteLayer = SqlitePersistenceLive.pipe(
+        Layer.provideMerge(serverConfigLayer),
+        Layer.provideMerge(NodeServices.layer),
+      );
+      const orchestrationLayer = OrchestrationEngineLive.pipe(
+        Layer.provide(OrchestrationProjectionSnapshotQueryLive),
+        Layer.provide(OrchestrationProjectionPipelineLive),
+        Layer.provide(OrchestrationEventStoreLive),
+        Layer.provide(OrchestrationCommandReceiptRepositoryLive),
+        Layer.provide(sqliteLayer),
+        Layer.provideMerge(serverConfigLayer),
+        Layer.provideMerge(NodeServices.layer),
+      );
+
+      return ManagedRuntime.make(
+        ThreadLoopSchedulerLive.pipe(
+          Layer.provide(sqliteLayer),
+          Layer.provideMerge(orchestrationLayer),
+        ),
+      );
+    };
+    const makeSqlRuntime = () =>
+      ManagedRuntime.make(
+        SqlitePersistenceLive.pipe(
+          Layer.provideMerge(makeServerConfigLayer()),
+          Layer.provideMerge(NodeServices.layer),
+        ),
+      );
+
+    const seedRuntime = makeSqlRuntime();
+
+    try {
+      const sql = await seedRuntime.runPromise(Effect.service(SqlClient.SqlClient));
+
+      await seedRuntime.runPromise(sql`DELETE FROM projection_projects`);
+      await seedRuntime.runPromise(sql`DELETE FROM projection_threads`);
+      await seedRuntime.runPromise(sql`DELETE FROM projection_thread_sessions`);
+      await seedRuntime.runPromise(sql`DELETE FROM projection_thread_loops`);
+
+      await seedRuntime.runPromise(sql`
+        INSERT INTO projection_projects (
+          project_id,
+          title,
+          workspace_root,
+          default_model_selection_json,
+          scripts_json,
+          created_at,
+          updated_at,
+          deleted_at
+        )
+        VALUES (
+          'project-restart',
+          'Project Restart',
+          '/tmp/project-restart',
+          '{"provider":"codex","model":"gpt-5-codex"}',
+          '[]',
+          '2026-04-07T11:00:00.000Z',
+          '2026-04-07T11:00:01.000Z',
+          NULL
+        )
+      `);
+      await seedRuntime.runPromise(sql`
+        INSERT INTO projection_threads (
+          thread_id,
+          project_id,
+          title,
+          model_selection_json,
+          runtime_mode,
+          interaction_mode,
+          branch,
+          worktree_path,
+          latest_turn_id,
+          created_at,
+          updated_at,
+          archived_at,
+          deleted_at
+        )
+        VALUES (
+          'thread-restart',
+          'project-restart',
+          'Thread Restart',
+          '{"provider":"codex","model":"gpt-5-codex"}',
+          'full-access',
+          'default',
+          NULL,
+          NULL,
+          NULL,
+          '2026-04-07T11:00:02.000Z',
+          '2026-04-07T11:00:03.000Z',
+          NULL,
+          NULL
+        )
+      `);
+      await seedRuntime.runPromise(sql`
+        INSERT INTO projection_thread_sessions (
+          thread_id,
+          status,
+          provider_name,
+          runtime_mode,
+          active_turn_id,
+          last_error,
+          updated_at
+        )
+        VALUES (
+          'thread-restart',
+          'ready',
+          'codex',
+          'full-access',
+          'turn-zombie-restart',
+          NULL,
+          '2026-04-07T11:00:04.000Z'
+        )
+      `);
+      await seedRuntime.runPromise(sql`
+        INSERT INTO projection_thread_loops (
+          thread_id,
+          enabled,
+          prompt,
+          interval_minutes,
+          next_run_at,
+          last_run_at,
+          last_error,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          'thread-restart',
+          1,
+          'Resume after restart',
+          30,
+          '2026-04-07T10:00:00.000Z',
+          NULL,
+          NULL,
+          '2026-04-07T11:00:05.000Z',
+          '2026-04-07T11:00:05.000Z'
+        )
+      `);
+    } finally {
+      await seedRuntime.dispose();
+    }
+
+    const restartRuntime = makeSchedulerRuntime();
+    const scope = await Effect.runPromise(Scope.make("sequential"));
+
+    try {
+      const engine = await restartRuntime.runPromise(Effect.service(OrchestrationEngineService));
+      const scheduler = await restartRuntime.runPromise(Effect.service(ThreadLoopScheduler));
+
+      const bootReadModel = await restartRuntime.runPromise(engine.getReadModel());
+      const bootThread = bootReadModel.threads.find(
+        (thread) => thread.id === asThreadId("thread-restart"),
+      );
+      assert.equal(bootThread?.session?.activeTurnId, null);
+
+      await restartRuntime.runPromise(scheduler.start().pipe(Scope.provide(scope)));
+
+      await waitFor(async () => {
+        const readModel = await restartRuntime.runPromise(engine.getReadModel());
+        const thread = readModel.threads.find((entry) => entry.id === asThreadId("thread-restart"));
+        return Boolean(
+          thread?.activities.some((activity) => activity.kind === "loop.tick.started") &&
+          thread.loop?.lastRunAt,
+        );
+      });
+
+      const readModel = await restartRuntime.runPromise(engine.getReadModel());
+      const thread = readModel.threads.find((entry) => entry.id === asThreadId("thread-restart"));
+      assert.isTrue(
+        thread?.activities.some((activity) => activity.kind === "loop.tick.started") ?? false,
+      );
+      assert.isTrue(typeof thread?.loop?.lastRunAt === "string");
+    } finally {
+      await Effect.runPromise(Scope.close(scope, Exit.void));
+      await restartRuntime.dispose();
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/server/src/orchestration/Layers/ThreadLoopScheduler.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadLoopScheduler.test.ts
@@ -1,0 +1,338 @@
+import { assert } from "@effect/vitest";
+import {
+  CommandId,
+  EventId,
+  ProjectId,
+  ThreadId,
+  TurnId,
+  type OrchestrationCommand,
+  type OrchestrationEvent,
+  type OrchestrationReadModel,
+} from "@t3tools/contracts";
+import { Effect, Exit, Layer, ManagedRuntime, PubSub, Ref, Scope, Stream } from "effect";
+import { afterEach, describe, it } from "vitest";
+
+import { ProjectionThreadLoopRepository } from "../../persistence/Services/ProjectionThreadLoops.ts";
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import { ThreadLoopScheduler } from "../Services/ThreadLoopScheduler.ts";
+import { makeThreadLoopScheduler } from "./ThreadLoopScheduler.ts";
+
+const asThreadId = (value: string) => ThreadId.makeUnsafe(value);
+const asProjectId = (value: string) => ProjectId.makeUnsafe(value);
+const now = "2026-04-07T12:00:00.000Z";
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  const poll = async (): Promise<void> => {
+    if (await predicate()) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("Timed out waiting for expectation.");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    return poll();
+  };
+
+  return poll();
+}
+
+describe("ThreadLoopScheduler", () => {
+  let runtime: ManagedRuntime.ManagedRuntime<ThreadLoopScheduler, never> | null = null;
+  let scope: Scope.Closeable | null = null;
+
+  afterEach(async () => {
+    if (scope) {
+      await Effect.runPromise(Scope.close(scope, Exit.void));
+    }
+    scope = null;
+    if (runtime) {
+      await runtime.dispose();
+    }
+    runtime = null;
+  });
+
+  async function createHarness(input: {
+    sessionStatus: "ready" | "running";
+    activeTurnId: string | null;
+  }) {
+    const commandsRef = Effect.runSync(Ref.make<Array<OrchestrationCommand>>([]));
+    const loopsRef = Effect.runSync(
+      Ref.make([
+        {
+          threadId: asThreadId("thread-1"),
+          enabled: true,
+          prompt: "Check the deployment",
+          intervalMinutes: 30,
+          nextRunAt: "2026-04-07T11:00:00.000Z",
+          lastRunAt: null,
+          lastError: null,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ]),
+    );
+    const readModelRef = Effect.runSync(
+      Ref.make<OrchestrationReadModel>({
+        snapshotSequence: 0,
+        updatedAt: now,
+        projects: [
+          {
+            id: asProjectId("project-1"),
+            title: "Project",
+            workspaceRoot: "/tmp/project",
+            defaultModelSelection: {
+              provider: "codex",
+              model: "gpt-5-codex",
+            },
+            scripts: [],
+            createdAt: now,
+            updatedAt: now,
+            deletedAt: null,
+          },
+        ],
+        threads: [
+          {
+            id: asThreadId("thread-1"),
+            projectId: asProjectId("project-1"),
+            title: "Thread",
+            modelSelection: {
+              provider: "codex",
+              model: "gpt-5-codex",
+            },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            latestTurn: null,
+            createdAt: now,
+            updatedAt: now,
+            archivedAt: null,
+            deletedAt: null,
+            messages: [],
+            proposedPlans: [],
+            activities: [],
+            checkpoints: [],
+            session: {
+              threadId: asThreadId("thread-1"),
+              status: input.sessionStatus,
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId: input.activeTurnId ? TurnId.makeUnsafe(input.activeTurnId) : null,
+              lastError: null,
+              updatedAt: now,
+            },
+            loop: {
+              enabled: true,
+              prompt: "Check the deployment",
+              intervalMinutes: 30,
+              nextRunAt: "2026-04-07T11:00:00.000Z",
+              lastRunAt: null,
+              lastError: null,
+              createdAt: now,
+              updatedAt: now,
+            },
+          },
+        ],
+      }),
+    );
+    const eventPubSub = Effect.runSync(PubSub.unbounded<OrchestrationEvent>());
+
+    runtime = ManagedRuntime.make(
+      Layer.effect(ThreadLoopScheduler, makeThreadLoopScheduler).pipe(
+        Layer.provideMerge(
+          Layer.succeed(ProjectionThreadLoopRepository, {
+            upsert: () => Effect.void,
+            getByThreadId: ({ threadId }) =>
+              Ref.get(loopsRef).pipe(
+                Effect.map((loops) => {
+                  const loop = loops.find((entry) => entry.threadId === threadId);
+                  return loop ? { _tag: "Some", value: loop } : { _tag: "None" };
+                }),
+              ) as never,
+            listAll: () => Ref.get(loopsRef),
+            listDue: ({ dueBefore }) =>
+              Ref.get(loopsRef).pipe(
+                Effect.map((loops) =>
+                  loops.filter(
+                    (loop) =>
+                      loop.enabled && loop.nextRunAt !== null && loop.nextRunAt <= dueBefore,
+                  ),
+                ),
+              ),
+            claimDueRun: ({ threadId, expectedNextRunAt, nextRunAt, updatedAt }) =>
+              Ref.modify(loopsRef, (loops) => {
+                let claimed = false;
+                const nextLoops = loops.map((loop) => {
+                  if (
+                    loop.threadId !== threadId ||
+                    !loop.enabled ||
+                    loop.nextRunAt !== expectedNextRunAt
+                  ) {
+                    return loop;
+                  }
+                  claimed = true;
+                  return {
+                    ...loop,
+                    nextRunAt,
+                    updatedAt,
+                  };
+                });
+                return [claimed, nextLoops] as const;
+              }),
+            deleteByThreadId: ({ threadId }) =>
+              Ref.update(loopsRef, (loops) =>
+                loops.filter((loop) => loop.threadId !== threadId),
+              ).pipe(Effect.asVoid),
+          }),
+        ),
+        Layer.provideMerge(
+          Layer.succeed(OrchestrationEngineService, {
+            getReadModel: () => Ref.get(readModelRef),
+            readEvents: () => Stream.empty,
+            dispatch: (command: OrchestrationCommand) =>
+              Effect.gen(function* () {
+                yield* Ref.update(commandsRef, (commands) => [...commands, command]);
+                if (command.type === "thread.loop.sync") {
+                  yield* Ref.update(readModelRef, (readModel) => ({
+                    ...readModel,
+                    threads: readModel.threads.map((thread) =>
+                      thread.id !== command.threadId || !thread.loop
+                        ? thread
+                        : {
+                            ...thread,
+                            loop: {
+                              ...thread.loop,
+                              ...(command.patch.enabled !== undefined
+                                ? { enabled: command.patch.enabled }
+                                : {}),
+                              ...(command.patch.nextRunAt !== undefined
+                                ? { nextRunAt: command.patch.nextRunAt }
+                                : {}),
+                              ...(command.patch.lastRunAt !== undefined
+                                ? { lastRunAt: command.patch.lastRunAt }
+                                : {}),
+                              ...(command.patch.lastError !== undefined
+                                ? { lastError: command.patch.lastError }
+                                : {}),
+                              updatedAt: command.createdAt,
+                            },
+                          },
+                    ),
+                  }));
+                }
+                return { sequence: 1 };
+              }),
+            streamDomainEvents: Stream.fromPubSub(eventPubSub),
+          }),
+        ),
+      ),
+    );
+
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    const scheduler = await runtime.runPromise(Effect.service(ThreadLoopScheduler));
+    await Effect.runPromise(scheduler.start().pipe(Scope.provide(scope)));
+
+    return {
+      commandsRef,
+      loopsRef,
+      eventPubSub,
+    };
+  }
+
+  it("dispatches thread.turn.start for a due loop on an idle thread", async () => {
+    const harness = await createHarness({
+      sessionStatus: "ready",
+      activeTurnId: null,
+    });
+
+    await waitFor(async () => {
+      const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+      return commands.some((command) => command.type === "thread.turn.start");
+    });
+
+    const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+    assert.isTrue(commands.some((command) => command.type === "thread.turn.start"));
+    assert.isTrue(
+      commands.some((command) => command.type === "thread.loop.sync" && "patch" in command),
+    );
+  });
+
+  it("skips a due loop while the thread is busy", async () => {
+    const harness = await createHarness({
+      sessionStatus: "running",
+      activeTurnId: "turn-active",
+    });
+
+    await waitFor(async () => {
+      const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+      return commands.some(
+        (command) =>
+          command.type === "thread.activity.append" &&
+          command.activity.kind === "loop.tick.skipped",
+      );
+    });
+
+    const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+    assert.isFalse(commands.some((command) => command.type === "thread.turn.start"));
+    assert.isTrue(
+      commands.some(
+        (command) =>
+          command.type === "thread.activity.append" &&
+          command.activity.kind === "loop.tick.skipped",
+      ),
+    );
+  });
+
+  it("pauses the loop when the thread is archived", async () => {
+    const harness = await createHarness({
+      sessionStatus: "ready",
+      activeTurnId: null,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    await Effect.runPromise(
+      PubSub.publish(harness.eventPubSub, {
+        sequence: 1,
+        eventId: EventId.makeUnsafe("evt-thread-archived"),
+        aggregateKind: "thread",
+        aggregateId: asThreadId("thread-1"),
+        occurredAt: "2026-04-07T12:05:00.000Z",
+        commandId: CommandId.makeUnsafe("cmd-thread-archived"),
+        causationEventId: null,
+        correlationId: CommandId.makeUnsafe("cmd-thread-archived"),
+        metadata: {},
+        type: "thread.archived",
+        payload: {
+          threadId: asThreadId("thread-1"),
+          archivedAt: "2026-04-07T12:05:00.000Z",
+          updatedAt: "2026-04-07T12:05:00.000Z",
+        },
+      }),
+    );
+
+    await waitFor(async () => {
+      const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+      return commands.some(
+        (command) =>
+          command.type === "thread.loop.sync" &&
+          command.patch.enabled === false &&
+          command.patch.nextRunAt === null,
+      );
+    });
+
+    const commands = await Effect.runPromise(Ref.get(harness.commandsRef));
+    assert.isTrue(
+      commands.some(
+        (command) =>
+          command.type === "thread.loop.sync" &&
+          command.patch.enabled === false &&
+          command.patch.nextRunAt === null,
+      ),
+    );
+  });
+});

--- a/apps/server/src/orchestration/Layers/ThreadLoopScheduler.test.ts
+++ b/apps/server/src/orchestration/Layers/ThreadLoopScheduler.test.ts
@@ -449,6 +449,7 @@ describe("ThreadLoopScheduler", () => {
       await seedRuntime.runPromise(sql`DELETE FROM projection_threads`);
       await seedRuntime.runPromise(sql`DELETE FROM projection_thread_sessions`);
       await seedRuntime.runPromise(sql`DELETE FROM projection_thread_loops`);
+      await seedRuntime.runPromise(sql`DELETE FROM projection_turns`);
 
       await seedRuntime.runPromise(sql`
         INSERT INTO projection_projects (
@@ -516,12 +517,46 @@ describe("ThreadLoopScheduler", () => {
         )
         VALUES (
           'thread-restart',
-          'ready',
+          'running',
           'codex',
           'full-access',
           'turn-zombie-restart',
           NULL,
           '2026-04-07T11:00:04.000Z'
+        )
+      `);
+      await seedRuntime.runPromise(sql`
+        INSERT INTO projection_turns (
+          thread_id,
+          turn_id,
+          pending_message_id,
+          source_proposed_plan_thread_id,
+          source_proposed_plan_id,
+          assistant_message_id,
+          state,
+          requested_at,
+          started_at,
+          completed_at,
+          checkpoint_turn_count,
+          checkpoint_ref,
+          checkpoint_status,
+          checkpoint_files_json
+        )
+        VALUES (
+          'thread-restart',
+          'turn-zombie-restart',
+          NULL,
+          NULL,
+          NULL,
+          NULL,
+          'running',
+          '2026-04-07T11:00:04.000Z',
+          '2026-04-07T11:00:04.000Z',
+          NULL,
+          NULL,
+          NULL,
+          NULL,
+          '[]'
         )
       `);
       await seedRuntime.runPromise(sql`
@@ -563,7 +598,10 @@ describe("ThreadLoopScheduler", () => {
       const bootThread = bootReadModel.threads.find(
         (thread) => thread.id === asThreadId("thread-restart"),
       );
+      assert.equal(bootThread?.session?.status, "interrupted");
       assert.equal(bootThread?.session?.activeTurnId, null);
+      assert.equal(bootThread?.latestTurn?.state, "interrupted");
+      assert.equal(bootThread?.latestTurn?.completedAt, "2026-04-07T11:00:04.000Z");
 
       await restartRuntime.runPromise(scheduler.start().pipe(Scope.provide(scope)));
 

--- a/apps/server/src/orchestration/Layers/ThreadLoopScheduler.ts
+++ b/apps/server/src/orchestration/Layers/ThreadLoopScheduler.ts
@@ -3,6 +3,7 @@ import {
   EventId,
   MessageId,
   ThreadId,
+  type OrchestrationSessionStatus,
   type OrchestrationEvent,
 } from "@t3tools/contracts";
 import { Cause, Effect, Layer, Stream } from "effect";
@@ -15,6 +16,7 @@ import {
   type ThreadLoopSchedulerShape,
 } from "../Services/ThreadLoopScheduler.ts";
 import { computeThreadLoopNextRunAt } from "../threadLoop.ts";
+import { sessionStatusAllowsActiveTurn } from "../sessionState.ts";
 
 const THREAD_LOOP_SCHEDULER_INTERVAL_MS = 10_000;
 
@@ -23,14 +25,36 @@ const serverCommandId = (tag: string) =>
 
 const isThreadLoopBusy = (thread: {
   readonly session: {
+    readonly status: OrchestrationSessionStatus;
+    readonly activeTurnId: string | null;
+  } | null;
+}) => thread.session !== null && sessionStatusAllowsActiveTurn(thread.session.status);
+
+const describeThreadLoopState = (input: {
+  readonly threadId: ThreadId;
+  readonly loop: {
+    readonly enabled: boolean;
+    readonly intervalMinutes: number;
+    readonly nextRunAt: string | null;
+    readonly lastRunAt: string | null;
+    readonly lastError: string | null;
+  };
+  readonly session: {
     readonly status: string;
     readonly activeTurnId: string | null;
   } | null;
-}) =>
-  thread.session !== null &&
-  (thread.session.status === "running" ||
-    thread.session.status === "starting" ||
-    thread.session.activeTurnId !== null);
+  readonly archivedAt: string | null;
+}) => ({
+  threadId: input.threadId,
+  loopEnabled: input.loop.enabled,
+  intervalMinutes: input.loop.intervalMinutes,
+  nextRunAt: input.loop.nextRunAt,
+  lastRunAt: input.loop.lastRunAt,
+  lastError: input.loop.lastError,
+  archivedAt: input.archivedAt,
+  sessionStatus: input.session?.status ?? null,
+  sessionActiveTurnId: input.session?.activeTurnId ?? null,
+});
 
 export const makeThreadLoopScheduler = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
@@ -108,6 +132,18 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
     const dueLoops = yield* projectionThreadLoopRepository.listDue({
       dueBefore: nowIso,
     });
+    if (dueLoops.length > 0) {
+      yield* Effect.logInfo("thread loop scheduler found due loops", {
+        nowIso,
+        dueLoopCount: dueLoops.length,
+        dueLoops: dueLoops.map((loop) => ({
+          threadId: loop.threadId,
+          nextRunAt: loop.nextRunAt,
+          intervalMinutes: loop.intervalMinutes,
+          updatedAt: loop.updatedAt,
+        })),
+      });
+    }
 
     for (const loop of dueLoops) {
       if (loop.nextRunAt === null) {
@@ -122,12 +158,23 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         updatedAt: nowIso,
       });
       if (!claimed) {
+        yield* Effect.logInfo("thread loop scheduler claim skipped", {
+          threadId: loop.threadId,
+          expectedNextRunAt: loop.nextRunAt,
+          nextRunAt,
+          nowIso,
+        });
         continue;
       }
 
       const readModel = yield* orchestrationEngine.getReadModel();
       const thread = readModel.threads.find((entry) => entry.id === loop.threadId);
       if (!thread) {
+        yield* Effect.logWarning("thread loop scheduler deleting orphaned loop row", {
+          threadId: loop.threadId,
+          nextRunAt: loop.nextRunAt,
+          nowIso,
+        });
         yield* projectionThreadLoopRepository
           .deleteByThreadId({
             threadId: loop.threadId,
@@ -143,6 +190,11 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (!thread.loop) {
+        yield* Effect.logWarning("thread loop scheduler deleting stale loop row", {
+          threadId: loop.threadId,
+          nextRunAt: loop.nextRunAt,
+          nowIso,
+        });
         yield* projectionThreadLoopRepository
           .deleteByThreadId({
             threadId: loop.threadId,
@@ -158,6 +210,15 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (!thread.loop.enabled) {
+        yield* Effect.logInfo("thread loop scheduler found disabled loop during due tick", {
+          ...describeThreadLoopState({
+            threadId: loop.threadId,
+            loop: thread.loop,
+            session: thread.session,
+            archivedAt: thread.archivedAt,
+          }),
+          nowIso,
+        });
         yield* syncLoopPatch({
           threadId: loop.threadId,
           createdAt: nowIso,
@@ -176,6 +237,15 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (thread.archivedAt !== null) {
+        yield* Effect.logInfo("thread loop scheduler pausing archived thread loop", {
+          ...describeThreadLoopState({
+            threadId: loop.threadId,
+            loop: thread.loop,
+            session: thread.session,
+            archivedAt: thread.archivedAt,
+          }),
+          nowIso,
+        });
         yield* syncLoopPatch({
           threadId: loop.threadId,
           createdAt: nowIso,
@@ -194,6 +264,16 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (isThreadLoopBusy(thread)) {
+        yield* Effect.logInfo("thread loop scheduler skipped due loop because thread is busy", {
+          ...describeThreadLoopState({
+            threadId: loop.threadId,
+            loop: thread.loop,
+            session: thread.session,
+            archivedAt: thread.archivedAt,
+          }),
+          claimedNextRunAt: nextRunAt,
+          nowIso,
+        });
         yield* syncLoopPatch({
           threadId: loop.threadId,
           createdAt: nowIso,
@@ -217,6 +297,16 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
 
+      yield* Effect.logInfo("thread loop scheduler dispatching automatic run", {
+        ...describeThreadLoopState({
+          threadId: loop.threadId,
+          loop: thread.loop,
+          session: thread.session,
+          archivedAt: thread.archivedAt,
+        }),
+        claimedNextRunAt: nextRunAt,
+        nowIso,
+      });
       yield* syncLoopPatch({
         threadId: loop.threadId,
         createdAt: nowIso,
@@ -275,6 +365,29 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
   });
 
   const start: ThreadLoopSchedulerShape["start"] = Effect.fn("start")(function* () {
+    const readModel = yield* orchestrationEngine.getReadModel();
+    const persistedLoops = yield* projectionThreadLoopRepository.listAll().pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("thread loop scheduler failed to inspect persisted loops on startup", {
+          cause: Cause.pretty(cause),
+        }).pipe(Effect.as([])),
+      ),
+    );
+    const activePersistedLoops = persistedLoops.filter((loop) => loop.enabled);
+    yield* Effect.logInfo("thread loop scheduler starting", {
+      persistedLoopCount: persistedLoops.length,
+      activePersistedLoopCount: activePersistedLoops.length,
+      activeLoops: activePersistedLoops.map((loop) => {
+        const thread = readModel.threads.find((entry) => entry.id === loop.threadId);
+        return describeThreadLoopState({
+          threadId: loop.threadId,
+          loop,
+          session: thread?.session ?? null,
+          archivedAt: thread?.archivedAt ?? null,
+        });
+      }),
+    });
+
     yield* Effect.forkScoped(
       Effect.gen(function* () {
         for (;;) {

--- a/apps/server/src/orchestration/Layers/ThreadLoopScheduler.ts
+++ b/apps/server/src/orchestration/Layers/ThreadLoopScheduler.ts
@@ -1,0 +1,274 @@
+import {
+  CommandId,
+  EventId,
+  MessageId,
+  ThreadId,
+  type OrchestrationEvent,
+} from "@t3tools/contracts";
+import { Cause, Effect, Layer, Stream } from "effect";
+
+import { ProjectionThreadLoopRepositoryLive } from "../../persistence/Layers/ProjectionThreadLoops.ts";
+import { ProjectionThreadLoopRepository } from "../../persistence/Services/ProjectionThreadLoops.ts";
+import { OrchestrationEngineService } from "../Services/OrchestrationEngine.ts";
+import {
+  ThreadLoopScheduler,
+  type ThreadLoopSchedulerShape,
+} from "../Services/ThreadLoopScheduler.ts";
+import { computeThreadLoopNextRunAt } from "../threadLoop.ts";
+
+const THREAD_LOOP_SCHEDULER_INTERVAL_MS = 10_000;
+
+const serverCommandId = (tag: string) =>
+  CommandId.makeUnsafe(`server:${tag}:${crypto.randomUUID()}`);
+
+const isThreadLoopBusy = (thread: {
+  readonly session: {
+    readonly status: string;
+    readonly activeTurnId: string | null;
+  } | null;
+}) =>
+  thread.session !== null &&
+  (thread.session.status === "running" ||
+    thread.session.status === "starting" ||
+    thread.session.activeTurnId !== null);
+
+export const makeThreadLoopScheduler = Effect.gen(function* () {
+  const orchestrationEngine = yield* OrchestrationEngineService;
+  const projectionThreadLoopRepository = yield* ProjectionThreadLoopRepository;
+
+  const appendLoopActivity = (input: {
+    readonly threadId: ThreadId;
+    readonly kind: "loop.tick.started" | "loop.tick.skipped" | "loop.tick.failed" | "loop.paused";
+    readonly summary: string;
+    readonly detail?: string;
+    readonly tone?: "info" | "error";
+    readonly createdAt: string;
+  }) =>
+    orchestrationEngine.dispatch({
+      type: "thread.activity.append",
+      commandId: serverCommandId("thread-loop-activity"),
+      threadId: input.threadId,
+      activity: {
+        id: EventId.makeUnsafe(crypto.randomUUID()),
+        tone: input.tone ?? "info",
+        kind: input.kind,
+        summary: input.summary,
+        payload: input.detail ? { detail: input.detail } : {},
+        turnId: null,
+        createdAt: input.createdAt,
+      },
+      createdAt: input.createdAt,
+    });
+
+  const syncLoopPatch = (input: {
+    readonly threadId: ThreadId;
+    readonly createdAt: string;
+    readonly patch: {
+      readonly enabled?: boolean;
+      readonly nextRunAt?: string | null;
+      readonly lastRunAt?: string | null;
+      readonly lastError?: string | null;
+    };
+  }) =>
+    orchestrationEngine.dispatch({
+      type: "thread.loop.sync",
+      commandId: serverCommandId("thread-loop-sync"),
+      threadId: input.threadId,
+      patch: input.patch,
+      createdAt: input.createdAt,
+    });
+
+  const pauseLoopForArchivedThread = Effect.fn("pauseLoopForArchivedThread")(function* (
+    event: Extract<OrchestrationEvent, { type: "thread.archived" }>,
+  ) {
+    const readModel = yield* orchestrationEngine.getReadModel();
+    const thread = readModel.threads.find((entry) => entry.id === event.payload.threadId);
+    if (!thread?.loop?.enabled) {
+      return;
+    }
+
+    yield* syncLoopPatch({
+      threadId: event.payload.threadId,
+      createdAt: event.occurredAt,
+      patch: {
+        enabled: false,
+        nextRunAt: null,
+        lastError: null,
+      },
+    });
+    yield* appendLoopActivity({
+      threadId: event.payload.threadId,
+      kind: "loop.paused",
+      summary: "Loop paused because the thread was archived",
+      createdAt: event.occurredAt,
+    });
+  });
+
+  const runDueThreadLoops = Effect.fn("runDueThreadLoops")(function* (nowIso: string) {
+    const dueLoops = yield* projectionThreadLoopRepository.listDue({
+      dueBefore: nowIso,
+    });
+
+    for (const loop of dueLoops) {
+      if (loop.nextRunAt === null) {
+        continue;
+      }
+
+      const nextRunAt = computeThreadLoopNextRunAt(nowIso, loop.intervalMinutes);
+      const claimed = yield* projectionThreadLoopRepository.claimDueRun({
+        threadId: loop.threadId,
+        expectedNextRunAt: loop.nextRunAt,
+        nextRunAt,
+        updatedAt: nowIso,
+      });
+      if (!claimed) {
+        continue;
+      }
+
+      yield* syncLoopPatch({
+        threadId: loop.threadId,
+        createdAt: nowIso,
+        patch: {
+          nextRunAt,
+        },
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("thread loop scheduler failed to sync next run", {
+            threadId: loop.threadId,
+            cause: Cause.pretty(cause),
+          }),
+        ),
+      );
+
+      const readModel = yield* orchestrationEngine.getReadModel();
+      const thread = readModel.threads.find((entry) => entry.id === loop.threadId);
+      if (!thread?.loop?.enabled) {
+        continue;
+      }
+      if (thread.archivedAt !== null) {
+        yield* syncLoopPatch({
+          threadId: loop.threadId,
+          createdAt: nowIso,
+          patch: {
+            enabled: false,
+            nextRunAt: null,
+            lastError: null,
+          },
+        });
+        yield* appendLoopActivity({
+          threadId: loop.threadId,
+          kind: "loop.paused",
+          summary: "Loop paused because the thread was archived",
+          createdAt: nowIso,
+        });
+        continue;
+      }
+      if (isThreadLoopBusy(thread)) {
+        yield* appendLoopActivity({
+          threadId: loop.threadId,
+          kind: "loop.tick.skipped",
+          summary: "Automatic loop run skipped because the thread is busy",
+          createdAt: nowIso,
+        });
+        continue;
+      }
+
+      yield* syncLoopPatch({
+        threadId: loop.threadId,
+        createdAt: nowIso,
+        patch: {
+          lastRunAt: nowIso,
+          lastError: null,
+        },
+      });
+      yield* appendLoopActivity({
+        threadId: loop.threadId,
+        kind: "loop.tick.started",
+        summary: "Automatic loop run started",
+        createdAt: nowIso,
+      });
+
+      yield* orchestrationEngine
+        .dispatch({
+          type: "thread.turn.start",
+          commandId: serverCommandId("thread-loop-turn-start"),
+          threadId: loop.threadId,
+          message: {
+            messageId: MessageId.makeUnsafe(`loop-msg:${crypto.randomUUID()}`),
+            role: "user",
+            text: loop.prompt,
+            attachments: [],
+          },
+          modelSelection: thread.modelSelection,
+          runtimeMode: thread.runtimeMode,
+          interactionMode: thread.interactionMode,
+          createdAt: nowIso,
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.gen(function* () {
+              const detail = Cause.pretty(cause);
+              yield* syncLoopPatch({
+                threadId: loop.threadId,
+                createdAt: nowIso,
+                patch: {
+                  lastError: detail,
+                },
+              });
+              yield* appendLoopActivity({
+                threadId: loop.threadId,
+                kind: "loop.tick.failed",
+                summary: "Automatic loop run failed",
+                detail,
+                tone: "error",
+                createdAt: nowIso,
+              });
+            }),
+          ),
+        );
+    }
+  });
+
+  const start: ThreadLoopSchedulerShape["start"] = Effect.fn("start")(function* () {
+    yield* Effect.forkScoped(
+      Effect.gen(function* () {
+        for (;;) {
+          const nowIso = new Date().toISOString();
+          yield* runDueThreadLoops(nowIso).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("thread loop scheduler tick failed", {
+                cause: Cause.pretty(cause),
+              }),
+            ),
+          );
+          yield* Effect.sleep(`${THREAD_LOOP_SCHEDULER_INTERVAL_MS} millis`);
+        }
+      }),
+    );
+
+    yield* Effect.forkScoped(
+      Stream.runForEach(orchestrationEngine.streamDomainEvents, (event) => {
+        if (event.type !== "thread.archived") {
+          return Effect.void;
+        }
+        return pauseLoopForArchivedThread(event).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("thread loop scheduler failed to pause archived thread loop", {
+              threadId: event.payload.threadId,
+              cause: Cause.pretty(cause),
+            }),
+          ),
+        );
+      }),
+    );
+  });
+
+  return {
+    start,
+  } satisfies ThreadLoopSchedulerShape;
+});
+
+export const ThreadLoopSchedulerLive = Layer.effect(
+  ThreadLoopScheduler,
+  makeThreadLoopScheduler,
+).pipe(Layer.provideMerge(ProjectionThreadLoopRepositoryLive));

--- a/apps/server/src/orchestration/Layers/ThreadLoopScheduler.ts
+++ b/apps/server/src/orchestration/Layers/ThreadLoopScheduler.ts
@@ -125,24 +125,54 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
 
-      yield* syncLoopPatch({
-        threadId: loop.threadId,
-        createdAt: nowIso,
-        patch: {
-          nextRunAt,
-        },
-      }).pipe(
-        Effect.catchCause((cause) =>
-          Effect.logWarning("thread loop scheduler failed to sync next run", {
-            threadId: loop.threadId,
-            cause: Cause.pretty(cause),
-          }),
-        ),
-      );
-
       const readModel = yield* orchestrationEngine.getReadModel();
       const thread = readModel.threads.find((entry) => entry.id === loop.threadId);
-      if (!thread?.loop?.enabled) {
+      if (!thread) {
+        yield* projectionThreadLoopRepository
+          .deleteByThreadId({
+            threadId: loop.threadId,
+          })
+          .pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("thread loop scheduler failed to delete orphaned loop row", {
+                threadId: loop.threadId,
+                cause: Cause.pretty(cause),
+              }),
+            ),
+          );
+        continue;
+      }
+      if (!thread.loop) {
+        yield* projectionThreadLoopRepository
+          .deleteByThreadId({
+            threadId: loop.threadId,
+          })
+          .pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("thread loop scheduler failed to delete stale loop row", {
+                threadId: loop.threadId,
+                cause: Cause.pretty(cause),
+              }),
+            ),
+          );
+        continue;
+      }
+      if (!thread.loop.enabled) {
+        yield* syncLoopPatch({
+          threadId: loop.threadId,
+          createdAt: nowIso,
+          patch: {
+            enabled: false,
+            nextRunAt: null,
+          },
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("thread loop scheduler failed to sync disabled loop", {
+              threadId: loop.threadId,
+              cause: Cause.pretty(cause),
+            }),
+          ),
+        );
         continue;
       }
       if (thread.archivedAt !== null) {
@@ -164,6 +194,20 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (isThreadLoopBusy(thread)) {
+        yield* syncLoopPatch({
+          threadId: loop.threadId,
+          createdAt: nowIso,
+          patch: {
+            nextRunAt,
+          },
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning("thread loop scheduler failed to sync next run", {
+              threadId: loop.threadId,
+              cause: Cause.pretty(cause),
+            }),
+          ),
+        );
         yield* appendLoopActivity({
           threadId: loop.threadId,
           kind: "loop.tick.skipped",
@@ -177,6 +221,7 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         threadId: loop.threadId,
         createdAt: nowIso,
         patch: {
+          nextRunAt,
           lastRunAt: nowIso,
           lastError: null,
         },

--- a/apps/server/src/orchestration/Layers/ThreadLoopScheduler.ts
+++ b/apps/server/src/orchestration/Layers/ThreadLoopScheduler.ts
@@ -30,32 +30,6 @@ const isThreadLoopBusy = (thread: {
   } | null;
 }) => thread.session !== null && sessionStatusAllowsActiveTurn(thread.session.status);
 
-const describeThreadLoopState = (input: {
-  readonly threadId: ThreadId;
-  readonly loop: {
-    readonly enabled: boolean;
-    readonly intervalMinutes: number;
-    readonly nextRunAt: string | null;
-    readonly lastRunAt: string | null;
-    readonly lastError: string | null;
-  };
-  readonly session: {
-    readonly status: string;
-    readonly activeTurnId: string | null;
-  } | null;
-  readonly archivedAt: string | null;
-}) => ({
-  threadId: input.threadId,
-  loopEnabled: input.loop.enabled,
-  intervalMinutes: input.loop.intervalMinutes,
-  nextRunAt: input.loop.nextRunAt,
-  lastRunAt: input.loop.lastRunAt,
-  lastError: input.loop.lastError,
-  archivedAt: input.archivedAt,
-  sessionStatus: input.session?.status ?? null,
-  sessionActiveTurnId: input.session?.activeTurnId ?? null,
-});
-
 export const makeThreadLoopScheduler = Effect.gen(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const projectionThreadLoopRepository = yield* ProjectionThreadLoopRepository;
@@ -132,18 +106,6 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
     const dueLoops = yield* projectionThreadLoopRepository.listDue({
       dueBefore: nowIso,
     });
-    if (dueLoops.length > 0) {
-      yield* Effect.logInfo("thread loop scheduler found due loops", {
-        nowIso,
-        dueLoopCount: dueLoops.length,
-        dueLoops: dueLoops.map((loop) => ({
-          threadId: loop.threadId,
-          nextRunAt: loop.nextRunAt,
-          intervalMinutes: loop.intervalMinutes,
-          updatedAt: loop.updatedAt,
-        })),
-      });
-    }
 
     for (const loop of dueLoops) {
       if (loop.nextRunAt === null) {
@@ -158,23 +120,12 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         updatedAt: nowIso,
       });
       if (!claimed) {
-        yield* Effect.logInfo("thread loop scheduler claim skipped", {
-          threadId: loop.threadId,
-          expectedNextRunAt: loop.nextRunAt,
-          nextRunAt,
-          nowIso,
-        });
         continue;
       }
 
       const readModel = yield* orchestrationEngine.getReadModel();
       const thread = readModel.threads.find((entry) => entry.id === loop.threadId);
       if (!thread) {
-        yield* Effect.logWarning("thread loop scheduler deleting orphaned loop row", {
-          threadId: loop.threadId,
-          nextRunAt: loop.nextRunAt,
-          nowIso,
-        });
         yield* projectionThreadLoopRepository
           .deleteByThreadId({
             threadId: loop.threadId,
@@ -190,11 +141,6 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (!thread.loop) {
-        yield* Effect.logWarning("thread loop scheduler deleting stale loop row", {
-          threadId: loop.threadId,
-          nextRunAt: loop.nextRunAt,
-          nowIso,
-        });
         yield* projectionThreadLoopRepository
           .deleteByThreadId({
             threadId: loop.threadId,
@@ -210,15 +156,6 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (!thread.loop.enabled) {
-        yield* Effect.logInfo("thread loop scheduler found disabled loop during due tick", {
-          ...describeThreadLoopState({
-            threadId: loop.threadId,
-            loop: thread.loop,
-            session: thread.session,
-            archivedAt: thread.archivedAt,
-          }),
-          nowIso,
-        });
         yield* syncLoopPatch({
           threadId: loop.threadId,
           createdAt: nowIso,
@@ -237,15 +174,6 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (thread.archivedAt !== null) {
-        yield* Effect.logInfo("thread loop scheduler pausing archived thread loop", {
-          ...describeThreadLoopState({
-            threadId: loop.threadId,
-            loop: thread.loop,
-            session: thread.session,
-            archivedAt: thread.archivedAt,
-          }),
-          nowIso,
-        });
         yield* syncLoopPatch({
           threadId: loop.threadId,
           createdAt: nowIso,
@@ -264,16 +192,6 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
       if (isThreadLoopBusy(thread)) {
-        yield* Effect.logInfo("thread loop scheduler skipped due loop because thread is busy", {
-          ...describeThreadLoopState({
-            threadId: loop.threadId,
-            loop: thread.loop,
-            session: thread.session,
-            archivedAt: thread.archivedAt,
-          }),
-          claimedNextRunAt: nextRunAt,
-          nowIso,
-        });
         yield* syncLoopPatch({
           threadId: loop.threadId,
           createdAt: nowIso,
@@ -297,16 +215,6 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
         continue;
       }
 
-      yield* Effect.logInfo("thread loop scheduler dispatching automatic run", {
-        ...describeThreadLoopState({
-          threadId: loop.threadId,
-          loop: thread.loop,
-          session: thread.session,
-          archivedAt: thread.archivedAt,
-        }),
-        claimedNextRunAt: nextRunAt,
-        nowIso,
-      });
       yield* syncLoopPatch({
         threadId: loop.threadId,
         createdAt: nowIso,
@@ -365,29 +273,6 @@ export const makeThreadLoopScheduler = Effect.gen(function* () {
   });
 
   const start: ThreadLoopSchedulerShape["start"] = Effect.fn("start")(function* () {
-    const readModel = yield* orchestrationEngine.getReadModel();
-    const persistedLoops = yield* projectionThreadLoopRepository.listAll().pipe(
-      Effect.catchCause((cause) =>
-        Effect.logWarning("thread loop scheduler failed to inspect persisted loops on startup", {
-          cause: Cause.pretty(cause),
-        }).pipe(Effect.as([])),
-      ),
-    );
-    const activePersistedLoops = persistedLoops.filter((loop) => loop.enabled);
-    yield* Effect.logInfo("thread loop scheduler starting", {
-      persistedLoopCount: persistedLoops.length,
-      activePersistedLoopCount: activePersistedLoops.length,
-      activeLoops: activePersistedLoops.map((loop) => {
-        const thread = readModel.threads.find((entry) => entry.id === loop.threadId);
-        return describeThreadLoopState({
-          threadId: loop.threadId,
-          loop,
-          session: thread?.session ?? null,
-          archivedAt: thread?.archivedAt ?? null,
-        });
-      }),
-    });
-
     yield* Effect.forkScoped(
       Effect.gen(function* () {
         for (;;) {

--- a/apps/server/src/orchestration/Schemas.ts
+++ b/apps/server/src/orchestration/Schemas.ts
@@ -7,6 +7,8 @@ import {
   ThreadMetaUpdatedPayload as ContractsThreadMetaUpdatedPayloadSchema,
   ThreadRuntimeModeSetPayload as ContractsThreadRuntimeModeSetPayloadSchema,
   ThreadInteractionModeSetPayload as ContractsThreadInteractionModeSetPayloadSchema,
+  ThreadLoopUpsertedPayload as ContractsThreadLoopUpsertedPayloadSchema,
+  ThreadLoopDeletedPayload as ContractsThreadLoopDeletedPayloadSchema,
   ThreadDeletedPayload as ContractsThreadDeletedPayloadSchema,
   ThreadUnarchivedPayload as ContractsThreadUnarchivedPayloadSchema,
   ThreadMessageSentPayload as ContractsThreadMessageSentPayloadSchema,
@@ -32,6 +34,8 @@ export const ThreadArchivedPayload = ContractsThreadArchivedPayloadSchema;
 export const ThreadMetaUpdatedPayload = ContractsThreadMetaUpdatedPayloadSchema;
 export const ThreadRuntimeModeSetPayload = ContractsThreadRuntimeModeSetPayloadSchema;
 export const ThreadInteractionModeSetPayload = ContractsThreadInteractionModeSetPayloadSchema;
+export const ThreadLoopUpsertedPayload = ContractsThreadLoopUpsertedPayloadSchema;
+export const ThreadLoopDeletedPayload = ContractsThreadLoopDeletedPayloadSchema;
 export const ThreadDeletedPayload = ContractsThreadDeletedPayloadSchema;
 export const ThreadUnarchivedPayload = ContractsThreadUnarchivedPayloadSchema;
 

--- a/apps/server/src/orchestration/Services/ThreadLoopScheduler.ts
+++ b/apps/server/src/orchestration/Services/ThreadLoopScheduler.ts
@@ -1,0 +1,19 @@
+/**
+ * ThreadLoopScheduler - Server-side scheduler for per-thread loops.
+ *
+ * Drives persisted loop state and dispatches loop-backed thread turns when a
+ * thread becomes due.
+ *
+ * @module ThreadLoopScheduler
+ */
+import { ServiceMap } from "effect";
+import type { Effect, Scope } from "effect";
+
+export interface ThreadLoopSchedulerShape {
+  readonly start: () => Effect.Effect<void, never, Scope.Scope>;
+}
+
+export class ThreadLoopScheduler extends ServiceMap.Service<
+  ThreadLoopScheduler,
+  ThreadLoopSchedulerShape
+>()("t3/orchestration/Services/ThreadLoopScheduler") {}

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -2,6 +2,7 @@ import type {
   OrchestrationCommand,
   OrchestrationEvent,
   OrchestrationReadModel,
+  ThreadLoop,
 } from "@t3tools/contracts";
 import { Effect } from "effect";
 
@@ -16,6 +17,36 @@ import {
 } from "./commandInvariants.ts";
 
 const nowIso = () => new Date().toISOString();
+const advanceLoopRunAt = (fromIso: string, intervalMinutes: number): string =>
+  new Date(Date.parse(fromIso) + intervalMinutes * 60_000).toISOString();
+
+function buildThreadLoopFromUpsert(input: {
+  readonly command: Extract<OrchestrationCommand, { type: "thread.loop.upsert" }>;
+  readonly existingLoop: ThreadLoop | null | undefined;
+}): ThreadLoop {
+  const { command, existingLoop } = input;
+  const intervalChanged =
+    existingLoop === null ||
+    existingLoop === undefined ||
+    existingLoop.intervalMinutes !== command.intervalMinutes;
+  const nextRunAt = command.enabled
+    ? intervalChanged || existingLoop?.nextRunAt === null || existingLoop?.nextRunAt === undefined
+      ? advanceLoopRunAt(command.createdAt, command.intervalMinutes)
+      : existingLoop.nextRunAt
+    : null;
+
+  return {
+    enabled: command.enabled,
+    prompt: command.prompt,
+    intervalMinutes: command.intervalMinutes,
+    nextRunAt,
+    lastRunAt: existingLoop?.lastRunAt ?? null,
+    lastError: existingLoop?.lastError ?? null,
+    createdAt: existingLoop?.createdAt ?? command.createdAt,
+    updatedAt: command.createdAt,
+  };
+}
+
 const defaultMetadata: Omit<OrchestrationEvent, "sequence" | "type" | "payload"> = {
   eventId: crypto.randomUUID() as OrchestrationEvent["eventId"],
   aggregateKind: "thread",
@@ -310,6 +341,51 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       };
     }
 
+    case "thread.loop.upsert": {
+      const targetThread = yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.loop-upserted",
+        payload: {
+          threadId: command.threadId,
+          loop: buildThreadLoopFromUpsert({
+            command,
+            existingLoop: targetThread.loop,
+          }),
+        },
+      };
+    }
+
+    case "thread.loop.delete": {
+      yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.loop-deleted",
+        payload: {
+          threadId: command.threadId,
+          deletedAt: command.createdAt,
+        },
+      };
+    }
+
     case "thread.turn.start": {
       const targetThread = yield* requireThread({
         readModel,
@@ -520,6 +596,47 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
         payload: {
           threadId: command.threadId,
           session: command.session,
+        },
+      };
+    }
+
+    case "thread.loop.sync": {
+      const targetThread = yield* requireThread({
+        readModel,
+        command,
+        threadId: command.threadId,
+      });
+      const existingLoop = targetThread.loop;
+      if (existingLoop === null || existingLoop === undefined) {
+        return yield* new OrchestrationCommandInvariantError({
+          commandType: command.type,
+          detail: `Thread '${command.threadId}' does not have a loop to sync.`,
+        });
+      }
+      return {
+        ...withEventBase({
+          aggregateKind: "thread",
+          aggregateId: command.threadId,
+          occurredAt: command.createdAt,
+          commandId: command.commandId,
+        }),
+        type: "thread.loop-upserted",
+        payload: {
+          threadId: command.threadId,
+          loop: {
+            ...existingLoop,
+            ...(command.patch.enabled !== undefined ? { enabled: command.patch.enabled } : {}),
+            ...(command.patch.nextRunAt !== undefined
+              ? { nextRunAt: command.patch.nextRunAt }
+              : {}),
+            ...(command.patch.lastRunAt !== undefined
+              ? { lastRunAt: command.patch.lastRunAt }
+              : {}),
+            ...(command.patch.lastError !== undefined
+              ? { lastError: command.patch.lastError }
+              : {}),
+            updatedAt: command.createdAt,
+          },
         },
       };
     }

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -94,6 +94,7 @@ describe("orchestration projector", () => {
         activities: [],
         checkpoints: [],
         session: null,
+        loop: null,
       },
     ]);
   });
@@ -202,6 +203,98 @@ describe("orchestration projector", () => {
       ),
     );
     expect(unarchived.threads[0]?.archivedAt).toBeNull();
+  });
+
+  it("applies thread.loop-upserted and thread.loop-deleted events", async () => {
+    const now = new Date().toISOString();
+    const loopAt = new Date(Date.parse(now) + 1_000).toISOString();
+    const deletedAt = new Date(Date.parse(now) + 2_000).toISOString();
+
+    const created = await Effect.runPromise(
+      projectEvent(
+        createEmptyReadModel(now),
+        makeEvent({
+          sequence: 1,
+          type: "thread.created",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: now,
+          commandId: "cmd-thread-create",
+          payload: {
+            threadId: "thread-1",
+            projectId: "project-1",
+            title: "demo",
+            modelSelection: {
+              provider: "codex",
+              model: "gpt-5-codex",
+            },
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            branch: null,
+            worktreePath: null,
+            createdAt: now,
+            updatedAt: now,
+          },
+        }),
+      ),
+    );
+
+    const withLoop = await Effect.runPromise(
+      projectEvent(
+        created,
+        makeEvent({
+          sequence: 2,
+          type: "thread.loop-upserted",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: loopAt,
+          commandId: "cmd-thread-loop-upsert",
+          payload: {
+            threadId: "thread-1",
+            loop: {
+              enabled: true,
+              prompt: "check inbox",
+              intervalMinutes: 1,
+              nextRunAt: loopAt,
+              lastRunAt: null,
+              lastError: null,
+              createdAt: loopAt,
+              updatedAt: loopAt,
+            },
+          },
+        }),
+      ),
+    );
+
+    expect(withLoop.threads[0]?.loop).toEqual({
+      enabled: true,
+      prompt: "check inbox",
+      intervalMinutes: 1,
+      nextRunAt: loopAt,
+      lastRunAt: null,
+      lastError: null,
+      createdAt: loopAt,
+      updatedAt: loopAt,
+    });
+
+    const withoutLoop = await Effect.runPromise(
+      projectEvent(
+        withLoop,
+        makeEvent({
+          sequence: 3,
+          type: "thread.loop-deleted",
+          aggregateKind: "thread",
+          aggregateId: "thread-1",
+          occurredAt: deletedAt,
+          commandId: "cmd-thread-loop-delete",
+          payload: {
+            threadId: "thread-1",
+          },
+        }),
+      ),
+    );
+
+    expect(withoutLoop.threads[0]?.loop).toBeNull();
   });
 
   it("keeps projector forward-compatible for unhandled event types", async () => {

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -289,6 +289,7 @@ describe("orchestration projector", () => {
           commandId: "cmd-thread-loop-delete",
           payload: {
             threadId: "thread-1",
+            deletedAt,
           },
         }),
       ),

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -18,6 +18,8 @@ import {
   ThreadCreatedPayload,
   ThreadDeletedPayload,
   ThreadInteractionModeSetPayload,
+  ThreadLoopDeletedPayload,
+  ThreadLoopUpsertedPayload,
   ThreadMetaUpdatedPayload,
   ThreadProposedPlanUpsertedPayload,
   ThreadRuntimeModeSetPayload,
@@ -268,6 +270,7 @@ export function projectEvent(
             activities: [],
             checkpoints: [],
             session: null,
+            loop: null,
           },
           event.type,
           "thread",
@@ -353,6 +356,28 @@ export function projectEvent(
           threads: updateThread(nextBase.threads, payload.threadId, {
             interactionMode: payload.interactionMode,
             updatedAt: payload.updatedAt,
+          }),
+        })),
+      );
+
+    case "thread.loop-upserted":
+      return decodeForEvent(ThreadLoopUpsertedPayload, event.payload, event.type, "payload").pipe(
+        Effect.map((payload) => ({
+          ...nextBase,
+          threads: updateThread(nextBase.threads, payload.threadId, {
+            loop: payload.loop,
+            updatedAt: event.occurredAt,
+          }),
+        })),
+      );
+
+    case "thread.loop-deleted":
+      return decodeForEvent(ThreadLoopDeletedPayload, event.payload, event.type, "payload").pipe(
+        Effect.map((payload) => ({
+          ...nextBase,
+          threads: updateThread(nextBase.threads, payload.threadId, {
+            loop: null,
+            updatedAt: event.occurredAt,
           }),
         })),
       );

--- a/apps/server/src/orchestration/sessionState.ts
+++ b/apps/server/src/orchestration/sessionState.ts
@@ -1,0 +1,18 @@
+import type { OrchestrationSession, OrchestrationSessionStatus } from "@t3tools/contracts";
+
+export function sessionStatusAllowsActiveTurn(status: OrchestrationSessionStatus): boolean {
+  return status === "starting" || status === "running";
+}
+
+export function sanitizeSessionActiveTurn<
+  T extends Pick<OrchestrationSession, "status" | "activeTurnId">,
+>(session: T): T {
+  if (session.activeTurnId === null || sessionStatusAllowsActiveTurn(session.status)) {
+    return session;
+  }
+
+  return {
+    ...session,
+    activeTurnId: null,
+  };
+}

--- a/apps/server/src/orchestration/sessionState.ts
+++ b/apps/server/src/orchestration/sessionState.ts
@@ -1,7 +1,20 @@
-import type { OrchestrationSession, OrchestrationSessionStatus } from "@t3tools/contracts";
+import type {
+  OrchestrationLatestTurn,
+  OrchestrationSession,
+  OrchestrationSessionStatus,
+} from "@t3tools/contracts";
 
 export function sessionStatusAllowsActiveTurn(status: OrchestrationSessionStatus): boolean {
   return status === "starting" || status === "running";
+}
+
+function staleBusyStatusFallback(
+  session: Pick<OrchestrationSession, "status" | "activeTurnId">,
+): OrchestrationSessionStatus {
+  if (session.activeTurnId !== null) {
+    return "interrupted";
+  }
+  return "ready";
 }
 
 export function sanitizeSessionActiveTurn<
@@ -14,5 +27,52 @@ export function sanitizeSessionActiveTurn<
   return {
     ...session,
     activeTurnId: null,
+  };
+}
+
+export function sanitizeBootSessionState<
+  T extends Pick<OrchestrationSession, "status" | "activeTurnId" | "updatedAt">,
+>(session: T, processStartedAt: string): T {
+  if (
+    sessionStatusAllowsActiveTurn(session.status) &&
+    Date.parse(session.updatedAt) < Date.parse(processStartedAt)
+  ) {
+    return {
+      ...session,
+      status: staleBusyStatusFallback(session),
+      activeTurnId: null,
+    };
+  }
+
+  return sanitizeSessionActiveTurn(session);
+}
+
+export function sanitizeBootLatestTurnState<T extends OrchestrationLatestTurn>(
+  latestTurn: T,
+  session: Pick<OrchestrationSession, "status" | "updatedAt"> | null,
+  processStartedAt: string,
+): T {
+  if (latestTurn.state !== "running") {
+    return latestTurn;
+  }
+
+  const staleBecauseSessionEnded =
+    session !== null && !sessionStatusAllowsActiveTurn(session.status);
+  const staleBecausePreBoot =
+    latestTurn.startedAt !== null &&
+    Date.parse(latestTurn.startedAt) < Date.parse(processStartedAt);
+
+  if (!staleBecauseSessionEnded && !staleBecausePreBoot) {
+    return latestTurn;
+  }
+
+  return {
+    ...latestTurn,
+    state: "interrupted",
+    completedAt:
+      latestTurn.completedAt ??
+      session?.updatedAt ??
+      latestTurn.startedAt ??
+      latestTurn.requestedAt,
   };
 }

--- a/apps/server/src/orchestration/threadLoop.ts
+++ b/apps/server/src/orchestration/threadLoop.ts
@@ -1,0 +1,4 @@
+export const THREAD_LOOP_MIN_INTERVAL_MINUTES = 1;
+
+export const computeThreadLoopNextRunAt = (fromIso: string, intervalMinutes: number): string =>
+  new Date(Date.parse(fromIso) + intervalMinutes * 60_000).toISOString();

--- a/apps/server/src/persistence/Layers/ProjectionThreadLoops.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadLoops.ts
@@ -1,0 +1,221 @@
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as SqlSchema from "effect/unstable/sql/SqlSchema";
+import { Effect, Layer, Option, Schema, Struct } from "effect";
+
+import { toPersistenceSqlError } from "../Errors.ts";
+import {
+  DeleteProjectionThreadLoopInput,
+  GetProjectionThreadLoopInput,
+  ListDueProjectionThreadLoopsInput,
+  ProjectionThreadLoop,
+  ProjectionThreadLoopRepository,
+  type ProjectionThreadLoopRepositoryShape,
+} from "../Services/ProjectionThreadLoops.ts";
+
+const ProjectionThreadLoopDbRowSchema = ProjectionThreadLoop.mapFields(
+  Struct.assign({
+    enabled: Schema.Number,
+  }),
+);
+
+function toProjectionThreadLoop(
+  row: Schema.Schema.Type<typeof ProjectionThreadLoopDbRowSchema>,
+): ProjectionThreadLoop {
+  return {
+    threadId: row.threadId,
+    enabled: row.enabled === 1,
+    prompt: row.prompt,
+    intervalMinutes: row.intervalMinutes,
+    nextRunAt: row.nextRunAt,
+    lastRunAt: row.lastRunAt,
+    lastError: row.lastError,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+const makeProjectionThreadLoopRepository = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const upsertProjectionThreadLoopRow = SqlSchema.void({
+    Request: ProjectionThreadLoop,
+    execute: (row) =>
+      sql`
+        INSERT INTO projection_thread_loops (
+          thread_id,
+          enabled,
+          prompt,
+          interval_minutes,
+          next_run_at,
+          last_run_at,
+          last_error,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          ${row.threadId},
+          ${row.enabled ? 1 : 0},
+          ${row.prompt},
+          ${row.intervalMinutes},
+          ${row.nextRunAt},
+          ${row.lastRunAt},
+          ${row.lastError},
+          ${row.createdAt},
+          ${row.updatedAt}
+        )
+        ON CONFLICT (thread_id)
+        DO UPDATE SET
+          enabled = excluded.enabled,
+          prompt = excluded.prompt,
+          interval_minutes = excluded.interval_minutes,
+          next_run_at = excluded.next_run_at,
+          last_run_at = excluded.last_run_at,
+          last_error = excluded.last_error,
+          created_at = excluded.created_at,
+          updated_at = excluded.updated_at
+      `,
+  });
+
+  const getProjectionThreadLoopRow = SqlSchema.findOneOption({
+    Request: GetProjectionThreadLoopInput,
+    Result: ProjectionThreadLoopDbRowSchema,
+    execute: ({ threadId }) =>
+      sql`
+        SELECT
+          thread_id AS "threadId",
+          enabled,
+          prompt,
+          interval_minutes AS "intervalMinutes",
+          next_run_at AS "nextRunAt",
+          last_run_at AS "lastRunAt",
+          last_error AS "lastError",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM projection_thread_loops
+        WHERE thread_id = ${threadId}
+      `,
+  });
+
+  const listProjectionThreadLoopRows = SqlSchema.findAll({
+    Request: Schema.Void,
+    Result: ProjectionThreadLoopDbRowSchema,
+    execute: () =>
+      sql`
+        SELECT
+          thread_id AS "threadId",
+          enabled,
+          prompt,
+          interval_minutes AS "intervalMinutes",
+          next_run_at AS "nextRunAt",
+          last_run_at AS "lastRunAt",
+          last_error AS "lastError",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM projection_thread_loops
+        ORDER BY created_at ASC, thread_id ASC
+      `,
+  });
+
+  const listDueProjectionThreadLoopRows = SqlSchema.findAll({
+    Request: ListDueProjectionThreadLoopsInput,
+    Result: ProjectionThreadLoopDbRowSchema,
+    execute: ({ dueBefore }) =>
+      sql`
+        SELECT
+          thread_id AS "threadId",
+          enabled,
+          prompt,
+          interval_minutes AS "intervalMinutes",
+          next_run_at AS "nextRunAt",
+          last_run_at AS "lastRunAt",
+          last_error AS "lastError",
+          created_at AS "createdAt",
+          updated_at AS "updatedAt"
+        FROM projection_thread_loops
+        WHERE enabled = 1
+          AND next_run_at IS NOT NULL
+          AND next_run_at <= ${dueBefore}
+        ORDER BY next_run_at ASC, thread_id ASC
+      `,
+  });
+
+  const deleteProjectionThreadLoopRow = SqlSchema.void({
+    Request: DeleteProjectionThreadLoopInput,
+    execute: ({ threadId }) =>
+      sql`
+        DELETE FROM projection_thread_loops
+        WHERE thread_id = ${threadId}
+      `,
+  });
+
+  const upsert: ProjectionThreadLoopRepositoryShape["upsert"] = (row) =>
+    upsertProjectionThreadLoopRow(row).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionThreadLoopRepository.upsert:query")),
+    );
+
+  const getByThreadId: ProjectionThreadLoopRepositoryShape["getByThreadId"] = (input) =>
+    getProjectionThreadLoopRow(input).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionThreadLoopRepository.getByThreadId:query")),
+      Effect.map(Option.map(toProjectionThreadLoop)),
+    );
+
+  const listAll: ProjectionThreadLoopRepositoryShape["listAll"] = () =>
+    listProjectionThreadLoopRows(void 0).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionThreadLoopRepository.listAll:query")),
+      Effect.map((rows) => rows.map(toProjectionThreadLoop)),
+    );
+
+  const listDue: ProjectionThreadLoopRepositoryShape["listDue"] = (input) =>
+    listDueProjectionThreadLoopRows(input).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionThreadLoopRepository.listDue:query")),
+      Effect.map((rows) => rows.map(toProjectionThreadLoop)),
+    );
+
+  const claimDueRun: ProjectionThreadLoopRepositoryShape["claimDueRun"] = (input) =>
+    Effect.gen(function* () {
+      yield* sql`
+        UPDATE projection_thread_loops
+        SET
+          next_run_at = ${input.nextRunAt},
+          updated_at = ${input.updatedAt}
+        WHERE thread_id = ${input.threadId}
+          AND enabled = 1
+          AND next_run_at = ${input.expectedNextRunAt}
+      `.pipe(
+        Effect.mapError(toPersistenceSqlError("ProjectionThreadLoopRepository.claimDueRun:update")),
+      );
+
+      const rows = yield* sql<{
+        readonly changed: number;
+      }>`
+        SELECT changes() AS "changed"
+      `.pipe(
+        Effect.mapError(
+          toPersistenceSqlError("ProjectionThreadLoopRepository.claimDueRun:changes"),
+        ),
+      );
+
+      return (rows[0]?.changed ?? 0) > 0;
+    });
+
+  const deleteByThreadId: ProjectionThreadLoopRepositoryShape["deleteByThreadId"] = (input) =>
+    deleteProjectionThreadLoopRow(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("ProjectionThreadLoopRepository.deleteByThreadId:query"),
+      ),
+    );
+
+  return {
+    upsert,
+    getByThreadId,
+    listAll,
+    listDue,
+    claimDueRun,
+    deleteByThreadId,
+  } satisfies ProjectionThreadLoopRepositoryShape;
+});
+
+export const ProjectionThreadLoopRepositoryLive = Layer.effect(
+  ProjectionThreadLoopRepository,
+  makeProjectionThreadLoopRepository,
+);

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -32,6 +32,7 @@ import Migration0016 from "./Migrations/016_CanonicalizeModelSelections.ts";
 import Migration0017 from "./Migrations/017_ProjectionThreadsArchivedAt.ts";
 import Migration0018 from "./Migrations/018_ProjectionThreadsArchivedAtIndex.ts";
 import Migration0019 from "./Migrations/019_ProjectionSnapshotLookupIndexes.ts";
+import Migration0020 from "./Migrations/020_ProjectionThreadLoops.ts";
 
 /**
  * Migration loader with all migrations defined inline.
@@ -63,6 +64,7 @@ export const migrationEntries = [
   [17, "ProjectionThreadsArchivedAt", Migration0017],
   [18, "ProjectionThreadsArchivedAtIndex", Migration0018],
   [19, "ProjectionSnapshotLookupIndexes", Migration0019],
+  [20, "ProjectionThreadLoops", Migration0020],
 ] as const;
 
 export const makeMigrationLoader = (throughId?: number) =>

--- a/apps/server/src/persistence/Migrations/020_ProjectionThreadLoops.ts
+++ b/apps/server/src/persistence/Migrations/020_ProjectionThreadLoops.ts
@@ -1,0 +1,25 @@
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as Effect from "effect/Effect";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS projection_thread_loops (
+      thread_id TEXT PRIMARY KEY,
+      enabled INTEGER NOT NULL,
+      prompt TEXT NOT NULL,
+      interval_minutes INTEGER NOT NULL,
+      next_run_at TEXT,
+      last_run_at TEXT,
+      last_error TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `;
+
+  yield* sql`
+    CREATE INDEX IF NOT EXISTS idx_projection_thread_loops_due
+    ON projection_thread_loops(enabled, next_run_at)
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadLoops.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadLoops.ts
@@ -1,0 +1,74 @@
+/**
+ * ProjectionThreadLoopRepository - Projection repository interface for thread loops.
+ *
+ * Owns persistence operations for projected per-thread loop configuration and
+ * runtime scheduling state.
+ *
+ * @module ProjectionThreadLoopRepository
+ */
+import { IsoDateTime, PositiveInt, ThreadId } from "@t3tools/contracts";
+import { Option, Schema, ServiceMap } from "effect";
+import type { Effect } from "effect";
+
+import type { ProjectionRepositoryError } from "../Errors.ts";
+
+export const ProjectionThreadLoop = Schema.Struct({
+  threadId: ThreadId,
+  enabled: Schema.Boolean,
+  prompt: Schema.String,
+  intervalMinutes: PositiveInt,
+  nextRunAt: Schema.NullOr(IsoDateTime),
+  lastRunAt: Schema.NullOr(IsoDateTime),
+  lastError: Schema.NullOr(Schema.String),
+  createdAt: IsoDateTime,
+  updatedAt: IsoDateTime,
+});
+export type ProjectionThreadLoop = typeof ProjectionThreadLoop.Type;
+
+export const GetProjectionThreadLoopInput = Schema.Struct({
+  threadId: ThreadId,
+});
+export type GetProjectionThreadLoopInput = typeof GetProjectionThreadLoopInput.Type;
+
+export const DeleteProjectionThreadLoopInput = Schema.Struct({
+  threadId: ThreadId,
+});
+export type DeleteProjectionThreadLoopInput = typeof DeleteProjectionThreadLoopInput.Type;
+
+export const ListDueProjectionThreadLoopsInput = Schema.Struct({
+  dueBefore: IsoDateTime,
+});
+export type ListDueProjectionThreadLoopsInput = typeof ListDueProjectionThreadLoopsInput.Type;
+
+export const ClaimProjectionThreadLoopRunInput = Schema.Struct({
+  threadId: ThreadId,
+  expectedNextRunAt: IsoDateTime,
+  nextRunAt: IsoDateTime,
+  updatedAt: IsoDateTime,
+});
+export type ClaimProjectionThreadLoopRunInput = typeof ClaimProjectionThreadLoopRunInput.Type;
+
+export interface ProjectionThreadLoopRepositoryShape {
+  readonly upsert: (loop: ProjectionThreadLoop) => Effect.Effect<void, ProjectionRepositoryError>;
+  readonly getByThreadId: (
+    input: GetProjectionThreadLoopInput,
+  ) => Effect.Effect<Option.Option<ProjectionThreadLoop>, ProjectionRepositoryError>;
+  readonly listAll: () => Effect.Effect<
+    ReadonlyArray<ProjectionThreadLoop>,
+    ProjectionRepositoryError
+  >;
+  readonly listDue: (
+    input: ListDueProjectionThreadLoopsInput,
+  ) => Effect.Effect<ReadonlyArray<ProjectionThreadLoop>, ProjectionRepositoryError>;
+  readonly claimDueRun: (
+    input: ClaimProjectionThreadLoopRunInput,
+  ) => Effect.Effect<boolean, ProjectionRepositoryError>;
+  readonly deleteByThreadId: (
+    input: DeleteProjectionThreadLoopInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+}
+
+export class ProjectionThreadLoopRepository extends ServiceMap.Service<
+  ProjectionThreadLoopRepository,
+  ProjectionThreadLoopRepositoryShape
+>()("t3/persistence/Services/ProjectionThreadLoops/ProjectionThreadLoopRepository") {}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -40,6 +40,7 @@ import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus"
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion";
 import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderCommandReactor";
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor";
+import { ThreadLoopSchedulerLive } from "./orchestration/Layers/ThreadLoopScheduler";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry";
 import { ServerSettingsLive } from "./serverSettings";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver";
@@ -97,11 +98,11 @@ const PlatformServicesLive = Layer.unwrap(
   }),
 );
 
-const ReactorLayerLive = Layer.empty.pipe(
-  Layer.provideMerge(OrchestrationReactorLive),
+const ReactorLayerLive = OrchestrationReactorLive.pipe(
   Layer.provideMerge(ProviderRuntimeIngestionLive),
   Layer.provideMerge(ProviderCommandReactorLive),
   Layer.provideMerge(CheckpointReactorLive),
+  Layer.provideMerge(ThreadLoopSchedulerLive),
   Layer.provideMerge(RuntimeReceiptBusLive),
 );
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -159,6 +159,8 @@ import { AVAILABLE_PROVIDER_OPTIONS, ProviderModelPicker } from "./chat/Provider
 import { ComposerCommandItem, ComposerCommandMenu } from "./chat/ComposerCommandMenu";
 import { ComposerPendingApprovalActions } from "./chat/ComposerPendingApprovalActions";
 import { CompactComposerControlsMenu } from "./chat/CompactComposerControlsMenu";
+import ThreadLoopControl from "./chat/ThreadLoopControl";
+import { useThreadActions } from "../hooks/useThreadActions";
 import { ComposerPrimaryActions } from "./chat/ComposerPrimaryActions";
 import { ComposerPendingApprovalPanel } from "./chat/ComposerPendingApprovalPanel";
 import { ComposerPendingUserInputPanel } from "./chat/ComposerPendingUserInputPanel";
@@ -575,6 +577,7 @@ function PersistentThreadTerminalDrawer({
 }
 
 export default function ChatView({ threadId }: ChatViewProps) {
+  const { deleteLoop, runLoopNow, upsertLoop } = useThreadActions();
   const serverThread = useThreadById(threadId);
   const setStoreThreadError = useStore((store) => store.setError);
   const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
@@ -4247,18 +4250,28 @@ export default function ChatView({ threadId }: ChatViewProps) {
                         />
 
                         {isComposerFooterCompact ? (
-                          <CompactComposerControlsMenu
-                            activePlan={Boolean(
-                              activePlan || sidebarProposedPlan || planSidebarOpen,
-                            )}
-                            interactionMode={interactionMode}
-                            planSidebarOpen={planSidebarOpen}
-                            runtimeMode={runtimeMode}
-                            traitsMenuContent={providerTraitsMenuContent}
-                            onToggleInteractionMode={toggleInteractionMode}
-                            onTogglePlanSidebar={togglePlanSidebar}
-                            onToggleRuntimeMode={toggleRuntimeMode}
-                          />
+                          <>
+                            <ThreadLoopControl
+                              compact={true}
+                              threadId={activeThread.id}
+                              loop={activeThread.loop}
+                              onUpsertLoop={upsertLoop}
+                              onDeleteLoop={deleteLoop}
+                              onRunNow={runLoopNow}
+                            />
+                            <CompactComposerControlsMenu
+                              activePlan={Boolean(
+                                activePlan || sidebarProposedPlan || planSidebarOpen,
+                              )}
+                              interactionMode={interactionMode}
+                              planSidebarOpen={planSidebarOpen}
+                              runtimeMode={runtimeMode}
+                              traitsMenuContent={providerTraitsMenuContent}
+                              onToggleInteractionMode={toggleInteractionMode}
+                              onTogglePlanSidebar={togglePlanSidebar}
+                              onToggleRuntimeMode={toggleRuntimeMode}
+                            />
+                          </>
                         ) : (
                           <>
                             {providerTraitsPicker ? (
@@ -4322,6 +4335,19 @@ export default function ChatView({ threadId }: ChatViewProps) {
                                 {runtimeMode === "full-access" ? "Full access" : "Supervised"}
                               </span>
                             </Button>
+
+                            <Separator
+                              orientation="vertical"
+                              className="mx-0.5 hidden h-4 sm:block"
+                            />
+
+                            <ThreadLoopControl
+                              threadId={activeThread.id}
+                              loop={activeThread.loop}
+                              onUpsertLoop={upsertLoop}
+                              onDeleteLoop={deleteLoop}
+                              onRunNow={runLoopNow}
+                            />
 
                             {activePlan || sidebarProposedPlan || planSidebarOpen ? (
                               <>

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -15,6 +15,7 @@ import {
 export const CompactComposerControlsMenu = memo(function CompactComposerControlsMenu(props: {
   activePlan: boolean;
   interactionMode: ProviderInteractionMode;
+  loopMenuContent?: ReactNode;
   planSidebarOpen: boolean;
   runtimeMode: RuntimeMode;
   traitsMenuContent?: ReactNode;
@@ -66,6 +67,12 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
           <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
           <MenuRadioItem value="full-access">Full access</MenuRadioItem>
         </MenuRadioGroup>
+        {props.loopMenuContent ? (
+          <>
+            <MenuDivider />
+            {props.loopMenuContent}
+          </>
+        ) : null}
         {props.activePlan ? (
           <>
             <MenuDivider />

--- a/apps/web/src/components/chat/ThreadLoopControl.tsx
+++ b/apps/web/src/components/chat/ThreadLoopControl.tsx
@@ -1,13 +1,15 @@
 import type { ThreadId } from "@t3tools/contracts";
 import {
   AlertCircleIcon,
-  Clock3Icon,
-  PauseCircleIcon,
-  PlayCircleIcon,
+  PauseIcon,
+  PlayIcon,
+  RefreshCwIcon,
+  RepeatIcon,
   Trash2Icon,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
@@ -23,30 +25,116 @@ import {
 } from "../ui/sheet";
 import { Switch } from "../ui/switch";
 import { Textarea } from "../ui/textarea";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import type { ThreadLoop } from "~/types";
 
 const THREAD_LOOP_INTERVAL_PRESETS = [1, 5, 15, 30, 60, 240] as const;
 
-function formatThreadLoopInterval(intervalMinutes: number): string {
-  if (intervalMinutes % 60 === 0) {
+function formatInterval(intervalMinutes: number): string {
+  if (intervalMinutes >= 60 && intervalMinutes % 60 === 0) {
     const hours = intervalMinutes / 60;
     return hours === 1 ? "1h" : `${hours}h`;
   }
-  return `${intervalMinutes} min`;
+  return `${intervalMinutes}m`;
 }
 
-function formatThreadLoopTimestamp(value: string | null | undefined): string {
-  if (!value) return "—";
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return "\u2014";
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+  return Number.isNaN(date.getTime()) ? "\u2014" : date.toLocaleString();
 }
 
-function buildThreadLoopTriggerLabel(loop: ThreadLoop | null | undefined): string {
-  if (!loop) return "+ Loop";
-  if (!loop.enabled) return "Loop pausado";
-  if (loop.lastError) return "Loop com erro";
-  return `Loop: ${formatThreadLoopInterval(loop.intervalMinutes)}`;
+function formatRelativeTime(value: string | null | undefined): string {
+  if (!value) return "\u2014";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "\u2014";
+  const now = Date.now();
+  const diff = date.getTime() - now;
+  const absDiff = Math.abs(diff);
+  if (absDiff < 60_000) return diff > 0 ? "in <1m" : "<1m ago";
+  if (absDiff < 3_600_000) {
+    const mins = Math.round(absDiff / 60_000);
+    return diff > 0 ? `in ${mins}m` : `${mins}m ago`;
+  }
+  const hours = Math.round(absDiff / 3_600_000);
+  return diff > 0 ? `in ${hours}h` : `${hours}h ago`;
 }
+
+type LoopStatus = "unconfigured" | "active" | "paused" | "error";
+
+function deriveStatus(loop: ThreadLoop | null | undefined): LoopStatus {
+  if (!loop) return "unconfigured";
+  if (loop.lastError) return "error";
+  if (!loop.enabled) return "paused";
+  return "active";
+}
+
+// ---------------------------------------------------------------------------
+// Trigger chip
+// ---------------------------------------------------------------------------
+
+const statusChipClasses: Record<LoopStatus, string> = {
+  unconfigured:
+    "border-input bg-background text-muted-foreground hover:bg-accent/50 dark:bg-input/32 dark:hover:bg-input/48",
+  active:
+    "border-success/24 bg-success/8 text-success-foreground hover:bg-success/14 dark:border-success/16 dark:bg-success/12 dark:hover:bg-success/18",
+  paused:
+    "border-input bg-muted/50 text-muted-foreground hover:bg-accent/50 dark:bg-input/20 dark:hover:bg-input/36",
+  error:
+    "border-warning/24 bg-warning/8 text-warning-foreground hover:bg-warning/14 dark:border-warning/16 dark:bg-warning/12 dark:hover:bg-warning/18",
+};
+
+function StatusDot({ status }: { status: LoopStatus }) {
+  if (status === "unconfigured") return null;
+  if (status === "active") {
+    return (
+      <span className="relative flex size-2">
+        <span className="absolute inline-flex size-full animate-ping rounded-full bg-success/60 duration-[2000ms]" />
+        <span className="relative inline-flex size-2 rounded-full bg-success" />
+      </span>
+    );
+  }
+  if (status === "paused") {
+    return <span className="inline-flex size-2 rounded-full bg-muted-foreground/40" />;
+  }
+  return <span className="inline-flex size-2 rounded-full bg-warning" />;
+}
+
+function LoopChipLabel({
+  loop,
+  status,
+  compact,
+}: {
+  loop: ThreadLoop | null | undefined;
+  status: LoopStatus;
+  compact?: boolean | undefined;
+}) {
+  if (status === "unconfigured") {
+    return (
+      <>
+        <RepeatIcon className="size-3.5 opacity-60" />
+        <span className={compact ? "sr-only" : "sr-only sm:not-sr-only"}>Loop</span>
+      </>
+    );
+  }
+  return (
+    <>
+      <StatusDot status={status} />
+      <span className={compact ? "sr-only" : "sr-only sm:not-sr-only"}>
+        {status === "error" ? "Loop error" : status === "paused" ? "Paused" : "Loop"}
+      </span>
+      {loop ? (
+        <span className={compact ? "sr-only" : "sr-only sm:not-sr-only font-mono text-[0.6875rem]"}>
+          {formatInterval(loop.intervalMinutes)}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
 
 export default function ThreadLoopControl(props: {
   threadId: ThreadId;
@@ -71,28 +159,47 @@ export default function ThreadLoopControl(props: {
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRunningNow, setIsRunningNow] = useState(false);
+  const [isTogglingPause, setIsTogglingPause] = useState(false);
 
   useEffect(() => {
-    if (!open) {
-      return;
-    }
+    if (!open) return;
     setEnabled(props.loop?.enabled ?? true);
     setPrompt(props.loop?.prompt ?? "");
     setIntervalMinutes(String(props.loop?.intervalMinutes ?? 30));
     setError(null);
   }, [open, props.loop]);
 
-  const triggerLabel = useMemo(() => buildThreadLoopTriggerLabel(props.loop), [props.loop]);
-  const triggerTitle = useMemo(() => {
-    if (!props.loop) {
-      return "Configure an automatic loop for this thread";
-    }
-    return [
-      triggerLabel,
-      `Next run: ${formatThreadLoopTimestamp(props.loop.nextRunAt)}`,
-      `Last run: ${formatThreadLoopTimestamp(props.loop.lastRunAt)}`,
-    ].join("\n");
-  }, [props.loop, triggerLabel]);
+  const status = useMemo(() => deriveStatus(props.loop), [props.loop]);
+
+  const tooltipText = useMemo(() => {
+    if (!props.loop) return "Configure a recurring loop";
+    const lines = [
+      props.loop.enabled ? "Loop active" : "Loop paused",
+      `Every ${formatInterval(props.loop.intervalMinutes)}`,
+    ];
+    if (props.loop.nextRunAt) lines.push(`Next: ${formatRelativeTime(props.loop.nextRunAt)}`);
+    if (props.loop.lastError) lines.push(`Error: ${props.loop.lastError}`);
+    return lines.join("\n");
+  }, [props.loop]);
+
+  const handleQuickTogglePause = useCallback(
+    async (event: React.MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+      if (!props.loop || isTogglingPause) return;
+      setIsTogglingPause(true);
+      try {
+        await props.onUpsertLoop(props.threadId, {
+          enabled: !props.loop.enabled,
+          prompt: props.loop.prompt,
+          intervalMinutes: props.loop.intervalMinutes,
+        });
+      } finally {
+        setIsTogglingPause(false);
+      }
+    },
+    [props, isTogglingPause],
+  );
 
   const handleSave = async () => {
     const trimmedPrompt = prompt.trim();
@@ -143,7 +250,7 @@ export default function ThreadLoopControl(props: {
       await props.onRunNow(props.threadId);
       setOpen(false);
     } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : "Failed to run loop now.");
+      setError(nextError instanceof Error ? nextError.message : "Failed to run now.");
     } finally {
       setIsRunningNow(false);
     }
@@ -151,107 +258,199 @@ export default function ThreadLoopControl(props: {
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <SheetTrigger
-        render={
-          <Button
-            variant="ghost"
-            className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
-            size="sm"
-            type="button"
-            title={triggerTitle}
-          />
-        }
-      >
-        {props.loop?.lastError ? (
-          <AlertCircleIcon className="size-4 text-amber-500" />
-        ) : props.loop?.enabled === false ? (
-          <PauseCircleIcon className="size-4" />
-        ) : (
-          <Clock3Icon className="size-4" />
-        )}
-        <span className={props.compact ? "sr-only" : "sr-only sm:not-sr-only"}>{triggerLabel}</span>
-      </SheetTrigger>
+      {/* ---- Trigger area: chip + optional quick pause/play ---- */}
+      <div className="flex items-center gap-0.5">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <SheetTrigger
+                render={
+                  <button
+                    type="button"
+                    className={[
+                      "inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap border font-medium outline-none transition-colors duration-150",
+                      "h-7 rounded-md px-2 text-xs sm:h-6 sm:text-[0.6875rem]",
+                      "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                      props.loop ? "rounded-r-none border-r-0" : "",
+                      statusChipClasses[status],
+                    ].join(" ")}
+                  />
+                }
+              />
+            }
+          >
+            <LoopChipLabel loop={props.loop} status={status} compact={props.compact} />
+          </TooltipTrigger>
+          <TooltipPopup className="max-w-56 whitespace-pre-line">{tooltipText}</TooltipPopup>
+        </Tooltip>
+
+        {/* Quick pause/resume toggle — only when loop exists */}
+        {props.loop ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  disabled={isTogglingPause}
+                  onClick={(event) => void handleQuickTogglePause(event)}
+                  className={[
+                    "inline-flex shrink-0 cursor-pointer items-center justify-center border border-l-0 outline-none transition-colors duration-150",
+                    "h-7 w-7 rounded-md rounded-l-none sm:h-6 sm:w-6",
+                    "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                    "disabled:pointer-events-none disabled:opacity-50",
+                    statusChipClasses[status],
+                  ].join(" ")}
+                />
+              }
+            >
+              {props.loop.enabled ? (
+                <PauseIcon className="size-3 fill-current" />
+              ) : (
+                <PlayIcon className="size-3 fill-current" />
+              )}
+            </TooltipTrigger>
+            <TooltipPopup>{props.loop.enabled ? "Pause loop" : "Resume loop"}</TooltipPopup>
+          </Tooltip>
+        ) : null}
+      </div>
+
+      {/* ---- Sheet panel ---- */}
       <SheetContent side="right">
         <SheetHeader>
-          <SheetTitle>Thread automation</SheetTitle>
+          <SheetTitle>Thread loop</SheetTitle>
           <SheetDescription>
-            Configure a recurring prompt for this thread. The scheduler runs on the server and skips
+            Configure a recurring prompt that runs automatically on a schedule. The server skips
             ticks while the thread is busy.
           </SheetDescription>
         </SheetHeader>
         <SheetPanel className="space-y-5">
-          <div className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-muted/30 px-4 py-3">
-            <div className="space-y-1">
-              <Label htmlFor="thread-loop-enabled">Loop active</Label>
-              <p className="text-muted-foreground text-xs">
-                Disable to keep the configuration without scheduling new automatic runs.
-              </p>
+          {/* Status banner when loop exists */}
+          {props.loop ? (
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3">
+              <div className="flex items-center gap-2.5">
+                <StatusDot status={status} />
+                <span className="text-sm font-medium">
+                  {status === "active"
+                    ? "Running"
+                    : status === "paused"
+                      ? "Paused"
+                      : status === "error"
+                        ? "Error"
+                        : "Off"}
+                </span>
+                {props.loop.nextRunAt && status === "active" ? (
+                  <Badge variant="outline" size="sm">
+                    Next {formatRelativeTime(props.loop.nextRunAt)}
+                  </Badge>
+                ) : null}
+              </div>
+              <Switch id="thread-loop-enabled" checked={enabled} onCheckedChange={setEnabled} />
             </div>
-            <Switch id="thread-loop-enabled" checked={enabled} onCheckedChange={setEnabled} />
-          </div>
+          ) : (
+            <div className="flex items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-4 py-3">
+              <div className="space-y-0.5">
+                <Label htmlFor="thread-loop-enabled" className="text-sm">
+                  Enable loop
+                </Label>
+                <p className="text-muted-foreground text-xs">
+                  The loop will start running after you save.
+                </p>
+              </div>
+              <Switch id="thread-loop-enabled" checked={enabled} onCheckedChange={setEnabled} />
+            </div>
+          )}
 
+          {/* Interval */}
           <div className="space-y-2">
-            <Label htmlFor="thread-loop-interval">Run every</Label>
-            <Input
-              id="thread-loop-interval"
-              type="number"
-              min={1}
-              step={1}
-              value={intervalMinutes}
-              onChange={(event) => setIntervalMinutes(event.target.value)}
-            />
-            <div className="flex flex-wrap gap-2">
+            <Label htmlFor="thread-loop-interval" className="text-sm">
+              Interval
+            </Label>
+            <div className="flex flex-wrap items-center gap-1.5">
               {THREAD_LOOP_INTERVAL_PRESETS.map((presetMinutes) => {
                 const selected = intervalMinutes === String(presetMinutes);
                 return (
-                  <Button
+                  <button
                     key={presetMinutes}
                     type="button"
-                    size="sm"
-                    variant={selected ? "secondary" : "outline"}
-                    className="h-8"
                     onClick={() => setIntervalMinutes(String(presetMinutes))}
+                    className={[
+                      "inline-flex h-7 items-center rounded-md border px-2.5 font-mono text-xs transition-colors duration-100 sm:h-6 sm:text-[0.6875rem]",
+                      "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+                      selected
+                        ? "border-primary/30 bg-primary/10 text-primary font-medium dark:border-primary/20 dark:bg-primary/16"
+                        : "border-input bg-background text-muted-foreground hover:bg-accent/50 dark:bg-input/32 dark:hover:bg-input/48",
+                    ].join(" ")}
                   >
-                    {formatThreadLoopInterval(presetMinutes)}
-                  </Button>
+                    {formatInterval(presetMinutes)}
+                  </button>
                 );
               })}
+              <div className="flex items-center gap-1.5">
+                <Input
+                  id="thread-loop-interval"
+                  type="number"
+                  min={1}
+                  step={1}
+                  value={intervalMinutes}
+                  onChange={(event) => setIntervalMinutes(event.target.value)}
+                  className="h-7 w-16 font-mono text-xs sm:h-6 sm:text-[0.6875rem]"
+                />
+                <span className="text-muted-foreground text-xs">min</span>
+              </div>
             </div>
-            <p className="text-muted-foreground text-xs">Interval in minutes.</p>
           </div>
 
+          {/* Prompt */}
           <div className="space-y-2">
-            <Label htmlFor="thread-loop-prompt">Loop prompt</Label>
+            <Label htmlFor="thread-loop-prompt" className="text-sm">
+              Prompt
+            </Label>
             <Textarea
               id="thread-loop-prompt"
-              rows={8}
+              rows={6}
               value={prompt}
               onChange={(event) => setPrompt(event.target.value)}
-              placeholder="Check the deployment and summarize the current status."
+              placeholder="Check the deployment status and summarize any issues."
+              className="text-sm leading-relaxed"
             />
           </div>
 
+          {/* Run history */}
           {props.loop ? (
-            <div className="space-y-2 rounded-xl border border-border/60 bg-muted/20 px-4 py-3 text-sm">
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-muted-foreground">Next run</span>
-                <span>{formatThreadLoopTimestamp(props.loop.nextRunAt)}</span>
-              </div>
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-muted-foreground">Last run</span>
-                <span>{formatThreadLoopTimestamp(props.loop.lastRunAt)}</span>
+            <div className="space-y-2">
+              <span className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+                History
+              </span>
+              <div className="rounded-lg border border-border/60 bg-muted/10 text-sm divide-y divide-border/40">
+                <div className="flex items-center justify-between gap-3 px-3.5 py-2.5">
+                  <span className="text-muted-foreground text-xs">Next run</span>
+                  <span className="text-xs tabular-nums">
+                    {formatTimestamp(props.loop.nextRunAt)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-3 px-3.5 py-2.5">
+                  <span className="text-muted-foreground text-xs">Last run</span>
+                  <span className="text-xs tabular-nums">
+                    {formatTimestamp(props.loop.lastRunAt)}
+                  </span>
+                </div>
               </div>
               {props.loop.lastError ? (
-                <div className="space-y-1 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
-                  <div className="font-medium text-amber-700 text-xs">Last automatic run error</div>
-                  <div className="text-xs text-amber-800">{props.loop.lastError}</div>
+                <div className="rounded-lg border border-warning/20 bg-warning/6 px-3.5 py-2.5 dark:border-warning/14 dark:bg-warning/10">
+                  <div className="flex items-center gap-1.5 text-xs font-medium text-warning-foreground">
+                    <AlertCircleIcon className="size-3.5 shrink-0" />
+                    Last run error
+                  </div>
+                  <p className="mt-1 text-xs text-warning-foreground/80 leading-relaxed">
+                    {props.loop.lastError}
+                  </p>
                 </div>
               ) : null}
             </div>
           ) : null}
 
           {error ? (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-destructive text-sm">
+            <div className="rounded-lg border border-destructive/20 bg-destructive/6 px-3.5 py-2.5 text-destructive-foreground text-sm dark:border-destructive/14 dark:bg-destructive/10">
               {error}
             </div>
           ) : null}
@@ -261,28 +460,35 @@ export default function ThreadLoopControl(props: {
             {props.loop ? (
               <Button
                 type="button"
-                variant="outline"
+                variant="destructive-outline"
+                size="sm"
                 onClick={() => void handleDelete()}
                 disabled={isDeleting || isSaving || isRunningNow}
               >
-                <Trash2Icon className="size-4" />
-                {isDeleting ? "Deleting..." : "Delete loop"}
+                <Trash2Icon className="size-3.5" />
+                {isDeleting ? "Deleting\u2026" : "Delete"}
               </Button>
             ) : null}
             {props.loop ? (
               <Button
                 type="button"
                 variant="outline"
+                size="sm"
                 onClick={() => void handleRunNow()}
                 disabled={isDeleting || isSaving || isRunningNow}
               >
-                <PlayCircleIcon className="size-4" />
-                {isRunningNow ? "Running..." : "Run now"}
+                <RefreshCwIcon className="size-3.5" />
+                {isRunningNow ? "Running\u2026" : "Run now"}
               </Button>
             ) : null}
           </div>
-          <Button type="button" onClick={() => void handleSave()} disabled={isSaving || isDeleting}>
-            {isSaving ? "Saving..." : "Save loop"}
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void handleSave()}
+            disabled={isSaving || isDeleting}
+          >
+            {isSaving ? "Saving\u2026" : props.loop ? "Update" : "Create loop"}
           </Button>
         </SheetFooter>
       </SheetContent>

--- a/apps/web/src/components/chat/ThreadLoopControl.tsx
+++ b/apps/web/src/components/chat/ThreadLoopControl.tsx
@@ -260,34 +260,50 @@ export default function ThreadLoopControl(props: {
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      {/* ---- Trigger area: chip + optional quick pause/play ---- */}
-      <div className="flex items-center gap-0.5">
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <SheetTrigger
-                render={
-                  <button
-                    type="button"
-                    className={[
-                      "inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap border font-medium outline-none transition-colors duration-150",
-                      "h-7 rounded-md px-2 text-xs sm:h-6 sm:text-[0.6875rem]",
-                      "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
-                      props.loop ? "rounded-r-none border-r-0" : "",
-                      statusChipClasses[status],
-                    ].join(" ")}
-                  />
-                }
-              />
-            }
-          >
-            <LoopChipLabel loop={props.loop} status={status} compact={props.compact} />
-          </TooltipTrigger>
-          <TooltipPopup className="max-w-56 whitespace-pre-line">{tooltipText}</TooltipPopup>
-        </Tooltip>
+      {/* ---- Trigger area ---- */}
+      {status === "unconfigured" ? (
+        /* Idle: matches the other ghost buttons in the composer bar */
+        <SheetTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="sm"
+              className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
+              type="button"
+              title={tooltipText}
+            />
+          }
+        >
+          <RepeatIcon className="size-4" />
+          <span className={props.compact ? "sr-only" : "sr-only sm:not-sr-only"}>Loop</span>
+        </SheetTrigger>
+      ) : (
+        /* Active/paused/error: chip style with quick pause/resume */
+        <div className="flex items-center gap-0.5">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <SheetTrigger
+                  render={
+                    <button
+                      type="button"
+                      className={[
+                        "inline-flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap border font-medium outline-none transition-colors duration-150",
+                        "h-8 rounded-lg px-2 text-xs sm:h-7 sm:text-[0.6875rem]",
+                        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                        "rounded-r-none border-r-0",
+                        statusChipClasses[status],
+                      ].join(" ")}
+                    />
+                  }
+                />
+              }
+            >
+              <LoopChipLabel loop={props.loop} status={status} compact={props.compact} />
+            </TooltipTrigger>
+            <TooltipPopup className="max-w-56 whitespace-pre-line">{tooltipText}</TooltipPopup>
+          </Tooltip>
 
-        {/* Quick pause/resume toggle — only when loop exists */}
-        {props.loop ? (
           <Tooltip>
             <TooltipTrigger
               render={
@@ -297,7 +313,7 @@ export default function ThreadLoopControl(props: {
                   onClick={(event) => void handleQuickTogglePause(event)}
                   className={[
                     "inline-flex shrink-0 cursor-pointer items-center justify-center border border-l-0 outline-none transition-colors duration-150",
-                    "h-7 w-7 rounded-md rounded-l-none sm:h-6 sm:w-6",
+                    "h-8 w-8 rounded-lg rounded-l-none sm:h-7 sm:w-7",
                     "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
                     "disabled:pointer-events-none disabled:opacity-50",
                     statusChipClasses[status],
@@ -305,16 +321,16 @@ export default function ThreadLoopControl(props: {
                 />
               }
             >
-              {props.loop.enabled ? (
+              {props.loop?.enabled ? (
                 <PauseIcon className="size-3 fill-current" />
               ) : (
                 <PlayIcon className="size-3 fill-current" />
               )}
             </TooltipTrigger>
-            <TooltipPopup>{props.loop.enabled ? "Pause loop" : "Resume loop"}</TooltipPopup>
+            <TooltipPopup>{props.loop?.enabled ? "Pause loop" : "Resume loop"}</TooltipPopup>
           </Tooltip>
-        ) : null}
-      </div>
+        </div>
+      )}
 
       {/* ---- Sheet panel ---- */}
       <SheetContent side="right">

--- a/apps/web/src/components/chat/ThreadLoopControl.tsx
+++ b/apps/web/src/components/chat/ThreadLoopControl.tsx
@@ -25,6 +25,8 @@ import { Switch } from "../ui/switch";
 import { Textarea } from "../ui/textarea";
 import type { ThreadLoop } from "~/types";
 
+const THREAD_LOOP_INTERVAL_PRESETS = [1, 5, 15, 30, 60, 240] as const;
+
 function formatThreadLoopInterval(intervalMinutes: number): string {
   if (intervalMinutes % 60 === 0) {
     const hours = intervalMinutes / 60;
@@ -198,6 +200,23 @@ export default function ThreadLoopControl(props: {
               value={intervalMinutes}
               onChange={(event) => setIntervalMinutes(event.target.value)}
             />
+            <div className="flex flex-wrap gap-2">
+              {THREAD_LOOP_INTERVAL_PRESETS.map((presetMinutes) => {
+                const selected = intervalMinutes === String(presetMinutes);
+                return (
+                  <Button
+                    key={presetMinutes}
+                    type="button"
+                    size="sm"
+                    variant={selected ? "secondary" : "outline"}
+                    className="h-8"
+                    onClick={() => setIntervalMinutes(String(presetMinutes))}
+                  >
+                    {formatThreadLoopInterval(presetMinutes)}
+                  </Button>
+                );
+              })}
+            </div>
             <p className="text-muted-foreground text-xs">Interval in minutes.</p>
           </div>
 
@@ -224,7 +243,7 @@ export default function ThreadLoopControl(props: {
               </div>
               {props.loop.lastError ? (
                 <div className="space-y-1 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
-                  <div className="font-medium text-amber-700 text-xs">Last error</div>
+                  <div className="font-medium text-amber-700 text-xs">Last automatic run error</div>
                   <div className="text-xs text-amber-800">{props.loop.lastError}</div>
                 </div>
               ) : null}

--- a/apps/web/src/components/chat/ThreadLoopControl.tsx
+++ b/apps/web/src/components/chat/ThreadLoopControl.tsx
@@ -1,8 +1,10 @@
 import type { ThreadId } from "@t3tools/contracts";
 import {
   AlertCircleIcon,
+  MinusIcon,
   PauseIcon,
   PlayIcon,
+  PlusIcon,
   RefreshCwIcon,
   RepeatIcon,
   Trash2Icon,
@@ -361,11 +363,56 @@ export default function ThreadLoopControl(props: {
           )}
 
           {/* Interval */}
-          <div className="space-y-2">
+          <div className="space-y-2.5">
             <Label htmlFor="thread-loop-interval" className="text-sm">
               Interval
             </Label>
-            <div className="flex flex-wrap items-center gap-1.5">
+
+            {/* [-] input [+] stepper row */}
+            <div className="flex items-center justify-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-xs"
+                onClick={() => {
+                  const current = Number.parseInt(intervalMinutes, 10);
+                  if (Number.isInteger(current) && current > 1) {
+                    setIntervalMinutes(String(current - 1));
+                  }
+                }}
+                disabled={Number.parseInt(intervalMinutes, 10) <= 1}
+                aria-label="Decrease interval"
+              >
+                <MinusIcon className="size-3.5" />
+              </Button>
+              <Input
+                id="thread-loop-interval"
+                type="number"
+                min={1}
+                step={1}
+                value={intervalMinutes}
+                onChange={(event) => setIntervalMinutes(event.target.value)}
+                className="h-7 w-16 font-mono text-xs sm:h-6 sm:text-[0.6875rem] [&_input]:h-full [&_input]:leading-[inherit] [&_input]:px-0 [&_input]:text-center [&_input]:[appearance:textfield] [&_input]:[-moz-appearance:textfield] [&_input::-webkit-inner-spin-button]:appearance-none [&_input::-webkit-outer-spin-button]:appearance-none"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-xs"
+                onClick={() => {
+                  const current = Number.parseInt(intervalMinutes, 10);
+                  if (Number.isInteger(current)) {
+                    setIntervalMinutes(String(current + 1));
+                  }
+                }}
+                aria-label="Increase interval"
+              >
+                <PlusIcon className="size-3.5" />
+              </Button>
+              <span className="text-muted-foreground text-xs">(min)</span>
+            </div>
+
+            {/* Preset chips row */}
+            <div className="flex flex-wrap justify-center gap-1.5">
               {THREAD_LOOP_INTERVAL_PRESETS.map((presetMinutes) => {
                 const selected = intervalMinutes === String(presetMinutes);
                 return (
@@ -385,18 +432,6 @@ export default function ThreadLoopControl(props: {
                   </button>
                 );
               })}
-              <div className="flex items-center gap-1.5">
-                <Input
-                  id="thread-loop-interval"
-                  type="number"
-                  min={1}
-                  step={1}
-                  value={intervalMinutes}
-                  onChange={(event) => setIntervalMinutes(event.target.value)}
-                  className="h-7 w-16 font-mono text-xs sm:h-6 sm:text-[0.6875rem]"
-                />
-                <span className="text-muted-foreground text-xs">min</span>
-              </div>
             </div>
           </div>
 

--- a/apps/web/src/components/chat/ThreadLoopControl.tsx
+++ b/apps/web/src/components/chat/ThreadLoopControl.tsx
@@ -1,0 +1,272 @@
+import type { ThreadId } from "@t3tools/contracts";
+import {
+  AlertCircleIcon,
+  Clock3Icon,
+  PauseCircleIcon,
+  PlayCircleIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetPanel,
+  SheetTitle,
+  SheetTrigger,
+} from "../ui/sheet";
+import { Switch } from "../ui/switch";
+import { Textarea } from "../ui/textarea";
+import type { ThreadLoop } from "~/types";
+
+function formatThreadLoopInterval(intervalMinutes: number): string {
+  if (intervalMinutes % 60 === 0) {
+    const hours = intervalMinutes / 60;
+    return hours === 1 ? "1h" : `${hours}h`;
+  }
+  return `${intervalMinutes} min`;
+}
+
+function formatThreadLoopTimestamp(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+}
+
+function buildThreadLoopTriggerLabel(loop: ThreadLoop | null | undefined): string {
+  if (!loop) return "+ Loop";
+  if (!loop.enabled) return "Loop pausado";
+  if (loop.lastError) return "Loop com erro";
+  return `Loop: ${formatThreadLoopInterval(loop.intervalMinutes)}`;
+}
+
+export default function ThreadLoopControl(props: {
+  threadId: ThreadId;
+  loop: ThreadLoop | null | undefined;
+  compact?: boolean;
+  onUpsertLoop: (
+    threadId: ThreadId,
+    input: {
+      enabled: boolean;
+      prompt: string;
+      intervalMinutes: number;
+    },
+  ) => Promise<void>;
+  onDeleteLoop: (threadId: ThreadId) => Promise<void>;
+  onRunNow: (threadId: ThreadId) => Promise<void>;
+}) {
+  const [open, setOpen] = useState(false);
+  const [enabled, setEnabled] = useState(props.loop?.enabled ?? true);
+  const [prompt, setPrompt] = useState(props.loop?.prompt ?? "");
+  const [intervalMinutes, setIntervalMinutes] = useState(String(props.loop?.intervalMinutes ?? 30));
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isRunningNow, setIsRunningNow] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setEnabled(props.loop?.enabled ?? true);
+    setPrompt(props.loop?.prompt ?? "");
+    setIntervalMinutes(String(props.loop?.intervalMinutes ?? 30));
+    setError(null);
+  }, [open, props.loop]);
+
+  const triggerLabel = useMemo(() => buildThreadLoopTriggerLabel(props.loop), [props.loop]);
+  const triggerTitle = useMemo(() => {
+    if (!props.loop) {
+      return "Configure an automatic loop for this thread";
+    }
+    return [
+      triggerLabel,
+      `Next run: ${formatThreadLoopTimestamp(props.loop.nextRunAt)}`,
+      `Last run: ${formatThreadLoopTimestamp(props.loop.lastRunAt)}`,
+    ].join("\n");
+  }, [props.loop, triggerLabel]);
+
+  const handleSave = async () => {
+    const trimmedPrompt = prompt.trim();
+    const parsedInterval = Number.parseInt(intervalMinutes, 10);
+
+    if (trimmedPrompt.length === 0) {
+      setError("Prompt is required.");
+      return;
+    }
+    if (!Number.isInteger(parsedInterval) || parsedInterval < 1) {
+      setError("Interval must be at least 1 minute.");
+      return;
+    }
+
+    setError(null);
+    setIsSaving(true);
+    try {
+      await props.onUpsertLoop(props.threadId, {
+        enabled,
+        prompt: trimmedPrompt,
+        intervalMinutes: parsedInterval,
+      });
+      setOpen(false);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Failed to save loop.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setError(null);
+    setIsDeleting(true);
+    try {
+      await props.onDeleteLoop(props.threadId);
+      setOpen(false);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Failed to delete loop.");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleRunNow = async () => {
+    setError(null);
+    setIsRunningNow(true);
+    try {
+      await props.onRunNow(props.threadId);
+      setOpen(false);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Failed to run loop now.");
+    } finally {
+      setIsRunningNow(false);
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        render={
+          <Button
+            variant="ghost"
+            className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
+            size="sm"
+            type="button"
+            title={triggerTitle}
+          />
+        }
+      >
+        {props.loop?.lastError ? (
+          <AlertCircleIcon className="size-4 text-amber-500" />
+        ) : props.loop?.enabled === false ? (
+          <PauseCircleIcon className="size-4" />
+        ) : (
+          <Clock3Icon className="size-4" />
+        )}
+        <span className={props.compact ? "sr-only" : "sr-only sm:not-sr-only"}>{triggerLabel}</span>
+      </SheetTrigger>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Thread automation</SheetTitle>
+          <SheetDescription>
+            Configure a recurring prompt for this thread. The scheduler runs on the server and skips
+            ticks while the thread is busy.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetPanel className="space-y-5">
+          <div className="flex items-center justify-between gap-3 rounded-xl border border-border/60 bg-muted/30 px-4 py-3">
+            <div className="space-y-1">
+              <Label htmlFor="thread-loop-enabled">Loop active</Label>
+              <p className="text-muted-foreground text-xs">
+                Disable to keep the configuration without scheduling new automatic runs.
+              </p>
+            </div>
+            <Switch id="thread-loop-enabled" checked={enabled} onCheckedChange={setEnabled} />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="thread-loop-interval">Run every</Label>
+            <Input
+              id="thread-loop-interval"
+              type="number"
+              min={1}
+              step={1}
+              value={intervalMinutes}
+              onChange={(event) => setIntervalMinutes(event.target.value)}
+            />
+            <p className="text-muted-foreground text-xs">Interval in minutes.</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="thread-loop-prompt">Loop prompt</Label>
+            <Textarea
+              id="thread-loop-prompt"
+              rows={8}
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Check the deployment and summarize the current status."
+            />
+          </div>
+
+          {props.loop ? (
+            <div className="space-y-2 rounded-xl border border-border/60 bg-muted/20 px-4 py-3 text-sm">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Next run</span>
+                <span>{formatThreadLoopTimestamp(props.loop.nextRunAt)}</span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-muted-foreground">Last run</span>
+                <span>{formatThreadLoopTimestamp(props.loop.lastRunAt)}</span>
+              </div>
+              {props.loop.lastError ? (
+                <div className="space-y-1 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2">
+                  <div className="font-medium text-amber-700 text-xs">Last error</div>
+                  <div className="text-xs text-amber-800">{props.loop.lastError}</div>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {error ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-destructive text-sm">
+              {error}
+            </div>
+          ) : null}
+        </SheetPanel>
+        <SheetFooter className="items-stretch sm:items-center sm:justify-between">
+          <div className="flex flex-1 flex-col-reverse gap-2 sm:flex-row sm:items-center">
+            {props.loop ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void handleDelete()}
+                disabled={isDeleting || isSaving || isRunningNow}
+              >
+                <Trash2Icon className="size-4" />
+                {isDeleting ? "Deleting..." : "Delete loop"}
+              </Button>
+            ) : null}
+            {props.loop ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void handleRunNow()}
+                disabled={isDeleting || isSaving || isRunningNow}
+              >
+                <PlayCircleIcon className="size-4" />
+                {isRunningNow ? "Running..." : "Run now"}
+              </Button>
+            ) : null}
+          </div>
+          <Button type="button" onClick={() => void handleSave()} disabled={isSaving || isDeleting}>
+            {isSaving ? "Saving..." : "Save loop"}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/web/src/components/chat/ThreadLoopControl.tsx
+++ b/apps/web/src/components/chat/ThreadLoopControl.tsx
@@ -369,7 +369,7 @@ export default function ThreadLoopControl(props: {
             </Label>
 
             {/* [-] input [+] stepper row */}
-            <div className="flex items-center justify-center gap-2">
+            <div className="flex items-center gap-2">
               <Button
                 type="button"
                 variant="outline"
@@ -412,7 +412,7 @@ export default function ThreadLoopControl(props: {
             </div>
 
             {/* Preset chips row */}
-            <div className="flex flex-wrap justify-center gap-1.5">
+            <div className="flex flex-wrap gap-1.5">
               {THREAD_LOOP_INTERVAL_PRESETS.map((presetMinutes) => {
                 const selected = intervalMinutes === String(presetMinutes);
                 return (

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -7,7 +7,7 @@ import { getFallbackThreadIdAfterDelete } from "../components/Sidebar.logic";
 import { useComposerDraftStore } from "../composerDraftStore";
 import { useHandleNewThread } from "./useHandleNewThread";
 import { gitRemoveWorktreeMutationOptions } from "../lib/gitReactQuery";
-import { newCommandId } from "../lib/utils";
+import { newCommandId, newMessageId } from "../lib/utils";
 import { readNativeApi } from "../nativeApi";
 import { useStore } from "../store";
 import { useTerminalStateStore } from "../terminalStateStore";
@@ -199,10 +199,80 @@ export function useThreadActions() {
     [appSettings.confirmThreadDelete, deleteThread],
   );
 
+  const upsertLoop = useCallback(
+    async (
+      threadId: ThreadId,
+      input: {
+        enabled: boolean;
+        prompt: string;
+        intervalMinutes: number;
+      },
+    ) => {
+      const api = readNativeApi();
+      if (!api) return;
+      await api.orchestration.dispatchCommand({
+        type: "thread.loop.upsert",
+        commandId: newCommandId(),
+        threadId,
+        enabled: input.enabled,
+        prompt: input.prompt,
+        intervalMinutes: input.intervalMinutes,
+        createdAt: new Date().toISOString(),
+      });
+    },
+    [],
+  );
+
+  const deleteLoop = useCallback(async (threadId: ThreadId) => {
+    const api = readNativeApi();
+    if (!api) return;
+    await api.orchestration.dispatchCommand({
+      type: "thread.loop.delete",
+      commandId: newCommandId(),
+      threadId,
+      createdAt: new Date().toISOString(),
+    });
+  }, []);
+
+  const runLoopNow = useCallback(async (threadId: ThreadId) => {
+    const api = readNativeApi();
+    if (!api) return;
+    const thread = useStore.getState().threads.find((entry) => entry.id === threadId);
+    if (!thread?.loop) {
+      throw new Error("This thread does not have a configured loop.");
+    }
+    if (
+      thread.session &&
+      (thread.session.orchestrationStatus === "running" ||
+        thread.session.orchestrationStatus === "starting" ||
+        thread.session.activeTurnId != null)
+    ) {
+      throw new Error("This thread is busy right now.");
+    }
+    await api.orchestration.dispatchCommand({
+      type: "thread.turn.start",
+      commandId: newCommandId(),
+      threadId,
+      message: {
+        messageId: newMessageId(),
+        role: "user",
+        text: thread.loop.prompt,
+        attachments: [],
+      },
+      modelSelection: thread.modelSelection,
+      runtimeMode: thread.runtimeMode,
+      interactionMode: thread.interactionMode,
+      createdAt: new Date().toISOString(),
+    });
+  }, []);
+
   return {
     archiveThread,
     unarchiveThread,
     deleteThread,
     confirmAndDeleteThread,
+    upsertLoop,
+    deleteLoop,
+    runLoopNow,
   };
 }

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -233,6 +233,32 @@ describe("store read model sync", () => {
     expect(next.threads[0]?.updatedAt).toBe("2026-02-27T00:05:00.000Z");
   });
 
+  it("maps thread loop state from the read model", () => {
+    const initialState = makeState(makeThread());
+    const readModel = makeReadModel(
+      makeReadModelThread({
+        loop: {
+          enabled: true,
+          prompt: "Check the deployment",
+          intervalMinutes: 30,
+          nextRunAt: "2026-02-27T00:30:00.000Z",
+          lastRunAt: null,
+          lastError: null,
+          createdAt: "2026-02-27T00:00:00.000Z",
+          updatedAt: "2026-02-27T00:00:00.000Z",
+        },
+      }),
+    );
+
+    const next = syncServerReadModel(initialState, readModel);
+
+    expect(next.threads[0]?.loop).toMatchObject({
+      enabled: true,
+      intervalMinutes: 30,
+      prompt: "Check the deployment",
+    });
+  });
+
   it("maps archivedAt from the read model", () => {
     const initialState = makeState(makeThread());
     const archivedAt = "2026-02-28T00:00:00.000Z";
@@ -246,6 +272,40 @@ describe("store read model sync", () => {
     );
 
     expect(next.threads[0]?.archivedAt).toBe(archivedAt);
+  });
+
+  it("applies thread.loop-upserted and thread.loop-deleted domain events", () => {
+    const initialState = makeState(makeThread());
+
+    const withLoop = applyOrchestrationEvent(
+      initialState,
+      makeEvent("thread.loop-upserted", {
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        loop: {
+          enabled: true,
+          prompt: "Check the deployment",
+          intervalMinutes: 15,
+          nextRunAt: "2026-02-27T00:15:00.000Z",
+          lastRunAt: null,
+          lastError: null,
+          createdAt: "2026-02-27T00:00:00.000Z",
+          updatedAt: "2026-02-27T00:00:00.000Z",
+        },
+      }),
+    );
+    expect(withLoop.threads[0]?.loop).toMatchObject({
+      enabled: true,
+      intervalMinutes: 15,
+    });
+
+    const deleted = applyOrchestrationEvent(
+      withLoop,
+      makeEvent("thread.loop-deleted", {
+        threadId: ThreadId.makeUnsafe("thread-1"),
+        deletedAt: "2026-02-27T00:01:00.000Z",
+      }),
+    );
+    expect(deleted.threads[0]?.loop ?? null).toBeNull();
   });
 
   it("replaces projects using snapshot order during recovery", () => {

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -176,6 +176,7 @@ function mapThread(thread: OrchestrationThread): Thread {
     worktreePath: thread.worktreePath,
     turnDiffSummaries: thread.checkpoints.map(mapTurnDiffSummary),
     activities: thread.activities.map((activity) => ({ ...activity })),
+    loop: thread.loop ? { ...thread.loop } : null,
   };
 }
 
@@ -663,6 +664,7 @@ export function applyOrchestrationEvent(state: AppState, event: OrchestrationEve
         activities: [],
         checkpoints: [],
         session: null,
+        loop: null,
       });
       const threads = existing
         ? state.threads.map((thread) => (thread.id === nextThread.id ? nextThread : thread))
@@ -889,6 +891,20 @@ export function applyOrchestrationEvent(state: AppState, event: OrchestrationEve
           updatedAt: event.occurredAt,
         };
       });
+    }
+
+    case "thread.loop-upserted": {
+      return updateThreadState(state, event.payload.threadId, (thread) => ({
+        ...thread,
+        loop: { ...event.payload.loop },
+      }));
+    }
+
+    case "thread.loop-deleted": {
+      return updateThreadState(state, event.payload.threadId, (thread) => ({
+        ...thread,
+        loop: null,
+      }));
     }
 
     case "thread.session-set": {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -4,6 +4,7 @@ import type {
   OrchestrationProposedPlanId,
   OrchestrationSessionStatus,
   OrchestrationThreadActivity,
+  ThreadLoop as ContractThreadLoop,
   ProjectScript as ContractProjectScript,
   ThreadId,
   ProjectId,
@@ -23,6 +24,7 @@ export const DEFAULT_THREAD_TERMINAL_HEIGHT = 280;
 export const DEFAULT_THREAD_TERMINAL_ID = "default";
 export const MAX_TERMINALS_PER_GROUP = 4;
 export type ProjectScript = ContractProjectScript;
+export type ThreadLoop = ContractThreadLoop;
 
 export interface ThreadTerminalGroup {
   id: string;
@@ -109,6 +111,7 @@ export interface Thread {
   worktreePath: string | null;
   turnDiffSummaries: TurnDiffSummary[];
   activities: OrchestrationThreadActivity[];
+  loop?: ThreadLoop | null;
 }
 
 export interface SidebarThreadSummary {

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -404,6 +404,62 @@ it.effect("accepts a source proposed plan reference in thread.turn.start", () =>
   }),
 );
 
+it.effect("decodes thread.loop.upsert commands", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeOrchestrationCommand({
+      type: "thread.loop.upsert",
+      commandId: "cmd-loop-upsert",
+      threadId: "thread-1",
+      enabled: true,
+      prompt: "check the deploy",
+      intervalMinutes: 30,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+    assert.strictEqual(parsed.type, "thread.loop.upsert");
+    if (parsed.type !== "thread.loop.upsert") {
+      throw new Error("Expected thread.loop.upsert command.");
+    }
+    assert.strictEqual(parsed.intervalMinutes, 30);
+    assert.strictEqual(parsed.prompt, "check the deploy");
+  }),
+);
+
+it.effect("decodes thread.loop-upserted events", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeOrchestrationEvent({
+      sequence: 1,
+      eventId: "event-loop-upserted",
+      aggregateKind: "thread",
+      aggregateId: "thread-1",
+      occurredAt: "2026-01-01T00:00:00.000Z",
+      commandId: "cmd-loop-upsert",
+      causationEventId: null,
+      correlationId: "cmd-loop-upsert",
+      metadata: {},
+      type: "thread.loop-upserted",
+      payload: {
+        threadId: "thread-1",
+        loop: {
+          enabled: true,
+          prompt: "check the deploy",
+          intervalMinutes: 30,
+          nextRunAt: "2026-01-01T00:30:00.000Z",
+          lastRunAt: null,
+          lastError: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      },
+    });
+    assert.strictEqual(parsed.type, "thread.loop-upserted");
+    if (parsed.type !== "thread.loop-upserted") {
+      throw new Error("Expected thread.loop-upserted event.");
+    }
+    assert.strictEqual(parsed.payload.loop.intervalMinutes, 30);
+    assert.strictEqual(parsed.payload.loop.nextRunAt, "2026-01-01T00:30:00.000Z");
+  }),
+);
+
 it.effect(
   "decodes thread.turn-start-requested defaults for provider, runtime mode, and interaction mode",
   () =>

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -8,6 +8,7 @@ import {
   IsoDateTime,
   MessageId,
   NonNegativeInt,
+  PositiveInt,
   ProjectId,
   ProviderItemId,
   ThreadId,
@@ -266,6 +267,18 @@ export const OrchestrationLatestTurn = Schema.Struct({
 });
 export type OrchestrationLatestTurn = typeof OrchestrationLatestTurn.Type;
 
+export const ThreadLoop = Schema.Struct({
+  enabled: Schema.Boolean,
+  prompt: TrimmedNonEmptyString,
+  intervalMinutes: PositiveInt,
+  nextRunAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(() => null)),
+  lastRunAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(() => null)),
+  lastError: Schema.NullOr(Schema.String).pipe(Schema.withDecodingDefault(() => null)),
+  createdAt: IsoDateTime,
+  updatedAt: IsoDateTime,
+});
+export type ThreadLoop = typeof ThreadLoop.Type;
+
 export const OrchestrationThread = Schema.Struct({
   id: ThreadId,
   projectId: ProjectId,
@@ -287,6 +300,7 @@ export const OrchestrationThread = Schema.Struct({
   activities: Schema.Array(OrchestrationThreadActivity),
   checkpoints: Schema.Array(OrchestrationCheckpointSummary),
   session: Schema.NullOr(OrchestrationSession),
+  loop: Schema.optional(Schema.NullOr(ThreadLoop).pipe(Schema.withDecodingDefault(() => null))),
 });
 export type OrchestrationThread = typeof OrchestrationThread.Type;
 
@@ -381,6 +395,23 @@ const ThreadInteractionModeSetCommand = Schema.Struct({
   commandId: CommandId,
   threadId: ThreadId,
   interactionMode: ProviderInteractionMode,
+  createdAt: IsoDateTime,
+});
+
+const ThreadLoopUpsertCommand = Schema.Struct({
+  type: Schema.Literal("thread.loop.upsert"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  enabled: Schema.Boolean,
+  prompt: TrimmedNonEmptyString,
+  intervalMinutes: PositiveInt,
+  createdAt: IsoDateTime,
+});
+
+const ThreadLoopDeleteCommand = Schema.Struct({
+  type: Schema.Literal("thread.loop.delete"),
+  commandId: CommandId,
+  threadId: ThreadId,
   createdAt: IsoDateTime,
 });
 
@@ -501,6 +532,8 @@ const DispatchableClientOrchestrationCommand = Schema.Union([
   ThreadMetaUpdateCommand,
   ThreadRuntimeModeSetCommand,
   ThreadInteractionModeSetCommand,
+  ThreadLoopUpsertCommand,
+  ThreadLoopDeleteCommand,
   ThreadTurnStartCommand,
   ThreadTurnInterruptCommand,
   ThreadApprovalRespondCommand,
@@ -522,6 +555,8 @@ export const ClientOrchestrationCommand = Schema.Union([
   ThreadMetaUpdateCommand,
   ThreadRuntimeModeSetCommand,
   ThreadInteractionModeSetCommand,
+  ThreadLoopUpsertCommand,
+  ThreadLoopDeleteCommand,
   ClientThreadTurnStartCommand,
   ThreadTurnInterruptCommand,
   ThreadApprovalRespondCommand,
@@ -588,6 +623,21 @@ const ThreadActivityAppendCommand = Schema.Struct({
   createdAt: IsoDateTime,
 });
 
+const ThreadLoopSyncPatch = Schema.Struct({
+  enabled: Schema.optional(Schema.Boolean),
+  nextRunAt: Schema.optional(Schema.NullOr(IsoDateTime)),
+  lastRunAt: Schema.optional(Schema.NullOr(IsoDateTime)),
+  lastError: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+const ThreadLoopSyncCommand = Schema.Struct({
+  type: Schema.Literal("thread.loop.sync"),
+  commandId: CommandId,
+  threadId: ThreadId,
+  patch: ThreadLoopSyncPatch,
+  createdAt: IsoDateTime,
+});
+
 const ThreadRevertCompleteCommand = Schema.Struct({
   type: Schema.Literal("thread.revert.complete"),
   commandId: CommandId,
@@ -603,6 +653,7 @@ const InternalOrchestrationCommand = Schema.Union([
   ThreadProposedPlanUpsertCommand,
   ThreadTurnDiffCompleteCommand,
   ThreadActivityAppendCommand,
+  ThreadLoopSyncCommand,
   ThreadRevertCompleteCommand,
 ]);
 export type InternalOrchestrationCommand = typeof InternalOrchestrationCommand.Type;
@@ -624,6 +675,8 @@ export const OrchestrationEventType = Schema.Literals([
   "thread.meta-updated",
   "thread.runtime-mode-set",
   "thread.interaction-mode-set",
+  "thread.loop-upserted",
+  "thread.loop-deleted",
   "thread.message-sent",
   "thread.turn-start-requested",
   "thread.turn-interrupt-requested",
@@ -719,6 +772,16 @@ export const ThreadInteractionModeSetPayload = Schema.Struct({
     Schema.withDecodingDefault(() => DEFAULT_PROVIDER_INTERACTION_MODE),
   ),
   updatedAt: IsoDateTime,
+});
+
+export const ThreadLoopUpsertedPayload = Schema.Struct({
+  threadId: ThreadId,
+  loop: ThreadLoop,
+});
+
+export const ThreadLoopDeletedPayload = Schema.Struct({
+  threadId: ThreadId,
+  deletedAt: IsoDateTime,
 });
 
 export const ThreadMessageSentPayload = Schema.Struct({
@@ -879,6 +942,16 @@ export const OrchestrationEvent = Schema.Union([
     ...EventBaseFields,
     type: Schema.Literal("thread.interaction-mode-set"),
     payload: ThreadInteractionModeSetPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.loop-upserted"),
+    payload: ThreadLoopUpsertedPayload,
+  }),
+  Schema.Struct({
+    ...EventBaseFields,
+    type: Schema.Literal("thread.loop-deleted"),
+    payload: ThreadLoopDeletedPayload,
   }),
   Schema.Struct({
     ...EventBaseFields,


### PR DESCRIPTION
## What Changed

- adds persisted per-thread loop state plus UI controls to configure and run thread loops from the chat composer
- fixes restart recovery for thread loops by sanitizing zombie session state before the UI and scheduler read it
- treats aborted and terminal provider lifecycle paths as true terminal states so loop scheduling and manual actions stop getting stuck behind stale `activeTurnId` values
- adds focused regression coverage for runtime ingestion, snapshot hydration, scheduler behavior, checkpoint timing, and restart recovery

## Why

I know this repo is not actively accepting contributions, and I know feature work is less likely to be accepted.

I'm still opening this as a draft because the thread loop feature is already implemented on this branch, and the follow-up work here specifically hardens the restart and recovery path that was leaving loops and manual actions stuck after closing the desktop app mid-turn.

The key fix is making sure persisted session state cannot come back as effectively "ready but still busy", which was enough to block both loop execution and manual loop runs after restart.

## UI Changes

Screenshots and interaction video are still pending. I'll add clear before/after images in a follow-up comment before asking for review.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `cd apps/server && bun run test src/orchestration/Layers/ProviderRuntimeIngestion.test.ts src/orchestration/Layers/ProjectionSnapshotQuery.test.ts src/orchestration/Layers/ThreadLoopScheduler.test.ts src/orchestration/Layers/CheckpointReactor.test.ts`

## Notes

- This is still feature-sized, not a tiny bugfix PR.
- The restart fix is intentionally server-side first: normalize bad session state before it reaches the UI, scheduler, and manual thread actions.
- I removed the temporary debug logging used during investigation from the final diff.
- Happy to split, shrink, or close this if it does not fit the direction you want.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add thread loop scheduling, restart recovery, and loop management UI
> - Adds a `ThreadLoopScheduler` background service that periodically scans due thread loops and auto-starts turns using the loop prompt; skips busy threads, disables loops on archived threads, and reschedules as needed.
> - Introduces thread loop commands (`thread.loop.upsert`, `thread.loop.delete`, `thread.loop.sync`) in the decider, new event types (`thread.loop-upserted`, `thread.loop-deleted`), and a `projection_thread_loops` table (migration 020) to persist loop state.
> - Adds boot-time session sanitization that downgrades stale `running` sessions to `interrupted` and clears orphaned `activeTurnId` values after a process restart.
> - Handles `turn.aborted` events in `ProviderRuntimeIngestion`, setting session status to `interrupted` and clearing active turn and buffered state.
> - Adds a `ThreadLoopControl` UI component in the chat composer footer for creating, updating, pausing/resuming, running, and deleting a thread loop, with status display and run history.
> - Risk: boot sanitization mutates session and turn state at startup; any session that was `running` before a restart will be marked `interrupted` with `completedAt` set to process start time.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 924050f. 32 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->