### PR TITLE
Copy project path from header badge

### DIFF
--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -9,12 +9,14 @@ import { scopeThreadRef } from "@t3tools/client-runtime";
 import { memo } from "react";
 import GitActionsControl from "../GitActionsControl";
 import { type DraftId } from "~/composerDraftStore";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { DiffIcon, TerminalSquareIcon } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
 import { Toggle } from "../ui/toggle";
 import { SidebarTrigger } from "../ui/sidebar";
+import { toastManager } from "../ui/toast";
 import { OpenInPicker } from "./OpenInPicker";
 
 interface ChatHeaderProps {
@@ -68,6 +70,24 @@ export const ChatHeader = memo(function ChatHeader({
   onToggleTerminal,
   onToggleDiff,
 }: ChatHeaderProps) {
+  const { copyToClipboard: copyPathToClipboard, isCopied: isProjectPathCopied } =
+    useCopyToClipboard<{ path: string }>({
+      onCopy: (ctx) => {
+        toastManager.add({
+          type: "success",
+          title: "Folder path copied",
+          description: ctx.path,
+        });
+      },
+      onError: (error) => {
+        toastManager.add({
+          type: "error",
+          title: "Failed to copy folder path",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        });
+      },
+    });
+
   return (
     <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
@@ -79,9 +99,40 @@ export const ChatHeader = memo(function ChatHeader({
           {activeThreadTitle}
         </h2>
         {activeProjectName && (
-          <Badge variant="outline" className="min-w-0 shrink overflow-hidden">
-            <span className="min-w-0 truncate">{activeProjectName}</span>
-          </Badge>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Badge
+                  variant="outline"
+                  className="min-w-0 shrink overflow-hidden"
+                  render={
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!openInCwd) return;
+                        copyPathToClipboard(openInCwd, { path: openInCwd });
+                      }}
+                      disabled={!openInCwd}
+                      aria-label={
+                        openInCwd
+                          ? `Copy project path for ${activeProjectName}`
+                          : `Project path unavailable for ${activeProjectName}`
+                      }
+                    />
+                  }
+                >
+                  <span className="min-w-0 truncate">{activeProjectName}</span>
+                </Badge>
+              }
+            />
+            <TooltipPopup side="bottom">
+              {!openInCwd
+                ? "Folder path unavailable"
+                : isProjectPathCopied
+                  ? "Folder path copied"
+                  : "Copy folder path"}
+            </TooltipPopup>
+          </Tooltip>
         )}
         {activeProjectName && !isGitRepo && (
           <Badge variant="outline" className="shrink-0 text-[10px] text-amber-700">


### PR DESCRIPTION
## Summary
- make the project name badge in the chat header copy the active folder path to the clipboard
- show the existing bottom toast notification with the copied path
- keep the existing open-in picker behavior unchanged

## Validation
- bun fmt
- bun lint
- bun typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds clipboard copying and toast feedback; main risk is minor UX/accessibility regressions if `openInCwd` is null or clipboard API is unavailable.
> 
> **Overview**
> Makes the chat header’s project name badge interactive: clicking it now copies `openInCwd` to the clipboard.
> 
> Adds tooltip state (copy/coped/unavailable) and triggers success/error toasts via `toastManager` using the shared `useCopyToClipboard` hook, while leaving the existing `OpenInPicker` control unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ee7c869fa198e9f2cd753c355e238a58ad35ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Copy project folder path to clipboard from chat header badge
> Makes the project name badge in [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/1967/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c) clickable, copying the project folder path (`openInCwd`) to the clipboard. A tooltip reflects the current state: unavailable, copied, or ready to copy. Success and error toasts are shown via `toastManager` on copy attempts. The button is disabled when no folder path is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9ee7c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->