### PR TITLE
fix: renderer OOM crash recovery and memory management

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -287,6 +287,10 @@ function captureBackendOutput(child: ChildProcess.ChildProcess): void {
 
 initializePackagedLogging();
 
+// Cap the renderer's V8 heap to 2 GB so GC runs more aggressively
+// instead of growing to 3.7 GB+ and crashing with OOM.
+app.commandLine.appendSwitch("js-flags", "--max-old-space-size=2048");
+
 if (process.platform === "linux") {
   app.commandLine.appendSwitch("class", LINUX_WM_CLASS);
 }
@@ -1391,6 +1395,26 @@ function createWindow(): BrowserWindow {
       void shell.openExternal(externalUrl);
     }
     return { action: "deny" };
+  });
+
+  window.webContents.on("render-process-gone", (_event, details) => {
+    writeDesktopLogHeader(`renderer crashed reason=${details.reason} exitCode=${details.exitCode}`);
+    if (details.reason === "crashed" || details.reason === "oom" || details.reason === "killed") {
+      setTimeout(() => {
+        if (!window.isDestroyed()) {
+          writeDesktopLogHeader("reloading renderer after crash");
+          window.webContents.reload();
+        }
+      }, 500);
+    }
+  });
+
+  window.webContents.on("unresponsive", () => {
+    writeDesktopLogHeader("renderer became unresponsive");
+  });
+
+  window.webContents.on("responsive", () => {
+    writeDesktopLogHeader("renderer became responsive again");
   });
 
   window.on("page-title-updated", (event) => {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -287,8 +287,9 @@ function captureBackendOutput(child: ChildProcess.ChildProcess): void {
 
 initializePackagedLogging();
 
-// Cap the renderer's V8 heap to 2 GB so GC runs more aggressively
-// instead of growing to 3.7 GB+ and crashing with OOM.
+// Cap V8 heap to 2 GB so GC runs more aggressively instead of
+// growing to 3.7 GB+ and crashing with OOM. This applies to both
+// the main process and all renderer/utility child processes.
 app.commandLine.appendSwitch("js-flags", "--max-old-space-size=2048");
 
 if (process.platform === "linux") {
@@ -1358,6 +1359,10 @@ function createWindow(): BrowserWindow {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
+      // Ensure the renderer's V8 heap is capped at 2 GB to prevent OOM crashes.
+      // app.commandLine.appendSwitch("js-flags", ...) alone doesn't propagate
+      // to sandboxed renderer processes reliably.
+      additionalArguments: ["--js-flags=--max-old-space-size=2048"],
     },
   });
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -54,6 +54,33 @@ const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
 const DEFAULT_BASE_BRANCH_CANDIDATES = ["main", "master"] as const;
 const GIT_LIST_BRANCHES_DEFAULT_LIMIT = 100;
 
+/**
+ * Negative cache for worktree paths that are known to be missing.
+ * Prevents repeated stat() calls on deleted worktree directories,
+ * which can create a tight ENOENT error loop with growing fiber IDs.
+ * Entries expire after 5 minutes so that re-created paths are picked up.
+ */
+const MISSING_WORKTREE_CACHE_TTL_MS = 5 * 60 * 1000;
+const missingWorktreePaths = new Map<string, number>();
+
+function isWorktreePathKnownMissing(path: string): boolean {
+  const cachedAt = missingWorktreePaths.get(path);
+  if (cachedAt === undefined) return false;
+  if (Date.now() - cachedAt > MISSING_WORKTREE_CACHE_TTL_MS) {
+    missingWorktreePaths.delete(path);
+    return false;
+  }
+  return true;
+}
+
+function markWorktreePathMissing(path: string): void {
+  missingWorktreePaths.set(path, Date.now());
+}
+
+function markWorktreePathPresent(path: string): void {
+  missingWorktreePaths.delete(path);
+}
+
 type TraceTailState = {
   processedChars: number;
   remainder: string;
@@ -1805,10 +1832,21 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       for (const line of worktreeList.stdout.split("\n")) {
         if (line.startsWith("worktree ")) {
           const candidatePath = line.slice("worktree ".length);
-          const exists = yield* fileSystem.stat(candidatePath).pipe(
-            Effect.map(() => true),
-            Effect.catch(() => Effect.succeed(false)),
-          );
+          let exists: boolean;
+          if (isWorktreePathKnownMissing(candidatePath)) {
+            exists = false;
+          } else {
+            exists = yield* fileSystem.stat(candidatePath).pipe(
+              Effect.map(() => {
+                markWorktreePathPresent(candidatePath);
+                return true;
+              }),
+              Effect.catch(() => {
+                markWorktreePathMissing(candidatePath);
+                return Effect.succeed(false);
+              }),
+            );
+          }
           currentPath = exists ? candidatePath : null;
         } else if (line.startsWith("branch refs/heads/") && currentPath) {
           worktreeMap.set(line.slice("branch refs/heads/".length), currentPath);

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -203,6 +203,7 @@ const makeThread = (input?: {
   worktreePath: null,
   turnDiffSummaries: [],
   activities: [],
+  hydrated: true,
 });
 
 afterEach(() => {
@@ -356,6 +357,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
       worktreePath: null,
       turnDiffSummaries: [],
       activities: [],
+      hydrated: true,
     });
 
     expect(
@@ -392,6 +394,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
       worktreePath: null,
       turnDiffSummaries: [],
       activities: [],
+      hydrated: true,
     });
 
     expect(
@@ -437,6 +440,7 @@ describe("hasServerAcknowledgedLocalDispatch", () => {
       worktreePath: null,
       turnDiffSummaries: [],
       activities: [],
+      hydrated: true,
     });
 
     expect(

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -41,6 +41,7 @@ export function buildLocalDraftThread(
     turnDiffSummaries: [],
     activities: [],
     proposedPlans: [],
+    hydrated: true,
   };
 }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -578,6 +578,7 @@ function PersistentThreadTerminalDrawer({
 export default function ChatView({ threadId }: ChatViewProps) {
   const serverThread = useThreadById(threadId);
   const setStoreThreadError = useStore((store) => store.setError);
+  const hydrateThreadAction = useStore((store) => store.hydrateThread);
   const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
   const activeThreadLastVisitedAt = useUiStateStore(
     (store) => store.threadLastVisitedAtById[threadId],
@@ -837,6 +838,26 @@ export default function ChatView({ threadId }: ChatViewProps) {
     [draftThread, fallbackDraftProject?.defaultModelSelection, localDraftError, threadId],
   );
   const activeThread = serverThread ?? localDraftThread;
+
+  // Re-hydrate thread data if this thread was evicted from memory
+  useEffect(() => {
+    if (serverThread && !serverThread.hydrated) {
+      const api = readNativeApi();
+      if (!api) return;
+      api.orchestration
+        .getSnapshot()
+        .then((snapshot) => {
+          const fullThread = snapshot.threads.find((t) => t.id === serverThread.id);
+          if (fullThread) {
+            hydrateThreadAction(serverThread.id, fullThread);
+          }
+        })
+        .catch((err) => {
+          console.error("Failed to hydrate thread", serverThread.id, err);
+        });
+    }
+  }, [serverThread?.id, serverThread?.hydrated, hydrateThreadAction]);
+
   const runtimeMode =
     composerDraft.runtimeMode ?? activeThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
   const interactionMode =
@@ -3897,6 +3918,15 @@ export default function ChatView({ threadId }: ChatViewProps) {
     }
     void onRevertToTurnCount(targetTurnCount);
   };
+
+  // Show loading state for dehydrated threads
+  if (activeThread && !activeThread.hydrated) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        Loading conversation...
+      </div>
+    );
+  }
 
   // Empty state: no active thread
   if (!activeThread) {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -664,6 +664,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     worktreePath: null,
     turnDiffSummaries: [],
     activities: [],
+    hydrated: true,
     ...overrides,
   };
 }

--- a/apps/web/src/lib/threadEviction.test.ts
+++ b/apps/web/src/lib/threadEviction.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { selectThreadsToEvict, EVICTION_KEEP_COUNT, type EvictableThread } from "./threadEviction";
+
+function makeEvictable(id: string, overrides: Partial<EvictableThread> = {}): EvictableThread {
+  return {
+    id,
+    hydrated: true,
+    isActive: false,
+    hasRunningSession: false,
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    messageCount: 0,
+    activityCount: 0,
+    ...overrides,
+  };
+}
+
+describe("selectThreadsToEvict", () => {
+  it("returns empty array when thread count is within keep limit", () => {
+    const threads = Array.from({ length: EVICTION_KEEP_COUNT }, (_, i) => makeEvictable(`t-${i}`));
+    expect(selectThreadsToEvict(threads, "t-0")).toEqual([]);
+  });
+
+  it("never evicts the active thread", () => {
+    const threads = Array.from({ length: EVICTION_KEEP_COUNT + 5 }, (_, i) =>
+      makeEvictable(`t-${i}`),
+    );
+    const result = selectThreadsToEvict(threads, "t-0");
+    expect(result).not.toContain("t-0");
+  });
+
+  it("never evicts threads with running sessions", () => {
+    const threads = [
+      ...Array.from({ length: EVICTION_KEEP_COUNT + 3 }, (_, i) => makeEvictable(`t-${i}`)),
+      makeEvictable("t-running", { hasRunningSession: true }),
+    ];
+    const result = selectThreadsToEvict(threads, "t-0");
+    expect(result).not.toContain("t-running");
+  });
+
+  it("evicts oldest idle threads first", () => {
+    const threads = [
+      makeEvictable("t-old", { updatedAt: "2026-01-01T00:00:00.000Z" }),
+      makeEvictable("t-new", { updatedAt: "2026-04-01T00:00:00.000Z" }),
+      ...Array.from({ length: EVICTION_KEEP_COUNT }, (_, i) =>
+        makeEvictable(`t-keep-${i}`, { updatedAt: "2026-03-01T00:00:00.000Z" }),
+      ),
+    ];
+    const result = selectThreadsToEvict(threads, "t-new");
+    expect(result).toContain("t-old");
+    expect(result).not.toContain("t-new");
+  });
+
+  it("skips already-dehydrated threads", () => {
+    const threads = [
+      makeEvictable("t-dehydrated", { hydrated: false }),
+      ...Array.from({ length: EVICTION_KEEP_COUNT + 2 }, (_, i) => makeEvictable(`t-${i}`)),
+    ];
+    const result = selectThreadsToEvict(threads, "t-0");
+    expect(result).not.toContain("t-dehydrated");
+  });
+});

--- a/apps/web/src/lib/threadEviction.ts
+++ b/apps/web/src/lib/threadEviction.ts
@@ -1,0 +1,47 @@
+/**
+ * Thread eviction policy for renderer memory management.
+ *
+ * Decides which threads should have their heavy data (messages, activities,
+ * proposedPlans, turnDiffSummaries) dropped from the Zustand store.
+ * Sidebar metadata is always retained.
+ */
+
+/** How many fully-hydrated threads to keep in memory at once. */
+export const EVICTION_KEEP_COUNT = 5;
+
+export interface EvictableThread {
+  id: string;
+  hydrated: boolean;
+  isActive: boolean;
+  hasRunningSession: boolean;
+  updatedAt: string;
+  messageCount: number;
+  activityCount: number;
+}
+
+/**
+ * Returns the IDs of threads that should be evicted (dehydrated).
+ * Never evicts: the active thread, threads with running sessions,
+ * or already-dehydrated threads.
+ */
+export function selectThreadsToEvict(
+  threads: ReadonlyArray<EvictableThread>,
+  activeThreadId: string | null,
+): string[] {
+  const evictable = threads.filter(
+    (t) => t.hydrated && !t.isActive && t.id !== activeThreadId && !t.hasRunningSession,
+  );
+
+  const hydratedCount = threads.filter((t) => t.hydrated).length;
+
+  if (hydratedCount <= EVICTION_KEEP_COUNT) {
+    return [];
+  }
+
+  const toEvictCount = hydratedCount - EVICTION_KEEP_COUNT;
+
+  // Sort by updatedAt ascending — oldest idle threads get evicted first
+  const sorted = evictable.toSorted((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+
+  return sorted.slice(0, toEvictCount).map((t) => t.id);
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -49,6 +49,7 @@ import { deriveOrchestrationBatchEffects } from "../orchestrationEventEffects";
 import { createOrchestrationRecoveryCoordinator } from "../orchestrationRecovery";
 import { deriveReplayRetryDecision } from "../orchestrationRecovery";
 import { getWsRpcClient } from "~/wsRpcClient";
+import { selectThreadsToEvict, type EvictableThread } from "~/lib/threadEviction";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -587,6 +588,32 @@ function EventRouter() {
 
   useServerWelcomeSubscription(handleWelcome);
   useServerConfigUpdatedSubscription(handleServerConfigUpdated);
+
+  const evictThread = useStore((store) => store.evictThreadData);
+  const allThreads = useStore((store) => store.threads);
+
+  // Evict inactive threads when navigating to keep memory bounded.
+  // This is a separate effect from the WS subscription lifecycle.
+  useEffect(() => {
+    const activeThreadId = pathname.startsWith("/chat/")
+      ? (pathname.split("/chat/")[1]?.split("/")[0] ?? null)
+      : null;
+
+    const evictable: EvictableThread[] = allThreads.map((t) => ({
+      id: t.id,
+      hydrated: t.hydrated,
+      isActive: t.id === activeThreadId,
+      hasRunningSession: t.session?.status === "running",
+      updatedAt: t.updatedAt ?? t.createdAt,
+      messageCount: t.messages.length,
+      activityCount: t.activities.length,
+    }));
+
+    const idsToEvict = selectThreadsToEvict(evictable, activeThreadId);
+    for (const id of idsToEvict) {
+      evictThread(id as any);
+    }
+  }, [pathname, evictThread, allThreads]);
 
   return null;
 }

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -14,6 +14,8 @@ import { describe, expect, it } from "vitest";
 import {
   applyOrchestrationEvent,
   applyOrchestrationEvents,
+  evictThreadData,
+  hydrateThread,
   syncServerReadModel,
   type AppState,
 } from "./store";
@@ -42,6 +44,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     latestTurn: null,
     branch: null,
     worktreePath: null,
+    hydrated: true,
     ...overrides,
   };
 }
@@ -833,5 +836,65 @@ describe("incremental orchestration updates", () => {
       state: "running",
     });
     expect(next.threads[0]?.latestTurn?.sourceProposedPlan).toBeUndefined();
+  });
+});
+
+describe("thread eviction", () => {
+  it("evictThreadData clears messages and activities but preserves metadata", () => {
+    const thread = makeThread({
+      messages: [
+        {
+          id: MessageId.makeUnsafe("msg-1"),
+          role: "user",
+          text: "hello",
+          createdAt: "2026-02-27T00:00:00.000Z",
+          streaming: false,
+        },
+      ],
+      activities: [
+        {
+          id: "act-1",
+          type: "tool_use",
+          turnId: TurnId.makeUnsafe("turn-1"),
+          payload: { tool: "bash", detail: "echo big output" },
+          createdAt: "2026-02-27T00:00:00.000Z",
+        } as any,
+      ],
+    });
+    const state = makeState(thread);
+    const next = evictThreadData(state, thread.id);
+    const evicted = next.threads.find((t) => t.id === thread.id)!;
+    expect(evicted.messages).toEqual([]);
+    expect(evicted.activities).toEqual([]);
+    expect(evicted.proposedPlans).toEqual([]);
+    expect(evicted.turnDiffSummaries).toEqual([]);
+    expect(evicted.hydrated).toBe(false);
+    expect(evicted.title).toBe(thread.title);
+    expect(evicted.id).toBe(thread.id);
+  });
+
+  it("hydrateThread replaces dehydrated thread with full data", () => {
+    const thread = makeThread({ id: ThreadId.makeUnsafe("t-dry") });
+    const state = makeState(thread);
+    const dehydrated = evictThreadData(state, thread.id);
+    const fullThread = makeReadModelThread({
+      id: ThreadId.makeUnsafe("t-dry"),
+      messages: [
+        {
+          id: MessageId.makeUnsafe("msg-1"),
+          role: "user" as const,
+          text: "hello",
+          turnId: null,
+          streaming: false,
+          createdAt: "2026-02-27T00:00:00.000Z",
+          updatedAt: "2026-02-27T00:00:00.000Z",
+        },
+      ],
+    });
+    const next = hydrateThread(dehydrated, thread.id, fullThread);
+    const hydrated = next.threads.find((t) => t.id === thread.id)!;
+    expect(hydrated.hydrated).toBe(true);
+    expect(hydrated.messages).toHaveLength(1);
+    expect(hydrated.messages[0]!.text).toBe("hello");
   });
 });

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -176,6 +176,7 @@ function mapThread(thread: OrchestrationThread): Thread {
     worktreePath: thread.worktreePath,
     turnDiffSummaries: thread.checkpoints.map(mapTurnDiffSummary),
     activities: thread.activities.map((activity) => ({ ...activity })),
+    hydrated: true,
   };
 }
 
@@ -1140,6 +1141,31 @@ export function setThreadBranch(
   });
 }
 
