### PR TITLE
feat: show full thread title in a tooltip when hovering sidebar thread names

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -57,6 +57,7 @@ vi.mock("../lib/gitStatusState", () => ({
 }));
 
 const THREAD_ID = "thread-browser-test" as ThreadId;
+const THREAD_TITLE = "Browser test thread";
 const ARCHIVED_SECONDARY_THREAD_ID = "thread-secondary-project-archived" as ThreadId;
 const PROJECT_ID = "project-1" as ProjectId;
 const SECOND_PROJECT_ID = "project-2" as ProjectId;
@@ -288,7 +289,7 @@ function createSnapshotForTargetUser(options: {
       {
         id: THREAD_ID,
         projectId: PROJECT_ID,
-        title: "Browser test thread",
+        title: THREAD_TITLE,
         modelSelection: {
           provider: "codex",
           model: "gpt-5",
@@ -3078,6 +3079,25 @@ describe("ChatView timeline estimator parity (full app)", () => {
         },
         { timeout: 4_000, interval: 16 },
       );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("exposes the full thread title on the sidebar row tooltip", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-thread-tooltip-target" as MessageId,
+        targetText: "thread tooltip target",
+      }),
+    });
+
+    try {
+      const threadRow = page.getByTestId(`thread-row-${THREAD_ID}`);
+
+      await expect.element(threadRow).toBeInTheDocument();
+      await expect.element(threadRow).toHaveAttribute("title", THREAD_TITLE);
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -3094,10 +3094,19 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
-      const threadRow = page.getByTestId(`thread-row-${THREAD_ID}`);
+      const threadTitle = page.getByTestId(`thread-title-${THREAD_ID}`);
 
-      await expect.element(threadRow).toBeInTheDocument();
-      await expect.element(threadRow).toHaveAttribute("title", THREAD_TITLE);
+      await expect.element(threadTitle).toBeInTheDocument();
+      await threadTitle.hover();
+
+      await vi.waitFor(
+        () => {
+          const tooltip = document.querySelector<HTMLElement>('[data-slot="tooltip-popup"]');
+          expect(tooltip).not.toBeNull();
+          expect(tooltip?.textContent).toContain(THREAD_TITLE);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -609,6 +609,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
         size="sm"
         isActive={isActive}
         data-testid={`thread-row-${thread.id}`}
+        title={renamingThreadKey === threadKey ? undefined : thread.title}
         className={`${resolveThreadRowClassName({
           isActive,
           isSelected,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -609,7 +609,6 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
         size="sm"
         isActive={isActive}
         data-testid={`thread-row-${thread.id}`}
-        title={renamingThreadKey === threadKey ? undefined : thread.title}
         className={`${resolveThreadRowClassName({
           isActive,
           isSelected,
@@ -648,7 +647,21 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
               onClick={handleRenameInputClick}
             />
           ) : (
-            <span className="min-w-0 flex-1 truncate text-xs">{thread.title}</span>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <span
+                    className="min-w-0 flex-1 truncate text-xs"
+                    data-testid={`thread-title-${thread.id}`}
+                  >
+                    {thread.title}
+                  </span>
+                }
+              />
+              <TooltipPopup side="top" className="max-w-80 whitespace-normal leading-tight">
+                {thread.title}
+              </TooltipPopup>
+            </Tooltip>
           )}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-1.5">


### PR DESCRIPTION
Closes #1993 

## What Changed

Shows the full thread title in a styled tooltip when hovering a sidebar thread name.

This keeps truncated thread labels readable without changing sidebar layout. The PR also adds browser test coverage for the hover tooltip.

## Why

Thread titles in the sidebar are visually truncated to fit the available width. When a title is longer than the sidebar row, there is no hover affordance to reveal the full name, which makes it harder to see full thread names, and to distinguish similarly named threads without opening them.

## UI Changes

Before:
<img width="303" height="132" alt="image" src="https://github.com/user-attachments/assets/aaefb457-44f9-4d96-88a4-7656b86edb1b" />

After:
(When hovering over the thread in the sidebar. Cursor is not visible in the screenshot.)
<img width="459" height="135" alt="image" src="https://github.com/user-attachments/assets/6c345d24-1904-4508-a8fa-821a2438d58e" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] ~I included a video for animation/interaction changes~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that wraps sidebar thread titles in an existing tooltip component and adds a browser test; no data, auth, or backend logic is affected.
> 
> **Overview**
> Sidebar thread rows now show the **full thread title** in a tooltip on hover, keeping the row label truncated while improving readability.
> 
> Adds a browser regression test in `ChatView.browser.tsx` that hovers the sidebar title (via new `data-testid="thread-title-<id>"`) and asserts the tooltip popup renders the complete title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe3e032f44a61bf1dabcec9d8a42c6d84bbe05f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show full thread title in a tooltip when hovering sidebar thread names
> Wraps the thread title `span` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/1994/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) with a `Tooltip` component that displays the full title on hover, using `side="top"` with wrapping styles. A `data-testid="thread-title-<id>"` attribute is added to the trigger element. A browser test in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/1994/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) verifies the tooltip appears on hover.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfe3e03.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->