### PR TITLE
Disable SSH askpass for upstream status fetches

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1023,9 +1023,11 @@ it.layer(TestLayer)("git integration", (it) => {
         expect(yield* git(source, ["branch", "--show-current"])).toBe("upstream/feature");
         const realGitCore = yield* GitCore;
         let fetchArgs: readonly string[] | null = null;
+        let fetchEnv: NodeJS.ProcessEnv | undefined;
         const core = yield* makeIsolatedGitCore((input) => {
           if (input.args[0] === "--git-dir" && input.args[2] === "fetch") {
             fetchArgs = [...input.args];
+            fetchEnv = input.env;
             return Effect.succeed({
               code: 0,
               stdout: "",
@@ -1049,6 +1051,9 @@ it.layer(TestLayer)("git integration", (it) => {
           remoteName,
           `+refs/heads/${featureBranch}:refs/remotes/${remoteName}/${featureBranch}`,
         ]);
+        expect(fetchEnv).toEqual({
+          SSH_ASKPASS_REQUIRE: "never",
+        });
       }),
     );
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -87,6 +87,7 @@ class StatusUpstreamRefreshCacheKey extends Data.Class<{
 
 interface ExecuteGitOptions {
   stdin?: string | undefined;
+  env?: NodeJS.ProcessEnv | undefined;
   timeoutMs?: number | undefined;
   allowNonZeroExit?: boolean | undefined;
   fallbackErrorMessage?: string | undefined;
@@ -799,6 +800,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       cwd,
       args,
       ...(options.stdin !== undefined ? { stdin: options.stdin } : {}),
+      ...(options.env !== undefined ? { env: options.env } : {}),
       allowNonZeroExit: true,
       ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
       ...(options.maxOutputBytes !== undefined ? { maxOutputBytes: options.maxOutputBytes } : {}),
@@ -932,6 +934,9 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", upstream.remoteName, refspec],
       {
         allowNonZeroExit: true,
+        env: {
+          SSH_ASKPASS_REQUIRE: "never",
+        },
         timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
       },
     ).pipe(Effect.asVoid);


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

- Extended `ExecuteGitOptions` with `env` field
- Pass `SSH_ASKPASS_REQUIRE=never` to upstream status fetch to prevent annoying popups that cannot be usefully responded

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

`GitCore.fetchUpstreamRefForStatus` periodically runs `git fetch`. When Git interacts with an SSH remote that requires a passphrase to unlock the SSH key, an ssh-askpass window pops up each time this is invoked if the key is not available in the SSH agent. With a timeout of 5 seconds, it is difficult to react and type the passphrase.

This change has minimal UX impact because users currently have to add the key manually nonetheless due to the timeout.

This should work around #356 and #1190.

Some possible remaining work:

- HTTPS credential handling
- A switch to disable automatic fetching.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- ~[ ] I included before/after screenshots for any UI changes~ Not applicable
- ~[ ] I included a video for animation/interaction changes~ Not applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only the background `GitCore.fetchUpstreamRefForStatus` `git fetch` gets an extra environment override to suppress SSH credential prompting, plus test adjustments to assert the new behavior.
> 
> **Overview**
> Upstream status refresh `git fetch` calls now run with `SSH_ASKPASS_REQUIRE=never` to prevent SSH askpass prompts during the periodic behind/ahead refresh.
> 
> This introduces an optional `env` field on `ExecuteGitOptions` and forwards it through `executeGit`, and updates the relevant checkout/status test to assert the fetch environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8379bcfef7bcad50ce54f212adfa58dac41839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `SSH_ASKPASS_REQUIRE=never` on upstream status fetches in `GitCore`
> - Adds an optional `env` field to the `ExecuteGitOptions` interface in [GitCore.ts](https://github.com/pingdotgg/t3code/pull/1921/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865), forwarded to the underlying `execute` call.
> - Sets `{ SSH_ASKPASS_REQUIRE: 'never' }` when calling `fetchUpstreamRefForStatus`, preventing SSH from prompting for credentials during background status fetches.
> - Behavioral Change: upstream `git fetch` calls now run with a modified environment; other `executeGit` callers are unaffected unless they pass `env` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae8379b.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->