### PR TITLE
Add rate limit display to ui

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -175,6 +175,60 @@ function createCollabNotificationHarness() {
   return { manager, context, emitEvent, updateSession };
 }
 
+function createRateLimitRefreshHarness() {
+  const manager = new CodexAppServerManager();
+  const context = {
+    session: {
+      provider: "codex",
+      status: "running",
+      threadId: asThreadId("thread_1"),
+      runtimeMode: "full-access",
+      model: "gpt-5.3-codex",
+      activeTurnId: "turn_1",
+      resumeCursor: { threadId: "provider_1" },
+      createdAt: "2026-02-10T00:00:00.000Z",
+      updatedAt: "2026-02-10T00:00:00.000Z",
+    },
+    account: {
+      type: "unknown",
+      planType: null,
+      sparkEnabled: true,
+    },
+    pending: new Map(),
+    pendingApprovals: new Map(),
+    pendingUserInputs: new Map(),
+    collabReceiverTurns: new Map<string, string>(),
+    nextRequestId: 1,
+    stopping: false,
+  };
+
+  const emitEvent = vi
+    .spyOn(manager as unknown as { emitEvent: (...args: unknown[]) => void }, "emitEvent")
+    .mockImplementation(() => {});
+  const updateSession = vi
+    .spyOn(manager as unknown as { updateSession: (...args: unknown[]) => void }, "updateSession")
+    .mockImplementation(() => {});
+  const sendRequest = vi
+    .spyOn(
+      manager as unknown as { sendRequest: (...args: unknown[]) => Promise<unknown> },
+      "sendRequest",
+    )
+    .mockResolvedValue({
+      account: {
+        type: "chatgpt",
+        planType: "pro",
+        rateLimits: {
+          primary: {
+            usedPercent: 25,
+            windowDurationMins: 300,
+          },
+        },
+      },
+    });
+
+  return { manager, context, emitEvent, updateSession, sendRequest };
+}
+
 describe("classifyCodexStderrLine", () => {
   it("ignores empty lines", () => {
     expect(classifyCodexStderrLine("   ")).toBeNull();
@@ -993,6 +1047,40 @@ describe("collab child conversation routing", () => {
         itemId: "call_child_1",
       }),
     );
+  });
+});
+
+describe("rate-limit refresh", () => {
+  it("refreshes account/read and emits account/rateLimits/updated after turn completion", async () => {
+    const { manager, context, emitEvent, sendRequest } = createRateLimitRefreshHarness();
+
+    (
+      manager as unknown as {
+        handleServerNotification: (context: unknown, notification: Record<string, unknown>) => void;
+      }
+    ).handleServerNotification(context, {
+      method: "turn/completed",
+      params: {
+        turn: { id: "turn_1", status: "completed" },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(sendRequest).toHaveBeenCalledWith(context, "account/read", {});
+      expect(emitEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "account/rateLimits/updated",
+          kind: "notification",
+          threadId: "thread_1",
+          payload: {
+            primary: {
+              usedPercent: 25,
+              windowDurationMins: 300,
+            },
+          },
+        }),
+      );
+    });
   });
 });
 

--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -507,22 +507,16 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
       this.writeMessage(context, { method: "initialized" });
       try {
-        const modelListResponse = await this.sendRequest(context, "model/list", {});
-        console.log("codex model/list response", modelListResponse);
-      } catch (error) {
-        console.log("codex model/list failed", error);
+        await this.sendRequest(context, "model/list", {});
+      } catch {
+        // model/list is opportunistic here; startup should continue without it.
       }
       try {
         const accountReadResponse = await this.sendRequest(context, "account/read", {});
-        console.log("codex account/read response", accountReadResponse);
         context.account = readCodexAccountSnapshot(accountReadResponse);
-        console.log("codex subscription status", {
-          type: context.account.type,
-          planType: context.account.planType,
-          sparkEnabled: context.account.sparkEnabled,
-        });
-      } catch (error) {
-        console.log("codex account/read failed", error);
+        this.emitRateLimitsUpdatedFromAccountRead(context, accountReadResponse);
+      } catch {
+        // account/read can fail transiently during startup; retry after session is ready.
       }
 
       const normalizedModel = resolveCodexModelForAccount(
@@ -628,6 +622,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         requestedRuntimeMode: input.runtimeMode,
       }).pipe(this.runPromise);
       this.emitLifecycleEvent(context, "session/ready", `Connected to thread ${providerThreadId}`);
