### PR TITLE
Fix: Respect app server model list and "prolite" account support.

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -310,6 +310,20 @@ describe("readCodexAccountSnapshot", () => {
     });
   });
 
+  it("keeps spark enabled for chatgpt pro lite accounts", () => {
+    expect(
+      readCodexAccountSnapshot({
+        type: "chatgpt",
+        email: "prolite@example.com",
+        planType: "prolite",
+      }),
+    ).toEqual({
+      type: "chatgpt",
+      planType: "prolite",
+      sparkEnabled: true,
+    });
+  });
+
   it("disables spark for api key accounts", () => {
     expect(
       readCodexAccountSnapshot({
@@ -354,6 +368,20 @@ describe("resolveCodexModelForAccount", () => {
         planType: "pro",
         sparkEnabled: true,
       }),
+    ).toBe("gpt-5.3-codex-spark");
+  });
+
+  it("keeps spark when the app-server reports it for an unknown chatgpt plan", () => {
+    expect(
+      resolveCodexModelForAccount(
+        "gpt-5.3-codex-spark",
+        {
+          type: "chatgpt",
+          planType: "unknown",
+          sparkEnabled: false,
+        },
+        new Set(["gpt-5.3-codex", "gpt-5.3-codex-spark"]),
+      ),
     ).toBe("gpt-5.3-codex-spark");
   });
 

--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -385,6 +385,20 @@ describe("resolveCodexModelForAccount", () => {
     ).toBe("gpt-5.3-codex-spark");
   });
 
+  it("falls back from spark to default when the app-server model set is empty", () => {
+    expect(
+      resolveCodexModelForAccount(
+        "gpt-5.3-codex-spark",
+        {
+          type: "chatgpt",
+          planType: "unknown",
+          sparkEnabled: false,
+        },
+        new Set(),
+      ),
+    ).toBe("gpt-5.3-codex");
+  });
+
   it("falls back from spark to default for api key auth", () => {
     expect(
       resolveCodexModelForAccount("gpt-5.3-codex-spark", {

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -511,9 +511,12 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       try {
         const modelListResponse = await this.sendRequest(context, "model/list", {});
         console.log("codex model/list response", modelListResponse);
-        context.availableModels = new Set(
-          parseCodexModelListResult(modelListResponse).map((model) => model.slug),
+        const availableModels = parseCodexModelListResult(modelListResponse).map(
+          (model) => model.slug,
         );
+        if (availableModels.length > 0) {
+          context.availableModels = new Set(availableModels);
+        }
       } catch (error) {
         console.log("codex model/list failed", error);
       }

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -32,6 +32,7 @@ import {
   type CodexAccountSnapshot,
 } from "./provider/codexAccount";
 import { buildCodexInitializeParams, killCodexChildProcess } from "./provider/codexAppServer";
+import { parseCodexModelListResult } from "./provider/codexModels";
 
 export { buildCodexInitializeParams } from "./provider/codexAppServer";
 export { readCodexAccountSnapshot, resolveCodexModelForAccount } from "./provider/codexAccount";
@@ -73,6 +74,7 @@ interface CodexUserInputAnswer {
 interface CodexSessionContext {
   session: ProviderSession;
   account: CodexAccountSnapshot;
+  availableModels?: ReadonlySet<string>;
   child: ChildProcessWithoutNullStreams;
   output: readline.Interface;
   pending: Map<PendingRequestKey, PendingRequest>;
@@ -509,6 +511,9 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       try {
         const modelListResponse = await this.sendRequest(context, "model/list", {});
         console.log("codex model/list response", modelListResponse);
+        context.availableModels = new Set(
+          parseCodexModelListResult(modelListResponse).map((model) => model.slug),
+        );
       } catch (error) {
         console.log("codex model/list failed", error);
       }
@@ -528,6 +533,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       const normalizedModel = resolveCodexModelForAccount(
         normalizeCodexModelSlug(input.model),
         context.account,
+        context.availableModels,
       );
       const sessionOverrides = {
         model: normalizedModel ?? null,
@@ -710,6 +716,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
     const normalizedModel = resolveCodexModelForAccount(
       normalizeCodexModelSlug(input.model ?? context.session.model),
       context.account,
+      context.availableModels,
     );
     if (normalizedModel) {
       turnStartParams.model = normalizedModel;

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -46,136 +46,20 @@ import {
   type CodexAccountSnapshot,
 } from "../codexAccount";
 import { probeCodexDiscovery } from "../codexAppServer";
+import {
+  BUILT_IN_CODEX_MODELS,
+  DEFAULT_CODEX_MODEL_CAPABILITIES,
+  getCodexModelCapabilities as getSharedCodexModelCapabilities,
+} from "../codexModels";
 import { CodexProvider } from "../Services/CodexProvider";
 import { ServerSettingsService } from "../../serverSettings";
 import { ServerSettingsError } from "@t3tools/contracts";
 
-const DEFAULT_CODEX_MODEL_CAPABILITIES: ModelCapabilities = {
-  reasoningEffortLevels: [
-    { value: "xhigh", label: "Extra High" },
-    { value: "high", label: "High", isDefault: true },
-    { value: "medium", label: "Medium" },
-    { value: "low", label: "Low" },
-  ],
-  supportsFastMode: true,
-  supportsThinkingToggle: false,
-  contextWindowOptions: [],
-  promptInjectedEffortLevels: [],
-};
-
 const PROVIDER = "codex" as const;
 const OPENAI_AUTH_PROVIDERS = new Set(["openai"]);
-const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
-  {
-    slug: "gpt-5.4",
-    name: "GPT-5.4",
-    isCustom: false,
-    capabilities: {
-      reasoningEffortLevels: [
-        { value: "xhigh", label: "Extra High" },
-        { value: "high", label: "High", isDefault: true },
-        { value: "medium", label: "Medium" },
-        { value: "low", label: "Low" },
-      ],
-      supportsFastMode: true,
-      supportsThinkingToggle: false,
-      contextWindowOptions: [],
-      promptInjectedEffortLevels: [],
-    },
-  },
-  {
-    slug: "gpt-5.4-mini",
-    name: "GPT-5.4 Mini",
-    isCustom: false,
-    capabilities: {
-      reasoningEffortLevels: [
-        { value: "xhigh", label: "Extra High" },
-        { value: "high", label: "High", isDefault: true },
-        { value: "medium", label: "Medium" },
-        { value: "low", label: "Low" },
-      ],
-      supportsFastMode: true,
-      supportsThinkingToggle: false,
-      contextWindowOptions: [],
-      promptInjectedEffortLevels: [],
-    },
-  },
-  {
-    slug: "gpt-5.3-codex",
-    name: "GPT-5.3 Codex",
-    isCustom: false,
-    capabilities: {
-      reasoningEffortLevels: [
-        { value: "xhigh", label: "Extra High" },
-        { value: "high", label: "High", isDefault: true },
-        { value: "medium", label: "Medium" },
-        { value: "low", label: "Low" },
-      ],
-      supportsFastMode: true,
-      supportsThinkingToggle: false,
-      contextWindowOptions: [],
-      promptInjectedEffortLevels: [],
-    },
-  },
-  {
-    slug: "gpt-5.3-codex-spark",
-    name: "GPT-5.3 Codex Spark",
-    isCustom: false,
-    capabilities: {
-      reasoningEffortLevels: [
-        { value: "xhigh", label: "Extra High" },
-        { value: "high", label: "High", isDefault: true },
-        { value: "medium", label: "Medium" },
-        { value: "low", label: "Low" },
-      ],
-      supportsFastMode: true,
-      supportsThinkingToggle: false,
-      contextWindowOptions: [],
-      promptInjectedEffortLevels: [],
-    },
-  },
-  {
-    slug: "gpt-5.2-codex",
-    name: "GPT-5.2 Codex",
-    isCustom: false,
-    capabilities: {
-      reasoningEffortLevels: [
-        { value: "xhigh", label: "Extra High" },
-        { value: "high", label: "High", isDefault: true },
-        { value: "medium", label: "Medium" },
-        { value: "low", label: "Low" },
-      ],
-      supportsFastMode: true,
-      supportsThinkingToggle: false,
-      contextWindowOptions: [],
-      promptInjectedEffortLevels: [],
-    },
-  },
-  {
-    slug: "gpt-5.2",
-    name: "GPT-5.2",
-    isCustom: false,
-    capabilities: {
-      reasoningEffortLevels: [
-        { value: "xhigh", label: "Extra High" },
-        { value: "high", label: "High", isDefault: true },
-        { value: "medium", label: "Medium" },
-        { value: "low", label: "Low" },
-      ],
-      supportsFastMode: true,
-      supportsThinkingToggle: false,
-      contextWindowOptions: [],
-      promptInjectedEffortLevels: [],
-    },
-  },
-];
 
 export function getCodexModelCapabilities(model: string | null | undefined): ModelCapabilities {
-  const slug = model?.trim();
-  return (
-    BUILT_IN_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
-    DEFAULT_CODEX_MODEL_CAPABILITIES
-  );
+  return getSharedCodexModelCapabilities(model);
 }
 
 export function parseAuthStatusFromOutput(result: CommandResult): {
@@ -341,6 +225,11 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     readonly homePath?: string;
     readonly cwd: string;
   }) => Effect.Effect<ReadonlyArray<ServerProviderSkill> | undefined>,
+  resolveModels?: (input: {
+    readonly binaryPath: string;
+    readonly homePath?: string;
+    readonly cwd: string;
+  }) => Effect.Effect<ReadonlyArray<ServerProviderModel> | undefined>,
 ): Effect.fn.Return<
   ServerProvider,
   ServerSettingsError,
@@ -355,7 +244,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   );
   const checkedAt = new Date().toISOString();
   const models = providerModelsFromSettings(
-    BUILT_IN_MODELS,
+    BUILT_IN_CODEX_MODELS,
     PROVIDER,
     codexSettings.customModels,
     DEFAULT_CODEX_MODEL_CAPABILITIES,
@@ -492,7 +381,22 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
         homePath: codexSettings.homePath,
       })
     : undefined;
-  const resolvedModels = adjustCodexModelsForAccount(models, account);
+  const reportedModels = resolveModels
+    ? yield* resolveModels({
+        binaryPath: codexSettings.binaryPath,
+        homePath: codexSettings.homePath,
+        cwd: process.cwd(),
+      }).pipe(Effect.orElseSucceed(() => undefined))
+    : undefined;
+  const resolvedModels =
+    reportedModels && reportedModels.length > 0
+      ? providerModelsFromSettings(
+          reportedModels,
+          PROVIDER,
+          codexSettings.customModels,
+          DEFAULT_CODEX_MODEL_CAPABILITIES,
+        )
+      : adjustCodexModelsForAccount(models, account);
 
   if (Result.isFailure(authProbe)) {
     const error = authProbe.failure;
@@ -586,6 +490,7 @@ export const CodexProviderLive = Layer.effect(
           cwd: process.cwd(),
         }).pipe(Effect.map((discovery) => discovery?.account)),
       (input) => getDiscovery(input).pipe(Effect.map((discovery) => discovery?.skills)),
+      (input) => getDiscovery(input).pipe(Effect.map((discovery) => discovery?.models)),
     ).pipe(
       Effect.provideService(ServerSettingsService, serverSettings),
       Effect.provideService(FileSystem.FileSystem, fileSystem),

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -221,6 +221,104 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
         ),
       );
 
+      it.effect("returns the prolite plan type in auth and keeps spark for supported plans", () =>
+        Effect.gen(function* () {
+          yield* withTempCodexHome();
+          const status = yield* checkCodexProviderStatus(() =>
+            Effect.succeed({
+              type: "chatgpt" as const,
+              planType: "prolite" as const,
+              sparkEnabled: true,
+            }),
+          );
+
+          assert.strictEqual(status.provider, "codex");
+          assert.strictEqual(status.status, "ready");
+          assert.strictEqual(status.auth.status, "authenticated");
+          assert.strictEqual(status.auth.type, "prolite");
+          assert.strictEqual(status.auth.label, "ChatGPT Pro Lite Subscription");
+          assert.deepStrictEqual(
+            status.models.some((model) => model.slug === "gpt-5.3-codex-spark"),
+            true,
+          );
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
+              if (joined === "login status") return { stdout: "Logged in\n", stderr: "", code: 0 };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("prefers models reported by codex app-server over account-plan spark gating", () =>
+        Effect.gen(function* () {
+          yield* withTempCodexHome();
+          const status = yield* checkCodexProviderStatus(
+            () =>
+              Effect.succeed({
+                type: "chatgpt" as const,
+                planType: "unknown" as const,
+                sparkEnabled: false,
+              }),
+            undefined,
+            () =>
+              Effect.succeed([
+                {
+                  slug: "gpt-5.3-codex",
+                  name: "GPT-5.3 Codex",
+                  isCustom: false,
+                  capabilities: {
+                    reasoningEffortLevels: [
+                      { value: "low", label: "Low" },
+                      { value: "medium", label: "Medium", isDefault: true },
+                      { value: "high", label: "High" },
+                    ],
+                    supportsFastMode: true,
+                    supportsThinkingToggle: false,
+                    contextWindowOptions: [],
+                    promptInjectedEffortLevels: [],
+                  },
+                },
+                {
+                  slug: "gpt-5.3-codex-spark",
+                  name: "GPT-5.3 Codex Spark",
+                  isCustom: false,
+                  capabilities: {
+                    reasoningEffortLevels: [
+                      { value: "low", label: "Low" },
+                      { value: "medium", label: "Medium" },
+                      { value: "high", label: "High", isDefault: true },
+                    ],
+                    supportsFastMode: true,
+                    supportsThinkingToggle: false,
+                    contextWindowOptions: [],
+                    promptInjectedEffortLevels: [],
+                  },
+                },
+              ]),
+          );
+
+          assert.strictEqual(status.provider, "codex");
+          assert.strictEqual(status.auth.type, "chatgpt");
+          assert.deepStrictEqual(
+            status.models.some((model) => model.slug === "gpt-5.3-codex-spark"),
+            true,
+          );
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
+              if (joined === "login status") return { stdout: "Logged in\n", stderr: "", code: 0 };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("includes probed codex skills in the provider snapshot", () =>
         Effect.gen(function* () {
           yield* withTempCodexHome();

--- a/apps/server/src/provider/codexAccount.ts
+++ b/apps/server/src/provider/codexAccount.ts
@@ -5,6 +5,7 @@ export type CodexPlanType =
   | "go"
   | "plus"
   | "pro"
+  | "prolite"
   | "team"
   | "business"
   | "enterprise"
@@ -19,7 +20,7 @@ export interface CodexAccountSnapshot {
 
 export const CODEX_DEFAULT_MODEL = "gpt-5.3-codex";
 export const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
-const CODEX_SPARK_ENABLED_PLAN_TYPES = new Set<CodexPlanType>(["pro"]);
+const CODEX_SPARK_ENABLED_PLAN_TYPES = new Set<CodexPlanType>(["pro", "prolite"]);
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object") {
@@ -87,6 +88,8 @@ export function codexAuthSubLabel(account: CodexAccountSnapshot | undefined): st
       return "ChatGPT Plus Subscription";
     case "pro":
       return "ChatGPT Pro Subscription";
+    case "prolite":
+      return "ChatGPT Pro Lite Subscription";
     case "team":
       return "ChatGPT Team Subscription";
     case "business":
@@ -114,10 +117,19 @@ export function adjustCodexModelsForAccount(
 export function resolveCodexModelForAccount(
   model: string | undefined,
   account: CodexAccountSnapshot,
+  availableModels?: ReadonlySet<string>,
 ): string | undefined {
+  if (!model) {
+    return model;
+  }
+
+  if (availableModels?.has(model)) {
+    return model;
+  }
+
   if (model !== CODEX_SPARK_MODEL || account.sparkEnabled) {
     return model;
   }
 
-  return CODEX_DEFAULT_MODEL;
+  return availableModels?.has(CODEX_DEFAULT_MODEL) === false ? model : CODEX_DEFAULT_MODEL;
 }

--- a/apps/server/src/provider/codexAccount.ts
+++ b/apps/server/src/provider/codexAccount.ts
@@ -119,11 +119,13 @@ export function resolveCodexModelForAccount(
   account: CodexAccountSnapshot,
   availableModels?: ReadonlySet<string>,
 ): string | undefined {
+  const hasTrustedAvailableModels = (availableModels?.size ?? 0) > 0;
+
   if (!model) {
     return model;
   }
 
-  if (availableModels?.has(model)) {
+  if (hasTrustedAvailableModels && availableModels?.has(model)) {
     return model;
   }
 
@@ -131,5 +133,7 @@ export function resolveCodexModelForAccount(
     return model;
   }
 
-  return availableModels?.has(CODEX_DEFAULT_MODEL) === false ? model : CODEX_DEFAULT_MODEL;
+  return hasTrustedAvailableModels && availableModels?.has(CODEX_DEFAULT_MODEL) === false
+    ? model
+    : CODEX_DEFAULT_MODEL;
 }

--- a/apps/server/src/provider/codexAppServer.ts
+++ b/apps/server/src/provider/codexAppServer.ts
@@ -1,7 +1,8 @@
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import readline from "node:readline";
-import type { ServerProviderSkill } from "@t3tools/contracts";
+import type { ServerProviderModel, ServerProviderSkill } from "@t3tools/contracts";
 import { readCodexAccountSnapshot, type CodexAccountSnapshot } from "./codexAccount";
+import { parseCodexModelListResult } from "./codexModels";
 
 interface JsonRpcProbeResponse {
   readonly id?: unknown;
@@ -14,6 +15,7 @@ interface JsonRpcProbeResponse {
 export interface CodexDiscoverySnapshot {
   readonly account: CodexAccountSnapshot;
   readonly skills: ReadonlyArray<ServerProviderSkill>;
+  readonly models: ReadonlyArray<ServerProviderModel>;
 }
 
 function readErrorMessage(response: JsonRpcProbeResponse): string | undefined {
@@ -125,6 +127,7 @@ export async function probeCodexDiscovery(input: {
     let completed = false;
     let account: CodexAccountSnapshot | undefined;
     let skills: ReadonlyArray<ServerProviderSkill> | undefined;
+    let models: ReadonlyArray<ServerProviderModel> | undefined;
 
     const cleanup = () => {
       output.removeAllListeners();
@@ -152,10 +155,17 @@ export async function probeCodexDiscovery(input: {
       );
 
     const maybeResolve = () => {
-      if (account && skills !== undefined) {
+      if (account && skills !== undefined && models !== undefined) {
         const resolvedAccount = account;
         const resolvedSkills = skills;
-        finish(() => resolve({ account: resolvedAccount, skills: resolvedSkills }));
+        const resolvedModels = models;
+        finish(() =>
+          resolve({
+            account: resolvedAccount,
+            skills: resolvedSkills,
+            models: resolvedModels,
+          }),
+        );
       }
     };
 
@@ -200,6 +210,7 @@ export async function probeCodexDiscovery(input: {
         writeMessage({ method: "initialized" });
         writeMessage({ id: 2, method: "skills/list", params: { cwds: [input.cwd] } });
         writeMessage({ id: 3, method: "account/read", params: {} });
+        writeMessage({ id: 4, method: "model/list", params: {} });
         return;
       }
 
@@ -218,6 +229,13 @@ export async function probeCodexDiscovery(input: {
         }
 
         account = readCodexAccountSnapshot(response.result);
+        maybeResolve();
+        return;
+      }
+
+      if (response.id === 4) {
+        const errorMessage = readErrorMessage(response);
+        models = errorMessage ? [] : parseCodexModelListResult(response.result);
         maybeResolve();
       }
     });

--- a/apps/server/src/provider/codexModels.test.ts
+++ b/apps/server/src/provider/codexModels.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { parseCodexModelListResult } from "./codexModels";
+
+describe("parseCodexModelListResult", () => {
+  it("keeps built-in display names for known models", () => {
+    expect(
+      parseCodexModelListResult({
+        data: [
+          {
+            id: "gpt-5.3-codex",
+            displayName: "gpt-5.3-codex",
+            hidden: false,
+            supportedReasoningEfforts: [
+              { reasoningEffort: "low" },
+              { reasoningEffort: "medium" },
+              { reasoningEffort: "high" },
+            ],
+            defaultReasoningEffort: "medium",
+          },
+          {
+            id: "hidden-model",
+            displayName: "Hidden",
+            hidden: true,
+            supportedReasoningEfforts: [{ reasoningEffort: "low" }],
+            defaultReasoningEffort: "low",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        slug: "gpt-5.3-codex",
+        name: "GPT-5.3 Codex",
+        isCustom: false,
+        capabilities: {
+          reasoningEffortLevels: [
+            { value: "low", label: "Low" },
+            { value: "medium", label: "Medium", isDefault: true },
+            { value: "high", label: "High" },
+          ],
+          supportsFastMode: true,
+          supportsThinkingToggle: false,
+          contextWindowOptions: [],
+          promptInjectedEffortLevels: [],
+        },
+      },
+    ]);
+  });
+
+  it("uses app-server display names for unknown models", () => {
+    expect(
+      parseCodexModelListResult({
+        data: [
+          {
+            id: "future-model",
+            displayName: "Future Model",
+            hidden: false,
+            supportedReasoningEfforts: [{ reasoningEffort: "medium" }],
+            defaultReasoningEffort: "medium",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        slug: "future-model",
+        name: "Future Model",
+        isCustom: false,
+        capabilities: {
+          reasoningEffortLevels: [{ value: "medium", label: "Medium", isDefault: true }],
+          supportsFastMode: true,
+          supportsThinkingToggle: false,
+          contextWindowOptions: [],
+          promptInjectedEffortLevels: [],
+        },
+      },
+    ]);
+  });
+});

--- a/apps/server/src/provider/codexModels.ts
+++ b/apps/server/src/provider/codexModels.ts
@@ -1,0 +1,230 @@
+import type { ModelCapabilities, ServerProviderModel } from "@t3tools/contracts";
+
+const DEFAULT_CODEX_REASONING_LABELS: Record<string, string> = {
+  xhigh: "Extra High",
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+export const DEFAULT_CODEX_MODEL_CAPABILITIES: ModelCapabilities = {
+  reasoningEffortLevels: [
+    { value: "xhigh", label: "Extra High" },
+    { value: "high", label: "High", isDefault: true },
+    { value: "medium", label: "Medium" },
+    { value: "low", label: "Low" },
+  ],
+  supportsFastMode: true,
+  supportsThinkingToggle: false,
+  contextWindowOptions: [],
+  promptInjectedEffortLevels: [],
+};
+
+export const BUILT_IN_CODEX_MODELS: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "gpt-5.4",
+    name: "GPT-5.4",
+    isCustom: false,
+    capabilities: {
+      reasoningEffortLevels: [
+        { value: "xhigh", label: "Extra High" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "medium", label: "Medium" },
+        { value: "low", label: "Low" },
+      ],
+      supportsFastMode: true,
+      supportsThinkingToggle: false,
+      contextWindowOptions: [],
+      promptInjectedEffortLevels: [],
+    },
+  },
+  {
+    slug: "gpt-5.4-mini",
+    name: "GPT-5.4 Mini",
+    isCustom: false,
+    capabilities: {
+      reasoningEffortLevels: [
+        { value: "xhigh", label: "Extra High" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "medium", label: "Medium" },
+        { value: "low", label: "Low" },
+      ],
+      supportsFastMode: true,
+      supportsThinkingToggle: false,
+      contextWindowOptions: [],
+      promptInjectedEffortLevels: [],
+    },
+  },
+  {
+    slug: "gpt-5.3-codex",
+    name: "GPT-5.3 Codex",
+    isCustom: false,
+    capabilities: {
+      reasoningEffortLevels: [
+        { value: "xhigh", label: "Extra High" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "medium", label: "Medium" },
+        { value: "low", label: "Low" },
+      ],
+      supportsFastMode: true,
+      supportsThinkingToggle: false,
+      contextWindowOptions: [],
+      promptInjectedEffortLevels: [],
+    },
+  },
+  {
+    slug: "gpt-5.3-codex-spark",
+    name: "GPT-5.3 Codex Spark",
+    isCustom: false,
+    capabilities: {
+      reasoningEffortLevels: [
+        { value: "xhigh", label: "Extra High" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "medium", label: "Medium" },
+        { value: "low", label: "Low" },
+      ],
+      supportsFastMode: true,
+      supportsThinkingToggle: false,
+      contextWindowOptions: [],
+      promptInjectedEffortLevels: [],
+    },
+  },
+  {
+    slug: "gpt-5.2-codex",
+    name: "GPT-5.2 Codex",
+    isCustom: false,
+    capabilities: {
+      reasoningEffortLevels: [
+        { value: "xhigh", label: "Extra High" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "medium", label: "Medium" },
+        { value: "low", label: "Low" },
+      ],
+      supportsFastMode: true,
+      supportsThinkingToggle: false,
+      contextWindowOptions: [],
+      promptInjectedEffortLevels: [],
+    },
+  },
+  {
+    slug: "gpt-5.2",
+    name: "GPT-5.2",
+    isCustom: false,
+    capabilities: {
+      reasoningEffortLevels: [
+        { value: "xhigh", label: "Extra High" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "medium", label: "Medium" },
+        { value: "low", label: "Low" },
+      ],
+      supportsFastMode: true,
+      supportsThinkingToggle: false,
+      contextWindowOptions: [],
+      promptInjectedEffortLevels: [],
+    },
+  },
+];
+
+function readObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
+}
+
+function readArray(value: unknown): ReadonlyArray<unknown> | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function nonEmptyTrimmed(value: unknown): string | undefined {
+  const candidate = readString(value)?.trim();
+  return candidate ? candidate : undefined;
+}
+
+function codexReasoningLabel(value: string): string {
+  return DEFAULT_CODEX_REASONING_LABELS[value] ?? value;
+}
+
+function parseCodexModelCapabilities(
+  record: Record<string, unknown>,
+  fallbackSlug: string,
+): ModelCapabilities {
+  const fallbackCapabilities =
+    BUILT_IN_CODEX_MODELS.find((candidate) => candidate.slug === fallbackSlug)?.capabilities ??
+    DEFAULT_CODEX_MODEL_CAPABILITIES;
+  const defaultReasoningEffort = nonEmptyTrimmed(record.defaultReasoningEffort);
+  const reasoningEffortLevels = (readArray(record.supportedReasoningEfforts) ?? [])
+    .flatMap((value) => {
+      const effortRecord = readObject(value);
+      const effort = nonEmptyTrimmed(
+        effortRecord?.reasoningEffort ?? effortRecord?.value ?? effortRecord?.id,
+      );
+      if (!effort) {
+        return [];
+      }
+
+      return [
+        {
+          value: effort,
+          label: codexReasoningLabel(effort),
+          ...(effort === defaultReasoningEffort ? { isDefault: true } : {}),
+        },
+      ];
+    })
+    .filter(
+      (candidate, index, values) =>
+        values.findIndex((entry) => entry.value === candidate.value) === index,
+    );
+
+  if (reasoningEffortLevels.length === 0) {
+    return fallbackCapabilities;
+  }
+
+  return {
+    reasoningEffortLevels,
+    supportsFastMode: fallbackCapabilities.supportsFastMode,
+    supportsThinkingToggle: false,
+    contextWindowOptions: [],
+    promptInjectedEffortLevels: [],
+  };
+}
+
+export function getCodexModelCapabilities(model: string | null | undefined): ModelCapabilities {
+  const slug = model?.trim();
+  return (
+    BUILT_IN_CODEX_MODELS.find((candidate) => candidate.slug === slug)?.capabilities ??
+    DEFAULT_CODEX_MODEL_CAPABILITIES
+  );
+}
+
+export function parseCodexModelListResult(result: unknown): ReadonlyArray<ServerProviderModel> {
+  const resultRecord = readObject(result);
+  const rawModels = readArray(resultRecord?.data) ?? readArray(result) ?? [];
+  const seen = new Set<string>();
+
+  return rawModels.flatMap((value) => {
+    const modelRecord = readObject(value);
+    if (!modelRecord || modelRecord.hidden === true) {
+      return [];
+    }
+
+    const slug = nonEmptyTrimmed(modelRecord.id) ?? nonEmptyTrimmed(modelRecord.model);
+    if (!slug || seen.has(slug)) {
+      return [];
+    }
+    seen.add(slug);
+
+    return [
+      {
+        slug,
+        name:
+          BUILT_IN_CODEX_MODELS.find((candidate) => candidate.slug === slug)?.name ??
+          nonEmptyTrimmed(modelRecord.displayName) ??
+          slug,
+        isCustom: false,
+        capabilities: parseCodexModelCapabilities(modelRecord, slug),
+      } satisfies ServerProviderModel,
+    ];
+  });
+}


### PR DESCRIPTION
## What Changed

Added support for the new distinction between pro and "prolite", aka pro 20x and pro 5x see https://help.openai.com/en/articles/9793128-what-is-chatgpt-pro

This is done through adding a profile for prolite, similar to the other plan types as well as respecting the app servers advertised model list.

## Why

The app server currently reports this account type as "unknown" which on the prolite plan specifically, prevents the use of gpt-5.3-codex-spark, since the code used to restrict it to pro accounts only.

That is why I decided to respect the advertised model selection, since the previous logic had special treatment for "pro" which is no longer fit for purpose. Although a one off patch could have been enough, this kind of change may well happen again in the future, and this change makes the app more robust.

This PR also looks larger than it really is since it moves the built in and advertised model info to apps/server/src/provider/codexModels.ts

## UI Changes
gpt-5.3-codex-spark now appears in the model selector on the prolite plan
Before ( 57d7746a )
<img width="806" height="446" alt="image" src="https://github.com/user-attachments/assets/9cdede2a-50fa-42a1-9bd5-42a61429dba5" />

After
<img width="685" height="366" alt="image" src="https://github.com/user-attachments/assets/198fd853-7e87-45a2-b7b5-c4373c0e72f8" />


## Other considerations
I wan not able to test this change on other account types, due to financial limitations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Codex model selection and provider discovery paths; mistakes could incorrectly hide/allow models or cause unexpected fallbacks, but changes are localized and covered by added tests.
> 
> **Overview**
> Adds **ChatGPT `prolite`** plan handling so Spark (`gpt-5.3-codex-spark`) is enabled and labeled correctly for Pro Lite accounts.
> 
> Updates Codex session startup and provider health checks to **fetch and use the app-server `model/list` results**: model resolution (`resolveCodexModelForAccount`) now accepts an optional `availableModels` set to keep models the app-server reports (and only falls back when that set is missing/empty).
> 
> Refactors built-in model metadata and model-list parsing into a shared `codexModels.ts`, and adds tests covering prolite, app-server model preference, and parsing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12664ddf7550a6ff98ea8a8e402bb64cbc30a2a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'prolite' plan support and respect app-server model list in Codex provider
> - Adds `'prolite'` to `CodexPlanType` and `CODEX_SPARK_ENABLED_PLAN_TYPES`, and adds a display label `'ChatGPT Pro Lite Subscription'` for prolite accounts in [codexAccount.ts](https://github.com/pingdotgg/t3code/pull/1980/files#diff-e2ef69363c008d96643fd58096e4e796cf3703e9ec85028a5b1e3b3f57b249a6).
> - Extends `resolveCodexModelForAccount` to accept an `availableModels` set from the app-server; if the requested model is in that set it is kept regardless of plan-based spark gating, and fallback avoids defaulting to a model the server does not report.
> - Updates `probeCodexDiscovery` in [codexAppServer.ts](https://github.com/pingdotgg/t3code/pull/1980/files#diff-1919a9cbec389ad8d355928da337efb6a13337cf7eabbbcbc42fb509ed23a58f) to send a `model/list` request and include the parsed result in `CodexDiscoverySnapshot`; the probe now waits for the model list before resolving.
> - Updates `checkCodexProviderStatus` in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/1980/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) to use app-server reported models when available, overriding plan-based spark gating.
> - Introduces `parseCodexModelListResult`, `BUILT_IN_CODEX_MODELS`, and `DEFAULT_CODEX_MODEL_CAPABILITIES` as shared utilities in [codexModels.ts](https://github.com/pingdotgg/t3code/pull/1980/files#diff-44cfcb4e940a2a8cee6c41ba7711c9e94345b7708c805e04a88ecb1b7bcabd11).
> - Behavioral Change: when the app-server returns a non-empty model list, that list takes precedence over plan-gated built-in models for both session model selection and provider status snapshots.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12664dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->