### PR TITLE
feat: add pinned threads and thread ID search

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -143,7 +143,7 @@ export function buildThreadActionItems(input: {
     return {
       kind: "action",
       value: `thread:${thread.id}`,
-      searchTerms: [thread.title, projectTitle ?? "", thread.branch ?? ""],
+      searchTerms: [thread.title, thread.id, projectTitle ?? "", thread.branch ?? ""],
       title: thread.title,
       description: descriptionParts.join(" · "),
       timestamp: formatRelativeTimeLabel(

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3,13 +3,16 @@ import {
   ArrowUpDownIcon,
   ChevronRightIcon,
   CloudIcon,
+  FilterIcon,
   GitPullRequestIcon,
+  PinIcon,
   PlusIcon,
   SearchIcon,
   SettingsIcon,
   SquarePenIcon,
   TerminalIcon,
   TriangleAlertIcon,
+  XIcon,
 } from "lucide-react";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { autoAnimate } from "@formkit/auto-animate";
@@ -393,6 +396,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
+  const isPinned = useUiStateStore((state) => state.pinnedThreadKeys[threadKey] === true);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const hasSelection = useThreadSelectionStore((state) => state.selectedThreadKeys.size > 0);
   const runningTerminalIds = useTerminalStateStore(
@@ -634,6 +638,9 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
               />
               <TooltipPopup side="top">{prStatus.tooltip}</TooltipPopup>
             </Tooltip>
+          )}
+          {isPinned && (
+            <PinIcon className="size-3 shrink-0 text-muted-foreground/50 rotate-[-30deg]" />
           )}
           {threadStatus && <ThreadStatusLabel status={threadStatus} />}
           {renamingThreadKey === threadKey ? (
@@ -963,6 +970,7 @@ interface SidebarProjectItemProps {
   suppressProjectClickForContextMenuRef: React.RefObject<boolean>;
   isManualProjectSorting: boolean;
   dragHandleProps: SortableProjectHandleProps | null;
+  threadFilterQuery: string;
 }
 
 const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjectItemProps) {
@@ -983,6 +991,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     suppressProjectClickForContextMenuRef,
     isManualProjectSorting,
     dragHandleProps,
+    threadFilterQuery,
   } = props;
   const threadSortOrder = useSettings<SidebarThreadSortOrder>(
     (settings) => settings.sidebarThreadSortOrder,
@@ -998,6 +1007,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   );
   const router = useRouter();
   const markThreadUnread = useUiStateStore((state) => state.markThreadUnread);
+  const pinnedThreadKeys = useUiStateStore((state) => state.pinnedThreadKeys);
+  const pinThreadAction = useUiStateStore((state) => state.pinThread);
+  const unpinThreadAction = useUiStateStore((state) => state.unpinThread);
   const toggleProject = useUiStateStore((state) => state.toggleProject);
   const toggleThreadSelection = useThreadSelectionStore((state) => state.toggleThread);
   const rangeSelectTo = useThreadSelectionStore((state) => state.rangeSelectTo);
@@ -1163,10 +1175,25 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         },
       });
     };
-    const visibleProjectThreads = sortThreads(
-      projectThreads.filter((thread) => thread.archivedAt === null),
-      threadSortOrder,
+    let filteredThreads = projectThreads.filter((thread) => thread.archivedAt === null);
+    // Apply search filter if provided
+    if (threadFilterQuery && threadFilterQuery.length > 0) {
+      const query = threadFilterQuery.toLowerCase();
+      filteredThreads = filteredThreads.filter(
+        (thread) =>
+          thread.id.toLowerCase().includes(query) ||
+          thread.title.toLowerCase().includes(query),
+      );
+    }
+    const sorted = sortThreads(filteredThreads, threadSortOrder);
+    // Sort pinned threads to the top while preserving relative order
+    const pinned = sorted.filter(
+      (thread) => pinnedThreadKeys[scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))],
     );
+    const unpinned = sorted.filter(
+      (thread) => !pinnedThreadKeys[scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))],
+    );
+    const visibleProjectThreads = [...pinned, ...unpinned];
     const projectStatus = resolveProjectStatusIndicator(
       visibleProjectThreads.map((thread) => resolveProjectThreadStatus(thread)),
     );
@@ -1177,7 +1204,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       projectStatus,
       visibleProjectThreads,
     };
