### PR TITLE
fix(web): persist diff selection per thread

### DIFF
--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -1,6 +1,7 @@
+import { TurnId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { parseDiffRouteSearch } from "./diffRouteSearch";
+import { diffRouteSearchEqual, parseDiffRouteSearch } from "./diffRouteSearch";
 
 describe("parseDiffRouteSearch", () => {
   it("parses valid diff search values", () => {
@@ -70,5 +71,57 @@ describe("parseDiffRouteSearch", () => {
     expect(parsed).toEqual({
       diff: "1",
     });
+  });
+});
+
+describe("diffRouteSearchEqual", () => {
+  const turnId = TurnId.make("turn-1");
+  const otherTurnId = TurnId.make("turn-2");
+
+  it("matches identical diff search state", () => {
+    expect(
+      diffRouteSearchEqual(
+        {
+          diff: "1",
+          diffTurnId: turnId,
+          diffFilePath: "src/app.ts",
+        },
+        {
+          diff: "1",
+          diffTurnId: turnId,
+          diffFilePath: "src/app.ts",
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("treats missing and differing fields as unequal", () => {
+    expect(diffRouteSearchEqual(undefined, {})).toBe(true);
+    expect(
+      diffRouteSearchEqual(
+        {
+          diff: "1",
+          diffTurnId: turnId,
+        },
+        {
+          diff: "1",
+          diffTurnId: otherTurnId,
+        },
+      ),
+    ).toBe(false);
+    expect(
+      diffRouteSearchEqual(
+        {
+          diff: "1",
+          diffTurnId: turnId,
+          diffFilePath: "src/app.ts",
+        },
+        {
+          diff: "1",
+          diffTurnId: turnId,
+          diffFilePath: "src/other.ts",
+        },
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -25,6 +25,17 @@ export function stripDiffSearchParams<T extends Record<string, unknown>>(
   return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
 }
 
+export function diffRouteSearchEqual(
+  left: DiffRouteSearch | undefined,
+  right: DiffRouteSearch | undefined,
+): boolean {
+  return (
+    left?.diff === right?.diff &&
+    left?.diffTurnId === right?.diffTurnId &&
+    left?.diffFilePath === right?.diffFilePath
+  );
+}
+
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
   const diff = isDiffOpenValue(search.diff) ? "1" : undefined;
   const diffTurnIdRaw = diff ? normalizeSearchString(search.diffTurnId) : undefined;

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -1,5 +1,15 @@
 import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
-import { Suspense, lazy, type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Suspense,
+  lazy,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import ChatView from "../components/ChatView";
 import { threadHasStarted } from "../components/ChatView.logic";
@@ -19,6 +29,10 @@ import {
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { selectEnvironmentState, selectThreadExistsByRef, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
+import {
+  createThreadDiffRouteMemoryState,
+  stepThreadDiffRouteMemory,
+} from "../threadDiffRouteMemory";
 import { resolveThreadRouteRef, buildThreadRouteParams } from "../threadRoutes";
 import { Sheet, SheetPopup } from "../components/ui/sheet";
 import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
@@ -194,6 +208,12 @@ function ChatThreadRouteView() {
   const diffOpen = search.diff === "1";
   const shouldUseDiffSheet = useMediaQuery(DIFF_INLINE_LAYOUT_MEDIA_QUERY);
   const currentThreadKey = threadRef ? `${threadRef.environmentId}:${threadRef.threadId}` : null;
+  const diffRouteMemoryRef = useRef(
+    createThreadDiffRouteMemoryState({
+      currentThreadKey,
+      currentSearch: search,
+    }),
+  );
   const [diffPanelMountState, setDiffPanelMountState] = useState(() => ({
     threadKey: currentThreadKey,
     hasOpenedDiff: diffOpen,
@@ -237,6 +257,26 @@ function ChatThreadRouteView() {
       },
     });
   }, [markDiffOpened, navigate, threadRef]);
+
+  useLayoutEffect(() => {
+    const transition = stepThreadDiffRouteMemory(diffRouteMemoryRef.current, {
+      currentThreadKey,
+      currentSearch: search,
+    });
+    diffRouteMemoryRef.current = transition.nextState;
+
+    if (threadRef && transition.restoredSearch) {
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: buildThreadRouteParams(threadRef),
+        replace: true,
+        search: (previous) => {
+          const rest = stripDiffSearchParams(previous);
+          return { ...rest, ...transition.restoredSearch };
+        },
+      });
+    }
+  }, [currentThreadKey, navigate, search, threadRef]);
 
   useEffect(() => {
     if (!threadRef || !bootstrapComplete) {

--- a/apps/web/src/threadDiffRouteMemory.test.ts
+++ b/apps/web/src/threadDiffRouteMemory.test.ts
@@ -1,0 +1,99 @@
+import { TurnId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  createThreadDiffRouteMemoryState,
+  stepThreadDiffRouteMemory,
+} from "./threadDiffRouteMemory";
+
+describe("threadDiffRouteMemory", () => {
+  it("restores each thread's last diff selection after switching away and back", () => {
+    const threadA = "env:thread-a";
+    const threadB = "env:thread-b";
+    const turnA = TurnId.make("turn-a");
+    const turnB = TurnId.make("turn-b");
+    const diffOnly = { diff: "1" as const };
+    const searchA = {
+      diff: "1" as const,
+      diffTurnId: turnA,
+      diffFilePath: "src/a.ts",
+    };
+    const searchB = {
+      diff: "1" as const,
+      diffTurnId: turnB,
+      diffFilePath: "src/b.ts",
+    };
+
+    let state = createThreadDiffRouteMemoryState({
+      currentThreadKey: threadA,
+      currentSearch: searchA,
+    });
+
+    const switchedToB = stepThreadDiffRouteMemory(state, {
+      currentThreadKey: threadB,
+      currentSearch: diffOnly,
+    });
+    state = switchedToB.nextState;
+
+    expect(switchedToB.restoredSearch).toBeNull();
+    expect(state.searchByThreadKey[threadA]).toEqual(searchA);
+
+    const selectedB = stepThreadDiffRouteMemory(state, {
+      currentThreadKey: threadB,
+      currentSearch: searchB,
+    });
+    state = selectedB.nextState;
+
+    expect(selectedB.restoredSearch).toBeNull();
+
+    const backToA = stepThreadDiffRouteMemory(state, {
+      currentThreadKey: threadA,
+      currentSearch: diffOnly,
+    });
+    state = backToA.nextState;
+
+    expect(backToA.restoredSearch).toEqual(searchA);
+    expect(state.searchByThreadKey[threadB]).toEqual(searchB);
+
+    const committedA = stepThreadDiffRouteMemory(state, {
+      currentThreadKey: threadA,
+      currentSearch: searchA,
+    });
+    state = committedA.nextState;
+
+    expect(committedA.restoredSearch).toBeNull();
+
+    const backToB = stepThreadDiffRouteMemory(state, {
+      currentThreadKey: threadB,
+      currentSearch: diffOnly,
+    });
+
+    expect(backToB.restoredSearch).toEqual(searchB);
+  });
+
+  it("restores a thread's closed diff state over a retained open panel", () => {
+    const threadA = "env:thread-a";
+    const threadB = "env:thread-b";
+
+    let state = createThreadDiffRouteMemoryState({
+      currentThreadKey: threadA,
+      currentSearch: {},
+    });
+
+    const switchedToB = stepThreadDiffRouteMemory(state, {
+      currentThreadKey: threadB,
+      currentSearch: { diff: "1" },
+    });
+    state = switchedToB.nextState;
+
+    expect(switchedToB.restoredSearch).toBeNull();
+    expect(state.searchByThreadKey[threadA]).toEqual({});
+
+    const backToA = stepThreadDiffRouteMemory(state, {
+      currentThreadKey: threadA,
+      currentSearch: { diff: "1" },
+    });
+
+    expect(backToA.restoredSearch).toEqual({});
+  });
+});

--- a/apps/web/src/threadDiffRouteMemory.ts
+++ b/apps/web/src/threadDiffRouteMemory.ts
@@ -1,0 +1,71 @@
+import { diffRouteSearchEqual, type DiffRouteSearch } from "./diffRouteSearch";
+
+export interface ThreadDiffRouteMemoryState {
+  previousThreadKey: string | null;
+  previousSearch: DiffRouteSearch;
+  searchByThreadKey: Record<string, DiffRouteSearch>;
+}
+
+export function createThreadDiffRouteMemoryState(input: {
+  currentThreadKey: string | null;
+  currentSearch: DiffRouteSearch;
+}): ThreadDiffRouteMemoryState {
+  return {
+    previousThreadKey: input.currentThreadKey,
+    previousSearch: input.currentSearch,
+    searchByThreadKey: {},
+  };
+}
+
+export function stepThreadDiffRouteMemory(
+  state: ThreadDiffRouteMemoryState,
+  input: {
+    currentThreadKey: string | null;
+    currentSearch: DiffRouteSearch;
+  },
+): {
+  nextState: ThreadDiffRouteMemoryState;
+  restoredSearch: DiffRouteSearch | null;
+} {
+  let searchByThreadKey = state.searchByThreadKey;
+
+  if (state.previousThreadKey && state.previousThreadKey !== input.currentThreadKey) {
+    const hasSavedPreviousSearch = Object.hasOwn(searchByThreadKey, state.previousThreadKey);
+    const savedPreviousSearch = searchByThreadKey[state.previousThreadKey];
+    if (
+      !hasSavedPreviousSearch ||
+      !diffRouteSearchEqual(savedPreviousSearch, state.previousSearch)
+    ) {
+      searchByThreadKey = {
+        ...searchByThreadKey,
+        [state.previousThreadKey]: state.previousSearch,
+      };
+    }
+  }
+
+  if (input.currentThreadKey) {
+    const hasSavedCurrentSearch = Object.hasOwn(searchByThreadKey, input.currentThreadKey);
+    const restoredSearch = hasSavedCurrentSearch
+      ? searchByThreadKey[input.currentThreadKey]!
+      : undefined;
+    if (restoredSearch && !diffRouteSearchEqual(restoredSearch, input.currentSearch)) {
+      return {
+        nextState: {
+          previousThreadKey: input.currentThreadKey,
+          previousSearch: restoredSearch,
+          searchByThreadKey,
+        },
+        restoredSearch,
+      };
+    }
+  }
+
+  return {
+    nextState: {
+      previousThreadKey: input.currentThreadKey,
+      previousSearch: input.currentSearch,
+      searchByThreadKey,
+    },
+    restoredSearch: null,
+  };
+}


### PR DESCRIPTION
## Summary
- confirm upstream only preserves `diff=1` across thread switches and drops per-thread diff selection state
- remember each thread's last diff route state in the server-thread route and restore it when revisiting that thread
- add focused tests for diff route equality and the per-thread diff memory transitions

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run --cwd apps/web test --run src/diffRouteSearch.test.ts src/threadDiffRouteMemory.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes route-search behavior and adds stateful restoration logic during thread navigation; risk is moderate due to potential for unexpected URL replace/navigation loops or stale diff state if edge cases aren’t covered.
> 
> **Overview**
> Persists each thread’s last diff viewer route state (`diff`, `diffTurnId`, `diffFilePath`) and restores it when navigating back to that thread, rather than only retaining `diff=1` across thread switches.
> 
> Adds `threadDiffRouteMemory` with a `useLayoutEffect` in the chat thread route to capture per-thread diff search state and `replace` the URL with the restored selection when needed, plus a new `diffRouteSearchEqual` helper and focused unit tests for both equality and restore transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df22a1452eff3eb687ff8fc733771b89ba719186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist diff panel selection per thread when switching between threads
> - Adds `threadDiffRouteMemory` to track and restore each thread's last diff route search state (selected turn, file path, open/closed) as users navigate between threads.
> - On thread switch, the previous thread's diff search is saved; when returning to a thread, the saved search is restored via a replace navigation.
> - Introduces `diffRouteSearchEqual` in [diffRouteSearch.ts](https://github.com/pingdotgg/t3code/pull/1950/files#diff-625b76b0ee5e0cd241579df3eec55eaf0d42a2403fe980a4f5dfffa6af912f8f) for stable field-by-field comparison to avoid unnecessary writes or navigations.
> - The restore logic in [_chat.$environmentId.$threadId.tsx](https://github.com/pingdotgg/t3code/pull/1950/files#diff-5873401c664d8c70d7bd404a83ecb5f76631a08bc699d6e4841186b329a2cf63) uses `useLayoutEffect` and a ref to run before paint, merging restored diff fields with the current non-diff search params.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df22a14.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->