### PR TITLE
Fix server publish check for bin entrypoint

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -177,7 +177,7 @@ const publishCmd = Command.make(
       const backupPath = `${packageJsonPath}.bak`;
 
       // Assert build assets exist
-      for (const relPath of ["dist/index.mjs", "dist/client/index.html"]) {
+      for (const relPath of ["dist/bin.mjs", "dist/client/index.html"]) {
         const abs = path.join(serverDir, relPath);
         if (!(yield* fs.exists(abs))) {
           return yield* new CliError({


### PR DESCRIPTION
## Summary
- Update the publish-time asset check to validate `dist/bin.mjs` instead of the old `dist/index.mjs` path.
- Keep the existing client asset validation for `dist/client/index.html`.

## Testing
- Not run (change only updates a publish path check).
- Lint/typecheck not run in this turn.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a pre-publish build-asset existence check to match the current server entrypoint filename; no runtime logic changes.
> 
> **Overview**
> Fixes the server publish CLI’s build-asset validation to require `dist/bin.mjs` instead of the old `dist/index.mjs`, while keeping the client check for `dist/client/index.html` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856a8542d92c005e6b0bb7839b2bc629f41e63e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix publish check to verify `dist/bin.mjs` instead of `dist/index.mjs`
> Updates the pre-publish asset assertion in [cli.ts](https://github.com/pingdotgg/t3code/pull/1885/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) to check for `dist/bin.mjs` rather than `dist/index.mjs`, matching the actual server build output filename.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 856a854.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->