### PR TITLE
Document remote server network access setup

### DIFF
--- a/REMOTE.md
+++ b/REMOTE.md
@@ -12,7 +12,22 @@ That gives you:
 - transport security at the network layer
 - less exposure than opening the server to the public internet
 
-## Headless Server Flow
+## Enabling Network Access
+
+There are two ways to expose your server for remote connections: from the desktop app or from the CLI.
+
+### Option 1: Desktop App
+
+If you are already running the desktop app and want to make it reachable from other devices:
+
+1. Open **Settings** → **Connections**.
+2. Under **Manage Local Backend**, toggle **Network access** on. This will restart the app and run the backend on all network interfaces.
+3. The settings panel will show the address the server is reachable at (e.g. `http://192.168.x.y:3773`).
+4. Use **Create Link** to generate a pairing link you can share with another device.
+
+### Option 2: Headless Server (CLI)
+
+Use this when you want to run the server without a GUI, for example on a remote machine over SSH.
 
 Run the server with `t3 serve`.
 


### PR DESCRIPTION
## Summary
- Add documentation for enabling network access from the desktop app.
- Document the `Settings` → `Connections` flow for turning on local backend network access and generating a pairing link.
- Clarify the headless CLI use case for running `t3 serve` on a remote machine.

## Testing
- Not run (documentation-only change).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update that adds guidance for exposing the local backend via the desktop app and clarifies the CLI/headless remote workflow; no runtime or security logic changes.
> 
> **Overview**
> Updates `REMOTE.md` to describe **two** supported ways to enable remote access: turning on **Network access** from the desktop app’s **Settings → Connections** (including where to find the reachable address and how to create a pairing link), or running `t3 serve` in a headless/SSH scenario.
> 
> Also reframes the old *headless server flow* section as part of a broader **Enabling Network Access** guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1955568479949cf55a1d070d29e204d2f0e3ff25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document network access setup for remote servers in REMOTE.md
> Updates [REMOTE.md](https://github.com/pingdotgg/t3code/pull/1872/files#diff-5f7aa1271b19681b2e771f630ff47acb2712fd8f7fd33edb07c84270772c56f6) to replace the 'Headless Server Flow' section with a new 'Enabling Network Access' section covering two options: using the desktop app's Settings → Connections UI (with network toggle, restart note, address display, and pairing link generation) or running `t3 serve` on a headless/SSH remote machine without a GUI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1955568.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->