### PR TITLE
fix(desktop): increase backend readiness timeout from 10s to 30s

### DIFF
--- a/apps/desktop/src/backendReadiness.ts
+++ b/apps/desktop/src/backendReadiness.ts
@@ -6,7 +6,7 @@ export interface WaitForHttpReadyOptions {
   readonly signal?: AbortSignal;
 }
 
-const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_INTERVAL_MS = 100;
 const DEFAULT_REQUEST_TIMEOUT_MS = 1_000;
 


### PR DESCRIPTION
## What Changed

`DEFAULT_TIMEOUT_MS` in `apps/desktop/src/backendReadiness.ts` from `10_000` to `30_000`.

## Why

The 10-second timeout is too tight for many machines. The backend consistently needs 10–12s to start (Node.js init → SQLite → migrations → HTTP listen), so the desktop gives up before the backend is ready — sometimes by less than a second.

Log evidence (v0.0.17, macOS x64):
- Last successful start: 9.18s (0.82s under the limit)
- Every cold start after that: 10.5–12s → timeout
- Backend reaches Listening 0.35–2s after the desktop gives up

30s gives comfortable headroom without affecting fast machines — the readiness check still polls every 100ms and resolves immediately when the backend responds.

Fixes #1916

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a default timeout value for desktop backend readiness polling, with no logic or data-handling changes.
> 
> **Overview**
> Increases the default backend readiness wait timeout in the desktop app from **10s to 30s**, reducing startup failures on slower/cold machines while keeping the existing polling behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27383525a019bdd0ceaa9f6b610befa581001d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase backend readiness timeout from 10s to 30s in desktop app
> Raises `DEFAULT_TIMEOUT_MS` in [backendReadiness.ts](https://github.com/pingdotgg/t3code/pull/1979/files#diff-ea3056a1bd7b0e94e80c44cfc828d06c6ff3801fd81efa93e3ee3bebada0a0bc) from 10,000ms to 30,000ms, giving the backend more time to become ready before timing out.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e273835.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->