### PR TITLE
Route desktop remote bootstrap auth through Electron main process

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -23,6 +23,7 @@ import type {
   ClientSettings,
   DesktopTheme,
   DesktopAppBranding,
+  DesktopJsonHttpRequest,
   DesktopServerExposureMode,
   DesktopServerExposureState,
   DesktopUpdateChannel,
@@ -99,6 +100,7 @@ const SET_SAVED_ENVIRONMENT_SECRET_CHANNEL = "desktop:set-saved-environment-secr
 const REMOVE_SAVED_ENVIRONMENT_SECRET_CHANNEL = "desktop:remove-saved-environment-secret";
 const GET_SERVER_EXPOSURE_STATE_CHANNEL = "desktop:get-server-exposure-state";
 const SET_SERVER_EXPOSURE_MODE_CHANNEL = "desktop:set-server-exposure-mode";
+const REQUEST_JSON_HTTP_CHANNEL = "desktop:request-json-http";
 const BASE_DIR = process.env.T3CODE_HOME?.trim() || Path.join(OS.homedir(), ".t3");
 const STATE_DIR = Path.join(BASE_DIR, "userdata");
 const DESKTOP_SETTINGS_PATH = Path.join(STATE_DIR, "desktop-settings.json");
@@ -254,6 +256,48 @@ function resolveDesktopDevServerUrl(): string {
   }
 
   return devServerUrl;
+}
+
+function normalizeDesktopJsonHttpRequest(
+  rawRequest: unknown,
+): Required<Pick<DesktopJsonHttpRequest, "url" | "method">> &
+  Pick<DesktopJsonHttpRequest, "headers" | "body"> {
+  if (typeof rawRequest !== "object" || rawRequest === null) {
+    throw new Error("Invalid desktop HTTP request payload.");
+  }
+
+  const { url, method, headers, body } = rawRequest as DesktopJsonHttpRequest;
+  if (typeof url !== "string" || url.trim().length === 0) {
+    throw new Error("Invalid desktop HTTP request URL.");
+  }
+
+  const parsedUrl = new URL(url);
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error("Desktop HTTP requests only support http and https URLs.");
+  }
+
+  if (method !== undefined && method !== "GET" && method !== "POST") {
+    throw new Error("Desktop HTTP requests only support GET and POST.");
+  }
+
+  if (headers !== undefined) {
+    if (typeof headers !== "object" || headers === null || Array.isArray(headers)) {
+      throw new Error("Invalid desktop HTTP request headers.");
+    }
+
+    for (const [headerName, headerValue] of Object.entries(headers)) {
+      if (typeof headerValue !== "string") {
+        throw new Error(`Invalid desktop HTTP request header '${headerName}'.`);
+      }
+    }
+  }
+
+  return {
+    url: parsedUrl.toString(),
+    method: method ?? "GET",
+    ...(headers !== undefined ? { headers } : {}),
+    ...(body !== undefined ? { body } : {}),
+  };
 }
 
 function backendChildEnv(): NodeJS.ProcessEnv {
@@ -1664,6 +1708,22 @@ function registerIpcHandlers(): void {
     });
     relaunchDesktopApp(`serverExposureMode=${nextMode}`);
     return nextState;
+  });
+
+  ipcMain.removeHandler(REQUEST_JSON_HTTP_CHANNEL);
+  ipcMain.handle(REQUEST_JSON_HTTP_CHANNEL, async (_event, rawRequest: unknown) => {
+    const request = normalizeDesktopJsonHttpRequest(rawRequest);
+    const response = await fetch(request.url, {
+      method: request.method,
+      ...(request.headers !== undefined ? { headers: request.headers } : {}),
+      ...(request.body !== undefined ? { body: JSON.stringify(request.body) } : {}),
+    });
+    const bodyText = await response.text();
+    return {
+      status: response.status,
+      ok: response.ok,
+      bodyText,
+    };
   });
 
   ipcMain.removeHandler(PICK_FOLDER_CHANNEL);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -280,6 +280,10 @@ function normalizeDesktopJsonHttpRequest(
     throw new Error("Desktop HTTP requests only support GET and POST.");
   }
 