-  }, [projectThreads, threadLastVisitedAts, threadSortOrder]);
+  }, [projectThreads, threadLastVisitedAts, threadSortOrder, pinnedThreadKeys, threadFilterQuery]);
 
   const pinnedCollapsedThread = useMemo(() => {
     const activeThreadKey = activeRouteThreadKey ?? undefined;
@@ -1226,11 +1253,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
       ),
     );
-    const renderedThreads = pinnedCollapsedThread
-      ? [pinnedCollapsedThread]
-      : visibleProjectThreads.filter((thread) =>
-          visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-        );
+    const hasActiveFilter = threadFilterQuery.length > 0;
+    const renderedThreads = hasActiveFilter
+      ? visibleProjectThreads
+      : pinnedCollapsedThread
+        ? [pinnedCollapsedThread]
+        : visibleProjectThreads.filter((thread) =>
+            visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
+          );
     const hiddenThreads = visibleProjectThreads.filter(
       (thread) =>
         !visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
@@ -1241,14 +1271,15 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         hiddenThreads.map((thread) => resolveProjectThreadStatus(thread)),
       ),
       renderedThreads,
-      showEmptyThreadState: projectExpanded && visibleProjectThreads.length === 0,
-      shouldShowThreadPanel: projectExpanded || pinnedCollapsedThread !== null,
+      showEmptyThreadState: (projectExpanded || hasActiveFilter) && visibleProjectThreads.length === 0,
+      shouldShowThreadPanel: projectExpanded || pinnedCollapsedThread !== null || (hasActiveFilter && visibleProjectThreads.length > 0),
     };
   }, [
     isThreadListExpanded,
     pinnedCollapsedThread,
     projectExpanded,
     projectThreads,
+    threadFilterQuery,
     threadLastVisitedAts,
     visibleProjectThreads,
   ]);
@@ -1631,9 +1662,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       const thread = sidebarThreadByKeyRef.current.get(threadKey) ?? null;
       if (!thread) return;
       const threadWorkspacePath = thread.worktreePath ?? project.cwd ?? null;
+      const isPinned = pinnedThreadKeys[threadKey] === true;
       const clicked = await api.contextMenu.show(
         [
           { id: "rename", label: "Rename thread" },
+          { id: isPinned ? "unpin" : "pin", label: isPinned ? "Unpin thread" : "Pin thread" },
           { id: "mark-unread", label: "Mark unread" },
           { id: "copy-path", label: "Copy Path" },
           { id: "copy-thread-id", label: "Copy Thread ID" },
@@ -1649,6 +1682,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         return;
       }
 
+      if (clicked === "pin") {
+        pinThreadAction(threadKey);
+        return;
+      }
+      if (clicked === "unpin") {
+        unpinThreadAction(threadKey);
+        return;
+      }
       if (clicked === "mark-unread") {
         markThreadUnread(threadKey, thread.latestTurn?.completedAt);
         return;
@@ -1689,6 +1730,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       copyThreadIdToClipboard,
       deleteThread,
       markThreadUnread,
+      pinThreadAction,
+      unpinThreadAction,
+      pinnedThreadKeys,
       project.cwd,
     ],
   );
