### PR TITLE
Fix Claude Code Chats in Supervised Mode (rather than Full Access Mode)

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -299,7 +299,7 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.deepEqual(createInput?.options.settingSources, ["user", "project", "local"]);
-      assert.equal(createInput?.options.permissionMode, undefined);
+      assert.equal(createInput?.options.permissionMode, "default");
       assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -39,6 +39,7 @@ import {
   TurnId,
   type UserInputQuestion,
   ClaudeCodeEffort,
+  RuntimeMode,
 } from "@t3tools/contracts";
 import {
   applyClaudePromptEffortPrefix,
@@ -2693,12 +2694,12 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ? modelSelection.options.thinking
           : undefined;
       const effectiveEffort = getEffectiveClaudeCodeEffort(effort);
-      const permissionMode: PermissionMode =
-        input.runtimeMode === "full-access"
-          ? "bypassPermissions"
-          : input.runtimeMode === "auto-accept-edits"
-            ? "acceptEdits"
-            : "default";
+      const runtimeModeToPermission: Record<RuntimeMode, PermissionMode> = {
+        "approval-required": "default",
+        "auto-accept-edits": "acceptEdits",
+        "full-access": "bypassPermissions",
+      };
+      const permissionMode = runtimeModeToPermission[input.runtimeMode];
       const settings = {
         ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
         ...(fastMode ? { fastMode: true } : {}),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2693,11 +2693,12 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           ? modelSelection.options.thinking
           : undefined;
       const effectiveEffort = getEffectiveClaudeCodeEffort(effort);
-      const runtimeModeToPermission: Record<string, PermissionMode> = {
-        "auto-accept-edits": "acceptEdits",
-        "full-access": "bypassPermissions",
-      };
-      const permissionMode = runtimeModeToPermission[input.runtimeMode];
+      const permissionMode: PermissionMode =
+        input.runtimeMode === "full-access"
+          ? "bypassPermissions"
+          : input.runtimeMode === "auto-accept-edits"
+            ? "acceptEdits"
+            : "default";
       const settings = {
         ...(typeof thinking === "boolean" ? { alwaysThinkingEnabled: thinking } : {}),
         ...(fastMode ? { fastMode: true } : {}),
@@ -2709,7 +2710,7 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         pathToClaudeCodeExecutable: claudeBinaryPath,
         settingSources: [...CLAUDE_SETTING_SOURCES],
         ...(effectiveEffort ? { effort: effectiveEffort } : {}),
-        ...(permissionMode ? { permissionMode } : {}),
+        permissionMode,
         ...(permissionMode === "bypassPermissions"
           ? { allowDangerouslySkipPermissions: true }
           : {}),


### PR DESCRIPTION
## What Changed

Fixes #1818 

## Why

When trying to use the Claude Code with `Supervised` rather than `Full access` mode, the chat rightaway fails with the error described in the issue.

The fix is to set the correct (`default`) permission mode when changing from `Full access` to `Supervised`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Claude SDK sessions are started by always sending an explicit `permissionMode`, which affects tool/file access behavior across runtime modes. Risk is moderate because incorrect mapping could unintentionally over- or under-restrict permissions at runtime.
> 
> **Overview**
> Fixes supervised (`runtimeMode: "approval-required"`) Claude sessions by mapping them to `permissionMode: "default"` instead of leaving `permissionMode` unset.
> 
> `ClaudeAdapter` now always includes `permissionMode` in the SDK query options (still using `bypassPermissions` for full-access and `acceptEdits` for auto-accept), and tests are updated to assert the new supervised-mode behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e65313f0b2f3add844b81e5769b2a5e165f77c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude Code chats in supervised mode by passing `permissionMode: "default"` for approval-required sessions
> Sessions started with `runtimeMode: "approval-required"` were not passing a `permissionMode` to the underlying query options, causing them to behave incorrectly. [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/1851/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) now maps `"approval-required"` to `permissionMode: "default"` and always includes `permissionMode` in query options for all runtime modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e65313.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->