### PR TITLE
Enhances submodule support and enables image attachments

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "allow": ["Bash(node:*)"]
+  }
+}

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -16,7 +16,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run src/bin.ts",
-    "build": "node scripts/cli.ts build",
+    "build": "bun scripts/cli.ts build",
     "start": "node dist/bin.mjs",
     "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -1,3 +1,6 @@
+import * as child_process from "node:child_process";
+import { createRequire } from "node:module";
+
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
@@ -7,6 +10,28 @@ import { Command } from "effect/unstable/cli";
 import { NetService } from "@t3tools/shared/Net";
 import { cli } from "./cli";
 import { version } from "../package.json" with { type: "json" };
+
+// On Windows, hide console windows for spawned child processes.
+// Effect's ChildProcess spawner doesn't pass `windowsHide` to Node's spawn,
+// so we patch it globally to prevent window flashes for CLI tools like `claude`.
+if (process.platform === "win32") {
+  // ESM namespace imports are immutable to rolldown's static analysis, so use
+  // createRequire to get the mutable CJS exports object for patching.
+  const cp = createRequire(import.meta.url)("node:child_process") as typeof child_process;
+  const originalSpawn = cp.spawn;
+  cp.spawn = function patchedSpawn(...args: Parameters<typeof child_process.spawn>) {
+    const options =
+      typeof args[1] === "object" && !Array.isArray(args[1])
+        ? args[1]
+        : typeof args[2] === "object"
+          ? args[2]
+          : undefined;
+    if (options && !("windowsHide" in options)) {
+      (options as { windowsHide?: boolean }).windowsHide = true;
+    }
+    return originalSpawn.apply(this, args);
+  } as typeof child_process.spawn;
+}
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 

--- a/apps/server/src/checkpointing/Diffs.ts
+++ b/apps/server/src/checkpointing/Diffs.ts
@@ -6,6 +6,19 @@ export interface TurnDiffFileSummary {
   readonly deletions: number;
 }
 
+/**
+ * A submodule entry detected in a unified diff, with the old and new commit SHAs.
+ * Used to expand submodule changes into individual file diffs.
+ */
+export interface SubmoduleCommitChange {
+  readonly path: string;
+  readonly fromCommit: string | null;
+  readonly toCommit: string | null;
+}
+
+/** Match `Subproject commit <sha>` lines in unified diff hunks. */
+const SUBPROJECT_COMMIT_RE = /^Subproject commit ([0-9a-f]+)/;
+
 export function parseTurnDiffFilesFromUnifiedDiff(
   diff: string,
 ): ReadonlyArray<TurnDiffFileSummary> {
@@ -23,5 +36,56 @@ export function parseTurnDiffFilesFromUnifiedDiff(
     })),
   );
 
-  return files.toSorted((left, right) => left.path.localeCompare(right.path));
+  // Remove submodule parent entries when expanded child files exist.
+  // e.g. if both "submodules/pm-core" and "submodules/pm-core/src/file.ts" are
+  // present, drop the parent so the tree shows individual files instead.
+  const result = files.filter(
+    (file) => !files.some((other) => other.path.startsWith(`${file.path}/`)),
+  );
+
+  return result.toSorted((left, right) => left.path.localeCompare(right.path));
+}
+
+/**
+ * Extract submodule commit changes from a unified diff.
+ * These are entries where the diff shows `Subproject commit` lines
+ * (mode 160000 gitlinks).
+ */
+export function extractSubmoduleChanges(diff: string): ReadonlyArray<SubmoduleCommitChange> {
+  const normalized = diff.replace(/\r\n/g, "\n").trim();
+  if (normalized.length === 0) return [];
+
+  const changes: SubmoduleCommitChange[] = [];
+  // Split by `diff --git` headers.
+  const fileDiffs = normalized.split(/(?=^diff --git )/m);
+
+  for (const fileDiff of fileDiffs) {
+    if (!fileDiff.startsWith("diff --git ")) continue;
+    // Check for mode 160000 (gitlink / submodule).
+    if (!/\b160000\b/.test(fileDiff)) continue;
+
+    // Extract path from "diff --git a/<path> b/<path>".
+    const headerMatch = fileDiff.match(/^diff --git a\/(.+?) b\/(.+)/m);
+    if (!headerMatch) continue;
+    const filePath = headerMatch[2]!;
+
+    let fromCommit: string | null = null;
+    let toCommit: string | null = null;
+
+    for (const line of fileDiff.split("\n")) {
+      if (line.startsWith("-Subproject commit ")) {
+        const m = line.slice(1).match(SUBPROJECT_COMMIT_RE);
+        if (m) fromCommit = m[1]!;
+      } else if (line.startsWith("+Subproject commit ")) {
+        const m = line.slice(1).match(SUBPROJECT_COMMIT_RE);
+        if (m) toCommit = m[1]!;
+      }
+    }
+
+    if (fromCommit || toCommit) {
+      changes.push({ path: filePath, fromCommit, toCommit });
+    }
+  }
+
+  return changes;
 }

--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -14,6 +14,7 @@ import { randomUUID } from "node:crypto";
 import { Effect, Layer, FileSystem, Path } from "effect";
 
 import { CheckpointInvariantError } from "../Errors.ts";
+import { extractSubmoduleChanges } from "../Diffs.ts";
 import { GitCommandError } from "@t3tools/contracts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { CheckpointStore, type CheckpointStoreShape } from "../Services/CheckpointStore.ts";
