### PR TITLE
fix(web): replace turn strip overlay gradients with mask-image fade

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -429,12 +429,6 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const headerRow = (
     <>
       <div className="relative min-w-0 flex-1 [-webkit-app-region:no-drag]">
-        {canScrollTurnStripLeft && (
-          <div className="pointer-events-none absolute inset-y-0 left-8 z-10 w-7 bg-linear-to-r from-card to-transparent" />
-        )}
-        {canScrollTurnStripRight && (
-          <div className="pointer-events-none absolute inset-y-0 right-8 z-10 w-7 bg-linear-to-l from-card to-transparent" />
-        )}
         <button
           type="button"
           className={cn(
@@ -466,6 +460,13 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         <div
           ref={turnStripRef}
           className="turn-chip-strip flex gap-1 overflow-x-auto px-8 py-0.5"
+          style={
+            canScrollTurnStripLeft || canScrollTurnStripRight
+              ? {
+                  maskImage: `linear-gradient(to right, ${canScrollTurnStripLeft ? "transparent, black 32px" : "black"}, ${canScrollTurnStripRight ? "black calc(100% - 32px), transparent" : "black"})`,
+                }
+              : undefined
+          }
           onWheel={onTurnStripWheel}
         >
           <button

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -463,7 +463,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
           style={
             canScrollTurnStripLeft || canScrollTurnStripRight
               ? {
-                  maskImage: `linear-gradient(to right, ${canScrollTurnStripLeft ? "transparent, black 32px" : "black"}, ${canScrollTurnStripRight ? "black calc(100% - 32px), transparent" : "black"})`,
+                  maskImage: `linear-gradient(to right, ${canScrollTurnStripLeft ? "transparent 24px, black 72px" : "black"}, ${canScrollTurnStripRight ? "black calc(100% - 72px), transparent calc(100% - 24px)" : "black"})`,
                 }
               : undefined
           }


### PR DESCRIPTION
## What Changed

Replaced the two gradient overlay divs on the turn chip strip with a `mask-image` on the scroll container.

## Why

The overlay divs paint a `from-card to-transparent` gradient on top of the turn pills near the arrows. With many turns, this causes a weird shading effect where the gradient bleeds over the pills.

Using `mask-image` makes the pills themselves fade out at the edges instead of layering a colored div on top. No more shading issues and it works with any theme.

## UI Changes

**Before:**

<img width="829" height="56" alt="2026-04-12_05-45" src="https://github.com/user-attachments/assets/1197e09d-fb1d-4025-b503-4e0b1f5f4b90" />

**After:**

<img width="610" height="49" alt="2026-04-12_05-43" src="https://github.com/user-attachments/assets/b9cd3401-c330-4007-8c8c-10d0914370ac" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change in `DiffPanel` that alters CSS rendering of the scroll fade; main risk is cross-browser/theme visual regressions.
> 
> **Overview**
> Updates the turn chip strip in `DiffPanel.tsx` to **remove the left/right absolute gradient overlay divs** and instead apply a **conditional `mask-image` linear-gradient** on the scroll container when it can scroll left/right.
> 
> This changes the scroll-edge affordance from a colored overlay to a fade-out of the chips themselves, avoiding shading artifacts near the arrow buttons and adapting to any theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b13088a5cc3160c1e8706c949e57a648a227fea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace turn strip overlay gradient divs with CSS `mask-image` fade in `DiffPanel`
> The left/right edge fade on the horizontal turn strip in [DiffPanel.tsx](https://github.com/pingdotgg/t3code/pull/1949/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) was previously achieved with two conditional overlay `<div>` elements. These are replaced with a `maskImage` CSS style applied directly to the scrollable strip element, using a `linear-gradient` that responds to `canScrollTurnStripLeft` and `canScrollTurnStripRight`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b13088.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->