### PR TITLE
Handle deleted git directories as non-repositories

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -40,6 +40,24 @@ function writeTextFile(
   });
 }
 
+function removePath(
+  targetPath: string,
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    yield* fileSystem.remove(targetPath, { recursive: true, force: true });
+  });
+}
+
+function makeDirectory(
+  dirPath: string,
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    yield* fileSystem.makeDirectory(dirPath, { recursive: true });
+  });
+}
+
 /** Run a raw git command for test setup (not under test). */
 function git(
   cwd: string,
@@ -293,6 +311,21 @@ it.layer(TestLayer)("git integration", (it) => {
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();
         const result = yield* (yield* GitCore).listBranches({ cwd: tmp });
+        expect(result.isRepo).toBe(false);
+        expect(result.hasOriginRemote).toBe(false);
+        expect(result.branches).toEqual([]);
+      }),
+    );
+
+    it.effect("returns isRepo: false for deleted directories", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const deletedDir = path.join(tmp, "deleted-repo");
+        yield* makeDirectory(deletedDir);
+        yield* removePath(deletedDir);
+
+        const result = yield* (yield* GitCore).listBranches({ cwd: deletedDir });
+
         expect(result.isRepo).toBe(false);
         expect(result.hasOriginRemote).toBe(false);
         expect(result.branches).toEqual([]);
@@ -1623,6 +1656,37 @@ it.layer(TestLayer)("git integration", (it) => {
         yield* writeTextFile(path.join(tmp, "README.md"), "updated\n");
         const dirty = yield* core.statusDetails(tmp);
         expect(dirty.hasWorkingTreeChanges).toBe(true);
+      }),
+    );
+
+    it.effect("returns a non-repo status for deleted directories", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const deletedDir = path.join(tmp, "deleted-repo");
+        yield* makeDirectory(deletedDir);
+        yield* removePath(deletedDir);
+        const core = yield* GitCore;
+
+        const status = yield* core.statusDetails(deletedDir);
+        const localStatus = yield* core.statusDetailsLocal(deletedDir);
+
+        expect(status).toEqual({
+          isRepo: false,
+          hasOriginRemote: false,
+          isDefaultBranch: false,
+          branch: null,
+          upstreamRef: null,
+          hasWorkingTreeChanges: false,
+          workingTree: {
+            files: [],
+            insertions: 0,
+            deletions: 0,
+          },
+          hasUpstream: false,
+          aheadCount: 0,
+          behindCount: 0,
+        });
+        expect(localStatus).toEqual(status);
       }),
     );
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -60,7 +60,7 @@ const STATUS_UPSTREAM_REFRESH_FAILURE_COOLDOWN = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
 const DEFAULT_BASE_BRANCH_CANDIDATES = ["main", "master"] as const;
 const GIT_LIST_BRANCHES_DEFAULT_LIMIT = 100;
