### PR TITLE
fix(server): set session to error state when sendTurn fails

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -757,7 +757,9 @@ describe("ProviderCommandReactor", () => {
 
     const readModel = await Effect.runPromise(harness.engine.getReadModel());
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-    expect(thread?.session).toBeNull();
+    expect(thread?.session).not.toBeNull();
+    expect(thread?.session?.status).toBe("stopped");
+    expect(thread?.session?.lastError).toContain("Provider turn start failed");
     expect(
       thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
     ).toMatchObject({
@@ -1129,6 +1131,8 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.providerName).toBe("codex");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+    expect(thread?.session?.status).toBe("error");
+    expect(thread?.session?.lastError).toContain("Provider turn start failed");
     expect(
       thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
     ).toMatchObject({
@@ -1136,6 +1140,27 @@ describe("ProviderCommandReactor", () => {
         detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
       },
     });
+
+    // Verify recovery: a subsequent turn with the correct provider succeeds.
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-provider-switch-recovery"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-provider-switch-recovery"),
+          role: "user",
+          text: "recover",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    expect(harness.sendTurn.mock.calls.length).toBe(2);
   });
 
   it("does not stop the active session when restart fails before rebind", async () => {
@@ -1569,5 +1594,191 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.status).toBe("stopped");
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.activeTurnId).toBeNull();
+  });
+
+  it("sets session to error when sendTurn fails with an existing session", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-err-session-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-err-session-1"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    harness.sendTurn.mockImplementationOnce(
+      () =>
+        Effect.fail(
+          new ProviderAdapterRequestError({
+            provider: "codex",
+            method: "sendTurn",
+            detail: "simulated failure",
+          }),
+        ) as never,
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-err-session-2"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-err-session-2"),
+          role: "user",
+          text: "second",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      return thread?.session?.status === "error";
+    });
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session?.status).toBe("error");
+    expect(thread?.session?.lastError).toContain("Provider turn start failed");
+    expect(thread?.session?.activeTurnId).toBeNull();
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toBeDefined();
+  });
+
+  it("sets session to stopped with lastError when turn start fails without a prior session", async () => {
+    const harness = await createHarness({
+      threadModelSelection: { provider: "codex", model: "gpt-5-codex" },
+    });
+    const now = new Date().toISOString();
+
+    // Request a provider that conflicts with the thread — fails before
+    // a session is ever created.
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-no-session"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-no-session"),
+          role: "user",
+          text: "hello",
+          attachments: [],
+        },
+        modelSelection: {
+          provider: "claudeAgent",
+          model: "claude-opus-4-6",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      // "stopped" — not "error" — because no real provider binding exists.
+      return thread?.session?.status === "stopped";
+    });
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    expect(thread?.session).not.toBeNull();
+    expect(thread?.session?.status).toBe("stopped");
+    expect(thread?.session?.lastError).toContain("Provider turn start failed");
+    expect(
+      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toBeDefined();
+  });
+
+  it("uses stopped status when turn fails after a previously stopped session", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    // Establish and then stop a session.
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-stopped-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-stopped-1"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.session.stop",
+        commandId: CommandId.make("cmd-session-stop-for-rebind"),
+        threadId: ThreadId.make("thread-1"),
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.stopSession.mock.calls.length === 1);
+
+    // Make the next startSession fail so ensureSessionForThread fails
+    // before a new binding is created.
+    harness.startSession.mockImplementationOnce(
+      (_: unknown, __: unknown) => Effect.fail(new Error("simulated start failure")) as never,
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-stopped-2"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-stopped-2"),
+          role: "user",
+          text: "second",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(async () => {
+      const readModel = await Effect.runPromise(harness.engine.getReadModel());
+      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+      return (
+        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
+        false
+      );
+    });
+
+    const readModel = await Effect.runPromise(harness.engine.getReadModel());
+    const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
+    // Must be "stopped" — not "error" — because the previous session was
+    // already stopped and no new binding was created before the failure.
+    expect(thread?.session?.status).toBe("stopped");
+    expect(thread?.session?.lastError).toContain("Provider turn start failed");
   });
 });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -576,13 +576,49 @@ const make = Effect.gen(function* () {
       createdAt: event.payload.createdAt,
     }).pipe(
       Effect.catchCause((cause) =>
-        appendProviderFailureActivity({
-          threadId: event.payload.threadId,
-          kind: "provider.turn.start.failed",
-          summary: "Provider turn start failed",
-          detail: Cause.pretty(cause),
-          turnId: null,
-          createdAt: event.payload.createdAt,
+        Effect.gen(function* () {
+          const errorDetail = Cause.pretty(cause);
+          yield* appendProviderFailureActivity({
+            threadId: event.payload.threadId,
+            kind: "provider.turn.start.failed",
+            summary: "Provider turn start failed",
+            detail: errorDetail,
+            turnId: null,
+            createdAt: event.payload.createdAt,
+          });
+          // Transition the thread session so the client can detect the
+          // failure.  Without this update isSendBusy stays true and the
+          // "Working for …" indicator hangs indefinitely.
+          //
+          // When a real provider binding exists, mark the session as
+          // "error" so the binding is preserved for potential recovery.
+          // When no session was bound yet (e.g. provider mismatch before
+          // session start), use "stopped" to avoid creating a synthetic
+          // session that looks bound without a backing ProviderService
+          // directory entry — ensureSessionForThread checks
+          // `status !== "stopped"` to decide whether to reuse a session.
+          const currentThread = yield* resolveThread(event.payload.threadId);
+          // A session record with status "stopped" has no backing
+          // ProviderService binding — treat it the same as no session.
+          // This mirrors the guard in ensureSessionForThread (line ~293).
+          const hasActiveSession =
+            currentThread?.session != null && currentThread.session.status !== "stopped";
+          const baseSession = currentThread?.session ?? {
+            threadId: event.payload.threadId,
+            providerName: thread.modelSelection.provider,
+            runtimeMode: thread.runtimeMode,
+          };
+          yield* setThreadSession({
+            threadId: event.payload.threadId,
+            session: {
+              ...baseSession,
+              status: hasActiveSession ? "error" : "stopped",
+              activeTurnId: null,
+              lastError: `Provider turn start failed: ${errorDetail}`,
+              updatedAt: event.payload.createdAt,
+            },
+            createdAt: event.payload.createdAt,
+          });
         }),
       ),
     );


### PR DESCRIPTION
## What Changed

When `sendTurnForThread` fails inside `ProviderCommandReactor`, the `catchCause` handler now also calls `setThreadSession` to transition the session into a terminal state, in addition to the existing failure activity.

- If an active provider binding exists: sets `status: "error"` (preserves binding for recovery).
- If no binding exists (e.g. provider mismatch before session start, or a previously stopped session): sets `status: "stopped"` to avoid creating a synthetic session without a backing `ProviderService` directory entry.

Both paths set `lastError` so the client can detect the failure.

Single-file production change in `ProviderCommandReactor.ts`. Four regression tests added covering existing-session, null-session, stopped-session failure paths, and recovery after a provider-switch error.

## Why

After the client dispatches `thread.turn.start`, the HTTP call succeeds so `turnStartSucceeded = true`. The client then waits for a server-side signal via `hasServerAcknowledgedLocalDispatch`, which checks for `phase === "running"`, `threadError`, or a session snapshot change.

When `sendTurn` fails server-side, the existing handler only appended a failure activity — it never updated the session. If the session was already bound and unchanged, none of the acknowledgment conditions were met: `phase` stayed `"ready"`, `threadError` was `null`, and the session snapshot was identical. This left `isSendBusy` permanently stuck, the send button disabled, and "Working for …" hanging until `Cmd+R`.

Previous attempts to fix this (#1348, #1393, #1542) added client-side workarounds. This change addresses the root cause on the server by ensuring the session always transitions to a detectable state on failure.

## Validation

- `bun fmt` — clean
- `bun lint` — clean
- 26/26 `ProviderCommandReactor` tests pass (4 new)
- Full orchestration + provider suite: 300/300 pass

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling in `ProviderCommandReactor` to mutate persisted session state on turn-start failures, which can affect client behavior and session reuse/recovery paths. Covered by new regression tests across existing-session and no-session scenarios, reducing risk but still touching orchestration state transitions.
> 
> **Overview**
> Ensures `thread.turn-start-requested` failures no longer only append a `provider.turn.start.failed` activity: the reactor now also calls `setThreadSession` to move the thread session into a detectable terminal state and populate `lastError`.
> 
> On failure, sessions with an existing non-`stopped` binding are marked `status: "error"` (preserving binding for recovery), while cases with no real binding (including previously `stopped` sessions) are marked `status: "stopped"` to avoid creating a synthetic bound session. Tests are updated/added to assert these statuses, `lastError`, and that a subsequent correct-provider turn can recover after a provider-switch failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee8e69d5a44182080d10521de1f5de73a9b9449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set thread session to error state when `sendTurn` fails in `ProviderCommandReactor`
> - When a `thread.turn.start` fails, the reactor now updates the thread session: if an active session existed it transitions to `status: 'error'`, otherwise it creates/updates a session with `status: 'stopped'`.
> - In both cases, `activeTurnId` is cleared and `lastError` is set to `'Provider turn start failed: …'`, alongside the existing `provider.turn.start.failed` activity.
> - New and updated tests in [`ProviderCommandReactor.test.ts`](https://github.com/pingdotgg/t3code/pull/1960/files#diff-24590cda9b5d40bcb845f474304592ddf62ae6d252d40be60e19435aa75347c4) cover the error, stopped, and recovery scenarios.
> - Behavioral Change: previously a failed turn start left the session in an ambiguous state; it now always reflects the failure explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aee8e69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->