### PR TITLE
Clean up leaked tmp_pack files after failed status refresh

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1132,6 +1132,88 @@ it.layer(TestLayer)("git integration", (it) => {
       }),
     );
 
+    it.effect("skips tmp_pack cleanup while a linked worktree fetch lock is active", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const gitCommonDir = path.join(tmp, ".git");
+        const packDir = path.join(gitCommonDir, "objects", "pack");
+        const linkedWorktreeFetchHeadLock = path.join(
+          gitCommonDir,
+          "worktrees",
+          "feature",
+          "FETCH_HEAD.lock",
+        );
+        yield* makeDirectory(packDir);
+        yield* makeDirectory(path.dirname(linkedWorktreeFetchHeadLock));
+
+        const leakedTmpPack = path.join(packDir, "tmp_pack_new");
+        yield* writeTextFile(linkedWorktreeFetchHeadLock, "locked\n");
+
+        const ok = (stdout = "") =>
+          Effect.succeed({
+            code: 0,
+            stdout,
+            stderr: "",
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          });
+
+        const core = yield* makeIsolatedGitCore((input) => {
+          if (
+            input.args[0] === "rev-parse" &&
+            input.args[1] === "--abbrev-ref" &&
+            input.args[2] === "--symbolic-full-name" &&
+            input.args[3] === "@{upstream}"
+          ) {
+            return ok("origin/main\n");
+          }
+          if (input.args[0] === "remote") {
+            return ok("origin\n");
+          }
+          if (input.args[0] === "rev-parse" && input.args[1] === "--git-common-dir") {
+            return ok(`${gitCommonDir}\n`);
+          }
+          if (input.args[0] === "--git-dir" && input.args[2] === "fetch") {
+            return Effect.gen(function* () {
+              yield* Effect.sync(() => {
+                writeFileSync(leakedTmpPack, "leaked temporary pack\n");
+              });
+              return yield* new GitCommandError({
+                operation: input.operation,
+                command: `git ${input.args.join(" ")}`,
+                cwd: input.cwd,
+                detail: "simulated fetch timeout",
+              });
+            });
+          }
+          if (input.operation === "GitCore.statusDetails.status") {
+            return ok("# branch.head main\n# branch.upstream origin/main\n# branch.ab +0 -0\n");
+          }
+          if (
+            input.operation === "GitCore.statusDetails.unstagedNumstat" ||
+            input.operation === "GitCore.statusDetails.stagedNumstat"
+          ) {
+            return ok();
+          }
+          if (input.operation === "GitCore.statusDetails.defaultRef") {
+            return ok("refs/remotes/origin/main\n");
+          }
+          return Effect.fail(
+            new GitCommandError({
+              operation: input.operation,
+              command: `git ${input.args.join(" ")}`,
+              cwd: input.cwd,
+              detail: "Unexpected git command in linked worktree fetch cleanup test.",
+            }),
+          );
+        });
+
+        const status = yield* core.statusDetails(tmp);
+        expect(status.branch).toBe("main");
+        expect(existsSync(leakedTmpPack)).toBe(true);
+      }),
+    );
+
     it.effect("throws when branch does not exist", () =>
       Effect.gen(function* () {
         const tmp = yield* makeTmpDir();

--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -974,6 +974,162 @@ it.layer(TestLayer)("git integration", (it) => {
           yield* core.statusDetails("/repo/worktrees/pr-123");
           expect(fetchCount).toBe(1);
         }),
+    );
+
+    it.effect("removes newly leaked tmp_pack files after a failed upstream refresh", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const gitCommonDir = path.join(tmp, ".git");
+        const packDir = path.join(gitCommonDir, "objects", "pack");
+        yield* makeDirectory(packDir);
+
+        const existingTmpPack = path.join(packDir, "tmp_pack_existing");
+        const leakedTmpPack = path.join(packDir, "tmp_pack_new");
+        const preservedPack = path.join(packDir, "pack-keep.pack");
+        yield* writeTextFile(existingTmpPack, "existing temporary pack\n");
+        yield* writeTextFile(preservedPack, "keep this pack file\n");
+
+        const ok = (stdout = "") =>
+          Effect.succeed({
+            code: 0,
+            stdout,
+            stderr: "",
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          });
+
+        const core = yield* makeIsolatedGitCore((input) => {
+          if (
+            input.args[0] === "rev-parse" &&
+            input.args[1] === "--abbrev-ref" &&
+            input.args[2] === "--symbolic-full-name" &&
+            input.args[3] === "@{upstream}"
+          ) {
+            return ok("origin/main\n");
+          }
+          if (input.args[0] === "remote") {
+            return ok("origin\n");
+          }
+          if (input.args[0] === "rev-parse" && input.args[1] === "--git-common-dir") {
+            return ok(`${gitCommonDir}\n`);
+          }
+          if (input.args[0] === "--git-dir" && input.args[2] === "fetch") {
+            return Effect.gen(function* () {
+              yield* Effect.sync(() => {
+                writeFileSync(leakedTmpPack, "leaked temporary pack\n");
+              });
+              return yield* new GitCommandError({
+                operation: input.operation,
+                command: `git ${input.args.join(" ")}`,
+                cwd: input.cwd,
+                detail: "simulated fetch timeout",
+              });
+            });
+          }
+          if (input.operation === "GitCore.statusDetails.status") {
+            return ok("# branch.head main\n# branch.upstream origin/main\n# branch.ab +0 -0\n");
+          }
+          if (
+            input.operation === "GitCore.statusDetails.unstagedNumstat" ||
+            input.operation === "GitCore.statusDetails.stagedNumstat"
+          ) {
+            return ok();
+          }
+          if (input.operation === "GitCore.statusDetails.defaultRef") {
+            return ok("refs/remotes/origin/main\n");
+          }
+          return Effect.fail(
+            new GitCommandError({
+              operation: input.operation,
+              command: `git ${input.args.join(" ")}`,
+              cwd: input.cwd,
+              detail: "Unexpected git command in tmp_pack cleanup test.",
+            }),
+          );
+        });
+
+        const status = yield* core.statusDetails(tmp);
+        expect(status.branch).toBe("main");
+        expect(existsSync(leakedTmpPack)).toBe(false);
+        expect(existsSync(existingTmpPack)).toBe(true);
+        expect(existsSync(preservedPack)).toBe(true);
+      }),
+    );
+
+    it.effect("skips tmp_pack cleanup while another fetch lock is active", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const gitCommonDir = path.join(tmp, ".git");
+        const packDir = path.join(gitCommonDir, "objects", "pack");
+        const fetchHeadLock = path.join(gitCommonDir, "FETCH_HEAD.lock");
+        yield* makeDirectory(packDir);
+
+        const leakedTmpPack = path.join(packDir, "tmp_pack_new");
+        yield* writeTextFile(fetchHeadLock, "locked\n");
+
+        const ok = (stdout = "") =>
+          Effect.succeed({
+            code: 0,
+            stdout,
+            stderr: "",
+            stdoutTruncated: false,
+            stderrTruncated: false,
+          });
+
+        const core = yield* makeIsolatedGitCore((input) => {
+          if (
+            input.args[0] === "rev-parse" &&
+            input.args[1] === "--abbrev-ref" &&
+            input.args[2] === "--symbolic-full-name" &&
+            input.args[3] === "@{upstream}"
+          ) {
+            return ok("origin/main\n");
+          }
+          if (input.args[0] === "remote") {
+            return ok("origin\n");
+          }
+          if (input.args[0] === "rev-parse" && input.args[1] === "--git-common-dir") {
+            return ok(`${gitCommonDir}\n`);
+          }
+          if (input.args[0] === "--git-dir" && input.args[2] === "fetch") {
+            return Effect.gen(function* () {
+              yield* Effect.sync(() => {
+                writeFileSync(leakedTmpPack, "leaked temporary pack\n");
+              });
+              return yield* new GitCommandError({
+                operation: input.operation,
+                command: `git ${input.args.join(" ")}`,
+                cwd: input.cwd,
+                detail: "simulated fetch timeout",
+              });
+            });
+          }
+          if (input.operation === "GitCore.statusDetails.status") {
+            return ok("# branch.head main\n# branch.upstream origin/main\n# branch.ab +0 -0\n");
+          }
+          if (
+            input.operation === "GitCore.statusDetails.unstagedNumstat" ||
+            input.operation === "GitCore.statusDetails.stagedNumstat"
+          ) {
+            return ok();
+          }
+          if (input.operation === "GitCore.statusDetails.defaultRef") {
+            return ok("refs/remotes/origin/main\n");
+          }
+          return Effect.fail(
+            new GitCommandError({
+              operation: input.operation,
+              command: `git ${input.args.join(" ")}`,
+              cwd: input.cwd,
+              detail: "Unexpected git command in concurrent fetch cleanup test.",
+            }),
+          );
+        });
+
+        const status = yield* core.statusDetails(tmp);
+        expect(status.branch).toBe("main");
+        expect(existsSync(leakedTmpPack)).toBe(true);
+      }),
     );
 
     it.effect("throws when branch does not exist", () =>

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -935,10 +935,25 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       ) as ReadonlySet<string>;
     });
 
