### PR TITLE
Harden secret store and resolve catalog overrides

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -14,6 +14,22 @@ import { resolveCatalogDependencies } from "../../../scripts/lib/resolve-catalog
 import rootPackageJson from "../../../package.json" with { type: "json" };
 import serverPackageJson from "../package.json" with { type: "json" };
 
+interface PackageJson {
+  name: string;
+  repository: {
+    type: string;
+    url: string;
+    directory: string;
+  };
+  bin: Record<string, string>;
+  type: string;
+  version: string;
+  engines: Record<string, string>;
+  files: string[];
+  dependencies: Record<string, string>;
+  overrides: Record<string, string>;
+}
+
 class CliError extends Data.TaggedError("CliError")<{
   readonly message: string;
   readonly cause?: unknown;
@@ -192,7 +208,7 @@ const publishCmd = Command.make(
           // Resolve catalog dependencies before any file mutations. If this throws,
           // acquire fails and no release hook runs, so filesystem must still be untouched.
           const version = Option.getOrElse(config.appVersion, () => serverPackageJson.version);
-          const pkg = {
+          const pkg: PackageJson = {
             name: serverPackageJson.name,
             repository: serverPackageJson.repository,
             bin: serverPackageJson.bin,
@@ -200,13 +216,19 @@ const publishCmd = Command.make(
             version,
             engines: serverPackageJson.engines,
             files: serverPackageJson.files,
-            dependencies: serverPackageJson.dependencies as Record<string, unknown>,
+            dependencies: serverPackageJson.dependencies,
+            overrides: rootPackageJson.overrides,
           };
 
           pkg.dependencies = resolveCatalogDependencies(
             pkg.dependencies,
             rootPackageJson.workspaces.catalog,
             "apps/server dependencies",
+          );
+          pkg.overrides = resolveCatalogDependencies(
+            pkg.overrides,
+            rootPackageJson.workspaces.catalog,
+            "root overrides",
           );
 
           const original = yield* fs.readFileString(packageJsonPath);

--- a/apps/server/src/auth/Layers/ServerSecretStore.ts
+++ b/apps/server/src/auth/Layers/ServerSecretStore.ts
@@ -1,6 +1,6 @@
 import * as Crypto from "node:crypto";
 
-import { Effect, FileSystem, Layer, Path } from "effect";
+import { Effect, FileSystem, Layer, Path, Predicate } from "effect";
 import * as PlatformError from "effect/PlatformError";
 
 import { ServerConfig } from "../../config.ts";
@@ -28,17 +28,14 @@ export const makeServerSecretStore = Effect.gen(function* () {
 
   const resolveSecretPath = (name: string) => path.join(serverConfig.secretsDir, `${name}.bin`);
 
-  const isMissingSecretFileError = (cause: unknown): cause is PlatformError.PlatformError =>
-    cause instanceof PlatformError.PlatformError && cause.reason._tag === "NotFound";
-
-  const isAlreadyExistsSecretFileError = (cause: unknown): cause is PlatformError.PlatformError =>
-    cause instanceof PlatformError.PlatformError && cause.reason._tag === "AlreadyExists";
+  const isPlatformError = (u: unknown): u is PlatformError.PlatformError =>
+    Predicate.isTagged(u, "PlatformError");
 
   const get: ServerSecretStoreShape["get"] = (name) =>
     fileSystem.readFile(resolveSecretPath(name)).pipe(
       Effect.map((bytes) => Uint8Array.from(bytes)),
       Effect.catch((cause) =>
-        isMissingSecretFileError(cause)
+        cause.reason._tag === "NotFound"
           ? Effect.succeed(null)
           : Effect.fail(
               new SecretStoreError({
@@ -108,7 +105,7 @@ export const makeServerSecretStore = Effect.gen(function* () {
         return create(name, generated).pipe(
           Effect.as(Uint8Array.from(generated)),
           Effect.catchTag("SecretStoreError", (error) =>
-            isAlreadyExistsSecretFileError(error.cause)
+            isPlatformError(error.cause) && error.cause.reason._tag === "AlreadyExists"
               ? get(name).pipe(
                   Effect.flatMap((created) =>
                     created !== null
@@ -129,7 +126,7 @@ export const makeServerSecretStore = Effect.gen(function* () {
   const remove: ServerSecretStoreShape["remove"] = (name) =>
     fileSystem.remove(resolveSecretPath(name)).pipe(
       Effect.catch((cause) =>
-        isMissingSecretFileError(cause)
+        cause instanceof PlatformError.PlatformError && cause.reason._tag === "NotFound"
           ? Effect.void
           : Effect.fail(
               new SecretStoreError({

--- a/apps/server/src/auth/Layers/ServerSecretStore.ts
+++ b/apps/server/src/auth/Layers/ServerSecretStore.ts
@@ -126,7 +126,7 @@ export const makeServerSecretStore = Effect.gen(function* () {
   const remove: ServerSecretStoreShape["remove"] = (name) =>
     fileSystem.remove(resolveSecretPath(name)).pipe(
       Effect.catch((cause) =>
-        cause instanceof PlatformError.PlatformError && cause.reason._tag === "NotFound"
+        cause.reason._tag === "NotFound"
           ? Effect.void
           : Effect.fail(
               new SecretStoreError({

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -2002,7 +2002,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
             "GitCore.removeWorktree",
             input.cwd,
             args,
-            `${commandLabel(args)} failed (cwd: ${input.cwd}): ${error instanceof Error ? error.message : String(error)}`,
+            `${commandLabel(args)} failed (cwd: ${input.cwd}): ${error.message}`,
             error,
           ),
         ),

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Schema } from "effect";
+import { Effect, Layer, Schema, SchemaIssue } from "effect";
 import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
 
 import { runProcess } from "../../processRunner";
@@ -154,7 +154,7 @@ function decodeGitHubJson<S extends Schema.Top>(
       (error) =>
         new GitHubCliError({
           operation,
-          detail: error instanceof Error ? `${invalidDetail}: ${error.message}` : invalidDetail,
+          detail: `${invalidDetail}: ${SchemaIssue.makeFormatterDefault()(error.issue)}`,
           cause: error,
         }),
     ),

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -238,14 +238,7 @@ sessionErrorLayer("CodexAdapterLive session errors", (it) => {
         .pipe(Effect.result);
 
       assert.equal(result._tag, "Failure");
-      if (result._tag !== "Failure") {
-        return;
-      }
-
       assert.equal(result.failure._tag, "ProviderAdapterSessionNotFoundError");
-      if (result.failure._tag !== "ProviderAdapterSessionNotFoundError") {
-        return;
-      }
       assert.equal(result.failure.provider, "codex");
       assert.equal(result.failure.threadId, "sess-missing");
       assert.equal(result.failure.cause instanceof Error, true);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -51,18 +51,11 @@ export interface CodexAdapterLiveOptions {
   readonly nativeEventLogger?: EventNdjsonLogger;
 }
 
-function toMessage(cause: unknown, fallback: string): string {
-  if (cause instanceof Error && cause.message.length > 0) {
-    return cause.message;
-  }
-  return fallback;
-}
-
 function toSessionError(
   threadId: ThreadId,
   cause: unknown,
 ): ProviderAdapterSessionNotFoundError | ProviderAdapterSessionClosedError | undefined {
-  const normalized = toMessage(cause, "").toLowerCase();
+  const normalized = cause instanceof Error ? cause.message.toLowerCase() : "";
   if (normalized.includes("unknown session") || normalized.includes("unknown provider session")) {
     return new ProviderAdapterSessionNotFoundError({
       provider: PROVIDER,
@@ -88,7 +81,7 @@ function toRequestError(threadId: ThreadId, method: string, cause: unknown): Pro
   return new ProviderAdapterRequestError({
     provider: PROVIDER,
     method,
-    detail: toMessage(cause, `${method} failed`),
+    detail: cause instanceof Error ? `${method} failed: ${cause.message}` : `${method} failed`,
     cause,
   });
 }
@@ -1427,7 +1420,7 @@ const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           new ProviderAdapterProcessError({
             provider: PROVIDER,
             threadId: input.threadId,
-            detail: toMessage(cause, "Failed to start Codex adapter session."),
+            detail: `Failed to start Codex adapter session: ${cause instanceof Error ? cause.message : String(cause)}.`,
             cause,
           }),
       });
@@ -1455,7 +1448,7 @@ const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           new ProviderAdapterRequestError({
             provider: PROVIDER,
             method: "turn/start",
-            detail: toMessage(cause, "Failed to read attachment file."),
+            detail: `Failed to read attachment file: ${cause.message}.`,
             cause,
           }),
       ),

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -389,7 +389,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
         auth: { status: "unknown" },
         message: isCommandMissingCause(error)
           ? "Codex CLI (`codex`) is not installed or not on PATH."
-          : `Failed to execute Codex CLI health check: ${error instanceof Error ? error.message : String(error)}.`,
+          : `Failed to execute Codex CLI health check: ${error.message}.`,
       },
     });
   }
@@ -489,10 +489,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
         version: parsedVersion,
         status: "warning",
         auth: { status: "unknown" },
-        message:
-          error instanceof Error
-            ? `Could not verify Codex authentication status: ${error.message}.`
-            : "Could not verify Codex authentication status.",
+        message: `Could not verify Codex authentication status: ${error.message}.`,
       },
     });
   }

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -32,8 +32,7 @@ export function nonEmptyTrimmed(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-export function isCommandMissingCause(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
+export function isCommandMissingCause(error: Error): boolean {
   const lower = error.message.toLowerCase();
   return lower.includes("enoent") || lower.includes("notfound");
 }

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -8,7 +8,6 @@ import {
 } from "@t3tools/contracts";
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import {
-  Data,
   Effect,
   Encoding,
   Equal,
@@ -17,6 +16,7 @@ import {
   FileSystem,
   Layer,
   Option,
+  Schema,
   Scope,
   Semaphore,
   SynchronizedRef,
@@ -54,22 +54,28 @@ const DEFAULT_OPEN_COLS = 120;
 const DEFAULT_OPEN_ROWS = 30;
 const TERMINAL_ENV_BLOCKLIST = new Set(["PORT", "ELECTRON_RENDERER_PORT", "ELECTRON_RUN_AS_NODE"]);
 
-type TerminalSubprocessChecker = (
-  terminalPid: number,
-) => Effect.Effect<boolean, TerminalSubprocessCheckError>;
+class TerminalSubprocessCheckError extends Schema.TaggedErrorClass<TerminalSubprocessCheckError>()(
+  "TerminalSubprocessCheckError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+    terminalPid: Schema.Number,
+    command: Schema.Literals(["powershell", "pgrep", "ps"]),
+  },
+) {}
 
-class TerminalSubprocessCheckError extends Data.TaggedError("TerminalSubprocessCheckError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-  readonly terminalPid: number;
-  readonly command: "powershell" | "pgrep" | "ps";
-}> {}
+class TerminalProcessSignalError extends Schema.TaggedErrorClass<TerminalProcessSignalError>()(
+  "TerminalProcessSignalError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+    signal: Schema.Literals(["SIGTERM", "SIGKILL"]),
+  },
+) {}
 
-class TerminalProcessSignalError extends Data.TaggedError("TerminalProcessSignalError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-  readonly signal: "SIGTERM" | "SIGKILL";
-}> {}
+interface TerminalSubprocessChecker {
+  (terminalPid: number): Effect.Effect<boolean, TerminalSubprocessCheckError>;
+}
 
 interface ShellCandidate {
   shell: string;
@@ -271,9 +277,8 @@ function isRetryableShellSpawnError(error: PtySpawnError): boolean {
 
     if (current instanceof Error) {
       messages.push(current.message);
-      const cause = (current as { cause?: unknown }).cause;
-      if (cause) {
-        queue.push(cause);
+      if (current.cause) {
+        queue.push(current.cause);
       }
       continue;
     }
@@ -876,7 +881,7 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
             Effect.logWarning("failed to persist terminal history", {
               threadId,
               terminalId,
-              error: error instanceof Error ? error.message : String(error),
+              error,
             }),
           ),
         );
@@ -959,7 +964,7 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
         Effect.catch((cleanupError) =>
           Effect.logWarning("failed to remove legacy terminal history", {
             threadId,
-            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+            error: cleanupError,
           }),
         ),
       );
@@ -975,7 +980,7 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
           Effect.logWarning("failed to delete terminal history", {
             threadId,
             terminalId,
-            error: error instanceof Error ? error.message : String(error),
+            error,
           }),
         ),
       );
@@ -985,7 +990,7 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
             Effect.logWarning("failed to delete terminal history", {
               threadId,
               terminalId,
-              error: error instanceof Error ? error.message : String(error),
+              error,
             }),
           ),
         );
@@ -1011,7 +1016,7 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
             Effect.catch((error) =>
               Effect.logWarning("failed to delete terminal histories for thread", {
                 threadId,
-                error: error instanceof Error ? error.message : String(error),
+                error,
               }),
             ),
           ),
@@ -1463,12 +1468,12 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
         const terminalPid = session.pid;
         const hasRunningSubprocess = yield* subprocessChecker(terminalPid).pipe(
           Effect.map(Option.some),
-          Effect.catch((error) =>
+          Effect.catch((reason) =>
             Effect.logWarning("failed to check terminal subprocess activity", {
               threadId: session.threadId,
               terminalId: session.terminalId,
               terminalPid,
-              error: error instanceof Error ? error.message : String(error),
+              reason,
             }).pipe(Effect.as(Option.none<boolean>())),
           ),
         );

--- a/apps/server/src/workspace/Layers/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceEntries.ts
@@ -214,9 +214,6 @@ function directoryAncestorsOf(relativePath: string): string[] {
   return directories;
 }
 
-const processErrorDetail = (cause: unknown): string =>
-  cause instanceof Error ? cause.message : String(cause);
-
 export const makeWorkspaceEntries = Effect.gen(function* () {
   const path = yield* Path.Path;
   const gitOption = yield* Effect.serviceOption(GitCore);
@@ -319,7 +316,7 @@ export const makeWorkspaceEntries = Effect.gen(function* () {
         new WorkspaceEntriesError({
           cwd,
           operation: "workspaceEntries.readDirectoryEntries",
-          detail: processErrorDetail(cause),
+          detail: cause instanceof Error ? cause.message : String(cause),
           cause,
         }),
     }).pipe(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -313,10 +313,7 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
                     worktreePath: input.worktreePath,
                     scriptId: input.scriptId,
                     terminalId: input.terminalId,
-                    detail:
-                      error instanceof Error
-                        ? error.message
-                        : "Unknown setup activity dispatch failure.",
+                    detail: error.message,
                   },
                 ),
               ),

--- a/apps/web/src/environments/primary/auth.ts
+++ b/apps/web/src/environments/primary/auth.ts
@@ -16,6 +16,14 @@ import {
 } from "../../pairingUrl";
 
 import { resolvePrimaryEnvironmentHttpUrl } from "./target";
+import { Data, Predicate } from "effect";
+
+export class BootstrapHttpError extends Data.TaggedError("BootstrapHttpError")<{
+  readonly message: string;
+  readonly status: number;
+}> {}
+const isBootstrapHttpError = (u: unknown): u is BootstrapHttpError =>
+  Predicate.isTagged(u, "BootstrapHttpError");
 
 export interface ServerPairingLinkRecord {
   readonly id: string;
@@ -87,10 +95,10 @@ export async function fetchSessionState(): Promise<AuthSessionState> {
       credentials: "include",
     });
     if (!response.ok) {
-      throw new BootstrapHttpError(
-        `Failed to load server auth session state (${response.status}).`,
-        response.status,
-      );
+      throw new BootstrapHttpError({
+        message: `Failed to load server auth session state (${response.status}).`,
+        status: response.status,
+      });
     }
     return (await response.json()) as AuthSessionState;
   });
@@ -115,10 +123,10 @@ async function exchangeBootstrapCredential(credential: string): Promise<AuthBoot
 
     if (!response.ok) {
       const message = await response.text();
-      throw new BootstrapHttpError(
-        message || `Failed to bootstrap auth session (${response.status}).`,
-        response.status,
-      );
+      throw new BootstrapHttpError({
+        message: message || `Failed to bootstrap auth session (${response.status}).`,
+        status: response.status,
+      });
     }
 
     return (await response.json()) as AuthBootstrapResult;
@@ -146,16 +154,6 @@ const TRANSIENT_BOOTSTRAP_STATUS_CODES = new Set([502, 503, 504]);
 const BOOTSTRAP_RETRY_TIMEOUT_MS = 15_000;
 const BOOTSTRAP_RETRY_STEP_MS = 500;
 
-export class BootstrapHttpError extends Error {
-  readonly status: number;
-
-  constructor(message: string, status: number) {
-    super(message);
-    this.name = "BootstrapHttpError";
-    this.status = status;
-  }
-}
-
 export async function retryTransientBootstrap<T>(operation: () => Promise<T>): Promise<T> {
   const startedAt = Date.now();
   while (true) {
@@ -182,7 +180,7 @@ function waitForBootstrapRetry(delayMs: number): Promise<void> {
 }
 
 function isTransientBootstrapError(error: unknown): boolean {
-  if (error instanceof BootstrapHttpError) {
+  if (isBootstrapHttpError(error)) {
     return TRANSIENT_BOOTSTRAP_STATUS_CODES.has(error.status);
   }
 

--- a/apps/web/src/environments/primary/context.ts
+++ b/apps/web/src/environments/primary/context.ts
@@ -52,10 +52,10 @@ async function fetchPrimaryEnvironmentDescriptor(): Promise<ExecutionEnvironment
       resolvePrimaryEnvironmentHttpUrl(SERVER_ENVIRONMENT_DESCRIPTOR_PATH),
     );
     if (!response.ok) {
-      throw new BootstrapHttpError(
-        `Failed to load server environment descriptor (${response.status}).`,
-        response.status,
-      );
+      throw new BootstrapHttpError({
+        message: `Failed to load server environment descriptor (${response.status}).`,
+        status: response.status,
+      });
     }
 
     const descriptor = (await response.json()) as ExecutionEnvironmentDescriptor;

--- a/package.json
+++ b/package.json
@@ -62,7 +62,13 @@
     "vitest": "catalog:"
   },
   "overrides": {
+    "@effect/atom-react": "catalog:",
+    "@effect/platform-bun": "catalog:",
+    "@effect/platform-node": "catalog:",
     "@effect/platform-node-shared": "catalog:",
+    "@effect/sql-sqlite-bun": "catalog:",
+    "@effect/vitest": "catalog:",
+    "effect": "catalog:",
     "vite": "^8.0.0"
   },
   "engines": {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -425,9 +425,9 @@ function validateBundledClientAssets(clientDir: string) {
 }
 
 function resolveDesktopRuntimeDependencies(
-  dependencies: Record<string, unknown> | undefined,
-  catalog: Record<string, unknown>,
-): Record<string, unknown> {
+  dependencies: Record<string, string> | undefined,
+  catalog: Record<string, string>,
+): Record<string, string> {
   if (!dependencies || Object.keys(dependencies).length === 0) {
     return {};
   }

--- a/scripts/lib/resolve-catalog.ts
+++ b/scripts/lib/resolve-catalog.ts
@@ -5,10 +5,10 @@
  * the concrete version string found in `catalog`. Throws on missing entries.
  */
 export function resolveCatalogDependencies(
-  dependencies: Record<string, unknown>,
-  catalog: Record<string, unknown>,
+  dependencies: Record<string, string>,
+  catalog: Record<string, string>,
   label: string,
-): Record<string, unknown> {
+): Record<string, string> {
   return Object.fromEntries(
     Object.entries(dependencies).map(([name, spec]) => {
       if (typeof spec !== "string" || !spec.startsWith("catalog:")) {


### PR DESCRIPTION
Closes #1887

## Summary
- harden server secret store error handling so missing files and already-existing secrets are handled explicitly
- resolve root-level catalog overrides into the published server package metadata
- remove redundant `instanceof` checks from the non-Claude typed error paths touched by this PR

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret storage and several error-mapping paths; while mostly defensive/error-message changes, regressions could affect secret reads/writes and provider/bootstrap resiliency.
> 
> **Overview**
> **Publishing now includes workspace overrides.** The server `publish` CLI writes a temporary `package.json` that resolves both `dependencies` *and* root-level `overrides` from the workspace catalog, with tighter typing around the generated metadata.
> 
> **Error handling is standardized and more informative.** The server secret store tightens concurrent/missing-file handling using tagged `PlatformError` detection; several layers (`GitHubCli`, `GitCore`, `CodexAdapter`/`CodexProvider`, terminal manager, workspace entries, websocket bootstrap logging) simplify `instanceof` branches and improve propagated error detail/log payloads. On the web side, `BootstrapHttpError` becomes an `effect` `Data.TaggedError` and transient-retry detection switches to tag-based predicates.
> 
> **Dependency/catalog typing is tightened.** `resolveCatalogDependencies` (and callers like desktop artifact build) now operate on `Record<string, string>` instead of `unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83abc7623b7023c995a57cf09a05a230d793c626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden secret store error handling and resolve catalog overrides in publish flow
> - Fixes `ServerSecretStore` error handling to branch on `cause.reason._tag` directly instead of using removed `isMissingSecretFileError`/`isAlreadyExistsSecretFileError` helpers, using `Predicate.isTagged` for `PlatformError` detection.
> - Extends the `publishCmd` handler in [cli.ts](https://github.com/pingdotgg/t3code/pull/1891/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) to write a resolved `overrides` field (from the root workspace catalog) alongside dependencies in the temporary `package.json` used for npm publish.
> - Replaces `instanceof`-based `BootstrapHttpError` with a `Data.TaggedError` and `Predicate.isTagged` guard across [auth.ts](https://github.com/pingdotgg/t3code/pull/1891/files#diff-890ed82ba4e0838569b58c8c7aff7ce2995879306e5287324879a4a91b33e27c) and [context.ts](https://github.com/pingdotgg/t3code/pull/1891/files#diff-1991ea7dc3bf72806740f3cd9bbaa76f0a749dba781021f754e0f13b162efd44).
> - Standardizes error detail construction across multiple adapters and layers to use `error.message` directly rather than `String(error)` fallbacks.
> - Tightens `resolveCatalogDependencies` parameter and return types from `Record<string, unknown>` to `Record<string, string>`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83abc76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->