### PR TITLE
[codex] Allow deleting non-empty projects from the sidebar

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -10,12 +10,15 @@ import {
   getProjectSortTimestamp,
   hasUnseenCompletion,
   isContextMenuPointerDown,
+  matchesProjectDeleteConfirmationPhrase,
   orderItemsByPreferredIds,
+  PROJECT_DELETE_CONFIRMATION_PHRASE,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
+  shouldRequireProjectDeleteConfirmation,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
@@ -161,6 +164,23 @@ describe("shouldClearThreadSelectionOnMouseDown", () => {
     } as unknown as HTMLElement;
 
     expect(shouldClearThreadSelectionOnMouseDown(unrelated)).toBe(true);
+  });
+});
+
+describe("project deletion confirmation", () => {
+  it("requires typed confirmation when the project still has threads", () => {
+    expect(shouldRequireProjectDeleteConfirmation(0)).toBe(false);
+    expect(shouldRequireProjectDeleteConfirmation(1)).toBe(true);
+  });
+
+  it("accepts the confirmation phrase with trimmed, case-insensitive input", () => {
+    expect(matchesProjectDeleteConfirmationPhrase(PROJECT_DELETE_CONFIRMATION_PHRASE)).toBe(true);
+    expect(matchesProjectDeleteConfirmationPhrase("  Permanently   Delete  ")).toBe(true);
+  });
+
+  it("rejects partial or incorrect confirmation phrases", () => {
+    expect(matchesProjectDeleteConfirmationPhrase("delete")).toBe(false);
+    expect(matchesProjectDeleteConfirmationPhrase("permanently-delete")).toBe(false);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -12,6 +12,7 @@ import { isLatestTurnSettled } from "../session-logic";
 
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
+export const PROJECT_DELETE_CONFIRMATION_PHRASE = "permanently delete";
 // Visible sidebar rows are prewarmed into the thread-detail cache so opening a
 // nearby thread usually reuses an already-hot subscription.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
@@ -158,6 +159,14 @@ export function hasUnseenCompletion(thread: ThreadStatusInput): boolean {
 export function shouldClearThreadSelectionOnMouseDown(target: HTMLElement | null): boolean {
   if (target === null) return true;
   return !target.closest(THREAD_SELECTION_SAFE_SELECTOR);
+}
+
+export function shouldRequireProjectDeleteConfirmation(threadCount: number): boolean {
+  return threadCount > 0;
+}
+
+export function matchesProjectDeleteConfirmationPhrase(input: string): boolean {
+  return input.trim().replace(/\s+/g, " ").toLowerCase() === PROJECT_DELETE_CONFIRMATION_PHRASE;
 }
 
 export function resolveSidebarNewThreadEnvMode(input: {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -102,6 +102,16 @@ import {
 } from "./desktopUpdate.logic";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
 import { Menu, MenuGroup, MenuPopup, MenuRadioGroup, MenuRadioItem, MenuTrigger } from "./ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import {
@@ -122,8 +132,11 @@ import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useCommandPaletteStore } from "../commandPaletteStore";
 import {
   getSidebarThreadIdsToPrewarm,
+  matchesProjectDeleteConfirmationPhrase,
+  PROJECT_DELETE_CONFIRMATION_PHRASE,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
+  shouldRequireProjectDeleteConfirmation,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
@@ -1141,6 +1154,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const [renamingThreadKey, setRenamingThreadKey] = useState<string | null>(null);
   const [renamingTitle, setRenamingTitle] = useState("");
   const [confirmingArchiveThreadKey, setConfirmingArchiveThreadKey] = useState<string | null>(null);
+  const [projectDeleteDialogOpen, setProjectDeleteDialogOpen] = useState(false);
+  const [projectDeleteConfirmationInput, setProjectDeleteConfirmationInput] = useState("");
+  const [projectDeletePending, setProjectDeletePending] = useState(false);
   const renamingCommittedRef = useRef(false);
   const renamingInputRef = useRef<HTMLInputElement | null>(null);
   const confirmArchiveButtonRefs = useRef(new Map<string, HTMLButtonElement>());
@@ -1318,6 +1334,72 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     [suppressProjectClickAfterDragRef, suppressProjectClickForContextMenuRef],
   );
 
+  const closeProjectDeleteDialog = useCallback(() => {
+    if (projectDeletePending) {
+      return;
+    }
+    setProjectDeleteDialogOpen(false);
+    setProjectDeleteConfirmationInput("");
+  }, [projectDeletePending]);
+
+  const deleteProject = useCallback(
+    async ({ deleteThreads }: { deleteThreads: boolean }) => {
+      setProjectDeletePending(true);
+      try {
+        const projectDraftThread = getDraftThreadByProjectRef(
+          scopeProjectRef(project.environmentId, project.id),
+        );
+        if (projectDraftThread) {
+          clearComposerDraftForThread(projectDraftThread.draftId);
+        }
+        if (deleteThreads) {
+          const deletedThreadKeys = new Set(
+            projectThreads.map((thread) =>
+              scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+            ),
+          );
+          for (const thread of projectThreads) {
+            await deleteThread(scopeThreadRef(thread.environmentId, thread.id), {
+              deletedThreadKeys,
+            });
+          }
+        }
+        clearProjectDraftThreadId(scopeProjectRef(project.environmentId, project.id));
+        const projectApi = readEnvironmentApi(project.environmentId);
+        if (!projectApi) {
+          throw new Error("Project API unavailable.");
+        }
+        await projectApi.orchestration.dispatchCommand({
+          type: "project.delete",
+          commandId: newCommandId(),
+          projectId: project.id,
+        });
+        setProjectDeleteDialogOpen(false);
+        setProjectDeleteConfirmationInput("");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unknown error removing project.";
+        console.error("Failed to remove project", { projectId: project.id, error });
+        toastManager.add({
+          type: "error",
+          title: `Failed to remove "${project.name}"`,
+          description: message,
+        });
+      } finally {
+        setProjectDeletePending(false);
+      }
+    },
+    [
+      clearComposerDraftForThread,
+      clearProjectDraftThreadId,
+      deleteThread,
+      getDraftThreadByProjectRef,
+      project.environmentId,
+      project.id,
+      project.name,
+      projectThreads,
+    ],
+  );
+
   const handleProjectButtonContextMenu = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.preventDefault();
@@ -1342,55 +1424,21 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         }
         if (clicked !== "delete") return;
 
-        if (projectThreads.length > 0) {
-          toastManager.add({
-            type: "warning",
-            title: "Project is not empty",
-            description: "Delete all threads in this project before removing it.",
-          });
+        if (shouldRequireProjectDeleteConfirmation(projectThreads.length)) {
+          setProjectDeleteConfirmationInput("");
+          setProjectDeleteDialogOpen(true);
           return;
         }
 
         const confirmed = await api.dialogs.confirm(`Remove project "${project.name}"?`);
         if (!confirmed) return;
-
-        try {
-          const projectDraftThread = getDraftThreadByProjectRef(
-            scopeProjectRef(project.environmentId, project.id),
-          );
-          if (projectDraftThread) {
-            clearComposerDraftForThread(projectDraftThread.draftId);
-          }
-          clearProjectDraftThreadId(scopeProjectRef(project.environmentId, project.id));
-          const projectApi = readEnvironmentApi(project.environmentId);
-          if (!projectApi) {
-            throw new Error("Project API unavailable.");
-          }
-          await projectApi.orchestration.dispatchCommand({
-            type: "project.delete",
-            commandId: newCommandId(),
-            projectId: project.id,
-          });
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : "Unknown error removing project.";
-          console.error("Failed to remove project", { projectId: project.id, error });
-          toastManager.add({
-            type: "error",
-            title: `Failed to remove "${project.name}"`,
-            description: message,
-          });
-        }
+        await deleteProject({ deleteThreads: false });
       })();
     },
     [
-      clearComposerDraftForThread,
-      clearProjectDraftThreadId,
       copyPathToClipboard,
-      getDraftThreadByProjectRef,
+      deleteProject,
       project.cwd,
-      project.environmentId,
-      project.id,
       project.name,
       projectThreads.length,
       suppressProjectClickForContextMenuRef,
@@ -1693,6 +1741,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     ],
   );
 
+  const projectDeleteThreadCount = projectThreads.length;
+  const projectDeleteConfirmationSatisfied = matchesProjectDeleteConfirmationPhrase(
+    projectDeleteConfirmationInput,
+  );
+  const projectDeleteThreadLabel = `${projectDeleteThreadCount} thread${
+    projectDeleteThreadCount === 1 ? "" : "s"
+  }`;
+
   return (
     <>
       <div className="group/project-header relative">
@@ -1817,6 +1873,60 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         expandThreadListForProject={expandThreadListForProject}
         collapseThreadListForProject={collapseThreadListForProject}
       />
+
+      <Dialog
+        open={projectDeleteDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeProjectDeleteDialog();
+            return;
+          }
+          setProjectDeleteDialogOpen(true);
+        }}
+      >
+        <DialogPopup showCloseButton={!projectDeletePending}>
+          <DialogHeader>
+            <DialogTitle>Delete "{project.name}"?</DialogTitle>
+            <DialogDescription>
+              Remove this project and permanently delete its {projectDeleteThreadLabel}.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Type <code>{PROJECT_DELETE_CONFIRMATION_PHRASE}</code> to confirm.
+            </p>
+            <Input
+              autoFocus
+              aria-label="Project delete confirmation"
+              placeholder={PROJECT_DELETE_CONFIRMATION_PHRASE}
+              value={projectDeleteConfirmationInput}
+              onChange={(event) => {
+                setProjectDeleteConfirmationInput(event.target.value);
+              }}
+            />
+          </DialogPanel>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={projectDeletePending}
+              onClick={closeProjectDeleteDialog}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={!projectDeleteConfirmationSatisfied || projectDeletePending}
+              onClick={() => {
+                void deleteProject({ deleteThreads: true });
+              }}
+            >
+              {projectDeletePending ? "Deleting..." : "Delete project"}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
     </>
   );
 });


