### PR TITLE
fix: add pointer cursor to the select trigger

### DIFF
--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -12,7 +12,7 @@ import { cn } from "~/lib/utils";
 const Select = SelectPrimitive.Root;
 
 const selectTriggerVariants = cva(
-  "relative inline-flex select-none items-center justify-between gap-2 border rounded-lg text-left text-base outline-none transition-[color,box-shadow,background-color] data-disabled:pointer-events-none data-disabled:opacity-64 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4",
+  "relative inline-flex cursor-pointer select-none items-center justify-between gap-2 border rounded-lg text-left text-base outline-none transition-[color,box-shadow,background-color] data-disabled:pointer-events-none data-disabled:opacity-64 sm:text-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4",
   {
     defaultVariants: {
       size: "default",


### PR DESCRIPTION
## What Changed

- Add `cursor-pointer` to the select trigger so the control reads as interactive.
- Keep the existing select trigger styling unchanged otherwise.

## Why

The permission mode selector was implemented with the shared custom `Select` primitive, while the adjacent composer controls used UI paths that already exposed a pointer cursor. That made one interactive control feel inconsistent even though it was clickable.

## UI Changes

Before:
<img width="220" height="68" alt="image" src="https://github.com/user-attachments/assets/794c4952-ce4e-4029-bd6f-9bf5158425c6" />

After:
<img width="114" height="42" alt="Pe4n6gQzGR" src="https://github.com/user-attachments/assets/87684d5a-d69a-41a3-b235-b95c2c5815ac" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] ~I included a video for animation/interaction changes~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk styling-only change that affects the cursor/affordance for all components using `selectTriggerVariants`, with no behavioral or data-handling impact.
> 
> **Overview**
> Improves UI affordance for the shared `Select` component by adding `cursor-pointer` to the base `selectTriggerVariants` styles, making select triggers consistently appear interactive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 387b43658f9fc13eda0de56609c041d25546babf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pointer cursor to the select trigger component
> Adds `cursor-pointer` to the base classes in `selectTriggerVariants` in [select.tsx](https://github.com/pingdotgg/t3code/pull/1997/files#diff-f8dc315356af4a3938a8bfea44f5cb369e197db435ab6b932a79253ad2844789), so select triggers consistently show a pointer cursor on hover.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 387b436.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->