+    const listFetchHeadLockPaths = Effect.fn("listFetchHeadLockPaths")(function* () {
+      const worktreesDir = path.join(gitCommonDir, "worktrees");
+      const worktreeEntries = yield* fileSystem
+        .readDirectory(worktreesDir, { recursive: false })
+        .pipe(Effect.orElseSucceed(() => [] as Array<string>));
+      return [
+        path.join(gitCommonDir, "FETCH_HEAD.lock"),
+        ...worktreeEntries.map((entry) => path.join(worktreesDir, entry, "FETCH_HEAD.lock")),
+      ];
+    });
+
     const hasConcurrentFetchLock = Effect.fn("hasConcurrentFetchLock")(function* () {
-      return yield* fileSystem
-        .exists(path.join(gitCommonDir, "FETCH_HEAD.lock"))
-        .pipe(Effect.orElseSucceed(() => false));
+      const fetchHeadLockPaths = yield* listFetchHeadLockPaths();
+      for (const fetchHeadLockPath of fetchHeadLockPaths) {
+        if (yield* fileSystem.exists(fetchHeadLockPath).pipe(Effect.orElseSucceed(() => false))) {
+          return true;
+        }
+      }
+      return false;
     });
 
     const removeLeakedTemporaryPackFiles = Effect.fn("removeLeakedTemporaryPackFiles")(function* (

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -58,6 +58,7 @@ const STATUS_UPSTREAM_REFRESH_INTERVAL = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_FAILURE_COOLDOWN = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
+const TEMPORARY_PACK_FILE_PREFIX = "tmp_pack_";
 const DEFAULT_BASE_BRANCH_CANDIDATES = ["main", "master"] as const;
 const GIT_LIST_BRANCHES_DEFAULT_LIMIT = 100;
 const NON_REPOSITORY_STATUS_DETAILS = Object.freeze<GitStatusDetails>({
@@ -923,15 +924,81 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
   ): Effect.Effect<void, GitCommandError> => {
     const fetchCwd =
       path.basename(gitCommonDir) === ".git" ? path.dirname(gitCommonDir) : gitCommonDir;
-    return executeGit(
-      "GitCore.fetchRemoteForStatus",
-      fetchCwd,
-      ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", remoteName],
-      {
-        allowNonZeroExit: true,
-        timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
-      },
-    ).pipe(Effect.asVoid);
+
+    const readTemporaryPackFiles = Effect.fn("readTemporaryPackFiles")(function* () {
+      const packDir = path.join(gitCommonDir, "objects", "pack");
+      const entries = yield* fileSystem
+        .readDirectory(packDir, { recursive: false })
+        .pipe(Effect.orElseSucceed(() => [] as Array<string>));
+      return new Set(
+        entries.filter((entry) => entry.startsWith(TEMPORARY_PACK_FILE_PREFIX)),
+      ) as ReadonlySet<string>;
+    });
+
+    const hasConcurrentFetchLock = Effect.fn("hasConcurrentFetchLock")(function* () {
+      return yield* fileSystem
+        .exists(path.join(gitCommonDir, "FETCH_HEAD.lock"))
+        .pipe(Effect.orElseSucceed(() => false));
+    });
+
+    const removeLeakedTemporaryPackFiles = Effect.fn("removeLeakedTemporaryPackFiles")(function* (
+      temporaryPackFilesBeforeFetch: ReadonlySet<string>,
+    ) {
+      if (yield* hasConcurrentFetchLock()) {
+        yield* Effect.logWarning(
+          "skipped leaked temporary git pack cleanup while another fetch is active",
+          {
+            gitCommonDir,
+          },
+        );
+        return;
+      }
+
+      const packDir = path.join(gitCommonDir, "objects", "pack");
+      const entries = yield* fileSystem
+        .readDirectory(packDir, { recursive: false })
+        .pipe(Effect.orElseSucceed(() => [] as Array<string>));
+      const leakedPackFiles = entries.filter(
+        (entry) =>
+          entry.startsWith(TEMPORARY_PACK_FILE_PREFIX) && !temporaryPackFilesBeforeFetch.has(entry),
+      );
+      if (leakedPackFiles.length === 0) {
+        return;
+      }
+
+      yield* Effect.logWarning("removed leaked temporary git pack files after failed refresh", {
+        gitCommonDir,
+        leakedPackFiles,
+      });
+
+      yield* Effect.forEach(
+        leakedPackFiles,
+        (entry) =>
+          fileSystem.remove(path.join(packDir, entry), { force: true }).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning("failed to remove leaked temporary git pack file", {
+                gitCommonDir,
+                packFile: entry,
+                error: error.message,
+              }),
+            ),
+          ),
+        { concurrency: "unbounded" },
+      );
+    });
+
+    return Effect.gen(function* () {
+      const temporaryPackFilesBeforeFetch = yield* readTemporaryPackFiles();
+      yield* executeGit(
+        "GitCore.fetchRemoteForStatus",
+        fetchCwd,
+        ["--git-dir", gitCommonDir, "fetch", "--quiet", "--no-tags", remoteName],
+        {
+          timeoutMs: Duration.toMillis(STATUS_UPSTREAM_REFRESH_TIMEOUT),
+          fallbackErrorMessage: "git fetch failed",
+        },
+      ).pipe(Effect.tapError(() => removeLeakedTemporaryPackFiles(temporaryPackFilesBeforeFetch)));
+    }).pipe(Effect.asVoid);
   };
 
   const resolveGitCommonDir = Effect.fn("resolveGitCommonDir")(function* (cwd: string) {


### PR DESCRIPTION
Closes #1965

## What was broken

Background git status refreshes could time out and leave new `tmp_pack_*` files behind in `.git/objects/pack`.
Repeated failures could accumulate those temporary pack files until the repository disk usage became destructive.

## Root cause

The background upstream refresh path stopped at the failed fetch result and never cleaned up temp pack artifacts created by that refresh attempt.

## What changed

- snapshot existing `tmp_pack_*` files before each background refresh fetch
- remove only newly created `tmp_pack_*` files when that refresh fails
- skip cleanup when `FETCH_HEAD.lock` indicates another fetch is active
- add regression coverage for both cleanup and lock-guard behavior

## Validation

- `bun fmt`
- `bun lint`
- `bun run --cwd apps/server test src/git/Layers/GitCore.test.ts`

Repo-wide `bun typecheck` is currently failing in untouched `apps/server/src/provider/Layers/ClaudeAdapter.ts` on this branch base, so I did not widen this bugfix PR to include unrelated provider changes.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clean up leaked `tmp_pack_` files after failed git fetch during status refresh
> - When a git fetch fails during `fetchRemoteForStatus`, any `tmp_pack_*` files created during the failed fetch are removed from `objects/pack`
> - Cleanup is skipped if a `FETCH_HEAD.lock` exists in the main git dir or any linked worktree, indicating a concurrent fetch is in progress
> - Introduces `TEMPORARY_PACK_FILE_PREFIX` constant and helper functions: `readTemporaryPackFiles`, `listFetchHeadLockPaths`, `hasConcurrentFetchLock`, and `removeLeakedTemporaryPackFiles` in [GitCore.ts](https://github.com/pingdotgg/t3code/pull/2026/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865)
> - Removal errors are tolerated and logged as warnings; pre-existing `tmp_pack_*` files and non-temporary pack files are preserved
> - Behavioral Change: `fetchRemoteForStatus` no longer passes `allowNonZeroExit` and now uses a `fallbackErrorMessage` for the fetch call
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 622083d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds filesystem cleanup and lock detection around background `git fetch` during `statusDetails`, which could accidentally remove files or behave incorrectly under unusual repo layouts/concurrent operations if the heuristics are wrong.
> 
> **Overview**
> Prevents disk bloat from failed background upstream refreshes by snapshotting pre-existing `.git/objects/pack/tmp_pack_*` files before the refresh `git fetch` and deleting only newly created `tmp_pack_*` artifacts when the fetch fails.
> 
> Cleanup is skipped when `FETCH_HEAD.lock` is present in the main repo or any linked worktree (indicating another fetch is in progress), and new tests cover both the cleanup behavior and the lock-guard scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622083d4bf9389b102ed06b891db8843e67ca4f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error recovery with improved cleanup of temporary files following unsuccessful git operations
  * Added concurrent operation detection to prevent cleanup conflicts during simultaneous git operations

* **Tests**
  * Added test coverage for failure recovery and cleanup scenarios
  * Added test coverage for concurrent operation handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->