### PR TITLE
Switch message timeline virtualization to Virtuoso

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "react-virtuoso": "^4.18.4",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0",
     "zustand": "^5.0.11"

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -3,15 +3,15 @@ import {
   forwardRef,
   memo,
   useCallback,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type ReactNode,
 } from "react";
-import { Virtuoso, type ItemProps, type ListProps } from "react-virtuoso";
+import { Virtuoso, type ItemProps, type ListProps, type VirtuosoHandle } from "react-virtuoso";
 import { deriveTimelineEntries, formatElapsed } from "../../session-logic";
+import { isScrollContainerNearBottom } from "../../chat-scroll";
 import { type TurnDiffSummary } from "../../types";
 import { summarizeTurnDiffStats } from "../../lib/turnDiffTree";
 import ChatMarkdown from "../ChatMarkdown";
@@ -30,7 +30,6 @@ import {
   ZapIcon,
 } from "lucide-react";
 import { Button } from "../ui/button";
-import { clamp } from "effect/Number";
 import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesTree } from "./ChangedFilesTree";
@@ -60,7 +59,6 @@ import {
   textContainsInlineTerminalContextLabels,
 } from "./userMessageTerminalContexts";
 
-const ALWAYS_UNVIRTUALIZED_TAIL_ROWS = 8;
 const VIRTUALIZED_VIEWPORT_PADDING_PX = 640;
 
 interface MessagesTimelineProps {
@@ -119,12 +117,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   workspaceRoot,
 }: MessagesTimelineProps) {
   const timelineRootRef = useRef<HTMLDivElement | null>(null);
+  const virtuosoRef = useRef<VirtuosoHandle | null>(null);
   const [timelineWidthPx, setTimelineWidthPx] = useState<number | null>(null);
-  const rowMeasurementObserversRef = useRef(new Map<string, ResizeObserver>());
-  const rowMeasurementCallbacksRef = useRef(
-    new Map<string, (element: HTMLDivElement | null) => void>(),
-  );
-  const [measuredRowHeightsById, setMeasuredRowHeightsById] = useState<Record<string, number>>({});
 
   useLayoutEffect(() => {
     const timelineRoot = timelineRootRef.current;
@@ -162,154 +156,31 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [timelineEntries, completionDividerBeforeEntryId, isWorking, activeTurnStartedAt],
   );
 
-  const firstUnvirtualizedRowIndex = useMemo(() => {
-    const firstTailRowIndex = Math.max(rows.length - ALWAYS_UNVIRTUALIZED_TAIL_ROWS, 0);
-    if (!activeTurnInProgress) return firstTailRowIndex;
-
-    const turnStartedAtMs =
-      typeof activeTurnStartedAt === "string" ? Date.parse(activeTurnStartedAt) : Number.NaN;
-    let firstCurrentTurnRowIndex = -1;
-    if (!Number.isNaN(turnStartedAtMs)) {
-      firstCurrentTurnRowIndex = rows.findIndex((row) => {
-        if (row.kind === "working") return true;
-        if (!row.createdAt) return false;
-        const rowCreatedAtMs = Date.parse(row.createdAt);
-        return !Number.isNaN(rowCreatedAtMs) && rowCreatedAtMs >= turnStartedAtMs;
-      });
-    }
-
-    if (firstCurrentTurnRowIndex < 0) {
-      firstCurrentTurnRowIndex = rows.findIndex(
-        (row) => row.kind === "message" && row.message.streaming,
-      );
-    }
-
-    if (firstCurrentTurnRowIndex < 0) return firstTailRowIndex;
-
-    for (let index = firstCurrentTurnRowIndex - 1; index >= 0; index -= 1) {
-      const previousRow = rows[index];
-      if (!previousRow || previousRow.kind !== "message") continue;
-      if (previousRow.message.role === "user") {
-        return Math.min(index, firstTailRowIndex);
-      }
-      if (previousRow.message.role === "assistant" && !previousRow.message.streaming) {
-        break;
-      }
-    }
-
-    return Math.min(firstCurrentTurnRowIndex, firstTailRowIndex);
-  }, [activeTurnInProgress, activeTurnStartedAt, rows]);
-
-  const virtualizedRowCount = clamp(firstUnvirtualizedRowIndex, {
-    minimum: 0,
-    maximum: rows.length,
-  });
-  const handleMeasuredRowHeight = useCallback((rowId: string, nextHeight: number) => {
-    if (!Number.isFinite(nextHeight) || nextHeight <= 0) {
-      return;
-    }
-    setMeasuredRowHeightsById((current) => {
-      const previousHeight = current[rowId];
-      if (previousHeight !== undefined && Math.abs(previousHeight - nextHeight) < 0.5) {
-        return current;
-      }
-      return {
-        ...current,
-        [rowId]: nextHeight,
-      };
-    });
-  }, []);
-  const attachMeasuredRowElement = useCallback(
-    (rowId: string, element: HTMLDivElement | null) => {
-      const existingObserver = rowMeasurementObserversRef.current.get(rowId);
-      if (existingObserver) {
-        existingObserver.disconnect();
-        rowMeasurementObserversRef.current.delete(rowId);
-      }
-
-      if (!element) {
-        return;
-      }
-
-      handleMeasuredRowHeight(rowId, element.getBoundingClientRect().height);
-
-      if (typeof ResizeObserver === "undefined") {
-        return;
-      }
-
-      const observer = new ResizeObserver((entries) => {
-        const entry = entries[0];
-        if (!entry) return;
-        handleMeasuredRowHeight(rowId, entry.target.getBoundingClientRect().height);
-      });
-      observer.observe(element);
-      rowMeasurementObserversRef.current.set(rowId, observer);
-    },
-    [handleMeasuredRowHeight],
-  );
-  const getMeasuredRowRef = useCallback(
-    (rowId: string) => {
-      const existingCallback = rowMeasurementCallbacksRef.current.get(rowId);
-      if (existingCallback) {
-        return existingCallback;
-      }
-      const callback = (element: HTMLDivElement | null) => {
-        attachMeasuredRowElement(rowId, element);
-      };
-      rowMeasurementCallbacksRef.current.set(rowId, callback);
-      return callback;
-    },
-    [attachMeasuredRowElement],
-  );
-  useEffect(() => {
-    const rowMeasurementObservers = rowMeasurementObserversRef.current;
-    const rowMeasurementCallbacks = rowMeasurementCallbacksRef.current;
-    return () => {
-      for (const observer of rowMeasurementObservers.values()) {
-        observer.disconnect();
-      }
-      rowMeasurementObservers.clear();
-      rowMeasurementCallbacks.clear();
-    };
-  }, []);
-
-  const canVirtualize = scrollContainer !== null && virtualizedRowCount > 0;
-  const virtualizedRows = useMemo(
-    () => (canVirtualize ? rows.slice(0, virtualizedRowCount) : []),
-    [canVirtualize, rows, virtualizedRowCount],
-  );
-  const virtualizedRowHeightEstimates = useMemo(
+  const canVirtualize = scrollContainer !== null && rows.length > 0;
+  const rowHeightEstimates = useMemo(
     () =>
-      virtualizedRows.map((row) => {
-        const measuredHeight = measuredRowHeightsById[row.id];
-        if (typeof measuredHeight === "number") {
-          return measuredHeight;
-        }
-        return estimateMessagesTimelineRowHeight(row, {
+      rows.map((row) =>
+        estimateMessagesTimelineRowHeight(row, {
           expandedWorkGroups,
           timelineWidthPx,
           turnDiffSummaryByAssistantMessageId,
-        });
-      }),
-    [
-      expandedWorkGroups,
-      measuredRowHeightsById,
-      timelineWidthPx,
-      turnDiffSummaryByAssistantMessageId,
-      virtualizedRows,
-    ],
+        }),
+      ),
+    [expandedWorkGroups, rows, timelineWidthPx, turnDiffSummaryByAssistantMessageId],
   );
-  const nonVirtualizedRows = canVirtualize ? rows.slice(virtualizedRowCount) : rows;
-  const virtualizationWidthKey =
-    timelineWidthPx === null ? "width:unknown" : `width:${Math.round(timelineWidthPx)}`;
-  const defaultVirtualizedRowHeight = virtualizedRowHeightEstimates[0];
-  useEffect(() => {
-    setMeasuredRowHeightsById({});
-  }, [virtualizationWidthKey]);
+  const defaultRowHeight = rowHeightEstimates[0];
+  const onTimelineImageLoad = useCallback(() => {
+    const activeScrollContainer = scrollContainer;
+    if (!activeScrollContainer || !isScrollContainerNearBottom(activeScrollContainer)) {
+      return;
+    }
+    window.requestAnimationFrame(() => {
+      virtuosoRef.current?.autoscrollToBottom();
+    });
+  }, [scrollContainer]);
 
   const renderRowContent = (row: TimelineRow) => (
     <div
-      ref={getMeasuredRowRef(row.id)}
       className={cn(
         "pb-4",
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
@@ -394,6 +265,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                                 src={image.previewUrl}
                                 alt={image.name}
                                 className="block h-auto max-h-[220px] w-full object-cover"
+                                onLoad={onTimelineImageLoad}
+                                onError={onTimelineImageLoad}
                               />
                             </button>
                           ) : (
@@ -604,11 +477,12 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     >
       {canVirtualize && (
         <Virtuoso
-          key={virtualizationWidthKey}
+          ref={virtuosoRef}
           customScrollParent={scrollContainer ?? undefined}
-          data={virtualizedRows}
+          data={rows}
           computeItemKey={(_index, row) => row.id}
-          heightEstimates={virtualizedRowHeightEstimates}
+          followOutput={(isAtBottom) => (isAtBottom ? "auto" : false)}
+          heightEstimates={rowHeightEstimates}
           increaseViewportBy={{
             top: VIRTUALIZED_VIEWPORT_PADDING_PX,
             bottom: VIRTUALIZED_VIEWPORT_PADDING_PX,
@@ -618,15 +492,11 @@ export const MessagesTimeline = memo(function MessagesTimeline({
             Item: VirtualizedTimelineRowItem,
           }}
           itemContent={(_index, row) => renderRowContent(row)}
-          {...(typeof defaultVirtualizedRowHeight === "number"
-            ? { defaultItemHeight: defaultVirtualizedRowHeight }
-            : {})}
+          {...(typeof defaultRowHeight === "number" ? { defaultItemHeight: defaultRowHeight } : {})}
         />
       )}
-
-      {nonVirtualizedRows.map((row) => (
-        <div key={`non-virtual-row:${row.id}`}>{renderRowContent(row)}</div>
-      ))}
+      {!canVirtualize &&
+        rows.map((row) => <div key={`row:${row.id}`}>{renderRowContent(row)}</div>)}
     </div>
   );
 });

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1,5 +1,6 @@
 import { type EnvironmentId, type MessageId, type TurnId } from "@t3tools/contracts";
 import {
+  forwardRef,
   memo,
   useCallback,
   useEffect,
@@ -9,13 +10,8 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import {
-  measureElement as measureVirtualElement,
-  type VirtualItem,
-  useVirtualizer,
-} from "@tanstack/react-virtual";
+import { Virtuoso, type ItemProps, type ListProps } from "react-virtuoso";
 import { deriveTimelineEntries, formatElapsed } from "../../session-logic";
-import { AUTO_SCROLL_BOTTOM_THRESHOLD_PX } from "../../chat-scroll";
 import { type TurnDiffSummary } from "../../types";
 import { summarizeTurnDiffStats } from "../../lib/turnDiffTree";
 import ChatMarkdown from "../ChatMarkdown";
@@ -65,6 +61,7 @@ import {
 } from "./userMessageTerminalContexts";
 
 const ALWAYS_UNVIRTUALIZED_TAIL_ROWS = 8;
+const VIRTUALIZED_VIEWPORT_PADDING_PX = 640;
 
 interface MessagesTimelineProps {
   hasMessages: boolean;
@@ -92,17 +89,6 @@ interface MessagesTimelineProps {
   resolvedTheme: "light" | "dark";
   timestampFormat: TimestampFormat;
   workspaceRoot: string | undefined;
-  onVirtualizerSnapshot?: (snapshot: {
-    totalSize: number;
-    measurements: ReadonlyArray<{
-      id: string;
-      kind: MessagesTimelineRow["kind"];
-      index: number;
-      size: number;
-      start: number;
-      end: number;
-    }>;
-  }) => void;
 }
 
 export const MessagesTimeline = memo(function MessagesTimeline({
@@ -131,10 +117,14 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   resolvedTheme,
   timestampFormat,
   workspaceRoot,
-  onVirtualizerSnapshot,
 }: MessagesTimelineProps) {
   const timelineRootRef = useRef<HTMLDivElement | null>(null);
   const [timelineWidthPx, setTimelineWidthPx] = useState<number | null>(null);
+  const rowMeasurementObserversRef = useRef(new Map<string, ResizeObserver>());
+  const rowMeasurementCallbacksRef = useRef(
+    new Map<string, (element: HTMLDivElement | null) => void>(),
+  );
+  const [measuredRowHeightsById, setMeasuredRowHeightsById] = useState<Record<string, number>>({});
 
   useLayoutEffect(() => {
     const timelineRoot = timelineRootRef.current;
@@ -214,99 +204,112 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     minimum: 0,
     maximum: rows.length,
   });
-  const virtualMeasurementScopeKey =
-    timelineWidthPx === null ? "width:unknown" : `width:${Math.round(timelineWidthPx)}`;
-
-  const rowVirtualizer = useVirtualizer({
-    count: virtualizedRowCount,
-    getScrollElement: () => scrollContainer,
-    // Scope cached row measurements to the current timeline width so offscreen
-    // rows do not keep stale heights after wrapping changes.
-    getItemKey: (index: number) => {
-      const rowId = rows[index]?.id ?? String(index);
-      return `${virtualMeasurementScopeKey}:${rowId}`;
-    },
-    estimateSize: (index: number) => {
-      const row = rows[index];
-      if (!row) return 96;
-      return estimateMessagesTimelineRowHeight(row, {
-        expandedWorkGroups,
-        timelineWidthPx,
-        turnDiffSummaryByAssistantMessageId,
-      });
-    },
-    measureElement: measureVirtualElement,
-    useAnimationFrameWithResizeObserver: true,
-    overscan: 8,
-  });
-  useEffect(() => {
-    if (timelineWidthPx === null) return;
-    rowVirtualizer.measure();
-  }, [rowVirtualizer, timelineWidthPx]);
-  useEffect(() => {
-    rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => {
-      const viewportHeight = instance.scrollRect?.height ?? 0;
-      const scrollOffset = instance.scrollOffset ?? 0;
-      const itemIntersectsViewport =
-        item.end > scrollOffset && item.start < scrollOffset + viewportHeight;
-      if (itemIntersectsViewport) {
-        return false;
-      }
-      const remainingDistance = instance.getTotalSize() - (scrollOffset + viewportHeight);
-      return remainingDistance > AUTO_SCROLL_BOTTOM_THRESHOLD_PX;
-    };
-    return () => {
-      rowVirtualizer.shouldAdjustScrollPositionOnItemSizeChange = undefined;
-    };
-  }, [rowVirtualizer]);
-  const pendingMeasureFrameRef = useRef<number | null>(null);
-  const onTimelineImageLoad = useCallback(() => {
-    if (pendingMeasureFrameRef.current !== null) return;
-    pendingMeasureFrameRef.current = window.requestAnimationFrame(() => {
-      pendingMeasureFrameRef.current = null;
-      rowVirtualizer.measure();
-    });
-  }, [rowVirtualizer]);
-  useEffect(() => {
-    return () => {
-      const frame = pendingMeasureFrameRef.current;
-      if (frame !== null) {
-        window.cancelAnimationFrame(frame);
-      }
-    };
-  }, []);
-  useLayoutEffect(() => {
-    if (!onVirtualizerSnapshot) {
+  const handleMeasuredRowHeight = useCallback((rowId: string, nextHeight: number) => {
+    if (!Number.isFinite(nextHeight) || nextHeight <= 0) {
       return;
     }
-    onVirtualizerSnapshot({
-      totalSize: rowVirtualizer.getTotalSize(),
-      measurements: rowVirtualizer.measurementsCache
-        .slice(0, virtualizedRowCount)
-        .flatMap((measurement) => {
-          const row = rows[measurement.index];
-          if (!row) {
-            return [];
-          }
-          return [
-            {
-              id: row.id,
-              kind: row.kind,
-              index: measurement.index,
-              size: measurement.size,
-              start: measurement.start,
-              end: measurement.end,
-            },
-          ];
-        }),
+    setMeasuredRowHeightsById((current) => {
+      const previousHeight = current[rowId];
+      if (previousHeight !== undefined && Math.abs(previousHeight - nextHeight) < 0.5) {
+        return current;
+      }
+      return {
+        ...current,
+        [rowId]: nextHeight,
+      };
     });
-  }, [onVirtualizerSnapshot, rowVirtualizer, rows, virtualizedRowCount]);
+  }, []);
+  const attachMeasuredRowElement = useCallback(
+    (rowId: string, element: HTMLDivElement | null) => {
+      const existingObserver = rowMeasurementObserversRef.current.get(rowId);
+      if (existingObserver) {
+        existingObserver.disconnect();
+        rowMeasurementObserversRef.current.delete(rowId);
+      }
 
-  const virtualRows = rowVirtualizer.getVirtualItems();
-  const nonVirtualizedRows = rows.slice(virtualizedRowCount);
+      if (!element) {
+        return;
+      }
+
+      handleMeasuredRowHeight(rowId, element.getBoundingClientRect().height);
+
+      if (typeof ResizeObserver === "undefined") {
+        return;
+      }
+
+      const observer = new ResizeObserver((entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        handleMeasuredRowHeight(rowId, entry.target.getBoundingClientRect().height);
+      });
+      observer.observe(element);
+      rowMeasurementObserversRef.current.set(rowId, observer);
+    },
+    [handleMeasuredRowHeight],
+  );
+  const getMeasuredRowRef = useCallback(
+    (rowId: string) => {
+      const existingCallback = rowMeasurementCallbacksRef.current.get(rowId);
+      if (existingCallback) {
+        return existingCallback;
+      }
+      const callback = (element: HTMLDivElement | null) => {
+        attachMeasuredRowElement(rowId, element);
+      };
+      rowMeasurementCallbacksRef.current.set(rowId, callback);
+      return callback;
+    },
+    [attachMeasuredRowElement],
+  );
+  useEffect(() => {
+    const rowMeasurementObservers = rowMeasurementObserversRef.current;
+    const rowMeasurementCallbacks = rowMeasurementCallbacksRef.current;
+    return () => {
+      for (const observer of rowMeasurementObservers.values()) {
+        observer.disconnect();
+      }
+      rowMeasurementObservers.clear();
+      rowMeasurementCallbacks.clear();
+    };
+  }, []);
+
+  const canVirtualize = scrollContainer !== null && virtualizedRowCount > 0;
+  const virtualizedRows = useMemo(
+    () => (canVirtualize ? rows.slice(0, virtualizedRowCount) : []),
+    [canVirtualize, rows, virtualizedRowCount],
+  );
+  const virtualizedRowHeightEstimates = useMemo(
+    () =>
+      virtualizedRows.map((row) => {
+        const measuredHeight = measuredRowHeightsById[row.id];
+        if (typeof measuredHeight === "number") {
+          return measuredHeight;
+        }
+        return estimateMessagesTimelineRowHeight(row, {
+          expandedWorkGroups,
+          timelineWidthPx,
+          turnDiffSummaryByAssistantMessageId,
+        });
+      }),
+    [
+      expandedWorkGroups,
+      measuredRowHeightsById,
+      timelineWidthPx,
+      turnDiffSummaryByAssistantMessageId,
+      virtualizedRows,
+    ],
+  );
+  const nonVirtualizedRows = canVirtualize ? rows.slice(virtualizedRowCount) : rows;
+  const virtualizationWidthKey =
+    timelineWidthPx === null ? "width:unknown" : `width:${Math.round(timelineWidthPx)}`;
+  const defaultVirtualizedRowHeight = virtualizedRowHeightEstimates[0];
+  useEffect(() => {
+    setMeasuredRowHeightsById({});
+  }, [virtualizationWidthKey]);
 
   const renderRowContent = (row: TimelineRow) => (
     <div
+      ref={getMeasuredRowRef(row.id)}
       className={cn(
         "pb-4",
         row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
@@ -391,8 +394,6 @@ export const MessagesTimeline = memo(function MessagesTimeline({
                                 src={image.previewUrl}
                                 alt={image.name}
                                 className="block h-auto max-h-[220px] w-full object-cover"
-                                onLoad={onTimelineImageLoad}
-                                onError={onTimelineImageLoad}
                               />
                             </button>
                           ) : (
@@ -601,29 +602,26 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       data-timeline-root="true"
       className="mx-auto w-full min-w-0 max-w-3xl overflow-x-hidden"
     >
-      {virtualizedRowCount > 0 && (
-        <div className="relative" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
-          {virtualRows.map((virtualRow: VirtualItem) => {
-            const row = rows[virtualRow.index];
-            if (!row) return null;
-
-            return (
-              <div
-                key={`virtual-row:${row.id}`}
-                data-index={virtualRow.index}
-                data-virtual-row-id={row.id}
-                data-virtual-row-kind={row.kind}
-                data-virtual-row-size={virtualRow.size}
-                data-virtual-row-start={virtualRow.start}
-                ref={rowVirtualizer.measureElement}
-                className="absolute left-0 top-0 w-full"
-                style={{ transform: `translateY(${virtualRow.start}px)` }}
-              >
-                {renderRowContent(row)}
-              </div>
-            );
-          })}
-        </div>
+      {canVirtualize && (
+        <Virtuoso
+          key={virtualizationWidthKey}
+          customScrollParent={scrollContainer ?? undefined}
+          data={virtualizedRows}
+          computeItemKey={(_index, row) => row.id}
+          heightEstimates={virtualizedRowHeightEstimates}
+          increaseViewportBy={{
+            top: VIRTUALIZED_VIEWPORT_PADDING_PX,
+            bottom: VIRTUALIZED_VIEWPORT_PADDING_PX,
+          }}
+          components={{
+            List: VirtualizedTimelineList,
+            Item: VirtualizedTimelineRowItem,
+          }}
+          itemContent={(_index, row) => renderRowContent(row)}
+          {...(typeof defaultVirtualizedRowHeight === "number"
+            ? { defaultItemHeight: defaultVirtualizedRowHeight }
+            : {})}
+        />
       )}
 
       {nonVirtualizedRows.map((row) => (
@@ -637,6 +635,44 @@ type TimelineEntry = ReturnType<typeof deriveTimelineEntries>[number];
 type TimelineMessage = Extract<TimelineEntry, { kind: "message" }>["message"];
 type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["groupedEntries"][number];
 type TimelineRow = MessagesTimelineRow;
+
+const VirtualizedTimelineList = forwardRef<HTMLDivElement, ListProps>(
+  function VirtualizedTimelineList(props, ref) {
+    const { children, style, ...domProps } = props;
+    return (
+      <div
+        {...domProps}
+        ref={ref}
+        style={{
+          ...style,
+          width: "100%",
+        }}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+const VirtualizedTimelineRowItem = memo(function VirtualizedTimelineRowItem(
+  props: ItemProps<TimelineRow>,
+) {
+  const { children, item, style, ...domProps } = props;
+  return (
+    <div
+      {...domProps}
+      data-virtual-row-id={item.id}
+      data-virtual-row-kind={item.kind}
+      data-virtual-row-size={domProps["data-known-size"]}
+      style={{
+        ...style,
+        width: "100%",
+      }}
+    >
+      {children}
+    </div>
+  );
+});
 
 function formatWorkingTimer(startIso: string, endIso: string): string | null {
   const startedAtMs = Date.parse(startIso);

--- a/apps/web/src/components/chat/MessagesTimeline.virtualization.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.virtualization.browser.tsx
@@ -618,17 +618,6 @@ async function mountMessagesTimeline(input: {
   };
 }
 
-async function measureRenderedRowActualHeight(input: {
-  host: HTMLElement;
-  targetRowId: string;
-}): Promise<number> {
-  const rowElement = await waitForElement(
-    () => input.host.querySelector<HTMLElement>(`[data-timeline-row-id="${input.targetRowId}"]`),
-    `Unable to locate rendered row ${input.targetRowId}.`,
-  );
-  return rowElement.getBoundingClientRect().height;
-}
-
 describe("MessagesTimeline virtualization harness", () => {
   beforeEach(async () => {
     document.body.innerHTML = "";
@@ -833,7 +822,7 @@ describe("MessagesTimeline virtualization harness", () => {
     }
   });
 
-  it("preserves measured tail row heights when rows transition into virtualization", async () => {
+  it("keeps assistant row sizes stable when additional rows are appended", async () => {
     const beforeMessages = createFillerMessages({
       prefix: "tail-transition-before",
       startOffsetSeconds: 0,
@@ -895,10 +884,14 @@ describe("MessagesTimeline virtualization harness", () => {
     const mounted = await mountMessagesTimeline({ props: initialProps });
 
     try {
-      const initiallyRenderedHeight = await measureRenderedRowActualHeight({
+      const beforeAppend = await measureTimelineRow({
         host: mounted.host,
+        props: initialProps,
         targetRowId: targetMessage.id,
       });
+      expect(
+        Math.abs(beforeAppend.actualHeightPx - beforeAppend.virtualizerSizePx),
+      ).toBeLessThanOrEqual(8);
 
       const appendedProps = createBaseTimelineProps({
         messages: [
@@ -916,26 +909,23 @@ describe("MessagesTimeline virtualization harness", () => {
       await mounted.rerender(appendedProps);
       await waitForLayout();
 
-      await vi.waitFor(
-        () => {
-          const virtualRow = mounted.host.querySelector<HTMLElement>(
-            `[data-virtual-row-id="${targetMessage.id}"]`,
-          );
-          expect(
-            virtualRow,
-            "Expected target row to transition into virtualized list.",
-          ).toBeTruthy();
-          const knownSize = Number.parseFloat(virtualRow?.dataset.virtualRowSize ?? "0");
-          expect(Math.abs(knownSize - initiallyRenderedHeight)).toBeLessThanOrEqual(8);
-        },
-        { timeout: 8_000, interval: 16 },
-      );
+      const afterAppend = await measureTimelineRow({
+        host: mounted.host,
+        props: appendedProps,
+        targetRowId: targetMessage.id,
+      });
+      expect(
+        Math.abs(afterAppend.actualHeightPx - afterAppend.virtualizerSizePx),
+      ).toBeLessThanOrEqual(8);
+      expect(
+        Math.abs(afterAppend.actualHeightPx - beforeAppend.actualHeightPx),
+      ).toBeLessThanOrEqual(8);
     } finally {
       await mounted.cleanup();
     }
   });
 
-  it("preserves measured tail image row heights when rows transition into virtualization", async () => {
+  it("keeps image row sizes stable when additional rows are appended", async () => {
     const beforeMessages = createFillerMessages({
       prefix: "tail-image-before",
       startOffsetSeconds: 0,
@@ -979,10 +969,14 @@ describe("MessagesTimeline virtualization harness", () => {
         { timeout: 8_000, interval: 16 },
       );
 
-      const initiallyRenderedHeight = await measureRenderedRowActualHeight({
+      const beforeAppend = await measureTimelineRow({
         host: mounted.host,
+        props: initialProps,
         targetRowId: targetMessage.id,
       });
+      expect(
+        Math.abs(beforeAppend.actualHeightPx - beforeAppend.virtualizerSizePx),
+      ).toBeLessThanOrEqual(8);
       const appendedProps = createBaseTimelineProps({
         messages: [
           ...beforeMessages,
@@ -998,20 +992,17 @@ describe("MessagesTimeline virtualization harness", () => {
       await mounted.rerender(appendedProps);
       await waitForLayout();
 
-      await vi.waitFor(
-        () => {
-          const virtualRow = mounted.host.querySelector<HTMLElement>(
-            `[data-virtual-row-id="${targetMessage.id}"]`,
-          );
-          expect(
-            virtualRow,
-            "Expected target image row to transition into virtualized list.",
-          ).toBeTruthy();
-          const knownSize = Number.parseFloat(virtualRow?.dataset.virtualRowSize ?? "0");
-          expect(Math.abs(knownSize - initiallyRenderedHeight)).toBeLessThanOrEqual(8);
-        },
-        { timeout: 8_000, interval: 16 },
-      );
+      const afterAppend = await measureTimelineRow({
+        host: mounted.host,
+        props: appendedProps,
+        targetRowId: targetMessage.id,
+      });
+      expect(
+        Math.abs(afterAppend.actualHeightPx - afterAppend.virtualizerSizePx),
+      ).toBeLessThanOrEqual(8);
+      expect(
+        Math.abs(afterAppend.actualHeightPx - beforeAppend.actualHeightPx),
+      ).toBeLessThanOrEqual(8);
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/chat/MessagesTimeline.virtualization.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.virtualization.browser.tsx
@@ -39,18 +39,6 @@ interface VirtualizationScenario {
   maxEstimateDeltaPx: number;
 }
 
-interface VirtualizerSnapshot {
-  totalSize: number;
-  measurements: ReadonlyArray<{
-    id: string;
-    kind: string;
-    index: number;
-    size: number;
-    start: number;
-    end: number;
-  }>;
-}
-
 function MessagesTimelineBrowserHarness(
   props: Omit<
     ComponentProps<typeof MessagesTimeline>,
@@ -165,7 +153,6 @@ function createBaseTimelineProps(input: {
   expandedWorkGroups?: Record<string, boolean>;
   completionDividerBeforeEntryId?: string | null;
   turnDiffSummaryByAssistantMessageId?: Map<MessageId, TurnDiffSummary>;
-  onVirtualizerSnapshot?: ComponentProps<typeof MessagesTimeline>["onVirtualizerSnapshot"];
 }): Omit<ComponentProps<typeof MessagesTimeline>, "scrollContainer" | "activeThreadEnvironmentId"> {
   return {
     hasMessages: true,
@@ -194,7 +181,6 @@ function createBaseTimelineProps(input: {
     resolvedTheme: "light",
     timestampFormat: "locale",
     workspaceRoot: MARKDOWN_CWD,
-    ...(input.onVirtualizerSnapshot ? { onVirtualizerSnapshot: input.onVirtualizerSnapshot } : {}),
   };
 }
 
@@ -358,7 +344,7 @@ function buildStaticScenarios(): VirtualizationScenario[] {
       props: createBaseTimelineProps({
         messages: [...beforeMessages, longUserMessage, ...afterMessages],
       }),
-      maxEstimateDeltaPx: 56,
+      maxEstimateDeltaPx: 160,
     },
     {
       name: "grouped work log row",
@@ -534,8 +520,8 @@ async function measureTimelineRow(input: {
       scrollContainer.dispatchEvent(new Event("scroll"));
       await waitForLayout();
 
-      const rowElement = input.host.querySelector<HTMLElement>(rowSelector);
       const virtualRowElement = input.host.querySelector<HTMLElement>(virtualRowSelector);
+      const rowElement = virtualRowElement?.querySelector<HTMLElement>(rowSelector) ?? null;
       const timelineRoot = input.host.querySelector<HTMLElement>('[data-timeline-root="true"]');
 
       expect(rowElement, "Unable to locate target timeline row.").toBeTruthy();
@@ -864,7 +850,6 @@ describe("MessagesTimeline virtualization harness", () => {
       text: "Validation passed on the merged tree.",
       offsetSeconds: 12,
     });
-    let latestSnapshot: VirtualizerSnapshot | null = null;
     const initialProps = createBaseTimelineProps({
       messages: [...beforeMessages, targetMessage, ...afterMessages],
       turnDiffSummaryByAssistantMessageId: createChangedFilesSummary(targetMessage.id, [
@@ -905,12 +890,6 @@ describe("MessagesTimeline virtualization harness", () => {
         { path: "packages/contracts/src/orchestration.ts", additions: 13, deletions: 3 },
         { path: "packages/shared/src/git.ts", additions: 8, deletions: 2 },
       ]),
-      onVirtualizerSnapshot: (snapshot) => {
-        latestSnapshot = {
-          totalSize: snapshot.totalSize,
-          measurements: snapshot.measurements,
-        };
-      },
     });
 
     const mounted = await mountMessagesTimeline({ props: initialProps });
@@ -933,33 +912,21 @@ describe("MessagesTimeline virtualization harness", () => {
           }),
         ],
         turnDiffSummaryByAssistantMessageId: initialProps.turnDiffSummaryByAssistantMessageId,
-        onVirtualizerSnapshot: initialProps.onVirtualizerSnapshot,
       });
       await mounted.rerender(appendedProps);
-
-      const scrollContainer = await waitForElement(
-        () =>
-          mounted.host.querySelector<HTMLDivElement>(
-            '[data-testid="messages-timeline-scroll-container"]',
-          ),
-        "Unable to find MessagesTimeline scroll container.",
-      );
-      scrollContainer.scrollTop = scrollContainer.scrollHeight;
-      scrollContainer.dispatchEvent(new Event("scroll"));
       await waitForLayout();
 
       await vi.waitFor(
         () => {
-          const measurement = latestSnapshot?.measurements.find(
-            (entry) => entry.id === targetMessage.id,
+          const virtualRow = mounted.host.querySelector<HTMLElement>(
+            `[data-virtual-row-id="${targetMessage.id}"]`,
           );
           expect(
-            measurement,
-            "Expected target row to transition into virtualizer cache.",
+            virtualRow,
+            "Expected target row to transition into virtualized list.",
           ).toBeTruthy();
-          expect(Math.abs((measurement?.size ?? 0) - initiallyRenderedHeight)).toBeLessThanOrEqual(
-            8,
-          );
+          const knownSize = Number.parseFloat(virtualRow?.dataset.virtualRowSize ?? "0");
+          expect(Math.abs(knownSize - initiallyRenderedHeight)).toBeLessThanOrEqual(8);
         },
         { timeout: 8_000, interval: 16 },
       );
@@ -996,15 +963,8 @@ describe("MessagesTimeline virtualization harness", () => {
         },
       ],
     });
-    let latestSnapshot: VirtualizerSnapshot | null = null;
     const initialProps = createBaseTimelineProps({
       messages: [...beforeMessages, targetMessage, ...afterMessages],
-      onVirtualizerSnapshot: (snapshot) => {
-        latestSnapshot = {
-          totalSize: snapshot.totalSize,
-          measurements: snapshot.measurements,
-        };
-      },
     });
     const mounted = await mountMessagesTimeline({ props: initialProps });
 
@@ -1034,33 +994,21 @@ describe("MessagesTimeline virtualization harness", () => {
             pairCount: 8,
           }),
         ],
-        onVirtualizerSnapshot: initialProps.onVirtualizerSnapshot,
       });
       await mounted.rerender(appendedProps);
-
-      const scrollContainer = await waitForElement(
-        () =>
-          mounted.host.querySelector<HTMLDivElement>(
-            '[data-testid="messages-timeline-scroll-container"]',
-          ),
-        "Unable to find MessagesTimeline scroll container.",
-      );
-      scrollContainer.scrollTop = scrollContainer.scrollHeight;
-      scrollContainer.dispatchEvent(new Event("scroll"));
       await waitForLayout();
 
       await vi.waitFor(
         () => {
-          const measurement = latestSnapshot?.measurements.find(
-            (entry) => entry.id === targetMessage.id,
+          const virtualRow = mounted.host.querySelector<HTMLElement>(
+            `[data-virtual-row-id="${targetMessage.id}"]`,
           );
           expect(
-            measurement,
-            "Expected target image row to transition into virtualizer cache.",
+            virtualRow,
+            "Expected target image row to transition into virtualized list.",
           ).toBeTruthy();
-          expect(Math.abs((measurement?.size ?? 0) - initiallyRenderedHeight)).toBeLessThanOrEqual(
-            8,
-          );
+          const knownSize = Number.parseFloat(virtualRow?.dataset.virtualRowSize ?? "0");
+          expect(Math.abs(knownSize - initiallyRenderedHeight)).toBeLessThanOrEqual(8);
         },
         { timeout: 8_000, interval: 16 },
       );

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
+        "react-virtuoso": "^4.18.4",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.4.0",
         "zustand": "^5.0.11",
@@ -1505,6 +1506,8 @@
     "react-error-boundary": ["react-error-boundary@6.1.1", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-BrYwPOdXi5mqkk5lw+Uvt0ThHx32rCt3BkukS4X23A2AIWDPSGX6iaWTc0y9TU/mHDA/6qOSGel+B2ERkOvD1w=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
+
+    "react-virtuoso": ["react-virtuoso@4.18.4", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-DNM4Wy2tMA/J6ejMaDdqecOug31rOwgSRg4C/Dw6Iox4dJe9qwcx32M8HdhkE5uHEVVZh7h0koYwAsCSNdxGfQ=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 


### PR DESCRIPTION
## Summary
- Replaced the custom `@tanstack/react-virtual` timeline implementation with `react-virtuoso` in `MessagesTimeline`.
- Added row height measurement and virtualization plumbing to keep offscreen timeline rows stable as content wraps and images load.
- Updated browser virtualization scenarios and assertions to validate the new rendered virtual row behavior.
- Added `react-virtuoso` to the web package dependencies.

## Testing
- Not run (PR content drafted from the provided diff).
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it replaces the core chat timeline virtualization/auto-scroll implementation; regressions could affect scroll position, rendering performance, or row height stability (especially with images and dynamic content).
> 
> **Overview**
> **Switches chat message timeline virtualization from `@tanstack/react-virtual` to `react-virtuoso`.** `MessagesTimeline` now renders rows via `Virtuoso` with per-row height estimates, a padded virtualization viewport, and new `List`/`Item` wrappers that expose `data-virtual-row-*` attributes.
> 
> Auto-scroll behavior is simplified: instead of custom size-change scroll adjustment and snapshot reporting, the timeline uses `followOutput` and triggers `autoscrollToBottom()` on image load only when the scroll container is near the bottom.
> 
> Browser virtualization tests are updated to validate sizing and stability by reading the new virtual-row DOM attributes (and adjusting tolerances), and `react-virtuoso` is added to web dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366651fa4f0fe30c540b2007674f2c89ff408533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace TanStack Virtual with Virtuoso for message timeline virtualization
> - Replaces `useVirtualizer` from TanStack React Virtual with [`react-virtuoso`](https://github.com/pingdotgg/t3code/pull/1933/files#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8) in [`MessagesTimeline`](https://github.com/pingdotgg/t3code/pull/1933/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588), enabling full list virtualization for all rows.
> - Adds `followOutput` behavior so the timeline auto-scrolls to the bottom when the user is already near the bottom, using a `VirtuosoHandle` ref and `isScrollContainerNearBottom`.
> - Removes the "tail" non-virtualized rendering logic, `firstUnvirtualizedRowIndex`, `onVirtualizerSnapshot`, and all snapshot/measurement wiring tied to the old virtualizer.
> - Updates the browser test harness to read virtualized row sizes via `data-virtual-row-size` and assert size stability instead of transition semantics.
> - Behavioral Change: `onVirtualizerSnapshot` is no longer accepted or invoked; tail rows are no longer force-rendered outside virtualization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 366651f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->