### PR TITLE
fix(server): suppress teardown-only Codex session closures

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -470,6 +470,60 @@ describe("startSession", () => {
       manager.stopAll();
     }
   });
+
+  it("supports silent shutdown without emitting session/closed lifecycle events", () => {
+    const manager = new CodexAppServerManager();
+    const emitLifecycleEvent = vi.spyOn(
+      manager as unknown as {
+        emitLifecycleEvent: (...args: unknown[]) => void;
+      },
+      "emitLifecycleEvent",
+    );
+    const updateSession = vi.spyOn(
+      manager as unknown as {
+        updateSession: (...args: unknown[]) => void;
+      },
+      "updateSession",
+    );
+    const sessions = (
+      manager as unknown as {
+        sessions: Map<string, unknown>;
+      }
+    ).sessions;
+
+    sessions.set("thread-1", {
+      session: {
+        provider: "codex",
+        status: "ready",
+        threadId: asThreadId("thread-1"),
+        runtimeMode: "full-access",
+        createdAt: "2026-03-19T00:00:00.000Z",
+        updatedAt: "2026-03-19T00:00:00.000Z",
+      },
+      account: {
+        type: "unknown",
+        planType: null,
+        sparkEnabled: true,
+      },
+      child: {
+        killed: true,
+      },
+      output: {
+        close: vi.fn(),
+      },
+      pending: new Map(),
+      pendingApprovals: new Map(),
+      pendingUserInputs: new Map(),
+      nextRequestId: 1,
+      stopping: false,
+    });
+
+    manager.stopAll({ emitLifecycleEvent: false });
+
+    expect(updateSession).toHaveBeenCalled();
+    expect(emitLifecycleEvent).not.toHaveBeenCalled();
+    expect(sessions.size).toBe(0);
+  });
 });
 
 describe("sendTurn", () => {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -127,6 +127,10 @@ export interface CodexAppServerStartSessionInput {
   readonly runtimeMode: RuntimeMode;
 }
 
+interface CodexAppServerStopOptions {
+  readonly emitLifecycleEvent?: boolean;
+}
+
 export interface CodexThreadTurnSnapshot {
   id: TurnId;
   items: unknown[];
@@ -895,7 +899,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     });
   }
 
-  stopSession(threadId: ThreadId): void {
+  stopSession(threadId: ThreadId, options?: CodexAppServerStopOptions): void {
     const context = this.sessions.get(threadId);
     if (!context) {
       return;
@@ -921,7 +925,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       status: "closed",
       activeTurnId: undefined,
     });
-    this.emitLifecycleEvent(context, "session/closed", "Session stopped");
+    if (options?.emitLifecycleEvent ?? true) {
+      this.emitLifecycleEvent(context, "session/closed", "Session stopped");
+    }
     this.sessions.delete(threadId);
   }
 
@@ -935,9 +941,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     return this.sessions.has(threadId);
   }
 
-  stopAll(): void {
+  stopAll(options?: CodexAppServerStopOptions): void {
     for (const threadId of this.sessions.keys()) {
-      this.stopSession(threadId);
+      this.stopSession(threadId, options);
     }
   }
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -86,7 +86,9 @@ class FakeCodexManager extends CodexAppServerManager {
     ): Promise<void> => undefined,
   );
 
-  public stopAllImpl = vi.fn(() => undefined);
+  public stopAllImpl = vi.fn(
+    (_options?: Parameters<CodexAppServerManager["stopAll"]>[0]) => undefined,
+  );
 
   override startSession(input: CodexAppServerStartSessionInput): Promise<ProviderSession> {
     return this.startSessionImpl(input);
@@ -134,8 +136,8 @@ class FakeCodexManager extends CodexAppServerManager {
     return false;
   }
 
-  override stopAll(): void {
-    this.stopAllImpl();
+  override stopAll(options?: Parameters<CodexAppServerManager["stopAll"]>[0]): void {
+    this.stopAllImpl(options);
   }
 }
 
@@ -428,6 +430,18 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
       }
       assert.equal(firstEvent.value.threadId, "thread-1");
       assert.equal(firstEvent.value.payload.reason, "Session stopped");