+export function evictThreadData(state: AppState, threadId: ThreadId): AppState {
+  return updateThreadState(state, threadId, (thread) => ({
+    ...thread,
+    messages: [],
+    activities: [],
+    proposedPlans: [],
+    turnDiffSummaries: [],
+    hydrated: false,
+  }));
+}
+
+export function hydrateThread(
+  state: AppState,
+  threadId: ThreadId,
+  serverThread: OrchestrationReadModel["threads"][number],
+): AppState {
+  const fresh = mapThread(serverThread);
+  return updateThreadState(state, threadId, (existing) => ({
+    ...fresh,
+    // Preserve any client-only state
+    session: existing.session ?? fresh.session,
+    hydrated: true,
+  }));
+}
+
 // ── Zustand store ────────────────────────────────────────────────────
 
 interface AppStore extends AppState {
@@ -1148,6 +1174,11 @@ interface AppStore extends AppState {
   applyOrchestrationEvents: (events: ReadonlyArray<OrchestrationEvent>) => void;
   setError: (threadId: ThreadId, error: string | null) => void;
   setThreadBranch: (threadId: ThreadId, branch: string | null, worktreePath: string | null) => void;
+  evictThreadData: (threadId: ThreadId) => void;
+  hydrateThread: (
+    threadId: ThreadId,
+    serverThread: OrchestrationReadModel["threads"][number],
+  ) => void;
 }
 
 export const useStore = create<AppStore>((set) => ({
@@ -1158,4 +1189,7 @@ export const useStore = create<AppStore>((set) => ({
   setError: (threadId, error) => set((state) => setError(state, threadId, error)),
   setThreadBranch: (threadId, branch, worktreePath) =>
     set((state) => setThreadBranch(state, threadId, branch, worktreePath)),
+  evictThreadData: (threadId) => set((state) => evictThreadData(state, threadId)),
+  hydrateThread: (threadId, serverThread) =>
+    set((state) => hydrateThread(state, threadId, serverThread)),
 }));

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -109,6 +109,8 @@ export interface Thread {
   worktreePath: string | null;
   turnDiffSummaries: TurnDiffSummary[];
   activities: OrchestrationThreadActivity[];
+  /** Whether this thread's full data (messages, activities, etc.) is loaded in memory. */
+  hydrated: boolean;
 }
 
 export interface SidebarThreadSummary {

--- a/apps/web/src/worktreeCleanup.test.ts
+++ b/apps/web/src/worktreeCleanup.test.ts
@@ -27,6 +27,7 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     latestTurn: null,
     branch: null,
     worktreePath: null,
+    hydrated: true,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #1686 — V8 OOM crash that kills the renderer during long sessions, causing the white-screen freeze.

**Root cause:** The renderer holds ALL thread data (messages, activities, tool outputs) for ALL threads in the Zustand store indefinitely. During long sessions with heavy tool use, the V8 heap grows to ~3.7GB and crashes. There is no crash recovery handler, so the user sees a dead white window while agents continue running invisibly in the background.

**This PR adds three layers of defense:**

- **Crash recovery** — `render-process-gone` handler auto-reloads the renderer after 500ms on crash/OOM, restoring real-time visibility into running agents. Also logs `unresponsive`/`responsive` events for diagnostics.
- **V8 heap cap** — `--max-old-space-size=2048` forces GC to run more aggressively at 2GB instead of growing unchecked to 3.7GB+.
- **Thread data eviction** — Only 5 threads stay fully hydrated in memory at a time. Inactive threads are dehydrated (messages/activities/plans/diffs cleared, sidebar metadata preserved) and re-fetched from the server on navigation. Threads with running agents are never evicted.

## Changes

| File | Change |
|------|--------|
| `apps/desktop/src/main.ts` | `render-process-gone` handler, `unresponsive`/`responsive` logging, `--max-old-space-size=2048` |
| `apps/web/src/lib/threadEviction.ts` | Eviction policy: which threads to dehydrate, when |
| `apps/web/src/types.ts` | `hydrated: boolean` on `Thread` |
| `apps/web/src/store.ts` | `evictThreadData` / `hydrateThread` pure actions |
| `apps/web/src/routes/__root.tsx` | Eviction triggered on navigation in `EventRouter` |
| `apps/web/src/components/ChatView.tsx` | Hydration trigger + loading state for dehydrated threads |
| Tests | `threadEviction.test.ts` (5 tests), `store.test.ts` (+2 tests), updated Thread factories |

## Evidence from live crash

Captured during development — the renderer crashed after 39 minutes of use:

```
coredumpctl: PID 393635 (t3-code-desktop --type=zygote)
Signal: 5 (TRAP)  ← V8 heap exhaustion
Core dump: 927.2MB (truncated)
```

Main process + backend + Claude agents all survived — only the renderer died with zero recovery. The desktop log showed no awareness of the crash (no `render-process-gone` handler existed).

## Test plan

- [x] `bun typecheck` — 0 errors
- [x] `bun lint` — 0 errors
- [x] `bun fmt` — clean
- [x] `bun run test` — 688/689 pass (1 pre-existing timeout in `MessagesTimeline.test.tsx`)
- [x] New tests: 7/7 pass (5 eviction policy + 2 store actions)
- [ ] Manual: long session stress test with heavy tool use
- [ ] Manual: verify dehydrated threads show loading state, then re-hydrate on navigation
- [ ] Manual: verify threads with running agents are not evicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Electron process flags/crash recovery and adds thread data eviction/hydration in the web store, which can affect app stability and state consistency if hydration/eviction edge cases are missed. Server-side change adds caching around filesystem checks and could mask newly-created worktrees for up to the TTL if incorrect.
> 
> **Overview**
> Prevents long-session renderer OOM/white-screen issues by **capping V8 heap to 2GB** (main + renderer) and adding **renderer crash/unresponsive diagnostics** plus an auto-reload on `render-process-gone` for crash/OOM/kill.
> 
> Adds **thread memory eviction** in the web app: introduces a `Thread.hydrated` flag, a keep-limit policy (`EVICTION_KEEP_COUNT=5`) to dehydrate inactive threads on navigation, and store actions to `evictThreadData` (drop messages/activities/plans/diffs) and `hydrateThread` (restore full thread from a server snapshot). `ChatView` now shows a loading state for dehydrated threads and re-hydrates them on demand.
> 
> On the server, adds a **negative cache for missing git worktree paths** to avoid repeated `stat()`/ENOENT loops when worktrees are deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b400cea684ce830b626be70b3817af6a7d724e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix renderer OOM crash recovery and add thread memory eviction in desktop app
> - Caps V8 heap at 2 GB for main and renderer processes in [main.ts](https://github.com/pingdotgg/t3code/pull/1843/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb) via `--max-old-space-size=2048`, and auto-reloads the renderer window 500ms after a crash, OOM, or kill event.
> - Adds a `hydrated` flag to the `Thread` type and implements `evictThreadData`/`hydrateThread` store reducers to dehydrate inactive threads (clearing messages, activities, plans, and diff summaries) and restore them on demand.
> - On route changes, [__root.tsx](https://github.com/pingdotgg/t3code/pull/1843/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) calls `selectThreadsToEvict` from the new [threadEviction.ts](https://github.com/pingdotgg/t3code/pull/1843/files#diff-a19fbefee0ddd8daf054795ff3d6863dc5bf394071277c3b496a67a058a66776) module to dehydrate threads beyond a keep threshold, skipping the active thread and any with running sessions.
> - When navigating to a dehydrated thread, `ChatView` shows a "Loading conversation..." placeholder and re-fetches the full thread from the server.
> - Adds a TTL-based negative cache in [GitCore.ts](https://github.com/pingdotgg/t3code/pull/1843/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865) to skip repeated `stat()` calls for missing worktree paths for up to 5 minutes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7b400c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->