@@ -86,6 +87,138 @@ const makeCheckpointStore = Effect.gen(function* () {
         Effect.catch(() => Effect.succeed(false)),
       );
 
+  /**
+   * Detect submodules with dirty working trees and create temporary commits
+   * inside each one, then update the parent's temp index so `git write-tree`
+   * captures the submodule's actual file state instead of its stale HEAD.
+   */
+  const captureSubmoduleSnapshots = Effect.fn("captureSubmoduleSnapshots")(function* (
+    cwd: string,
+    tempDir: string,
+    parentEnv: NodeJS.ProcessEnv,
+  ) {
+    // Detect submodule paths via .gitmodules config.
+    const submoduleListResult = yield* git.execute({
+      operation: "CheckpointStore.captureSubmoduleSnapshots.list",
+      cwd,
+      args: ["config", "--file", ".gitmodules", "--get-regexp", "^submodule\\..*\\.path$"],
+      allowNonZeroExit: true,
+    });
+    if (submoduleListResult.code !== 0 || submoduleListResult.stdout.trim().length === 0) {
+      return;
+    }
+
+    // Parse "submodule.<name>.path <value>" lines.
+    const submodulePaths: string[] = [];
+    for (const line of submoduleListResult.stdout.split(/\r?\n/g)) {
+      const parts = line.trim().split(/\s+/);
+      const subPath = parts.at(-1);
+      if (subPath && subPath.length > 0) {
+        submodulePaths.push(subPath);
+      }
+    }
+    if (submodulePaths.length === 0) return;
+
+    yield* Effect.all(
+      submodulePaths.map((subPath) =>
+        captureOneSubmoduleSnapshot(cwd, subPath, tempDir, parentEnv).pipe(
+          Effect.catch(() => Effect.void),
+        ),
+      ),
+      { concurrency: "unbounded" },
+    );
+  });
+
+  /**
+   * For a single submodule, create a temp commit from its working tree and
+   * update the parent's temp index to reference it.
+   */
+  const captureOneSubmoduleSnapshot = Effect.fn("captureOneSubmoduleSnapshot")(function* (
+    parentCwd: string,
+    submodulePath: string,
+    tempDir: string,
+    parentEnv: NodeJS.ProcessEnv,
+  ) {
+    const subCwd = path.join(parentCwd, submodulePath);
+
+    // Check that the submodule is an initialized git repo.
+    const isRepo = yield* git
+      .execute({
+        operation: "CheckpointStore.captureOneSubmoduleSnapshot.isRepo",
+        cwd: subCwd,
+        args: ["rev-parse", "--is-inside-work-tree"],
+        allowNonZeroExit: true,
+      })
+      .pipe(Effect.map((r) => r.code === 0 && r.stdout.trim() === "true"));
+    if (!isRepo) return;
+
+    // Check if the submodule has any dirty changes (staged or unstaged).
+    const statusResult = yield* git.execute({
+      operation: "CheckpointStore.captureOneSubmoduleSnapshot.status",
+      cwd: subCwd,
+      args: ["status", "--porcelain"],
+      allowNonZeroExit: true,
+    });
+    if (statusResult.code !== 0 || statusResult.stdout.trim().length === 0) {
+      return; // Clean submodule, nothing to snapshot.
+    }
+
+    // Create a temp index for the submodule and capture its working tree.
+    const subTempIndex = path.join(tempDir, `sub-index-${randomUUID()}`);
+    const subEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      GIT_INDEX_FILE: subTempIndex,
+      GIT_AUTHOR_NAME: "T3 Code",
+      GIT_AUTHOR_EMAIL: "t3code@users.noreply.github.com",
+      GIT_COMMITTER_NAME: "T3 Code",
+      GIT_COMMITTER_EMAIL: "t3code@users.noreply.github.com",
+    };
+
+    // Populate the temp index from the submodule's HEAD.
+    const subHasHead = yield* hasHeadCommit(subCwd);
+    if (subHasHead) {
+      yield* git.execute({
+        operation: "CheckpointStore.captureOneSubmoduleSnapshot.readTree",
+        cwd: subCwd,
+        args: ["read-tree", "HEAD"],
+        env: subEnv,
+      });
+    }
+
+    yield* git.execute({
+      operation: "CheckpointStore.captureOneSubmoduleSnapshot.add",
+      cwd: subCwd,
+      args: ["add", "-A", "--", "."],
+      env: subEnv,
+    });
+
+    const subTreeResult = yield* git.execute({
+      operation: "CheckpointStore.captureOneSubmoduleSnapshot.writeTree",
+      cwd: subCwd,
+      args: ["write-tree"],
+      env: subEnv,
+    });
+    const subTreeOid = subTreeResult.stdout.trim();
+    if (subTreeOid.length === 0) return;
+
+    const subCommitResult = yield* git.execute({
+      operation: "CheckpointStore.captureOneSubmoduleSnapshot.commitTree",
+      cwd: subCwd,
+      args: ["commit-tree", subTreeOid, "-m", "t3 submodule checkpoint snapshot"],
+      env: subEnv,
+    });
+    const subCommitOid = subCommitResult.stdout.trim();
+    if (subCommitOid.length === 0) return;
+
+    // Update the parent's temp index to point to this new submodule commit.
+    yield* git.execute({
+      operation: "CheckpointStore.captureOneSubmoduleSnapshot.updateParentIndex",
+      cwd: parentCwd,
+      args: ["update-index", "--cacheinfo", `160000,${subCommitOid},${submodulePath}`],
+      env: parentEnv,
+    });
+  });
+
   const captureCheckpoint: CheckpointStoreShape["captureCheckpoint"] = Effect.fn(
     "captureCheckpoint",
   )(function* (input) {
@@ -120,6 +253,12 @@ const makeCheckpointStore = Effect.gen(function* () {
           args: ["add", "-A", "--", "."],
           env: commitEnv,
         });
+
+        // Capture dirty submodule working trees into temporary commits so that
+        // the parent checkpoint tree reflects their actual file state.
+        yield* captureSubmoduleSnapshots(input.cwd, tempDir, commitEnv).pipe(
+          Effect.catch(() => Effect.void),
+        );
 
         const writeTreeResult = yield* git.execute({
           operation,
@@ -246,6 +385,49 @@ const makeCheckpointStore = Effect.gen(function* () {
         cwd: input.cwd,
         args: ["diff", "--patch", "--minimal", "--no-color", fromCommitOid, toCommitOid],
       });
+
+      // Expand submodule diffs: for each submodule whose commit changed, run
+      // git diff inside the submodule directory and append the file-level patch.
+      const submoduleChanges = extractSubmoduleChanges(result.stdout);
+      if (submoduleChanges.length > 0) {
+        const expansions = yield* Effect.all(
+          submoduleChanges.map((sub) => {
+            if (!sub.fromCommit || !sub.toCommit) return Effect.succeed("");
+            const subCwd = path.join(input.cwd, sub.path);
+            return git
+              .execute({
+                operation: "CheckpointStore.diffSubmodule",
+                cwd: subCwd,
+                args: [
+                  "diff",
+                  "--patch",
+                  "--minimal",
+                  "--no-color",
+                  "--ignore-submodules=all",
+                  sub.fromCommit,
+                  sub.toCommit,
+                ],
+              })
+              .pipe(
+                Effect.map((r) => {
+                  if (r.stdout.trim().length === 0) return "";
+                  // Rewrite paths in the submodule diff to be relative to parent.
+                  return r.stdout.replace(
+                    /^(diff --git a\/)(.+?)( b\/)(.+)/gm,
+                    `$1${sub.path}/$2$3${sub.path}/$4`,
+                  );
+                }),
+                Effect.catch(() => Effect.succeed("")),
+              );
+          }),
+          { concurrency: "unbounded" },
+        );
+
+        const expandedPatch = expansions.filter((p) => p.length > 0).join("\n");
+        if (expandedPatch.length > 0) {
+          return `${result.stdout}\n${expandedPatch}`;
+        }
+      }
 
       return result.stdout;
     },

--- a/apps/server/src/git/Layers/ClaudeTextGeneration.ts
+++ b/apps/server/src/git/Layers/ClaudeTextGeneration.ts
@@ -117,7 +117,6 @@ const makeClaudeTextGeneration = Effect.gen(function* () {
         ],
         {
           cwd,
-          shell: process.platform === "win32",
           stdin: {
             stream: Stream.encodeText(Stream.make(prompt)),
           },

--- a/apps/server/src/git/Layers/CodexTextGeneration.ts
+++ b/apps/server/src/git/Layers/CodexTextGeneration.ts
@@ -186,7 +186,6 @@ const makeCodexTextGeneration = Effect.gen(function* () {
             ...(codexSettings?.homePath ? { CODEX_HOME: codexSettings.homePath } : {}),
           },
           cwd,
-          shell: process.platform === "win32",
           stdin: {
             stream: Stream.encodeText(Stream.make(prompt)),
           },

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1713,6 +1713,134 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("detects submodule changes in status details", () =>
+      Effect.gen(function* () {
+        const ok = (stdout = "") =>
+          Effect.succeed({
+            code: 0,
+            stdout,
+            stderr: "",
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          });
+
+        const core = yield* makeIsolatedGitCore((input) => {
+          if (input.operation === "GitCore.statusDetails.status") {
+            return ok(
+              [
+                "# branch.head main",
+                "# branch.upstream origin/main",
+                "# branch.ab +0 -0",
+                "1 .M SC.. 160000 160000 160000 abc1234567890123456789012345678901234abcd def5678901234567890123456789012345678abcd my-submodule",
+                "1 .M N... 100644 100644 100644 abc1234567890123456789012345678901234abcd def5678901234567890123456789012345678abcd regular-file.ts",
+              ].join("\n"),
+            );
+          }
+          if (input.operation === "GitCore.statusDetails.unstagedNumstat") {
+            return ok("-\t-\tmy-submodule\n5\t2\tregular-file.ts");
+          }
+          if (input.operation === "GitCore.statusDetails.stagedNumstat") {
+            return ok("");
+          }
+          if (input.operation === "GitCore.statusDetails.defaultRef") {
+            return ok("refs/remotes/origin/main\n");
+          }
+          if (input.args[0] === "remote") {
+            return ok("origin\n");
+          }
+          return ok();
+        });
+
+        const details = yield* core.statusDetailsLocal("/repo");
+        expect(details.hasWorkingTreeChanges).toBe(true);
+        expect(details.workingTree.files).toHaveLength(2);
+
+        const submoduleFile = details.workingTree.files.find((f) => f.path === "my-submodule");
+        expect(submoduleFile).toBeDefined();
+        expect(submoduleFile!.isSubmodule).toBe(true);
+        expect(submoduleFile!.insertions).toBe(0);
+        expect(submoduleFile!.deletions).toBe(0);
+        // SC.. = commit-only change, no dirty content → no expanded files
+        expect(submoduleFile!.submoduleFiles).toBeUndefined();
+
+        const regularFile = details.workingTree.files.find((f) => f.path === "regular-file.ts");
+        expect(regularFile).toBeDefined();
+        expect(regularFile!.isSubmodule).toBeUndefined();
+        expect(regularFile!.insertions).toBe(5);
+        expect(regularFile!.deletions).toBe(2);
+      }),
+    );
+
+    it.effect("expands dirty submodule to show individual file changes", () =>
+      Effect.gen(function* () {
+        const ok = (stdout = "") =>
+          Effect.succeed({
+            code: 0,
+            stdout,
+            stderr: "",
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          });
+
+        const core = yield* makeIsolatedGitCore((input) => {
+          // Parent repo status: submodule with modified content (S.M.)
+          if (input.operation === "GitCore.statusDetails.status") {
+            return ok(
+              [
+                "# branch.head main",
+                "# branch.upstream origin/main",
+                "# branch.ab +0 -0",
+                "1 .M S.M. 160000 160000 160000 abc1234567890123456789012345678901234abcd def5678901234567890123456789012345678abcd submodules/pm-core",
+              ].join("\n"),
+            );
+          }
+          if (input.operation === "GitCore.statusDetails.unstagedNumstat") {
+            return ok("-\t-\tsubmodules/pm-core");
+          }
+          if (input.operation === "GitCore.statusDetails.stagedNumstat") {
+            return ok("");
+          }
+          if (input.operation === "GitCore.statusDetails.defaultRef") {
+            return ok("refs/remotes/origin/main\n");
+          }
+          if (input.args[0] === "remote") {
+            return ok("origin\n");
+          }
+
+          // Submodule-level git commands (cwd ends with submodule path)
+          if (input.operation === "GitCore.expandSubmodule.unstagedNumstat") {
+            return ok("10\t3\tsrc/core.ts\n2\t1\tsrc/utils.ts");
+          }
+          if (input.operation === "GitCore.expandSubmodule.stagedNumstat") {
+            return ok("");
+          }
+          if (input.operation === "GitCore.expandSubmodule.status") {
+            return ok("? new-file.txt");
+          }
+
+          return ok();
+        });
+
+        const details = yield* core.statusDetailsLocal("/repo");
+        expect(details.hasWorkingTreeChanges).toBe(true);
+
+        const subEntry = details.workingTree.files.find((f) => f.path === "submodules/pm-core");
+        expect(subEntry).toBeDefined();
+        expect(subEntry!.isSubmodule).toBe(true);
+        expect(subEntry!.submoduleFiles).toBeDefined();
+        expect(subEntry!.submoduleFiles).toHaveLength(3);
+
+        const coreFile = subEntry!.submoduleFiles!.find((f) => f.path === "src/core.ts");
+        expect(coreFile).toEqual({ path: "src/core.ts", insertions: 10, deletions: 3 });
+
+        const utilsFile = subEntry!.submoduleFiles!.find((f) => f.path === "src/utils.ts");
+        expect(utilsFile).toEqual({ path: "src/utils.ts", insertions: 2, deletions: 1 });
+
+        const newFile = subEntry!.submoduleFiles!.find((f) => f.path === "new-file.txt");
+        expect(newFile).toEqual({ path: "new-file.txt", insertions: 0, deletions: 0 });
+      }),
+    );
+
     it.effect("computes ahead count against base branch when no upstream is configured", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -167,26 +167,46 @@ function chunkPathsForGitCheckIgnore(relativePaths: readonly string[]): string[]
   return chunks;
 }
 
-function parsePorcelainPath(line: string): string | null {
+function parsePorcelainEntry(
+  line: string,
+): { path: string; isSubmodule: boolean; isSubmoduleDirty: boolean } | null {
+  // Untracked (?) and ignored (!) entries are never submodules.
   if (line.startsWith("? ") || line.startsWith("! ")) {
     const simple = line.slice(2).trim();
-    return simple.length > 0 ? simple : null;
+    return simple.length > 0 ? { path: simple, isSubmodule: false, isSubmoduleDirty: false } : null;
   }
 
+  // Ordinary changed (1), rename/copy (2), unmerged (u) entries.
   if (!(line.startsWith("1 ") || line.startsWith("2 ") || line.startsWith("u "))) {
     return null;
   }
 
+  // Detect submodule via the <sub> field at space-separated index 2.
+  // Porcelain v2 format: "1 XY <sub> <mH> <mI> <mW> <hH> <hI> <path>"
+  // <sub> is "N..." for non-submodules or "S<C><M><U>" for submodules.
+  // Submodule flags: S=submodule, C=commits differ, M=modified content, U=untracked content.
+  let isSubmodule = false;
+  let isSubmoduleDirty = false;
+  const spaceFields = line.split(/\s+/);
+  const subField = spaceFields[2];
+  if (subField && subField.startsWith("S")) {
+    isSubmodule = true;
+    // Dirty when submodule has modified tracked content (M) or untracked files (U).
+    isSubmoduleDirty = subField.includes("M") || subField.includes("U");
+  }
+
+  // Extract the file path (after tab for rename/copy, or last space-separated token).
   const tabIndex = line.indexOf("\t");
   if (tabIndex >= 0) {
     const fromTab = line.slice(tabIndex + 1);
     const [filePath] = fromTab.split("\t");
-    return filePath?.trim().length ? filePath.trim() : null;
+    const path = filePath?.trim();
+    return path && path.length > 0 ? { path, isSubmodule, isSubmoduleDirty } : null;
   }
 
   const parts = line.trim().split(/\s+/g);
   const filePath = parts.at(-1) ?? "";
-  return filePath.length > 0 ? filePath : null;
+  return filePath.length > 0 ? { path: filePath, isSubmodule, isSubmoduleDirty } : null;
 }
 
 function parseBranchLine(line: string): { name: string; current: boolean } | null {
@@ -1196,6 +1216,67 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     return branchLastCommit;
   });
 
+  /**
+   * Fetch individual file changes inside a dirty submodule by running
+   * git diff/status within the submodule directory itself.
+   */
+  const expandDirtySubmoduleFiles = Effect.fn("expandDirtySubmoduleFiles")(function* (
+    parentCwd: string,
+    submodulePath: string,
+  ) {
+    const submoduleCwd = path.join(parentCwd, submodulePath);
+    const [unstagedStdout, stagedStdout, statusResult] = yield* Effect.all(
+      [
+        runGitStdout("GitCore.expandSubmodule.unstagedNumstat", submoduleCwd, [
+          "diff",
+          "--numstat",
+          "--ignore-submodules=all",
+        ]),
+        runGitStdout("GitCore.expandSubmodule.stagedNumstat", submoduleCwd, [
+          "diff",
+          "--cached",
+          "--numstat",
+          "--ignore-submodules=all",
+        ]),
+        executeGit("GitCore.expandSubmodule.status", submoduleCwd, ["status", "--porcelain=2"], {
+          allowNonZeroExit: true,
+          timeoutMs: 10_000,
+        }),
+      ],
+      { concurrency: "unbounded" },
+    );
+
+    const allNumstat = [
+      ...parseNumstatEntries(unstagedStdout),
+      ...parseNumstatEntries(stagedStdout),
+    ];
+    const fileMap = new Map<string, { insertions: number; deletions: number }>();
+    for (const entry of allNumstat) {
+      const existing = fileMap.get(entry.path) ?? { insertions: 0, deletions: 0 };
+      existing.insertions += entry.insertions;
+      existing.deletions += entry.deletions;
+      fileMap.set(entry.path, existing);
+    }
+
+    // Pick up untracked files from the submodule's porcelain output.
+    if (statusResult.code === 0) {
+      for (const line of statusResult.stdout.split(/\r?\n/g)) {
+        const entry = parsePorcelainEntry(line);
+        if (entry && !fileMap.has(entry.path)) {
+          fileMap.set(entry.path, { insertions: 0, deletions: 0 });
+        }
+      }
+    }
+
+    return Array.from(fileMap.entries())
+      .map(([filePath, stat]) => ({
+        path: filePath,
+        insertions: stat.insertions,
+        deletions: stat.deletions,
+      }))
+      .toSorted((a, b) => a.path.localeCompare(b.path));
+  });
+
   const readStatusDetailsLocal = Effect.fn("readStatusDetailsLocal")(function* (cwd: string) {
     const statusResult = yield* executeGit(
       "GitCore.statusDetails.status",
@@ -1252,7 +1333,10 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     let aheadCount = 0;
     let behindCount = 0;
     let hasWorkingTreeChanges = false;
-    const changedFilesWithoutNumstat = new Set<string>();
+    const changedFileEntries = new Map<
+      string,
+      { isSubmodule: boolean; isSubmoduleDirty: boolean }
+    >();
 
     for (const line of statusStdout.split(/\r?\n/g)) {
       if (line.startsWith("# branch.head ")) {
@@ -1274,8 +1358,13 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       }
       if (line.trim().length > 0 && !line.startsWith("#")) {
         hasWorkingTreeChanges = true;
-        const pathValue = parsePorcelainPath(line);
-        if (pathValue) changedFilesWithoutNumstat.add(pathValue);
+        const entry = parsePorcelainEntry(line);
+        if (entry) {
+          changedFileEntries.set(entry.path, {
+            isSubmodule: entry.isSubmodule,
+            isSubmoduleDirty: entry.isSubmoduleDirty,
+          });
+        }
       }
     }
 
@@ -1288,9 +1377,17 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
 
     const stagedEntries = parseNumstatEntries(stagedNumstatStdout);
     const unstagedEntries = parseNumstatEntries(unstagedNumstatStdout);
-    const fileStatMap = new Map<string, { insertions: number; deletions: number }>();
+    const fileStatMap = new Map<
+      string,
+      { insertions: number; deletions: number; isSubmodule: boolean }
+    >();
     for (const entry of [...stagedEntries, ...unstagedEntries]) {
-      const existing = fileStatMap.get(entry.path) ?? { insertions: 0, deletions: 0 };
+      const porcelainMeta = changedFileEntries.get(entry.path);
+      const existing = fileStatMap.get(entry.path) ?? {
+        insertions: 0,
+        deletions: 0,
+        isSubmodule: porcelainMeta?.isSubmodule ?? false,
+      };
       existing.insertions += entry.insertions;
       existing.deletions += entry.deletions;
       fileStatMap.set(entry.path, existing);
@@ -1302,15 +1399,60 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       .map(([filePath, stat]) => {
         insertions += stat.insertions;
         deletions += stat.deletions;
-        return { path: filePath, insertions: stat.insertions, deletions: stat.deletions };
+        const entry: {
+          path: string;
+          insertions: number;
+          deletions: number;
+          isSubmodule?: true;
+        } = {
+          path: filePath,
+          insertions: stat.insertions,
+          deletions: stat.deletions,
+        };
+        if (stat.isSubmodule) entry.isSubmodule = true;
+        return entry;
       })
       .toSorted((a, b) => a.path.localeCompare(b.path));
 
-    for (const filePath of changedFilesWithoutNumstat) {
+    for (const [filePath, meta] of changedFileEntries) {
       if (fileStatMap.has(filePath)) continue;
-      files.push({ path: filePath, insertions: 0, deletions: 0 });
+      const entry: { path: string; insertions: number; deletions: number; isSubmodule?: true } = {
+        path: filePath,
+        insertions: 0,
+        deletions: 0,
+      };
+      if (meta.isSubmodule) entry.isSubmodule = true;
+      files.push(entry);
     }
     files.sort((a, b) => a.path.localeCompare(b.path));
+
+    // Expand dirty submodules: fetch individual file changes inside each one.
+    const dirtySubmodules = files.filter(
+      (f) => f.isSubmodule && changedFileEntries.get(f.path)?.isSubmoduleDirty,
+    );
+    if (dirtySubmodules.length > 0) {
+      const expansions = yield* Effect.all(
+        dirtySubmodules.map((sub) =>
+          expandDirtySubmoduleFiles(cwd, sub.path).pipe(
+            Effect.catch(() =>
+              Effect.succeed([] as Array<{ path: string; insertions: number; deletions: number }>),
+            ),
+          ),
+        ),
+        { concurrency: "unbounded" },
+      );
+      for (let i = 0; i < dirtySubmodules.length; i++) {
+        const subEntry = dirtySubmodules[i]!;
+        const subFiles = expansions[i]!;
+        if (subFiles.length > 0) {
+          (
+            subEntry as {
+              submoduleFiles?: Array<{ path: string; insertions: number; deletions: number }>;
+            }
+          ).submoduleFiles = subFiles;
+        }
+      }
+    }
 
     return {
       isRepo: true,
@@ -1384,6 +1526,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       "diff",
       "--cached",
       "--name-status",
+      "--submodule=short",
     ]).pipe(Effect.map((stdout) => stdout.trim()));
     if (stagedSummary.length === 0) {
       return null;
@@ -1392,7 +1535,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     const stagedPatch = yield* runGitStdoutWithOptions(
       "GitCore.prepareCommitContext.stagedPatch",
       cwd,
-      ["diff", "--cached", "--patch", "--minimal"],
+      ["diff", "--cached", "--patch", "--minimal", "--submodule=short"],
       {
         maxOutputBytes: PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES,
         truncateOutputAtMaxBytes: true,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2314,12 +2314,14 @@ export default function ChatView(props: ChatViewProps) {
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
       });
+      const planFollowUpImages = [...composerImages];
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);
       composerRef.current?.resetCursorState();
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
+        images: planFollowUpImages,
       });
       return;
     }
@@ -2752,9 +2754,11 @@ export default function ChatView(props: ChatViewProps) {
     async ({
       text,
       interactionMode: nextInteractionMode,
+      images = [],
     }: {
       text: string;
       interactionMode: "default" | "plan";
+      images?: ReadonlyArray<ComposerImageAttachment>;
     }) => {
       const api = readEnvironmentApi(environmentId);
       if (
@@ -2796,6 +2800,27 @@ export default function ChatView(props: ChatViewProps) {
         text: trimmed,
       });
 
+      const turnAttachmentsPromise =
+        images.length > 0
+          ? Promise.all(
+              images.map(async (image) => ({
+                type: "image" as const,
+                name: image.name,
+                mimeType: image.mimeType,
+                sizeBytes: image.sizeBytes,
+                dataUrl: await readFileAsDataUrl(image.file),
+              })),
+            )
+          : Promise.resolve([]);
+      const optimisticAttachments = images.map((image) => ({
+        type: "image" as const,
+        id: image.id,
+        name: image.name,
+        mimeType: image.mimeType,
+        sizeBytes: image.sizeBytes,
+        previewUrl: image.previewUrl,
+      }));
+
       sendInFlightRef.current = true;
       beginLocalDispatch({ preparingWorktree: false });
       setThreadError(threadIdForSend, null);
@@ -2812,12 +2837,15 @@ export default function ChatView(props: ChatViewProps) {
           id: messageIdForSend,
           role: "user",
           text: outgoingMessageText,
+          ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
           createdAt: messageCreatedAt,
           streaming: false,
         },
       ]);
 
       try {
+        const turnAttachments = await turnAttachmentsPromise;
+
         await persistThreadSettingsForNextTurn({
           threadId: threadIdForSend,
           createdAt: messageCreatedAt,
@@ -2841,7 +2869,7 @@ export default function ChatView(props: ChatViewProps) {
             messageId: messageIdForSend,
             role: "user",
             text: outgoingMessageText,
-            attachments: [],
+            attachments: turnAttachments,
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: activeThread.title,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -7,7 +7,13 @@ import type {
 } from "@t3tools/contracts";
 import { useIsMutating, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
-import { ChevronDownIcon, CloudUploadIcon, GitCommitIcon, InfoIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  CloudUploadIcon,
+  GitCommitIcon,
+  InfoIcon,
+  PackageIcon,
+} from "lucide-react";
 import { GitHubIcon } from "./Icons";
 import {
   buildGitActionProgressStages,
@@ -1042,61 +1048,112 @@ export default function GitActionsControl({
                         {allFiles.map((file) => {
                           const isExcluded = excludedFiles.has(file.path);
                           return (
-                            <div
-                              key={file.path}
-                              className="flex w-full items-center gap-2 rounded-md px-2 py-1 font-mono text-xs transition-colors hover:bg-accent/50"
-                            >
-                              {isEditingFiles && (
-                                <Checkbox
-                                  checked={!excludedFiles.has(file.path)}
-                                  onCheckedChange={() => {
-                                    setExcludedFiles((prev) => {
-                                      const next = new Set(prev);
-                                      if (next.has(file.path)) {
-                                        next.delete(file.path);
-                                      } else {
-                                        next.add(file.path);
-                                      }
-                                      return next;
-                                    });
-                                  }}
-                                />
-                              )}
-                              <button
-                                type="button"
-                                className="flex flex-1 items-center justify-between gap-3 text-left truncate"
-                                onClick={() => openChangedFileInEditor(file.path)}
-                              >
-                                <span
-                                  className={`truncate${isExcluded ? " text-muted-foreground" : ""}`}
+                            <div key={file.path}>
+                              <div className="flex w-full items-center gap-2 rounded-md px-2 py-1 font-mono text-xs transition-colors hover:bg-accent/50">
+                                {isEditingFiles && (
+                                  <Checkbox
+                                    checked={!excludedFiles.has(file.path)}
+                                    onCheckedChange={() => {
+                                      setExcludedFiles((prev) => {
+                                        const next = new Set(prev);
+                                        if (next.has(file.path)) {
+                                          next.delete(file.path);
+                                        } else {
+                                          next.add(file.path);
+                                        }
+                                        return next;
+                                      });
+                                    }}
+                                  />
+                                )}
+                                <button
+                                  type="button"
+                                  className="flex flex-1 items-center justify-between gap-3 text-left truncate"
+                                  onClick={() => openChangedFileInEditor(file.path)}
                                 >
-                                  {file.path}
-                                </span>
-                                <span className="shrink-0">
-                                  {isExcluded ? (
-                                    <span className="text-muted-foreground">Excluded</span>
-                                  ) : (
-                                    <>
-                                      <span className="text-success">+{file.insertions}</span>
-                                      <span className="text-muted-foreground"> / </span>
-                                      <span className="text-destructive">-{file.deletions}</span>
-                                    </>
-                                  )}
-                                </span>
-                              </button>
+                                  <span
+                                    className={`flex items-center gap-1.5 truncate${isExcluded ? " text-muted-foreground" : ""}`}
+                                  >
+                                    {file.isSubmodule && (
+                                      <PackageIcon className="size-3 shrink-0 text-muted-foreground" />
+                                    )}
+                                    <span className="truncate">{file.path}</span>
+                                  </span>
+                                  <span className="shrink-0">
+                                    {isExcluded ? (
+                                      <span className="text-muted-foreground">Excluded</span>
+                                    ) : file.isSubmodule ? (
+                                      <span className="text-muted-foreground italic">
+                                        submodule
+                                      </span>
+                                    ) : (
+                                      <>
+                                        <span className="text-success">+{file.insertions}</span>
+                                        <span className="text-muted-foreground"> / </span>
+                                        <span className="text-destructive">-{file.deletions}</span>
+                                      </>
+                                    )}
+                                  </span>
+                                </button>
+                              </div>
+                              {file.isSubmodule &&
+                                file.submoduleFiles &&
+                                file.submoduleFiles.length > 0 &&
+                                !isExcluded && (
+                                  <div className="ml-6 border-l border-border/50 pl-2">
+                                    {file.submoduleFiles.map((subFile) => (
+                                      <div
+                                        key={subFile.path}
+                                        className="flex items-center justify-between gap-3 rounded-md px-2 py-0.5 font-mono text-[11px] text-muted-foreground"
+                                      >
+                                        <span className="truncate">{subFile.path}</span>
+                                        <span className="shrink-0">
+                                          <span className="text-success/80">
+                                            +{subFile.insertions}
+                                          </span>
+                                          <span className="text-muted-foreground"> / </span>
+                                          <span className="text-destructive/80">
+                                            -{subFile.deletions}
+                                          </span>
+                                        </span>
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
                             </div>
                           );
                         })}
                       </div>
                     </ScrollArea>
-                    <div className="flex justify-end font-mono">
-                      <span className="text-success">
-                        +{selectedFiles.reduce((sum, f) => sum + f.insertions, 0)}
-                      </span>
-                      <span className="text-muted-foreground"> / </span>
-                      <span className="text-destructive">
-                        -{selectedFiles.reduce((sum, f) => sum + f.deletions, 0)}
-                      </span>
+                    <div className="flex justify-end gap-2 font-mono">
+                      {(() => {
+                        const regularFiles = selectedFiles.filter((f) => !f.isSubmodule);
+                        const submoduleCount = selectedFiles.length - regularFiles.length;
+                        const totalInsertions = regularFiles.reduce(
+                          (sum, f) => sum + f.insertions,
+                          0,
+                        );
+                        const totalDeletions = regularFiles.reduce(
+                          (sum, f) => sum + f.deletions,
+                          0,
+                        );
+                        return (
+                          <>
+                            {regularFiles.length > 0 && (
+                              <>
+                                <span className="text-success">+{totalInsertions}</span>
+                                <span className="text-muted-foreground">/</span>
+                                <span className="text-destructive">-{totalDeletions}</span>
+                              </>
+                            )}
+                            {submoduleCount > 0 && (
+                              <span className="text-muted-foreground italic">
+                                {submoduleCount} {submoduleCount === 1 ? "submodule" : "submodules"}
+                              </span>
+                            )}
+                          </>
+                        );
+                      })()}
                     </div>
                   </div>
                 )}

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -213,6 +213,16 @@ const GitStatusLocalShape = {
         path: TrimmedNonEmptyStringSchema,
         insertions: NonNegativeInt,
         deletions: NonNegativeInt,
+        isSubmodule: Schema.optional(Schema.Boolean),
+        submoduleFiles: Schema.optional(
+          Schema.Array(
+            Schema.Struct({
+              path: TrimmedNonEmptyStringSchema,
+              insertions: NonNegativeInt,
+              deletions: NonNegativeInt,
+            }),
+          ),
+        ),
       }),
     ),
     insertions: NonNegativeInt,


### PR DESCRIPTION
## What Changed
*   **Detailed Submodule Management**: The application now deeply integrates with Git submodules. This includes detecting individual file changes within dirty submodules for `git status` and expanding submodule commit diffs into file-level patches. Checkpoints also now accurately capture the working tree state of dirty submodules, ensuring comprehensive snapshots.
*   **Image Attachments in Chat**: Users can now include image attachments when submitting plan follow-up messages in the chat view, providing richer context.
*   **Bun Runtime Adoption**: Server-side build scripts have been migrated to utilize the `bun` runtime for improved performance.
*   **Git Command Execution**: Simplified `git` command execution by removing redundant `shell: true` options.

## Why
This update significantly improves the handling of Git submodules, offering greater transparency and control over changes within them. Users working with repositories that use submodules will now benefit from seeing granular file-level modifications, not just commit hash changes, in their local status, generated diffs, and checkpoints. This provides a more complete and accurate understanding of their codebase state.

Additionally, the ability to attach images to plan follow-up messages enhances communication by allowing for visual explanations and context sharing directly within the conversation flow. The move to `bun` streamlines our build processes, contributing to overall system efficiency.

## UI Changes
*   The Git actions control now visually identifies submodules with a dedicated icon.
*   For dirty submodules, the file list within the Git actions control will now expand to show individual file changes (insertions and deletions) inside the submodule.
*   The summary of changes at the bottom of the Git actions control now differentiates between regular file changes and the number of changed submodules.
*   The chat composer now supports adding image attachments for plan follow-up messages.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches git status/diff and checkpoint capture logic (including submodule expansion and temp commits), which can affect correctness and performance across many repos. Also changes client message attachment handling and server process spawning behavior, requiring cross-platform validation.
> 
> **Overview**
> **Git submodule support is expanded end-to-end.** `GitCore.statusDetailsLocal` now detects submodule entries, marks them with `isSubmodule`, and (when dirty) expands them into per-file `submoduleFiles`; the contracts schema is updated accordingly and UI (`GitActionsControl`) renders submodules distinctly (icon/label), shows nested file stats, and excludes submodules from line-change totals.
> 
> **Checkpoint diff/capture now accounts for submodules.** Checkpoint capture snapshots dirty submodule working trees via temporary submodule commits referenced in the parent temp index, and `diffCheckpoints` expands gitlink changes by running diffs inside each submodule and rewriting paths; unified-diff file summaries now drop parent paths when child paths exist.
> 
> **Chat plan follow-ups can include images.** `ChatView` carries composer images through plan follow-up submission, shows optimistic attachments, and sends image data URLs to the server.
> 
> **Tooling/process tweaks.** Server build/publish CLI switches to Bun (`#!/usr/bin/env bun`, `bun scripts/cli.ts build`), Windows child process spawning is patched to default `windowsHide`, and text-generation layers stop forcing `shell` on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f73f024480708f0e7eb2906cfd445402858a1b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add submodule support to Git status and checkpointing, and fix image attachments in plan follow-ups
> - `GitCore.readStatusDetailsLocal` now detects submodule entries via porcelain v2, expands dirty submodules to per-file changes using `git diff --numstat` and `git status`, and includes this in the `GitStatusLocalShape` contract
> - Checkpoint capture in `CheckpointStore` records dirty submodule working trees as temporary commits in the parent tree, and `diffCheckpoints` expands submodule diffs to file-level patches with rewritten path prefixes
> - The commit dialog in `GitActionsControl` visually distinguishes submodules with an icon, italic label, and indented per-file stats; totals exclude submodule commit-only changes
> - Images attached to plan follow-up messages are now preserved, rendered optimistically, and transmitted in the turn start payload instead of being dropped
> - On Windows, a global patch in `bin.ts` sets `windowsHide=true` on all `child_process.spawn` calls by default, and the `shell: process.platform === 'win32'` option is removed from Claude and Codex subprocess spawning
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f73f024.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->