### PR TITLE
window controls overlay (windows&linux)

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -7,6 +7,7 @@ import * as Path from "node:path";
 import {
   app,
   BrowserWindow,
+  type BrowserWindowConstructorOptions,
   clipboard,
   dialog,
   ipcMain,
@@ -118,6 +119,15 @@ const DESKTOP_UPDATE_CHANNEL = "latest";
 const DESKTOP_UPDATE_ALLOW_PRERELEASE = false;
 const DESKTOP_LOOPBACK_HOST = "127.0.0.1";
 const DESKTOP_REQUIRED_PORT_PROBE_HOSTS = ["0.0.0.0", "::"] as const;
+const TITLEBAR_HEIGHT = 40;
+const TITLEBAR_COLOR = "#01000000"; // #00000000 does not work correctly on Linux
+const TITLEBAR_LIGHT_SYMBOL_COLOR = "#1f2937";
+const TITLEBAR_DARK_SYMBOL_COLOR = "#f8fafc";
+
+type WindowTitleBarOptions = Pick<
+  BrowserWindowConstructorOptions,
+  "titleBarOverlay" | "titleBarStyle" | "trafficLightPosition"
+>;
 
 type DesktopUpdateErrorContext = DesktopUpdateState["errorContext"];
 type LinuxDesktopNamedApp = Electron.App & {
@@ -1649,6 +1659,46 @@ function getInitialWindowBackgroundColor(): string {
   return nativeTheme.shouldUseDarkColors ? "#0a0a0a" : "#ffffff";
 }
 
+function getWindowTitleBarOptions(): WindowTitleBarOptions {
+  if (process.platform === "darwin") {
+    return {
+      titleBarStyle: "hiddenInset",
+      trafficLightPosition: { x: 16, y: 18 },
+    };
+  }
+
+  return {
+    titleBarStyle: "hidden",
+    titleBarOverlay: {
+      color: TITLEBAR_COLOR,
+      height: TITLEBAR_HEIGHT,
+      symbolColor: nativeTheme.shouldUseDarkColors
+        ? TITLEBAR_DARK_SYMBOL_COLOR
+        : TITLEBAR_LIGHT_SYMBOL_COLOR,
+    },
+  };
+}
+
+function syncWindowAppearance(window: BrowserWindow): void {
+  if (window.isDestroyed()) {
+    return;
+  }
+
+  window.setBackgroundColor(getInitialWindowBackgroundColor());
+  const { titleBarOverlay } = getWindowTitleBarOptions();
+  if (typeof titleBarOverlay === "object") {
+    window.setTitleBarOverlay(titleBarOverlay);
+  }
+}
+
+function syncAllWindowAppearance(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    syncWindowAppearance(window);
+  }
+}
+
+nativeTheme.on("updated", syncAllWindowAppearance);
+
 function createWindow(): BrowserWindow {
   const window = new BrowserWindow({
     width: 1100,
@@ -1660,8 +1710,7 @@ function createWindow(): BrowserWindow {
     backgroundColor: getInitialWindowBackgroundColor(),
     ...getIconOption(),
     title: APP_DISPLAY_NAME,
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: { x: 16, y: 18 },
+    ...getWindowTitleBarOptions(),
     webPreferences: {
       preload: Path.join(__dirname, "preload.js"),
       contextIsolation: true,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3295,7 +3295,7 @@ export default function ChatView(props: ChatViewProps) {
         className={cn(
           "border-b border-border px-3 sm:px-5",
           isElectron
-            ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+2em)]"
+            ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]"
             : "py-2 sm:py-3",
         )}
       >

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3295,7 +3295,7 @@ export default function ChatView(props: ChatViewProps) {
         className={cn(
           "border-b border-border px-3 sm:px-5",
           isElectron
-            ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+3em)]"
+            ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+2em)]"
             : "py-2 sm:py-3",
         )}
       >

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3295,7 +3295,7 @@ export default function ChatView(props: ChatViewProps) {
         className={cn(
           "border-b border-border px-3 sm:px-5",
           isElectron
-            ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+3em)]"
+            ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+3em)]"
             : "py-2 sm:py-3",
         )}
       >

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3294,7 +3294,9 @@ export default function ChatView(props: ChatViewProps) {
       <header
         className={cn(
           "border-b border-border px-3 sm:px-5",
-          isElectron ? "drag-region flex h-[52px] items-center" : "py-2 sm:py-3",
+          isElectron
+            ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+3em)]"
+            : "py-2 sm:py-3",
         )}
       >
         <ChatHeader

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -313,6 +313,7 @@ type ChatViewProps =
       environmentId: EnvironmentId;
       threadId: ThreadId;
       onDiffPanelOpen?: () => void;
