### PR TITLE
Pad composer model picker to prevent ring clipping

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1902,7 +1902,7 @@ export const ChatComposer = memo(
                   isComposerFooterCompact ? "gap-1.5" : "gap-2 sm:gap-0",
                 )}
               >
-                <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                <div className="-m-1 flex min-w-0 flex-1 items-center gap-1 overflow-x-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                   <ProviderModelPicker
                     compact={isComposerFooterCompact}
                     provider={selectedProvider}


### PR DESCRIPTION
Before
<img width="1194" height="188" alt="image" src="https://github.com/user-attachments/assets/45b44777-a405-4980-a0cd-dc9e52894fbd" />


After 
<img width="1706" height="552" alt="CleanShot 2026-04-13 at 10 57 06@2x" src="https://github.com/user-attachments/assets/daa95875-7ec9-42ad-a8c7-c5f7bc6e14d0" />



## Summary
- Add padding around the composer model picker container so focus rings no longer get clipped.
- Preserve the existing compact layout and horizontal scrolling behavior.

## Testing
- Not run (PR content only).
- Visual check recommended for the composer footer focus ring in both compact and regular states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, CSS-only layout tweak to add padding around the composer footer model picker area; minimal functional risk beyond potential minor spacing/scroll behavior changes.
> 
> **Overview**
> Adjusts the chat composer footer layout by adding padding (and compensating negative margin) to the horizontally scrollable container that wraps `ProviderModelPicker`, preventing focus rings from being clipped while keeping the compact/scrolling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd1dfb23a9e208be932d612f8af21be57e86fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pad composer model picker to prevent focus ring clipping
> Adds `-m-1 p-1` to the provider/model picker container in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/1992/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) so the focus ring is no longer clipped by the scrollable footer area.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dd1dfb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->