### PR TITLE
Handle non-git drafts in local mode

### DIFF
--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -138,6 +138,17 @@ describe("resolveEffectiveEnvMode", () => {
       }),
     ).toBe("worktree");
   });
+
+  it("falls back to local mode for non-git projects even if the draft prefers worktree mode", () => {
+    expect(
+      resolveEffectiveEnvMode({
+        activeWorktreePath: null,
+        hasServerThread: false,
+        draftThreadEnvMode: "worktree",
+        isGitRepo: false,
+      }),
+    ).toBe("local");
+  });
 });
 
 describe("resolveEnvModeLabel", () => {

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -54,8 +54,12 @@ export function resolveEffectiveEnvMode(input: {
   activeWorktreePath: string | null;
   hasServerThread: boolean;
   draftThreadEnvMode: EnvMode | undefined;
+  isGitRepo?: boolean;
 }): EnvMode {
-  const { activeWorktreePath, hasServerThread, draftThreadEnvMode } = input;
+  const { activeWorktreePath, hasServerThread, draftThreadEnvMode, isGitRepo = true } = input;
+  if (!isGitRepo) {
+    return "local";
+  }
   if (!hasServerThread) {
     if (activeWorktreePath) {
       return "local";

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -49,7 +49,7 @@ import { BrowserWsRpcHarness, type NormalizedWsRpcRequestBody } from "../../test
 import { estimateTimelineMessageHeight } from "./timelineHeight";
 import { DEFAULT_CLIENT_SETTINGS } from "@t3tools/contracts/settings";
 
-const { gitStatusStateRef } = vi.hoisted(() => ({
+const { gitStatusStateRef, refreshGitStatusResultRef, refreshGitStatusSpy } = vi.hoisted(() => ({
   gitStatusStateRef: {
     current: { data: null, error: null, cause: null, isPending: false } as {
       data: unknown;
@@ -58,12 +58,14 @@ const { gitStatusStateRef } = vi.hoisted(() => ({
       isPending: boolean;
     },
   },
+  refreshGitStatusResultRef: { current: null as unknown },
+  refreshGitStatusSpy: vi.fn(() => Promise.resolve(refreshGitStatusResultRef.current)),
 }));
 
 vi.mock("../lib/gitStatusState", () => ({
   useGitStatus: () => gitStatusStateRef.current,
   useGitStatuses: () => new Map(),
-  refreshGitStatus: () => Promise.resolve(null),
+  refreshGitStatus: refreshGitStatusSpy,
   resetGitStatusStateForTests: () => undefined,
 }));
 
@@ -1470,6 +1472,8 @@ describe("ChatView timeline estimator parity (full app)", () => {
     wsRequests.length = 0;
     customWsRpcResolver = null;
     gitStatusStateRef.current = { data: null, error: null, cause: null, isPending: false };
+    refreshGitStatusResultRef.current = null;
+    refreshGitStatusSpy.mockClear();
     useComposerDraftStore.setState({
       draftsByThreadKey: {},
       draftThreadsByThreadKey: {},
@@ -2461,6 +2465,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
   });
 
   it("falls back to local send behavior for non-git drafts even when worktree mode is persisted", async () => {
+    const draftId = draftIdFromPath("/draft/draft-non-git-local-fallback");
     gitStatusStateRef.current = {
       data: {
         isRepo: false,
@@ -2480,7 +2485,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     };
     useComposerDraftStore.setState({
       draftThreadsByThreadKey: {
-        [THREAD_KEY]: {
+        [draftId]: {
           threadId: THREAD_ID,
           environmentId: LOCAL_ENVIRONMENT_ID,
           projectId: PROJECT_ID,
@@ -2494,14 +2499,18 @@ describe("ChatView timeline estimator parity (full app)", () => {
         },
       },
       logicalProjectDraftThreadKeyByLogicalProjectKey: {
-        [PROJECT_DRAFT_KEY]: THREAD_KEY,
+        [PROJECT_DRAFT_KEY]: draftId,
       },
     });
 
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,
       snapshot: createDraftOnlySnapshot(),
+      initialPath: `/draft/${draftId}`,
       resolveRpc: (body) => {
+        if (body._tag === WS_METHODS.gitListBranches) {
+          return new Promise<never>(() => {});
+        }
         if (body._tag === ORCHESTRATION_WS_METHODS.dispatchCommand) {
           return {
             sequence: fixture.snapshot.snapshotSequence + 1,
@@ -2548,6 +2557,105 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       expect(useComposerDraftStore.getState().getDraftThread(THREAD_REF)?.envMode ?? null).toBe(
         "local",
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("refreshes pending git status before tripping the worktree base-branch guard", async () => {
+    const draftId = draftIdFromPath("/draft/draft-non-git-race");
+    gitStatusStateRef.current = {
+      data: null,
+      error: null,
+      cause: null,
+      isPending: true,
+    };
+    refreshGitStatusResultRef.current = {
+      isRepo: false,
+      hasOriginRemote: false,
+      isDefaultBranch: false,
+      branch: null,
+      hasWorkingTreeChanges: false,
+      workingTree: { files: [], insertions: 0, deletions: 0 },
+      hasUpstream: false,
+      aheadCount: 0,
+      behindCount: 0,
+      pr: null,
+    };
+    useComposerDraftStore.setState({
+      draftThreadsByThreadKey: {
+        [draftId]: {
+          threadId: THREAD_ID,
+          environmentId: LOCAL_ENVIRONMENT_ID,
+          projectId: PROJECT_ID,
+          logicalProjectKey: PROJECT_DRAFT_KEY,
+          createdAt: NOW_ISO,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          envMode: "worktree",
+        },
+      },
+      logicalProjectDraftThreadKeyByLogicalProjectKey: {
+        [PROJECT_DRAFT_KEY]: draftId,
+      },
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      initialPath: `/draft/${draftId}`,
+      resolveRpc: (body) => {
+        if (body._tag === WS_METHODS.gitListBranches) {
+          return new Promise<never>(() => {});
+        }
+        if (body._tag === ORCHESTRATION_WS_METHODS.dispatchCommand) {
+          return {
+            sequence: fixture.snapshot.snapshotSequence + 1,
+          };
+        }
+        return undefined;
+      },
+    });
+
+    try {
+      useComposerDraftStore.getState().setPrompt(THREAD_REF, "Ship it");
+      await waitForLayout();
+
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          expect(refreshGitStatusSpy).toHaveBeenCalledWith({
+            environmentId: LOCAL_ENVIRONMENT_ID,
+            cwd: "/repo/project",
+          });
+          const dispatchRequest = wsRequests.find(
+            (request) => request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand,
+          ) as
+            | {
+                _tag: string;
+                bootstrap?: {
+                  createThread?: { projectId?: string };
+                  prepareWorktree?: unknown;
+                };
+              }
+            | undefined;
+          expect(dispatchRequest).toMatchObject({
+            _tag: ORCHESTRATION_WS_METHODS.dispatchCommand,
+            bootstrap: {
+              createThread: {
+                projectId: PROJECT_ID,
+              },
+            },
+          });
+          expect(dispatchRequest?.bootstrap?.prepareWorktree).toBeUndefined();
+        },
+        { timeout: 8_000, interval: 16 },
       );
     } finally {
       await mounted.cleanup();

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -49,8 +49,19 @@ import { BrowserWsRpcHarness, type NormalizedWsRpcRequestBody } from "../../test
 import { estimateTimelineMessageHeight } from "./timelineHeight";
 import { DEFAULT_CLIENT_SETTINGS } from "@t3tools/contracts/settings";
 
+const { gitStatusStateRef } = vi.hoisted(() => ({
+  gitStatusStateRef: {
+    current: { data: null, error: null, cause: null, isPending: false } as {
+      data: unknown;
+      error: unknown;
+      cause: unknown;
+      isPending: boolean;
+    },
+  },
+}));
+
 vi.mock("../lib/gitStatusState", () => ({
-  useGitStatus: () => ({ data: null, error: null, cause: null, isPending: false }),
+  useGitStatus: () => gitStatusStateRef.current,
   useGitStatuses: () => new Map(),
   refreshGitStatus: () => Promise.resolve(null),
   resetGitStatusStateForTests: () => undefined,
@@ -1458,6 +1469,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
     document.body.innerHTML = "";
     wsRequests.length = 0;
     customWsRpcResolver = null;
+    gitStatusStateRef.current = { data: null, error: null, cause: null, isPending: false };
     useComposerDraftStore.setState({
       draftsByThreadKey: {},
       draftThreadsByThreadKey: {},
@@ -2444,6 +2456,100 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
     } finally {
       resolveDispatch({ sequence: fixture.snapshot.snapshotSequence + 1 });
+      await mounted.cleanup();
+    }
+  });
+
+  it("falls back to local send behavior for non-git drafts even when worktree mode is persisted", async () => {
+    gitStatusStateRef.current = {
+      data: {
+        isRepo: false,
+        hasOriginRemote: false,
+        isDefaultBranch: false,
+        branch: null,
+        hasWorkingTreeChanges: false,
+        workingTree: { files: [], insertions: 0, deletions: 0 },
+        hasUpstream: false,
+        aheadCount: 0,
+        behindCount: 0,
+        pr: null,
+      },
+      error: null,
+      cause: null,
+      isPending: false,
+    };
+    useComposerDraftStore.setState({
+      draftThreadsByThreadKey: {
+        [THREAD_KEY]: {
+          threadId: THREAD_ID,
+          environmentId: LOCAL_ENVIRONMENT_ID,
+          projectId: PROJECT_ID,
+          logicalProjectKey: PROJECT_DRAFT_KEY,
+          createdAt: NOW_ISO,
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          branch: null,
+          worktreePath: null,
+          envMode: "worktree",
+        },
+      },
+      logicalProjectDraftThreadKeyByLogicalProjectKey: {
+        [PROJECT_DRAFT_KEY]: THREAD_KEY,
+      },
+    });
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createDraftOnlySnapshot(),
+      resolveRpc: (body) => {
+        if (body._tag === ORCHESTRATION_WS_METHODS.dispatchCommand) {
+          return {
+            sequence: fixture.snapshot.snapshotSequence + 1,
+          };
+        }
+        return undefined;
+      },
+    });
+
+    try {
+      useComposerDraftStore.getState().setPrompt(THREAD_REF, "Ship it");
+      await waitForLayout();
+
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          const dispatchRequest = wsRequests.find(
+            (request) => request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand,
+          ) as
+            | {
+                _tag: string;
+                bootstrap?: {
+                  createThread?: { projectId?: string };
+                  prepareWorktree?: unknown;
+                };
+              }
+            | undefined;
+          expect(dispatchRequest).toMatchObject({
+            _tag: ORCHESTRATION_WS_METHODS.dispatchCommand,
+            bootstrap: {
+              createThread: {
+                projectId: PROJECT_ID,
+              },
+            },
+          });
+          expect(dispatchRequest?.bootstrap?.prepareWorktree).toBeUndefined();
+          expect(document.querySelector('button[aria-label="Preparing worktree"]')).toBeNull();
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      expect(useComposerDraftStore.getState().getDraftThread(THREAD_REF)?.envMode ?? null).toBe(
+        "local",
+      );
+    } finally {
       await mounted.cleanup();
     }
   });

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -31,7 +31,7 @@ import { truncate } from "@t3tools/shared/String";
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
-import { useGitStatus } from "~/lib/gitStatusState";
+import { refreshGitStatus, useGitStatus } from "~/lib/gitStatusState";
 import { usePrimaryEnvironmentId } from "../environments/primary";
 import { readEnvironmentApi } from "../environmentApi";
 import { isElectron } from "../env";
@@ -2547,16 +2547,48 @@ export default function ChatView(props: ChatViewProps) {
     if (!activeProject) return;
     const threadIdForSend = activeThread.id;
     const isFirstMessage = !isServerThread || activeThread.messages.length === 0;
-    const baseBranchForWorktree =
-      isFirstMessage && envMode === "worktree" && !activeThread.worktreePath
-        ? activeThread.branch
-        : null;
+    let envModeForSend = envMode;
+    let threadBranchForSend = activeThread.branch;
+
+    if (
+      isFirstMessage &&
+      envMode === "worktree" &&
+      !activeThread.worktreePath &&
+      !threadBranchForSend &&
+      gitCwd
+    ) {
+      const latestGitStatus = await refreshGitStatus({
+        environmentId,
+        cwd: gitCwd,
+      }).catch(() => gitStatusQuery.data);
+
+      if (latestGitStatus?.isRepo === false) {
+        envModeForSend = "local";
+        threadBranchForSend = null;
+        if (isLocalDraftThread) {
+          setDraftThreadContext(composerDraftTarget, {
+            envMode: "local",
+            branch: null,
+            worktreePath: null,
+          });
+        }
+      } else if (latestGitStatus?.branch) {
+        threadBranchForSend = latestGitStatus.branch;
+        if (isLocalDraftThread) {
+          setDraftThreadContext(composerDraftTarget, {
+            envMode: "worktree",
+            branch: latestGitStatus.branch,
+          });
+        }
+      }
+    }
 
     // In worktree mode, require an explicit base branch so we don't silently
     // fall back to local execution when branch selection is missing.
     const shouldCreateWorktree =
-      isFirstMessage && envMode === "worktree" && !activeThread.worktreePath;
-    if (shouldCreateWorktree && !activeThread.branch) {
+      isFirstMessage && envModeForSend === "worktree" && !activeThread.worktreePath;
+    const baseBranchForWorktree = shouldCreateWorktree ? threadBranchForSend : null;
+    if (shouldCreateWorktree && !threadBranchForSend) {
       setThreadError(threadIdForSend, "Select a base branch before sending in New worktree mode.");
       return;
     }
@@ -2690,7 +2722,7 @@ export default function ChatView(props: ChatViewProps) {
                       modelSelection: threadCreateModelSelection,
                       runtimeMode,
                       interactionMode,
-                      branch: activeThread.branch,
+                      branch: threadBranchForSend,
                       worktreePath: activeThread.worktreePath,
                       createdAt: activeThread.createdAt,
                     },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2196,7 +2196,38 @@ export default function ChatView(props: ChatViewProps) {
     activeWorktreePath,
     hasServerThread: isServerThread,
     draftThreadEnvMode: isLocalDraftThread ? draftThread?.envMode : undefined,
+    isGitRepo,
   });
+  const draftThreadEnvMode = draftThread?.envMode;
+  const draftThreadBranch = draftThread?.branch;
+
+  useEffect(() => {
+    if (!isLocalDraftThread) {
+      return;
+    }
+    if (!draftThread) {
+      return;
+    }
+    if (gitStatusQuery.data?.isRepo !== false) {
+      return;
+    }
+    if (draftThreadEnvMode !== "worktree" && draftThreadBranch === null) {
+      return;
+    }
+    setDraftThreadContext(composerDraftTarget, {
+      envMode: "local",
+      branch: null,
+      worktreePath: null,
+    });
+  }, [
+    composerDraftTarget,
+    draftThread,
+    draftThreadBranch,
+    draftThreadEnvMode,
+    gitStatusQuery.data?.isRepo,
+    isLocalDraftThread,
+    setDraftThreadContext,
+  ]);
 
   useEffect(() => {
     if (!activeThreadId) {


### PR DESCRIPTION
Closes #1914

## What was broken

Draft threads could stay in `New worktree` mode for directories that are not Git repositories. On the first send, that pushed users into the base-branch guard even though the project could only run locally.

## Root cause

The draft env-mode resolver treated persisted `worktree` mode as authoritative without considering the active project's Git status, so non-git drafts kept a worktree-only send path.

## What changed

- fall back to local mode when the active project is known to be non-git
- normalize draft thread state away from stale worktree metadata for non-git projects
- add regression coverage for the shared env-mode resolver and the browser send flow

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle non-git projects in local draft mode by falling back from worktree to local send
> - `resolveEffectiveEnvMode` in [BranchToolbar.logic.ts](https://github.com/pingdotgg/t3code/pull/1930/files#diff-22eaeeb6cc7f6e680a66d29924a8aa6c56a51450578462389a4b649102ea655f) gains an optional `isGitRepo` flag; when `false`, it returns `'local'` regardless of the draft's persisted mode.
> - Local drafts on non-git projects automatically reset their thread context to local mode (null branch and worktree path) via a new `useEffect` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1930/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
> - Before enforcing the base-branch requirement on a first worktree-mode message, `ChatView` now calls `refreshGitStatus`; if the project is not a git repo, it falls back to a local send and skips `prepareWorktree`.
> - Behavioral Change: drafts saved in `worktree` mode will silently send as local when the project is not a git repo.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f56bf0c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the first-send dispatch path and draft thread state normalization for worktree creation, which could affect message sending/worktree bootstrapping behavior. Changes are scoped and covered by new unit + browser regression tests but still impact a core interaction flow.
> 
> **Overview**
> Fixes drafts getting stuck in `New worktree` mode for non-git projects by making env-mode resolution explicitly fall back to `local` when `isRepo` is false, even if `worktree` was persisted.
> 
> Normalizes local draft thread state when git status indicates a non-repo (clearing `branch`/`worktreePath` and forcing `envMode: "local"`), and updates the send flow to **refresh git status** before enforcing the worktree base-branch guard—falling back to local dispatch (or persisting the detected branch) based on the refreshed result.
> 
> Adds regression coverage in `BranchToolbar.logic` tests and full-app `ChatView.browser` tests for non-git fallback and the pending-status refresh race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f56bf0c2b959934c64cf3be759822fd312a05a56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->