+      reserveTitleBarControlInset?: boolean;
       routeKind: "server";
       draftId?: never;
     }
@@ -320,6 +321,7 @@ type ChatViewProps =
       environmentId: EnvironmentId;
       threadId: ThreadId;
       onDiffPanelOpen?: () => void;
+      reserveTitleBarControlInset?: boolean;
       routeKind: "draft";
       draftId: DraftId;
     };
@@ -573,7 +575,13 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
 });
 
 export default function ChatView(props: ChatViewProps) {
-  const { environmentId, threadId, routeKind, onDiffPanelOpen } = props;
+  const {
+    environmentId,
+    threadId,
+    routeKind,
+    onDiffPanelOpen,
+    reserveTitleBarControlInset = true,
+  } = props;
   const draftId = routeKind === "draft" ? props.draftId : null;
   const routeThreadRef = useMemo(
     () => scopeThreadRef(environmentId, threadId),
@@ -3295,7 +3303,11 @@ export default function ChatView(props: ChatViewProps) {
         className={cn(
           "border-b border-border px-3 sm:px-5",
           isElectron
-            ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]"
+            ? cn(
+                "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)]",
+                reserveTitleBarControlInset &&
+                  "wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]",
+              )
             : "py-2 sm:py-3",
         )}
       >

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -12,7 +12,7 @@ function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
   return cn(
     "flex items-center justify-between gap-2 px-4",
     shouldUseDragRegion
-      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+4em)]"
+      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+4em)]"
       : "h-12",
   );
 }

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -11,7 +11,9 @@ function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
   const shouldUseDragRegion = isElectron && mode !== "sheet";
   return cn(
     "flex items-center justify-between gap-2 px-4",
-    shouldUseDragRegion ? "drag-region h-[52px] border-b border-border" : "h-12",
+    shouldUseDragRegion
+      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+4em)]"
+      : "h-12",
   );
 }
 

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -13,7 +13,7 @@ function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
     "flex items-center justify-between gap-2 px-4 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]",
     shouldUseDragRegion
       ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)]"
-      : "h-12",
+      : "h-12 wco:max-h-[env(titlebar-area-height)]",
   );
 }
 

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -12,7 +12,7 @@ function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
   return cn(
     "flex items-center justify-between gap-2 px-4",
     shouldUseDragRegion
-      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+4em)]"
+      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+4em)]"
       : "h-12",
   );
 }

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -10,9 +10,9 @@ export type DiffPanelMode = "inline" | "sheet" | "sidebar";
 function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
   const shouldUseDragRegion = isElectron && mode !== "sheet";
   return cn(
-    "flex items-center justify-between gap-2 px-4",
+    "flex items-center justify-between gap-2 px-4 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]",
     shouldUseDragRegion
-      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]"
+      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)]"
       : "h-12",
   );
 }

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -12,7 +12,7 @@ function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
   return cn(
     "flex items-center justify-between gap-2 px-4",
     shouldUseDragRegion
-      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+2em)]"
+      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]"
       : "h-12",
   );
 }

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -12,7 +12,7 @@ function getDiffPanelHeaderRowClassName(mode: DiffPanelMode) {
   return cn(
     "flex items-center justify-between gap-2 px-4",
     shouldUseDragRegion
-      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+4em)]"
+      ? "drag-region h-[52px] border-b border-border wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+2em)]"
       : "h-12",
   );
 }

