### PR TITLE
fix(desktop): keep resizable sidebar rail off adjacent scrollbars

### DIFF
--- a/apps/web/src/components/ui/sidebar.browser.tsx
+++ b/apps/web/src/components/ui/sidebar.browser.tsx
@@ -1,0 +1,235 @@
+import "../../index.css";
+
+import type { CSSProperties } from "react";
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { Sidebar, SidebarProvider, SidebarRail } from "./sidebar";
+
+const INITIAL_SIDEBAR_WIDTH_PX = 360;
+const SIDEBAR_MIN_WIDTH_PX = 280;
+
+async function nextFrame(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+}
+
+async function waitForLayout(): Promise<void> {
+  await nextFrame();
+  await nextFrame();
+  await nextFrame();
+}
+
+async function setViewport(width: number, height: number): Promise<void> {
+  await page.viewport(width, height);
+  await waitForLayout();
+}
+
+function parseSidebarWidth(wrapper: HTMLElement): number {
+  const width = Number.parseFloat(wrapper.style.getPropertyValue("--sidebar-width"));
+  if (!Number.isFinite(width)) {
+    throw new Error("Expected sidebar wrapper to expose a numeric --sidebar-width.");
+  }
+  return width;
+}
+
+function dispatchPointerEvent(target: EventTarget, type: string, init: PointerEventInit): boolean {
+  return target.dispatchEvent(
+    new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      isPrimary: true,
+      pointerType: "mouse",
+      ...init,
+    }),
+  );
+}
+
+function stubPointerCapture(rail: HTMLButtonElement) {
+  let capturedPointerId: number | null = null;
+
+  rail.setPointerCapture = (pointerId: number) => {
+    capturedPointerId = pointerId;
+  };
+  rail.releasePointerCapture = (pointerId: number) => {
+    if (capturedPointerId === pointerId) {
+      capturedPointerId = null;
+    }
+  };
+  rail.hasPointerCapture = (pointerId: number) => capturedPointerId === pointerId;
+}
+
+async function mountSidebarHarness(side: "left" | "right" = "right") {
+  await setViewport(1280, 800);
+
+  const host = document.createElement("div");
+  document.body.append(host);
+  const onResize = vi.fn();
+
+  const sidebar = (
+    <SidebarProvider
+      className="w-auto min-h-0 flex-none bg-transparent"
+      style={{ "--sidebar-width": `${INITIAL_SIDEBAR_WIDTH_PX}px` } as CSSProperties}
+      defaultOpen
+    >
+      <Sidebar
+        side={side}
+        collapsible="offcanvas"
+        className="border-l border-border bg-card text-foreground"
+        resizable={{
+          minWidth: SIDEBAR_MIN_WIDTH_PX,
+          onResize,
+        }}
+      >
+        <div className="h-full p-4">Diff panel content</div>
+        <SidebarRail />
+      </Sidebar>
+    </SidebarProvider>
+  );
+  const mainPane = (
+    <main
+      className="min-w-0 flex-1 overflow-y-scroll border-r border-dashed border-border/60"
+      data-testid="main-scroll-pane"
+    >
+      <div className="min-h-[200vh] p-6">
+        <p>Main pane content</p>
+      </div>
+    </main>
+  );
+
+  const screen = await render(
+    <div className="fixed inset-0 flex overflow-hidden bg-background text-foreground">
+      {side === "left" ? sidebar : mainPane}
+      {side === "left" ? mainPane : sidebar}
+    </div>,
+    { container: host },
+  );
+  await waitForLayout();
+
+  return {
+    onResize,
+    cleanup: async () => {
+      await screen.unmount();
+      host.remove();
+    },
+  };
+}
+
+function getMainPaneEdgeX(mainRect: DOMRect, side: "left" | "right"): number {
+  return side === "right" ? mainRect.right - 2 : mainRect.left + 2;
+}
+
+function getResizeDeltaX(side: "left" | "right"): number {
+  return side === "right" ? -80 : 80;
+}
+
+describe("SidebarRail", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  for (const side of ["left", "right"] as const) {
+    it(`keeps the expanded ${side} rail off the main pane edge hit target`, async () => {
+      const mounted = await mountSidebarHarness(side);
+
+      try {
+        await expect.element(page.getByLabelText("Resize Sidebar")).toBeVisible();
+
+        await vi.waitFor(() => {
+          const mainPane = document.querySelector<HTMLElement>('[data-testid="main-scroll-pane"]');
+          const rail = document.querySelector<HTMLElement>("[data-slot='sidebar-rail']");
+          if (!mainPane || !rail) {
+            throw new Error("Expected the main pane and sidebar rail to be mounted.");
+          }
+
+          const mainRect = mainPane.getBoundingClientRect();
+          const hitTarget = document.elementFromPoint(
+            getMainPaneEdgeX(mainRect, side),
+            mainRect.top + mainRect.height / 2,
+          );
+
+          expect(hitTarget).not.toBeNull();
+          expect(hitTarget instanceof Element && rail.contains(hitTarget)).toBe(false);
+        });
+      } finally {
+        await mounted.cleanup();
+      }
+    });
+
+    it(`still resizes an expanded ${side} sidebar from inside the panel edge`, async () => {
+      const mounted = await mountSidebarHarness(side);
+
+      try {
+        await expect.element(page.getByLabelText("Resize Sidebar")).toBeVisible();
+
+        const rail = await vi.waitFor(() => {
+          const element = document.querySelector<HTMLButtonElement>("[data-slot='sidebar-rail']");
+          if (!element) {
+            throw new Error("Expected the sidebar rail to be mounted.");
+          }
+          return element;
+        });
+        const wrapper = await vi.waitFor(() => {
+          const element = document.querySelector<HTMLElement>("[data-slot='sidebar-wrapper']");
+          if (!element) {
+            throw new Error("Expected the sidebar wrapper to be mounted.");
+          }
+          return element;
+        });
+        const sidebarContainer = await vi.waitFor(() => {
+          const element = document.querySelector<HTMLElement>("[data-slot='sidebar-container']");
+          if (!element) {
+            throw new Error("Expected the sidebar container to be mounted.");
+          }
+          if (element.getBoundingClientRect().width <= 0) {
+            throw new Error("Expected the sidebar container to have a measurable width.");
+          }
+          return element;
+        });
+
+        stubPointerCapture(rail);
+
+        const initialWidth = sidebarContainer.getBoundingClientRect().width;
+        const railRect = rail.getBoundingClientRect();
+        const startX = railRect.left + railRect.width / 2;
+        const startY = railRect.top + railRect.height / 2;
+        const resizeDeltaX = getResizeDeltaX(side);
+
+        dispatchPointerEvent(rail, "pointerdown", {
+          button: 0,
+          clientX: startX,
+          clientY: startY,
+          pointerId: 1,
+        });
+        dispatchPointerEvent(rail, "pointermove", {
+          clientX: startX + resizeDeltaX,
+          clientY: startY,
+          pointerId: 1,
+        });
+
+        await vi.waitFor(() => {
+          expect(parseSidebarWidth(wrapper)).toBeGreaterThan(initialWidth);
+        });
+
+        dispatchPointerEvent(rail, "pointerup", {
+          button: 0,
+          clientX: startX + resizeDeltaX,
+          clientY: startY,
+          pointerId: 1,
+        });
+
+        await vi.waitFor(() => {
+          expect(mounted.onResize).toHaveBeenCalled();
+          const nextWidth = mounted.onResize.mock.calls.at(-1)?.[0];
+          expect(typeof nextWidth).toBe("number");
+          expect(nextWidth).toBeGreaterThan(initialWidth);
+        });
+      } finally {
+        await mounted.cleanup();
+      }
+    });
+  }
+});

