### PR TITLE
fix: Isolate thread reactor workers to prevent head-of-line blocking

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -66,6 +66,16 @@ async function waitFor(
 }
 
 describe("ProviderCommandReactor", () => {
+  type HarnessOptions = {
+    readonly baseDir?: string;
+    readonly threadModelSelection?: ModelSelection;
+    readonly sessionModelSwitch?: "unsupported" | "in-session";
+    readonly startSessionImplementation?: (
+      input: unknown,
+      session: ProviderSession,
+    ) => Effect.Effect<ProviderSession>;
+  };
+
   let runtime: ManagedRuntime.ManagedRuntime<
     OrchestrationEngineService | ProviderCommandReactor,
     unknown
@@ -93,11 +103,7 @@ describe("ProviderCommandReactor", () => {
     createdBaseDirs.clear();
   });
 
-  async function createHarness(input?: {
-    readonly baseDir?: string;
-    readonly threadModelSelection?: ModelSelection;
-    readonly sessionModelSwitch?: "unsupported" | "in-session";
-  }) {
+  async function createHarness(input?: HarnessOptions) {
     const now = new Date().toISOString();
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "t3code-reactor-"));
     createdBaseDirs.add(baseDir);
@@ -110,28 +116,32 @@ describe("ProviderCommandReactor", () => {
       provider: "codex",
       model: "gpt-5-codex",
     };
-    const startSession = vi.fn((_: unknown, input: unknown) => {
+    const startSessionImplementation: NonNullable<HarnessOptions["startSessionImplementation"]> =
+      input?.startSessionImplementation ??
+      ((_: unknown, session: ProviderSession) => Effect.succeed(session));
+    const startSession = vi.fn((_: unknown, startInput: unknown) => {
       const sessionIndex = nextSessionIndex++;
       const resumeCursor =
-        typeof input === "object" && input !== null && "resumeCursor" in input
-          ? input.resumeCursor
+        typeof startInput === "object" && startInput !== null && "resumeCursor" in startInput
+          ? startInput.resumeCursor
           : undefined;
       const threadId =
-        typeof input === "object" &&
-        input !== null &&
-        "threadId" in input &&
-        typeof input.threadId === "string"
-          ? ThreadId.make(input.threadId)
+        typeof startInput === "object" &&
+        startInput !== null &&
+        "threadId" in startInput &&
+        typeof startInput.threadId === "string"
+          ? ThreadId.make(startInput.threadId)
           : ThreadId.make(`thread-${sessionIndex}`);
       const session: ProviderSession = {
         provider: modelSelection.provider,
         status: "ready" as const,
         runtimeMode:
-          typeof input === "object" &&
-          input !== null &&
-          "runtimeMode" in input &&
-          (input.runtimeMode === "approval-required" || input.runtimeMode === "full-access")
-            ? input.runtimeMode
+          typeof startInput === "object" &&
+          startInput !== null &&
+          "runtimeMode" in startInput &&
+          (startInput.runtimeMode === "approval-required" ||
+            startInput.runtimeMode === "full-access")
+            ? startInput.runtimeMode
             : "full-access",
         ...(modelSelection.model !== undefined ? { model: modelSelection.model } : {}),
         threadId,
@@ -139,8 +149,13 @@ describe("ProviderCommandReactor", () => {
         createdAt: now,
         updatedAt: now,
       };
-      runtimeSessions.push(session);
-      return Effect.succeed(session);
+      return startSessionImplementation(startInput, session).pipe(
+        Effect.tap((resolvedSession) =>
+          Effect.sync(() => {
+            runtimeSessions.push(resolvedSession);
+          }),
+        ),
+      );
     });
     const sendTurn = vi.fn((_: unknown) =>
       Effect.succeed({
@@ -323,6 +338,96 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("does not let one hung thread start block another thread", async () => {
+    const harness = await createHarness({
+      startSessionImplementation: (input, session) => {
+        const threadId =
+          typeof input === "object" &&
+          input !== null &&
+          "threadId" in input &&
+          typeof input.threadId === "string"
+            ? input.threadId
+            : null;
+        return threadId === "thread-1" ? Effect.never : Effect.succeed(session);
+      },
+    });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-thread-create-2"),
+        threadId: ThreadId.make("thread-2"),
+        projectId: asProjectId("project-1"),
+        title: "Thread 2",
+        modelSelection: {
+          provider: "codex",
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: null,
+        worktreePath: null,
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-hung-thread-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-hung-thread-1"),
+          role: "user",
+          text: "thread one hangs on start",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-hung-thread-2"),
+        threadId: ThreadId.make("thread-2"),
+        message: {
+          messageId: asMessageId("user-message-hung-thread-2"),
+          role: "user",
+          text: "thread two should still run",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length >= 2);
+    await waitFor(() =>
+      harness.sendTurn.mock.calls.some(
+        ([payload]) =>
+          typeof payload === "object" &&
+          payload !== null &&
+          "threadId" in payload &&
+          payload.threadId === ThreadId.make("thread-2"),
+      ),
+    );
+
+    expect(
+      harness.sendTurn.mock.calls.some(
+        ([payload]) =>
+          typeof payload === "object" &&
+          payload !== null &&
+          "threadId" in payload &&
+          payload.threadId === ThreadId.make("thread-1"),
+      ),
+    ).toBe(false);
   });
 
   it("generates a thread title on the first turn", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,7 +12,7 @@ import {
   type TurnId,
 } from "@t3tools/contracts";
 import { Cache, Cause, Duration, Effect, Equal, Layer, Option, Schema, Stream } from "effect";
-import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
+import { type DrainableWorker, makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
@@ -787,7 +787,19 @@ const make = Effect.gen(function* () {
       }),
     );
 
-  const worker = yield* makeDrainableWorker(processDomainEventSafely);
+  const workersByThreadId = new Map<ThreadId, DrainableWorker<ProviderIntentEvent>>();
+
+  const workerForThread = (threadId: ThreadId) =>
+    Effect.gen(function* () {
+      const existing = workersByThreadId.get(threadId);
+      if (existing) {
+        return existing;
+      }
+
+      const created = yield* makeDrainableWorker(processDomainEventSafely);
+      workersByThreadId.set(threadId, created);
+      return created;
+    });
 
   const start: ProviderCommandReactorShape["start"] = Effect.fn("start")(function* () {
     const processEvent = Effect.fn("processEvent")(function* (event: OrchestrationEvent) {
@@ -799,6 +811,7 @@ const make = Effect.gen(function* () {
         event.type === "thread.user-input-response-requested" ||
         event.type === "thread.session-stop-requested"
       ) {
+        const worker = yield* workerForThread(event.payload.threadId);
         return yield* worker.enqueue(event);
       }
     });
@@ -810,7 +823,13 @@ const make = Effect.gen(function* () {
 
   return {
     start,
-    drain: worker.drain,
+    drain: Effect.gen(function* () {
+      const workers = Array.from(workersByThreadId.values());
+      yield* Effect.forEach(workers, (worker) => worker.drain, {
+        concurrency: "unbounded",
+        discard: true,
+      });
+    }),
   } satisfies ProviderCommandReactorShape;
 });
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Users can keep working in healthy threads even if another thread gets stuck starting a session. This replaces the single provider command reactor worker with per-thread drainable workers so provider intents are queued independently by threadId while preserving per-thread ordering, and it keeps the hanging-thread regression coverage with a test that verifies a blocked thread-1 start does not prevent thread-2 from reaching sendTurn.

## Why

A hung or slow thread start could block the shared reactor queue and make unrelated threads look broken. The failure scenario here is one thread stalling during session startup or resume, followed by another thread trying to start a turn and getting stuck behind the same worker. Isolating reactor workers by thread removes that head-of-line blocking, keeps unaffected threads responsive, and preserves serialized processing within each individual thread.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the reactor’s event-queueing/concurrency model, which could affect ordering, draining behavior, and resource usage across threads if worker lifecycle isn’t handled correctly.
> 
> **Overview**
> Prevents head-of-line blocking in `ProviderCommandReactor` by replacing the single `DrainableWorker` with a per-thread worker map keyed by `threadId`, so provider-intent events are queued/serialized per thread but processed independently across threads.
> 
> Updates `drain` to wait on all active thread workers, and extends the test harness to allow custom `startSession` behavior plus a new regression test proving a hung session start in `thread-1` does not stop `thread-2` from reaching `sendTurn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde0e2a6bf097134cf3c1320e2ef600b5b2804ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Isolate `ProviderCommandReactor` thread workers to prevent head-of-line blocking
> - Replaces a single global `DrainableWorker` with a per-thread worker map in [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/1945/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d), keyed by `ThreadId`.
> - Workers are lazily created and memoized via a `workerForThread` effect; the `drain` method now drains all per-thread workers concurrently.
> - Adds a test in [ProviderCommandReactor.test.ts](https://github.com/pingdotgg/t3code/pull/1945/files#diff-24590cda9b5d40bcb845f474304592ddf62ae6d252d40be60e19435aa75347c4) that verifies a hung session start on one thread does not block turn processing on another.
> - Behavioral Change: events that previously queued behind a blocked thread will now process independently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bde0e2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->