### PR TITLE
fix(web): harmonize typography in chat messages and code blocks

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -164,7 +164,7 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNo
   );
 
   return (
-    <div className="chat-markdown-codeblock">
+    <div className="chat-markdown-codeblock leading-snug">
       <button
         type="button"
         className="chat-markdown-copy-button"

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -428,7 +428,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                       </Button>
                     )}
                   </div>
-                  <p className="text-right text-[10px] text-muted-foreground/30">
+                  <p className="text-right text-xs text-muted-foreground/50">
                     {formatTimestamp(row.message.createdAt, timestampFormat)}
                   </p>
                 </div>
@@ -515,7 +515,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                     </div>
                   );
                 })()}
-                <p className="mt-1.5 text-[10px] text-muted-foreground/30">
+                <p className="mt-1.5 text-xs text-muted-foreground/50">
                   {formatMessageMeta(
                     row.message.createdAt,
                     row.message.streaming
@@ -742,9 +742,9 @@ const UserMessageBody = memo(function UserMessageBody(props: {
   }
 
   return (
-    <pre className="whitespace-pre-wrap wrap-break-word font-mono text-sm leading-relaxed text-foreground">
+    <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
       {props.text}
-    </pre>
+    </div>
   );
 });
 
@@ -871,7 +871,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           <div className="max-w-full">
             <p
               className={cn(
-                "truncate text-[11px] leading-5",
+                "truncate text-xs leading-5",
                 workToneClass(workEntry.tone),
                 preview ? "text-muted-foreground/70" : "",
               )}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -703,7 +703,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
         }
 
         return (
-          <div className="wrap-break-word whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground">
+          <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
             {inlineNodes}
           </div>
         );
@@ -731,7 +731,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
     }
 
     return (
-      <div className="wrap-break-word whitespace-pre-wrap font-mono text-sm leading-relaxed text-foreground">
+      <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
         {inlineNodes}
       </div>
     );

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -336,7 +336,7 @@ label:has(> select#reasoning-effort) select {
   background: transparent;
   padding: 0;
   line-height: 1.5;
-  font-size: 0.875rem;
+  font-size: 0.75rem;
 }
 
 .chat-markdown .chat-markdown-codeblock {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -335,7 +335,6 @@ label:has(> select#reasoning-effort) select {
   border: none;
   background: transparent;
   padding: 0;
-  line-height: 1.5;
   font-size: 0.75rem;
 }
 


### PR DESCRIPTION
## What Changed
- Replaced arbitrary font sizes (text-[10px], text-[11px]) with Tailwind's standard text-xs class for timestamps and work-entry labels.
- Increased timestamp/meta opacity from text-muted-foreground/30 to text-muted-foreground/50 so they're easier to read.
- Changed user message body from \<pre\> (monospace) to \<div\>, removing monospace styling on plain user input.
- Reduced inline code font size from 0.875rem to 0.75rem so inline code doesn't appear larger 
than surrounding prose.
- Added leading-snug to markdown code blocks for tighter line spacing.


## Why
Chat typography used a mix of ad-hoc pixel sizes (10px, 11px, 0.875rem) and inconsistent opacity values, making the UI feel unpolished and harder to maintain. Standardizing on Tailwind's type scale (text-xs = 12px) and bumping the timestamp opacity improves readability without changing the visual hierarchy. Switching user messages from \<pre\> to \<div\> changes previous behavior where plain text was rendered in a monospace font, which looked out of place compared to the rest of the UI.

## UI Changes
- Timestamps and work-entry labels are slightly larger and more readable (10–11px → 12px, 30% → 50% opacity).
- User messages now render in the default proportional font instead of monospace.
- Inline code in markdown is slightly smaller to sit better within body text.
- Code blocks have tighter line height.

### Before
<img width="932" height="685" alt="before" src="https://github.com/user-attachments/assets/3728f38a-37aa-4552-8264-5c68de5335d8" />

### After
<img width="931" height="684" alt="after" src="https://github.com/user-attachments/assets/5303b1b7-b777-4523-96a1-690f414c25a8" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes to chat typography and wrappers; main risk is minor layout/whitespace regressions in message rendering across browsers.
> 
> **Overview**
> Standardizes chat UI typography by switching timestamp/meta/work-entry text to Tailwind `text-xs` and increasing muted text opacity for better readability.
> 
> Adjusts message rendering styles: user message bodies no longer use a `<pre>`/`font-mono` wrapper (while preserving whitespace via CSS), and markdown code presentation is tightened by adding `leading-snug` to code blocks and reducing `pre code` font size to `0.75rem`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8896a18b2d3291eee5a594b1835ffbc32870d328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harmonize typography in chat messages and code blocks
> - User message text in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/1861/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) no longer uses a monospace font; plain text messages now render in a `<div>` instead of `<pre>`, preserving whitespace via `whitespace-pre-wrap`.
> - Timestamps switch from `text-[10px]/opacity-30` to `text-xs/opacity-50`, and work entry lines move from a fixed `11px` to `text-xs`.
> - Code blocks in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/1861/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) gain `leading-snug`, and [index.css](https://github.com/pingdotgg/t3code/pull/1861/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) reduces inline code font size from `0.875rem` to `0.75rem` and removes the explicit line-height.
> - Behavioral Change: removing `font-mono` from user messages changes the visual appearance of all user-sent text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8896a18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->