### PR TITLE
Harden workspace git indexing against repo-configured fsmonitor execution

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -219,7 +219,10 @@ it.layer(TestLayer)("git integration", (it) => {
 
         const seenChunks: string[][] = [];
         const core = yield* makeIsolatedGitCore((input) => {
-          if (input.args.join(" ") !== "check-ignore --no-index -z --stdin") {
+          if (
+            input.args.join(" ") !==
+            "-c core.fsmonitor=false -c core.untrackedCache=false check-ignore --no-index -z --stdin"
+          ) {
             return Effect.fail(
               new GitCommandError({
                 operation: input.operation,
@@ -250,6 +253,35 @@ it.layer(TestLayer)("git integration", (it) => {
         expect(seenChunks.length).toBeGreaterThan(1);
         expect(seenChunks.flat()).toEqual(relativePaths);
         expect(result).toEqual(expectedPaths);
+      }),
+    );
+
+    it.effect("listWorkspaceFiles disables fsmonitor and untracked cache helpers", () =>
+      Effect.gen(function* () {
+        const core = yield* makeIsolatedGitCore((input) => {
+          expect(input.args).toEqual([
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.untrackedCache=false",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+          ]);
+          return Effect.succeed({
+            code: 0,
+            stdout: "src/index.ts\0README.md\0",
+            stderr: "",
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          });
+        });
+
+        const result = yield* core.listWorkspaceFiles("/virtual/repo");
+        expect(result.paths).toEqual(["src/index.ts", "README.md"]);
+        expect(result.truncated).toBe(false);
       }),
     );
   });

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -47,6 +47,12 @@ const RANGE_DIFF_SUMMARY_MAX_OUTPUT_BYTES = 19_000;
 const RANGE_DIFF_PATCH_MAX_OUTPUT_BYTES = 59_000;
 const WORKSPACE_FILES_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 const GIT_CHECK_IGNORE_MAX_STDIN_BYTES = 256 * 1024;
+const WORKSPACE_GIT_HARDENED_CONFIG_ARGS = [
+  "-c",
+  "core.fsmonitor=false",
+  "-c",
+  "core.untrackedCache=false",
+] as const;
 const STATUS_UPSTREAM_REFRESH_INTERVAL = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_FAILURE_COOLDOWN = Duration.seconds(5);
@@ -1619,7 +1625,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     executeGit(
       "GitCore.listWorkspaceFiles",
       cwd,
-      ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+      [...WORKSPACE_GIT_HARDENED_CONFIG_ARGS, "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
       {
         allowNonZeroExit: true,
         timeoutMs: 20_000,
@@ -1637,7 +1643,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
               createGitCommandError(
                 "GitCore.listWorkspaceFiles",
                 cwd,
-                ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+                [...WORKSPACE_GIT_HARDENED_CONFIG_ARGS, "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
                 result.stderr.trim().length > 0 ? result.stderr.trim() : "git ls-files failed",
               ),
             ),
@@ -1657,7 +1663,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
         const result = yield* executeGit(
           "GitCore.filterIgnoredPaths",
           cwd,
-          ["check-ignore", "--no-index", "-z", "--stdin"],
+          [...WORKSPACE_GIT_HARDENED_CONFIG_ARGS, "check-ignore", "--no-index", "-z", "--stdin"],
           {
             stdin: `${chunk.join("\0")}\0`,
             allowNonZeroExit: true,
@@ -1671,7 +1677,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
           return yield* createGitCommandError(
             "GitCore.filterIgnoredPaths",
             cwd,
-            ["check-ignore", "--no-index", "-z", "--stdin"],
+            [...WORKSPACE_GIT_HARDENED_CONFIG_ARGS, "check-ignore", "--no-index", "-z", "--stdin"],
             result.stderr.trim().length > 0 ? result.stderr.trim() : "git check-ignore failed",
           );
         }

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1625,7 +1625,14 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     executeGit(
       "GitCore.listWorkspaceFiles",
       cwd,
-      [...WORKSPACE_GIT_HARDENED_CONFIG_ARGS, "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+      [
+        ...WORKSPACE_GIT_HARDENED_CONFIG_ARGS,
+        "ls-files",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "-z",
+      ],
       {
         allowNonZeroExit: true,
         timeoutMs: 20_000,
@@ -1643,7 +1650,14 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
               createGitCommandError(
                 "GitCore.listWorkspaceFiles",
                 cwd,
-                [...WORKSPACE_GIT_HARDENED_CONFIG_ARGS, "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+                [
+                  ...WORKSPACE_GIT_HARDENED_CONFIG_ARGS,
+                  "ls-files",
+                  "--cached",
+                  "--others",
+                  "--exclude-standard",
+                  "-z",
+                ],
                 result.stderr.trim().length > 0 ? result.stderr.trim() : "git ls-files failed",
               ),
             ),


### PR DESCRIPTION
### Motivation
- Workspace indexing invoked `git ls-files` and `git check-ignore` inside repositories which allowed repo-configured helpers like `core.fsmonitor` to execute attacker-supplied code in untrusted repos.
- The change aims to remove that local RCE vector while preserving the intended workspace-indexing semantics and ignore filtering.

### Description
- Add a `WORKSPACE_GIT_HARDENED_CONFIG_ARGS` constant with `-c core.fsmonitor=false` and `-c core.untrackedCache=false` to explicitly disable repo-configured fsmonitor/untracked-cache helpers. 
- Prepend the hardened config args to the `git ls-files ... -z` invocation in `listWorkspaceFiles` so workspace file enumeration no longer honors repo helpers. 
- Prepend the same hardened config args to the `git check-ignore --no-index -z --stdin` invocations used by `filterIgnoredPaths` so ignore filtering also cannot trigger repo helpers. 
- Update `GitCore` unit tests to expect the hardened args for the check-ignore path and add an additional test asserting the hardened args are passed to `ls-files` while verifying returned paths remain unchanged.

### Testing
- Modified and added unit tests in `apps/server/src/git/Layers/GitCore.test.ts` to assert the hardened git args are used; these tests were committed with the change. 
- Attempted to run required repository checks `bun fmt`, `bun lint`, and `bun typecheck`, but they could not be executed in this environment because `bun` is not installed (`/bin/bash: bun: command not found`). 
- No automated test runner (`bun run test` / Vitest) was executed here due to the same missing `bun` runtime, so test execution results are not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d81a853540832a89dfc590eafbfbb8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the arguments used for workspace file enumeration and ignore filtering, which could affect performance/behavior in some repos despite being a targeted hardening change. Main risk is unexpected differences in `git ls-files`/`git check-ignore` output or timing on edge-case configurations.
> 
> **Overview**
> **Hardens workspace indexing against repo-configured helper execution.** Workspace indexing now prepends `-c core.fsmonitor=false -c core.untrackedCache=false` to the git commands used by `listWorkspaceFiles` (`git ls-files …`) and `filterIgnoredPaths` (`git check-ignore …`) to prevent repository config from triggering fsmonitor/untracked-cache helpers.
> 
> Tests were updated to expect the hardened args for `check-ignore`, and a new unit test asserts `listWorkspaceFiles` passes the hardened config while preserving parsed path output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b143961285687246b684070a080527e2a2ab386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable fsmonitor and untracked cache for workspace git indexing commands
> Adds a shared `WORKSPACE_GIT_HARDENED_CONFIG_ARGS` constant (`-c core.fsmonitor=false -c core.untrackedCache=false`) and prepends it to the git invocations in `GitCore.listWorkspaceFiles` and `GitCore.filterIgnoredPaths`. This prevents repo-configured fsmonitor hooks from interfering with workspace file indexing and ignore filtering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b14396.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->