@@ -2055,6 +2099,10 @@ interface SidebarProjectsContentProps {
   suppressProjectClickForContextMenuRef: React.RefObject<boolean>;
   attachProjectListAutoAnimateRef: (node: HTMLElement | null) => void;
   projectsLength: number;
+  threadFilterQuery: string;
+  setThreadFilterQuery: (query: string) => void;
+  showThreadFilter: boolean;
+  setShowThreadFilter: (show: boolean) => void;
 }
 
 const SidebarProjectsContent = memo(function SidebarProjectsContent(
@@ -2094,6 +2142,10 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     suppressProjectClickForContextMenuRef,
     attachProjectListAutoAnimateRef,
     projectsLength,
+    threadFilterQuery,
+    setThreadFilterQuery,
+    showThreadFilter,
+    setShowThreadFilter,
   } = props;
 
   const handleProjectSortOrderChange = useCallback(
@@ -2174,6 +2226,33 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 render={
                   <button
                     type="button"
+                    aria-label="Filter threads"
+                    data-testid="sidebar-filter-threads-trigger"
+                    className={`inline-flex size-5 cursor-pointer items-center justify-center rounded-md transition-colors hover:bg-accent hover:text-foreground ${
+                      showThreadFilter
+                        ? "text-primary"
+                        : "text-muted-foreground/60"
+                    }`}
+                    onClick={() => {
+                      if (showThreadFilter) {
+                        setThreadFilterQuery("");
+                        setShowThreadFilter(false);
+                      } else {
+                        setShowThreadFilter(true);
+                      }
+                    }}
+                  />
+                }
+              >
+                <FilterIcon className="size-3.5" />
+              </TooltipTrigger>
+              <TooltipPopup side="right">Filter threads by ID</TooltipPopup>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
                     aria-label="Add project"
                     data-testid="sidebar-add-project-trigger"
                     className="inline-flex size-5 cursor-pointer items-center justify-center rounded-md text-muted-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
@@ -2187,6 +2266,38 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
             </Tooltip>
           </div>
         </div>
+
+        {showThreadFilter && (
+          <div className="mb-1.5 flex items-center gap-1.5 px-2">
+            <div className="relative flex flex-1 items-center">
+              <SearchIcon className="pointer-events-none absolute left-2 size-3 text-muted-foreground/50" />
+              <input
+                autoFocus
+                type="text"
+                placeholder="Filter by thread ID or title..."
+                className="h-7 w-full rounded-md border border-border/60 bg-background/80 pl-7 pr-7 text-xs text-foreground placeholder:text-muted-foreground/40 outline-none focus:border-ring focus:ring-1 focus:ring-ring"
+                value={threadFilterQuery}
+                onChange={(e) => setThreadFilterQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setThreadFilterQuery("");
+                    setShowThreadFilter(false);
+                  }
+                }}
+              />
+              {threadFilterQuery.length > 0 && (
+                <button
+                  type="button"
+                  aria-label="Clear filter"
+                  className="absolute right-1.5 inline-flex size-4 cursor-pointer items-center justify-center rounded-sm text-muted-foreground/50 hover:text-foreground"
+                  onClick={() => setThreadFilterQuery("")}
+                >
+                  <XIcon className="size-3" />
+                </button>
+              )}
+            </div>
+          </div>
+        )}
 
         {isManualProjectSorting ? (
           <DndContext
@@ -2226,6 +2337,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         }
                         isManualProjectSorting={isManualProjectSorting}
                         dragHandleProps={dragHandleProps}
+                        threadFilterQuery={threadFilterQuery}
                       />
                     )}
                   </SortableProjectItem>
@@ -2256,6 +2368,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
                 isManualProjectSorting={isManualProjectSorting}
                 dragHandleProps={null}
+                threadFilterQuery={threadFilterQuery}
               />
             ))}
           </SidebarMenu>
@@ -2295,6 +2408,14 @@ export default function Sidebar() {
   const [expandedThreadListsByProject, setExpandedThreadListsByProject] = useState<
     ReadonlySet<string>
   >(() => new Set());
+  const [threadFilterQuery, setThreadFilterQuery] = useState("");
+  const [showThreadFilter, setShowThreadFilter] = useState(false);
+  const handleSetThreadFilterQuery = useCallback((query: string) => {
+    setThreadFilterQuery(query);
+    if (query.length > 0) {
+      setShowThreadFilter(true);
+    }
+  }, []);
   const { showThreadJumpHints, updateThreadJumpHintsVisibility } = useThreadJumpHintVisibility();
   const dragInProgressRef = useRef(false);
   const suppressProjectClickAfterDragRef = useRef(false);
@@ -3004,6 +3125,10 @@ export default function Sidebar() {
             suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
             attachProjectListAutoAnimateRef={attachProjectListAutoAnimateRef}
             projectsLength={projects.length}
+            threadFilterQuery={threadFilterQuery}
+            setThreadFilterQuery={handleSetThreadFilterQuery}
+            showThreadFilter={showThreadFilter}
+            setShowThreadFilter={setShowThreadFilter}
           />
 
           <SidebarSeparator />

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1243,9 +1243,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         },
       });
     };
-    const hasOverflowingThreads = visibleProjectThreads.length > THREAD_PREVIEW_LIMIT;
+    const hasActiveFilter = threadFilterQuery.length > 0;
+    // When filtering, show all matches — no preview limit or overflow
+    const hasOverflowingThreads = !hasActiveFilter && visibleProjectThreads.length > THREAD_PREVIEW_LIMIT;
     const previewThreads =
-      isThreadListExpanded || !hasOverflowingThreads
+      hasActiveFilter || isThreadListExpanded || !hasOverflowingThreads
         ? visibleProjectThreads
         : visibleProjectThreads.slice(0, THREAD_PREVIEW_LIMIT);
     const visibleThreadKeys = new Set(
@@ -1253,7 +1255,6 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
       ),
     );
