### PR TITLE
Add support for pinned threads in the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -14,6 +14,7 @@ type SidebarProject = {
   updatedAt?: string | undefined;
 };
 type SidebarThreadSortInput = Pick<Thread, "createdAt" | "updatedAt"> & {
+  isPinned?: boolean;
   latestUserMessageAt?: string | null;
   messages?: Pick<Thread["messages"][number], "createdAt" | "role">[];
 };
@@ -485,6 +486,12 @@ export function sortThreadsForSidebar<
   T extends Pick<Thread, "id" | "createdAt" | "updatedAt"> & SidebarThreadSortInput,
 >(threads: readonly T[], sortOrder: SidebarThreadSortOrder): T[] {
   return threads.toSorted((left, right) => {
+    const leftPinned = left.isPinned === true;
+    const rightPinned = right.isPinned === true;
+    if (leftPinned !== rightPinned) {
+      return rightPinned ? 1 : -1;
+    }
+
     const rightTimestamp = getThreadSortTimestamp(right, sortOrder);
     const leftTimestamp = getThreadSortTimestamp(left, sortOrder);
     const byTimestamp =

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRightIcon,
   FolderIcon,
   GitPullRequestIcon,
+  PinIcon,
   PlusIcon,
   SettingsIcon,
   SquarePenIcon,
@@ -258,7 +259,9 @@ function resolveThreadPr(
 interface SidebarThreadRowProps {
   threadId: ThreadId;
   projectCwd: string | null;
-  orderedProjectThreadIds: readonly ThreadId[];
+  isPinned: boolean;
+  folderLabel?: string | null;
+  orderedSidebarThreadIds: readonly ThreadId[];
   routeThreadId: ThreadId | null;
   selectedThreadIds: ReadonlySet<ThreadId>;
   showThreadJumpHints: boolean;
@@ -276,7 +279,7 @@ interface SidebarThreadRowProps {
   handleThreadClick: (
     event: MouseEvent,
     threadId: ThreadId,
-    orderedProjectThreadIds: readonly ThreadId[],
+    orderedSidebarThreadIds: readonly ThreadId[],
   ) => void;
   navigateToThread: (threadId: ThreadId) => void;
   handleMultiSelectContextMenu: (position: { x: number; y: number }) => Promise<void>;
@@ -353,7 +356,7 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
           isSelected,
         })} relative isolate`}
         onClick={(event) => {
-          props.handleThreadClick(event, thread.id, props.orderedProjectThreadIds);
+          props.handleThreadClick(event, thread.id, props.orderedSidebarThreadIds);
         }}
         onKeyDown={(event) => {
           if (event.key !== "Enter" && event.key !== " ") return;
@@ -399,6 +402,21 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
             </Tooltip>
           )}
           {threadStatus && <ThreadStatusLabel status={threadStatus} />}
+          {props.isPinned ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span
+                    aria-label="Pinned thread"
+                    className="inline-flex shrink-0 items-center justify-center text-amber-600 dark:text-amber-300/90"
+                  >
+                    <PinIcon className="size-3 rotate-45" />
+                  </span>
+                }
+              />
+              <TooltipPopup side="top">Pinned</TooltipPopup>
+            </Tooltip>
+          ) : null}
           {props.renamingThreadId === thread.id ? (
             <input
               ref={props.onRenamingInputMount}
@@ -425,7 +443,14 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
               onClick={(event) => event.stopPropagation()}
             />
           ) : (
-            <span className="min-w-0 flex-1 truncate text-xs">{thread.title}</span>
+            <div className="flex min-w-0 flex-1 items-baseline gap-1.5 overflow-hidden">
+              <span className="truncate text-xs">{thread.title}</span>
+              {props.folderLabel ? (
+                <span className="shrink truncate text-[10px] text-muted-foreground/45">
+                  /{props.folderLabel}
+                </span>
+              ) : null}
+            </div>
           )}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1.5">
@@ -677,14 +702,17 @@ export default function Sidebar() {
   const projects = useStore((store) => store.projects);
   const sidebarThreadsById = useStore((store) => store.sidebarThreadsById);
   const threadIdsByProjectId = useStore((store) => store.threadIdsByProjectId);
-  const { projectExpandedById, projectOrder, threadLastVisitedAtById } = useUiStateStore(
-    useShallow((store) => ({
-      projectExpandedById: store.projectExpandedById,
-      projectOrder: store.projectOrder,
-      threadLastVisitedAtById: store.threadLastVisitedAtById,
-    })),
-  );
+  const { pinnedThreadIds, projectExpandedById, projectOrder, threadLastVisitedAtById } =
+    useUiStateStore(
+      useShallow((store) => ({
+        pinnedThreadIds: store.pinnedThreadIds,
+        projectExpandedById: store.projectExpandedById,
+        projectOrder: store.projectOrder,
+        threadLastVisitedAtById: store.threadLastVisitedAtById,
+      })),
+    );
   const markThreadUnread = useUiStateStore((store) => store.markThreadUnread);
+  const setThreadPinned = useUiStateStore((store) => store.setThreadPinned);
   const toggleProject = useUiStateStore((store) => store.toggleProject);
   const reorderProjects = useUiStateStore((store) => store.reorderProjects);
   const clearComposerDraftForThread = useComposerDraftStore((store) => store.clearDraftThread);
@@ -757,8 +785,19 @@ export default function Sidebar() {
     [orderedProjects, projectExpandedById],
   );
   const sidebarThreads = useMemo(() => Object.values(sidebarThreadsById), [sidebarThreadsById]);
+  const pinnedThreadIdSet = useMemo(() => new Set(pinnedThreadIds), [pinnedThreadIds]);
   const projectCwdById = useMemo(
     () => new Map(projects.map((project) => [project.id, project.cwd] as const)),
+    [projects],
+  );
+  const projectFolderLabelById = useMemo(
+    () =>
+      new Map(
+        projects.map((project) => [
+          project.id,
+          project.cwd.split(/[/\\]/).findLast(isNonEmptyString) ?? project.name,
+        ]),
+      ),
     [projects],
   );
   const routeTerminalOpen = routeThreadId
@@ -815,7 +854,14 @@ export default function Sidebar() {
     (projectId: ProjectId) => {
       const latestThread = sortThreadsForSidebar(
         (threadIdsByProjectId[projectId] ?? [])
-          .map((threadId) => sidebarThreadsById[threadId])
+          .map((threadId) => {
+            const thread = sidebarThreadsById[threadId];
+            return thread
+              ? Object.assign({}, thread, {
+                  isPinned: pinnedThreadIdSet.has(thread.id),
+                })
+              : undefined;
+          })
           .filter((thread): thread is NonNullable<typeof thread> => thread !== undefined)
           .filter((thread) => thread.archivedAt === null),
         appSettings.sidebarThreadSortOrder,
@@ -827,7 +873,13 @@ export default function Sidebar() {
         params: { threadId: latestThread.id },
       });
     },
-    [appSettings.sidebarThreadSortOrder, navigate, sidebarThreadsById, threadIdsByProjectId],
+    [
+      appSettings.sidebarThreadSortOrder,
+      navigate,
+      pinnedThreadIdSet,
+      sidebarThreadsById,
+      threadIdsByProjectId,
+    ],
   );
 
   const addProjectFromPath = useCallback(
@@ -1099,6 +1151,10 @@ export default function Sidebar() {
       const clicked = await api.contextMenu.show(
         [
           { id: "rename", label: "Rename thread" },
+          {
+            id: "toggle-pin",
+            label: pinnedThreadIdSet.has(threadId) ? "Unpin thread" : "Pin thread",
+          },
           { id: "mark-unread", label: "Mark unread" },
           { id: "copy-path", label: "Copy Path" },
           { id: "copy-thread-id", label: "Copy Thread ID" },
@@ -1113,6 +1169,11 @@ export default function Sidebar() {
         setRenamingThreadId(threadId);
         setRenamingTitle(thread.title);
         renamingCommittedRef.current = false;
+        return;
+      }
+
+      if (clicked === "toggle-pin") {
+        setThreadPinned(threadId, !pinnedThreadIdSet.has(threadId));
         return;
       }
 
@@ -1156,7 +1217,9 @@ export default function Sidebar() {
       copyThreadIdToClipboard,
       deleteThread,
       markThreadUnread,
+      pinnedThreadIdSet,
       projectCwdById,
+      setThreadPinned,
       sidebarThreadsById,
     ],
   );
@@ -1171,11 +1234,25 @@ export default function Sidebar() {
 
       const clicked = await api.contextMenu.show(
         [
+          {
+            id: "toggle-pin",
+            label: ids.every((id) => pinnedThreadIdSet.has(id))
+              ? `Unpin (${count})`
+              : `Pin (${count})`,
+          },
           { id: "mark-unread", label: `Mark unread (${count})` },
           { id: "delete", label: `Delete (${count})`, destructive: true },
         ],
         position,
       );
+
+      if (clicked === "toggle-pin") {
+        const shouldPin = !ids.every((id) => pinnedThreadIdSet.has(id));
+        for (const id of ids) {
+          setThreadPinned(id, shouldPin);
+        }
+        return;
+      }
 
       if (clicked === "mark-unread") {
         for (const id of ids) {
@@ -1209,8 +1286,10 @@ export default function Sidebar() {
       clearSelection,
       deleteThread,
       markThreadUnread,
+      pinnedThreadIdSet,
       removeFromSelection,
       selectedThreadIds,
+      setThreadPinned,
       sidebarThreadsById,
     ],
   );
@@ -1427,6 +1506,20 @@ export default function Sidebar() {
     () => sidebarThreads.filter((thread) => thread.archivedAt === null),
     [sidebarThreads],
   );
+  const pinnedThreads = useMemo(
+    () =>
+      sortThreadsForSidebar(
+        visibleThreads
+          .filter((thread) => pinnedThreadIdSet.has(thread.id))
+          .map((thread) =>
+            Object.assign({}, thread, {
+              isPinned: true,
+            }),
+          ),
+        appSettings.sidebarThreadSortOrder,
+      ),
+    [appSettings.sidebarThreadSortOrder, pinnedThreadIdSet, visibleThreads],
+  );
   const sortedProjects = useMemo(
     () =>
       sortProjectsForSidebar(sidebarProjects, visibleThreads, appSettings.sidebarProjectSortOrder),
@@ -1445,7 +1538,14 @@ export default function Sidebar() {
           });
         const projectThreads = sortThreadsForSidebar(
           (threadIdsByProjectId[project.id] ?? [])
-            .map((threadId) => sidebarThreadsById[threadId])
+            .map((threadId) => {
+              const thread = sidebarThreadsById[threadId];
+              return thread
+                ? Object.assign({}, thread, {
+                    isPinned: pinnedThreadIdSet.has(thread.id),
+                  })
+                : undefined;
+            })
             .filter((thread): thread is NonNullable<typeof thread> => thread !== undefined)
             .filter((thread) => thread.archivedAt === null),
           appSettings.sidebarThreadSortOrder,
@@ -1496,15 +1596,33 @@ export default function Sidebar() {
       expandedThreadListsByProject,
       routeThreadId,
       sortedProjects,
+      pinnedThreadIdSet,
       sidebarThreadsById,
       threadIdsByProjectId,
       threadLastVisitedAtById,
     ],
   );
-  const visibleSidebarThreadIds = useMemo(
-    () => getVisibleSidebarThreadIds(renderedProjects),
-    [renderedProjects],
-  );
+  const visibleSidebarThreadIds = useMemo(() => {
+    const renderedThreadIds = getVisibleSidebarThreadIds([
+      {
+        shouldShowThreadPanel: pinnedThreads.length > 0,
+        renderedThreadIds: pinnedThreads.map((thread) => thread.id),
+      },
+      ...renderedProjects,
+    ]);
+
+    const uniqueThreadIds: ThreadId[] = [];
+    const seenThreadIds = new Set<ThreadId>();
+    for (const threadId of renderedThreadIds) {
+      if (seenThreadIds.has(threadId)) {
+        continue;
+      }
+      seenThreadIds.add(threadId);
+      uniqueThreadIds.push(threadId);
+    }
+
+    return uniqueThreadIds;
+  }, [pinnedThreads, renderedProjects]);
   const threadJumpCommandById = useMemo(() => {
     const mapping = new Map<ThreadId, NonNullable<ReturnType<typeof threadJumpCommandForIndex>>>();
     for (const [visibleThreadIndex, threadId] of visibleSidebarThreadIds.entries()) {
@@ -1797,7 +1915,8 @@ export default function Sidebar() {
                 key={threadId}
                 threadId={threadId}
                 projectCwd={project.cwd}
-                orderedProjectThreadIds={orderedProjectThreadIds}
+                isPinned={pinnedThreadIdSet.has(threadId)}
+                orderedSidebarThreadIds={orderedProjectThreadIds}
                 routeThreadId={routeThreadId}
                 selectedThreadIds={selectedThreadIds}
                 showThreadJumpHints={showThreadJumpHints}
@@ -2109,6 +2228,57 @@ export default function Sidebar() {
                     </AlertAction>
                   ) : null}
                 </Alert>
+              </SidebarGroup>
+            ) : null}
+            {pinnedThreads.length > 0 ? (
+              <SidebarGroup className="px-2 pt-2 pb-0">
+                <div className="mb-1 flex items-center justify-between pl-2 pr-1.5">
+                  <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+                    Pinned
+                  </span>
+                </div>
+                <SidebarMenu>
+                  <SidebarMenuItem className="rounded-md">
+                    <SidebarMenuSub
+                      ref={attachThreadListAutoAnimateRef}
+                      className="mx-1 my-0 w-full translate-x-0 gap-0.5 overflow-hidden px-1.5 py-0"
+                    >
+                      {pinnedThreads.map((thread) => (
+                        <SidebarThreadRow
+                          key={thread.id}
+                          threadId={thread.id}
+                          projectCwd={projectCwdById.get(thread.projectId) ?? null}
+                          isPinned
+                          folderLabel={projectFolderLabelById.get(thread.projectId) ?? null}
+                          orderedSidebarThreadIds={orderedSidebarThreadIds}
+                          routeThreadId={routeThreadId}
+                          selectedThreadIds={selectedThreadIds}
+                          showThreadJumpHints={showThreadJumpHints}
+                          jumpLabel={threadJumpLabelById.get(thread.id) ?? null}
+                          appSettingsConfirmThreadArchive={appSettings.confirmThreadArchive}
+                          renamingThreadId={renamingThreadId}
+                          renamingTitle={renamingTitle}
+                          setRenamingTitle={setRenamingTitle}
+                          onRenamingInputMount={handleRenamingInputMount}
+                          hasRenameCommitted={hasRenameCommitted}
+                          markRenameCommitted={markRenameCommitted}
+                          confirmingArchiveThreadId={confirmingArchiveThreadId}
+                          setConfirmingArchiveThreadId={setConfirmingArchiveThreadId}
+                          confirmArchiveButtonRefs={confirmArchiveButtonRefs}
+                          handleThreadClick={handleThreadClick}
+                          navigateToThread={navigateToThread}
+                          handleMultiSelectContextMenu={handleMultiSelectContextMenu}
+                          handleThreadContextMenu={handleThreadContextMenu}
+                          clearSelection={clearSelection}
+                          commitRename={commitRename}
+                          cancelRename={cancelRename}
+                          attemptArchiveThread={attemptArchiveThread}
+                          openPrLink={openPrLink}
+                        />
+                      ))}
+                    </SidebarMenuSub>
+                  </SidebarMenuItem>
+                </SidebarMenu>
               </SidebarGroup>
             ) : null}
             <SidebarGroup className="px-2 py-2">

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -23,7 +23,6 @@ export function useThreadActions() {
     (store) => store.clearProjectDraftThreadById,
   );
   const clearTerminalState = useTerminalStateStore((state) => state.clearTerminalState);
-  const pinnedThreadIds = useUiStateStore((state) => state.pinnedThreadIds);
   const routeThreadId = useParams({
     strict: false,
     select: (params) => (params.threadId ? ThreadId.makeUnsafe(params.threadId) : null),
@@ -113,6 +112,7 @@ export function useThreadActions() {
       }
 
       const deletedThreadIds = opts.deletedThreadIds ?? new Set<ThreadId>();
+      const pinnedThreadIds = useUiStateStore.getState().pinnedThreadIds;
       const shouldNavigateToFallback = routeThreadId === threadId;
       const fallbackThreadId = getFallbackThreadIdAfterDelete({
         threads: threads.map((entry) =>
@@ -176,7 +176,6 @@ export function useThreadActions() {
       clearTerminalState,
       appSettings.sidebarThreadSortOrder,
       navigate,
-      pinnedThreadIds,
       removeWorktreeMutation,
       routeThreadId,
     ],

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -2,6 +2,7 @@ import { ThreadId } from "@t3tools/contracts";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { useCallback } from "react";
+import { useUiStateStore } from "../uiStateStore";
 
 import { getFallbackThreadIdAfterDelete } from "../components/Sidebar.logic";
 import { useComposerDraftStore } from "../composerDraftStore";
@@ -22,6 +23,7 @@ export function useThreadActions() {
     (store) => store.clearProjectDraftThreadById,
   );
   const clearTerminalState = useTerminalStateStore((state) => state.clearTerminalState);
+  const pinnedThreadIds = useUiStateStore((state) => state.pinnedThreadIds);
   const routeThreadId = useParams({
     strict: false,
     select: (params) => (params.threadId ? ThreadId.makeUnsafe(params.threadId) : null),
@@ -113,7 +115,11 @@ export function useThreadActions() {
       const deletedThreadIds = opts.deletedThreadIds ?? new Set<ThreadId>();
       const shouldNavigateToFallback = routeThreadId === threadId;
       const fallbackThreadId = getFallbackThreadIdAfterDelete({
-        threads,
+        threads: threads.map((entry) =>
+          Object.assign({}, entry, {
+            isPinned: pinnedThreadIds.includes(entry.id),
+          }),
+        ),
         deletedThreadId: threadId,
         deletedThreadIds,
         sortOrder: appSettings.sidebarThreadSortOrder,
@@ -170,6 +176,7 @@ export function useThreadActions() {
       clearTerminalState,
       appSettings.sidebarThreadSortOrder,
       navigate,
+      pinnedThreadIds,
       removeWorktreeMutation,
       routeThreadId,
     ],

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -5,6 +5,7 @@ import {
   clearThreadUi,
   markThreadUnread,
   reorderProjects,
+  setThreadPinned,
   setProjectExpanded,
   syncProjects,
   syncThreads,
@@ -16,6 +17,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectExpandedById: {},
     projectOrder: [],
     threadLastVisitedAtById: {},
+    pinnedThreadIds: [],
     ...overrides,
   };
 }
@@ -137,6 +139,7 @@ describe("uiStateStore pure functions", () => {
         [thread1]: "2026-02-25T12:35:00.000Z",
         [thread2]: "2026-02-25T12:36:00.000Z",
       },
+      pinnedThreadIds: [thread1, thread2],
     });
 
     const next = syncThreads(initialState, [{ id: thread1 }]);
@@ -144,6 +147,7 @@ describe("uiStateStore pure functions", () => {
     expect(next.threadLastVisitedAtById).toEqual({
       [thread1]: "2026-02-25T12:35:00.000Z",
     });
+    expect(next.pinnedThreadIds).toEqual([thread1]);
   });
 
   it("syncThreads seeds visit state for unseen snapshot threads", () => {
@@ -183,10 +187,24 @@ describe("uiStateStore pure functions", () => {
       threadLastVisitedAtById: {
         [thread1]: "2026-02-25T12:35:00.000Z",
       },
+      pinnedThreadIds: [thread1],
     });
 
     const next = clearThreadUi(initialState, thread1);
 
     expect(next.threadLastVisitedAtById).toEqual({});
+    expect(next.pinnedThreadIds).toEqual([]);
+  });
+
+  it("setThreadPinned adds and removes pinned threads", () => {
+    const thread1 = ThreadId.makeUnsafe("thread-1");
+    const thread2 = ThreadId.makeUnsafe("thread-2");
+    const pinnedState = setThreadPinned(makeUiState({ pinnedThreadIds: [thread2] }), thread1, true);
+
+    expect(pinnedState.pinnedThreadIds).toEqual([thread1, thread2]);
+
+    const unpinnedState = setThreadPinned(pinnedState, thread2, false);
+
+    expect(unpinnedState.pinnedThreadIds).toEqual([thread1]);
   });
 });

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -19,6 +19,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 interface PersistedUiState {
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
+  pinnedThreadIds?: string[];
 }
 
 export interface UiProjectState {
@@ -28,6 +29,7 @@ export interface UiProjectState {
 
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
+  pinnedThreadIds: ThreadId[];
 }
 
 export interface UiState extends UiProjectState, UiThreadState {}
@@ -46,10 +48,12 @@ const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
   threadLastVisitedAtById: {},
+  pinnedThreadIds: [],
 };
 
 const persistedExpandedProjectCwds = new Set<string>();
 const persistedProjectOrderCwds: string[] = [];
+const persistedPinnedThreadIds: ThreadId[] = [];
 const currentProjectCwdById = new Map<ProjectId, string>();
 let legacyKeysCleanedUp = false;
 
@@ -66,12 +70,18 @@ function readPersistedState(): UiState {
           continue;
         }
         hydratePersistedProjectState(JSON.parse(legacyRaw) as PersistedUiState);
-        return initialState;
+        return {
+          ...initialState,
+          pinnedThreadIds: [...persistedPinnedThreadIds],
+        };
       }
       return initialState;
     }
     hydratePersistedProjectState(JSON.parse(raw) as PersistedUiState);
-    return initialState;
+    return {
+      ...initialState,
+      pinnedThreadIds: [...persistedPinnedThreadIds],
+    };
   } catch {
     return initialState;
   }
@@ -80,6 +90,7 @@ function readPersistedState(): UiState {
 function hydratePersistedProjectState(parsed: PersistedUiState): void {
   persistedExpandedProjectCwds.clear();
   persistedProjectOrderCwds.length = 0;
+  persistedPinnedThreadIds.length = 0;
   for (const cwd of parsed.expandedProjectCwds ?? []) {
     if (typeof cwd === "string" && cwd.length > 0) {
       persistedExpandedProjectCwds.add(cwd);
@@ -88,6 +99,15 @@ function hydratePersistedProjectState(parsed: PersistedUiState): void {
   for (const cwd of parsed.projectOrderCwds ?? []) {
     if (typeof cwd === "string" && cwd.length > 0 && !persistedProjectOrderCwds.includes(cwd)) {
       persistedProjectOrderCwds.push(cwd);
+    }
+  }
+  for (const threadId of parsed.pinnedThreadIds ?? []) {
+    if (
+      typeof threadId === "string" &&
+      threadId.length > 0 &&
+      !persistedPinnedThreadIds.includes(threadId as ThreadId)
+    ) {
+      persistedPinnedThreadIds.push(threadId as ThreadId);
     }
   }
 }
@@ -112,6 +132,7 @@ function persistState(state: UiState): void {
       JSON.stringify({
         expandedProjectCwds,
         projectOrderCwds,
+        pinnedThreadIds: state.pinnedThreadIds,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -145,6 +166,10 @@ function projectOrdersEqual(left: readonly ProjectId[], right: readonly ProjectI
   return (
     left.length === right.length && left.every((projectId, index) => projectId === right[index])
   );
+}
+
+function threadIdListsEqual(left: readonly ThreadId[], right: readonly ThreadId[]): boolean {
+  return left.length === right.length && left.every((threadId, index) => threadId === right[index]);
 }
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
@@ -261,12 +286,19 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
       nextThreadLastVisitedAtById[thread.id] = thread.seedVisitedAt;
     }
   }
-  if (recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById)) {
+  const nextPinnedThreadIds = state.pinnedThreadIds.filter((threadId) =>
+    retainedThreadIds.has(threadId),
+  );
+  if (
+    recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById) &&
+    threadIdListsEqual(state.pinnedThreadIds, nextPinnedThreadIds)
+  ) {
     return state;
   }
   return {
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
+    pinnedThreadIds: nextPinnedThreadIds,
   };
 }
 
@@ -317,7 +349,9 @@ export function markThreadUnread(
 }
 
 export function clearThreadUi(state: UiState, threadId: ThreadId): UiState {
-  if (!(threadId in state.threadLastVisitedAtById)) {
+  const hasVisitState = threadId in state.threadLastVisitedAtById;
+  const isPinned = state.pinnedThreadIds.includes(threadId);
+  if (!hasVisitState && !isPinned) {
     return state;
   }
   const nextThreadLastVisitedAtById = { ...state.threadLastVisitedAtById };
@@ -325,6 +359,21 @@ export function clearThreadUi(state: UiState, threadId: ThreadId): UiState {
   return {
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
+    pinnedThreadIds: state.pinnedThreadIds.filter((pinnedThreadId) => pinnedThreadId !== threadId),
+  };
+}
+
+export function setThreadPinned(state: UiState, threadId: ThreadId, pinned: boolean): UiState {
+  const alreadyPinned = state.pinnedThreadIds.includes(threadId);
+  if (alreadyPinned === pinned) {
+    return state;
+  }
+
+  return {
+    ...state,
+    pinnedThreadIds: pinned
+      ? [threadId, ...state.pinnedThreadIds]
+      : state.pinnedThreadIds.filter((pinnedThreadId) => pinnedThreadId !== threadId),
   };
 }
 
@@ -387,6 +436,7 @@ interface UiStateStore extends UiState {
   markThreadVisited: (threadId: ThreadId, visitedAt?: string) => void;
   markThreadUnread: (threadId: ThreadId, latestTurnCompletedAt: string | null | undefined) => void;
   clearThreadUi: (threadId: ThreadId) => void;
+  setThreadPinned: (threadId: ThreadId, pinned: boolean) => void;
   toggleProject: (projectId: ProjectId) => void;
   setProjectExpanded: (projectId: ProjectId, expanded: boolean) => void;
   reorderProjects: (draggedProjectId: ProjectId, targetProjectId: ProjectId) => void;
@@ -401,6 +451,7 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
   markThreadUnread: (threadId, latestTurnCompletedAt) =>
     set((state) => markThreadUnread(state, threadId, latestTurnCompletedAt)),
   clearThreadUi: (threadId) => set((state) => clearThreadUi(state, threadId)),
+  setThreadPinned: (threadId, pinned) => set((state) => setThreadPinned(state, threadId, pinned)),
   toggleProject: (projectId) => set((state) => toggleProject(state, projectId)),
   setProjectExpanded: (projectId, expanded) =>
     set((state) => setProjectExpanded(state, projectId, expanded)),

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -162,14 +162,8 @@ function recordsEqual<T>(left: Record<string, T>, right: Record<string, T>): boo
   return true;
 }
 
-function projectOrdersEqual(left: readonly ProjectId[], right: readonly ProjectId[]): boolean {
-  return (
-    left.length === right.length && left.every((projectId, index) => projectId === right[index])
-  );
-}
-
-function threadIdListsEqual(left: readonly ThreadId[], right: readonly ThreadId[]): boolean {
-  return left.length === right.length && left.every((threadId, index) => threadId === right[index]);
+function arraysEqual<T>(left: readonly T[], right: readonly T[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
@@ -257,7 +251,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
 
   if (
     recordsEqual(state.projectExpandedById, nextExpandedById) &&
-    projectOrdersEqual(state.projectOrder, nextProjectOrder) &&
+    arraysEqual(state.projectOrder, nextProjectOrder) &&
     !cwdMappingChanged
   ) {
     return state;
@@ -291,7 +285,7 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
   );
   if (
     recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById) &&
-    threadIdListsEqual(state.pinnedThreadIds, nextPinnedThreadIds)
+    arraysEqual(state.pinnedThreadIds, nextPinnedThreadIds)
   ) {
     return state;
   }


### PR DESCRIPTION
### What changed
This PR adds support for pinning threads in the UI so important conversations are easier to keep in view.

Pinned threads now:

- Can be pinned and unpinned from the sidebar thread context menu
- Appear in a dedicated Pinned section above the project folders
- Still remain visible inside their original project folder
- Show a minimal folder indicator in the pinned section so it’s clear which project they belong to
- Stay pinned across reloads via persisted UI state

### Why
Made it easier to keep track of important threads

### Details

- Pin state is stored in the existing web UI state store
- Pinned threads are sorted ahead of unpinned threads
- Sidebar navigation keeps a deduplicated logical ordering so keyboard traversal and jump hints do not treat the same pinned thread as two separate entries

### UI

<img width="1470" height="889" alt="Screenshot 2026-04-07 at 21 09 35" src="https://github.com/user-attachments/assets/ee2a5cc5-8e29-4a92-861c-9d49fd85d1b1" />
<img width="1467" height="889" alt="Screenshot 2026-04-07 at 21 09 23" src="https://github.com/user-attachments/assets/77fc5823-2f2a-4acb-8b13-df081bae7add" />

### Checklist

- [x] This PR is small and focused
- [x]  I explained what changed and why
- [x]  I included before/after screenshots for any UI changes
- [ ]  I included a video for animation/interaction changes

### Testing

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes sidebar rendering/order and navigation indexes, plus persists new `pinnedThreadIds` in localStorage; regressions could affect thread selection, sorting, and post-delete navigation.
> 
> **Overview**
> Adds **pinned threads** support in the sidebar: threads can now be pinned/unpinned via single- and multi-select context menus, and pinned items render in a new `Pinned` section above projects with a pin indicator and optional project folder suffix.
> 
> Updates thread ordering logic so `sortThreadsForSidebar` prioritizes `isPinned`, and rebuilds `visibleSidebarThreadIds` as *pinned-first then projects* with deduping to keep keyboard traversal/jump hints stable even when a thread appears in both places.
> 
> Extends `uiStateStore` to store/persist `pinnedThreadIds` (including pruning on `syncThreads`/`clearThreadUi`) and updates delete fallback selection in `useThreadActions` to respect pin ordering; includes new unit tests for pin state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de609c57cbced897d81b6bb3c7f83ec23b9acd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pinned threads support to the sidebar
> - Introduces a `Pinned` section at the top of the sidebar that shows pinned threads with a pin icon and folder label suffix.
> - Adds `setThreadPinned` to [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/1824/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8), persisting pin state in localStorage and pruning stale ids when threads are deleted.
> - Single and multi-select context menus expose a `toggle-pin` action; `sortThreadsForSidebar` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/1824/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) now places pinned threads before unpinned ones.
> - Fallback thread selection after deletion in [useThreadActions.ts](https://github.com/pingdotgg/t3code/pull/1824/files#diff-7d3463056176ee1e173c0ae885b4305a70a7cc854fee7040d9b9a5a28dfbda50) now respects pin ordering.
> - Behavioral Change: `visibleSidebarThreadIds` (used for keyboard navigation) is rebuilt as pinned threads first, then per-project threads, deduplicated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9de609c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->