--- a/apps/web/src/components/ui/sidebar.test.tsx
+++ b/apps/web/src/components/ui/sidebar.test.tsx
@@ -2,16 +2,29 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+  Sidebar,
   SidebarMenuAction,
   SidebarMenuButton,
   SidebarMenuSubButton,
   SidebarProvider,
+  SidebarRail,
 } from "./sidebar";
 
 function renderSidebarButton(className?: string) {
   return renderToStaticMarkup(
     <SidebarProvider>
       <SidebarMenuButton className={className}>Projects</SidebarMenuButton>
+    </SidebarProvider>,
+  );
+}
+
+function renderSidebarRail(props?: { defaultOpen?: boolean; side?: "left" | "right" }) {
+  return renderToStaticMarkup(
+    <SidebarProvider defaultOpen={props?.defaultOpen ?? true}>
+      <Sidebar side={props?.side ?? "left"} collapsible="offcanvas" resizable>
+        <div>Sidebar content</div>
+        <SidebarRail />
+      </Sidebar>
     </SidebarProvider>,
   );
 }
@@ -49,5 +62,26 @@ describe("sidebar interactive cursors", () => {
 
     expect(html).toContain('data-slot="sidebar-menu-sub-button"');
     expect(html).toContain("cursor-pointer");
+  });
+
+  it("pins resize rails inside expanded sidebar edges", () => {
+    const leftHtml = renderSidebarRail({ side: "left" }).replaceAll("&amp;", "&");
+    const rightHtml = renderSidebarRail({ side: "right" }).replaceAll("&amp;", "&");
+
+    expect(leftHtml).toContain("[[data-side=left][data-state=expanded]_&]:right-0");
+    expect(leftHtml).toContain("[[data-side=left][data-state=expanded]_&]:after:right-0");
+    expect(rightHtml).toContain("[[data-side=right][data-state=expanded]_&]:left-0");
+    expect(rightHtml).toContain("[[data-side=right][data-state=expanded]_&]:after:left-0");
+  });
+
+  it("keeps collapsed offcanvas rails non-interactive", () => {
+    const html = renderSidebarRail({ defaultOpen: false, side: "right" }).replaceAll("&amp;", "&");
+
+    expect(html).toContain(
+      "[[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none",
+    );
+    expect(html).toContain(
+      "[[data-side=right][data-collapsible=offcanvas][data-state=collapsed]_&]:-left-2",
+    );
   });
 });

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -75,6 +75,24 @@ type SidebarInstanceContextProps = {
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null);
 const SidebarInstanceContext = React.createContext<SidebarInstanceContextProps | null>(null);