-    const hasActiveFilter = threadFilterQuery.length > 0;
     const renderedThreads = hasActiveFilter
       ? visibleProjectThreads
       : pinnedCollapsedThread
@@ -1261,10 +1262,12 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         : visibleProjectThreads.filter((thread) =>
             visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
           );
-    const hiddenThreads = visibleProjectThreads.filter(
-      (thread) =>
-        !visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-    );
+    const hiddenThreads = hasActiveFilter
+      ? []
+      : visibleProjectThreads.filter(
+          (thread) =>
+            !visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
+        );
     return {
       hasOverflowingThreads,
       hiddenThreadStatus: resolveProjectStatusIndicator(

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -18,6 +18,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
+    pinnedThreadKeys: {},
     ...overrides,
   };
 }

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -19,6 +19,7 @@ interface PersistedUiState {
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
+  pinnedThreadKeys?: string[];
 }
 
 export interface UiProjectState {
@@ -29,6 +30,7 @@ export interface UiProjectState {
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
+  pinnedThreadKeys: Record<string, boolean>;
 }
 
 export interface UiState extends UiProjectState, UiThreadState {}
@@ -48,6 +50,7 @@ const initialState: UiState = {
   projectOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
+  pinnedThreadKeys: {},
 };
 
 const persistedExpandedProjectCwds = new Set<string>();
@@ -74,11 +77,18 @@ function readPersistedState(): UiState {
     }
     const parsed = JSON.parse(raw) as PersistedUiState;
     hydratePersistedProjectState(parsed);
+    const pinnedThreadKeys: Record<string, boolean> = {};
+    for (const key of parsed.pinnedThreadKeys ?? []) {
+      if (typeof key === "string" && key.length > 0) {
+        pinnedThreadKeys[key] = true;
+      }
+    }
     return {
       ...initialState,
       threadChangedFilesExpandedById: sanitizePersistedThreadChangedFilesExpanded(
         parsed.threadChangedFilesExpandedById,
       ),
+      pinnedThreadKeys,
     };
   } catch {
     return initialState;
@@ -151,12 +161,16 @@ function persistState(state: UiState): void {
         return Object.keys(nextTurns).length > 0 ? [[threadId, nextTurns]] : [];
       }),
     );
+    const pinnedThreadKeys = Object.entries(state.pinnedThreadKeys)
+      .filter(([, pinned]) => pinned)
+      .map(([key]) => key);
     window.localStorage.setItem(
       PERSISTED_STATE_KEY,
       JSON.stringify({
         expandedProjectCwds,
         projectOrderCwds,
         threadChangedFilesExpandedById,
+        pinnedThreadKeys,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -328,12 +342,16 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
       retainedThreadIds.has(threadId),
     ),
   );
+  const nextPinnedThreadKeys = Object.fromEntries(
+    Object.entries(state.pinnedThreadKeys).filter(([threadId]) => retainedThreadIds.has(threadId)),
+  );
   if (
     recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById) &&
     nestedBooleanRecordsEqual(
       state.threadChangedFilesExpandedById,
       nextThreadChangedFilesExpandedById,
-    )
+    ) &&
+    recordsEqual(state.pinnedThreadKeys, nextPinnedThreadKeys)
   ) {
     return state;
   }
@@ -341,6 +359,7 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
     threadChangedFilesExpandedById: nextThreadChangedFilesExpandedById,
+    pinnedThreadKeys: nextPinnedThreadKeys,
   };
 }
 
