### PR TITLE
Prevent live thread branches from regressing to temp worktree names

### DIFF
--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1020,6 +1020,15 @@ describe("resolveLiveThreadBranchUpdate", () => {
 
     assert.equal(update, null);
   });
+
+  it("does not regress a semantic thread branch back to a temporary worktree branch", () => {
+    const update = resolveLiveThreadBranchUpdate({
+      threadBranch: "t3code/github-query-rate-limit",
+      gitStatus: status({ branch: "t3code/bda76797" }),
+    });
+
+    assert.equal(update, null);
+  });
 });
 
 describe("resolveAutoFeatureBranchName", () => {

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -3,6 +3,7 @@ import type {
   GitStackedAction,
   GitStatusResult,
 } from "@t3tools/contracts";
+import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 
 export type GitActionIconName = "commit" | "push" | "pr";
 
@@ -351,6 +352,15 @@ export function resolveLiveThreadBranchUpdate(input: {
   }
 
   if (input.threadBranch === input.gitStatus.branch) {
+    return null;
+  }
+
+  if (
+    input.threadBranch !== null &&
+    input.gitStatus.branch !== null &&
+    !isTemporaryWorktreeBranch(input.threadBranch) &&
+    isTemporaryWorktreeBranch(input.gitStatus.branch)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Preserve semantic thread branch names when the current git status reports a temporary `t3code/<sha>` worktree branch.
- Add a guard in `resolveLiveThreadBranchUpdate` so live thread branch updates only adopt temporary worktree names when the thread branch is already temporary.
- Cover the regression with a logic test for semantic thread branches.

## Testing
- Not run (not requested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to `resolveLiveThreadBranchUpdate` that only blocks adopting temporary worktree branch names, plus a regression test.
> 
> **Overview**
> Prevents live thread branch metadata from being overwritten by temporary worktree branch names (`t3code/<sha>`) when a semantic branch name is already stored.
> 
> Adds a guard in `resolveLiveThreadBranchUpdate` using `isTemporaryWorktreeBranch` and covers the scenario with a new unit test to avoid regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a7e53fe6decd7dffe15337d82704b044278f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent `resolveLiveThreadBranchUpdate` from regressing semantic thread branches to temporary worktree names
> When a thread already has a semantic branch name (e.g. `t3code/github-query-rate-limit`), `resolveLiveThreadBranchUpdate` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/1995/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) now returns `null` if the live git status reports a temporary worktree branch (e.g. `t3code/bda76797`), blocking the regression. A corresponding test case is added in [GitActionsControl.logic.test.ts](https://github.com/pingdotgg/t3code/pull/1995/files#diff-79f146696fea703958d884951c23db9a7b4f33ef2f6fa4721329eca56a48bdfb) to cover this guard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1a7e53.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->