### PR TITLE
Coalesce status refreshes by remote

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -826,7 +826,7 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
-    it.effect("shares upstream refreshes across worktrees that use the same git common dir", () =>
+    it.effect("coalesces upstream refreshes across sibling worktrees on the same remote", () =>
       Effect.gen(function* () {
         const ok = (stdout = "") =>
           Effect.succeed({
@@ -845,7 +845,9 @@ it.layer(TestLayer)("git integration", (it) => {
             input.args[2] === "--symbolic-full-name" &&
             input.args[3] === "@{upstream}"
           ) {
-            return ok("origin/main\n");
+            return ok(
+              input.cwd === "/repo/worktrees/pr-123" ? "origin/feature/pr-123\n" : "origin/main\n",
+            );
           }
           if (input.args[0] === "remote") {
             return ok("origin\n");
@@ -856,10 +858,22 @@ it.layer(TestLayer)("git integration", (it) => {
           if (input.args[0] === "--git-dir" && input.args[2] === "fetch") {
             fetchCount += 1;
             expect(input.cwd).toBe("/repo");
+            expect(input.args).toEqual([
+              "--git-dir",
+              "/repo/.git",
+              "fetch",
+              "--quiet",
+              "--no-tags",
+              "origin",
+            ]);
             return ok();
           }
           if (input.operation === "GitCore.statusDetails.status") {
-            return ok("# branch.head main\n# branch.upstream origin/main\n# branch.ab +0 -0\n");
+            return ok(
+              input.cwd === "/repo/worktrees/pr-123"
+                ? "# branch.head feature/pr-123\n# branch.upstream origin/feature/pr-123\n# branch.ab +0 -0\n"
+                : "# branch.head main\n# branch.upstream origin/main\n# branch.ab +0 -0\n",
+            );
           }
           if (
             input.operation === "GitCore.statusDetails.unstagedNumstat" ||
@@ -886,70 +900,80 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
-    it.effect("briefly backs off failed upstream refreshes across sibling worktrees", () =>
-      Effect.gen(function* () {
-        const ok = (stdout = "") =>
-          Effect.succeed({
-            code: 0,
-            stdout,
-            stderr: "",
-            stdoutTruncated: false,
-            stderrTruncated: false,
-          });
+    it.effect(
+      "briefly backs off failed upstream refreshes across sibling worktrees on one remote",
+      () =>
+        Effect.gen(function* () {
+          const ok = (stdout = "") =>
+            Effect.succeed({
+              code: 0,
+              stdout,
+              stderr: "",
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            });
 
-        let fetchCount = 0;
-        const core = yield* makeIsolatedGitCore((input) => {
-          if (
-            input.args[0] === "rev-parse" &&
-            input.args[1] === "--abbrev-ref" &&
-            input.args[2] === "--symbolic-full-name" &&
-            input.args[3] === "@{upstream}"
-          ) {
-            return ok("origin/main\n");
-          }
-          if (input.args[0] === "remote") {
-            return ok("origin\n");
-          }
-          if (input.args[0] === "rev-parse" && input.args[1] === "--git-common-dir") {
-            return ok("/repo/.git\n");
-          }
-          if (input.args[0] === "--git-dir" && input.args[2] === "fetch") {
-            fetchCount += 1;
+          let fetchCount = 0;
+          const core = yield* makeIsolatedGitCore((input) => {
+            if (
+              input.args[0] === "rev-parse" &&
+              input.args[1] === "--abbrev-ref" &&
+              input.args[2] === "--symbolic-full-name" &&
+              input.args[3] === "@{upstream}"
+            ) {
+              return ok(
+                input.cwd === "/repo/worktrees/pr-123"
+                  ? "origin/feature/pr-123\n"
+                  : "origin/main\n",
+              );
+            }
+            if (input.args[0] === "remote") {
+              return ok("origin\n");
+            }
+            if (input.args[0] === "rev-parse" && input.args[1] === "--git-common-dir") {
+              return ok("/repo/.git\n");
+            }
+            if (input.args[0] === "--git-dir" && input.args[2] === "fetch") {
+              fetchCount += 1;
+              return Effect.fail(
+                new GitCommandError({
+                  operation: input.operation,
+                  command: `git ${input.args.join(" ")}`,
+                  cwd: input.cwd,
+                  detail: "simulated fetch timeout",
+                }),
+              );
+            }
+            if (input.operation === "GitCore.statusDetails.status") {
+              return ok(
+                input.cwd === "/repo/worktrees/pr-123"
+                  ? "# branch.head feature/pr-123\n# branch.upstream origin/feature/pr-123\n# branch.ab +0 -0\n"
+                  : "# branch.head main\n# branch.upstream origin/main\n# branch.ab +0 -0\n",
+              );
+            }
+            if (
+              input.operation === "GitCore.statusDetails.unstagedNumstat" ||
+              input.operation === "GitCore.statusDetails.stagedNumstat"
+            ) {
+              return ok();
+            }
+            if (input.operation === "GitCore.statusDetails.defaultRef") {
+              return ok("refs/remotes/origin/main\n");
+            }
             return Effect.fail(
               new GitCommandError({
                 operation: input.operation,
                 command: `git ${input.args.join(" ")}`,
                 cwd: input.cwd,
-                detail: "simulated fetch timeout",
+                detail: "Unexpected git command in refresh failure cooldown test.",
               }),
             );
-          }
-          if (input.operation === "GitCore.statusDetails.status") {
-            return ok("# branch.head main\n# branch.upstream origin/main\n# branch.ab +0 -0\n");
-          }
-          if (
-            input.operation === "GitCore.statusDetails.unstagedNumstat" ||
-            input.operation === "GitCore.statusDetails.stagedNumstat"
-          ) {
-            return ok();
-          }
-          if (input.operation === "GitCore.statusDetails.defaultRef") {
-            return ok("refs/remotes/origin/main\n");
-          }
-          return Effect.fail(
-            new GitCommandError({
-              operation: input.operation,
-              command: `git ${input.args.join(" ")}`,
-              cwd: input.cwd,
-              detail: "Unexpected git command in refresh failure cooldown test.",
-            }),
-          );
-        });
+          });
 
-        yield* core.statusDetails("/repo/worktrees/main");
-        yield* core.statusDetails("/repo/worktrees/pr-123");
-        expect(fetchCount).toBe(1);
-      }),
+          yield* core.statusDetails("/repo/worktrees/main");
+          yield* core.statusDetails("/repo/worktrees/pr-123");
+          expect(fetchCount).toBe(1);
+        }),
     );
 
     it.effect("throws when branch does not exist", () =>
@@ -1047,7 +1071,6 @@ it.layer(TestLayer)("git integration", (it) => {
           "--quiet",
           "--no-tags",
           remoteName,
-          `+refs/heads/${featureBranch}:refs/remotes/${remoteName}/${featureBranch}`,
         ]);
       }),
     );

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -78,11 +78,9 @@ type TraceTailState = {
   remainder: string;
 };
 
-class StatusUpstreamRefreshCacheKey extends Data.Class<{
+class StatusRemoteRefreshCacheKey extends Data.Class<{
   gitCommonDir: string;
-  upstreamRef: string;
   remoteName: string;
-  upstreamBranch: string;
 }> {}
 
 interface ExecuteGitOptions {
@@ -919,17 +917,16 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     );
   });
 
-  const fetchUpstreamRefForStatus = (
+  const fetchRemoteForStatus = (
     gitCommonDir: string,
-    upstream: { upstreamRef: string; remoteName: string; upstreamBranch: string },
+    remoteName: string,
   ): Effect.Effect<void, GitCommandError> => {
-    const refspec = `+refs/heads/${upstream.upstreamBranch}:refs/remotes/${upstream.upstreamRef}`;
     const fetchCwd =
       path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
     return executeGit(
-      "GitCore.fetchUpstreamRefForStatus",
+      "GitCore.fetchRemoteForStatus",
       fetchCwd,
-      ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", upstream.remoteName, refspec],
+      ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", remoteName],
       {
         allowNonZeroExit: true,
         timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
@@ -945,18 +942,14 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     return path.isAbsolute(gitCommonDir) ? gitCommonDir : path.resolve(cwd, gitCommonDir);
   });
 
-  const refreshStatusUpstreamCacheEntry = Effect.fn("refreshStatusUpstreamCacheEntry")(function* (
-    cacheKey: StatusUpstreamRefreshCacheKey,
+  const refreshStatusRemoteCacheEntry = Effect.fn("refreshStatusRemoteCacheEntry")(function* (
+    cacheKey: StatusRemoteRefreshCacheKey,
   ) {
-    yield* fetchUpstreamRefForStatus(cacheKey.gitCommonDir, {
-      upstreamRef: cacheKey.upstreamRef,
-      remoteName: cacheKey.remoteName,
-      upstreamBranch: cacheKey.upstreamBranch,
-    });
+    yield* fetchRemoteForStatus(cacheKey.gitCommonDir, cacheKey.remoteName);
     return true as const;
   });
 
-  const statusUpstreamRefreshCache = yield* Cache.makeWith(refreshStatusUpstreamCacheEntry, {
+  const statusRemoteRefreshCache = yield* Cache.makeWith(refreshStatusRemoteCacheEntry, {
     capacity: STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY,
     // Keep successful refreshes warm and briefly back off failed refreshes to avoid retry storms.
     timeToLive: (exit) =>
@@ -972,12 +965,10 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     if (!upstream) return;
     const gitCommonDir = yield* resolveGitCommonDir(cwd);
     yield* Cache.get(
-      statusUpstreamRefreshCache,
-      new StatusUpstreamRefreshCacheKey({
+      statusRemoteRefreshCache,
+      new StatusRemoteRefreshCacheKey({
         gitCommonDir,
-        upstreamRef: upstream.upstreamRef,
         remoteName: upstream.remoteName,
-        upstreamBranch: upstream.upstreamBranch,
       }),
     );
   });


### PR DESCRIPTION
## Summary
- Change status upstream refresh caching to key off `gitCommonDir` and remote name instead of the full upstream ref details.
- Simplify the status refresh fetch to use `git fetch --quiet --no-tags <remote>` for sibling worktrees on the same remote.
- Update integration coverage for shared refreshes and failed-refresh backoff across worktrees, and adjust the fetch expectation accordingly.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `statusDetails` upstream refresh cache key and fetch strategy, which can alter when/what refs get updated and may affect status accuracy or fetch load across worktrees/remotes.
> 
> **Overview**
> **Coalesces `statusDetails` refresh work across worktrees by remote.** The upstream-refresh cache key is simplified from `(gitCommonDir, upstreamRef/branch)` to `(gitCommonDir, remoteName)`, so sibling worktrees tracking different branches on the same remote share a single refresh and failure backoff window.
> 
> **Simplifies refresh fetching.** Status refresh now runs `git fetch --quiet --no-tags <remote>` (instead of fetching a specific upstream refspec), and tests are updated to assert the new fetch args and to cover coalescing/backoff when worktrees have different upstream refs on the same remote.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17dfc2e9e8285aa139ff2073f5fe14b6653127c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Coalesce git status remote refreshes by remote name instead of per-branch
> - Changes the status refresh cache key from `(gitCommonDir, upstreamRef, upstreamBranch)` to `(gitCommonDir, remoteName)` in [`GitCore.ts`](https://github.com/pingdotgg/t3code/pull/1940/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865), so all branches sharing the same remote and common dir share a single fetch entry.
> - Replaces the branch-specific refspec fetch with a broad `git fetch --quiet --no-tags <remote>` call, fetching all refs from the remote at once.
> - Behavioral Change: worktrees on the same remote now trigger at most one fetch per TTL window instead of one per tracked branch; this reduces fetch frequency but means a branch-specific fetch is no longer issued.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17dfc2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->