### PR TITLE
Fix mobile new-thread action visibility

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -1629,21 +1629,32 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         });
         return;
       }
+
+      const rawBlock = block as {
+        readonly type?: string;
+        readonly name?: unknown;
+        readonly input?: unknown;
+        readonly id?: unknown;
+      };
       if (
-        block.type !== "tool_use" &&
-        block.type !== "server_tool_use" &&
-        block.type !== "mcp_tool_use"
+        rawBlock.type !== "tool_use" &&
+        rawBlock.type !== "server_tool_use" &&
+        rawBlock.type !== "mcp_tool_use"
       ) {
         return;
       }
 
-      const toolName = block.name;
+      if (typeof rawBlock.name !== "string" || typeof rawBlock.id !== "string") {
+        return;
+      }
+
+      const toolName = rawBlock.name;
       const itemType = classifyToolItemType(toolName);
       const toolInput =
-        typeof block.input === "object" && block.input !== null
-          ? (block.input as Record<string, unknown>)
+        typeof rawBlock.input === "object" && rawBlock.input !== null
+          ? (rawBlock.input as Record<string, unknown>)
           : {};
-      const itemId = block.id;
+      const itemId = rawBlock.id;
       const detail = summarizeToolRequest(toolName, toolInput);
       const inputFingerprint =
         Object.keys(toolInput).length > 0 ? toolInputFingerprint(toolInput) : undefined;

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -3474,6 +3474,45 @@ describe("ChatView timeline estimator parity (full app)", () => {
       await mounted.cleanup();
     }
   });
+
+  it("shows the project new-thread action on mobile without hover", async () => {
+    const mounted = await mountChatView({
+      viewport: COMPACT_FOOTER_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-mobile-new-thread-test" as MessageId,
+        targetText: "mobile new thread target",
+      }),
+    });
+
+    try {
+      await page.getByRole("button", { name: "Toggle Sidebar" }).click();
+      await waitForLayout();
+
+      const newThreadButton = await waitForElement(
+        () => document.querySelector<HTMLButtonElement>('[data-testid="new-thread-button"]'),
+        "Unable to find new thread button.",
+      );
+      const newThreadAction = newThreadButton.parentElement;
+
+      expect(
+        newThreadAction,
+        "New-thread button should render inside a visibility wrapper.",
+      ).not.toBeNull();
+      expect(getComputedStyle(newThreadAction!).opacity).toBe("1");
+      expect(getComputedStyle(newThreadAction!).pointerEvents).toBe("auto");
+
+      await newThreadButton.click();
+
+      await waitForURL(
+        mounted.router,
+        (path) => UUID_ROUTE_RE.test(path),
+        "Mobile new-thread action should create a draft thread without hover.",
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("creates a fresh draft after the previous draft thread is promoted", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1682,7 +1682,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         <SidebarMenuButton
           ref={isManualProjectSorting ? dragHandleProps?.setActivatorNodeRef : undefined}
           size="sm"
-          className={`gap-2 px-2 py-1.5 text-left hover:bg-accent group-hover/project-header:bg-accent group-hover/project-header:text-sidebar-accent-foreground ${
+          className={`gap-2 pl-2 pr-8 py-1.5 text-left hover:bg-accent group-hover/project-header:bg-accent group-hover/project-header:text-sidebar-accent-foreground ${
             isManualProjectSorting ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"
           }`}
           {...(isManualProjectSorting && dragHandleProps ? dragHandleProps.attributes : {})}
@@ -1732,7 +1732,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                       ? "Remote project"
                       : "Available in multiple environments"
                   }
-                  className="pointer-events-none absolute top-1 right-1.5 inline-flex size-5 items-center justify-center rounded-md text-muted-foreground/50 transition-opacity duration-150 group-hover/project-header:opacity-0 group-focus-within/project-header:opacity-0"
+                  className="pointer-events-none absolute top-1 right-1.5 hidden size-5 items-center justify-center rounded-md text-muted-foreground/50 transition-opacity duration-150 md:inline-flex md:group-hover/project-header:opacity-0 md:group-focus-within/project-header:opacity-0"
                 />
               }
             >
@@ -1746,7 +1746,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         <Tooltip>
           <TooltipTrigger
             render={
-              <div className="pointer-events-none absolute top-1 right-1.5 opacity-0 transition-opacity duration-150 group-hover/project-header:pointer-events-auto group-hover/project-header:opacity-100 group-focus-within/project-header:pointer-events-auto group-focus-within/project-header:opacity-100">
+              <div className="pointer-events-auto absolute top-1 right-1.5 opacity-100 transition-opacity duration-150 md:pointer-events-none md:opacity-0 md:group-hover/project-header:pointer-events-auto md:group-hover/project-header:opacity-100 md:group-focus-within/project-header:pointer-events-auto md:group-focus-within/project-header:opacity-100">
                 <button
                   type="button"
                   aria-label={`Create new thread in ${project.name}`}


### PR DESCRIPTION
Closes #1924

## What was broken

On mobile, the project header hid the new-thread action behind desktop-style hover behavior, so touch users could not reliably start a thread from the sidebar.

## Root cause

The project header crossfaded the remote badge and the new-thread action using hover/focus-only visibility rules. In the mobile sidebar sheet there is no reliable hover state, so the action stayed hidden and non-interactive.

## What changed

- reserve stable space for the project-header action slot
- show the new-thread action by default in the mobile sidebar layout while keeping the desktop hover/focus reveal
- add a focused browser regression that opens the mobile sidebar and verifies the action is visible and creates a draft thread without hover
- tighten Claude content-block narrowing so the repository typecheck stays green with the current SDK typings


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix new-thread action visibility in mobile sidebar for project items
> - In [`Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/1988/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), the new-thread action on `SidebarProjectItem` is now always visible and clickable on small screens (opacity 100, pointer-events auto), with hover/focus behavior retained on medium screens and above via `md:` prefixes.
> - The remote environment cloud icon is hidden on small screens to free space for the action button.
> - Project header button padding is adjusted from `px-2` to `pl-2 pr-8` to accommodate the action on the right.
> - A browser test in [`ChatView.browser.tsx`](https://github.com/pingdotgg/t3code/pull/1988/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) verifies the button is visible and clickable in a compact viewport without hover.
> - Defensive null checks are added in [`ClaudeAdapter.ts`](https://github.com/pingdotgg/t3code/pull/1988/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) to ignore tool-use content blocks with missing or non-string `name` or `id`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5bf922f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tweaks sidebar interaction/visibility rules across breakpoints and adds a mobile regression test; also tightens Claude SDK stream event parsing, which could affect tool-call event emission if unexpected payload shapes appear.
> 
> **Overview**
> Fixes the project-level **New thread** action in the sidebar so it is *visible and clickable on mobile* without relying on hover/focus, while preserving the existing hover/focus reveal behavior on `md+` screens and adjusting header padding/spacing accordingly.
> 
> Adds a browser regression test ensuring the mobile sidebar sheet shows the action with `pointer-events` enabled and that tapping it navigates to a new draft thread route.
> 
> Hardens `ClaudeAdapter` tool-use `content_block_start` handling by narrowing/validating `type`, `name`, and `id` before treating a block as a tool call, avoiding unsafe access under current SDK typings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf922f38111f348e8a928443e82f9c27f63287b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->