### PR TITLE
Preserve live stream subscriptions across explicit reconnects

### DIFF
--- a/apps/web/src/rpc/wsTransport.test.ts
+++ b/apps/web/src/rpc/wsTransport.test.ts
@@ -639,6 +639,115 @@ describe("WsTransport", () => {
     await transport.dispose();
   });
 
+  it("re-subscribes live stream listeners after an explicit transport reconnect", async () => {
+    const transport = createTransport("ws://localhost:3020");
+    const listener = vi.fn();
+    const onResubscribe = vi.fn();
+
+    const unsubscribe = transport.subscribe(
+      (client) => client[WS_METHODS.subscribeServerLifecycle]({}),
+      listener,
+      { onResubscribe },
+    );
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    const firstSocket = getSocket();
+    firstSocket.open();
+
+    await waitFor(() => {
+      expect(firstSocket.sent).toHaveLength(1);
+    });
+
+    const firstRequest = JSON.parse(firstSocket.sent[0] ?? "{}") as { id: string };
+    const firstEvent = {
+      version: 1,
+      sequence: 1,
+      type: "welcome",
+      payload: {
+        environment: {
+          environmentId: "environment-local",
+          label: "Local environment",
+          platform: { os: "darwin", arch: "arm64" },
+          serverVersion: "0.0.0-test",
+          capabilities: { repositoryIdentity: true },
+        },
+        cwd: "/tmp/one",
+        projectName: "one",
+      },
+    };
+
+    firstSocket.serverMessage(
+      JSON.stringify({
+        _tag: "Chunk",
+        requestId: firstRequest.id,
+        values: [firstEvent],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(listener).toHaveBeenLastCalledWith(firstEvent);
+    });
+
+    await transport.reconnect();
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(2);
+    });
+
+    const secondSocket = getSocket();
+    expect(secondSocket).not.toBe(firstSocket);
+    expect(firstSocket.readyState).toBe(MockWebSocket.CLOSED);
+
+    secondSocket.open();
+
+    await waitFor(() => {
+      expect(secondSocket.sent).toHaveLength(1);
+    });
+
+    const secondRequest = JSON.parse(secondSocket.sent[0] ?? "{}") as {
+      id: string;
+      tag: string;
+    };
+    expect(secondRequest.tag).toBe(WS_METHODS.subscribeServerLifecycle);
+    expect(secondRequest.id).not.toBe(firstRequest.id);
+    expect(onResubscribe).toHaveBeenCalledOnce();
+
+    const secondEvent = {
+      version: 1,
+      sequence: 2,
+      type: "welcome",
+      payload: {
+        environment: {
+          environmentId: "environment-local",
+          label: "Local environment",
+          platform: { os: "darwin", arch: "arm64" },
+          serverVersion: "0.0.0-test",
+          capabilities: { repositoryIdentity: true },
+        },
+        cwd: "/tmp/two",
+        projectName: "two",
+      },
+    };
+
+    secondSocket.serverMessage(
+      JSON.stringify({
+        _tag: "Chunk",
+        requestId: secondRequest.id,
+        values: [secondEvent],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(listener).toHaveBeenLastCalledWith(secondEvent);
+    });
+
+    unsubscribe();
+    await transport.dispose();
+  });
+
   it("does not fire onResubscribe when the first stream attempt exits before any value", async () => {
     const transport = createTransport("ws://localhost:3020");
     const listener = vi.fn();

--- a/apps/web/src/rpc/wsTransport.ts
+++ b/apps/web/src/rpc/wsTransport.ts
@@ -121,6 +121,7 @@ export class WsTransport {
           return;
         }
 
+        const session = this.session;
         try {
           if (hasReceivedValue) {
             try {
@@ -130,7 +131,6 @@ export class WsTransport {
             }
           }
 
-          const session = this.session;
           const runningStream = this.runStreamOnSession(
             session,
             connect,
@@ -148,6 +148,10 @@ export class WsTransport {
           cancelCurrentStream = NOOP;
           if (!active || this.disposed) {
             return;
+          }
+
+          if (session !== this.session) {
+            continue;
           }
 
           const formattedError = formatErrorMessage(error);


### PR DESCRIPTION
## Summary
- Preserve active WebSocket stream subscriptions when the transport is explicitly reconnected.
- Avoid resubscribing against a stale session after reconnect by checking the session that initiated the stream.
- Add coverage for reconnecting an active subscription and verifying the listener resumes on the new socket.

## Testing
- Added `apps/web/src/rpc/wsTransport.test.ts` coverage for explicit reconnect behavior.
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`
- Not run: `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `WsTransport.subscribe` retry logic during reconnects, which could affect real-time stream reliability if session tracking is wrong. Scope is small and guarded by a new reconnect resubscription test.
> 
> **Overview**
> Active `WsTransport.subscribe` streams now survive an explicit `reconnect()` by continuing the subscription loop on the new session and **skipping retry/resubscribe handling for errors from the old session**.
> 
> Adds a Vitest case asserting that a live stream listener is re-subscribed on the new socket after `reconnect()`, with `onResubscribe` firing and events continuing to deliver.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c0ae4e7cf08c6f7f54a3ad38584b06a278508b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve live stream subscriptions across explicit reconnects in `WsTransport`
> - When `transport.reconnect()` is called, the subscription loop now captures a session snapshot at the start of each iteration and checks in the catch block whether the session has changed; if so, the error is ignored and the loop continues immediately.
> - This allows listeners to re-subscribe on the new session without prematurely terminating or logging a spurious disconnect for the stale session.
> - A new test in [wsTransport.test.ts](https://github.com/pingdotgg/t3code/pull/1972/files#diff-b5ef2531b397ef5ecd82322ee43f94fe7e5a9254217abd01ffd5fdfc6ccf6944) verifies that after reconnect, a new subscribe request is sent, `onResubscribe` fires once, and subsequent events are delivered to the original listener.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1c0ae4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->