### PR TITLE
Fix archived-only project deletion (superseded)

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -965,6 +965,89 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("tracks server tool blocks as runtime tool items", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 8).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      const session = yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      const turn = yield* adapter.sendTurn({
+        threadId: session.threadId,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-server-tool",
+        uuid: "stream-server-tool-start",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "server_tool_use",
+            id: "server-tool-1",
+            name: "Bash",
+            input: {
+              command: "pwd",
+            },
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-server-tool",
+        uuid: "stream-server-tool-stop",
+        parent_tool_use_id: null,
+        event: {
+          type: "content_block_stop",
+          index: 0,
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        errors: [],
+        session_id: "sdk-session-server-tool",
+        uuid: "result-server-tool",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const toolStarted = runtimeEvents.find((event) => event.type === "item.started");
+      assert.equal(toolStarted?.type, "item.started");
+      if (toolStarted?.type === "item.started") {
+        assert.equal(toolStarted.payload.itemType, "command_execution");
+        assert.equal(String(toolStarted.turnId), String(turn.turnId));
+      }
+
+      const toolCompleted = runtimeEvents.find(
+        (event) =>
+          event.type === "item.completed" && event.payload.itemType === "command_execution",
+      );
+      assert.equal(toolCompleted?.type, "item.completed");
+      if (toolCompleted?.type === "item.completed") {
+        assert.equal(String(toolCompleted.turnId), String(turn.turnId));
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("classifies Claude Task tool invocations as collaboration agent work", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -909,6 +909,38 @@ function sdkNativeItemId(message: SDKMessage): string | undefined {
   return undefined;
 }
 
+type ClaudeToolStartBlock = {
+  readonly type: "tool_use" | "server_tool_use" | "mcp_tool_use";
+  readonly id: string;
+  readonly name: string;
+  readonly input?: unknown;
+};
+
+function getClaudeToolStartBlock(block: unknown): ClaudeToolStartBlock | undefined {
+  if (typeof block !== "object" || block === null) {
+    return undefined;
+  }
+
+  const candidate = block as Record<string, unknown>;
+  if (
+    candidate.type !== "tool_use" &&
+    candidate.type !== "server_tool_use" &&
+    candidate.type !== "mcp_tool_use"
+  ) {
+    return undefined;
+  }
+  if (typeof candidate.id !== "string" || typeof candidate.name !== "string") {
+    return undefined;
+  }
+
+  return {
+    type: candidate.type,
+    id: candidate.id,
+    name: candidate.name,
+    ...(Object.hasOwn(candidate, "input") ? { input: candidate.input } : {}),
+  };
+}
+
 const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   options?: ClaudeAdapterLiveOptions,
 ) {
@@ -1629,21 +1661,18 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
         return;
       }
-      if (
-        block.type !== "tool_use" &&
-        block.type !== "server_tool_use" &&
-        block.type !== "mcp_tool_use"
-      ) {
+      const toolBlock = getClaudeToolStartBlock(block);
+      if (!toolBlock) {
         return;
       }
 
-      const toolName = block.name;
+      const toolName = toolBlock.name;
       const itemType = classifyToolItemType(toolName);
       const toolInput =
-        typeof block.input === "object" && block.input !== null
-          ? (block.input as Record<string, unknown>)
+        typeof toolBlock.input === "object" && toolBlock.input !== null
+          ? (toolBlock.input as Record<string, unknown>)
           : {};
-      const itemId = block.id;
+      const itemId = toolBlock.id;
       const detail = summarizeToolRequest(toolName, toolInput);
       const inputFingerprint =
         Object.keys(toolInput).length > 0 ? toolInputFingerprint(toolInput) : undefined;

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   createThreadJumpHintVisibilityController,
+  getSidebarThreadsByIds,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
   getFallbackThreadIdAfterDelete,
@@ -618,6 +619,55 @@ describe("getVisibleThreadsForProject", () => {
       threads.map((thread) => thread.id),
     );
     expect(result.hiddenThreads).toEqual([]);
+  });
+});
+
+describe("getSidebarThreadsByIds", () => {
+  it("filters out archived and missing threads by default", () => {
+    const visibleThread = makeThread({
+      id: ThreadId.makeUnsafe("thread-visible"),
+      archivedAt: null,
+    });
+    const archivedThread = makeThread({
+      id: ThreadId.makeUnsafe("thread-archived"),
+      archivedAt: "2026-03-09T10:11:00.000Z",
+    });
+
+    const result = getSidebarThreadsByIds({
+      threadIds: [
+        ThreadId.makeUnsafe("thread-visible"),
+        ThreadId.makeUnsafe("thread-missing"),
+        ThreadId.makeUnsafe("thread-archived"),
+      ],
+      threadsById: {
+        [visibleThread.id]: visibleThread,
+        [archivedThread.id]: archivedThread,
+      },
+    });
+
+    expect(result).toEqual([visibleThread]);
+  });
+
+  it("can include archived threads for callers that need the full project set", () => {
+    const visibleThread = makeThread({
+      id: ThreadId.makeUnsafe("thread-visible"),
+      archivedAt: null,
+    });
+    const archivedThread = makeThread({
+      id: ThreadId.makeUnsafe("thread-archived"),
+      archivedAt: "2026-03-09T10:11:00.000Z",
+    });
+
+    const result = getSidebarThreadsByIds({
+      threadIds: [visibleThread.id, archivedThread.id],
+      threadsById: {
+        [visibleThread.id]: visibleThread,
+        [archivedThread.id]: archivedThread,
+      },
+      includeArchived: true,
+    });
+
+    expect(result).toEqual([visibleThread, archivedThread]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -241,6 +241,26 @@ export function getVisibleSidebarThreadIds<TThreadId>(
   );
 }
 
+export function getSidebarThreadsByIds<
+  TThreadId extends PropertyKey,
+  TThread extends { archivedAt: string | null },
+>(input: {
+  threadIds: readonly TThreadId[];
+  threadsById: Partial<Record<TThreadId, TThread | undefined>>;
+  includeArchived?: boolean;
+}): TThread[] {
+  const threads = input.threadIds.flatMap((threadId) => {
+    const thread = input.threadsById[threadId];
+    return thread === undefined ? [] : [thread];
+  });
+
+  if (input.includeArchived) {
+    return threads;
+  }
+
+  return threads.filter((thread) => thread.archivedAt === null);
+}
+
 export function resolveAdjacentThreadId<T>(input: {
   threadIds: readonly T[];
   currentThreadId: T | null;

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -110,6 +110,7 @@ import {
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { isNonEmpty as isNonEmptyString } from "effect/String";
 import {
+  getSidebarThreadsByIds,
   getVisibleSidebarThreadIds,
   getVisibleThreadsForProject,
   resolveAdjacentThreadId,
@@ -850,10 +851,10 @@ export default function Sidebar() {
   const focusMostRecentThreadForProject = useCallback(
     (projectId: ProjectId) => {
       const latestThread = sortThreadsForSidebar(
-        (threadIdsByProjectId[projectId] ?? [])
-          .map((threadId) => sidebarThreadsById[threadId])
-          .filter((thread): thread is NonNullable<typeof thread> => thread !== undefined)
-          .filter((thread) => thread.archivedAt === null),
+        getSidebarThreadsByIds({
+          threadIds: threadIdsByProjectId[projectId] ?? [],
+          threadsById: sidebarThreadsById,
+        }),
         appSettings.sidebarThreadSortOrder,
       )[0];
       if (!latestThread) return;
@@ -1252,8 +1253,11 @@ export default function Sidebar() {
       }
       if (clicked !== "delete") return;
 
-      const projectThreadIds = threadIdsByProjectId[projectId] ?? [];
-      if (projectThreadIds.length > 0) {
+      const visibleProjectThreads = getSidebarThreadsByIds({
+        threadIds: threadIdsByProjectId[projectId] ?? [],
+        threadsById: sidebarThreadsById,
+      });
+      if (visibleProjectThreads.length > 0) {
         toastManager.add({
           type: "warning",
           title: "Project is not empty",
@@ -1292,6 +1296,7 @@ export default function Sidebar() {
       copyPathToClipboard,
       getDraftThreadByProjectId,
       projects,
+      sidebarThreadsById,
       threadIdsByProjectId,
     ],
   );
@@ -1400,10 +1405,10 @@ export default function Sidebar() {
             },
           });
         const projectThreads = sortThreadsForSidebar(
-          (threadIdsByProjectId[project.id] ?? [])
-            .map((threadId) => sidebarThreadsById[threadId])
-            .filter((thread): thread is NonNullable<typeof thread> => thread !== undefined)
-            .filter((thread) => thread.archivedAt === null),
+          getSidebarThreadsByIds({
+            threadIds: threadIdsByProjectId[project.id] ?? [],
+            threadsById: sidebarThreadsById,
+          }),
           appSettings.sidebarThreadSortOrder,
         );
         const projectStatus = resolveProjectStatusIndicator(


### PR DESCRIPTION
## What changed

This fixes the sidebar bug where a project that only contains archived threads appears empty but still cannot be removed.

The project deletion guard in `Sidebar.tsx` now checks only visible project threads, matching the same archived-thread filtering the sidebar already uses when rendering per-project thread lists.

To keep that logic consistent, I extracted a small shared helper in `Sidebar.logic.ts` and used it in the relevant sidebar call sites.

I also added focused regression coverage for the archived-thread filtering helper.

## Why

The root cause was a mismatch between two sidebar code paths:

- project rendering filtered archived threads out, so archived-only projects looked empty
- project deletion checked raw `threadIdsByProjectId`, which still included archived threads

That made users hit a misleading `Project is not empty` warning even when the UI showed no threads under the project.

## Impact

Projects that only contain archived threads can now be removed successfully from the sidebar.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --cwd apps/web test -- src/components/Sidebar.logic.test.ts`
- `bun run --cwd apps/server test -- src/provider/Layers/ClaudeAdapter.test.ts`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project deletion check to correctly handle archived-only projects
> - Introduces `getSidebarThreadsByIds` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/1896/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to map thread IDs to thread objects, filtering out missing entries and archived threads by default.
> - Fixes a bug in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1896/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) where deleting a project with only archived threads was incorrectly blocked; the deletion guard now uses `getSidebarThreadsByIds` which excludes archived threads from the active thread count.
> - Also extends Claude adapter in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/1896/files#diff-d7dbffa9ad1a6f15e826a38ade915e1641f1b345d06da87d48cfc1f99b9ccd8a) to handle `server_tool_use` and `mcp_tool_use` content blocks alongside `tool_use`, validated via a new `getClaudeToolStartBlock` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d3763d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->