### PR TITLE
fix(web): allow concurrent browser tests to retry ports

### DIFF
--- a/apps/web/vitest.browser.config.ts
+++ b/apps/web/vitest.browser.config.ts
@@ -14,6 +14,11 @@ export default mergeConfig(
         "~": srcPath,
       },
     },
+    server: {
+      // The app dev server uses a fixed port, but browser tests need to allow
+      // concurrent runs to claim the next available port.
+      strictPort: false,
+    },
     test: {
       include: ["src/components/**/*.browser.tsx"],
       browser: {
@@ -21,6 +26,9 @@ export default mergeConfig(
         provider: playwright(),
         instances: [{ browser: "chromium" }],
         headless: true,
+        api: {
+          strictPort: false,
+        },
       },
       testTimeout: 30_000,
       hookTimeout: 30_000,


### PR DESCRIPTION
## Summary
- disable strict fixed-port behavior in the browser test config
- let concurrent browser test runs retry onto the next available port instead of failing
- keep the normal app dev server behavior unchanged

## Testing
- bun fmt
- bun lint
- bun typecheck
- bun run test:browser -- src/components/chat/TraitsPicker.browser.tsx
- ran the same browser test twice in parallel and both passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts test/dev-server port binding behavior in `vitest.browser.config.ts`, with no runtime app logic changes.
> 
> **Overview**
> Allows **concurrent Vitest browser test runs** by disabling fixed-port behavior in `vitest.browser.config.ts` (`server.strictPort: false` and `test.browser.api.strictPort: false`), so the test runner can fall back to the next available port instead of failing when a port is already in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4531219c371f71a8de8bf3aa6ad5823acb59d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow browser test servers to retry ports when default is in use
> Sets `strictPort: false` in both the Vite server config and the Vitest browser API config in [vitest.browser.config.ts](https://github.com/pingdotgg/t3code/pull/1951/files#diff-43f48c0992bbe908637d5a870df41dd0f71674ba3129eaf13bb777139ebdbc33), so concurrent browser test runs no longer fail when the default port is already bound.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5e45312.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->