### PR TITLE
fix(server): distinguish missing cwd from missing binary in codex version check

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -470,6 +470,35 @@ describe("startSession", () => {
       manager.stopAll();
     }
   });
+
+  it("reports missing working directory instead of missing binary when cwd does not exist", async () => {
+    const manager = new CodexAppServerManager();
+    const events: Array<{ method: string; kind: string; message?: string }> = [];
+    manager.on("event", (event) => {
+      events.push({
+        method: event.method,
+        kind: event.kind,
+        ...(event.message ? { message: event.message } : {}),
+      });
+    });
+
+    const missingCwd = path.join(os.tmpdir(), `t3code-nonexistent-${randomUUID()}`);
+    try {
+      await expect(
+        manager.startSession({
+          threadId: asThreadId("thread-cwd-missing"),
+          provider: "codex",
+          binaryPath: "codex",
+          cwd: missingCwd,
+          runtimeMode: "full-access",
+        }),
+      ).rejects.toThrow(/Working directory.*does not exist/);
+      expect(events).toHaveLength(1);
+      expect(events[0]?.method).toBe("session/startFailed");
+    } finally {
+      manager.stopAll();
+    }
+  });
 });
 
 describe("sendTurn", () => {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -1,6 +1,7 @@
 import { type ChildProcessWithoutNullStreams, spawn, spawnSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
 import readline from "node:readline";
 
 import {
@@ -1553,6 +1554,14 @@ function assertSupportedCodexCliVersion(input: {
       lower.includes("command not found") ||
       lower.includes("not found")
     ) {
+      // Disambiguate: ENOENT can mean the binary is missing OR the cwd
+      // does not exist.  Check the cwd in the error path so we surface
+      // the right message without a racy preflight.
+      try {
+        fs.accessSync(input.cwd);
+      } catch {
+        throw new Error(`Working directory '${input.cwd}' does not exist or is not accessible.`);
+      }
       throw new Error(`Codex CLI (${input.binaryPath}) is not installed or not executable.`);
     }
     throw new Error(


### PR DESCRIPTION
  ## What Changed

  `assertSupportedCodexCliVersion` now disambiguates ENOENT errors before blaming the binary. When `spawnSync`
  fails with an ENOENT-class error, the handler checks whether the working directory is accessible. If the cwd is
   the problem, the error message reports `"Working directory '…' does not exist or is not accessible"` instead
  of `"Codex CLI (codex) is not installed or not executable"`.

  The check runs only in the error path (not as a preflight), so there is no TOCTOU race.

  Single-file production change in `codexAppServerManager.ts`. One regression test added.

  ## Why

  `assertSupportedCodexCliVersion` passes the project directory as `cwd` to `spawnSync`. When that directory has
  been deleted or moved, Node emits ENOENT. The existing error handler treats any ENOENT as a missing binary,
  producing the misleading message `"Codex CLI (codex) is not installed or not executable"` — even when the CLI
  is installed and on PATH.

  This is confusing for users who see a "not installed" banner after simply moving a project folder.

  Fixes #975, fixes #1932

  ## Before / After

Before:
<img width="840" height="338" alt="Screenshot 2026-04-12 at 18 15 13" src="https://github.com/user-attachments/assets/249b87d4-46eb-4c93-b662-81fe92a39130" />

After:
<img width="942" height="343" alt="Screenshot 2026-04-12 at 18 12 44" src="https://github.com/user-attachments/assets/d3518abf-f49a-493b-9a2f-d87c724231f6" />


  ## Validation

  - `bun fmt` — clean
  - `bun lint` — clean
  - 38/38 `codexAppServerManager` tests pass (1 new)

  ## Checklist

  - [x] This PR is small and focused
  - [x] I explained what changed and why
  - [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to the Codex CLI version-check error path and adds a single regression test; main behavior only differs when `spawnSync` fails with ENOENT-like errors.
> 
> **Overview**
> Improves `assertSupportedCodexCliVersion` to **disambiguate ENOENT-style failures** by checking `cwd` accessibility before reporting a missing/unexecutable Codex CLI binary, surfacing a clearer “working directory does not exist or is not accessible” error when appropriate.
> 
> Adds a regression test in `codexAppServerManager.test.ts` to ensure `startSession` emits `session/startFailed` and throws the new cwd-specific error when the provided `cwd` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d0d25b0c9f0414e3e704e5676a72fc1bf465019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `assertSupportedCodexCliVersion` to distinguish missing working directory from missing binary
> When the Codex CLI version check fails with an ENOENT-like error, it was not clear whether the binary or the working directory was missing. Now, [codexAppServerManager.ts](https://github.com/pingdotgg/t3code/pull/1961/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9) checks `cwd` accessibility via `fs.accessSync` before concluding the binary is absent, throwing a specific `'Working directory ... does not exist or is not accessible.'` error when the directory is the problem. A corresponding test case is added in [codexAppServerManager.test.ts](https://github.com/pingdotgg/t3code/pull/1961/files#diff-e0b57ec17b32e60d14081ebeb4bcfb13db511905869ef4ffbd669b229c0bb2c1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d0d25b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->