### PR TITLE
fix(web): fall back to persisted draft bytes for transient image attachments

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -5,6 +5,7 @@ import { useStore } from "../store";
 import {
   MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
   buildExpiredTerminalContextToastCopy,
+  buildTurnImageAttachments,
   createLocalDispatchSnapshot,
   deriveComposerSendState,
   hasServerAcknowledgedLocalDispatch,
@@ -74,6 +75,94 @@ describe("buildExpiredTerminalContextToastCopy", () => {
       title: "Expired terminal contexts omitted from message",
       description: "Re-add it if you want that terminal output included.",
     });
+  });
+});
+
+describe("buildTurnImageAttachments", () => {
+  it("uses the live file bytes when the file is still readable", async () => {
+    const image = {
+      type: "image" as const,
+      id: "image-1",
+      name: "simulator_screenshot_123.png",
+      mimeType: "image/png",
+      sizeBytes: 4,
+      previewUrl: "blob:image-1",
+      file: new File(["live"], "simulator_screenshot_123.png", { type: "image/png" }),
+    };
+
+    await expect(
+      buildTurnImageAttachments({
+        images: [image],
+        readFile: vi.fn(async () => "data:image/png;base64,bGl2ZQ=="),
+      }),
+    ).resolves.toEqual([
+      {
+        type: "image",
+        name: "simulator_screenshot_123.png",
+        mimeType: "image/png",
+        sizeBytes: 4,
+        dataUrl: "data:image/png;base64,bGl2ZQ==",
+      },
+    ]);
+  });
+
+  it("falls back to persisted draft bytes when the live file is gone", async () => {
+    const image = {
+      type: "image" as const,
+      id: "image-1",
+      name: "simulator_screenshot_123.png",
+      mimeType: "image/png",
+      sizeBytes: 4,
+      previewUrl: "blob:image-1",
+      file: new File(["live"], "simulator_screenshot_123.png", { type: "image/png" }),
+    };
+
+    await expect(
+      buildTurnImageAttachments({
+        images: [image],
+        persistedAttachments: [
+          {
+            id: "image-1",
+            name: "simulator_screenshot_123.png",
+            mimeType: "image/png",
+            sizeBytes: 4,
+            dataUrl: "data:image/png;base64,c2F2ZWQ=",
+          },
+        ],
+        readFile: vi.fn(async () => {
+          throw new Error("ENOENT");
+        }),
+      }),
+    ).resolves.toEqual([
+      {
+        type: "image",
+        name: "simulator_screenshot_123.png",
+        mimeType: "image/png",
+        sizeBytes: 4,
+        dataUrl: "data:image/png;base64,c2F2ZWQ=",
+      },
+    ]);
+  });
+
+  it("still fails when neither the live file nor a persisted draft copy is available", async () => {
+    const image = {
+      type: "image" as const,
+      id: "image-1",
+      name: "simulator_screenshot_123.png",
+      mimeType: "image/png",
+      sizeBytes: 4,
+      previewUrl: "blob:image-1",
+      file: new File(["live"], "simulator_screenshot_123.png", { type: "image/png" }),
+    };
+
+    await expect(
+      buildTurnImageAttachments({
+        images: [image],
+        readFile: vi.fn(async () => {
+          throw new Error("ENOENT");
+        }),
+      }),
+    ).rejects.toThrow("ENOENT");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,7 +1,17 @@
-import { ProjectId, type ModelSelection, type ThreadId, type TurnId } from "@t3tools/contracts";
+import {
+  ProjectId,
+  type ModelSelection,
+  type ThreadId,
+  type TurnId,
+  type UploadChatAttachment,
+} from "@t3tools/contracts";
 import { type ChatMessage, type SessionPhase, type Thread, type ThreadSession } from "../types";
 import { randomUUID } from "~/lib/utils";
-import { type ComposerImageAttachment, type DraftThreadState } from "../composerDraftStore";
+import {
+  type ComposerImageAttachment,
+  type DraftThreadState,
+  type PersistedComposerImageAttachment,
+} from "../composerDraftStore";
 import { Schema } from "effect";
 import { useStore } from "../store";
 import {
@@ -127,6 +137,38 @@ export function readFileAsDataUrl(file: File): Promise<string> {
     });
     reader.readAsDataURL(file);
   });
+}
+
+export async function buildTurnImageAttachments(input: {
+  images: ReadonlyArray<ComposerImageAttachment>;
+  persistedAttachments?: ReadonlyArray<PersistedComposerImageAttachment>;
+  readFile?: (file: File) => Promise<string>;
+}): Promise<UploadChatAttachment[]> {
+  const persistedAttachmentById = new Map(
+    (input.persistedAttachments ?? []).map((attachment) => [attachment.id, attachment] as const),
+  );
+  const readFile = input.readFile ?? readFileAsDataUrl;
+  return await Promise.all(
+    input.images.map(async (image) => {
+      let dataUrl: string;
+      try {
+        dataUrl = await readFile(image.file);
+      } catch (error) {
+        const persistedAttachment = persistedAttachmentById.get(image.id);
+        if (!persistedAttachment) {
+          throw error;
+        }
+        dataUrl = persistedAttachment.dataUrl;
+      }
+      return {
+        type: "image" as const,
+        name: image.name,
+        mimeType: image.mimeType,
+        sizeBytes: image.sizeBytes,
+        dataUrl,
+      };
+    }),
+  );
 }
 
 export function buildTemporaryWorktreeBranchName(): string {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3112,6 +3112,12 @@ export default function ChatView({ threadId }: ChatViewProps) {
         setPrompt(promptForSend);
         setComposerCursor(collapseExpandedComposerCursor(promptForSend, promptForSend.length));
         addComposerImagesToDraft(composerImagesSnapshot.map(cloneComposerImageForRetry));
+        if (persistedComposerAttachmentsSnapshot.length > 0) {
+          syncComposerDraftPersistedAttachments(
+            threadIdForSend,
+            persistedComposerAttachmentsSnapshot,
+          );
+        }
         addComposerTerminalContextsToDraft(composerTerminalContextsSnapshot);
         setComposerTrigger(detectComposerTrigger(promptForSend, promptForSend.length));
       }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -174,6 +174,7 @@ import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
 import {
   MAX_HIDDEN_MOUNTED_TERMINAL_THREADS,
   buildExpiredTerminalContextToastCopy,
+  buildTurnImageAttachments,
   buildLocalDraftThread,
   buildTemporaryWorktreeBranchName,
   cloneComposerImageForRetry,
@@ -2933,6 +2934,7 @@ export default function ChatView({ threadId }: ChatViewProps) {
     beginLocalDispatch({ preparingWorktree: Boolean(baseBranchForWorktree) });
 
     const composerImagesSnapshot = [...composerImages];
+    const persistedComposerAttachmentsSnapshot = [...composerDraft.persistedAttachments];
     const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
     const messageTextForSend = appendTerminalContextsToPrompt(
       promptForSend,
@@ -2947,15 +2949,11 @@ export default function ChatView({ threadId }: ChatViewProps) {
       effort: selectedPromptEffort,
       text: messageTextForSend || IMAGE_ONLY_BOOTSTRAP_PROMPT,
     });
-    const turnAttachmentsPromise = Promise.all(
-      composerImagesSnapshot.map(async (image) => ({
-        type: "image" as const,
-        name: image.name,
-        mimeType: image.mimeType,
-        sizeBytes: image.sizeBytes,
-        dataUrl: await readFileAsDataUrl(image.file),
-      })),
-    );
+    const turnAttachmentsPromise = buildTurnImageAttachments({
+      images: composerImagesSnapshot,
+      persistedAttachments: persistedComposerAttachmentsSnapshot,
+      readFile: readFileAsDataUrl,
+    });
     const optimisticAttachments = composerImagesSnapshot.map((image) => ({
       type: "image" as const,
       id: image.id,


### PR DESCRIPTION
## What Changed

Uses the persisted draft image bytes as a fallback when sending image attachments if the original `File` can no longer be read.

This fixes a case where transient attachments, like iOS Simulator screenshots dragged directly into T3 Code, can disappear before send. If the live file is still readable, the existing behavior is unchanged.

## Why

iOS Simulator screenshots can be short-lived when dragged directly from the simulator preview. By the time the message is sent, the file may already be gone, which causes the attachment send to fail even though the draft already persisted the image data locally.

This change reuses that persisted draft data as a fallback instead of introducing a new cache or special-case storage path.

## UI Changes

No UI changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the image-attachment send path to fall back to persisted draft data when `FileReader` fails, which could affect message sending and attachment integrity if IDs/matches are wrong. Scope is limited to web client composer attachment handling and is covered by new unit tests.
> 
> **Overview**
> **Improves reliability of sending image attachments.** When building turn attachments, the web client now tries to read the live `File` bytes first and, if that fails, falls back to the matching persisted draft `dataUrl` (by attachment `id`).
> 
> This factors the logic into `buildTurnImageAttachments` and updates `ChatView` send/retry handling to snapshot and restore `persistedAttachments` alongside images, with new tests covering live-read, fallback, and hard-failure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e33777f54bef63e4142ec038045d303dd1647bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to persisted draft bytes for transient image attachments on send
> - Extracts a new `buildTurnImageAttachments` helper in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/1836/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) that reads live file bytes via `readFileAsDataUrl`, falling back to a matching persisted attachment's `dataUrl` when the live file is unreadable, and rejecting only if neither is available.
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1836/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to use `buildTurnImageAttachments` and snapshot `persistedAttachments` before send; on send failure, syncs the snapshot back into the composer draft to restore state.
> - Behavioral Change: image send no longer fails immediately if the live `File` object is stale or missing, as long as a persisted copy exists.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e33777f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->