### PR TITLE
Fix nightly desktop product name

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -5,6 +5,7 @@ import { ConfigProvider, Effect, Option } from "effect";
 import {
   resolveBuildOptions,
   resolveDesktopBuildIconAssets,
+  resolveDesktopProductName,
   resolveDesktopUpdateChannel,
   resolveMockUpdateServerPort,
   resolveMockUpdateServerUrl,
@@ -15,6 +16,11 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
   it("resolves the dedicated nightly updater channel from nightly versions", () => {
     assert.equal(resolveDesktopUpdateChannel("0.0.17-nightly.20260413.42"), "nightly");
     assert.equal(resolveDesktopUpdateChannel("0.0.17"), "latest");
+  });
+
+  it("switches desktop packaging product names to nightly for nightly builds", () => {
+    assert.equal(resolveDesktopProductName("0.0.17"), "T3 Code (Alpha)");
+    assert.equal(resolveDesktopProductName("0.0.17-nightly.20260413.42"), "T3 Code (Nightly)");
   });
 
   it("switches desktop packaging icons to the nightly artwork for nightly versions", () => {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -503,10 +503,15 @@ export function resolveMockUpdateServerUrl(mockUpdateServerPort: number | undefi
   return `http://localhost:${mockUpdateServerPort ?? 3000}`;
 }
 
+export function resolveDesktopProductName(version: string): string {
+  return resolveDesktopUpdateChannel(version) === "nightly"
+    ? "T3 Code (Nightly)"
+    : (desktopPackageJson.productName ?? "T3 Code");
+}
+
 const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   platform: typeof BuildPlatform.Type,
   target: string,
-  productName: string,
   version: string,
   signed: boolean,
   mockUpdates: boolean,
@@ -514,7 +519,7 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
 ) {
   const buildConfig: Record<string, unknown> = {
     appId: "com.t3tools.t3code",
-    productName,
+    productName: resolveDesktopProductName(version),
     artifactName: "T3-Code-${version}-${arch}.${ext}",
     directories: {
       buildResources: "apps/desktop/resources",
@@ -732,7 +737,6 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     build: yield* createBuildConfig(
       options.platform,
       options.target,
-      desktopPackageJson.productName ?? "T3 Code",
       appVersion,
       options.signed,
       options.mockUpdates,


### PR DESCRIPTION
## Summary
- derive the packaged desktop product name from the release version
- package nightly desktop builds as `T3 Code (Nightly)` instead of `T3 Code (Alpha)`
- cover the nightly product-name mapping in the desktop artifact script tests

## Testing
- bun run test (in `scripts`)
- bun fmt
- bun lint
- bun typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only desktop packaging metadata in the build script and adds a unit test, with no runtime or security-impacting logic.
> 
> **Overview**
> Nightly desktop builds now derive their packaged `productName` from the version string, branding `-nightly.*` releases as **`T3 Code (Nightly)`** while non-nightly builds use the `apps/desktop/package.json` `productName` fallback.
> 
> `createBuildConfig` no longer accepts a caller-provided `productName` and instead resolves it internally via the new `resolveDesktopProductName`, with test coverage added for the nightly/non-nightly mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bed91115421e8e41db5596699c2554ff6507b03e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nightly desktop build to use 'T3 Code (Nightly)' as the product name
> Adds `resolveDesktopProductName` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/2025/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d), which returns `'T3 Code (Nightly)'` when the version resolves to the nightly update channel, and the package's `productName` otherwise. The `createBuildConfig` function now calls this internally instead of accepting `productName` as a parameter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bed9111.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->