### PR TITLE
fix(git): hide stale merged/closed PRs on the default branch

### DIFF
--- a/apps/server/src/git/Layers/GitManager.test.ts
+++ b/apps/server/src/git/Layers/GitManager.test.ts
@@ -1188,6 +1188,36 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("status hides merged PRs on the default branch", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+
+      const { manager } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            JSON.stringify([
+              {
+                number: 23,
+                title: "Merged PR",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/23",
+                baseRefName: "feature/status-default-branch-target",
+                headRefName: "main",
+                state: "MERGED",
+                mergedAt: "2026-01-30T10:00:00Z",
+                updatedAt: "2026-01-30T10:00:00Z",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const status = yield* manager.status({ cwd: repoDir });
+      expect(status.branch).toBe("main");
+      expect(status.pr).toBeNull();
+    }),
+  );
+
   it.effect("status prefers open PR when merged PR has newer updatedAt", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/Layers/GitManager.ts
+++ b/apps/server/src/git/Layers/GitManager.ts
@@ -687,7 +687,13 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
             branch: details.branch,
             upstreamRef: details.upstreamRef,
           }).pipe(
-            Effect.map((latest) => (latest ? toStatusPr(latest) : null)),
+            Effect.map((latest) => {
+              if (!latest) return null;
+              // On the default branch, only surface open PRs.
+              // Merged/closed matches are usually reverse-merge history, not the thread's PR context.
+              if (details.isDefaultBranch && latest.state !== "open") return null;
+              return toStatusPr(latest);
+            }),
             Effect.catch(() => Effect.succeed(null)),
           )
         : null;


### PR DESCRIPTION
## What Changed

Added a filter so that merged and closed PRs are not surfaced when the current branch is the default branch (main/master). Open PRs on the default branch are still shown normally.

## Why

When a PR was created with `main` as the head branch (e.g. a reverse merge from main into a feature branch), that merged PR would keep showing up in the sidebar status every time you were on `main`. This happened because `findLatestPr` falls back to the most recently updated PR regardless of state when no open PR exists.

On a feature branch this fallback makes sense since seeing "PR merged" is useful feedback. On the default branch it's just noise from old reverse merges that aren't relevant to the current context.

The fix checks `isDefaultBranch` (already available from `statusDetails`) and skips non-open PRs when it's true, keeping the feature branch behavior unchanged.

I ran into this while working on `main` for a smaller project that had an old reverse-merge PR. The merged PR kept showing up in the sidebar even though it wasn't relevant anymore.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small conditional change to `GitManager` status PR selection plus a focused test, affecting only whether PR metadata is shown while on the default branch.
> 
> **Overview**
> Updates `GitManager` remote `status` to **suppress merged/closed PR matches when the current branch is the default branch**, returning `pr: null` unless the latest match is still `open`.
> 
> Adds a regression test ensuring a merged PR with `headRefName: main` does not appear in status while on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda0993ef951e7d1cfd9cb78521e0535b55fa663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide stale merged/closed PRs from `manager.status` when on the default branch
> When `isDefaultBranch` is true, `manager.status` now returns `null` for `status.pr` if the latest PR is not in the `open` state. Previously, merged or closed PRs would still appear in status regardless of branch context. Behavioral Change: callers on the default branch that previously received a merged/closed PR in `status.pr` will now receive `null`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dda0993.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->