### PR TITLE
fix(web): resolve logical-to-physical key mismatch in project drag reorder

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2330,7 +2330,7 @@ export default function Sidebar() {
   const activeEnvironmentId = useStore((store) => store.activeEnvironmentId);
   const projectExpandedById = useUiStateStore((store) => store.projectExpandedById);
   const projectOrder = useUiStateStore((store) => store.projectOrder);
-  const reorderProjectGroup = useUiStateStore((store) => store.reorderProjectGroup);
+  const reorderProjects = useUiStateStore((store) => store.reorderProjects);
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const isOnSettings = pathname.startsWith("/settings");
@@ -2698,9 +2698,9 @@ export default function Sidebar() {
       if (!activeProject || !overProject) return;
       const activeMemberKeys = activeProject.memberProjectRefs.map(scopedProjectKey);
       const overMemberKeys = overProject.memberProjectRefs.map(scopedProjectKey);
-      reorderProjectGroup(activeMemberKeys, overMemberKeys);
+      reorderProjects(activeMemberKeys, overMemberKeys);
     },
-    [sidebarProjectSortOrder, reorderProjectGroup, sidebarProjects],
+    [sidebarProjectSortOrder, reorderProjects, sidebarProjects],
   );
 
   const handleProjectDragStart = useCallback(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2330,7 +2330,7 @@ export default function Sidebar() {
   const activeEnvironmentId = useStore((store) => store.activeEnvironmentId);
   const projectExpandedById = useUiStateStore((store) => store.projectExpandedById);
   const projectOrder = useUiStateStore((store) => store.projectOrder);
-  const reorderProjects = useUiStateStore((store) => store.reorderProjects);
+  const reorderProjectGroup = useUiStateStore((store) => store.reorderProjectGroup);
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const isOnSettings = pathname.startsWith("/settings");
@@ -2696,18 +2696,11 @@ export default function Sidebar() {
       const activeProject = sidebarProjects.find((project) => project.projectKey === active.id);
       const overProject = sidebarProjects.find((project) => project.projectKey === over.id);
       if (!activeProject || !overProject) return;
-      // projectOrder stores physical keys, but projectKey is a logical key
-      // that may differ (e.g. canonicalKey from repositoryIdentity). Resolve
-      // back to the representative's physical key for the reorder.
-      const activePhysicalKey = scopedProjectKey(
-        scopeProjectRef(activeProject.environmentId, activeProject.id),
-      );
-      const overPhysicalKey = scopedProjectKey(
-        scopeProjectRef(overProject.environmentId, overProject.id),
-      );
-      reorderProjects(activePhysicalKey, overPhysicalKey);
+      const activeMemberKeys = activeProject.memberProjectRefs.map(scopedProjectKey);
+      const overMemberKeys = overProject.memberProjectRefs.map(scopedProjectKey);
+      reorderProjectGroup(activeMemberKeys, overMemberKeys);
     },
-    [sidebarProjectSortOrder, reorderProjects, sidebarProjects],
+    [sidebarProjectSortOrder, reorderProjectGroup, sidebarProjects],
   );
 
   const handleProjectDragStart = useCallback(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2696,7 +2696,16 @@ export default function Sidebar() {
       const activeProject = sidebarProjects.find((project) => project.projectKey === active.id);
       const overProject = sidebarProjects.find((project) => project.projectKey === over.id);
       if (!activeProject || !overProject) return;
-      reorderProjects(activeProject.projectKey, overProject.projectKey);
+      // projectOrder stores physical keys, but projectKey is a logical key
+      // that may differ (e.g. canonicalKey from repositoryIdentity). Resolve
+      // back to the representative's physical key for the reorder.
+      const activePhysicalKey = scopedProjectKey(
+        scopeProjectRef(activeProject.environmentId, activeProject.id),
+      );
+      const overPhysicalKey = scopedProjectKey(
+        scopeProjectRef(overProject.environmentId, overProject.id),
+      );
+      reorderProjects(activePhysicalKey, overPhysicalKey);
     },
     [sidebarProjectSortOrder, reorderProjects, sidebarProjects],
   );

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 import {
   clearThreadUi,
   markThreadUnread,
-  reorderProjectGroup,
   reorderProjects,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
@@ -59,7 +58,7 @@ describe("uiStateStore pure functions", () => {
       projectOrder: [project1, project2, project3],
     });
 
-    const next = reorderProjects(initialState, project1, project3);
+    const next = reorderProjects(initialState, [project1], [project3]);
 
     expect(next.projectOrder).toEqual([project2, project3, project1]);
   });