### PR DESCRIPTION
## Summary
- replace the non-empty project warning toast with a typed confirmation dialog in the sidebar
- delete the project's threads before dispatching `project.delete`
- add unit coverage for the confirmation phrase matching and requirement

## Why
- `#665` asks for deleting non-empty projects from the sidebar instead of blocking on a toast
- `#1880` reports that archived threads can leave a project looking empty but still undeletable

## Validation
- `bun fmt`
- `bun lint`
- `PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" bun typecheck`

Closes #665
Fixes #1880


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow deleting non-empty projects from the sidebar with typed confirmation
> - Replaces the warning toast that blocked deletion of projects with threads with a typed-confirmation dialog in `SidebarProjectItem`.
> - When a project has one or more threads, the user must type "permanently delete" (case-insensitive, whitespace-normalized) to enable the delete button; the project and all its threads are then deleted.
> - When a project has no threads, the existing simple confirm dialog is shown and only the project is deleted.
> - Adds `shouldRequireProjectDeleteConfirmation`, `matchesProjectDeleteConfirmationPhrase`, and `PROJECT_DELETE_CONFIRMATION_PHRASE` to [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/2032/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) with corresponding tests.
> - Behavioral Change: non-empty project deletion now succeeds (previously blocked) and the deletion dialog is modal with a pending state that prevents closing mid-delete.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e4014c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->