--- a/apps/web/src/components/NoActiveThreadState.tsx
+++ b/apps/web/src/components/NoActiveThreadState.tsx
@@ -16,7 +16,7 @@ export function NoActiveThreadState() {
           )}
         >
           {isElectron ? (
-            <span className="text-xs text-muted-foreground/50 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+2em)]">
+            <span className="text-xs text-muted-foreground/50 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]">
               No active thread
             </span>
           ) : (

--- a/apps/web/src/components/NoActiveThreadState.tsx
+++ b/apps/web/src/components/NoActiveThreadState.tsx
@@ -10,11 +10,15 @@ export function NoActiveThreadState() {
         <header
           className={cn(
             "border-b border-border px-3 sm:px-5",
-            isElectron ? "drag-region flex h-[52px] items-center" : "py-2 sm:py-3",
+            isElectron
+              ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:px-0"
+              : "py-2 sm:py-3",
           )}
         >
           {isElectron ? (
-            <span className="text-xs text-muted-foreground/50">No active thread</span>
+            <span className="text-xs text-muted-foreground/50 wco:pl-[env(titlebar-area-x)]">
+              No active thread
+            </span>
           ) : (
             <div className="flex items-center gap-2">
               <SidebarTrigger className="size-7 shrink-0 md:hidden" />

--- a/apps/web/src/components/NoActiveThreadState.tsx
+++ b/apps/web/src/components/NoActiveThreadState.tsx
@@ -16,7 +16,7 @@ export function NoActiveThreadState() {
           )}
         >
           {isElectron ? (
-            <span className="text-xs text-muted-foreground/50 wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x))]">
+            <span className="text-xs text-muted-foreground/50 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x))]">
               No active thread
             </span>
           ) : (

--- a/apps/web/src/components/NoActiveThreadState.tsx
+++ b/apps/web/src/components/NoActiveThreadState.tsx
@@ -11,12 +11,12 @@ export function NoActiveThreadState() {
           className={cn(
             "border-b border-border px-3 sm:px-5",
             isElectron
-              ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)] wco:px-0"
+              ? "drag-region flex h-[52px] items-center wco:h-[env(titlebar-area-height)]"
               : "py-2 sm:py-3",
           )}
         >
           {isElectron ? (
-            <span className="text-xs text-muted-foreground/50 wco:pl-[env(titlebar-area-x)]">
+            <span className="text-xs text-muted-foreground/50 wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x))]">
               No active thread
             </span>
           ) : (

--- a/apps/web/src/components/NoActiveThreadState.tsx
+++ b/apps/web/src/components/NoActiveThreadState.tsx
@@ -16,7 +16,7 @@ export function NoActiveThreadState() {
           )}
         >
           {isElectron ? (
-            <span className="text-xs text-muted-foreground/50 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x))]">
+            <span className="text-xs text-muted-foreground/50 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+2em)]">
               No active thread
             </span>
           ) : (

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -105,7 +105,6 @@ import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Menu, MenuGroup, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
-import { cn } from "~/lib/utils";
 import {
   SidebarContent,
   SidebarFooter,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -105,6 +105,7 @@ import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Menu, MenuGroup, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+import { cn } from "~/lib/utils";
 import {
   SidebarContent,
   SidebarFooter,
@@ -1974,7 +1975,7 @@ const SidebarChromeHeader = memo(function SidebarChromeHeader({
   );
 
   return isElectron ? (
-    <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px]">
+    <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px] wco:h-[env(titlebar-area-height)] wco:pl-[calc(env(titlebar-area-x)+1em)]">
       {wordmark}
     </SidebarHeader>
   ) : (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @custom-variant dark (&:is(.dark, .dark *));
+@custom-variant wco (&:where(.wco *));
 
 @theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @custom-variant dark (&:is(.dark, .dark *));
+/* Window Controls Overlay: active when Electron exposes native titlebar control geometry. */
 @custom-variant wco (&:is(.wco, .wco *));
 
 @theme inline {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 @custom-variant dark (&:is(.dark, .dark *));
-@custom-variant wco (&:where(.wco *));
+@custom-variant wco (&:is(.wco, .wco *));
 
 @theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;

--- a/apps/web/src/lib/windowControlsOverlay.ts
+++ b/apps/web/src/lib/windowControlsOverlay.ts
@@ -1,0 +1,40 @@
+const WCO_CLASS_NAME = "wco";
+
+interface WindowControlsOverlayLike {
+  readonly visible: boolean;
+  addEventListener(type: "geometrychange", listener: EventListener): void;
+  removeEventListener(type: "geometrychange", listener: EventListener): void;
+}
+
+interface NavigatorWithWindowControlsOverlay extends Navigator {
+  readonly windowControlsOverlay?: WindowControlsOverlayLike;
+}
+
+function getWindowControlsOverlay(): WindowControlsOverlayLike | null {
+  if (typeof navigator === "undefined") {
+    return null;
+  }
+
+  return (navigator as NavigatorWithWindowControlsOverlay).windowControlsOverlay ?? null;
+}
+
+export function syncDocumentWindowControlsOverlayClass(): () => void {
+  if (typeof document === "undefined") {
+    return () => {};
+  }
+
+  const overlay = getWindowControlsOverlay();
+  const update = () => {
+    document.documentElement.classList.toggle(WCO_CLASS_NAME, overlay !== null && overlay.visible);
+  };
+
+  update();
+  if (!overlay) {
+    return () => {};
+  }
+
+  overlay.addEventListener("geometrychange", update);
+  return () => {
+    overlay.removeEventListener("geometrychange", update);
+  };
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -9,11 +9,16 @@ import "./index.css";
 import { isElectron } from "./env";
 import { getRouter } from "./router";
 import { APP_DISPLAY_NAME } from "./branding";
+import { syncDocumentWindowControlsOverlayClass } from "./lib/windowControlsOverlay";
 
 // Electron loads the app from a file-backed shell, so hash history avoids path resolution issues.
 const history = isElectron ? createHashHistory() : createBrowserHistory();
 
 const router = getRouter(history);
+
+if (isElectron) {
+  syncDocumentWindowControlsOverlayClass();
+}
 
 document.title = APP_DISPLAY_NAME;
 

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -269,6 +269,7 @@ function ChatThreadRouteView() {
             environmentId={threadRef.environmentId}
             threadId={threadRef.threadId}
             onDiffPanelOpen={markDiffOpened}
+            reserveTitleBarControlInset={!diffOpen}
             routeKind="server"
           />
         </SidebarInset>

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -56,7 +56,7 @@ function SettingsContentLayout() {
         )}
 
         {isElectron && (
-          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5 wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+5em)]">
+          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5 wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+2em)]">
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
             </span>

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -56,7 +56,7 @@ function SettingsContentLayout() {
         )}
 
         {isElectron && (
-          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5 wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+2em)]">
+          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5 wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]">
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
             </span>

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -56,7 +56,7 @@ function SettingsContentLayout() {
         )}
 
         {isElectron && (
-          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5 wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+5em)]">
+          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5 wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+5em)]">
             <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
             </span>

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -57,7 +57,7 @@ function SettingsContentLayout() {
 
         {isElectron && (
           <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5 wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+5em)]">
-            <span className="text-xs font-medium tracking-wide text-muted-foreground/70 wco:pl-[env(titlebar-area-x)]">
+            <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
               Settings
             </span>
             <div className="ms-auto flex items-center gap-2">

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -56,8 +56,8 @@ function SettingsContentLayout() {
         )}
 
         {isElectron && (
-          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5">
-            <span className="text-xs font-medium tracking-wide text-muted-foreground/70">
+          <div className="drag-region flex h-[52px] shrink-0 items-center border-b border-border px-5 wco:h-[env(titlebar-area-height)] wco:pr-[calc(env(titlebar-area-width)-env(titlebar-area-x)+5em)]">
+            <span className="text-xs font-medium tracking-wide text-muted-foreground/70 wco:pl-[env(titlebar-area-x)]">
               Settings
             </span>
             <div className="ms-auto flex items-center gap-2">


### PR DESCRIPTION
## What Changed

Added support for window controls overlay on Windows and Linux. It makes titlebar controls render inside app area. Layout was changed to account this and move buttons/logo so they don't intersect with controls.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->
Because it makes app look better and makes it use less vertical space.

## UI Changes

### Before (Linux):
<img width="1144" height="852" alt="image" src="https://github.com/user-attachments/assets/7c523703-2e4d-488d-b13d-1e766eaaac9a" />

### After (Linux):
<img width="850" height="608" alt="Знімок екрана 2026-04-13 о 00 16 41" src="https://github.com/user-attachments/assets/a526db6c-b597-4c1e-8a5f-a0683062d68e" />

### After (Linux, [custom electron build](https://github.com/electron/electron/pull/50978)):
<img width="838" height="594" alt="Знімок екрана 2026-04-13 о 00 12 23" src="https://github.com/user-attachments/assets/85b47d76-3754-4b42-a1c8-eaa3b9608991" />

### Before (Windows):
<img width="1138" height="822" alt="image" src="https://github.com/user-attachments/assets/4d948518-7a9e-4ae3-a208-696111ff4b01" />

### After (Windows):
<img width="677" height="456" alt="Знімок екрана 2026-04-13 о 00 13 22" src="https://github.com/user-attachments/assets/60d0b3a1-9d75-4bdc-b6c5-3c3b7d4d5eca" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Electron window chrome and multiple header layouts to integrate Window Controls Overlay; regressions are possible in cross-platform window sizing/drag regions and theme-driven titlebar rendering.
> 
> **Overview**
> Adds **Window Controls Overlay** support for the Electron desktop app on Windows/Linux by switching non-macOS windows to `titleBarStyle: "hidden"` with a themed `titleBarOverlay`, and re-syncing overlay/background on `nativeTheme` changes.
> 
> Updates web UI headers (chat, sidebar, diff panel, settings, empty state) to apply `wco:`-scoped layout insets and dynamic titlebar height so content/buttons don’t overlap native window controls, including an optional `reserveTitleBarControlInset` behavior when the diff panel is open.
> 
> Introduces a `wco` Tailwind variant and a small runtime (`syncDocumentWindowControlsOverlayClass`) that toggles a `.wco` class based on `navigator.windowControlsOverlay` visibility in Electron.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1ef380d97338d74d516c0213f12941f3e817921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add window controls overlay support for Windows and Linux in Electron
> - Adds platform-specific title bar configuration in [`main.ts`](https://github.com/pingdotgg/t3code/pull/1969/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb): macOS keeps the existing `hiddenInset` style, while Windows/Linux use a `hidden` style with a native title bar overlay sized and colored to match the system theme.
> - Syncs overlay appearance and background color at runtime when `nativeTheme` changes, keeping all open windows consistent with the current light/dark mode.
> - Adds a [`windowControlsOverlay`](https://github.com/pingdotgg/t3code/pull/1969/files#diff-0b4bc2286c6db8c805258eaec400a41bb45075d438330415672e821a0c99d9bf) helper that toggles a `wco` CSS class on the document root based on overlay visibility, exposed as a Tailwind variant in [`index.css`](https://github.com/pingdotgg/t3code/pull/1969/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd).
> - Updates headers in `ChatView`, `DiffPanelShell`, `NoActiveThreadState`, `Sidebar`, and `Settings` to reserve space for native window controls when the overlay is active, adjusting height and padding via the `wco` variant.
> - The chat header stops reserving the right-side title bar inset when the diff panel is open.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1ef380.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->