@@ -71,25 +70,12 @@ describe("uiStateStore pure functions", () => {
       projectOrder: [project1, project2],
     });
 
-    const next = reorderProjects(initialState, ProjectId.make("missing"), project2);
+    const next = reorderProjects(initialState, [ProjectId.make("missing")], [project2]);
 
     expect(next).toBe(initialState);
   });
 
-  it("reorderProjectGroup moves a single-member group to a target position", () => {
-    const project1 = ProjectId.make("project-1");
-    const project2 = ProjectId.make("project-2");
-    const project3 = ProjectId.make("project-3");
-    const initialState = makeUiState({
-      projectOrder: [project1, project2, project3],
-    });
-
-    const next = reorderProjectGroup(initialState, [project1], [project3]);
-
-    expect(next.projectOrder).toEqual([project2, project3, project1]);
-  });
-
-  it("reorderProjectGroup moves all member keys of a multi-member group together", () => {
+  it("reorderProjects moves all member keys of a multi-member group together", () => {
     const keyALocal = "env-local:proj-a";
     const keyARemote = "env-remote:proj-a";
     const keyB = "env-local:proj-b";
@@ -98,12 +84,12 @@ describe("uiStateStore pure functions", () => {
       projectOrder: [keyALocal, keyARemote, keyB, keyC],
     });
 
-    const next = reorderProjectGroup(initialState, [keyALocal, keyARemote], [keyC]);
+    const next = reorderProjects(initialState, [keyALocal, keyARemote], [keyC]);
 
     expect(next.projectOrder).toEqual([keyB, keyC, keyALocal, keyARemote]);
   });
 
-  it("reorderProjectGroup handles member keys scattered across projectOrder", () => {
+  it("reorderProjects handles member keys scattered across projectOrder", () => {
     const keyALocal = "env-local:proj-a";
     const keyB = "env-local:proj-b";
     const keyARemote = "env-remote:proj-a";
@@ -112,12 +98,12 @@ describe("uiStateStore pure functions", () => {
       projectOrder: [keyALocal, keyB, keyARemote, keyC],
     });
 
-    const next = reorderProjectGroup(initialState, [keyALocal, keyARemote], [keyC]);
+    const next = reorderProjects(initialState, [keyALocal, keyARemote], [keyC]);
 
     expect(next.projectOrder).toEqual([keyB, keyC, keyALocal, keyARemote]);
   });
 
-  it("reorderProjectGroup places group after target when dragged from before a non-last target", () => {
+  it("reorderProjects places group after target when dragged from before a non-last target", () => {
     const keyALocal = "env-local:proj-a";
     const keyARemote = "env-remote:proj-a";
     const keyB = "env-local:proj-b";
@@ -127,12 +113,12 @@ describe("uiStateStore pure functions", () => {
       projectOrder: [keyALocal, keyARemote, keyB, keyC, keyD],
     });
 
-    const next = reorderProjectGroup(initialState, [keyALocal, keyARemote], [keyC]);
+    const next = reorderProjects(initialState, [keyALocal, keyARemote], [keyC]);
 
     expect(next.projectOrder).toEqual([keyB, keyC, keyALocal, keyARemote, keyD]);
   });
 
-  it("reorderProjectGroup places group before target when dragged from after", () => {
+  it("reorderProjects places group before target when dragged from after", () => {
     const keyB = "env-local:proj-b";
     const keyC = "env-local:proj-c";
     const keyALocal = "env-local:proj-a";
@@ -141,12 +127,12 @@ describe("uiStateStore pure functions", () => {
       projectOrder: [keyB, keyC, keyALocal, keyARemote],
     });
 
-    const next = reorderProjectGroup(initialState, [keyALocal, keyARemote], [keyB]);
+    const next = reorderProjects(initialState, [keyALocal, keyARemote], [keyB]);
 
     expect(next.projectOrder).toEqual([keyALocal, keyARemote, keyB, keyC]);
   });
 
-  it("reorderProjectGroup with multi-member target inserts after first target occurrence", () => {
+  it("reorderProjects with multi-member target inserts after first target occurrence", () => {
     const keyALocal = "env-local:proj-a";
     const keyARemote = "env-remote:proj-a";
     const keyBLocal = "env-local:proj-b";
@@ -155,7 +141,7 @@ describe("uiStateStore pure functions", () => {
       projectOrder: [keyALocal, keyARemote, keyBLocal, keyBRemote],
     });
 
-    const next = reorderProjectGroup(
+    const next = reorderProjects(
       initialState,
       [keyALocal, keyARemote],
       [keyBLocal, keyBRemote],
@@ -166,24 +152,24 @@ describe("uiStateStore pure functions", () => {
     expect(next.projectOrder).toEqual([keyBLocal, keyALocal, keyARemote, keyBRemote]);
   });
 
-  it("reorderProjectGroup is a no-op when dragged group equals target group", () => {
+  it("reorderProjects is a no-op when dragged group equals target group", () => {
     const key1 = "env-local:proj-a";
     const key2 = "env-remote:proj-a";
     const initialState = makeUiState({
       projectOrder: [key1, key2, "env-local:proj-b"],
     });
 
-    const next = reorderProjectGroup(initialState, [key1, key2], [key1, key2]);
+    const next = reorderProjects(initialState, [key1, key2], [key1, key2]);
 
     expect(next).toBe(initialState);
   });
 
-  it("reorderProjectGroup is a no-op when dragged keys are not in projectOrder", () => {
+  it("reorderProjects is a no-op when dragged keys are not in projectOrder", () => {
     const initialState = makeUiState({
       projectOrder: ["env-local:proj-a", "env-local:proj-b"],
     });
 
-    const next = reorderProjectGroup(initialState, ["env-local:missing"], ["env-local:proj-b"]);
+    const next = reorderProjects(initialState, ["env-local:missing"], ["env-local:proj-b"]);
 
     expect(next).toBe(initialState);
   });

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -117,6 +117,35 @@ describe("uiStateStore pure functions", () => {
     expect(next.projectOrder).toEqual([keyB, keyC, keyALocal, keyARemote]);
   });
 
+  it("reorderProjectGroup places group after target when dragged from before a non-last target", () => {
+    const keyALocal = "env-local:proj-a";
+    const keyARemote = "env-remote:proj-a";
+    const keyB = "env-local:proj-b";
+    const keyC = "env-local:proj-c";
+    const keyD = "env-local:proj-d";
+    const initialState = makeUiState({
+      projectOrder: [keyALocal, keyARemote, keyB, keyC, keyD],
+    });
+
+    const next = reorderProjectGroup(initialState, [keyALocal, keyARemote], [keyC]);
+
+    expect(next.projectOrder).toEqual([keyB, keyC, keyALocal, keyARemote, keyD]);
+  });
+
+  it("reorderProjectGroup places group before target when dragged from after", () => {
+    const keyB = "env-local:proj-b";
+    const keyC = "env-local:proj-c";
+    const keyALocal = "env-local:proj-a";
+    const keyARemote = "env-remote:proj-a";
+    const initialState = makeUiState({
+      projectOrder: [keyB, keyC, keyALocal, keyARemote],
+    });
+
+    const next = reorderProjectGroup(initialState, [keyALocal, keyARemote], [keyB]);
+
+    expect(next.projectOrder).toEqual([keyALocal, keyARemote, keyB, keyC]);
+  });
+
   it("reorderProjectGroup is a no-op when dragged group equals target group", () => {
     const key1 = "env-local:proj-a";
     const key2 = "env-remote:proj-a";

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   clearThreadUi,
   markThreadUnread,
+  reorderProjectGroup,
   reorderProjects,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
@@ -61,6 +62,81 @@ describe("uiStateStore pure functions", () => {
     const next = reorderProjects(initialState, project1, project3);
 
     expect(next.projectOrder).toEqual([project2, project3, project1]);
+  });
+
+  it("reorderProjects is a no-op when dragged key is not in projectOrder", () => {
+    const project1 = ProjectId.make("project-1");
+    const project2 = ProjectId.make("project-2");
+    const initialState = makeUiState({
+      projectOrder: [project1, project2],
+    });
+
+    const next = reorderProjects(initialState, ProjectId.make("missing"), project2);
+
+    expect(next).toBe(initialState);
+  });
+
+  it("reorderProjectGroup moves a single-member group to a target position", () => {
+    const project1 = ProjectId.make("project-1");
+    const project2 = ProjectId.make("project-2");
+    const project3 = ProjectId.make("project-3");
+    const initialState = makeUiState({
+      projectOrder: [project1, project2, project3],
+    });
+
+    const next = reorderProjectGroup(initialState, [project1], [project3]);
+
+    expect(next.projectOrder).toEqual([project2, project3, project1]);
+  });
+
+  it("reorderProjectGroup moves all member keys of a multi-member group together", () => {
+    const keyALocal = "env-local:proj-a";
+    const keyARemote = "env-remote:proj-a";
+    const keyB = "env-local:proj-b";
+    const keyC = "env-local:proj-c";
+    const initialState = makeUiState({
+      projectOrder: [keyALocal, keyARemote, keyB, keyC],
+    });
+
+    const next = reorderProjectGroup(initialState, [keyALocal, keyARemote], [keyC]);
+
+    expect(next.projectOrder).toEqual([keyB, keyC, keyALocal, keyARemote]);
+  });
+
+  it("reorderProjectGroup handles member keys scattered across projectOrder", () => {
+    const keyALocal = "env-local:proj-a";
+    const keyB = "env-local:proj-b";
+    const keyARemote = "env-remote:proj-a";
+    const keyC = "env-local:proj-c";
+    const initialState = makeUiState({
+      projectOrder: [keyALocal, keyB, keyARemote, keyC],
+    });
+
+    const next = reorderProjectGroup(initialState, [keyALocal, keyARemote], [keyC]);
+
+    expect(next.projectOrder).toEqual([keyB, keyC, keyALocal, keyARemote]);
+  });
+
+  it("reorderProjectGroup is a no-op when dragged group equals target group", () => {
+    const key1 = "env-local:proj-a";
+    const key2 = "env-remote:proj-a";
+    const initialState = makeUiState({
+      projectOrder: [key1, key2, "env-local:proj-b"],
+    });
+
+    const next = reorderProjectGroup(initialState, [key1, key2], [key1, key2]);
+
+    expect(next).toBe(initialState);
+  });
+
+  it("reorderProjectGroup is a no-op when dragged keys are not in projectOrder", () => {
+    const initialState = makeUiState({
+      projectOrder: ["env-local:proj-a", "env-local:proj-b"],
+    });
+
+    const next = reorderProjectGroup(initialState, ["env-local:missing"], ["env-local:proj-b"]);
+
+    expect(next).toBe(initialState);
   });
 
   it("syncProjects preserves current project order during snapshot recovery", () => {

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -141,11 +141,7 @@ describe("uiStateStore pure functions", () => {
       projectOrder: [keyALocal, keyARemote, keyBLocal, keyBRemote],
     });
 
-    const next = reorderProjects(
-      initialState,
-      [keyALocal, keyARemote],
-      [keyBLocal, keyBRemote],
-    );
+    const next = reorderProjects(initialState, [keyALocal, keyARemote], [keyBLocal, keyBRemote]);
 
     // Target members may become non-contiguous; this is fine because the
     // sidebar groups by logical key using first-occurrence positioning.

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -146,6 +146,26 @@ describe("uiStateStore pure functions", () => {
     expect(next.projectOrder).toEqual([keyALocal, keyARemote, keyB, keyC]);
   });
 
+  it("reorderProjectGroup with multi-member target inserts after first target occurrence", () => {
+    const keyALocal = "env-local:proj-a";
+    const keyARemote = "env-remote:proj-a";
+    const keyBLocal = "env-local:proj-b";
+    const keyBRemote = "env-remote:proj-b";
+    const initialState = makeUiState({
+      projectOrder: [keyALocal, keyARemote, keyBLocal, keyBRemote],
+    });
+
+    const next = reorderProjectGroup(
+      initialState,
+      [keyALocal, keyARemote],
+      [keyBLocal, keyBRemote],
+    );
+
+    // Target members may become non-contiguous; this is fine because the
+    // sidebar groups by logical key using first-occurrence positioning.
+    expect(next.projectOrder).toEqual([keyBLocal, keyALocal, keyARemote, keyBRemote]);
+  });
+
   it("reorderProjectGroup is a no-op when dragged group equals target group", () => {
     const key1 = "env-local:proj-a";
     const key2 = "env-remote:proj-a";

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -527,16 +527,21 @@ export function reorderProjectGroup(
   const projectOrder = [...state.projectOrder];
 
   const removed: string[] = [];
+  let draggedBeforeTarget = 0;
   for (let i = projectOrder.length - 1; i >= 0; i--) {
     if (draggedSet.has(projectOrder[i]!)) {
       removed.unshift(projectOrder.splice(i, 1)[0]!);
+      if (i < originalTargetIndex) {
+        draggedBeforeTarget++;
+      }
     }
   }
   if (removed.length === 0) {
     return state;
   }
 
-  projectOrder.splice(originalTargetIndex, 0, ...removed);
+  const insertIndex = originalTargetIndex - Math.max(0, draggedBeforeTarget - 1);
+  projectOrder.splice(insertIndex, 0, ...removed);
   return {
     ...state,
     projectOrder,

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -482,31 +482,6 @@ export function setProjectExpanded(state: UiState, projectId: string, expanded: 
 
 export function reorderProjects(
   state: UiState,
-  draggedProjectId: string,
-  targetProjectId: string,
-): UiState {
-  if (draggedProjectId === targetProjectId) {
-    return state;
-  }
-  const draggedIndex = state.projectOrder.findIndex((projectId) => projectId === draggedProjectId);
-  const targetIndex = state.projectOrder.findIndex((projectId) => projectId === targetProjectId);
-  if (draggedIndex < 0 || targetIndex < 0) {
-    return state;
-  }
-  const projectOrder = [...state.projectOrder];
-  const [draggedProject] = projectOrder.splice(draggedIndex, 1);
-  if (!draggedProject) {
-    return state;
-  }
-  projectOrder.splice(targetIndex, 0, draggedProject);
-  return {
-    ...state,
-    projectOrder,
-  };
-}
-
-export function reorderProjectGroup(
-  state: UiState,
   draggedProjectIds: readonly string[],
   targetProjectIds: readonly string[],
 ): UiState {
@@ -557,8 +532,7 @@ interface UiStateStore extends UiState {
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   toggleProject: (projectId: string) => void;
   setProjectExpanded: (projectId: string, expanded: boolean) => void;
-  reorderProjects: (draggedProjectId: string, targetProjectId: string) => void;
-  reorderProjectGroup: (
+  reorderProjects: (
     draggedProjectIds: readonly string[],
     targetProjectIds: readonly string[],
   ) => void;
@@ -578,10 +552,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
   toggleProject: (projectId) => set((state) => toggleProject(state, projectId)),
   setProjectExpanded: (projectId, expanded) =>
     set((state) => setProjectExpanded(state, projectId, expanded)),
-  reorderProjects: (draggedProjectId, targetProjectId) =>
-    set((state) => reorderProjects(state, draggedProjectId, targetProjectId)),
-  reorderProjectGroup: (draggedProjectIds, targetProjectIds) =>
-    set((state) => reorderProjectGroup(state, draggedProjectIds, targetProjectIds)),
+  reorderProjects: (draggedProjectIds, targetProjectIds) =>
+    set((state) => reorderProjects(state, draggedProjectIds, targetProjectIds)),
 }));
 
 useUiStateStore.subscribe((state) => debouncedPersistState.maybeExecute(state));

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -505,6 +505,44 @@ export function reorderProjects(
   };
 }
 
+export function reorderProjectGroup(
+  state: UiState,
+  draggedProjectIds: readonly string[],
+  targetProjectIds: readonly string[],
+): UiState {
+  if (draggedProjectIds.length === 0) {
+    return state;
+  }
+  const draggedSet = new Set(draggedProjectIds);
+  const targetSet = new Set(targetProjectIds);
+  if (draggedProjectIds.every((id) => targetSet.has(id))) {
+    return state;
+  }
+
+  const originalTargetIndex = state.projectOrder.findIndex((id) => targetSet.has(id));
+  if (originalTargetIndex < 0) {
+    return state;
+  }
+
+  const projectOrder = [...state.projectOrder];
+
+  const removed: string[] = [];
+  for (let i = projectOrder.length - 1; i >= 0; i--) {
+    if (draggedSet.has(projectOrder[i]!)) {
+      removed.unshift(projectOrder.splice(i, 1)[0]!);
+    }
+  }
+  if (removed.length === 0) {
+    return state;
+  }
+
+  projectOrder.splice(originalTargetIndex, 0, ...removed);
+  return {
+    ...state,
+    projectOrder,
+  };
+}
+
 interface UiStateStore extends UiState {
   syncProjects: (projects: readonly SyncProjectInput[]) => void;
   syncThreads: (threads: readonly SyncThreadInput[]) => void;
@@ -515,6 +553,10 @@ interface UiStateStore extends UiState {
   toggleProject: (projectId: string) => void;
   setProjectExpanded: (projectId: string, expanded: boolean) => void;
   reorderProjects: (draggedProjectId: string, targetProjectId: string) => void;
+  reorderProjectGroup: (
+    draggedProjectIds: readonly string[],
+    targetProjectIds: readonly string[],
+  ) => void;
 }
 
 export const useUiStateStore = create<UiStateStore>((set) => ({
@@ -533,6 +575,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setProjectExpanded(state, projectId, expanded)),
   reorderProjects: (draggedProjectId, targetProjectId) =>
     set((state) => reorderProjects(state, draggedProjectId, targetProjectId)),
+  reorderProjectGroup: (draggedProjectIds, targetProjectIds) =>
+    set((state) => reorderProjectGroup(state, draggedProjectIds, targetProjectIds)),
 }));
 
 useUiStateStore.subscribe((state) => debouncedPersistState.maybeExecute(state));


### PR DESCRIPTION
## What Changed

The drag-end handler in `Sidebar.tsx` was passing logical project keys (from `deriveLogicalProjectKey`) to `reorderProjects()`, but `projectOrder` in `uiStateStore` stores physical keys (`environmentId:projectId`). For any project with a git remote, the logical key is the `canonicalKey` (e.g. `github.com/owner/repo`) which doesn't match the physical key, so `findIndex` returned `-1` and the reorder silently did nothing.

The fix resolves the representative project's physical key before calling `reorderProjects`.

## Why

This is a v0.0.16 regression introduced in #1768, which changed `sidebarProjects` to group by logical key for multi-environment support but didn't update the drag handler to translate back to physical keys. Manual sort drag-and-drop is completely broken for any project with a git remote.

Fixes #1902

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] ~~I included before/after screenshots for any UI changes~~ (no visual change, behavior fix only)
- [ ] ~~I included a video for animation/interaction changes~~ (N/A)

Tested by building a local AppImage from this branch and confirming drag-and-drop reorder works and persists across restarts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the project drag-and-drop reorder algorithm and its store API to move groups of project keys together; mistakes could corrupt or unexpectedly reshuffle persisted manual ordering but the impact is limited to sidebar UI state.
> 
> **Overview**
> Fixes manual sidebar project drag-and-drop for multi-environment/grouped projects by reordering **physical member project keys** instead of a single logical key.
> 
> `reorderProjects` now accepts arrays of dragged/target IDs and removes/inserts all dragged members as a unit, with expanded unit tests covering missing keys, scattered members, relative insertion, and multi-member targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 275f9fa5ecbd32e0747503072a7fe2b983da79ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix logical-to-physical key mismatch in project drag-and-drop reorder
> - Multi-environment projects share a logical group but have separate physical keys. The previous `reorderProjects` logic passed a single key, causing only one environment's entry to move.
> - `reorderProjects` in [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/1904/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8) now accepts arrays of `draggedProjectIds` and `targetProjectIds`, moving all member keys of a group together.
> - [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1904/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) collects all member `scopedProjectKeys` for both the dragged and target projects before calling `reorderProjects`.
> - Insertion position is determined by whether the dragged group was before or after the target group in the existing order.
> - Behavioral Change: `reorderProjects` now expects arrays instead of single strings; callers passing a single ID must wrap it in an array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 275f9fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->