### PR TITLE
fix: trim publisherName to prevent Windows auto-update signature

### DIFF
--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -186,7 +186,9 @@ interface StagePackageJson {
 }
 
 const AzureTrustedSigningOptionsConfig = Config.all({
-  publisherName: Config.string("AZURE_TRUSTED_SIGNING_PUBLISHER_NAME"),
+  publisherName: Config.string("AZURE_TRUSTED_SIGNING_PUBLISHER_NAME").pipe(
+    Config.map((s) => s.trim()),
+  ),
   endpoint: Config.string("AZURE_TRUSTED_SIGNING_ENDPOINT"),
   certificateProfileName: Config.string("AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME"),
   codeSigningAccountName: Config.string("AZURE_TRUSTED_SIGNING_ACCOUNT_NAME"),


### PR DESCRIPTION
mismatch

The AZURE_TRUSTED_SIGNING_PUBLISHER_NAME secret contains a trailing space
that propagates into app-update.yml. electron-updater does a strict === comparison between this value and the certificate CN, so "T3 Tools Inc " !== "T3 Tools Inc" causes updates to be rejected with "not signed by the application owner".

Add .trim() via Config.map to strip whitespace as defense-in-depth.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only normalizes `AZURE_TRUSTED_SIGNING_PUBLISHER_NAME` by trimming whitespace, affecting Windows signing metadata but not altering signing behavior otherwise.
> 
> **Overview**
> Prevents Windows auto-update signature mismatches by trimming whitespace from `AZURE_TRUSTED_SIGNING_PUBLISHER_NAME` when building `azureSignOptions`, ensuring the generated publisher name matches the certificate CN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1e15e766c27005e7ec97319e6242b7d5993a235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trim `publisherName` to prevent Windows auto-update signature failures
> Trims leading and trailing whitespace from the `AZURE_TRUSTED_SIGNING_PUBLISHER_NAME` env var in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/1892/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d). Whitespace in the publisher name can cause signature verification mismatches during Windows auto-update checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1e15e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->