+  if (body !== undefined && (method ?? "GET") !== "POST") {
+    throw new Error("Desktop HTTP request body is only allowed with POST method.");
+  }
+
   if (headers !== undefined) {
     if (typeof headers !== "object" || headers === null || Array.isArray(headers)) {
       throw new Error("Invalid desktop HTTP request headers.");

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -24,6 +24,7 @@ const SET_SAVED_ENVIRONMENT_SECRET_CHANNEL = "desktop:set-saved-environment-secr
 const REMOVE_SAVED_ENVIRONMENT_SECRET_CHANNEL = "desktop:remove-saved-environment-secret";
 const GET_SERVER_EXPOSURE_STATE_CHANNEL = "desktop:get-server-exposure-state";
 const SET_SERVER_EXPOSURE_MODE_CHANNEL = "desktop:set-server-exposure-mode";
+const REQUEST_JSON_HTTP_CHANNEL = "desktop:request-json-http";
 
 contextBridge.exposeInMainWorld("desktopBridge", {
   getAppBranding: () => {
@@ -53,6 +54,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     ipcRenderer.invoke(REMOVE_SAVED_ENVIRONMENT_SECRET_CHANNEL, environmentId),
   getServerExposureState: () => ipcRenderer.invoke(GET_SERVER_EXPOSURE_STATE_CHANNEL),
   setServerExposureMode: (mode) => ipcRenderer.invoke(SET_SERVER_EXPOSURE_MODE_CHANNEL, mode),
+  requestJsonHttp: (request) => ipcRenderer.invoke(REQUEST_JSON_HTTP_CHANNEL, request),
   pickFolder: (options) => ipcRenderer.invoke(PICK_FOLDER_CHANNEL, options),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -307,6 +307,7 @@ const createDesktopBridgeStub = (overrides?: {
         endpointUrl: mode === "network-accessible" ? "http://192.168.1.44:3773" : null,
         advertisedHost: mode === "network-accessible" ? "192.168.1.44" : null,
       })),
+    requestJsonHttp: vi.fn().mockRejectedValue(new Error("requestJsonHttp not implemented")),
     pickFolder: vi.fn().mockResolvedValue(null),
     confirm: vi.fn().mockResolvedValue(false),
     setTheme: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/environments/remote/api.test.ts
+++ b/apps/web/src/environments/remote/api.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
       location: {
         origin: "https://app.example.com",
       },
+      desktopBridge: undefined,
     },
   });
   vi.restoreAllMocks();
@@ -227,6 +228,48 @@ describe("remote environment api", () => {
         bearerToken: "bearer-token",
       }),
     ).resolves.toBe("wss://remote.example.com/?wsToken=ws-token");