-const NON_REPOSITORY_STATUS_DETAILS = {
+const NON_REPOSITORY_STATUS_DETAILS = Object.freeze<GitStatusDetails>({
   isRepo: false,
   hasOriginRemote: false,
   isDefaultBranch: false,
@@ -71,7 +71,7 @@ const NON_REPOSITORY_STATUS_DETAILS = {
   hasUpstream: false,
   aheadCount: 0,
   behindCount: 0,
-} satisfies GitStatusDetails;
+});
 
 type TraceTailState = {
   processedChars: number;

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -27,6 +27,7 @@ import {
   type ExecuteGitProgress,
   type GitCommitOptions,
   type GitCoreShape,
+  type GitStatusDetails,
   type ExecuteGitInput,
   type ExecuteGitResult,
 } from "../Services/GitCore.ts";
@@ -59,6 +60,18 @@ const STATUS_UPSTREAM_REFRESH_FAILURE_COOLDOWN = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
 const DEFAULT_BASE_BRANCH_CANDIDATES = ["main", "master"] as const;
 const GIT_LIST_BRANCHES_DEFAULT_LIMIT = 100;
+const NON_REPOSITORY_STATUS_DETAILS = {
+  isRepo: false,
+  hasOriginRemote: false,
+  isDefaultBranch: false,
+  branch: null,
+  upstreamRef: null,
+  hasWorkingTreeChanges: false,
+  workingTree: { files: [], insertions: 0, deletions: 0 },
+  hasUpstream: false,
+  aheadCount: 0,
+  behindCount: 0,
+} satisfies GitStatusDetails;
 
 type TraceTailState = {
   processedChars: number;
@@ -357,6 +370,16 @@ function createGitCommandError(
 
 function quoteGitCommand(args: ReadonlyArray<string>): string {
   return `git ${args.join(" ")}`;
+}
+
+function isMissingGitCwdError(error: GitCommandError): boolean {
+  const normalized = `${error.detail}\n${error.message}`.toLowerCase();
+  return (
+    normalized.includes("no such file or directory") ||
+    normalized.includes("notfound: filesystem.access") ||
+    normalized.includes("enoent") ||
+    normalized.includes("not a directory")
+  );
 }
 
 function toGitCommandError(
@@ -1190,7 +1213,11 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       {
         allowNonZeroExit: true,
       },
-    );
+    ).pipe(Effect.catchIf(isMissingGitCwdError, () => Effect.succeed(null)));
+
+    if (statusResult === null) {
+      return NON_REPOSITORY_STATUS_DETAILS;
+    }
 
     if (statusResult.code !== 0) {
       const stderr = statusResult.stderr.trim();
@@ -1322,7 +1349,10 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
   );
 
   const statusDetails: GitCoreShape["statusDetails"] = Effect.fn("statusDetails")(function* (cwd) {
-    yield* refreshStatusUpstreamIfStale(cwd).pipe(Effect.ignoreCause({ log: true }));
+    yield* refreshStatusUpstreamIfStale(cwd).pipe(
+      Effect.catchIf(isMissingGitCwdError, () => Effect.void),
+      Effect.ignoreCause({ log: true }),
+    );
     return yield* readStatusDetailsLocal(cwd);
   });
 
@@ -1719,6 +1749,16 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
         timeoutMs: 10_000,
         allowNonZeroExit: true,
       },
+    ).pipe(
+      Effect.catchIf(isMissingGitCwdError, () =>
+        Effect.succeed({
+          code: 128,
+          stdout: "",
+          stderr: "fatal: not a git repository",
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        }),
+      ),
     );
 
     if (localBranchResult.code !== 0) {

--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -123,6 +123,58 @@ layer("GitHubCliLive", (it) => {
     }),
   );
 
+  it.effect("skips invalid entries when parsing pr lists", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 0,
+            title: "invalid",
+            url: "https://github.com/pingdotgg/codething-mvp/pull/0",
+            baseRefName: "main",
+            headRefName: "feature/invalid",
+          },
+          {
+            number: 43,
+            title: "  Valid PR  ",
+            url: " https://github.com/pingdotgg/codething-mvp/pull/43 ",
+            baseRefName: " main ",
+            headRefName: " feature/pr-list ",
+            headRepository: {
+              nameWithOwner: "   ",
+            },
+            headRepositoryOwner: {
+              login: "   ",
+            },
+          },
+        ]),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+
+      const result = yield* Effect.gen(function* () {
+        const gh = yield* GitHubCli;
+        return yield* gh.listOpenPullRequests({
+          cwd: "/repo",
+          headSelector: "feature/pr-list",
+        });
+      });
+
+      assert.deepStrictEqual(result, [
+        {
+          number: 43,
+          title: "Valid PR",
+          url: "https://github.com/pingdotgg/codething-mvp/pull/43",
+          baseRefName: "main",
+          headRefName: "feature/pr-list",
+          state: "open",
+        },
+      ]);
+    }),
+  );
+
   it.effect("reads repository clone URLs", () =>
     Effect.gen(function* () {
       mockedRunProcess.mockResolvedValueOnce({

--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -76,6 +76,53 @@ layer("GitHubCliLive", (it) => {
     }),
   );
 
+  it.effect("trims pull request fields decoded from gh json", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 42,
+          title: "  Add PR thread creation  \n",
+          url: " https://github.com/pingdotgg/codething-mvp/pull/42 ",
+          baseRefName: " main ",
+          headRefName: "\tfeature/pr-threads\t",
+          state: "OPEN",
+          mergedAt: null,
+          isCrossRepository: true,
+          headRepository: {
+            nameWithOwner: " octocat/codething-mvp ",
+          },
+          headRepositoryOwner: {
+            login: " octocat ",
+          },
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+
+      const result = yield* Effect.gen(function* () {
+        const gh = yield* GitHubCli;
+        return yield* gh.getPullRequest({
+          cwd: "/repo",
+          reference: "#42",
+        });
+      });
+
+      assert.deepStrictEqual(result, {
+        number: 42,
+        title: "Add PR thread creation",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/42",
+        baseRefName: "main",
+        headRefName: "feature/pr-threads",
+        state: "open",
+        isCrossRepository: true,
+        headRepositoryNameWithOwner: "octocat/codething-mvp",
+        headRepositoryOwnerLogin: "octocat",
+      });
+    }),
+  );
+
   it.effect("reads repository clone URLs", () =>
     Effect.gen(function* () {
       mockedRunProcess.mockResolvedValueOnce({

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -1,5 +1,5 @@
-import { Effect, Layer, Schema, SchemaIssue } from "effect";
-import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
+import { Effect, Layer, Result, Schema, SchemaIssue } from "effect";
+import { TrimmedNonEmptyString } from "@t3tools/contracts";
 
 import { runProcess } from "../../processRunner";
 import { GitHubCliError } from "@t3tools/contracts";
@@ -7,8 +7,12 @@ import {
   GitHubCli,
   type GitHubRepositoryCloneUrls,
   type GitHubCliShape,
-  type GitHubPullRequestSummary,
 } from "../Services/GitHubCli.ts";
+import {
+  decodeGitHubPullRequestJson,
+  decodeGitHubPullRequestListJson,
+  formatGitHubJsonDecodeError,
+} from "../githubPullRequests.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -63,75 +67,11 @@ function normalizeGitHubCliError(operation: "execute" | "stdout", error: unknown
   });
 }
 
-function normalizePullRequestState(input: {
-  state?: string | null | undefined;
-  mergedAt?: string | null | undefined;
-}): "open" | "closed" | "merged" {
-  const mergedAt = input.mergedAt;
-  const state = input.state;
-  if ((typeof mergedAt === "string" && mergedAt.trim().length > 0) || state === "MERGED") {
-    return "merged";
-  }
-  if (state === "CLOSED") {
-    return "closed";
-  }
-  return "open";
-}
-
-const RawGitHubPullRequestSchema = Schema.Struct({
-  number: PositiveInt,
-  title: TrimmedNonEmptyString,
-  url: TrimmedNonEmptyString,
-  baseRefName: TrimmedNonEmptyString,
-  headRefName: TrimmedNonEmptyString,
-  state: Schema.optional(Schema.NullOr(Schema.String)),
-  mergedAt: Schema.optional(Schema.NullOr(Schema.String)),
-  isCrossRepository: Schema.optional(Schema.Boolean),
-  headRepository: Schema.optional(
-    Schema.NullOr(
-      Schema.Struct({
-        nameWithOwner: Schema.String,
-      }),
-    ),
-  ),
-  headRepositoryOwner: Schema.optional(
-    Schema.NullOr(
-      Schema.Struct({
-        login: Schema.String,
-      }),
-    ),
-  ),
-});
-
 const RawGitHubRepositoryCloneUrlsSchema = Schema.Struct({
   nameWithOwner: TrimmedNonEmptyString,
   url: TrimmedNonEmptyString,
   sshUrl: TrimmedNonEmptyString,
 });
-
-function normalizePullRequestSummary(
-  raw: Schema.Schema.Type<typeof RawGitHubPullRequestSchema>,
-): GitHubPullRequestSummary {
-  const headRepositoryNameWithOwner = raw.headRepository?.nameWithOwner ?? null;
-  const headRepositoryOwnerLogin =
-    raw.headRepositoryOwner?.login ??
-    (typeof headRepositoryNameWithOwner === "string" && headRepositoryNameWithOwner.includes("/")
-      ? (headRepositoryNameWithOwner.split("/")[0] ?? null)
-      : null);
-  return {
-    number: raw.number,
-    title: raw.title,
-    url: raw.url,
-    baseRefName: raw.baseRefName,
-    headRefName: raw.headRefName,
-    state: normalizePullRequestState(raw),
-    ...(typeof raw.isCrossRepository === "boolean"
-      ? { isCrossRepository: raw.isCrossRepository }
-      : {}),
-    ...(headRepositoryNameWithOwner ? { headRepositoryNameWithOwner } : {}),
-    ...(headRepositoryOwnerLogin ? { headRepositoryOwnerLogin } : {}),
-  };
-}
 
 function normalizeRepositoryCloneUrls(
   raw: Schema.Schema.Type<typeof RawGitHubRepositoryCloneUrlsSchema>,
@@ -194,14 +134,24 @@ const makeGitHubCli = Effect.sync(() => {
         Effect.flatMap((raw) =>
           raw.length === 0
             ? Effect.succeed([])
-            : decodeGitHubJson(
-                raw,
-                Schema.Array(RawGitHubPullRequestSchema),
-                "listOpenPullRequests",
-                "GitHub CLI returned invalid PR list JSON.",
+            : Effect.sync(() => decodeGitHubPullRequestListJson(raw)).pipe(
+                Effect.flatMap((decoded) => {
+                  if (!Result.isSuccess(decoded)) {
+                    return Effect.fail(
+                      new GitHubCliError({
+                        operation: "listOpenPullRequests",
+                        detail: `GitHub CLI returned invalid PR list JSON: ${formatGitHubJsonDecodeError(decoded.failure)}`,
+                        cause: decoded.failure,
+                      }),
+                    );
+                  }
+
+                  return Effect.succeed(
+                    decoded.success.map(({ updatedAt: _updatedAt, ...summary }) => summary),
+                  );
+                }),
               ),
         ),
-        Effect.map((pullRequests) => pullRequests.map(normalizePullRequestSummary)),
       ),
     getPullRequest: (input) =>
       execute({
@@ -216,14 +166,24 @@ const makeGitHubCli = Effect.sync(() => {
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
-          decodeGitHubJson(
-            raw,
-            RawGitHubPullRequestSchema,
-            "getPullRequest",
-            "GitHub CLI returned invalid pull request JSON.",
+          Effect.sync(() => decodeGitHubPullRequestJson(raw)).pipe(
+            Effect.flatMap((decoded) => {
+              if (!Result.isSuccess(decoded)) {
+                return Effect.fail(
+                  new GitHubCliError({
+                    operation: "getPullRequest",
+                    detail: `GitHub CLI returned invalid pull request JSON: ${formatGitHubJsonDecodeError(decoded.failure)}`,
+                    cause: decoded.failure,
+                  }),
+                );
+              }
+
+              return Effect.succeed(
+                (({ updatedAt: _updatedAt, ...summary }) => summary)(decoded.success),
+              );
+            }),
           ),
         ),
-        Effect.map(normalizePullRequestSummary),
       ),
     getRepositoryCloneUrls: (input) =>
       execute({

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -712,6 +712,44 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("status trims PR metadata returned by gh before publishing it", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/status-trimmed-pr"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/status-trimmed-pr"]);
+
+      const { manager } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            JSON.stringify([
+              {
+                number: 14,
+                title: "  Existing PR title  \n",
+                url: " https://github.com/pingdotgg/codething-mvp/pull/14 ",
+                baseRefName: " main ",
+                headRefName: "\tfeature/status-trimmed-pr\t",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.pr).toEqual({
+        number: 14,
+        title: "Existing PR title",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/14",
+        baseBranch: "main",
+        headBranch: "feature/status-trimmed-pr",
+        state: "open",
+      });
+    }),
+  );
+
   it.effect("status returns an explicit non-repo result for non-git directories", () =>
     Effect.gen(function* () {
       const cwd = yield* makeTempDir("t3code-git-manager-non-repo-");

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -801,6 +801,55 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("status preserves lowercase merged and closed PR states from gh json", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/status-lowercase-state"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/status-lowercase-state"]);
+
+      const { manager } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            JSON.stringify([
+              {
+                number: 16,
+                title: "Closed PR",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/16",
+                baseRefName: "main",
+                headRefName: "feature/status-lowercase-state",
+                state: "closed",
+                updatedAt: "2026-01-01T00:00:00.000Z",
+              },
+              {
+                number: 17,
+                title: "Merged PR",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/17",
+                baseRefName: "main",
+                headRefName: "feature/status-lowercase-state",
+                state: "merged",
+                updatedAt: "2026-01-02T00:00:00.000Z",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.pr).toEqual({
+        number: 17,
+        title: "Merged PR",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/17",
+        baseBranch: "main",
+        headBranch: "feature/status-lowercase-state",
+        state: "merged",
+      });
+    }),
+  );
+
   it.effect("status returns an explicit non-repo result for non-git directories", () =>
     Effect.gen(function* () {
       const cwd = yield* makeTempDir("t3code-git-manager-non-repo-");

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -750,6 +750,57 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("status ignores invalid gh pr list entries and keeps valid ones", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/status-valid-pr-entry"]);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature/status-valid-pr-entry"]);
+
+      const { manager } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            JSON.stringify([
+              {
+                number: 0,
+                title: "invalid",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/0",
+                baseRefName: "main",
+                headRefName: "feature/invalid",
+              },
+              {
+                number: 15,
+                title: "  Valid PR title  ",
+                url: " https://github.com/pingdotgg/codething-mvp/pull/15 ",
+                baseRefName: " main ",
+                headRefName: "\tfeature/status-valid-pr-entry\t",
+                headRepository: {
+                  nameWithOwner: "   ",
+                },
+                headRepositoryOwner: {
+                  login: "   ",
+                },
+              },
+            ]),
+          ],
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+
+      expect(status.pr).toEqual({
+        number: 15,
+        title: "Valid PR title",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/15",
+        baseBranch: "main",
+        headBranch: "feature/status-valid-pr-entry",
+        state: "open",
+      });
+    }),
+  );
+
   it.effect("status returns an explicit non-repo result for non-git directories", () =>
     Effect.gen(function* () {
       const cwd = yield* makeTempDir("t3code-git-manager-non-repo-");

--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -186,6 +186,24 @@ function makeTempDir(
   });
 }
 
+function removePath(
+  targetPath: string,
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    yield* fileSystem.remove(targetPath, { recursive: true, force: true });
+  });
+}
+
+function makeDirectory(
+  dirPath: string,
+): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    yield* fileSystem.makeDirectory(dirPath, { recursive: true });
+  });
+}
+
 function runGit(
   cwd: string,
   args: readonly string[],
@@ -697,6 +715,35 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
   it.effect("status returns an explicit non-repo result for non-git directories", () =>
     Effect.gen(function* () {
       const cwd = yield* makeTempDir("t3code-git-manager-non-repo-");
+      const { manager } = yield* makeManager();
+
+      const status = yield* manager.status({ cwd });
+
+      expect(status).toEqual({
+        isRepo: false,
+        hasOriginRemote: false,
+        isDefaultBranch: false,
+        branch: null,
+        hasWorkingTreeChanges: false,
+        workingTree: {
+          files: [],
+          insertions: 0,
+          deletions: 0,
+        },
+        hasUpstream: false,
+        aheadCount: 0,
+        behindCount: 0,
+        pr: null,
+      });
+    }),
+  );
+
+  it.effect("status returns an explicit non-repo result for deleted directories", () =>
+    Effect.gen(function* () {
+      const rootDir = yield* makeTempDir("t3code-git-manager-missing-dir-");
+      const cwd = path.join(rootDir, "deleted-repo");
+      yield* makeDirectory(cwd);
+      yield* removePath(cwd);
       const { manager } = yield* makeManager();
 
       const status = yield* manager.status({ cwd });

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -276,15 +276,16 @@ function parsePullRequestList(raw: unknown): PullRequestInfo[] {
         : typeof headRepositoryOwnerRecord?.login === "string"
           ? headRepositoryOwnerRecord.login
           : null;
+    const normalizedTitle = typeof title === "string" ? title.trim() : null;
+    const normalizedUrl = typeof url === "string" ? url.trim() : null;
+    const normalizedBaseRefName = typeof baseRefName === "string" ? baseRefName.trim() : null;
+    const normalizedHeadRefName = typeof headRefName === "string" ? headRefName.trim() : null;
+    const normalizedHeadRepositoryNameWithOwner = headRepositoryNameWithOwner?.trim() || null;
+    const normalizedHeadRepositoryOwnerLogin = headRepositoryOwnerLogin?.trim() || null;
     if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) {
       continue;
     }
-    if (
-      typeof title !== "string" ||
-      typeof url !== "string" ||
-      typeof baseRefName !== "string" ||
-      typeof headRefName !== "string"
-    ) {
+    if (!normalizedTitle || !normalizedUrl || !normalizedBaseRefName || !normalizedHeadRefName) {
       continue;
     }
 
@@ -305,15 +306,19 @@ function parsePullRequestList(raw: unknown): PullRequestInfo[] {
 
     parsed.push({
       number,
-      title,
-      url,
-      baseRefName,
-      headRefName,
+      title: normalizedTitle,
+      url: normalizedUrl,
+      baseRefName: normalizedBaseRefName,
+      headRefName: normalizedHeadRefName,
       state: normalizedState,
       updatedAt: typeof updatedAt === "string" && updatedAt.trim().length > 0 ? updatedAt : null,
       ...(typeof isCrossRepository === "boolean" ? { isCrossRepository } : {}),
-      ...(headRepositoryNameWithOwner ? { headRepositoryNameWithOwner } : {}),
-      ...(headRepositoryOwnerLogin ? { headRepositoryOwnerLogin } : {}),
+      ...(normalizedHeadRepositoryNameWithOwner
+        ? { headRepositoryNameWithOwner: normalizedHeadRepositoryNameWithOwner }
+        : {}),
+      ...(normalizedHeadRepositoryOwnerLogin
+        ? { headRepositoryOwnerLogin: normalizedHeadRepositoryOwnerLogin }
+        : {}),
     });
   }
   return parsed;

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -1,7 +1,18 @@
 import { randomUUID } from "node:crypto";
 import { realpathSync } from "node:fs";
 
-import { Cache, Duration, Effect, Exit, FileSystem, Layer, Option, Path, Ref } from "effect";
+import {
+  Cache,
+  Duration,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Option,
+  Path,
+  Ref,
+  Result,
+} from "effect";
 import {
   GitActionProgressEvent,
   GitActionProgressPhase,
@@ -34,6 +45,10 @@ import { ProjectSetupScriptRunner } from "../../project/Services/ProjectSetupScr
 import { extractBranchNameFromRemoteRef } from "../remoteRefs.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import type { GitManagerServiceError } from "@t3tools/contracts";
+import {
+  decodeGitHubPullRequestListJson,
+  formatGitHubJsonDecodeError,
+} from "../githubPullRequests.ts";
 
 const COMMIT_TIMEOUT_MS = 10 * 60_000;
 const MAX_PROGRESS_TEXT_LENGTH = 500;
@@ -238,90 +253,6 @@ function matchesBranchHeadContext(
     return false;
   }
   return true;
-}
-
-function parsePullRequestList(raw: unknown): PullRequestInfo[] {
-  if (!Array.isArray(raw)) return [];
-
-  const parsed: PullRequestInfo[] = [];
-  for (const entry of raw) {
-    if (!entry || typeof entry !== "object") continue;
-    const record = entry as Record<string, unknown>;
-    const number = record.number;
-    const title = record.title;
-    const url = record.url;
-    const baseRefName = record.baseRefName;
-    const headRefName = record.headRefName;
-    const state = record.state;
-    const mergedAt = record.mergedAt;
-    const updatedAt = record.updatedAt;
-    const isCrossRepository = record.isCrossRepository;
-    const headRepositoryRecord =
-      typeof record.headRepository === "object" && record.headRepository !== null
-        ? (record.headRepository as Record<string, unknown>)
-        : null;
-    const headRepositoryOwnerRecord =
-      typeof record.headRepositoryOwner === "object" && record.headRepositoryOwner !== null
-        ? (record.headRepositoryOwner as Record<string, unknown>)
-        : null;
-    const headRepositoryNameWithOwner =
-      typeof record.headRepositoryNameWithOwner === "string"
-        ? record.headRepositoryNameWithOwner
-        : typeof headRepositoryRecord?.nameWithOwner === "string"
-          ? headRepositoryRecord.nameWithOwner
-          : null;
-    const headRepositoryOwnerLogin =
-      typeof record.headRepositoryOwnerLogin === "string"
-        ? record.headRepositoryOwnerLogin
-        : typeof headRepositoryOwnerRecord?.login === "string"
-          ? headRepositoryOwnerRecord.login
-          : null;
-    const normalizedTitle = typeof title === "string" ? title.trim() : null;
-    const normalizedUrl = typeof url === "string" ? url.trim() : null;
-    const normalizedBaseRefName = typeof baseRefName === "string" ? baseRefName.trim() : null;
-    const normalizedHeadRefName = typeof headRefName === "string" ? headRefName.trim() : null;
-    const normalizedHeadRepositoryNameWithOwner = headRepositoryNameWithOwner?.trim() || null;
-    const normalizedHeadRepositoryOwnerLogin = headRepositoryOwnerLogin?.trim() || null;
-    if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) {
-      continue;
-    }
-    if (!normalizedTitle || !normalizedUrl || !normalizedBaseRefName || !normalizedHeadRefName) {
-      continue;
-    }
-
-    let normalizedState: "open" | "closed" | "merged";
-    if (
-      (typeof mergedAt === "string" && mergedAt.trim().length > 0) ||
-      state === "MERGED" ||
-      state === "merged"
-    ) {
-      normalizedState = "merged";
-    } else if (state === "OPEN" || state === "open" || state === undefined || state === null) {
-      normalizedState = "open";
-    } else if (state === "CLOSED" || state === "closed") {
-      normalizedState = "closed";
-    } else {
-      continue;
-    }
-
-    parsed.push({
-      number,
-      title: normalizedTitle,
-      url: normalizedUrl,
-      baseRefName: normalizedBaseRefName,
-      headRefName: normalizedHeadRefName,
-      state: normalizedState,
-      updatedAt: typeof updatedAt === "string" && updatedAt.trim().length > 0 ? updatedAt : null,
-      ...(typeof isCrossRepository === "boolean" ? { isCrossRepository } : {}),
-      ...(normalizedHeadRepositoryNameWithOwner
-        ? { headRepositoryNameWithOwner: normalizedHeadRepositoryNameWithOwner }
-        : {}),
-      ...(normalizedHeadRepositoryOwnerLogin
-        ? { headRepositoryOwnerLogin: normalizedHeadRepositoryOwnerLogin }
-        : {}),
-    });
-  }
-  return parsed;
 }
 
 function toPullRequestInfo(summary: GitHubPullRequestSummary): PullRequestInfo {
@@ -952,13 +883,23 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
         continue;
       }
 
-      const parsedJson = yield* Effect.try({
-        try: () => JSON.parse(raw) as unknown,
-        catch: (cause) =>
-          gitManagerError("findLatestPr", "GitHub CLI returned invalid PR list JSON.", cause),
-      });
+      const pullRequests = yield* Effect.sync(() => decodeGitHubPullRequestListJson(raw)).pipe(
+        Effect.flatMap((decoded) => {
+          if (!Result.isSuccess(decoded)) {
+            return Effect.fail(
+              gitManagerError(
+                "findLatestPr",
+                `GitHub CLI returned invalid PR list JSON: ${formatGitHubJsonDecodeError(decoded.failure)}`,
+                decoded.failure,
+              ),
+            );
+          }
 
-      for (const pr of parsePullRequestList(parsedJson)) {
+          return Effect.succeed(decoded.success);
+        }),
+      );
+
+      for (const pr of pullRequests) {
         if (!matchesBranchHeadContext(pr, headContext)) {
           continue;
         }

--- a/apps/server/src/git/githubPullRequests.ts
+++ b/apps/server/src/git/githubPullRequests.ts
@@ -50,13 +50,14 @@ function normalizeGitHubPullRequestState(input: {
   state?: string | null | undefined;
   mergedAt?: string | null | undefined;
 }): "open" | "closed" | "merged" {
+  const normalizedState = input.state?.trim().toUpperCase();
   if (
     (typeof input.mergedAt === "string" && input.mergedAt.trim().length > 0) ||
-    input.state === "MERGED"
+    normalizedState === "MERGED"
   ) {
     return "merged";
   }
-  if (input.state === "CLOSED") {
+  if (normalizedState === "CLOSED") {
     return "closed";
   }
   return "open";

--- a/apps/server/src/git/githubPullRequests.ts
+++ b/apps/server/src/git/githubPullRequests.ts
@@ -1,4 +1,4 @@
-import { Cause, Result, Schema } from "effect";
+import { Cause, Exit, Result, Schema } from "effect";
 import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
 import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
 
@@ -28,18 +28,23 @@ const GitHubPullRequestSchema = Schema.Struct({
   headRepository: Schema.optional(
     Schema.NullOr(
       Schema.Struct({
-        nameWithOwner: TrimmedNonEmptyString,
+        nameWithOwner: Schema.String,
       }),
     ),
   ),
   headRepositoryOwner: Schema.optional(
     Schema.NullOr(
       Schema.Struct({
-        login: TrimmedNonEmptyString,
+        login: Schema.String,
       }),
     ),
   ),
 });
+
+function trimOptionalString(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
 
 function normalizeGitHubPullRequestState(input: {
   state?: string | null | undefined;
@@ -60,9 +65,9 @@ function normalizeGitHubPullRequestState(input: {
 function normalizeGitHubPullRequestRecord(
   raw: Schema.Schema.Type<typeof GitHubPullRequestSchema>,
 ): NormalizedGitHubPullRequestRecord {
-  const headRepositoryNameWithOwner = raw.headRepository?.nameWithOwner ?? null;
+  const headRepositoryNameWithOwner = trimOptionalString(raw.headRepository?.nameWithOwner);
   const headRepositoryOwnerLogin =
-    raw.headRepositoryOwner?.login ??
+    trimOptionalString(raw.headRepositoryOwner?.login) ??
     (typeof headRepositoryNameWithOwner === "string" && headRepositoryNameWithOwner.includes("/")
       ? (headRepositoryNameWithOwner.split("/")[0] ?? null)
       : null);
@@ -84,8 +89,9 @@ function normalizeGitHubPullRequestRecord(
   };
 }
 
-const decodeGitHubPullRequestList = decodeJsonResult(Schema.Array(GitHubPullRequestSchema));
+const decodeGitHubPullRequestList = decodeJsonResult(Schema.Array(Schema.Unknown));
 const decodeGitHubPullRequest = decodeJsonResult(GitHubPullRequestSchema);
+const decodeGitHubPullRequestEntry = Schema.decodeUnknownExit(GitHubPullRequestSchema);
 
 export const formatGitHubJsonDecodeError = formatSchemaError;
 
@@ -97,7 +103,15 @@ export function decodeGitHubPullRequestListJson(
 > {
   const result = decodeGitHubPullRequestList(raw);
   if (Result.isSuccess(result)) {
-    return Result.succeed(result.success.map(normalizeGitHubPullRequestRecord));
+    const pullRequests: NormalizedGitHubPullRequestRecord[] = [];
+    for (const entry of result.success) {
+      const decodedEntry = decodeGitHubPullRequestEntry(entry);
+      if (Exit.isFailure(decodedEntry)) {
+        continue;
+      }
+      pullRequests.push(normalizeGitHubPullRequestRecord(decodedEntry.value));
+    }
+    return Result.succeed(pullRequests);
   }
   return Result.fail(result.failure);
 }

--- a/apps/server/src/git/githubPullRequests.ts
+++ b/apps/server/src/git/githubPullRequests.ts
@@ -1,0 +1,113 @@
+import { Cause, Result, Schema } from "effect";
+import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
+import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
+
+export interface NormalizedGitHubPullRequestRecord {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly baseRefName: string;
+  readonly headRefName: string;
+  readonly state: "open" | "closed" | "merged";
+  readonly updatedAt: string | null;
+  readonly isCrossRepository?: boolean;
+  readonly headRepositoryNameWithOwner?: string | null;
+  readonly headRepositoryOwnerLogin?: string | null;
+}
+
+const GitHubPullRequestSchema = Schema.Struct({
+  number: PositiveInt,
+  title: TrimmedNonEmptyString,
+  url: TrimmedNonEmptyString,
+  baseRefName: TrimmedNonEmptyString,
+  headRefName: TrimmedNonEmptyString,
+  state: Schema.optional(Schema.NullOr(Schema.String)),
+  mergedAt: Schema.optional(Schema.NullOr(Schema.String)),
+  updatedAt: Schema.optional(Schema.NullOr(Schema.String)),
+  isCrossRepository: Schema.optional(Schema.Boolean),
+  headRepository: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        nameWithOwner: TrimmedNonEmptyString,
+      }),
+    ),
+  ),
+  headRepositoryOwner: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        login: TrimmedNonEmptyString,
+      }),
+    ),
+  ),
+});
+
+function normalizeGitHubPullRequestState(input: {
+  state?: string | null | undefined;
+  mergedAt?: string | null | undefined;
+}): "open" | "closed" | "merged" {
+  if (
+    (typeof input.mergedAt === "string" && input.mergedAt.trim().length > 0) ||
+    input.state === "MERGED"
+  ) {
+    return "merged";
+  }
+  if (input.state === "CLOSED") {
+    return "closed";
+  }
+  return "open";
+}
+
+function normalizeGitHubPullRequestRecord(
+  raw: Schema.Schema.Type<typeof GitHubPullRequestSchema>,
+): NormalizedGitHubPullRequestRecord {
+  const headRepositoryNameWithOwner = raw.headRepository?.nameWithOwner ?? null;
+  const headRepositoryOwnerLogin =
+    raw.headRepositoryOwner?.login ??
+    (typeof headRepositoryNameWithOwner === "string" && headRepositoryNameWithOwner.includes("/")
+      ? (headRepositoryNameWithOwner.split("/")[0] ?? null)
+      : null);
+
+  return {
+    number: raw.number,
+    title: raw.title,
+    url: raw.url,
+    baseRefName: raw.baseRefName,
+    headRefName: raw.headRefName,
+    state: normalizeGitHubPullRequestState(raw),
+    updatedAt:
+      typeof raw.updatedAt === "string" && raw.updatedAt.trim().length > 0 ? raw.updatedAt : null,
+    ...(typeof raw.isCrossRepository === "boolean"
+      ? { isCrossRepository: raw.isCrossRepository }
+      : {}),
+    ...(headRepositoryNameWithOwner ? { headRepositoryNameWithOwner } : {}),
+    ...(headRepositoryOwnerLogin ? { headRepositoryOwnerLogin } : {}),
+  };
+}
+
+const decodeGitHubPullRequestList = decodeJsonResult(Schema.Array(GitHubPullRequestSchema));
+const decodeGitHubPullRequest = decodeJsonResult(GitHubPullRequestSchema);
+
+export const formatGitHubJsonDecodeError = formatSchemaError;
+
+export function decodeGitHubPullRequestListJson(
+  raw: string,
+): Result.Result<
+  ReadonlyArray<NormalizedGitHubPullRequestRecord>,
+  Cause.Cause<Schema.SchemaError>
+> {
+  const result = decodeGitHubPullRequestList(raw);
+  if (Result.isSuccess(result)) {
+    return Result.succeed(result.success.map(normalizeGitHubPullRequestRecord));
+  }
+  return Result.fail(result.failure);
+}
+
+export function decodeGitHubPullRequestJson(
+  raw: string,
+): Result.Result<NormalizedGitHubPullRequestRecord, Cause.Cause<Schema.SchemaError>> {
+  const result = decodeGitHubPullRequest(raw);
+  if (Result.isSuccess(result)) {
+    return Result.succeed(normalizeGitHubPullRequestRecord(result.success));
+  }
+  return Result.fail(result.failure);
+}


### PR DESCRIPTION
## Summary
- Treat missing or deleted `cwd` paths as explicit non-repository states instead of surfacing git/fs errors.
- Add a shared non-repo status shape in `GitCore` so status callers return stable defaults for deleted directories.
- Update `statusDetails`, branch lookup, and manager-level status handling to degrade cleanly when the working directory no longer exists.
- Add integration coverage for both `GitCore` and `GitManager` to verify deleted directories return `isRepo: false` with empty status data.

## Testing
- `bun run test apps/server/src/git/Layers/GitCore.test.ts`
- `bun run test apps/server/src/git/Layers/GitManager.test.ts`
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling paths in `GitCore`/`GitManager` so missing working directories and upstream refresh failures now degrade to non-repo defaults instead of surfacing errors, which can affect status/branch reporting behavior. Adds shared GitHub PR JSON decoding/normalization that may change how PR metadata is accepted/filtered from `gh` output.
> 
> **Overview**
> **Treat deleted/missing git working directories as explicit non-repositories.** `GitCore.statusDetailsLocal`, `statusDetails`, and `listBranches` now detect “missing cwd” failures and return stable `isRepo: false` results (via a new `NON_REPOSITORY_STATUS_DETAILS` constant) rather than throwing.
> 
> **Centralize and tighten GitHub PR JSON parsing.** Adds `githubPullRequests.ts` to decode/normalize `gh` PR JSON (trims fields, normalizes state, skips invalid entries) and updates `GitHubCli` and `GitManager` to use it with clearer schema-formatted errors.
> 
> **Tests updated/added** to cover deleted-directory behavior for `GitCore`/`GitManager` and PR metadata trimming/invalid-entry filtering in `GitHubCli` and manager status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e0eb430f7b366f79c298b5b529dca47a9cc2b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle deleted git directories as non-repositories in status and branch listing
> - `listBranches`, `statusDetails`, and `statusDetailsLocal` in [`GitCore.ts`](https://github.com/pingdotgg/t3code/pull/1907/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865) now return a non-repository result instead of throwing when the working directory no longer exists on disk.
> - Adds `isMissingGitCwdError` to detect ENOENT/invalid-directory errors from git commands, and a `NON_REPOSITORY_STATUS_DETAILS` constant as the canonical non-repo response.
> - Centralizes GitHub PR JSON decoding into a new [`githubPullRequests.ts`](https://github.com/pingdotgg/t3code/pull/1907/files#diff-c3c3b0e4528df215a4073821f50b0d0de65bc25f7b59b7368076571b1632588a) module with schema-driven normalization; `GitHubCli` and `GitManager` now use these shared decoders instead of ad-hoc parsing.
> - Invalid PR list entries are silently dropped by the decoder; decode failures produce structured schema-based error messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99e0eb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->