### PR TITLE
Select desktop backend port by sequential scan

### DIFF
--- a/apps/desktop/src/backendPort.test.ts
+++ b/apps/desktop/src/backendPort.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveDesktopBackendPort } from "./backendPort";
+
+describe("resolveDesktopBackendPort", () => {
+  it("returns the starting port when it is available", async () => {
+    const canListenOnHost = vi.fn(async (port: number) => port === 3773);
+
+    await expect(
+      resolveDesktopBackendPort({
+        host: "127.0.0.1",
+        startPort: 3773,
+        canListenOnHost,
+      }),
+    ).resolves.toBe(3773);
+
+    expect(canListenOnHost).toHaveBeenCalledTimes(1);
+    expect(canListenOnHost).toHaveBeenCalledWith(3773, "127.0.0.1");
+  });
+
+  it("increments sequentially until it finds an available port", async () => {
+    const canListenOnHost = vi.fn(async (port: number) => port === 3775);
+
+    await expect(
+      resolveDesktopBackendPort({
+        host: "127.0.0.1",
+        startPort: 3773,
+        canListenOnHost,
+      }),
+    ).resolves.toBe(3775);
+
+    expect(canListenOnHost.mock.calls).toEqual([
+      [3773, "127.0.0.1"],
+      [3774, "127.0.0.1"],
+      [3775, "127.0.0.1"],
+    ]);
+  });
+
+  it("fails when the scan range is exhausted", async () => {
+    const canListenOnHost = vi.fn(async () => false);
+
+    await expect(
+      resolveDesktopBackendPort({
+        host: "127.0.0.1",
+        startPort: 65534,
+        maxPort: 65535,
+        canListenOnHost,
+      }),
+    ).rejects.toThrow("No desktop backend port is available on 127.0.0.1 between 65534 and 65535");
+
+    expect(canListenOnHost.mock.calls).toEqual([
+      [65534, "127.0.0.1"],
+      [65535, "127.0.0.1"],
+    ]);
+  });
+});

--- a/apps/desktop/src/backendPort.ts
+++ b/apps/desktop/src/backendPort.ts
@@ -1,0 +1,53 @@
+import * as Effect from "effect/Effect";
+import { NetService } from "@t3tools/shared/Net";
+
+export const DEFAULT_DESKTOP_BACKEND_PORT = 3773;
+const MAX_TCP_PORT = 65_535;
+
+export interface ResolveDesktopBackendPortOptions {
+  readonly host: string;
+  readonly startPort?: number;
+  readonly maxPort?: number;
+  readonly canListenOnHost?: (port: number, host: string) => Promise<boolean>;
+}
+
+const defaultCanListenOnHost = async (port: number, host: string): Promise<boolean> =>
+  Effect.service(NetService).pipe(
+    Effect.flatMap((net) => net.canListenOnHost(port, host)),
+    Effect.provide(NetService.layer),
+    Effect.runPromise,
+  );
+
+const isValidPort = (port: number): boolean =>
+  Number.isInteger(port) && port >= 1 && port <= MAX_TCP_PORT;
+
+export async function resolveDesktopBackendPort({
+  host,
+  startPort = DEFAULT_DESKTOP_BACKEND_PORT,
+  maxPort = MAX_TCP_PORT,
+  canListenOnHost = defaultCanListenOnHost,
+}: ResolveDesktopBackendPortOptions): Promise<number> {
+  if (!isValidPort(startPort)) {
+    throw new Error(`Invalid desktop backend start port: ${startPort}`);
+  }
+
+  if (!isValidPort(maxPort)) {
+    throw new Error(`Invalid desktop backend max port: ${maxPort}`);
+  }
+
+  if (maxPort < startPort) {
+    throw new Error(`Desktop backend max port ${maxPort} is below start port ${startPort}`);
+  }
+
+  // Keep desktop startup predictable across app restarts by probing upward from
+  // the same preferred port instead of picking a fresh ephemeral port.
+  for (let port = startPort; port <= maxPort; port += 1) {
+    if (await canListenOnHost(port, host)) {
+      return port;
+    }
+  }
+
+  throw new Error(
+    `No desktop backend port is available on ${host} between ${startPort} and ${maxPort}`,
+  );
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -18,7 +18,6 @@ import {
   shell,
 } from "electron";
 import type { MenuItemConstructorOptions } from "electron";
-import * as Effect from "effect/Effect";
 import type {
   ClientSettings,
   DesktopTheme,
@@ -32,9 +31,9 @@ import type {
 import { autoUpdater } from "electron-updater";
 
 import type { ContextMenuItem } from "@t3tools/contracts";
-import { NetService } from "@t3tools/shared/Net";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { parsePersistedServerObservabilitySettings } from "@t3tools/shared/serverSettings";
+import { DEFAULT_DESKTOP_BACKEND_PORT, resolveDesktopBackendPort } from "./backendPort";
 import {
   DEFAULT_DESKTOP_SETTINGS,
   readDesktopSettings,
@@ -1771,14 +1770,13 @@ async function bootstrap(): Promise<void> {
 
   backendPort =
     configuredBackendPort ??
-    (await Effect.service(NetService).pipe(
-      Effect.flatMap((net) => net.reserveLoopbackPort(DESKTOP_LOOPBACK_HOST)),
-      Effect.provide(NetService.layer),
-      Effect.runPromise,
-    ));
+    (await resolveDesktopBackendPort({
+      host: DESKTOP_LOOPBACK_HOST,
+      startPort: DEFAULT_DESKTOP_BACKEND_PORT,
+    }));
   writeDesktopLogHeader(
     configuredBackendPort === undefined
-      ? `reserved backend port via NetService port=${backendPort}`
+      ? `selected backend port via sequential scan startPort=${DEFAULT_DESKTOP_BACKEND_PORT} port=${backendPort}`
       : `using configured backend port port=${backendPort}`,
   );
   backendBootstrapToken = Crypto.randomBytes(24).toString("hex");


### PR DESCRIPTION
So that your host is more stable across restarts when doing remote 

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop backend port selection during startup, which can affect app launch reliability and port-collision behavior if the preferred range is busy. Logic is straightforward and covered by new unit tests, but it touches the bootstrap path.
> 
> **Overview**
> Desktop startup now selects the backend port by **sequentially probing** from a stable preferred port (default `3773`) instead of reserving a random ephemeral loopback port.
> 
> This introduces `resolveDesktopBackendPort` (with validation and bounded scan) plus Vitest coverage, and updates `main.ts` bootstrap/logging to use the new resolver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca8118f26f6733bcedd9d7a08d4a0b17f618d68f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Select desktop backend port by sequential scan from port 3773
> - Replaces `NetService.reserveLoopbackPort` with a new `resolveDesktopBackendPort` function in [backendPort.ts](https://github.com/pingdotgg/t3code/pull/1870/files#diff-217b73e8c6ec253adeb7dc498d6dda9dd089e4d340438e85d7ea51c75e8033c7) that scans ports sequentially from a start port until it finds one available via `canListenOnHost`.
> - When `T3CODE_PORT` is unset, the desktop app now selects a backend port by scanning from `DEFAULT_DESKTOP_BACKEND_PORT` (3773) on the loopback host.
> - Validates `startPort` and `maxPort` inputs and throws if no available port is found within the range.
> - Behavioral Change: port selection now uses the first available port starting at 3773 rather than reserving an OS-assigned loopback port.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca8118f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->