+  });
+
+  it("uses the desktop bridge for remote descriptor requests inside Electron", async () => {
+    const requestJsonHttp = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      bodyText: JSON.stringify({
+        environmentId: "environment-remote",
+        label: "Remote environment",
+        platform: {
+          os: "linux",
+          arch: "x64",
+        },
+        serverVersion: "0.0.0-test",
+        capabilities: {
+          repositoryIdentity: true,
+        },
+      }),
+    });
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+    Object.assign(window, {
+      desktopBridge: {
+        requestJsonHttp,
+      },
+    });
+
+    await expect(
+      fetchRemoteEnvironmentDescriptor({
+        httpBaseUrl: "https://remote.example.com/",
+      }),
+    ).resolves.toMatchObject({
+      environmentId: "environment-remote",
+      label: "Remote environment",
+    });
+
+    expect(requestJsonHttp).toHaveBeenCalledWith({
+      url: "https://remote.example.com/.well-known/t3/environment",
+      method: "GET",
+      headers: {},
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/environments/remote/api.ts
+++ b/apps/web/src/environments/remote/api.ts
@@ -2,6 +2,7 @@ import type {
   AuthBearerBootstrapResult,
   AuthSessionState,
   AuthWebSocketTokenResult,
+  DesktopBridge,
   ExecutionEnvironmentDescriptor,
 } from "@t3tools/contracts";
 
@@ -52,16 +53,36 @@ async function fetchRemoteJson<T>(input: {
   readonly body?: unknown;
 }): Promise<T> {
   const requestUrl = remoteEndpointUrl(input.httpBaseUrl, input.pathname);
-  let response: Response;
+  const headers = {
+    ...(input.body !== undefined ? { "content-type": "application/json" } : {}),
+    ...(input.bearerToken ? { authorization: `Bearer ${input.bearerToken}` } : {}),
+  };
+  let responseBodyText: string;
+  let responseOk: boolean;
+  let responseStatus: number;
   try {
-    response = await fetch(requestUrl, {
-      method: input.method ?? "GET",
-      headers: {
-        ...(input.body !== undefined ? { "content-type": "application/json" } : {}),
-        ...(input.bearerToken ? { authorization: `Bearer ${input.bearerToken}` } : {}),
-      },
-      ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
-    });
+    const desktopBridge: DesktopBridge | undefined =
+      typeof window !== "undefined" ? window.desktopBridge : undefined;
+    if (desktopBridge?.requestJsonHttp) {
+      const response = await desktopBridge.requestJsonHttp({
+        url: requestUrl,
+        method: input.method ?? "GET",
+        headers,
+        ...(input.body !== undefined ? { body: input.body } : {}),
+      });
+      responseBodyText = response.bodyText;
+      responseOk = response.ok;
+      responseStatus = response.status;
+    } else {
+      const response = await fetch(requestUrl, {
+        method: input.method ?? "GET",
+        headers,
+        ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
+      });
+      responseBodyText = await response.text();
+      responseOk = response.ok;
+      responseStatus = response.status;
+    }
   } catch (error) {
     throw new Error(
       `Failed to fetch remote auth endpoint ${requestUrl} (${(error as Error).message}).`,
@@ -69,17 +90,17 @@ async function fetchRemoteJson<T>(input: {
     );
   }
 
-  if (!response.ok) {
+  if (!responseOk) {
     throw new RemoteEnvironmentAuthHttpError(
       await readRemoteAuthErrorMessage(
-        response,
-        `Remote auth request failed (${response.status}).`,
+        new Response(responseBodyText, { status: responseStatus }),
+        `Remote auth request failed (${responseStatus}).`,
       ),
-      response.status,
+      responseStatus,
     );
   }
 
-  return (await response.json()) as T;
+  return JSON.parse(responseBodyText) as T;
 }
 
 export async function bootstrapRemoteBearerSession(input: {

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -179,6 +179,9 @@ function makeDesktopBridge(overrides: Partial<DesktopBridge> = {}): DesktopBridg
       endpointUrl: null,
       advertisedHost: null,
     }),
+    requestJsonHttp: async () => {
+      throw new Error("requestJsonHttp not implemented in test");
+    },
     pickFolder: async () => null,
     confirm: async () => true,
     setTheme: async () => undefined,

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -145,6 +145,19 @@ export interface PickFolderOptions {
   initialPath?: string | null;
 }
 
+export interface DesktopJsonHttpRequest {
+  url: string;
+  method?: "GET" | "POST";
+  headers?: Readonly<Record<string, string>>;
+  body?: unknown;
+}
+
+export interface DesktopJsonHttpResponse {
+  status: number;
+  ok: boolean;
+  bodyText: string;
+}
+
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
   getLocalEnvironmentBootstrap: () => DesktopEnvironmentBootstrap | null;
@@ -159,6 +172,7 @@ export interface DesktopBridge {
   removeSavedEnvironmentSecret: (environmentId: EnvironmentId) => Promise<void>;
   getServerExposureState: () => Promise<DesktopServerExposureState>;
   setServerExposureMode: (mode: DesktopServerExposureMode) => Promise<DesktopServerExposureState>;
+  requestJsonHttp: (request: DesktopJsonHttpRequest) => Promise<DesktopJsonHttpResponse>;
   pickFolder: (options?: PickFolderOptions) => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Routes desktop remote bootstrap/auth JSON requests through Electron main-process IPC instead of issuing them from the renderer.

Adds the preload bridge, main-process handler, shared IPC contract updates, and tests covering the desktop path while leaving the normal web flow unchanged.

## Why

Fixes #1928.

Desktop remote pairing was failing when the remote server did not allow the desktop renderer origin via CORS, because the environment bootstrap/auth flow was being performed directly from the renderer.

Handling those requests in the Electron main process removes the renderer CORS dependency without widening the change into the regular browser path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new IPC surface that can issue arbitrary `http(s)` GET/POST requests from the Electron main process, which increases SSRF/network-access risk if misused despite basic validation.
> 
> **Overview**
> Remote environment bootstrap/auth JSON requests in Electron are now proxied through the main process instead of using renderer `fetch`, avoiding CORS failures against remote servers.
> 
> This adds a new `desktop:request-json-http` IPC endpoint (exposed as `desktopBridge.requestJsonHttp`) with request validation in the main process and updates `fetchRemoteJson` to prefer this bridge when present, plus associated contract/type updates and test stubs/coverage for the Electron path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae72c23c6c7cbf4e681d324b4a7a00ff546e27b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Route remote bootstrap auth requests through the Electron main process
> - Adds a `requestJsonHttp` IPC channel (`desktop:request-json-http`) handled in the Electron main process, supporting GET/POST with optional headers and body, returning status, ok, and body text.
> - Extends `DesktopBridge` in [`packages/contracts/src/ipc.ts`](https://github.com/pingdotgg/t3code/pull/2036/files#diff-b3653a8424fd66e30684757f240a41b389e093822f7c4139866bcae9e917a38a) with `DesktopJsonHttpRequest` and `DesktopJsonHttpResponse` types, and exposes `desktopBridge.requestJsonHttp` to the renderer via the preload context bridge.
> - Modifies `fetchRemoteJson` in [`apps/web/src/environments/remote/api.ts`](https://github.com/pingdotgg/t3code/pull/2036/files#diff-582551bc715b0366ec7e0da1d822a7b290da7d8cfda75ed082f086107bf9dd72) to route through `desktopBridge.requestJsonHttp` when running in Electron, falling back to `window.fetch` in browser contexts.
> - Behavioral Change: error handling in `fetchRemoteJson` now reads body text and HTTP status from the bridge response rather than from the fetch `Response` object directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae72c23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->