### PR TITLE
feat(web): add tooltip to composer file mention pill

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -438,6 +438,8 @@ function renderMentionChipDom(container: HTMLElement, pathValue: string): void {
   container.textContent = "";
   container.style.setProperty("user-select", "none");
   container.style.setProperty("-webkit-user-select", "none");
+  container.title = pathValue;
+  container.setAttribute("aria-label", pathValue);
 
   const theme = resolvedThemeFromDocument();
   const icon = document.createElement("img");

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -32,11 +32,8 @@ import {
   type ElementNode,
   type LexicalNode,
   type SerializedLexicalNode,
-  TextNode,
-  type EditorConfig,
   type EditorState,
   type NodeKey,
-  type SerializedTextNode,
   type Spread,
 } from "lexical";
 import {
@@ -103,7 +100,7 @@ type SerializedComposerMentionNode = Spread<
     type: "composer-mention";
     version: 1;
   },
-  SerializedTextNode
+  SerializedLexicalNode
 >;
 
 type SerializedComposerSkillNode = Spread<
@@ -132,7 +129,40 @@ const ComposerTerminalContextActionsContext = createContext<{
   onRemoveTerminalContext: () => {},
 });
 
-class ComposerMentionNode extends TextNode {
+function ComposerMentionDecorator(props: { path: string }) {
+  const theme = resolvedThemeFromDocument();
+  const chip = (
+    <span
+      className={COMPOSER_INLINE_CHIP_CLASS_NAME}
+      contentEditable={false}
+      spellCheck={false}
+      data-composer-mention-chip="true"
+    >
+      <img
+        alt=""
+        aria-hidden="true"
+        className={COMPOSER_INLINE_CHIP_ICON_CLASS_NAME}
+        loading="lazy"
+        src={getVscodeIconUrlForEntry(props.path, inferEntryKindFromPath(props.path), theme)}
+      />
+      <span className={COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME}>{basenameOfPath(props.path)}</span>
+    </span>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={chip} />
+      <TooltipPopup
+        side="top"
+        className="max-w-[30rem] whitespace-normal leading-tight wrap-anywhere"
+      >
+        {props.path}
+      </TooltipPopup>
+    </Tooltip>
+  );
+}
+
+class ComposerMentionNode extends DecoratorNode<ReactElement> {
   __path: string;
 
   static override getType(): string {
@@ -144,12 +174,12 @@ class ComposerMentionNode extends TextNode {
   }
 
   static override importJSON(serializedNode: SerializedComposerMentionNode): ComposerMentionNode {
-    return $createComposerMentionNode(serializedNode.path);
+    return $createComposerMentionNode(serializedNode.path).updateFromJSON(serializedNode);
   }
 
   constructor(path: string, key?: NodeKey) {
+    super(key);
     const normalizedPath = path.startsWith("@") ? path.slice(1) : path;
-    super(`@${normalizedPath}`, key);
     this.__path = normalizedPath;
   }
 
@@ -162,41 +192,26 @@ class ComposerMentionNode extends TextNode {
     };
   }
 
-  override createDOM(_config: EditorConfig): HTMLElement {
+  override createDOM(): HTMLElement {
     const dom = document.createElement("span");
-    dom.className = COMPOSER_INLINE_CHIP_CLASS_NAME;
-    dom.contentEditable = "false";
-    dom.setAttribute("spellcheck", "false");
-    renderMentionChipDom(dom, this.__path);
+    dom.className = "inline-flex align-middle leading-none";
     return dom;
   }
 
-  override updateDOM(
-    prevNode: ComposerMentionNode,
-    dom: HTMLElement,
-    _config: EditorConfig,
-  ): boolean {
-    dom.contentEditable = "false";
-    if (prevNode.__text !== this.__text || prevNode.__path !== this.__path) {
-      renderMentionChipDom(dom, this.__path);
-    }
+  override updateDOM(): false {
     return false;
   }
 
-  override canInsertTextBefore(): false {
-    return false;
+  override getTextContent(): string {
+    return `@${this.__path}`;
   }
 
-  override canInsertTextAfter(): false {
-    return false;
-  }
-
-  override isTextEntity(): true {
+  override isInline(): true {
     return true;
   }
 
-  override isToken(): true {
-    return true;
+  override decorate(): ReactElement {
+    return <ComposerMentionDecorator path={this.__path} />;
   }
 }
 
@@ -434,28 +449,6 @@ function resolvedThemeFromDocument(): "light" | "dark" {
   return document.documentElement.classList.contains("dark") ? "dark" : "light";
 }
 
-function renderMentionChipDom(container: HTMLElement, pathValue: string): void {
-  container.textContent = "";
-  container.style.setProperty("user-select", "none");
-  container.style.setProperty("-webkit-user-select", "none");
-  container.title = pathValue;
-  container.setAttribute("aria-label", pathValue);
-
-  const theme = resolvedThemeFromDocument();
-  const icon = document.createElement("img");
-  icon.alt = "";
-  icon.ariaHidden = "true";
-  icon.className = COMPOSER_INLINE_CHIP_ICON_CLASS_NAME;
-  icon.loading = "lazy";
-  icon.src = getVscodeIconUrlForEntry(pathValue, inferEntryKindFromPath(pathValue), theme);
-
-  const label = document.createElement("span");
-  label.className = COMPOSER_INLINE_CHIP_LABEL_CLASS_NAME;
-  label.textContent = basenameOfPath(pathValue);
-
-  container.append(icon, label);
-}
-
 function terminalContextSignature(contexts: ReadonlyArray<TerminalContextDraft>): string {
   return contexts
     .map((context) =>
@@ -597,12 +590,9 @@ function getAbsoluteOffsetForPoint(node: LexicalNode, pointOffset: number): numb
   }
 
   if ($isTextNode(node)) {
-    if (node instanceof ComposerMentionNode) {
-      return getAbsoluteOffsetForInlineTokenPoint(node, offset, pointOffset);
-    }
     return offset + Math.min(pointOffset, node.getTextContentSize());
   }
-  if (node instanceof ComposerSkillNode || node instanceof ComposerTerminalContextNode) {
+  if (isComposerInlineTokenNode(node)) {
     return getAbsoluteOffsetForInlineTokenPoint(node, offset, pointOffset);
   }
 
@@ -644,12 +634,9 @@ function getExpandedAbsoluteOffsetForPoint(node: LexicalNode, pointOffset: numbe
   }
 
   if ($isTextNode(node)) {
-    if (node instanceof ComposerMentionNode) {
-      return getExpandedAbsoluteOffsetForInlineTokenPoint(node, offset, pointOffset);
-    }
     return offset + Math.min(pointOffset, node.getTextContentSize());
   }
-  if (node instanceof ComposerSkillNode || node instanceof ComposerTerminalContextNode) {
+  if (isComposerInlineTokenNode(node)) {
     return getExpandedAbsoluteOffsetForInlineTokenPoint(node, offset, pointOffset);
   }
 
@@ -675,10 +662,7 @@ function findSelectionPointAtOffset(
   node: LexicalNode,
   remainingRef: { value: number },
 ): { key: string; offset: number; type: "text" | "element" } | null {
-  if (node instanceof ComposerMentionNode || node instanceof ComposerSkillNode) {
-    return findSelectionPointForInlineToken(node, remainingRef);
-  }
-  if (node instanceof ComposerTerminalContextNode) {
+  if (isComposerInlineTokenNode(node)) {
     return findSelectionPointForInlineToken(node, remainingRef);
   }
 


### PR DESCRIPTION
## What Changed

Migrated `ComposerMentionNode` from `TextNode` to `DecoratorNode` and added a `<Tooltip />` that shows the full file path on hover. Also cleaned up the offset/selection functions to use `isComposerInlineTokenNode` instead of per-type `instanceof` checks.

## Why

The mention pill only shows the basename, so when multiple files share the same name (e.g. `src/utils/index.ts` and `src/api/index.ts`) there's no way to tell them apart. `ComposerMentionNode` was the only inline chip still on `TextNode`, Skills and Terminal already used `DecoratorNode`, so this aligns all three and enables proper `<Tooltip />` support.

## UI Changes

<img width="587" height="108" alt="image" src="https://github.com/user-attachments/assets/788b6768-ede1-455c-afdd-f959c8a1ab5c" />
<img width="279" height="90" alt="image" src="https://github.com/user-attachments/assets/d29194f4-2f9a-4f98-8a2f-52e1d3d2878c" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors the Lexical `ComposerMentionNode` from a `TextNode` to a `DecoratorNode`, which can affect editor serialization and cursor/selection behavior around inline tokens.
> 
> **Overview**
> Shows the full file path when hovering a composer file mention chip by rendering the mention as a `DecoratorNode` with a `Tooltip` (while still displaying only the basename in the chip).
> 
> This removes the previous manual DOM rendering/update logic for mention chips, adjusts mention JSON import/export to the new node type, and consolidates selection/offset calculations to treat mentions the same as other inline token nodes via `isComposerInlineTokenNode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0311e7d894f4eb30e903e731f66ad12232d98955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show full file path on composer mention pill hover
> - Refactors `ComposerMentionNode` in [ComposerPromptEditor.tsx](https://github.com/pingdotgg/t3code/pull/1944/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4) from a `TextNode` to a `DecoratorNode`, switching from imperative DOM rendering to a new `ComposerMentionDecorator` React component.
> - The decorator renders an inline, non-editable chip with an icon and label, wrapped in a tooltip that displays the full file path on hover.
> - Consolidates offset and selection point utilities to handle mention nodes via the generic `isComposerInlineTokenNode` path, removing mention-specific branches.
> - Behavioral Change: mention nodes now serialize as `SerializedLexicalNode` instead of `SerializedTextNode`; existing serialized mention data may need re-validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0311e7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->