### PR TITLE
fix(ui): prevent input overflow in plan mode

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3335,7 +3335,7 @@ export default function ChatView(props: ChatViewProps) {
       {/* Main content area with optional plan sidebar */}
       <div className="flex min-h-0 min-w-0 flex-1">
         {/* Chat column */}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           {/* Messages Wrapper */}
           <div className="relative flex min-h-0 flex-1 flex-col">
             {/* Messages */}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1898,7 +1898,7 @@ export const ChatComposer = memo(
                 data-chat-composer-footer="true"
                 data-chat-composer-footer-compact={isComposerFooterCompact ? "true" : "false"}
                 className={cn(
-                  "flex min-w-0 flex-nowrap items-center justify-between gap-2 overflow-visible px-2.5 pb-2.5 sm:px-3 sm:pb-3",
+                  "flex min-w-0 flex-nowrap items-center justify-between gap-2 overflow-hidden px-2.5 pb-2.5 sm:px-3 sm:pb-3",
                   isComposerFooterCompact ? "gap-1.5" : "gap-2 sm:gap-0",
                 )}
               >


### PR DESCRIPTION
## What Changed
i had the problem that in plan mode the chat box overflowed when implementing the plan (when the sidebar for the plan opened)

this just fix it :)) 

also no problem if this is not getting merged/reviewed just :) 

## UI Changes
before:
<img width="999" height="260" alt="36 Claude Opus 46" src="https://github.com/user-attachments/assets/8b0a8ac3-5d75-4320-b72a-832d6bcb4a72" />

after:
<img width="1109" height="349" alt="Screenshot 2026-04-12 at 09 37 43" src="https://github.com/user-attachments/assets/ca7105c6-d5a5-4bef-b1a0-8811fa9cfc8d" />

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix input overflow in chat plan mode
> Adds `overflow-hidden` to the chat column container in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/1954/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and changes the composer footer in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/1954/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) from `overflow-visible` to `overflow-hidden`, so overflowing content is clipped and inner scroll regions handle scrolling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d28ec56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->