### PR TITLE
fix: avoid copy button overlapping long code blocks

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -341,12 +341,14 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown .chat-markdown-codeblock {
+  --chat-markdown-codeblock-copy-button-space: 1.5rem;
   position: relative;
   margin: 0.65rem 0;
 }
 
 .chat-markdown .chat-markdown-codeblock pre {
   margin: 0;
+  padding-right: calc(0.9rem + var(--chat-markdown-codeblock-copy-button-space));
 }
 
 .chat-markdown .chat-markdown-copy-button {
@@ -363,6 +365,7 @@ label:has(> select#reasoning-effort) select {
   border: 1px solid var(--border);
   background: color-mix(in srgb, var(--background) 82%, transparent);
   color: var(--muted-foreground);
+  cursor: pointer;
   opacity: 0;
   pointer-events: none;
   transition:


### PR DESCRIPTION
## What Changed

Adjusted the chat markdown code block styling so long single-line snippets no longer render underneath the copy button. The code block now reserves space on the right for the button, and the copy button shows a pointer cursor so it reads as interactive.

## Why

Long one-line code blocks, such as shell commands, could scroll their final characters underneath the copy button, which made the output harder to read. Reserving that space keeps the full line visible while preserving the existing copy affordance.

## UI Changes

**Before:**

<img width="914" height="720" alt="Before" src="https://github.com/user-attachments/assets/ad5990d8-f90e-4b27-af72-f89bb9c18ed7" />

**After:**

<img width="1092" height="798" alt="After" src="https://github.com/user-attachments/assets/7862eab1-8635-4d88-b59e-db7d3021127c" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

This addresses https://github.com/pingdotgg/t3code/issues/1531

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change limited to chat markdown code block presentation; main risk is minor layout regressions across themes/screen sizes.
> 
> **Overview**
> Chat markdown code blocks now **reserve horizontal space** for the copy button by adding right padding to the `pre`, preventing long single-line snippets from being obscured.
> 
> Also makes the copy button feel interactive by setting `cursor: pointer` (no behavior changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba24fd5dd7edf271bdb98aaf2ad997f7c6a3eeac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix copy button overlapping long code blocks in chat markdown
> Adds right-side padding to `pre` elements inside `.chat-markdown-codeblock` so code content no longer runs under the copy button. Uses a CSS custom property `--chat-markdown-codeblock-copy-button-space` to keep the spacing consistent. Also adds `cursor: pointer` to the copy button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba24fd5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->