+const SIDEBAR_RAIL_POSITION_CLASS_NAME = [
+  "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear sm:flex",
+  "[[data-side=left][data-state=expanded]_&]:right-0",
+  "[[data-side=right][data-state=expanded]_&]:left-0",
+  "[[data-side=left][data-collapsible=icon][data-state=collapsed]_&]:right-0",
+  "[[data-side=right][data-collapsible=icon][data-state=collapsed]_&]:left-0",
+  "[[data-side=left][data-collapsible=offcanvas][data-state=collapsed]_&]:-right-2",
+  "[[data-side=right][data-collapsible=offcanvas][data-state=collapsed]_&]:-left-2",
+  "[[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none",
+].join(" ");
+const SIDEBAR_RAIL_DIVIDER_CLASS_NAME = [
+  "after:absolute after:inset-y-0 after:w-[2px] hover:after:bg-sidebar-border",
+  "[[data-side=left][data-state=expanded]_&]:after:right-0",
+  "[[data-side=right][data-state=expanded]_&]:after:left-0",
+  "[[data-side=left][data-collapsible=icon][data-state=collapsed]_&]:after:right-0",
+  "[[data-side=right][data-collapsible=icon][data-state=collapsed]_&]:after:left-0",
+  "[[data-collapsible=offcanvas][data-state=collapsed]_&]:after:left-full",
+].join(" ");
 
 function useSidebar() {
   const context = React.useContext(SidebarContext);
@@ -568,13 +586,11 @@ function SidebarRail({
     <button
       aria-label={railLabel}
       className={cn(
-        /* disable pointer events only when offcanvas sidebar is collapsed, that's when the rail sits over the native scrollbar on windows and linux. icon mode stays fully clickable. */
-        "-translate-x-1/2 group-data-[side=left]:-right-4 absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=right]:left-0 sm:flex [[data-collapsible=offcanvas][data-state=collapsed]_&]:pointer-events-none",
+        /* Keep the expanded rail fully inside the sidebar edge so it never steals the main pane's scrollbar hit target. */
+        SIDEBAR_RAIL_POSITION_CLASS_NAME,
+        SIDEBAR_RAIL_DIVIDER_CLASS_NAME,
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:after:left-full",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
         className,
       )}
       data-sidebar="rail"


### PR DESCRIPTION
- Description: The right resizable sidebar rail was overlapping the main chat pane’s native scrollbar, so hovering the scrollbar showed the resize cursor and dragging resized the sidebar instead of scrolling. The previous selector set also did not explicitly position rails for `collapsible="icon"` collapsed sidebars.

- What changed: This updates the shared sidebar rail selectors so expanded left/right sidebars keep the rail fully inside the sidebar edge, offcanvas-collapsed rails stay non-interactive, and collapsed-icon sidebars get explicit rail and divider positioning. It also adds regression coverage for rail placement and resizing behavior so current and future side panels inherit the fix without route-specific workarounds.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Moved `SidebarRail` positioning into explicit selector sets in the shared sidebar component so the expanded rail sits inside the sidebar boundary instead of overlapping the adjacent pane. Added explicit collapsed-icon positioning for both left and right sidebars, while keeping offcanvas-collapsed rails non-interactive.

Added regression tests for:
- static rail class output in `sidebar.test.tsx`
- browser-level hit testing to verify the main pane edge is no longer captured by the rail
- browser-level resize behavior to confirm the rail still resizes correctly from inside the sidebar edge

## Why

When the right diff sidebar was open, the resize rail extended over the main chat pane’s native scrollbar. That made the scrollbar effectively unclickable because pointer hover and drag were captured by the rail instead.

Fixing this in the shared sidebar component is the right scope because the problem is structural, not specific to the diff panel. Any future right-side panel using the same sidebar rail would otherwise inherit the same bug.

## UI Changes

Before:
- Hovering the main chat pane scrollbar with the right sidebar open showed the resize cursor.
- Dragging the scrollbar resized the sidebar instead of scrolling.

After:
- The main chat pane scrollbar remains clickable and draggable with the right sidebar open.
- The sidebar can still be resized from its own inside edge.

Screenshots/video to attach:
- Before

https://github.com/user-attachments/assets/98c58eb0-f237-4faf-a9d4-288708b50921

- After

https://github.com/user-attachments/assets/c0c613bf-28c3-44e0-91b5-2103410f609a



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared `SidebarRail` positioning/interaction CSS, which can affect resize/toggle hit targets across all desktop sidebars. Adds coverage, but regressions could impact basic navigation/resizing UX.
> 
> **Overview**
> Fixes desktop resizable sidebar rails so the *expanded* rail sits fully inside the sidebar edge (left and right) instead of overlapping the adjacent pane’s scrollbar hit area.
> 
> Refactors `SidebarRail` class logic into shared selector constants, adds explicit positioning for `collapsible="icon"` collapsed sidebars, and keeps `offcanvas`-collapsed rails non-interactive.
> 
> Adds regression tests: static markup assertions for the new rail selectors and a new Vitest browser test that hit-tests the main pane edge and verifies resizing still works from inside the sidebar boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8deb6926ffbc9ea1e56d33aee573dee114a5045d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `SidebarRail` positioning to avoid overlapping adjacent scrollbar hit targets
> - Repositions the expanded `SidebarRail` to sit fully inside the sidebar edge (`left-0`/`right-0`) instead of straddling the boundary, preventing it from intercepting clicks on adjacent scrollbars.
> - Collapsed offcanvas rails are pushed to a negative offset (`-left-2`/`-right-2`) and set to `pointer-events-none` so they don't intercept any interaction.
> - The rail's divider pseudo-element is aligned to the inside edge rather than centered on the rail.
> - Adds browser-based Vitest tests in [sidebar.browser.tsx](https://github.com/pingdotgg/t3code/pull/2019/files#diff-7a77a6132e99065df5f19b679c5c9880b1e7f357bf2701cdaeebfc4c991ce966) verifying the rail does not overlap the main pane scrollbar, and unit tests in [sidebar.test.tsx](https://github.com/pingdotgg/t3code/pull/2019/files#diff-a3703d898ff88e3822c28b86af910b609c0391b0c8c36aaf9978a2375455a92d) asserting correct class selectors for both sides and states.
> - Behavioral Change: the rail divider and interactive hit area are now entirely inside the sidebar boundary in expanded state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8deb692.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->