### PR TITLE
feature: Allow model and harness selection before submitting implementation in a new thread

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -629,6 +629,7 @@ export default function ChatView(props: ChatViewProps) {
   const setLogicalProjectDraftThreadId = useComposerDraftStore(
     (store) => store.setLogicalProjectDraftThreadId,
   );
+  const applyComposerDraftStickyState = useComposerDraftStore((store) => store.applyStickyState);
   const draftThread = useComposerDraftStore((store) =>
     routeKind === "server"
       ? store.getDraftSessionByRef(routeThreadRef)
@@ -3031,131 +3032,41 @@ export default function ChatView(props: ChatViewProps) {
   );
 
   const onImplementPlanInNewThread = useCallback(async () => {
-    const api = readEnvironmentApi(environmentId);
-    if (
-      !api ||
-      !activeThread ||
-      !activeProject ||
-      !activeProposedPlan ||
-      !isServerThread ||
-      isSendBusy ||
-      isConnecting ||
-      sendInFlightRef.current
-    ) {
+    if (!activeThread || !activeProject || !activeProposedPlan) {
       return;
     }
 
-    const sendCtx = composerRef.current?.getSendContext();
-    if (!sendCtx) {
-      return;
-    }
-    const {
-      selectedProvider: ctxSelectedProvider,
-      selectedModel: ctxSelectedModel,
-      selectedProviderModels: ctxSelectedProviderModels,
-      selectedPromptEffort: ctxSelectedPromptEffort,
-      selectedModelSelection: ctxSelectedModelSelection,
-    } = sendCtx;
-
-    const createdAt = new Date().toISOString();
+    const nextDraftId = newDraftId();
     const nextThreadId = newThreadId();
     const planMarkdown = activeProposedPlan.planMarkdown;
     const implementationPrompt = buildPlanImplementationPrompt(planMarkdown);
-    const outgoingImplementationPrompt = formatOutgoingPrompt({
-      provider: ctxSelectedProvider,
-      model: ctxSelectedModel,
-      models: ctxSelectedProviderModels,
-      effort: ctxSelectedPromptEffort,
-      text: implementationPrompt,
+    const logicalProjectKey = deriveLogicalProjectKey(activeProject);
+    const activeProjectRef = scopeProjectRef(activeProject.environmentId, activeProject.id);
+
+    setLogicalProjectDraftThreadId(logicalProjectKey, activeProjectRef, nextDraftId, {
+      threadId: nextThreadId,
+      createdAt: new Date().toISOString(),
+      branch: activeThread.branch ?? null,
+      worktreePath: activeThread.worktreePath ?? null,
+      runtimeMode,
+      interactionMode: DEFAULT_INTERACTION_MODE,
     });
-    const nextThreadTitle = truncate(buildPlanImplementationThreadTitle(planMarkdown));
-    const nextThreadModelSelection: ModelSelection = ctxSelectedModelSelection;
+    applyComposerDraftStickyState(nextDraftId);
+    setComposerDraftPrompt(nextDraftId, implementationPrompt);
 
-    sendInFlightRef.current = true;
-    beginLocalDispatch({ preparingWorktree: false });
-    const finish = () => {
-      sendInFlightRef.current = false;
-      resetLocalDispatch();
-    };
-
-    await api.orchestration
-      .dispatchCommand({
-        type: "thread.create",
-        commandId: newCommandId(),
-        threadId: nextThreadId,
-        projectId: activeProject.id,
-        title: nextThreadTitle,
-        modelSelection: nextThreadModelSelection,
-        runtimeMode,
-        interactionMode: "default",
-        branch: activeThread.branch,
-        worktreePath: activeThread.worktreePath,
-        createdAt,
-      })
-      .then(() => {
-        return api.orchestration.dispatchCommand({
-          type: "thread.turn.start",
-          commandId: newCommandId(),
-          threadId: nextThreadId,
-          message: {
-            messageId: newMessageId(),
-            role: "user",
-            text: outgoingImplementationPrompt,
-            attachments: [],
-          },
-          modelSelection: ctxSelectedModelSelection,
-          titleSeed: nextThreadTitle,
-          runtimeMode,
-          interactionMode: "default",
-          sourceProposedPlan: {
-            threadId: activeThread.id,
-            planId: activeProposedPlan.id,
-          },
-          createdAt,
-        });
-      })
-      .then(() => {
-        return waitForStartedServerThread(scopeThreadRef(activeThread.environmentId, nextThreadId));
-      })
-      .then(() => {
-        // Signal that the plan sidebar should open on the new thread.
-        planSidebarOpenOnNextThreadRef.current = true;
-        return navigate({
-          to: "/$environmentId/$threadId",
-          params: {
-            environmentId: activeThread.environmentId,
-            threadId: nextThreadId,
-          },
-        });
-      })
-      .catch(async (err: unknown) => {
-        await api.orchestration
-          .dispatchCommand({
-            type: "thread.delete",
-            commandId: newCommandId(),
-            threadId: nextThreadId,
-          })
-          .catch(() => undefined);
-        toastManager.add({
-          type: "error",
-          title: "Could not start implementation thread",
-          description:
-            err instanceof Error ? err.message : "An error occurred while creating the new thread.",
-        });
-      })
-      .then(finish, finish);
+    await navigate({
+      to: "/draft/$draftId",
+      params: buildDraftThreadRouteParams(nextDraftId),
+    });
   }, [
     activeProject,
     activeProposedPlan,
     activeThread,
-    beginLocalDispatch,
-    isConnecting,
-    isSendBusy,
-    isServerThread,
+    applyComposerDraftStickyState,
     navigate,
-    resetLocalDispatch,
     runtimeMode,
-    environmentId,
+    setComposerDraftPrompt,
+    setLogicalProjectDraftThreadId,
   ]);
 
   const onProviderModelSelect = useCallback(


### PR DESCRIPTION
### What Changed                                

onImplementPlanInNewThread in ChatView.tsx now navigates to a new draft thread with the implementation prompt pre-filled in the composer, instead of immediately creating a server thread and auto-submitting.
                                                                                                                                                                        
A single new store hook extraction (applyStickyState) was added alongside the existing composer draft hooks.                                                          
   
###   Why                                                                                                                                                                   
                                                            
  Previously, "Implement in a new thread" locked the user into whatever model and harness were active on the plan thread — there was no opportunity to change them before the implementation run started. 
  
  Plan generation and implementation often benefit from different models or access modes (e.g. plan with a reasoning model under Supervised, implement with a faster model under Full access).                                                                                                         
                                                            
  Using the existing draft-thread flow solves this cleanly: the draft composer already exposes the model picker and harness selector, so no new UI is needed. The implementation prompt is pre-filled so the user can review it, adjust settings, and submit when ready.
                                                                                                                                                                        
###   UI Changes                                                

  Before: Clicking "Implement in a new thread" immediately starts the implementation run in a new thread — the user arrives mid-execution with no chance to change the model or harness.
                                                                                                                                                                        
  After: Clicking "Implement in a new thread" opens a new draft thread with the implementation prompt pre-filled in the composer. The user can change the model, harness
   (Supervised / Auto-accept / Full access), or edit the prompt before manually submitting.
                                      

https://github.com/user-attachments/assets/66971251-ef0d-4f92-85a9-4501c11268ba
                                                                                                                                  
   
###   Checklist                                                                                                                                                             
                                                            
  - This PR is small and focused
  - I explained what changed and why
  - I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the "Implement in a new thread" flow from immediate server-side thread creation/turn start to client-side draft creation and navigation, which could affect user expectations and any logic relying on automatic orchestration dispatch.
> 
> **Overview**
> **"Implement in a new thread" now opens a draft instead of auto-submitting.** `onImplementPlanInNewThread` in `ChatView.tsx` no longer calls orchestration APIs to `thread.create` and `thread.turn.start`.
> 
> Instead it creates a new draft/thread mapping via `setLogicalProjectDraftThreadId`, applies sticky composer state (`applyStickyState`), pre-fills the implementation prompt, and navigates to `/draft/$draftId` so users can adjust model/runtime/harness before sending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7315dc528b445102c2c97b96dd4b36a573ec6d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Navigate to a draft thread on 'implement plan in new thread' to allow model and harness selection
> - Previously, `onImplementPlanInNewThread` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1877/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) immediately created a server thread and started a turn via orchestration APIs.
> - Now it creates a local draft thread, applies composer sticky state, sets the implementation prompt, and navigates to the draft route — letting the user choose a model and harness before submitting.
> - Behavioral Change: The action no longer triggers server-side thread creation or turn execution; instead it redirects to a draft view with the prompt pre-filled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7315dc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->