### PR TITLE
fix(web): allow removing projects that still contain threads

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1318,19 +1318,25 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         }
         if (clicked !== "delete") return;
 
-        if (projectThreads.length > 0) {
-          toastManager.add({
-            type: "warning",
-            title: "Project is not empty",
-            description: "Delete all threads in this project before removing it.",
-          });
-          return;
-        }
-
-        const confirmed = await api.dialogs.confirm(`Remove project "${project.name}"?`);
+        const confirmed = await api.dialogs.confirm(
+          [
+            `Remove project "${project.name}"?`,
+            projectThreads.length > 0
+              ? `This will also delete ${projectThreads.length} thread${projectThreads.length === 1 ? "" : "s"} in this project.`
+              : null,
+            "Your files on disk will not be affected.",
+          ]
+            .filter(Boolean)
+            .join("\n"),
+        );
         if (!confirmed) return;
 
         try {
+          // Delete all threads in the project first
+          for (const thread of projectThreads) {
+            await deleteThread(scopeThreadRef(thread.environmentId, thread.id));
+          }
+
           const projectDraftThread = getDraftThreadByProjectRef(
             scopeProjectRef(project.environmentId, project.id),
           );
@@ -1363,12 +1369,13 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       clearComposerDraftForThread,
       clearProjectDraftThreadId,
       copyPathToClipboard,
+      deleteThread,
       getDraftThreadByProjectRef,
       project.cwd,
       project.environmentId,
       project.id,
       project.name,
-      projectThreads.length,
+      projectThreads,
       suppressProjectClickForContextMenuRef,
     ],
   );


### PR DESCRIPTION
## Summary
- Removing a project with existing threads showed a blocking warning toast ("Project is not empty") and refused to proceed, forcing users to manually delete every thread first.
- The confirmation dialog now automatically deletes all threads before removing the project.
- The dialog also clarifies that files on disk are not affected.

## What changed
- Replaced the blocking toast with a cascading delete: all threads are deleted before the project is removed.
- Updated the native confirmation dialog message to include thread count (when applicable) and a reassurance that local files remain untouched.
- Added `deleteThread` and `projectThreads` to the `useCallback` dependency array.

## Before
<img width="502" height="160" alt="Screenshot 2026-04-11 at 06 46 27" src="https://github.com/user-attachments/assets/c5fda800-05a5-42ff-a9a6-a169ad30bf80" />


## After
https://github.com/user-attachments/assets/a1058779-2123-430a-a57e-38bab949ea27


## Test plan
- [ ] Right-click a project with threads → "Remove project" → confirm → project and threads removed
- [ ] Right-click an empty project → "Remove project" → confirm → project removed
- [ ] Cancel the confirmation → nothing happens
- [ ] Files on disk remain untouched after removal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deletion behavior to automatically delete all threads before removing a project, which could cause unintended data loss or partial-failure states if thread deletions fail mid-sequence.
> 
> **Overview**
> Removing a project from the sidebar no longer blocks when the project contains threads; it now confirms and then **deletes all threads in the project** before dispatching the `project.delete` command.
> 
> The confirmation dialog message is expanded to include the number of threads that will be deleted (when non-zero) and to clarify that files on disk are unaffected, and the callback dependencies are updated to track `deleteThread` and `projectThreads`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88532c1feb2a8955364b840495fe5f2b4467faa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->