+      void this.refreshRateLimitsFromAccountRead(context);
       return { ...context.session };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start Codex session.";
@@ -1110,6 +1105,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         activeTurnId: undefined,
         lastError: errorMessage ?? context.session.lastError,
       });
+      void this.refreshRateLimitsFromAccountRead(context);
       return;
     }
 
@@ -1294,6 +1290,60 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
 
   private emitEvent(event: ProviderEvent): void {
     this.emit("event", event);
+  }
+
+  private async refreshRateLimitsFromAccountRead(context: CodexSessionContext): Promise<void> {
+    try {
+      const accountReadResponse = await this.sendRequest(context, "account/read", {});
+      context.account = readCodexAccountSnapshot(accountReadResponse);
+      this.emitRateLimitsUpdatedFromAccountRead(context, accountReadResponse);
+    } catch {
+      // Best-effort refresh; keep turn/session flow predictable even if this fails.
+    }
+  }
+
+  private emitRateLimitsUpdatedFromAccountRead(
+    context: CodexSessionContext,
+    accountReadResponse: unknown,
+  ): void {
+    const rateLimits = this.extractRateLimitsFromAccountRead(accountReadResponse);
+    if (rateLimits === undefined) {
+      return;
+    }
+
+    this.emitEvent({
+      id: EventId.make(randomUUID()),
+      kind: "notification",
+      provider: "codex",
+      threadId: context.session.threadId,
+      createdAt: new Date().toISOString(),
+      method: "account/rateLimits/updated",
+      payload: rateLimits,
+    });
+  }
+
+  private extractRateLimitsFromAccountRead(accountReadResponse: unknown): unknown | undefined {
+    const root = this.readObject(accountReadResponse);
+    if (!root) {
+      return undefined;
+    }
+
+    const account = this.readObject(root, "account");
+    const nestedRateLimits = account?.rateLimits ?? account?.rate_limits;
+    if (nestedRateLimits !== undefined) {
+      return nestedRateLimits;
+    }
+
+    const topLevelRateLimits = root.rateLimits ?? root.rate_limits;
+    if (topLevelRateLimits !== undefined) {
+      return topLevelRateLimits;
+    }
+
+    if (root.primary !== undefined || root.secondary !== undefined) {
+      return root;
+    }
+
+    return undefined;
   }
 
   private assertSupportedCodexCliVersion(input: {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -5,6 +5,9 @@ import {
   MessageId,
   type OrchestrationEvent,
   type OrchestrationProposedPlanId,
+  type ProviderRateLimitsSnapshot,
+  type ProviderRateLimitWindow,
+  type ProviderRateLimitCredits,
   CheckpointRef,
   isToolLifecycleItemType,
   ThreadId,
@@ -501,6 +504,129 @@ function runtimeEventToActivities(
   return [];
 }
 
+// -----------------------------------------------------------------------------
+// Rate-limit normalisation (Codex + Claude)
+// -----------------------------------------------------------------------------
+
+function rlAsObject(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  return value as Record<string, unknown>;
+}
+
+function rlAsNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function rlAsString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function normalizeRateLimitWindow(raw: unknown): ProviderRateLimitWindow | null {
+  const source = rlAsObject(raw);
+  if (!source) return null;
+  const usedPercent = rlAsNumber(source.usedPercent ?? source.used_percent);
+  if (usedPercent === undefined) return null;
+  return {
+    usedPercent,
+    windowDurationMins: rlAsNumber(source.windowDurationMins ?? source.window_duration_mins),
+    resetsAt: rlAsNumber(source.resetsAt ?? source.resets_at),
+  };
+}
+
+function normalizeCredits(raw: unknown): ProviderRateLimitCredits | null {
+  const source = rlAsObject(raw);
+  if (!source) return null;
+  const hasCredits = source.hasCredits ?? source.has_credits;
+  const unlimited = source.unlimited;
+  const balance = source.balance ?? null;
+  return {
+    hasCredits: typeof hasCredits === "boolean" ? hasCredits : false,
+    unlimited: typeof unlimited === "boolean" ? unlimited : false,
+    balance:
+      typeof balance === "string" ? balance : typeof balance === "number" ? String(balance) : null,
+  };
+}
+
+/**
+ * Normalize raw rate-limit payloads from Codex or Claude into the canonical
+ * `ProviderRateLimitsSnapshot` shape.
+ *
+ * Codex sends: `{ primary: { usedPercent, windowDurationMins, resetsAt }, secondary, credits, planType }`
+ * Claude sends: `{ type: "rate_limit_event", rate_limit_info: { status, resetsAt, rateLimitType, utilization } }`
+ */
+function normalizeRateLimits(
+  raw: unknown,
+  provider: "codex" | "claudeAgent",
+  previous: ProviderRateLimitsSnapshot | null | undefined,
+): ProviderRateLimitsSnapshot | null {
+  const root = rlAsObject(raw);
+  if (!root) return null;
+
+  // --- Claude path ---
+  if (provider === "claudeAgent") {
+    // The adapter wraps the full SDK message: { type: "rate_limit_event", rate_limit_info: { ... } }
+    const claudeInfo = rlAsObject(root.rate_limit_info);
+    if (!claudeInfo) return null;
+
+    const utilization = rlAsNumber(claudeInfo.utilization);
+    const usedPercent = utilization !== undefined ? Math.round(utilization * 100) : undefined;
+    const resetsAt = rlAsNumber(claudeInfo.resetsAt);
+    const rateLimitType = rlAsString(claudeInfo.rateLimitType ?? claudeInfo.rate_limit_type);
+    const status = rlAsString(claudeInfo.status);
+
+    // Map Claude rateLimitType to primary (5-hour) or secondary (7-day) window.
+    const isSecondary =
+      rateLimitType === "seven_day" ||
+      rateLimitType === "seven_day_opus" ||
+      rateLimitType === "seven_day_sonnet";
+
+    const previousPrimary = previous?.primary ?? null;
+    const previousSecondary = previous?.secondary ?? null;
+
+    // utilization is optional in the Claude SDK.
+    // Priority: real value → rejected sentinel → last known value for this window → 0 (unknown).
+    // Defaulting to 0 on the first event without utilization is intentional: it lets the component
+    // display the resetsAt date even when Anthropic omits the utilization field.
+    const previousWindow = isSecondary ? previousSecondary : previousPrimary;
+    const effectiveUsedPercent =
+      usedPercent ?? (status === "rejected" ? 100 : (previousWindow?.usedPercent ?? 0));
+
+    const window: ProviderRateLimitWindow = {
+      usedPercent: effectiveUsedPercent,
+      resetsAt,
+    };
+
+    return {
+      limitId: rateLimitType ?? previous?.limitId ?? null,
+      planType: previous?.planType ?? null,
+      primary: isSecondary ? previousPrimary : window,
+      secondary: isSecondary ? window : previousSecondary,
+      credits: previous?.credits ?? null,
+    };
+  }
+
+  // --- Codex path ---
+  // The adapter passes `event.payload ?? {}` as rateLimits; the actual data
+  // may be nested under `rateLimits` / `rate_limits` or flat at the root.
+  const codexSource = rlAsObject(root.rateLimits ?? root.rate_limits) ?? root;
+  const codexPrimary = normalizeRateLimitWindow(codexSource.primary);
+  const codexSecondary = normalizeRateLimitWindow(codexSource.secondary);
+
+  if (!codexPrimary && !codexSecondary) return null;
+
+  const codexCredits = normalizeCredits(codexSource.credits);
+  const codexPlanType = rlAsString(codexSource.planType ?? codexSource.plan_type);
+  const codexLimitId = rlAsString(codexSource.limitId ?? codexSource.limit_id);
+
+  return {
+    limitId: codexLimitId ?? previous?.limitId ?? null,
+    planType: codexPlanType ?? previous?.planType ?? null,
+    primary: codexPrimary ?? previous?.primary ?? null,
+    secondary: codexSecondary ?? previous?.secondary ?? null,
+    credits: codexCredits ?? previous?.credits ?? null,
+  };
+}
+
 const make = Effect.fn("make")(function* () {
   const orchestrationEngine = yield* OrchestrationEngineService;
   const providerService = yield* ProviderService;
@@ -990,6 +1116,7 @@ const make = Effect.fn("make")(function* () {
             activeTurnId: nextActiveTurnId,
             lastError,
             updatedAt: now,
+            rateLimits: thread.session?.rateLimits ?? null,
           },
           createdAt: now,
         });
@@ -1140,6 +1267,31 @@ const make = Effect.fn("make")(function* () {
       yield* clearTurnStateForSession(thread.id);
     }
 
+    // --- Rate limits: normalise and persist on session ---
+    if (event.type === "account.rate-limits.updated") {
+      const raw = (event.payload as { rateLimits?: unknown }).rateLimits;
+      const previousRateLimits = thread.session?.rateLimits ?? null;
+      const rateLimits = normalizeRateLimits(raw, event.provider, previousRateLimits);
+      if (rateLimits) {
+        yield* orchestrationEngine.dispatch({
+          type: "thread.session.set",
+          commandId: providerCommandId(event, "rate-limits-session-set"),
+          threadId: thread.id,
+          session: {
+            threadId: thread.id,
+            status: thread.session?.status ?? "ready",
+            providerName: thread.session?.providerName ?? event.provider,
+            runtimeMode: thread.session?.runtimeMode ?? "full-access",
+            activeTurnId: thread.session?.activeTurnId ?? null,
+            lastError: thread.session?.lastError ?? null,
+            updatedAt: now,
+            rateLimits,
+          },
+          createdAt: now,
+        });
+      }
+    }
+
     if (event.type === "runtime.error") {
       const runtimeErrorMessage = event.payload.message;
 
@@ -1160,6 +1312,7 @@ const make = Effect.fn("make")(function* () {
             activeTurnId: eventTurnId ?? null,
             lastError: runtimeErrorMessage,
             updatedAt: now,
+            rateLimits: thread.session?.rateLimits ?? null,
           },
           createdAt: now,
         });

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -3,7 +3,7 @@ import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { memo, useMemo } from "react";
 
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
-import { useStore } from "../store";
+import { type AppState, selectLatestRateLimitsForProvider, useStore } from "../store";
 import { createProjectSelectorByRef, createThreadSelectorByRef } from "../storeSelectors";
 import {
   type EnvMode,
@@ -13,6 +13,7 @@ import {
 import { BranchToolbarBranchSelector } from "./BranchToolbarBranchSelector";
 import { BranchToolbarEnvironmentSelector } from "./BranchToolbarEnvironmentSelector";
 import { BranchToolbarEnvModeSelector } from "./BranchToolbarEnvModeSelector";
+import { BranchToolbarRateLimit } from "./BranchToolbarRateLimit";
 import { Separator } from "./ui/separator";
 
 interface BranchToolbarProps {
@@ -77,6 +78,19 @@ export const BranchToolbar = memo(function BranchToolbar({
   const showEnvironmentPicker =
     availableEnvironments && availableEnvironments.length > 1 && onEnvironmentChange;
 
+  const activeProvider =
+    serverThread?.session?.provider ??
+    serverThread?.modelSelection.provider ??
+    activeProject?.defaultModelSelection?.provider ??
+    null;
+  const providerRateLimitsSelector = useMemo(
+    () => (state: AppState) =>
+      selectLatestRateLimitsForProvider(state, environmentId, activeProvider),
+    [environmentId, activeProvider],
+  );
+  const latestProviderRateLimits = useStore(providerRateLimitsSelector);
+  const displayedRateLimits = serverThread?.session?.rateLimits ?? latestProviderRateLimits ?? null;
+
   if (!hasActiveThread || !activeProject) return null;
 
   return (
@@ -100,6 +114,8 @@ export const BranchToolbar = memo(function BranchToolbar({
           onEnvModeChange={onEnvModeChange}
         />
       </div>
+
+      <BranchToolbarRateLimit rateLimits={displayedRateLimits} />
 
       <BranchToolbarBranchSelector
         environmentId={environmentId}

--- a/apps/web/src/components/BranchToolbarRateLimit.tsx
+++ b/apps/web/src/components/BranchToolbarRateLimit.tsx
@@ -1,0 +1,86 @@
+import type { ProviderRateLimitsSnapshot } from "@t3tools/contracts";
+import { memo } from "react";
+
+interface BranchToolbarRateLimitProps {
+  rateLimits: ProviderRateLimitsSnapshot | null | undefined;
+}
+
+function formatRemainingPercent(usedPercent: number): string {
+  const remaining = Math.max(0, 100 - Math.round(usedPercent));
+  return `${remaining}%`;
+}
+
+function formatResetDate(resetsAt: number | null | undefined): string | null {
+  if (resetsAt == null || !Number.isFinite(resetsAt)) return null;
+  const resetMs = resetsAt > 1_000_000_000_000 ? resetsAt : resetsAt * 1000;
+  const diffMs = resetMs - Date.now();
+  if (diffMs <= 0) return null;
+  const date = new Date(resetMs);
+  const month = date.toLocaleString("en-US", { month: "short" });
+  const day = date.getDate();
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${month} ${day} ${hours}:${minutes}`;
+}
+
+function formatResetsIn(resetsAt: number | null | undefined): string | null {
+  if (resetsAt == null || !Number.isFinite(resetsAt)) return null;
+  // resetsAt may be seconds (Codex) or milliseconds (Claude) — normalise.
+  const resetMs = resetsAt > 1_000_000_000_000 ? resetsAt : resetsAt * 1000;
+  const diffMs = resetMs - Date.now();
+  if (diffMs <= 0) return null;
+  const totalMinutes = Math.ceil(diffMs / 60_000);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes > 0 ? `${hours}h${minutes}m` : `${hours}h`;
+}
+
+function usageTone(usedPercent: number | null | undefined): string {
+  if (usedPercent == null) return "text-muted-foreground/50";
+  if (usedPercent >= 100) return "text-red-500";
+  if (usedPercent >= 80) return "text-amber-500";
+  return "text-muted-foreground/60";
+}
+
+export const BranchToolbarRateLimit = memo(function BranchToolbarRateLimit({
+  rateLimits,
+}: BranchToolbarRateLimitProps) {
+  const primary = rateLimits?.primary ?? null;
+  const secondary = rateLimits?.secondary ?? null;
+
+  const primaryRemaining = primary ? formatRemainingPercent(primary.usedPercent) : "--";
+  const primaryResets = primary ? formatResetsIn(primary.resetsAt) : null;
+  const secondaryRemaining = secondary ? formatRemainingPercent(secondary.usedPercent) : "--";
+  const secondaryResets = secondary ? formatResetDate(secondary.resetsAt) : null;
+
+  const parts = [
+    { key: "primary-remaining", text: `rate-limit | 5h ${primaryRemaining}` },
+    ...(primaryResets ? [{ key: "primary-resets", text: primaryResets }] : []),
+    { key: "secondary-remaining", text: `weekly ${secondaryRemaining}` },
+    ...(secondaryResets ? [{ key: "secondary-resets", text: secondaryResets }] : []),
+  ];
+
+  // Determine overall tone from the most constrained window.
+  const maxUsed =
+    primary?.usedPercent !== undefined
+      ? primary.usedPercent
+      : secondary?.usedPercent !== undefined
+        ? secondary.usedPercent
+        : null;
+
+  return (
+    <span className={`inline-flex items-center gap-1 text-xs font-medium ${usageTone(maxUsed)}`}>
+      {parts.map((part, i) => (
+        <span key={part.key} className="inline-flex items-center gap-1">
+          {i > 0 && (
+            <span className="text-muted-foreground/30" aria-hidden="true">
+              ·
+            </span>
+          )}
+          {part.text}
+        </span>
+      ))}
+    </span>
+  );
+});

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -16,6 +16,7 @@ import type {
   OrchestrationThreadActivity,
   ProjectId,
   ProviderKind,
+  ProviderRateLimitsSnapshot,
   ScopedProjectRef,
   ScopedThreadRef,
   ThreadId,
@@ -151,6 +152,7 @@ function mapSession(session: OrchestrationSession): ThreadSession {
     createdAt: session.updatedAt,
     updatedAt: session.updatedAt,
     ...(session.lastError ? { lastError: session.lastError } : {}),
+    ...(session.rateLimits !== undefined ? { rateLimits: session.rateLimits } : {}),
   };
 }
 
@@ -1789,6 +1791,34 @@ export function selectSidebarThreadsForProjectRefs(
   if (refs.length === 0) return [];
   if (refs.length === 1) return selectSidebarThreadsForProjectRef(state, refs[0]);
   return refs.flatMap((ref) => selectSidebarThreadsForProjectRef(state, ref));
+}
+
+export function selectLatestRateLimitsForProvider(
+  state: AppState,
+  environmentId: EnvironmentId | null | undefined,
+  provider: ProviderKind | null | undefined,
+): ProviderRateLimitsSnapshot | null {
+  if (!environmentId || !provider) {
+    return null;
+  }
+
+  const environmentState = selectEnvironmentState(state, environmentId);
+  let latestUpdatedAt: string | null = null;
+  let latestRateLimits: ProviderRateLimitsSnapshot | null = null;
+
+  for (const threadId of environmentState.threadIds) {
+    const session = environmentState.threadSessionById[threadId];
+    if (!session || session.provider !== provider || !session.rateLimits) {
+      continue;
+    }
+
+    if (latestUpdatedAt === null || session.updatedAt > latestUpdatedAt) {
+      latestUpdatedAt = session.updatedAt;
+      latestRateLimits = session.rateLimits;
+    }
+  }
+
+  return latestRateLimits;
 }
 
 export function selectBootstrapCompleteForActiveEnvironment(state: AppState): boolean {

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -165,4 +165,5 @@ export interface ThreadSession {
   updatedAt: string;
   lastError?: string;
   orchestrationStatus: OrchestrationSessionStatus;
+  rateLimits?: import("@t3tools/contracts").ProviderRateLimitsSnapshot | null;
 }

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -203,6 +203,29 @@ export const OrchestrationSessionStatus = Schema.Literals([
 ]);
 export type OrchestrationSessionStatus = typeof OrchestrationSessionStatus.Type;
 
+export const ProviderRateLimitWindow = Schema.Struct({
+  usedPercent: Schema.Number,
+  windowDurationMins: Schema.optional(Schema.Number),
+  resetsAt: Schema.optional(Schema.Number),
+});
+export type ProviderRateLimitWindow = typeof ProviderRateLimitWindow.Type;
+
+export const ProviderRateLimitCredits = Schema.Struct({
+  hasCredits: Schema.Boolean,
+  unlimited: Schema.Boolean,
+  balance: Schema.optional(Schema.NullOr(Schema.String)),
+});
+export type ProviderRateLimitCredits = typeof ProviderRateLimitCredits.Type;
+
+export const ProviderRateLimitsSnapshot = Schema.Struct({
+  limitId: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  planType: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  primary: Schema.optional(Schema.NullOr(ProviderRateLimitWindow)),
+  secondary: Schema.optional(Schema.NullOr(ProviderRateLimitWindow)),
+  credits: Schema.optional(Schema.NullOr(ProviderRateLimitCredits)),
+});
+export type ProviderRateLimitsSnapshot = typeof ProviderRateLimitsSnapshot.Type;
+
 export const OrchestrationSession = Schema.Struct({
   threadId: ThreadId,
   status: OrchestrationSessionStatus,
@@ -211,6 +234,7 @@ export const OrchestrationSession = Schema.Struct({
   activeTurnId: Schema.NullOr(TurnId),
   lastError: Schema.NullOr(TrimmedNonEmptyString),
   updatedAt: IsoDateTime,
+  rateLimits: Schema.optional(Schema.NullOr(ProviderRateLimitsSnapshot)),
 });
 export type OrchestrationSession = typeof OrchestrationSession.Type;
 


### PR DESCRIPTION
## What Changed

- Added provider rate-limit snapshots to the orchestration session contract so the server and web app can persist and read normalized limit state.
- Updated the Codex app-server manager to read rate-limit data from `account/read`, emit `account/rate-limits.updated` events, and refresh that data after session startup and turn completion.
- Added rate-limit normalization in provider runtime ingestion so Codex and Claude payloads converge into the same `ProviderRateLimitsSnapshot` shape.
- Stored the latest rate-limit state on the thread session and exposed the latest provider-level snapshot in the web state.
- Added a new `BranchToolbarRateLimit` UI component and rendered it in the branch toolbar to show remaining 5h and weekly quota plus reset timing.

## Why

The app already has access to provider rate-limit information, but the git-stage flow does not surface it in a consistent way. That makes it harder to understand whether a staging failure or blocked action is caused by quota pressure versus a normal product bug.

This approach keeps the behavior predictable under partial or delayed provider updates:
- Codex rate limits are refreshed opportunistically from `account/read` without blocking session startup or turn completion.
- Provider-specific payloads are normalized once on the server instead of leaking raw formats into the client.
- The toolbar can render either thread-local session limits or the latest known provider snapshot, which helps preserve useful UI state across turns and reconnects.

## UI Changes

The branch toolbar now displays rate-limit status in the center area, including:
- remaining 5h quota
- remaining weekly quota
- reset timing for each window when available

I did not attach screenshots/video in this draft yet.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the orchestration session contract and session-update ingestion path, so mistakes could break session hydration or event handling across providers. Changes are mostly additive/best-effort but span server, contracts, and UI.
> 
> **Overview**
> **Adds end-to-end rate-limit snapshot support** by extending `OrchestrationSession` with optional `rateLimits` and introducing canonical `ProviderRateLimitsSnapshot`/window/credits types.
> 
> On the server, Codex now extracts rate limits from `account/read`, emits `account/rateLimits/updated`, and refreshes rate limits opportunistically after session startup and `turn/completed`; runtime ingestion normalizes Codex/Claude payloads into the canonical shape and persists it onto the thread session.
> 
> On the web, session mapping and store selectors are updated to carry `rateLimits`, and the branch toolbar now renders a new `BranchToolbarRateLimit` readout using either the thread’s session limits or the latest provider-wide snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31407347fff69ad8d9d377edbe656defdb812eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add rate limit handling to git stage flow by refreshing and displaying provider rate limits
> - After session start and on `turn/completed`, `CodexAppServerManager` performs a best-effort `account/read` request and emits an `account/rateLimits/updated` notification with the extracted rate-limit payload.
> - `ProviderRuntimeIngestion` handles `account.rate-limits.updated` events, normalizes the payload into a canonical `ProviderRateLimitsSnapshot`, and persists it into the thread session via `thread.session.set`.
> - `BranchToolbar` now renders a new `BranchToolbarRateLimit` component showing primary (5h) and secondary (weekly) window usage with contextual coloring, sourced from a new `selectLatestRateLimitsForProvider` store selector.
> - New `ProviderRateLimitsSnapshot`, `ProviderRateLimitWindow`, and `ProviderRateLimitCredits` schemas are added to `packages/contracts/src/orchestration.ts` and the `OrchestrationSession` schema is extended to carry an optional `rateLimits` field.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f314073. 8 files reviewed, 3 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->