### PR TITLE
Fix desktop inline diff panel layout and resize behavior

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -4741,4 +4741,53 @@ describe("ChatView timeline estimator parity (full app)", () => {
       await mounted.cleanup();
     }
   });
+
+  it("renders the desktop diff panel below the chat header instead of resizing it", async () => {
+    const mounted = await mountChatView({
+      viewport: WIDE_FOOTER_VIEWPORT,
+      initialPath: `/${LOCAL_ENVIRONMENT_ID}/${THREAD_ID}?diff=1`,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-diff-layout-target" as MessageId,
+        targetText: "diff layout thread",
+      }),
+    });
+
+    try {
+      const header = await waitForElement(
+        () => document.querySelector<HTMLElement>('[data-chat-header="true"]'),
+        "Unable to find chat header.",
+      );
+      const composerForm = await waitForElement(
+        () => document.querySelector<HTMLElement>('[data-chat-composer-form="true"]'),
+        "Unable to find chat composer form.",
+      );
+      const resizeHandle = await waitForElement(
+        () =>
+          document.querySelector<HTMLElement>('[data-chat-messages-aside-resize-handle="true"]'),
+        "Unable to find inline diff resize handle.",
+      );
+      const diffAside = await waitForElement(
+        () => document.querySelector<HTMLElement>('[data-chat-messages-aside="open"]'),
+        "Unable to find inline diff panel container.",
+      );
+
+      await vi.waitFor(
+        () => {
+          const headerRect = header.getBoundingClientRect();
+          const composerRect = composerForm.getBoundingClientRect();
+          const diffAsideRect = diffAside.getBoundingClientRect();
+
+          expect(headerRect.right).toBeGreaterThan(diffAsideRect.left + 1);
+          expect(composerRect.right).toBeLessThanOrEqual(diffAsideRect.left + 1);
+          expect(diffAsideRect.top).toBeGreaterThanOrEqual(headerRect.bottom - 1);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      await waitForLayout();
+      expect(getComputedStyle(resizeHandle).cursor).toBe("col-resize");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
 });

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -105,6 +105,7 @@ const WIDE_FOOTER_VIEWPORT: ViewportSpec = {
   textTolerancePx: 44,
   attachmentTolerancePx: 56,
 };
+const CHAT_DIFF_INLINE_WIDTH_STORAGE_KEY = "chat_diff_inline_width";
 const COMPACT_FOOTER_VIEWPORT: ViewportSpec = {
   name: "compact-footer",
   width: 430,
@@ -4786,6 +4787,75 @@ describe("ChatView timeline estimator parity (full app)", () => {
 
       await waitForLayout();
       expect(getComputedStyle(resizeHandle).cursor).toBe("col-resize");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("keeps the desktop inline diff panel collapsed after closing during resize sync", async () => {
+    const mounted = await mountChatView({
+      viewport: WIDE_FOOTER_VIEWPORT,
+      initialPath: `/${LOCAL_ENVIRONMENT_ID}/${THREAD_ID}?diff=1`,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-diff-collapse-target" as MessageId,
+        targetText: "diff collapse thread",
+      }),
+    });
+
+    try {
+      const toggleDiffButton = await waitForElement(
+        () => document.querySelector<HTMLButtonElement>('[aria-label="Toggle diff panel"]'),
+        "Unable to find diff toggle button.",
+      );
+
+      toggleDiffButton.click();
+      await waitForLayout();
+
+      const closedDiffAside = await waitForElement(
+        () => document.querySelector<HTMLElement>('[data-chat-messages-aside="closed"]'),
+        "Unable to find closed inline diff panel container.",
+      );
+
+      await mounted.setContainerSize({
+        width: 1_120,
+        height: WIDE_FOOTER_VIEWPORT.height,
+      });
+
+      await vi.waitFor(
+        () => {
+          expect(closedDiffAside.getBoundingClientRect().width).toBeLessThanOrEqual(1);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("restores the persisted desktop inline diff width on mount", async () => {
+    localStorage.setItem(CHAT_DIFF_INLINE_WIDTH_STORAGE_KEY, JSON.stringify(520));
+
+    const mounted = await mountChatView({
+      viewport: WIDE_FOOTER_VIEWPORT,
+      initialPath: `/${LOCAL_ENVIRONMENT_ID}/${THREAD_ID}?diff=1`,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-diff-persisted-width-target" as MessageId,
+        targetText: "diff persisted width thread",
+      }),
+    });
+
+    try {
+      const diffAside = await waitForElement(
+        () => document.querySelector<HTMLElement>('[data-chat-messages-aside="open"]'),
+        "Unable to find open inline diff panel container.",
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(diffAside.getBoundingClientRect().width).toBeCloseTo(520, 0);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -831,7 +831,6 @@ export default function ChatView(props: ChatViewProps) {
       observer.disconnect();
     };
   }, [hasMessagesAside, messagesAsideOpen]);
-  }, [hasMessagesAside, messagesAsideOpen]);
 
   const handleMessagesAsideResizePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -737,10 +737,13 @@ export default function ChatView(props: ChatViewProps) {
   );
   const legendListRef = useRef<LegendListRef | null>(null);
   const isAtEndRef = useRef(true);
-  const initialMessagesAsideWidthPx = useMemo(
-    () => getLocalStorageItem(CHAT_DIFF_INLINE_WIDTH_STORAGE_KEY, Schema.Finite),
-    [],
-  );
+  const initialMessagesAsideWidthPx = useMemo(() => {
+    try {
+      return getLocalStorageItem(CHAT_DIFF_INLINE_WIDTH_STORAGE_KEY, Schema.Finite);
+    } catch {
+      return null;
+    }
+  }, []);
   const splitContentRef = useRef<HTMLDivElement | null>(null);
   const messagesAsideContainerRef = useRef<HTMLDivElement | null>(null);
   const messagesAsideWidthRef = useRef<number | null>(initialMessagesAsideWidthPx);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -29,7 +29,18 @@ import { applyClaudePromptEffortPrefix } from "@t3tools/shared/model";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
 import { Debouncer } from "@tanstack/react-pacer";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import * as Schema from "effect/Schema";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
 import { useGitStatus } from "~/lib/gitStatusState";
@@ -162,7 +173,7 @@ import {
   shouldWriteThreadErrorToCurrentServerThread,
   waitForStartedServerThread,
 } from "./ChatView.logic";
-import { useLocalStorage } from "~/hooks/useLocalStorage";
+import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "~/hooks/useLocalStorage";
 import { useComposerHandleContext } from "../composerHandleContext";
 import {
   useServerAvailableEditors,
@@ -309,6 +320,26 @@ function formatOutgoingPrompt(params: {
 }
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
+const CHAT_DIFF_INLINE_WIDTH_STORAGE_KEY = "chat_diff_inline_width";
+const CHAT_DIFF_INLINE_DEFAULT_WIDTH_RATIO = 0.48;
+const CHAT_DIFF_INLINE_MIN_WIDTH = 26 * 16;
+const CHAT_DIFF_MAIN_CONTENT_MIN_WIDTH = 24 * 16;
+
+function clampInlineDiffWidth(width: number, availableWidth: number) {
+  const maximumAllowedWidth = Math.max(0, availableWidth - CHAT_DIFF_MAIN_CONTENT_MIN_WIDTH);
+  if (maximumAllowedWidth <= 0) {
+    return 0;
+  }
+  const minimumAllowedWidth = Math.min(CHAT_DIFF_INLINE_MIN_WIDTH, maximumAllowedWidth);
+  return Math.max(minimumAllowedWidth, Math.min(width, maximumAllowedWidth));
+}
+
+function resolveDefaultInlineDiffWidth(availableWidth: number) {
+  return clampInlineDiffWidth(
+    availableWidth * CHAT_DIFF_INLINE_DEFAULT_WIDTH_RATIO,
+    availableWidth,
+  );
+}
 
 type ChatViewProps =
   | {
@@ -316,6 +347,8 @@ type ChatViewProps =
       threadId: ThreadId;
       onDiffPanelOpen?: () => void;
       reserveTitleBarControlInset?: boolean;
+      messagesAside?: ReactNode;
+      messagesAsideOpen?: boolean;
       routeKind: "server";
       draftId?: never;
     }
@@ -324,6 +357,8 @@ type ChatViewProps =
       threadId: ThreadId;
       onDiffPanelOpen?: () => void;
       reserveTitleBarControlInset?: boolean;
+      messagesAside?: ReactNode;
+      messagesAsideOpen?: boolean;
       routeKind: "draft";
       draftId: DraftId;
     };
@@ -583,7 +618,10 @@ export default function ChatView(props: ChatViewProps) {
     routeKind,
     onDiffPanelOpen,
     reserveTitleBarControlInset = true,
+    messagesAside,
+    messagesAsideOpen = false,
   } = props;
+  const hasMessagesAside = messagesAside !== null && messagesAside !== undefined;
   const draftId = routeKind === "draft" ? props.draftId : null;
   const routeThreadRef = useMemo(
     () => scopeThreadRef(environmentId, threadId),
@@ -699,10 +737,194 @@ export default function ChatView(props: ChatViewProps) {
   );
   const legendListRef = useRef<LegendListRef | null>(null);
   const isAtEndRef = useRef(true);
+  const initialMessagesAsideWidthPx = useMemo(
+    () => getLocalStorageItem(CHAT_DIFF_INLINE_WIDTH_STORAGE_KEY, Schema.Finite),
+    [],
+  );
+  const splitContentRef = useRef<HTMLDivElement | null>(null);
+  const messagesAsideContainerRef = useRef<HTMLDivElement | null>(null);
+  const messagesAsideWidthRef = useRef<number | null>(initialMessagesAsideWidthPx);
+  const [messagesAsideWidthPx, setMessagesAsideWidthPx] = useState<number | null>(
+    initialMessagesAsideWidthPx,
+  );
+  const messagesAsideResizeStateRef = useRef<{
+    pointerId: number;
+    handle: HTMLButtonElement;
+    rafId: number | null;
+    startWidth: number;
+    startX: number;
+    width: number;
+  } | null>(null);
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewPromotionInFlightByMessageIdRef = useRef<Record<string, true>>({});
   const sendInFlightRef = useRef(false);
   const terminalOpenByThreadRef = useRef<Record<string, boolean>>({});
+
+  const stopMessagesAsideResize = useCallback((pointerId?: number) => {
+    const resizeState = messagesAsideResizeStateRef.current;
+    if (!resizeState) {
+      return;
+    }
+    if (resizeState.rafId !== null) {
+      window.cancelAnimationFrame(resizeState.rafId);
+    }
+    if (typeof pointerId === "number") {
+      try {
+        if (resizeState.handle.hasPointerCapture(pointerId)) {
+          resizeState.handle.releasePointerCapture(pointerId);
+        }
+      } catch {
+        // Synthetic pointer events in tests may not establish native capture state.
+      }
+    }
+    if (resizeState.width > 0) {
+      messagesAsideWidthRef.current = resizeState.width;
+      setMessagesAsideWidthPx(resizeState.width);
+      setLocalStorageItem(CHAT_DIFF_INLINE_WIDTH_STORAGE_KEY, resizeState.width, Schema.Finite);
+    }
+    messagesAsideContainerRef.current?.style.removeProperty("transition-duration");
+    messagesAsideResizeStateRef.current = null;
+    document.body.style.removeProperty("cursor");
+    document.body.style.removeProperty("user-select");
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      stopMessagesAsideResize();
+    };
+  }, [stopMessagesAsideResize]);
+
+  useLayoutEffect(() => {
+    if (!hasMessagesAside) {
+      return;
+    }
+    const splitElement = splitContentRef.current;
+    const asideElement = messagesAsideContainerRef.current;
+    if (!splitElement) {
+      return;
+    }
+
+    const syncWidth = () => {
+      const availableWidth = splitElement.clientWidth;
+      const candidate = clampInlineDiffWidth(
+        messagesAsideWidthRef.current ?? resolveDefaultInlineDiffWidth(availableWidth),
+        availableWidth,
+      );
+      messagesAsideWidthRef.current = candidate > 0 ? candidate : null;
+      if (asideElement) {
+        asideElement.style.width = messagesAsideOpen && candidate > 0 ? `${candidate}px` : "0px";
+      }
+      if (messagesAsideResizeStateRef.current) {
+        return;
+      }
+      setMessagesAsideWidthPx((previous) => (previous === candidate ? previous : candidate));
+    };
+
+    syncWidth();
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(syncWidth);
+    observer.observe(splitElement);
+    return () => {
+      observer.disconnect();
+    };
+  }, [hasMessagesAside, messagesAsideOpen]);
+
+  const handleMessagesAsideResizePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0 || !messagesAsideOpen) {
+        return;
+      }
+      const splitElement = splitContentRef.current;
+      const asideElement = messagesAsideContainerRef.current;
+      if (!splitElement) {
+        return;
+      }
+      const startWidth = clampInlineDiffWidth(
+        messagesAsideWidthPx ?? resolveDefaultInlineDiffWidth(splitElement.clientWidth),
+        splitElement.clientWidth,
+      );
+      if (startWidth <= 0) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      if (asideElement) {
+        asideElement.style.setProperty("transition-duration", "0ms");
+      }
+      messagesAsideResizeStateRef.current = {
+        pointerId: event.pointerId,
+        handle: event.currentTarget,
+        rafId: null,
+        startWidth,
+        startX: event.clientX,
+        width: startWidth,
+      };
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // Synthetic pointer events in tests may not establish native capture state.
+      }
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [messagesAsideOpen, messagesAsideWidthPx],
+  );
+
+  const handleMessagesAsideResizePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      const resizeState = messagesAsideResizeStateRef.current;
+      const splitElement = splitContentRef.current;
+      const asideElement = messagesAsideContainerRef.current;
+      if (
+        !resizeState ||
+        resizeState.pointerId !== event.pointerId ||
+        !splitElement ||
+        !asideElement
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      const nextWidth = clampInlineDiffWidth(
+        resizeState.startWidth + (resizeState.startX - event.clientX),
+        splitElement.clientWidth,
+      );
+      if (resizeState.rafId !== null) {
+        window.cancelAnimationFrame(resizeState.rafId);
+      }
+      resizeState.rafId = window.requestAnimationFrame(() => {
+        const activeResizeState = messagesAsideResizeStateRef.current;
+        if (!activeResizeState) {
+          return;
+        }
+        activeResizeState.rafId = null;
+        activeResizeState.width = nextWidth;
+        messagesAsideWidthRef.current = nextWidth;
+        asideElement.style.width = `${nextWidth}px`;
+      });
+    },
+    [],
+  );
+
+  const handleMessagesAsideResizePointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      const resizeState = messagesAsideResizeStateRef.current;
+      if (!resizeState || resizeState.pointerId !== event.pointerId) {
+        return;
+      }
+      event.preventDefault();
+      stopMessagesAsideResize(event.pointerId);
+    },
+    [stopMessagesAsideResize],
+  );
+  const resolvedMessagesAsideWidthStyle =
+    messagesAsideOpen && messagesAsideWidthPx !== null && messagesAsideWidthPx > 0
+      ? { width: `${messagesAsideWidthPx}px` }
+      : { width: "0px" };
 
   const terminalState = useTerminalStateStore((state) =>
     selectThreadTerminalState(state.terminalStateByThreadKey, routeThreadRef),
@@ -3185,6 +3407,7 @@ export default function ChatView(props: ChatViewProps) {
     <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
       {/* Top bar */}
       <header
+        data-chat-header="true"
         className={cn(
           "border-b border-border px-3 sm:px-5",
           isElectron
@@ -3234,146 +3457,181 @@ export default function ChatView(props: ChatViewProps) {
       {/* Main content area with optional plan sidebar */}
       <div className="flex min-h-0 min-w-0 flex-1">
         {/* Chat column */}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          {/* Messages Wrapper */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
-            {/* Messages — LegendList handles virtualization and scrolling internally */}
-            <MessagesTimeline
-              key={activeThread.id}
-              isWorking={isWorking}
-              activeTurnInProgress={isWorking || !latestTurnSettled}
-              activeTurnId={activeLatestTurn?.turnId ?? null}
-              activeTurnStartedAt={activeWorkStartedAt}
-              listRef={legendListRef}
-              timelineEntries={timelineEntries}
-              completionDividerBeforeEntryId={completionDividerBeforeEntryId}
-              completionSummary={completionSummary}
-              turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
-              activeThreadEnvironmentId={activeThread.environmentId}
-              routeThreadKey={routeThreadKey}
-              onOpenTurnDiff={onOpenTurnDiff}
-              revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
-              onRevertUserMessage={onRevertUserMessage}
-              isRevertingCheckpoint={isRevertingCheckpoint}
-              onImageExpand={onExpandTimelineImage}
-              markdownCwd={gitCwd ?? undefined}
-              resolvedTheme={resolvedTheme}
-              timestampFormat={timestampFormat}
-              workspaceRoot={activeWorkspaceRoot}
-              onIsAtEndChange={onIsAtEndChange}
-            />
+        <div ref={splitContentRef} className="flex min-h-0 min-w-0 flex-1">
+          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+            {/* Messages Wrapper */}
+            <div className="relative flex min-h-0 flex-1 flex-col">
+              {/* Messages — LegendList handles virtualization and scrolling internally */}
+              <MessagesTimeline
+                key={activeThread.id}
+                isWorking={isWorking}
+                activeTurnInProgress={isWorking || !latestTurnSettled}
+                activeTurnId={activeLatestTurn?.turnId ?? null}
+                activeTurnStartedAt={activeWorkStartedAt}
+                listRef={legendListRef}
+                timelineEntries={timelineEntries}
+                completionDividerBeforeEntryId={completionDividerBeforeEntryId}
+                completionSummary={completionSummary}
+                turnDiffSummaryByAssistantMessageId={turnDiffSummaryByAssistantMessageId}
+                activeThreadEnvironmentId={activeThread.environmentId}
+                routeThreadKey={routeThreadKey}
+                onOpenTurnDiff={onOpenTurnDiff}
+                revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
+                onRevertUserMessage={onRevertUserMessage}
+                isRevertingCheckpoint={isRevertingCheckpoint}
+                onImageExpand={onExpandTimelineImage}
+                markdownCwd={gitCwd ?? undefined}
+                resolvedTheme={resolvedTheme}
+                timestampFormat={timestampFormat}
+                workspaceRoot={activeWorkspaceRoot}
+                onIsAtEndChange={onIsAtEndChange}
+              />
 
-            {/* scroll to bottom pill — shown when user has scrolled away from the bottom */}
-            {showScrollToBottom && (
-              <div className="pointer-events-none absolute bottom-1 left-1/2 z-30 flex -translate-x-1/2 justify-center py-1.5">
-                <button
-                  type="button"
-                  onClick={() => scrollToEnd(true)}
-                  className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
-                >
-                  <ChevronDownIcon className="size-3.5" />
-                  Scroll to bottom
-                </button>
-              </div>
+              {/* scroll to bottom pill — shown when user has scrolled away from the bottom */}
+              {showScrollToBottom && (
+                <div className="pointer-events-none absolute bottom-1 left-1/2 z-30 flex -translate-x-1/2 justify-center py-1.5">
+                  <button
+                    type="button"
+                    onClick={() => scrollToEnd(true)}
+                    className="pointer-events-auto flex items-center gap-1.5 rounded-full border border-border/60 bg-card px-3 py-1 text-muted-foreground text-xs shadow-sm transition-colors hover:border-border hover:text-foreground hover:cursor-pointer"
+                  >
+                    <ChevronDownIcon className="size-3.5" />
+                    Scroll to bottom
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* Input bar */}
+            <div className={cn("px-3 pt-1.5 sm:px-5 sm:pt-2", isGitRepo ? "pb-1" : "pb-3 sm:pb-4")}>
+              <ChatComposer
+                ref={composerRef}
+                composerDraftTarget={composerDraftTarget}
+                environmentId={environmentId}
+                routeKind={routeKind}
+                routeThreadRef={routeThreadRef}
+                draftId={draftId}
+                activeThreadId={activeThreadId}
+                activeThreadEnvironmentId={activeThread?.environmentId}
+                activeThread={activeThread}
+                isServerThread={isServerThread}
+                isLocalDraftThread={isLocalDraftThread}
+                phase={phase}
+                isConnecting={isConnecting}
+                isSendBusy={isSendBusy}
+                isPreparingWorktree={isPreparingWorktree}
+                activePendingApproval={activePendingApproval}
+                pendingApprovals={pendingApprovals}
+                pendingUserInputs={pendingUserInputs}
+                activePendingProgress={activePendingProgress}
+                activePendingResolvedAnswers={activePendingResolvedAnswers}
+                activePendingIsResponding={activePendingIsResponding}
+                activePendingDraftAnswers={activePendingDraftAnswers}
+                activePendingQuestionIndex={activePendingQuestionIndex}
+                respondingRequestIds={respondingRequestIds}
+                showPlanFollowUpPrompt={showPlanFollowUpPrompt}
+                activeProposedPlan={activeProposedPlan}
+                activePlan={activePlan as { turnId?: TurnId } | null}
+                sidebarProposedPlan={sidebarProposedPlan as { turnId?: TurnId } | null}
+                planSidebarLabel={planSidebarLabel}
+                planSidebarOpen={planSidebarOpen}
+                runtimeMode={runtimeMode}
+                interactionMode={interactionMode}
+                lockedProvider={lockedProvider}
+                providerStatuses={providerStatuses as ServerProvider[]}
+                activeProjectDefaultModelSelection={activeProject?.defaultModelSelection}
+                activeThreadModelSelection={activeThread?.modelSelection}
+                activeThreadActivities={activeThread?.activities}
+                resolvedTheme={resolvedTheme}
+                settings={settings}
+                gitCwd={gitCwd}
+                promptRef={promptRef}
+                composerImagesRef={composerImagesRef}
+                composerTerminalContextsRef={composerTerminalContextsRef}
+                shouldAutoScrollRef={isAtEndRef}
+                scheduleStickToBottom={scrollToEnd}
+                onSend={onSend}
+                onInterrupt={onInterrupt}
+                onImplementPlanInNewThread={onImplementPlanInNewThread}
+                onRespondToApproval={onRespondToApproval}
+                onSelectActivePendingUserInputOption={onSelectActivePendingUserInputOption}
+                onAdvanceActivePendingUserInput={onAdvanceActivePendingUserInput}
+                onPreviousActivePendingUserInputQuestion={onPreviousActivePendingUserInputQuestion}
+                onChangeActivePendingUserInputCustomAnswer={
+                  onChangeActivePendingUserInputCustomAnswer
+                }
+                onProviderModelSelect={onProviderModelSelect}
+                toggleInteractionMode={toggleInteractionMode}
+                handleRuntimeModeChange={handleRuntimeModeChange}
+                handleInteractionModeChange={handleInteractionModeChange}
+                togglePlanSidebar={togglePlanSidebar}
+                focusComposer={focusComposer}
+                scheduleComposerFocus={scheduleComposerFocus}
+                setThreadError={setThreadError}
+                onExpandImage={onExpandTimelineImage}
+              />
+            </div>
+
+            {isGitRepo && (
+              <BranchToolbar
+                environmentId={activeThread.environmentId}
+                threadId={activeThread.id}
+                {...(routeKind === "draft" && draftId ? { draftId } : {})}
+                onEnvModeChange={onEnvModeChange}
+                {...(canOverrideServerThreadEnvMode ? { effectiveEnvModeOverride: envMode } : {})}
+                {...(canOverrideServerThreadEnvMode
+                  ? {
+                      activeThreadBranchOverride: activeThreadBranch,
+                      onActiveThreadBranchOverrideChange: setPendingServerThreadBranch,
+                    }
+                  : {})}
+                envLocked={envLocked}
+                onComposerFocusRequest={scheduleComposerFocus}
+                {...(canCheckoutPullRequestIntoThread
+                  ? { onCheckoutPullRequestRequest: openPullRequestDialog }
+                  : {})}
+                {...(hasMultipleEnvironments
+                  ? {
+                      availableEnvironments: logicalProjectEnvironments,
+                      onEnvironmentChange,
+                    }
+                  : {})}
+              />
             )}
           </div>
 
-          {/* Input bar */}
-          <div className={cn("px-3 pt-1.5 sm:px-5 sm:pt-2", isGitRepo ? "pb-1" : "pb-3 sm:pb-4")}>
-            <ChatComposer
-              ref={composerRef}
-              composerDraftTarget={composerDraftTarget}
-              environmentId={environmentId}
-              routeKind={routeKind}
-              routeThreadRef={routeThreadRef}
-              draftId={draftId}
-              activeThreadId={activeThreadId}
-              activeThreadEnvironmentId={activeThread?.environmentId}
-              activeThread={activeThread}
-              isServerThread={isServerThread}
-              isLocalDraftThread={isLocalDraftThread}
-              phase={phase}
-              isConnecting={isConnecting}
-              isSendBusy={isSendBusy}
-              isPreparingWorktree={isPreparingWorktree}
-              activePendingApproval={activePendingApproval}
-              pendingApprovals={pendingApprovals}
-              pendingUserInputs={pendingUserInputs}
-              activePendingProgress={activePendingProgress}
-              activePendingResolvedAnswers={activePendingResolvedAnswers}
-              activePendingIsResponding={activePendingIsResponding}
-              activePendingDraftAnswers={activePendingDraftAnswers}
-              activePendingQuestionIndex={activePendingQuestionIndex}
-              respondingRequestIds={respondingRequestIds}
-              showPlanFollowUpPrompt={showPlanFollowUpPrompt}
-              activeProposedPlan={activeProposedPlan}
-              activePlan={activePlan as { turnId?: TurnId } | null}
-              sidebarProposedPlan={sidebarProposedPlan as { turnId?: TurnId } | null}
-              planSidebarLabel={planSidebarLabel}
-              planSidebarOpen={planSidebarOpen}
-              runtimeMode={runtimeMode}
-              interactionMode={interactionMode}
-              lockedProvider={lockedProvider}
-              providerStatuses={providerStatuses as ServerProvider[]}
-              activeProjectDefaultModelSelection={activeProject?.defaultModelSelection}
-              activeThreadModelSelection={activeThread?.modelSelection}
-              activeThreadActivities={activeThread?.activities}
-              resolvedTheme={resolvedTheme}
-              settings={settings}
-              gitCwd={gitCwd}
-              promptRef={promptRef}
-              composerImagesRef={composerImagesRef}
-              composerTerminalContextsRef={composerTerminalContextsRef}
-              shouldAutoScrollRef={isAtEndRef}
-              scheduleStickToBottom={scrollToEnd}
-              onSend={onSend}
-              onInterrupt={onInterrupt}
-              onImplementPlanInNewThread={onImplementPlanInNewThread}
-              onRespondToApproval={onRespondToApproval}
-              onSelectActivePendingUserInputOption={onSelectActivePendingUserInputOption}
-              onAdvanceActivePendingUserInput={onAdvanceActivePendingUserInput}
-              onPreviousActivePendingUserInputQuestion={onPreviousActivePendingUserInputQuestion}
-              onChangeActivePendingUserInputCustomAnswer={
-                onChangeActivePendingUserInputCustomAnswer
-              }
-              onProviderModelSelect={onProviderModelSelect}
-              toggleInteractionMode={toggleInteractionMode}
-              handleRuntimeModeChange={handleRuntimeModeChange}
-              handleInteractionModeChange={handleInteractionModeChange}
-              togglePlanSidebar={togglePlanSidebar}
-              focusComposer={focusComposer}
-              scheduleComposerFocus={scheduleComposerFocus}
-              setThreadError={setThreadError}
-              onExpandImage={onExpandTimelineImage}
-            />
-          </div>
+          {hasMessagesAside ? (
+            <div className="relative flex h-full min-h-0 shrink-0 items-stretch">
+              <button
+                type="button"
+                aria-label="Resize diff panel"
+                data-chat-messages-aside-resize-handle="true"
+                className={cn(
+                  "group/diff-resize absolute inset-y-0 left-0 z-20 hidden w-4 -translate-x-1/2 touch-none border-0 bg-transparent transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+                  "cursor-col-resize after:bg-border/60 hover:after:bg-border focus-visible:after:bg-border focus-visible:outline-none",
+                  messagesAsideOpen ? "opacity-100" : "pointer-events-none opacity-0",
+                )}
+                onPointerDown={handleMessagesAsideResizePointerDown}
+                onPointerMove={handleMessagesAsideResizePointerMove}
+                onPointerUp={handleMessagesAsideResizePointerUp}
+                onPointerCancel={handleMessagesAsideResizePointerUp}
+              />
+              <div
+                ref={messagesAsideContainerRef}
+                data-chat-messages-aside={messagesAsideOpen ? "open" : "closed"}
+                aria-hidden={!messagesAsideOpen}
+                className={cn(
+                  "flex h-full min-h-0 shrink-0 overflow-hidden transition-[width] duration-200 ease-linear",
+                  messagesAsideOpen ? undefined : "w-0",
+                  !messagesAsideOpen && "pointer-events-none",
+                )}
+                style={resolvedMessagesAsideWidthStyle}
+              >
+                <div className="flex h-full min-h-0 w-full min-w-0 flex-col">{messagesAside}</div>
+              </div>
+            </div>
+          ) : null}
 
-          {isGitRepo && (
-            <BranchToolbar
-              environmentId={activeThread.environmentId}
-              threadId={activeThread.id}
-              {...(routeKind === "draft" && draftId ? { draftId } : {})}
-              onEnvModeChange={onEnvModeChange}
-              {...(canOverrideServerThreadEnvMode ? { effectiveEnvModeOverride: envMode } : {})}
-              {...(canOverrideServerThreadEnvMode
-                ? {
-                    activeThreadBranchOverride: activeThreadBranch,
-                    onActiveThreadBranchOverrideChange: setPendingServerThreadBranch,
-                  }
-                : {})}
-              envLocked={envLocked}
-              onComposerFocusRequest={scheduleComposerFocus}
-              {...(canCheckoutPullRequestIntoThread
-                ? { onCheckoutPullRequestRequest: openPullRequestDialog }
-                : {})}
-              {...(hasMultipleEnvironments
-                ? {
-                    availableEnvironments: logicalProjectEnvironments,
-                    onEnvironmentChange,
-                  }
-                : {})}
-            />
-          )}
           {pullRequestDialogState ? (
             <PullRequestThreadDialog
               key={pullRequestDialogState.key}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -831,6 +831,7 @@ export default function ChatView(props: ChatViewProps) {
       observer.disconnect();
     };
   }, [hasMessagesAside, messagesAsideOpen]);
+  }, [hasMessagesAside, messagesAsideOpen]);
 
   const handleMessagesAsideResizePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLButtonElement>) => {

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -461,6 +461,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         <ScrollFadeEffect
           ref={turnStripRef}
           orientation="horizontal"
+          data-scroll-fade-left={canScrollTurnStripLeft ? "true" : undefined}
           className={cn(
             "turn-chip-strip flex gap-1 px-8 py-0.5",
             "[--mask-width:1.75rem] [--mask-offset-left:2rem] [--mask-offset-right:2rem]",

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -36,6 +36,7 @@ import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { useSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
+import { ScrollFadeEffect } from "./ScrollFadeEffect";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
 type DiffRenderMode = "stacked" | "split";
@@ -457,16 +458,15 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         >
           <ChevronRightIcon className="size-3.5" />
         </button>
-        <div
+        <ScrollFadeEffect
           ref={turnStripRef}
-          className="turn-chip-strip flex gap-1 overflow-x-auto px-8 py-0.5"
-          style={
-            canScrollTurnStripLeft || canScrollTurnStripRight
-              ? {
-                  maskImage: `linear-gradient(to right, ${canScrollTurnStripLeft ? "transparent 24px, black 72px" : "black"}, ${canScrollTurnStripRight ? "black calc(100% - 72px), transparent calc(100% - 24px)" : "black"})`,
-                }
-              : undefined
-          }
+          orientation="horizontal"
+          className={cn(
+            "turn-chip-strip flex gap-1 px-8 py-0.5",
+            "[--mask-width:1.75rem] [--mask-offset-left:2rem] [--mask-offset-right:2rem]",
+            !canScrollTurnStripLeft && "[--left-mask-width:0px]",
+            !canScrollTurnStripRight && "[--right-mask-width:0px]",
+          )}
           onWheel={onTurnStripWheel}
         >
           <button
@@ -517,7 +517,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
               </div>
             </button>
           ))}
-        </div>
+        </ScrollFadeEffect>
       </div>
       <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
         <ToggleGroup
@@ -558,15 +558,15 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   return (
     <DiffPanelShell mode={mode} header={headerRow}>
       {!activeThread ? (
-        <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
+        <div className="flex h-full min-h-0 flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
           Select a thread to inspect turn diffs.
         </div>
       ) : !isGitRepo ? (
-        <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
+        <div className="flex h-full min-h-0 flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
           Turn diffs are unavailable because this project is not a git repository.
         </div>
       ) : orderedTurnDiffSummaries.length === 0 ? (
-        <div className="flex flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
+        <div className="flex h-full min-h-0 flex-1 items-center justify-center px-5 text-center text-xs text-muted-foreground/70">
           No completed turns yet.
         </div>
       ) : (

--- a/apps/web/src/components/DiffPanelShell.tsx
+++ b/apps/web/src/components/DiffPanelShell.tsx
@@ -27,10 +27,8 @@ export function DiffPanelShell(props: {
   return (
     <div
       className={cn(
-        "flex h-full min-w-0 flex-col bg-background",
-        props.mode === "inline"
-          ? "w-[42vw] min-w-[360px] max-w-[560px] shrink-0 border-l border-border"
-          : "w-full",
+        "flex h-full min-h-0 min-w-0 flex-1 flex-col self-stretch bg-background",
+        "w-full",
       )}
     >
       {shouldUseDragRegion ? (
@@ -40,7 +38,7 @@ export function DiffPanelShell(props: {
           <div className={getDiffPanelHeaderRowClassName(props.mode)}>{props.header}</div>
         </div>
       )}
-      {props.children}
+      <div className="flex min-h-0 flex-1 flex-col">{props.children}</div>
     </div>
   );
 }

--- a/apps/web/src/components/ScrollFadeEffect.tsx
+++ b/apps/web/src/components/ScrollFadeEffect.tsx
@@ -1,0 +1,28 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { forwardRef } from "react";
+
+import { cn } from "~/lib/utils";
+
+export type ScrollFadeEffectProps = ComponentPropsWithoutRef<"div"> & {
+  orientation?: "horizontal" | "vertical";
+};
+
+export const ScrollFadeEffect = forwardRef<HTMLDivElement, ScrollFadeEffectProps>(
+  ({ className, orientation = "vertical", ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        data-orientation={orientation}
+        className={cn(
+          "data-[orientation=horizontal]:overflow-x-auto data-[orientation=horizontal]:overflow-y-hidden",
+          "data-[orientation=vertical]:overflow-y-auto data-[orientation=vertical]:overflow-x-hidden",
+          "data-[orientation=horizontal]:scroll-fade-effect-x data-[orientation=vertical]:scroll-fade-effect-y",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+ScrollFadeEffect.displayName = "ScrollFadeEffect";

--- a/apps/web/src/components/ScrollFadeEffect.tsx
+++ b/apps/web/src/components/ScrollFadeEffect.tsx
@@ -14,9 +14,9 @@ export const ScrollFadeEffect = forwardRef<HTMLDivElement, ScrollFadeEffectProps
         ref={ref}
         data-orientation={orientation}
         className={cn(
-          "data-[orientation=horizontal]:overflow-x-auto data-[orientation=horizontal]:overflow-y-hidden",
-          "data-[orientation=vertical]:overflow-y-auto data-[orientation=vertical]:overflow-x-hidden",
-          "data-[orientation=horizontal]:scroll-fade-effect-x data-[orientation=vertical]:scroll-fade-effect-y",
+          orientation === "horizontal"
+            ? "scroll-fade-effect-x overflow-x-auto overflow-y-hidden"
+            : "scroll-fade-effect-y overflow-x-hidden overflow-y-auto",
           className,
         )}
         {...props}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -164,9 +164,11 @@
   animation-fill-mode: both;
 }
 
-@supports not (animation-timeline: scroll(self inline)) {
-  .scroll-fade-effect-x {
-    --left-mask-width: var(--mask-width);
+@layer utilities {
+  @supports not (animation-timeline: scroll(self inline)) {
+    .scroll-fade-effect-x[data-scroll-fade-left="true"] {
+      --left-mask-width: var(--mask-width);
+    }
   }
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -111,6 +111,7 @@
   --mask-offset-top: 0px;
   --mask-offset-bottom: 0px;
   --scroll-buffer: 2rem;
+  --bottom-mask-height: var(--mask-height);
 
   mask-image:
     linear-gradient(to top, transparent, black 90%),
@@ -139,6 +140,7 @@
   --mask-offset-left: 0px;
   --mask-offset-right: 0px;
   --scroll-buffer: 2rem;
+  --right-mask-width: var(--mask-width);
 
   mask-image:
     linear-gradient(to left, transparent, black 90%),

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -46,6 +46,30 @@
 }
 
 @layer base {
+  @keyframes show-top-mask {
+    to {
+      --top-mask-height: var(--mask-height);
+    }
+  }
+
+  @keyframes hide-bottom-mask {
+    to {
+      --bottom-mask-height: 0px;
+    }
+  }
+
+  @keyframes show-left-mask {
+    to {
+      --left-mask-width: var(--mask-width);
+    }
+  }
+
+  @keyframes hide-right-mask {
+    to {
+      --right-mask-width: 0px;
+    }
+  }
+
   * {
     @apply border-border outline-ring/50;
   }
@@ -56,6 +80,86 @@
     @apply text-foreground relative;
     background-color: var(--app-chrome-background);
   }
+}
+
+@property --top-mask-height {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+@property --bottom-mask-height {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 64px;
+}
+
+@property --left-mask-width {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+@property --right-mask-width {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 64px;
+}
+
+@utility scroll-fade-effect-y {
+  --mask-height: 64px;
+  --mask-offset-top: 0px;
+  --mask-offset-bottom: 0px;
+  --scroll-buffer: 2rem;
+
+  mask-image:
+    linear-gradient(to top, transparent, black 90%),
+    linear-gradient(to bottom, transparent 0%, black 100%), linear-gradient(black, black);
+  mask-size:
+    100% var(--top-mask-height),
+    100% var(--bottom-mask-height),
+    100% 100%;
+  mask-repeat: no-repeat, no-repeat, no-repeat;
+  mask-position:
+    0 var(--mask-offset-top),
+    0 calc(100% - var(--mask-offset-bottom)),
+    0 0;
+  mask-composite: exclude;
+
+  animation-name: show-top-mask, hide-bottom-mask;
+  animation-timeline: scroll(self), scroll(self);
+  animation-range:
+    0 var(--scroll-buffer),
+    calc(100% - var(--scroll-buffer)) 100%;
+  animation-fill-mode: both;
+}
+
+@utility scroll-fade-effect-x {
+  --mask-width: 64px;
+  --mask-offset-left: 0px;
+  --mask-offset-right: 0px;
+  --scroll-buffer: 2rem;
+
+  mask-image:
+    linear-gradient(to left, transparent, black 90%),
+    linear-gradient(to right, transparent 0%, black 100%), linear-gradient(black, black);
+  mask-size:
+    var(--left-mask-width) 100%,
+    var(--right-mask-width) 100%,
+    100% 100%;
+  mask-repeat: no-repeat, no-repeat, no-repeat;
+  mask-position:
+    var(--mask-offset-left) 0,
+    calc(100% - var(--mask-offset-right)) 0,
+    0 0;
+  mask-composite: exclude;
+
+  animation-name: show-left-mask, hide-right-mask;
+  animation-timeline: scroll(self inline), scroll(self inline);
+  animation-range:
+    0 var(--scroll-buffer),
+    calc(100% - var(--scroll-buffer)) 100%;
+  animation-fill-mode: both;
 }
 
 /* Suppress all transitions during theme changes */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -140,6 +140,7 @@
   --mask-offset-left: 0px;
   --mask-offset-right: 0px;
   --scroll-buffer: 2rem;
+  --left-mask-width: var(--mask-width);
   --right-mask-width: var(--mask-width);
 
   mask-image:

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -140,7 +140,6 @@
   --mask-offset-left: 0px;
   --mask-offset-right: 0px;
   --scroll-buffer: 2rem;
-  --left-mask-width: var(--mask-width);
   --right-mask-width: var(--mask-width);
 
   mask-image:
@@ -163,6 +162,12 @@
     0 var(--scroll-buffer),
     calc(100% - var(--scroll-buffer)) 100%;
   animation-fill-mode: both;
+}
+
+@supports not (animation-timeline: scroll(self inline)) {
+  .scroll-fade-effect-x {
+    --left-mask-width: var(--mask-width);
+  }
 }
 
 /* Suppress all transitions during theme changes */

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -11,24 +11,16 @@ import {
   type DiffPanelMode,
 } from "../components/DiffPanelShell";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
-import {
-  type DiffRouteSearch,
-  parseDiffRouteSearch,
-  stripDiffSearchParams,
-} from "../diffRouteSearch";
+import { type DiffRouteSearch, parseDiffRouteSearch } from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { selectEnvironmentState, selectThreadExistsByRef, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
 import { resolveThreadRouteRef, buildThreadRouteParams } from "../threadRoutes";
 import { Sheet, SheetPopup } from "../components/ui/sheet";
-import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
+import { SidebarInset } from "~/components/ui/sidebar";
 
 const DiffPanel = lazy(() => import("../components/DiffPanel"));
 const DIFF_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 1180px)";
-const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
-const DIFF_INLINE_DEFAULT_WIDTH = "clamp(28rem,48vw,44rem)";
-const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 26 * 16;
-const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
 
 const DiffPanelSheet = (props: {
   children: ReactNode;
@@ -71,94 +63,6 @@ const LazyDiffPanel = (props: { mode: DiffPanelMode }) => {
         <DiffPanel mode={props.mode} />
       </Suspense>
     </DiffWorkerPoolProvider>
-  );
-};
-
-const DiffPanelInlineSidebar = (props: {
-  diffOpen: boolean;
-  onCloseDiff: () => void;
-  onOpenDiff: () => void;
-  renderDiffContent: boolean;
-}) => {
-  const { diffOpen, onCloseDiff, onOpenDiff, renderDiffContent } = props;
-  const onOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        onOpenDiff();
-        return;
-      }
-      onCloseDiff();
-    },
-    [onCloseDiff, onOpenDiff],
-  );
-  const shouldAcceptInlineSidebarWidth = useCallback(
-    ({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }) => {
-      const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
-      if (!composerForm) return true;
-      const composerViewport = composerForm.parentElement;
-      if (!composerViewport) return true;
-      const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
-      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
-
-      const viewportStyle = window.getComputedStyle(composerViewport);
-      const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
-      const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
-      const viewportContentWidth = Math.max(
-        0,
-        composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
-      );
-      const formRect = composerForm.getBoundingClientRect();
-      const composerFooter = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-footer='true']",
-      );
-      const composerRightActions = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-actions='right']",
-      );
-      const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
-      const composerFooterGap = composerFooter
-        ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
-          Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
-          0
-        : 0;
-      const minimumComposerWidth =
-        COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
-      const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
-      const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
-      const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
-
-      if (previousSidebarWidth.length > 0) {
-        wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
-      } else {
-        wrapper.style.removeProperty("--sidebar-width");
-      }
-
-      return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
-    },
-    [],
-  );
-
-  return (
-    <SidebarProvider
-      defaultOpen={false}
-      open={diffOpen}
-      onOpenChange={onOpenChange}
-      className="w-auto min-h-0 flex-none bg-transparent"
-      style={{ "--sidebar-width": DIFF_INLINE_DEFAULT_WIDTH } as React.CSSProperties}
-    >
-      <Sidebar
-        side="right"
-        collapsible="offcanvas"
-        className="border-l border-border bg-card text-foreground"
-        resizable={{
-          minWidth: DIFF_INLINE_SIDEBAR_MIN_WIDTH,
-          shouldAcceptWidth: shouldAcceptInlineSidebarWidth,
-          storageKey: DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
-        }}
-      >
-        {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
-        <SidebarRail />
-      </Sidebar>
-    </SidebarProvider>
   );
 };
 
@@ -223,20 +127,6 @@ function ChatThreadRouteView() {
       search: { diff: undefined },
     });
   }, [navigate, threadRef]);
-  const openDiff = useCallback(() => {
-    if (!threadRef) {
-      return;
-    }
-    markDiffOpened();
-    void navigate({
-      to: "/$environmentId/$threadId",
-      params: buildThreadRouteParams(threadRef),
-      search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
-      },
-    });
-  }, [markDiffOpened, navigate, threadRef]);
 
   useEffect(() => {
     if (!threadRef || !bootstrapComplete) {
@@ -255,31 +145,28 @@ function ChatThreadRouteView() {
     finalizePromotedDraftThreadByRef(threadRef);
   }, [draftThread?.promotedTo, serverThreadStarted, threadRef]);
 
+  const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
+  const inlineDiffPanel = useMemo(
+    () => (!shouldUseDiffSheet && shouldRenderDiffContent ? <LazyDiffPanel mode="inline" /> : null),
+    [shouldUseDiffSheet, shouldRenderDiffContent],
+  );
+
   if (!threadRef || !bootstrapComplete || !routeThreadExists) {
     return null;
   }
 
-  const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
-
   if (!shouldUseDiffSheet) {
     return (
-      <>
-        <SidebarInset className="h-dvh  min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
-          <ChatView
-            environmentId={threadRef.environmentId}
-            threadId={threadRef.threadId}
-            onDiffPanelOpen={markDiffOpened}
-            reserveTitleBarControlInset={!diffOpen}
-            routeKind="server"
-          />
-        </SidebarInset>
-        <DiffPanelInlineSidebar
-          diffOpen={diffOpen}
-          onCloseDiff={closeDiff}
-          onOpenDiff={openDiff}
-          renderDiffContent={shouldRenderDiffContent}
+      <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+        <ChatView
+          environmentId={threadRef.environmentId}
+          threadId={threadRef.threadId}
+          onDiffPanelOpen={markDiffOpened}
+          messagesAside={inlineDiffPanel}
+          messagesAsideOpen={diffOpen}
+          routeKind="server"
         />
-      </>
+      </SidebarInset>
     );
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a set of closely related desktop diff panel regressions in the web app.

On desktop, opening the diff panel was still affecting the layout in the wrong places. The header needed to stay fixed while the diff opened inside the main messages area and pushed the rest of the post-header content with it. The inline panel also needed to behave like the original implementation during resize, and the diff header turn strip needed a proper edge fade instead of a detached overlay.

## What changed

The desktop thread route now mounts the diff panel inline inside `ChatView` instead of rendering it as a separate sibling sidebar. `ChatView` owns the split layout below the header, so the diff opens in the same space as the messages, composer, and checkout toolbar without shifting the header itself.

The inline diff panel now has a draggable resize handle with `col-resize` cursor feedback. The resize path uses direct DOM width updates during pointer drag and only persists the final width when the drag ends, which restores the smoother behavior from the original implementation and avoids React-driven drag lag.

The diff shell layout was also adjusted so desktop inline empty states fill the available height correctly. That keeps states like `No completed turns yet.` centered inside the panel instead of sitting at the top of the body.

Finally, the diff turn-strip edge fade no longer uses a painted overlay. The fade is now applied to the scrollable content itself with a dedicated `ScrollFadeEffect` component and matching mask utilities, which fixes the header misalignment artifact visible while horizontally scrolling the turn chips.

## User-visible effect

Before this change:
<img width="687" height="1071" alt="image" src="https://github.com/user-attachments/assets/143278b0-1fd5-444d-a6b4-46e5961b752d" />

- Opening the desktop diff panel resized or shifted layout in ways that affected the header.
- The inline resize interaction felt constrained and laggy.
- Empty-state content in the inline diff panel did not stay vertically centered on desktop.
- The turn-strip edge fade could drift visually and appear as a detached dark patch over the header controls.

After this change:
<img width="673" height="1072" alt="image" src="https://github.com/user-attachments/assets/953eebba-c030-42cb-8712-2fb0d27b39f9" />

- The header stays fixed while the diff opens below it in the main content area.
- The composer and checkout area shift with the inline diff, not the header.
- The inline diff can be resized smoothly with cursor feedback.
- Empty states are centered inside the desktop inline panel.
- The turn-strip edge fade is aligned with the scrolling content.

## Validation

- `bun fmt`
- `bun lint` (existing repo warnings only)
- `bun typecheck`

## Notes

This is intentionally scoped to the desktop inline diff layout and its related diff-header interactions. It does not change the mobile diff sheet behavior.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop inline diff panel layout and resize behavior in ChatView
> - Moves inline diff panel rendering and resize logic from the route-level `DiffPanelInlineSidebar` into [`ChatView`](https://github.com/pingdotgg/t3code/pull/1970/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) via new `messagesAside` and `messagesAsideOpen` props, placing the panel below the chat header as a right-side aside.
> - Adds pointer-event-based drag-to-resize with `col-resize` cursor, width clamping to enforce minimum widths for both the chat column and the panel, and localStorage persistence of the chosen width.
> - Introduces a [`ScrollFadeEffect`](https://github.com/pingdotgg/t3code/pull/1970/files#diff-c7f4d07e5230476caf4a38f8bdbe523515a2a2f6b8de99b05a9b2338b20e86c9) component and supporting CSS scroll-timeline utilities in [`index.css`](https://github.com/pingdotgg/t3code/pull/1970/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to fade panel scroll edges, with a fallback for browsers without scroll-timeline support.
> - [`DiffPanelShell`](https://github.com/pingdotgg/t3code/pull/1970/files#diff-786cee27ae51161a906257158a81e0a9a1aaa462ac9ffe29d2d5c3b8a07f487e) no longer sets a fixed width or `border-l` in inline mode; it fills available space provided by the parent.
> - Behavioral Change: title bar control inset reservation is no longer toggled by `diffOpen` in the chat thread route.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dccbb2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors desktop chat/diff layout composition and adds custom pointer-driven resize + width persistence logic, which can affect core chat rendering and responsiveness across viewports.
> 
> **Overview**
> Fixes desktop inline diff layout by **moving diff rendering into `ChatView`** via new `messagesAside`/`messagesAsideOpen` props, so opening the diff splits only the post-header content instead of resizing the header.
> 
> Adds a **pointer-based resize handle** for the inline diff aside with width clamping, `ResizeObserver` sync, and persistence to localStorage (`chat_diff_inline_width`), plus browser tests covering header positioning, collapse behavior during resize sync, and width restore.
> 
> Improves diff UI polish by making `DiffPanelShell` fill its parent (better inline empty-state centering) and by introducing `ScrollFadeEffect` + new CSS mask utilities to apply a scroll-edge fade directly to the diff turn-strip content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dccbb2cc7a551615ab4e31562477fd7c1f5e42a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->