### PR TITLE
fix: make file uri links clickable

### DIFF
--- a/apps/web/src/components/ChatMarkdown.browser.tsx
+++ b/apps/web/src/components/ChatMarkdown.browser.tsx
@@ -1,0 +1,76 @@
+import "../index.css";
+
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+const { openInPreferredEditorMock, readLocalApiMock } = vi.hoisted(() => ({
+  openInPreferredEditorMock: vi.fn(async () => "vscode"),
+  readLocalApiMock: vi.fn(() => ({
+    server: { getConfig: vi.fn(async () => ({ availableEditors: ["vscode"] })) },
+    shell: { openInEditor: vi.fn(async () => undefined) },
+  })),
+}));
+
+vi.mock("../editorPreferences", () => ({
+  openInPreferredEditor: openInPreferredEditorMock,
+}));
+
+vi.mock("../localApi", () => ({
+  readLocalApi: readLocalApiMock,
+}));
+
+import ChatMarkdown from "./ChatMarkdown";
+
+describe("ChatMarkdown", () => {
+  afterEach(() => {
+    openInPreferredEditorMock.mockClear();
+    readLocalApiMock.mockClear();
+    localStorage.clear();
+    document.body.innerHTML = "";
+  });
+
+  it("rewrites file uri hrefs into direct paths before rendering", async () => {
+    const filePath =
+      "/Users/yashsingh/p/sco/claude-code-extract/src/utils/permissions/PermissionRule.ts";
+    const screen = await render(
+      <ChatMarkdown text={`[PermissionRule.ts](file://${filePath})`} cwd="/repo/project" />,
+    );
+
+    try {
+      const link = page.getByRole("link", { name: "PermissionRule.ts" });
+      await expect.element(link).toBeInTheDocument();
+      await expect.element(link).toHaveAttribute("href", filePath);
+
+      await link.click();
+
+      await vi.waitFor(() => {
+        expect(openInPreferredEditorMock).toHaveBeenCalledWith(expect.anything(), filePath);
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("keeps line anchors working after rewriting file uri hrefs", async () => {
+    const filePath =
+      "/Users/yashsingh/p/sco/claude-code-extract/src/utils/permissions/PermissionRule.ts";
+    const screen = await render(
+      <ChatMarkdown text={`[PermissionRule.ts:1](file://${filePath}#L1)`} cwd="/repo/project" />,
+    );
+
+    try {
+      const link = page.getByRole("link", { name: "PermissionRule.ts:1" });
+      await expect.element(link).toBeInTheDocument();
+      await expect.element(link).toHaveAttribute("href", `${filePath}#L1`);
+
+      await link.click();
+
+      await vi.waitFor(() => {
+        expect(openInPreferredEditorMock).toHaveBeenCalledWith(expect.anything(), `${filePath}:1`);
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+});

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -15,13 +15,14 @@ import React, {
 } from "react";
 import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
+import { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { openInPreferredEditor } from "../editorPreferences";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
 import { fnv1a32 } from "../lib/diffRendering";
 import { LRUCache } from "../lib/lruCache";
 import { useTheme } from "../hooks/useTheme";
-import { resolveMarkdownFileLinkTarget } from "../markdown-links";
+import { resolveMarkdownFileLinkTarget, rewriteMarkdownFileUriHref } from "../markdown-links";
 import { readLocalApi } from "../localApi";
 
 class CodeHighlightErrorBoundary extends React.Component<
@@ -238,6 +239,9 @@ function SuspenseShikiCodeBlock({
 function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
+  const markdownUrlTransform = useCallback((href: string) => {
+    return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
+  }, []);
   const markdownComponents = useMemo<Components>(
     () => ({
       a({ node: _node, href, ...props }) {
@@ -290,7 +294,11 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
 
   return (
     <div className="chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={markdownComponents}
+        urlTransform={markdownUrlTransform}
+      >
         {text}
       </ReactMarkdown>
     </div>

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveMarkdownFileLinkTarget } from "./markdown-links";
+import { resolveMarkdownFileLinkTarget, rewriteMarkdownFileUriHref } from "./markdown-links";
+
+describe("rewriteMarkdownFileUriHref", () => {
+  it("rewrites file uri hrefs into direct path hrefs", () => {
+    expect(rewriteMarkdownFileUriHref("file:///Users/julius/project/src/main.ts#L42")).toBe(
+      "/Users/julius/project/src/main.ts#L42",
+    );
+  });
+
+  it("preserves encoded octets so file paths are decoded only once later", () => {
+    expect(rewriteMarkdownFileUriHref("file:///Users/julius/project/file%2520name.md")).toBe(
+      "/Users/julius/project/file%2520name.md",
+    );
+  });
+});
 
 describe("resolveMarkdownFileLinkTarget", () => {
   it("resolves absolute posix file paths", () => {

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -38,23 +38,34 @@ function stripSearchAndHash(value: string): { path: string; hash: string } {
   return { path, hash: rawHash };
 }
 
-function parseFileUrlHref(href: string): { path: string; hash: string } | null {
+function parseFileUrlHref(
+  href: string,
+  options?: { readonly decodePath?: boolean },
+): { path: string; hash: string } | null {
   try {
     const parsed = new URL(href);
     if (parsed.protocol.toLowerCase() !== "file:") return null;
 
-    const decodedPath = safeDecode(parsed.pathname);
-    if (decodedPath.length === 0) return null;
+    const rawPath = parsed.pathname;
+    if (rawPath.length === 0) return null;
 
     // Browser URL parser encodes "C:/foo" as "/C:/foo" for file URLs.
-    const normalizedPath = /^\/[A-Za-z]:[\\/]/.test(decodedPath)
-      ? decodedPath.slice(1)
-      : decodedPath;
+    const normalizedPath = /^\/[A-Za-z]:[\\/]/.test(rawPath) ? rawPath.slice(1) : rawPath;
 
-    return { path: normalizedPath, hash: parsed.hash };
+    return {
+      path: options?.decodePath === false ? normalizedPath : safeDecode(normalizedPath),
+      hash: parsed.hash,
+    };
   } catch {
     return null;
   }
+}
+
+export function rewriteMarkdownFileUriHref(href: string | undefined): string | null {
+  if (!href) return null;
+  const target = parseFileUrlHref(href.trim(), { decodePath: false });
+  if (!target) return null;
+  return `${target.path}${target.hash}`;
 }
 
 function looksLikePosixFilesystemPath(path: string): boolean {


### PR DESCRIPTION
## What Changed

Sometimes codex likes to output links as a file uri instead of just making the link the path as we'd expect. This pr strips the `file://` so these links are clickable again.

## UI Changes

N/A

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-scoped change to markdown link transformation with added unit/browser tests; main risk is unexpected URL rewriting edge cases for non-file links.
> 
> **Overview**
> **Fixes `file://` links in chat markdown so they’re clickable.** `ChatMarkdown` now uses a custom `urlTransform` to rewrite `file:` URIs into plain filesystem-path `href`s (preserving `#L…` anchors) while falling back to `react-markdown`’s `defaultUrlTransform` for everything else.
> 
> Adds `rewriteMarkdownFileUriHref` (and extends `parseFileUrlHref` to optionally avoid decoding) to prevent double-decoding issues, plus new unit tests and a browser-level `ChatMarkdown` test verifying rewritten `href`s and editor-open behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7b0b92e93d6b3dcd00136dbfe320a59293176c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file URI links to be clickable in ChatMarkdown
> - Adds `rewriteMarkdownFileUriHref` in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/1867/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) to convert `file://` URIs to direct filesystem paths, preserving hash anchors and keeping path octets encoded for single-pass decoding downstream.
> - Wires this into [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/1867/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) via a `urlTransform` prop on `ReactMarkdown`, falling back to `defaultUrlTransform` for non-file URLs.
> - Clicking a rewritten link continues to call `openInPreferredEditor` with the resolved path and optional line number.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f7b0b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->