### PR TITLE
fix: intellij not being visible even though it's installed

### DIFF
--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -228,7 +228,7 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
 
   it.effect("falls back to open -a on macOS when CLI is missing but .app is installed", () =>
     Effect.gen(function* () {
-      const idea = EDITORS.find(e => e.id === "idea")
+      const idea = EDITORS.find((e) => e.id === "idea");
       assert.isDefined(idea);
 
       if (!isAppInstalled(idea, "darwin")) return;
@@ -240,7 +240,7 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       );
       assert.deepEqual(launch, {
         command: "open",
-        args: ["-a", "IntelliJ IDEA", "/tmp/workspace"],
+        args: ["-a", "IntelliJ IDEA", "--args", "/tmp/workspace"],
       });
     }),
   );
@@ -408,7 +408,7 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
   );
 
   it("includes editors detected via macOS .app bundle", () => {
-    const idea = EDITORS.find(e => e.id === "idea")
+    const idea = EDITORS.find((e) => e.id === "idea");
     assert.isDefined(idea);
 
     if (!isAppInstalled(idea, "darwin")) return;

--- a/apps/server/src/open.test.ts
+++ b/apps/server/src/open.test.ts
@@ -5,10 +5,12 @@ import { FileSystem, Path, Effect } from "effect";
 
 import {
   isCommandAvailable,
+  isAppInstalled,
   launchDetached,
   resolveAvailableEditors,
   resolveEditorLaunch,
 } from "./open";
+import {EDITORS} from "@t3tools/contracts";
 
 it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
   it.effect("returns commands for command-based editors", () =>
@@ -82,7 +84,8 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
 
       const ideaLaunch = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace", editor: "idea" },
-        "darwin",
+        "linux",
+        { PATH: "" },
       );
       assert.deepEqual(ideaLaunch, {
         command: "idea",
@@ -172,7 +175,8 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
 
       const ideaLineOnly = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace/AGENTS.md:48", editor: "idea" },
-        "darwin",
+        "linux",
+        { PATH: "" },
       );
       assert.deepEqual(ideaLineOnly, {
         command: "idea",
@@ -181,7 +185,8 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
 
       const ideaLineAndColumn = yield* resolveEditorLaunch(
         { cwd: "/tmp/workspace/src/open.ts:71:5", editor: "idea" },
-        "darwin",
+        "linux",
+        { PATH: "" },
       );
       assert.deepEqual(ideaLineAndColumn, {
         command: "idea",
@@ -217,6 +222,25 @@ it.layer(NodeServices.layer)("resolveEditorLaunch", (it) => {
       assert.deepEqual(result, {
         command: "zed",
         args: ["/tmp/workspace"],
+      });
+    }),
+  );
+
+  it.effect("falls back to open -a on macOS when CLI is missing but .app is installed", () =>
+    Effect.gen(function* () {
+      const idea = EDITORS.find(e => e.id === "idea")
+      assert.isDefined(idea);
+
+      if (!isAppInstalled(idea, "darwin")) return;
+
+      const launch = yield* resolveEditorLaunch(
+        { cwd: "/tmp/workspace", editor: "idea" },
+        "darwin",
+        { PATH: "" },
+      );
+      assert.deepEqual(launch, {
+        command: "open",
+        args: ["-a", "IntelliJ IDEA", "/tmp/workspace"],
       });
     }),
   );
@@ -382,6 +406,16 @@ it.layer(NodeServices.layer)("resolveAvailableEditors", (it) => {
       assert.deepEqual(editors, ["zed", "file-manager"]);
     }),
   );
+
+  it("includes editors detected via macOS .app bundle", () => {
+    const idea = EDITORS.find(e => e.id === "idea")
+    assert.isDefined(idea);
+
+    if (!isAppInstalled(idea, "darwin")) return;
+
+    const editors = resolveAvailableEditors("darwin", { PATH: "" });
+    assert.isTrue(editors.includes("idea"));
+  });
 
   it("omits file-manager when the platform opener is unavailable", () => {
     const editors = resolveAvailableEditors("linux", {

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -10,7 +10,7 @@ import { spawn } from "node:child_process";
 import { accessSync, constants, statSync } from "node:fs";
 import { extname, join } from "node:path";
 
-import {EDITORS, OpenError, type EditorId, EditorDefinition} from "@t3tools/contracts";
+import { EDITORS, OpenError, type EditorId, EditorDefinition } from "@t3tools/contracts";
 import { ServiceMap, Effect, Layer } from "effect";
 
 // ==============================
@@ -53,10 +53,7 @@ function parseTargetPathAndPosition(target: string): {
   };
 }
 
-function resolveCommandEditorArgs(
-  editor: (typeof EDITORS)[number],
-  target: string,
-): ReadonlyArray<string> {
+function resolveCommandEditorArgs(editor: EditorDefinition, target: string): ReadonlyArray<string> {
   const parsedTarget = parseTargetPathAndPosition(target);
 
   switch (editor.launchStyle) {
@@ -213,10 +210,10 @@ function resolveAppPaths(appName: string, platform: NodeJS.Platform): ReadonlyAr
 }
 
 export function isAppInstalled(
-    editor: EditorDefinition,
-    platform: NodeJS.Platform
-): editor is EditorDefinition & {appName: string} {
-  if (!("appName" in editor)) return false
+  editor: EditorDefinition,
+  platform: NodeJS.Platform,
+): editor is EditorDefinition & { appName: string } {
+  if (!("appName" in editor)) return false;
   for (const appPath of resolveAppPaths(editor.appName, platform)) {
     try {
       statSync(appPath);
@@ -297,24 +294,22 @@ export const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
 
   if (editorDef.commands) {
     const command = resolveAvailableCommand(editorDef.commands, { platform, env });
+    const args = resolveCommandEditorArgs(editorDef, input.cwd);
     if (command) {
-      return {
-        command,
-        args: resolveCommandEditorArgs(editorDef, input.cwd),
-      };
+      return { command, args };
     }
 
     if (isAppInstalled(editorDef, platform)) {
-      return {
-        command: "open",
-        args: ["-a", editorDef.appName, input.cwd],
-      };
+      switch (platform) {
+        case "darwin":
+          return {
+            command: "open",
+            args: ["-a", editorDef.appName, "--args", ...args],
+          };
+      }
     }
 
-    return {
-      command: editorDef.commands[0],
-      args: resolveCommandEditorArgs(editorDef, input.cwd),
-    };
+    return { command: editorDef.commands[0], args };
   }
 
   if (editorDef.id !== "file-manager") {

--- a/apps/server/src/open.ts
+++ b/apps/server/src/open.ts
@@ -10,7 +10,7 @@ import { spawn } from "node:child_process";
 import { accessSync, constants, statSync } from "node:fs";
 import { extname, join } from "node:path";
 
-import { EDITORS, OpenError, type EditorId } from "@t3tools/contracts";
+import {EDITORS, OpenError, type EditorId, EditorDefinition} from "@t3tools/contracts";
 import { ServiceMap, Effect, Layer } from "effect";
 
 // ==============================
@@ -203,6 +203,31 @@ export function isCommandAvailable(
   return false;
 }
 
+function resolveAppPaths(appName: string, platform: NodeJS.Platform): ReadonlyArray<string> {
+  switch (platform) {
+    case "darwin":
+      return [`/Applications/${appName}.app`];
+    default:
+      return [];
+  }
+}
+
+export function isAppInstalled(
+    editor: EditorDefinition,
+    platform: NodeJS.Platform
+): editor is EditorDefinition & {appName: string} {
+  if (!("appName" in editor)) return false
+  for (const appPath of resolveAppPaths(editor.appName, platform)) {
+    try {
+      statSync(appPath);
+      return true;
+    } catch {
+      // not found at this path
+    }
+  }
+  return false;
+}
+
 export function resolveAvailableEditors(
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
@@ -220,6 +245,8 @@ export function resolveAvailableEditors(
 
     const command = resolveAvailableCommand(editor.commands, { platform, env });
     if (command !== null) {
+      available.push(editor.id);
+    } else if (isAppInstalled(editor, platform)) {
       available.push(editor.id);
     }
   }
@@ -269,10 +296,23 @@ export const resolveEditorLaunch = Effect.fn("resolveEditorLaunch")(function* (
   }
 
   if (editorDef.commands) {
-    const command =
-      resolveAvailableCommand(editorDef.commands, { platform, env }) ?? editorDef.commands[0];
+    const command = resolveAvailableCommand(editorDef.commands, { platform, env });
+    if (command) {
+      return {
+        command,
+        args: resolveCommandEditorArgs(editorDef, input.cwd),
+      };
+    }
+
+    if (isAppInstalled(editorDef, platform)) {
+      return {
+        command: "open",
+        args: ["-a", editorDef.appName, input.cwd],
+      };
+    }
+
     return {
-      command,
+      command: editorDef.commands[0],
       args: resolveCommandEditorArgs(editorDef, input.cwd),
     };
   }

--- a/packages/contracts/src/editor.ts
+++ b/packages/contracts/src/editor.ts
@@ -4,11 +4,12 @@ import { TrimmedNonEmptyString } from "./baseSchemas";
 export const EditorLaunchStyle = Schema.Literals(["direct-path", "goto", "line-column"]);
 export type EditorLaunchStyle = typeof EditorLaunchStyle.Type;
 
-type EditorDefinition = {
+export type EditorDefinition = {
   readonly id: string;
   readonly label: string;
   readonly commands: readonly [string, ...string[]] | null;
   readonly launchStyle: EditorLaunchStyle;
+  readonly appName?: string;
 };
 
 export const EDITORS = [
@@ -24,7 +25,13 @@ export const EDITORS = [
   { id: "vscodium", label: "VSCodium", commands: ["codium"], launchStyle: "goto" },
   { id: "zed", label: "Zed", commands: ["zed", "zeditor"], launchStyle: "direct-path" },
   { id: "antigravity", label: "Antigravity", commands: ["agy"], launchStyle: "goto" },
-  { id: "idea", label: "IntelliJ IDEA", commands: ["idea"], launchStyle: "line-column" },
+  {
+    id: "idea",
+    label: "IntelliJ IDEA",
+    commands: ["idea"],
+    launchStyle: "line-column",
+    appName: "IntelliJ IDEA",
+  },
   { id: "file-manager", label: "File Manager", commands: null, launchStyle: "direct-path" },
 ] as const satisfies ReadonlyArray<EditorDefinition>;
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Small bug not finding Intellij IDEA even though it's installed if the CLI is not present. 

I didn't went ahead and implemented windows and linux because the changes would have been much greater and I'm trying to adhere to the small contributions or bugs guideline. I'm up to do it if you want though (I'm not really sure if this is a problem in other platforms). Open to feedback as well.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

There's a bug not finding Intellij IDEA on Mac.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

Here's the fixed result:
<img width="1581" height="1155" alt="image" src="https://github.com/user-attachments/assets/3e583d7e-efb6-4047-882d-133ffdab8b03" />

As you can see in this image, I have Intellij installed and open (running it with npx t3 so you can see the difference) but it's not visible on the dropdown.

<img width="1728" height="1117" alt="Screenshot 2026-04-07 at 15 35 55" src="https://github.com/user-attachments/assets/e19e5ddd-6c97-401a-8444-d6f89b3488a6" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized to editor detection/launch logic on macOS; main risk is incorrect `.app` path assumptions causing editors to appear/launch unexpectedly.
> 
> **Overview**
> Fixes IntelliJ IDEA not appearing/launching on macOS when its CLI (`idea`) is not on `PATH`.
> 
> Adds optional `appName` to editor definitions plus a new `isAppInstalled` check for `/Applications/<app>.app`, and updates `resolveAvailableEditors`/`resolveEditorLaunch` to fall back to `open -a <appName> --args ...` when the app bundle exists. Tests are updated/extended to cover the new macOS fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a4a35d6c4d4709c50ae8cf1e1beb2390d5e5be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix IntelliJ not appearing in editor list when CLI is missing but app is installed on macOS
> - Adds `appName` metadata to the IntelliJ IDEA entry in `EDITORS` and a new `isAppInstalled` helper that checks for `.app` bundles in `/Applications` on macOS.
> - `resolveAvailableEditors` now includes editors whose `.app` bundle is detected even when no CLI command is found.
> - `resolveEditorLaunch` falls back to `open -a <AppName> --args ...` on macOS when the CLI is unavailable but the `.app` bundle is present, instead of returning the unavailable CLI command.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a4a35d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->