### PR TITLE
Clear tracked RPCs on reconnect

### DIFF
--- a/apps/web/src/rpc/wsTransport.test.ts
+++ b/apps/web/src/rpc/wsTransport.test.ts
@@ -417,6 +417,56 @@ describe("WsTransport", () => {
     await transport.dispose();
   }, 5_000);
 
+  it("clears slow unary request tracking when the transport reconnects", async () => {
+    const slowAckThresholdMs = 25;
+    setSlowRpcAckThresholdMsForTests(slowAckThresholdMs);
+    const transport = createTransport("ws://localhost:3020");
+
+    const requestPromise = transport.request((client) =>
+      client[WS_METHODS.serverUpsertKeybinding]({
+        command: "terminal.toggle",
+        key: "ctrl+k",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    const firstSocket = getSocket();
+    firstSocket.open();
+
+    await waitFor(() => {
+      expect(firstSocket.sent).toHaveLength(1);
+    });
+
+    const firstRequest = JSON.parse(firstSocket.sent[0] ?? "{}") as { id: string };
+
+    await waitFor(() => {
+      expect(getSlowRpcAckRequests()).toMatchObject([
+        {
+          requestId: firstRequest.id,
+          tag: WS_METHODS.serverUpsertKeybinding,
+        },
+      ]);
+    }, 1_000);
+
+    void requestPromise.catch(() => undefined);
+
+    await transport.reconnect();
+
+    expect(getSlowRpcAckRequests()).toEqual([]);
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(2);
+    });
+
+    const secondSocket = getSocket();
+    secondSocket.open();
+
+    await transport.dispose();
+  }, 5_000);
+
   it("sends unary RPC requests and resolves successful exits", async () => {
     const transport = createTransport("ws://localhost:3020");
 

--- a/apps/web/src/rpc/wsTransport.ts
+++ b/apps/web/src/rpc/wsTransport.ts
@@ -12,6 +12,7 @@ import {
 import { RpcClient } from "effect/unstable/rpc";
 
 import { ClientTracingLive } from "../observability/clientTracing";
+import { clearAllTrackedRpcRequests } from "./requestLatencyState";
 import {
   createWsRpcProtocolLayer,
   makeWsRpcProtocolClient,
@@ -189,6 +190,7 @@ export class WsTransport {
         throw new Error("Transport disposed");
       }
 
+      clearAllTrackedRpcRequests();
       const previousSession = this.session;
       this.session = this.createSession();
       await this.closeSession(previousSession);


### PR DESCRIPTION
## Summary
- Clear any tracked slow unary RPC requests before starting a new WebSocket session.
- Add a regression test that verifies reconnecting drops stale request tracking.

## Testing
- `bun run test apps/web/src/rpc/wsTransport.test.ts`
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to client-side request-latency bookkeeping plus a regression test. Main risk is unintended masking of in-flight slow-request diagnostics during reconnects.
> 
> **Overview**
> Clears any pending/slow unary RPC-ack tracking when `WsTransport.reconnect()` starts a new WebSocket session, preventing stale request IDs from persisting across reconnects.
> 
> Adds a regression test asserting that a slow-tracked unary request is dropped from `getSlowRpcAckRequests()` after an explicit transport reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e322bd08df8b8226a9b2d613c1b621973a201e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear tracked RPC requests on `WsTransport` reconnect
> Calls `clearAllTrackedRpcRequests()` at the start of `WsTransport.reconnect` before creating a new session, so stale slow-ack tracking entries from the previous connection are discarded. A new test in [wsTransport.test.ts](https://github.com/pingdotgg/t3code/pull/2000/files#diff-b5ef2531b397ef5ecd82322ee43f94fe7e5a9254217abd01ffd5fdfc6ccf6944) verifies the tracking is cleared after reconnect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e322bd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->