@@ -393,17 +412,46 @@ export function markThreadUnread(
 export function clearThreadUi(state: UiState, threadId: string): UiState {
   const hasVisitedState = threadId in state.threadLastVisitedAtById;
   const hasChangedFilesState = threadId in state.threadChangedFilesExpandedById;
-  if (!hasVisitedState && !hasChangedFilesState) {
+  const hasPinnedState = threadId in state.pinnedThreadKeys;
+  if (!hasVisitedState && !hasChangedFilesState && !hasPinnedState) {
     return state;
   }
   const nextThreadLastVisitedAtById = { ...state.threadLastVisitedAtById };
   const nextThreadChangedFilesExpandedById = { ...state.threadChangedFilesExpandedById };
+  const nextPinnedThreadKeys = { ...state.pinnedThreadKeys };
   delete nextThreadLastVisitedAtById[threadId];
   delete nextThreadChangedFilesExpandedById[threadId];
+  delete nextPinnedThreadKeys[threadId];
   return {
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
     threadChangedFilesExpandedById: nextThreadChangedFilesExpandedById,
+    pinnedThreadKeys: nextPinnedThreadKeys,
+  };
+}
+
+export function pinThread(state: UiState, threadKey: string): UiState {
+  if (state.pinnedThreadKeys[threadKey]) {
+    return state;
+  }
+  return {
+    ...state,
+    pinnedThreadKeys: {
+      ...state.pinnedThreadKeys,
+      [threadKey]: true,
+    },
+  };
+}
+
+export function unpinThread(state: UiState, threadKey: string): UiState {
+  if (!state.pinnedThreadKeys[threadKey]) {
+    return state;
+  }
+  const nextPinnedThreadKeys = { ...state.pinnedThreadKeys };
+  delete nextPinnedThreadKeys[threadKey];
+  return {
+    ...state,
+    pinnedThreadKeys: nextPinnedThreadKeys,
   };
 }
 
@@ -536,6 +584,8 @@ interface UiStateStore extends UiState {
     draggedProjectIds: readonly string[],
     targetProjectIds: readonly string[],
   ) => void;
+  pinThread: (threadKey: string) => void;
+  unpinThread: (threadKey: string) => void;
 }
 
 export const useUiStateStore = create<UiStateStore>((set) => ({
@@ -554,6 +604,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setProjectExpanded(state, projectId, expanded)),
   reorderProjects: (draggedProjectIds, targetProjectIds) =>
     set((state) => reorderProjects(state, draggedProjectIds, targetProjectIds)),
+  pinThread: (threadKey) => set((state) => pinThread(state, threadKey)),
+  unpinThread: (threadKey) => set((state) => unpinThread(state, threadKey)),
 }));
 
 useUiStateStore.subscribe((state) => debouncedPersistState.maybeExecute(state));


### PR DESCRIPTION
## Summary
- **Pinned threads**: Right-click any thread → "Pin thread" to pin it to the top of its project's thread list. Persisted to localStorage. Visual pin icon indicator. Unpin via context menu.
- **Thread ID search in Command Palette**: Pasting a copied thread ID into ⌘K now finds the matching thread (previously only searched by title/branch/project).
- **Sidebar filter input**: New filter icon next to the Projects header opens an inline search that filters threads by ID or title across all projects, including collapsed ones.

## Changed files
- `apps/web/src/uiStateStore.ts` — `pinnedThreadKeys` state, `pinThread()`/`unpinThread()` actions, persistence & cleanup
- `apps/web/src/components/Sidebar.tsx` — Pin icon, context menu entries, pinned-first sorting, filter input UI, auto-expand on filter
- `apps/web/src/components/CommandPalette.logic.ts` — Added `thread.id` to `searchTerms`
- `apps/web/src/uiStateStore.test.ts` — Updated test fixture

## Test plan
- [ ] Right-click a thread → "Pin thread" → thread moves to top with pin icon
- [ ] Right-click pinned thread → "Unpin thread" → returns to normal position
- [ ] Pin persists after page reload
- [ ] ⌘K → paste a thread ID → thread appears in results
- [ ] Click filter icon in sidebar → type thread ID → matching threads shown (even in collapsed projects)
- [ ] Press Escape or click filter icon again to dismiss filter
- [ ] Existing tests pass (`uiStateStore`, `CommandPalette.logic`, `threadSort`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted UI state (`pinnedThreadKeys`) and modifies sidebar thread ordering/filtering logic, which could affect thread visibility/order and localStorage migrations if buggy.
> 
> **Overview**
> Adds **pinned threads** in the sidebar: threads can be pin/unpinned from the context menu, display a pin indicator, persist via `uiStateStore` localStorage, and are sorted to the top of each project’s thread list.
> 
> Adds a sidebar **thread filter** UI that filters threads by ID or title (showing all matches without the preview limit), and extends command palette thread search to include `thread.id` in `searchTerms` for ID-based lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53d01937dc929eb0adaebb8d81735deb9190aaf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pinned threads and thread ID search to the sidebar
> - Threads can be pinned or unpinned via the sidebar context menu; pinned threads appear at the top of each project's thread list and display a pin icon in their row.
> - Pin state is persisted to localStorage and restored on load, with cleanup when threads are removed or their UI state is cleared.
> - A filter control in the sidebar header lets users search threads by ID or title, with the filter input toggled via a toolbar button.
> - Thread IDs are now included in command palette search terms so threads can be found by ID in addition to title, project, and branch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53d0193.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->