### PR TITLE
fix(web): preserve selected model when changing reasoning effort

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -173,10 +173,11 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
         return;
       }
       setProviderModelOptions(threadTarget, provider, nextOptions, {
+        ...(model ? { baseModel: model } : {}),
         persistSticky: true,
       });
     },
-    [persistence, provider, setProviderModelOptions],
+    [model, persistence, provider, setProviderModelOptions],
   );
   const {
     caps,

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1046,6 +1046,33 @@ describe("composerDraftStore modelSelection", () => {
     );
   });
 
+  it("preserves the caller-provided base model when options are updated before a draft selection exists", () => {
+    const store = useComposerDraftStore.getState();
+
+    store.setProviderModelOptions(
+      threadRef,
+      "codex",
+      {
+        reasoningEffort: "high",
+      },
+      {
+        baseModel: "gpt-5.4-mini",
+        persistSticky: true,
+      },
+    );
+
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)?.modelSelectionByProvider.codex).toEqual(
+      modelSelection("codex", "gpt-5.4-mini", {
+        reasoningEffort: "high",
+      }),
+    );
+    expect(useComposerDraftStore.getState().stickyModelSelectionByProvider.codex).toEqual(
+      modelSelection("codex", "gpt-5.4-mini", {
+        reasoningEffort: "high",
+      }),
+    );
+  });
+
   it("updates only the draft when sticky persistence is disabled", () => {
     const store = useComposerDraftStore.getState();
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -342,6 +342,7 @@ interface ComposerDraftStoreState {
     provider: ProviderKind,
     nextProviderOptions: ProviderModelOptions[ProviderKind] | null | undefined,
     options?: {
+      baseModel?: string;
       persistSticky?: boolean;
     },
   ) => void;
@@ -2301,6 +2302,8 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             normalizedProvider,
           );
           const providerOpts = normalizedOpts?.[normalizedProvider];
+          const normalizedBaseModel =
+            normalizeModelSlug(options?.baseModel, normalizedProvider) ?? undefined;
 
           set((state) => {
             const existing = state.draftsByThreadKey[threadKey];
@@ -2312,7 +2315,10 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             if (providerOpts) {
               nextMap[normalizedProvider] = {
                 provider: normalizedProvider,
-                model: currentForProvider?.model ?? DEFAULT_MODEL_BY_PROVIDER[normalizedProvider],
+                model:
+                  currentForProvider?.model ??
+                  normalizedBaseModel ??
+                  DEFAULT_MODEL_BY_PROVIDER[normalizedProvider],
                 options: providerOpts,
               };
             } else if (currentForProvider?.options) {
@@ -2330,7 +2336,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                 base.modelSelectionByProvider[normalizedProvider] ??
                 ({
                   provider: normalizedProvider,
-                  model: DEFAULT_MODEL_BY_PROVIDER[normalizedProvider],
+                  model: normalizedBaseModel ?? DEFAULT_MODEL_BY_PROVIDER[normalizedProvider],
                 } as ModelSelection);
               if (providerOpts) {
                 nextStickyMap[normalizedProvider] = {


### PR DESCRIPTION
IMPORTANT: i tried to fix it manually but gpt codex 5.3 xhigh explained me why i have skill issues, reviewed by my skill issued brain.

## What Changed

closes #1844, preserving the selected base model when changing the reasoning effort

## Why

bug in issue #1844 with certain state changing reasoning effort changes to the default model GPT5.4 (in codex)

imo changing between gpt-5.4-mini xhigh and gpt-5.4 medium/high helps into pushing further for $20 users, accidentally using gpt-5.4-xhigh has a huge impact for limits 

## UI Changes

None

## Checklist

- [ x ] This PR is small and focused
- [ x ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ x ] I included a video for animation/interaction changes


https://github.com/user-attachments/assets/8c75841c-e6de-4a40-8b25-1b49126b2b76


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches composer draft model-selection persistence logic; bugs here could cause unexpected model changes or incorrect sticky settings across threads/providers, but the change is small and covered by a targeted test.
> 
> **Overview**
> Fixes a model-selection regression where changing provider traits (notably Codex `reasoningEffort`) could reset the chosen model back to the provider default.
> 
> `TraitsPicker` now passes the currently selected `model` as `baseModel` when persisting option changes, and `composerDraftStore.setProviderModelOptions` accepts/normalizes this `baseModel` and uses it when a draft/provider selection doesn’t exist yet (including sticky snapshots). Adds a unit test covering this “options update before selection exists” scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87fbe8788e54e90cb394474267833065bddc5a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve selected model when changing reasoning effort in chat composer
> - Extends `setProviderModelOptions` in [composerDraftStore.ts](https://github.com/pingdotgg/t3code/pull/1999/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a) to accept an optional `baseModel` parameter, used as the initial model when no model is currently set for the provider in draft or sticky state.
> - Updates [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/1999/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45) to pass the current model as `baseModel` when calling `setProviderModelOptions`, so changing reasoning effort no longer resets the selected model.
> - Adds a test in [composerDraftStore.test.ts](https://github.com/pingdotgg/t3code/pull/1999/files#diff-61714da43700c6105d471eadf7c6f4e80aee8189d14bed8e4362b66dded855e1) covering that the provided `baseModel` is reflected in both draft and sticky selections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87fbe87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->