### PR TITLE
Remove Claude subscription-based model adjustment

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -276,18 +276,6 @@ function extractClaudeAuthMethodFromOutput(result: CommandResult): string | unde
   return Option.getOrUndefined(findAuthMethod(parsed.success));
 }
 
-// ── Dynamic model capability adjustment ─────────────────────────────
-
-/** Subscription types where the 1M context window is included in the plan. */
-const PREMIUM_SUBSCRIPTION_TYPES = new Set([
-  "max",
-  "maxplan",
-  "max5",
-  "max20",
-  "enterprise",
-  "team",
-]);
-
 function toTitleCaseWords(value: string): string {
   return value
     .split(/[\s_-]+/g)
@@ -346,41 +334,6 @@ function claudeAuthMetadata(input: {
   }
 
   return undefined;
-}
-
-/**
- * Adjust the built-in model list based on the user's detected subscription.
- *
- * - Premium tiers (Max, Enterprise, Team): 1M context becomes the default.
- * - Other tiers (Pro, free, unknown): 200k context stays the default;
- *   1M remains available as a manual option so users can still enable it.
- */
-export function adjustModelsForSubscription(
-  baseModels: ReadonlyArray<ServerProviderModel>,
-  subscriptionType: string | undefined,
-): ReadonlyArray<ServerProviderModel> {
-  const normalized = subscriptionType?.toLowerCase().replace(/[\s_-]+/g, "");
-  if (!normalized || !PREMIUM_SUBSCRIPTION_TYPES.has(normalized)) {
-    return baseModels;
-  }
-
-  // Flip 1M to be the default for premium users
-  return baseModels.map((model) => {
-    const caps = model.capabilities;
-    if (!caps || caps.contextWindowOptions.length === 0) return model;
-
-    return {
-      ...model,
-      capabilities: {
-        ...caps,
-        contextWindowOptions: caps.contextWindowOptions.map((opt) =>
-          opt.value === "1m"
-            ? { value: opt.value, label: opt.label, isDefault: true as const }
-            : { value: opt.value, label: opt.label },
-        ),
-      },
-    };
-  });
 }
 
 // ── SDK capability probe ────────────────────────────────────────────
@@ -563,8 +516,6 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     subscriptionType = yield* resolveSubscriptionType(claudeSettings.binaryPath);
   }
 
-  const resolvedModels = adjustModelsForSubscription(models, subscriptionType);
-
   // ── Handle auth results (same logic as before, adjusted models) ──
 
   if (Result.isFailure(authProbe)) {
@@ -573,7 +524,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
       provider: PROVIDER,
       enabled: claudeSettings.enabled,
       checkedAt,
-      models: resolvedModels,
+      models,
       probe: {
         installed: true,
         version: parsedVersion,
@@ -592,7 +543,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
       provider: PROVIDER,
       enabled: claudeSettings.enabled,
       checkedAt,
-      models: resolvedModels,
+      models,
       probe: {
         installed: true,
         version: parsedVersion,
@@ -609,7 +560,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
     provider: PROVIDER,
     enabled: claudeSettings.enabled,
     checkedAt,
-    models: resolvedModels,
+    models,
     probe: {
       installed: true,
       version: parsedVersion,


### PR DESCRIPTION
## Summary
- Remove the subscription-driven model adjustment logic from `ClaudeProvider`.
- Return the provider's model list unchanged during Claude status checks.
- Delete the unused premium subscription normalization and 1M-default flipping code.

## Testing
- Not run (PR description only).
- Verify Claude provider status responses still include the expected model list shape.
- Confirm the default model behavior now comes solely from the upstream/provider-provided metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Claude provider status responses to stop rewriting model capability defaults based on detected subscription, which may alter default context window selection for some users. Risk is limited to provider metadata/UX, with no auth or data handling changes.
> 
> **Overview**
> Removes the subscription-tier driven model adjustment in `ClaudeProvider` that previously promoted the `1m` context window option to default for premium plans.
> 
> `checkClaudeProviderStatus` now always returns the `models` list from settings/built-ins unchanged (while still detecting subscription/auth method for metadata), simplifying behavior and making defaults come solely from the provider model definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 205a70fd437893abcbb93b5047338987f1899b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove subscription-based default context window adjustment from `ClaudeProvider`
> Removes `adjustModelsForSubscription` and `PREMIUM_SUBSCRIPTION_TYPES` from [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/1899/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3). The provider now returns the base models array unchanged for all subscription types. Behavioral Change: premium subscribers no longer have the 1M context window set as the default option.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 205a70f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->