+    }),
+  );
+
+  it.effect("suppresses lifecycle events when adapter stopAll tears down sessions", () =>
+    Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+
+      yield* adapter.stopAll();
+
+      assert.deepEqual(lifecycleManager.stopAllImpl.mock.calls.at(-1), [
+        { emitLifecycleEvent: false },
+      ]);
     }),
   );
 
@@ -976,6 +990,26 @@ lifecycleLayer("CodexAdapterLive lifecycle", (it) => {
     }),
   );
 });
+
+it.effect("suppresses lifecycle events when the adapter scope finalizes", () =>
+  Effect.gen(function* () {
+    const manager = new FakeCodexManager();
+    const layer = makeCodexAdapterLive({ manager }).pipe(
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(providerSessionDirectoryTestLayer),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        yield* CodexAdapter;
+      }).pipe(Effect.provide(layer)),
+    );
+
+    assert.deepEqual(manager.stopAllImpl.mock.calls, [[{ emitLifecycleEvent: false }]]);
+  }),
+);
 
 afterAll(() => {
   if (lifecycleManager.stopAllImpl.mock.calls.length === 0) {

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1366,7 +1366,7 @@ const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   const manager = yield* Effect.acquireRelease(acquireManager(), (manager) =>
     Effect.sync(() => {
       try {
-        manager.stopAll();
+        manager.stopAll({ emitLifecycleEvent: false });
       } catch {
         // Finalizers should never fail and block shutdown.
       }
@@ -1565,7 +1565,7 @@ const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
 
   const stopAll: CodexAdapterShape["stopAll"] = () =>
     Effect.sync(() => {
-      manager.stopAll();
+      manager.stopAll({ emitLifecycleEvent: false });
     });
 
   const runtimeEventQueue = yield* Queue.unbounded<ProviderRuntimeEvent>();


### PR DESCRIPTION
Allow CodexAppServerManager stopAll/stopSession to suppress session/closed lifecycle emission, and use that path from CodexAdapter stopAll and adapter finalization.

Add manager and adapter coverage for silent teardown behavior.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Closing or reloading T3 Code no longer emits spurious Codex session-exited events during teardown.

Technically, this adds a silent shutdown path to `CodexAppServerManager.stopSession` / `stopAll` so teardown-only cleanup can skip `session/closed` lifecycle emission, and updates `CodexAdapter.stopAll` plus adapter finalization to use that path. I also added manager- and adapter-level tests to verify teardown still clears sessions without reporting a real session exit.

## Why

Today, when the Codex adapter shuts down, it tears down all tracked sessions through the same path used for an intentional session stop. That causes teardown to emit `session/closed`, which is then projected as a real `session.exited` runtime event even though the app is just shutting down.

For users, that can surface as threads being treated like they explicitly exited when they only closed or restarted the app. This change keeps intentional session stops observable, but makes teardown-only cleanup quiet so shutdown does not create misleading lifecycle events or leave session state looking more final than it really is.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional flag to suppress `session/closed` emission during teardown and updates adapter shutdown paths; behavior for explicit session stops remains unchanged by default.
> 
> **Overview**
> Prevents shutdown/reload of the Codex adapter from producing misleading “session exited” runtime events by adding a *silent teardown* option.
> 
> `CodexAppServerManager.stopSession`/`stopAll` now accept an `emitLifecycleEvent` option (defaulting to `true`) and skip emitting `session/closed` when disabled; `CodexAdapter.stopAll` and the adapter finalizer now call `stopAll({ emitLifecycleEvent: false })`. Tests were added/updated to verify sessions are still cleared and lifecycle events are suppressed during teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b35243cb46b12978c393208a6dfeace24b8857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress `session/closed` lifecycle events during Codex adapter teardown
> - Adds an optional `emitLifecycleEvent` flag to `CodexAppServerManager.stopSession` and `stopAll`, defaulting to `true` for existing behavior.
> - Updates `makeCodexAdapter` in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/1946/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) to pass `{ emitLifecycleEvent: false }` when stopping sessions during adapter teardown or scope finalization.
> - Sessions are still stopped and `updateSession` is still called; only the `session/closed` lifecycle event is suppressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7b3524.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->