### PR TITLE
[codex] fix composer footer compact layout

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -717,17 +717,30 @@ function createSnapshotWithPendingUserInput(): OrchestrationReadModel {
   };
 }
 
-function createSnapshotWithPlanFollowUpPrompt(): OrchestrationReadModel {
+function createSnapshotWithPlanFollowUpPrompt(options?: {
+  modelSelection?: { provider: "codex"; model: string };
+  planMarkdown?: string;
+}): OrchestrationReadModel {
   const snapshot = createSnapshotForTargetUser({
     targetMessageId: "msg-user-plan-follow-up-target" as MessageId,
     targetText: "plan follow-up thread",
   });
+  const modelSelection = options?.modelSelection ?? {
+    provider: "codex" as const,
+    model: "gpt-5",
+  };
+  const planMarkdown =
+    options?.planMarkdown ?? "# Follow-up plan\n\n- Keep the composer footer stable on resize.";
 
   return {
     ...snapshot,
+    projects: snapshot.projects.map((project) =>
+      project.id === PROJECT_ID ? { ...project, defaultModelSelection: modelSelection } : project,
+    ),
     threads: snapshot.threads.map((thread) =>
       thread.id === THREAD_ID
         ? Object.assign({}, thread, {
+            modelSelection,
             interactionMode: "plan",
             latestTurn: {
               turnId: "turn-plan-follow-up" as TurnId,
@@ -741,7 +754,7 @@ function createSnapshotWithPlanFollowUpPrompt(): OrchestrationReadModel {
               {
                 id: "plan-follow-up-browser-test",
                 turnId: "turn-plan-follow-up" as TurnId,
-                planMarkdown: "# Follow-up plan\n\n- Keep the composer footer stable on resize.",
+                planMarkdown,
                 implementedAt: null,
                 implementationThreadId: null,
                 createdAt: isoAt(1_002),
@@ -3606,8 +3619,9 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
       const initialModelPickerOffset =
         initialModelPicker.getBoundingClientRect().left - footer.getBoundingClientRect().left;
+      const initialImplementButton = await waitForButtonByText("Implement");
+      const initialImplementWidth = initialImplementButton.getBoundingClientRect().width;
 
-      await waitForButtonByText("Implement");
       await waitForElement(
         () =>
           document.querySelector<HTMLButtonElement>('button[aria-label="Implementation actions"]'),
@@ -3639,9 +3653,77 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
           expect(Math.abs(implementRect.right - implementActionsRect.left)).toBeLessThanOrEqual(1);
           expect(Math.abs(implementRect.top - implementActionsRect.top)).toBeLessThanOrEqual(1);
+          expect(Math.abs(implementRect.width - initialImplementWidth)).toBeLessThanOrEqual(1);
           expect(Math.abs(compactModelPickerOffset - initialModelPickerOffset)).toBeLessThanOrEqual(
             1,
           );
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("keeps the wide desktop follow-up layout expanded when the footer still fits", async () => {
+    const mounted = await mountChatView({
+      viewport: WIDE_FOOTER_VIEWPORT,
+      snapshot: createSnapshotWithPlanFollowUpPrompt({
+        modelSelection: { provider: "codex", model: "gpt-5.3-codex-spark" },
+        planMarkdown:
+          "# Imaginary Long-Range Plan: T3 Code Adaptive Orchestration and Safe-Delay Execution Initiative",
+      }),
+    });
+
+    try {
+      await waitForButtonByText("Implement");
+
+      await vi.waitFor(
+        () => {
+          const footer = document.querySelector<HTMLElement>('[data-chat-composer-footer="true"]');
+          const actions = document.querySelector<HTMLElement>(
+            '[data-chat-composer-actions="right"]',
+          );
+
+          expect(footer?.dataset.chatComposerFooterCompact).toBe("false");
+          expect(actions?.dataset.chatComposerPrimaryActionsCompact).toBe("false");
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("compacts the footer when a wide desktop follow-up layout starts overflowing", async () => {
+    const mounted = await mountChatView({
+      viewport: WIDE_FOOTER_VIEWPORT,
+      snapshot: createSnapshotWithPlanFollowUpPrompt({
+        modelSelection: { provider: "codex", model: "gpt-5.3-codex-spark" },
+        planMarkdown:
+          "# Imaginary Long-Range Plan: T3 Code Adaptive Orchestration and Safe-Delay Execution Initiative",
+      }),
+    });
+
+    try {
+      await waitForButtonByText("Implement");
+
+      await mounted.setContainerSize({
+        width: 804,
+        height: WIDE_FOOTER_VIEWPORT.height,
+      });
+
+      await expectComposerActionsContained();
+
+      await vi.waitFor(
+        () => {
+          const footer = document.querySelector<HTMLElement>('[data-chat-composer-footer="true"]');
+          const actions = document.querySelector<HTMLElement>(
+            '[data-chat-composer-actions="right"]',
+          );
+
+          expect(footer?.dataset.chatComposerFooterCompact).toBe("true");
+          expect(actions?.dataset.chatComposerPrimaryActionsCompact).toBe("true");
         },
         { timeout: 8_000, interval: 16 },
       );

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -55,8 +55,6 @@ import {
   removeInlineTerminalContextPlaceholder,
 } from "../../lib/terminalContext";
 import {
-  resolveComposerFooterContentWidth,
-  shouldForceCompactComposerFooterForFit,
   shouldUseCompactComposerPrimaryActions,
   shouldUseCompactComposerFooter,
 } from "../composerFooterLayout";
@@ -646,9 +644,6 @@ export const ChatComposer = memo(
     const composerEditorRef = useRef<ComposerPromptEditorHandle>(null);
     const composerFormRef = useRef<HTMLFormElement>(null);
     const composerFormHeightRef = useRef(0);
-    const composerFooterRef = useRef<HTMLDivElement>(null);
-    const composerFooterLeadingRef = useRef<HTMLDivElement>(null);
-    const composerFooterActionsRef = useRef<HTMLDivElement>(null);
     const composerSelectLockRef = useRef(false);
     const composerMenuOpenRef = useRef(false);
     const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
@@ -1017,31 +1012,17 @@ export const ChatComposer = memo(
       const measureComposerFormWidth = () => composerForm.clientWidth;
       const measureFooterCompactness = () => {
         const composerFormWidth = measureComposerFormWidth();
-        const heuristicFooterCompact = shouldUseCompactComposerFooter(composerFormWidth, {
+        const footerCompact = shouldUseCompactComposerFooter(composerFormWidth, {
           hasWideActions: composerFooterHasWideActions,
         });
-        const footer = composerFooterRef.current;
-        const footerStyle = footer ? window.getComputedStyle(footer) : null;
-        const footerContentWidth = resolveComposerFooterContentWidth({
-          footerWidth: footer?.clientWidth ?? null,
-          paddingLeft: footerStyle ? Number.parseFloat(footerStyle.paddingLeft) : null,
-          paddingRight: footerStyle ? Number.parseFloat(footerStyle.paddingRight) : null,
-        });
-        const fitInput = {
-          footerContentWidth,
-          leadingContentWidth: composerFooterLeadingRef.current?.scrollWidth ?? null,
-          actionsWidth: composerFooterActionsRef.current?.scrollWidth ?? null,
-        };
-        const nextFooterCompact =
-          heuristicFooterCompact || shouldForceCompactComposerFooterForFit(fitInput);
-        const nextPrimaryActionsCompact =
-          nextFooterCompact &&
+        const primaryActionsCompact =
+          footerCompact &&
           shouldUseCompactComposerPrimaryActions(composerFormWidth, {
             hasWideActions: composerFooterHasWideActions,
           });
         return {
-          primaryActionsCompact: nextPrimaryActionsCompact,
-          footerCompact: nextFooterCompact,
+          primaryActionsCompact,
+          footerCompact,
         };
       };
 
@@ -1795,7 +1776,6 @@ export const ChatComposer = memo(
               </div>
             ) : (
               <div
-                ref={composerFooterRef}
                 data-chat-composer-footer="true"
                 data-chat-composer-footer-compact={isComposerFooterCompact ? "true" : "false"}
                 className={cn(
@@ -1803,15 +1783,7 @@ export const ChatComposer = memo(
                   isComposerFooterCompact ? "gap-1.5" : "gap-2 sm:gap-0",
                 )}
               >
-                <div
-                  ref={composerFooterLeadingRef}
-                  className={cn(
-                    "flex min-w-0 flex-1 items-center",
-                    isComposerFooterCompact
-                      ? "gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-                      : "gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden sm:min-w-max sm:overflow-visible",
-                  )}
-                >
+                <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                   <ProviderModelPicker
                     compact={isComposerFooterCompact}
                     provider={selectedProvider}
@@ -1865,7 +1837,6 @@ export const ChatComposer = memo(
 
                 {/* Right side: send / stop button */}
                 <div
-                  ref={composerFooterActionsRef}
                   data-chat-composer-actions="right"
                   data-chat-composer-primary-actions-compact={
                     isComposerPrimaryActionsCompact ? "true" : "false"

--- a/apps/web/src/components/chat/ComposerPrimaryActions.tsx
+++ b/apps/web/src/components/chat/ComposerPrimaryActions.tsx
@@ -140,7 +140,7 @@ export const ComposerPrimaryActions = memo(function ComposerPrimaryActions({
         <Button
           type="submit"
           size="sm"
-          className={cn("h-9 rounded-l-full rounded-r-none sm:h-8", compact ? "px-3" : "px-4")}
+          className="h-9 rounded-l-full rounded-r-none px-4 sm:h-8"
           disabled={isSendBusy || isConnecting}
         >
           {isConnecting || isSendBusy ? "Sending..." : "Implement"}

--- a/apps/web/src/components/composerFooterLayout.test.ts
+++ b/apps/web/src/components/composerFooterLayout.test.ts
@@ -4,9 +4,6 @@ import {
   COMPOSER_FOOTER_COMPACT_BREAKPOINT_PX,
   COMPOSER_FOOTER_WIDE_ACTIONS_COMPACT_BREAKPOINT_PX,
   COMPOSER_PRIMARY_ACTIONS_COMPACT_BREAKPOINT_PX,
-  measureComposerFooterOverflowPx,
-  resolveComposerFooterContentWidth,
-  shouldForceCompactComposerFooterForFit,
   shouldUseCompactComposerPrimaryActions,
   shouldUseCompactComposerFooter,
 } from "./composerFooterLayout";
@@ -54,101 +51,5 @@ describe("shouldUseCompactComposerPrimaryActions", () => {
         hasWideActions: true,
       }),
     ).toBe(false);
-  });
-});
-
-describe("measureComposerFooterOverflowPx", () => {
-  it("returns the overflow amount when content exceeds the footer width", () => {
-    expect(
-      measureComposerFooterOverflowPx({
-        footerContentWidth: 500,
-        leadingContentWidth: 340,
-        actionsWidth: 180,
-      }),
-    ).toBe(28);
-  });
-
-  it("returns zero when content fits", () => {
-    expect(
-      measureComposerFooterOverflowPx({
-        footerContentWidth: 500,
-        leadingContentWidth: 320,
-        actionsWidth: 160,
-      }),
-    ).toBe(0);
-  });
-});
-
-describe("shouldForceCompactComposerFooterForFit", () => {
-  it("stays expanded when content widths fit within the footer", () => {
-    expect(
-      shouldForceCompactComposerFooterForFit({
-        footerContentWidth: 500,
-        leadingContentWidth: 320,
-        actionsWidth: 160,
-      }),
-    ).toBe(false);
-  });
-
-  it("stays expanded when minor overflow can be recovered by compacting primary actions", () => {
-    expect(
-      shouldForceCompactComposerFooterForFit({
-        footerContentWidth: 500,
-        leadingContentWidth: 340,
-        actionsWidth: 180,
-      }),
-    ).toBe(false);
-  });
-
-  it("forces footer compact mode when action compaction would not recover enough space", () => {
-    expect(
-      shouldForceCompactComposerFooterForFit({
-        footerContentWidth: 500,
-        leadingContentWidth: 420,
-        actionsWidth: 220,
-      }),
-    ).toBe(true);
-  });
-
-  it("ignores incomplete measurements", () => {
-    expect(
-      shouldForceCompactComposerFooterForFit({
-        footerContentWidth: null,
-        leadingContentWidth: 340,
-        actionsWidth: 180,
-      }),
-    ).toBe(false);
-  });
-});
-
-describe("resolveComposerFooterContentWidth", () => {
-  it("subtracts horizontal padding from the measured footer width", () => {
-    expect(
-      resolveComposerFooterContentWidth({
-        footerWidth: 500,
-        paddingLeft: 10,
-        paddingRight: 10,
-      }),
-    ).toBe(480);
-  });
-
-  it("clamps negative widths to zero", () => {
-    expect(
-      resolveComposerFooterContentWidth({
-        footerWidth: 10,
-        paddingLeft: 8,
-        paddingRight: 8,
-      }),
-    ).toBe(0);
-  });
-
-  it("returns null when measurements are incomplete", () => {
-    expect(
-      resolveComposerFooterContentWidth({
-        footerWidth: null,
-        paddingLeft: 8,
-        paddingRight: 8,
-      }),
-    ).toBeNull();
   });
 });

--- a/apps/web/src/components/composerFooterLayout.ts
+++ b/apps/web/src/components/composerFooterLayout.ts
@@ -2,8 +2,6 @@ export const COMPOSER_FOOTER_COMPACT_BREAKPOINT_PX = 620;
 export const COMPOSER_FOOTER_WIDE_ACTIONS_COMPACT_BREAKPOINT_PX = 780;
 export const COMPOSER_PRIMARY_ACTIONS_COMPACT_BREAKPOINT_PX =
   COMPOSER_FOOTER_WIDE_ACTIONS_COMPACT_BREAKPOINT_PX;
-const COMPOSER_FOOTER_CONTENT_GAP_PX = 8;
-const COMPOSER_PRIMARY_ACTIONS_COMPACT_RECOVERY_PX = 120;
 
 export function shouldUseCompactComposerFooter(
   width: number | null,
@@ -23,47 +21,4 @@ export function shouldUseCompactComposerPrimaryActions(
     return false;
   }
   return width !== null && width < COMPOSER_PRIMARY_ACTIONS_COMPACT_BREAKPOINT_PX;
-}
-
-export function measureComposerFooterOverflowPx(input: {
-  footerContentWidth: number | null;
-  leadingContentWidth: number | null;
-  actionsWidth: number | null;
-}): number | null {
-  const footerContentWidth = input.footerContentWidth;
-  const leadingContentWidth = input.leadingContentWidth;
-  const actionsWidth = input.actionsWidth;
-  if (footerContentWidth === null || leadingContentWidth === null || actionsWidth === null) {
-    return null;
-  }
-  return Math.max(
-    0,
-    leadingContentWidth + actionsWidth + COMPOSER_FOOTER_CONTENT_GAP_PX - footerContentWidth,
-  );
-}
-
-export function shouldForceCompactComposerFooterForFit(input: {
-  footerContentWidth: number | null;
-  leadingContentWidth: number | null;
-  actionsWidth: number | null;
-}): boolean {
-  const overflowPx = measureComposerFooterOverflowPx(input);
-  if (overflowPx === null) {
-    return false;
-  }
-  return overflowPx > COMPOSER_PRIMARY_ACTIONS_COMPACT_RECOVERY_PX;
-}
-
-export function resolveComposerFooterContentWidth(input: {
-  footerWidth: number | null;
-  paddingLeft: number | null;
-  paddingRight: number | null;
-}): number | null {
-  const footerWidth = input.footerWidth;
-  const paddingLeft = input.paddingLeft;
-  const paddingRight = input.paddingRight;
-  if (footerWidth === null || paddingLeft === null || paddingRight === null) {
-    return null;
-  }
-  return Math.max(0, footerWidth - paddingLeft - paddingRight);
 }


### PR DESCRIPTION
## What changed

- removed the composer footer's measurement-based overflow heuristic and switched back to breakpoint-driven compacting
- made the left-side footer controls yield space via horizontal scrolling so they cannot push the right action cluster out of bounds
- kept the plan follow-up `Implement` button width stable across the compact transition to remove the remaining layout shift
- added browser regressions for both wide-desktop fit states and the plan follow-up resize path

## Why

The previous fix still allowed a dead zone where the footer could overflow near the compact breakpoint. The follow-up measurement-based heuristic also made the layout too sensitive to scroll width and introduced false compacting. The more reliable fix is to make the footer layout itself resilient: the leading controls can shrink and scroll, while the primary actions stay pinned.

## UI changes

before
<img width="795" height="244" alt="image" src="https://github.com/user-attachments/assets/77f180c0-65a8-4a0e-9e89-02e739a5d845" />

after

https://github.com/user-attachments/assets/e8c25f34-2a23-4b8d-bf1b-47432d36de7d



## Impact

- prevents the composer action buttons from overflowing during plan follow-up states
- preserves the expanded desktop layout when the footer still fits
- removes the `Implement` button width jump when compact mode activates

## Validation

- `bun fmt`
- `bun run --cwd apps/web test src/components/composerFooterLayout.test.ts`
- `bun run --cwd apps/web test:browser src/components/ChatView.browser.tsx --testNamePattern "wide desktop follow-up layout|keeps plan follow-up footer actions fused and aligned after a real resize"`
- `bun lint`
- `bun typecheck`

## Notes

`bun lint` still reports one pre-existing warning in `apps/web/src/environments/runtime/catalog.test.ts` about `resolveRegistryRead` function scoping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI layout logic for the chat composer footer is reworked and could cause regressions at edge viewport widths or in wide-action states (plan follow-up, pending input). Changes are localized to client layout/behavior and covered by added browser tests.
> 
> **Overview**
> **Chat composer footer compaction is reverted to pure breakpoint logic.** The measurement-based overflow heuristic is removed (and associated helpers/tests deleted), so compact/primary-action modes now depend only on container width and `hasWideActions`.
> 
> **Footer layout is made more resilient under tight widths.** The left control cluster always uses horizontal scrolling so it yields space without pushing the right action buttons out of bounds, and the plan follow-up `Implement` button padding is fixed to keep its width stable across compact transitions.
> 
> **Regression coverage is expanded.** Browser tests now validate wide-desktop plan follow-up stays expanded when it fits, compacts when it overflows, and that `Implement` width/alignment remain stable after a real resize (with snapshot helpers extended to vary model/plan text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0292198e879348821346f99d8bc831e39585e250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix composer footer compact layout to use width-based breakpoints only
> - Removes DOM measurement logic (`measureComposerFooterOverflowPx`, `resolveComposerFooterContentWidth`, `shouldForceCompactComposerFooterForFit`) from [composerFooterLayout.ts](https://github.com/pingdotgg/t3code/pull/1894/files#diff-f2c45cfa4b4b1e011f20b2464141c82ddc1b7023b5d2707e33b4ab4504c747f8) and [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/1894/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a), replacing it with pure width-based heuristics.
> - The leading section in the composer footer now always uses `overflow-x-auto` instead of switching between overflow modes based on compact state.
> - Fixes the Implement button in [ComposerPrimaryActions.tsx](https://github.com/pingdotgg/t3code/pull/1894/files#diff-28d31fd574e3535ff0779ae0eb5d4e013538daa6a7fea0bde46121e112310081) to always use `px-4` padding, giving it a consistent width across compact and non-compact modes.
> - Behavioral Change: compact state now depends solely on container width breakpoints and `hasWideActions`, not on measured content overflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0292198.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->