### PR TITLE
fix(web): add close icon for slow request toast

### DIFF
--- a/apps/web/src/components/WebSocketConnectionSurface.tsx
+++ b/apps/web/src/components/WebSocketConnectionSurface.tsx
@@ -373,6 +373,9 @@ export function SlowRpcAckToastCoordinator() {
       timeout: 0,
       title: "Some requests are slow",
       type: "warning" as const,
+      data: {
+        showCloseButton: true,
+      },
     };
 
     if (toastIdRef.current) {

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -12,6 +12,7 @@ import {
   InfoIcon,
   LoaderCircleIcon,
   TriangleAlertIcon,
+  XIcon,
 } from "lucide-react";
 
 import { cn } from "~/lib/utils";
@@ -31,6 +32,7 @@ export type ThreadToastData = {
   tooltipStyle?: boolean;
   dismissAfterVisibleMs?: number;
   hideCopyButton?: boolean;
+  showCloseButton?: boolean;
 };
 
 const toastManager = Toast.createToastManager<ThreadToastData>();
@@ -302,9 +304,23 @@ function Toasts({ position = "top-right" }: { position: ToastPosition }) {
                 dismissAfterVisibleMs={toast.data?.dismissAfterVisibleMs}
                 toastId={toast.id}
               />
+              {toast.data?.showCloseButton ? (
+                <button
+                  aria-label="Dismiss notification"
+                  className={cn(
+                    buttonVariants({ size: "icon-xs", variant: "ghost" }),
+                    "absolute top-2 right-2 z-10 size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground",
+                  )}
+                  onClick={() => toastManager.close(toast.id)}
+                  type="button"
+                >
+                  <XIcon className="size-3" />
+                </button>
+              ) : null}
               <Toast.Content
                 className={cn(
                   "pointer-events-auto flex items-center justify-between gap-1.5 overflow-hidden px-3.5 py-3 text-sm transition-opacity duration-250 data-expanded:opacity-100",
+                  toast.data?.showCloseButton ? "pr-8" : null,
                   hideCollapsedContent &&
                     "not-data-expanded:pointer-events-none not-data-expanded:opacity-0",
                 )}
@@ -397,12 +413,30 @@ function AnchoredToasts() {
                   data-slot="toast-popup"
                   toast={toast}
                 >
+                  {toast.data?.showCloseButton ? (
+                    <button
+                      aria-label="Dismiss notification"
+                      className={cn(
+                        buttonVariants({ size: "icon-xs", variant: "ghost" }),
+                        "absolute top-2 right-2 z-10 size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground",
+                      )}
+                      onClick={() => anchoredToastManager.close(toast.id)}
+                      type="button"
+                    >
+                      <XIcon className="size-3" />
+                    </button>
+                  ) : null}
                   {tooltipStyle ? (
                     <Toast.Content className="pointer-events-auto px-2 py-1">
                       <Toast.Title data-slot="toast-title" />
                     </Toast.Content>
                   ) : (
-                    <Toast.Content className="pointer-events-auto flex items-center justify-between gap-1.5 overflow-hidden px-3.5 py-3 text-sm">
+                    <Toast.Content
+                      className={cn(
+                        "pointer-events-auto flex items-center justify-between gap-1.5 overflow-hidden px-3.5 py-3 text-sm",
+                        toast.data?.showCloseButton ? "pr-8" : null,
+                      )}
+                    >
                       <div className="flex min-w-0 flex-1 gap-2">
                         {Icon && (
                           <div


### PR DESCRIPTION
## What Changed

- Added an opt-in toast close affordance via `showCloseButton` in toast data.
- Updated the toast renderer to display a subtle top-right `x` close control when `showCloseButton` is enabled. This is in line with the styling of the buttons in the settings menu to stay in theme. Design taken from "refresh provider" button to maintain consistency.
- Enabled `showCloseButton` for the `Some requests are slow` warning toast in `SlowRpcAckToastCoordinator`.

## Why

The slow-requests toast is pinned (`timeout: 0`) and was only dismissible via swipe/drag, which is not discoverable on desktop and feels touch-centric. Many users would probably think it's stuck and struggle to dismiss it (including me).
Adding an explicit close control makes dismissal obvious and reliable without changing the underlying slow-request detection behavior.

## UI Changes

Before:
- `Some requests are slow` toast had no visible dismiss control. 

Screenshot: <img width="370" height="80" alt="image" src="https://github.com/user-attachments/assets/baa2cde8-97b1-4d71-8e68-1982c4133f2f" />


After:
- `Some requests are slow` toast includes a subtle top-right `x` close control.

Screenshot: 
<img width="367" height="73" alt="image" src="https://github.com/user-attachments/assets/7239b56f-2831-4f29-a368-de06b5904180" />


Interaction video:
- Shows clicking the `x` to dismiss the toast.

Video: 

https://github.com/user-attachments/assets/d808d1a8-9ed7-49b0-b5d7-b40b31df73af



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to toast rendering and metadata; minimal risk beyond minor layout/styling regressions for toasts that opt into the new close button.
> 
> **Overview**
> Adds an opt-in `showCloseButton` flag to toast data and updates both stacked and anchored toast renderers to display a top-right X dismiss control (with padding adjustments) when enabled.
> 
> Enables this flag for the persistent (timeout `0`) “Some requests are slow” warning in `SlowRpcAckToastCoordinator`, making it explicitly dismissible on desktop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d9bd1a3cf372ab3ac26f80e7956b16d46bdbe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add close button to slow request toast
> - Adds an `XIcon` close button to toasts that set `data.showCloseButton: true` in [toast.tsx](https://github.com/pingdotgg/t3code/pull/2040/files#diff-dbb38a4f02a67491223157a9f1aba388365f4cd55652e1f32847ffda53aee7f2), wiring it to `toastManager.close(toast.id)` for both `Toasts` and `AnchoredToasts` components.
> - Sets `showCloseButton: true` on the slow-ack warning toast in [WebSocketConnectionSurface.tsx](https://github.com/pingdotgg/t3code/pull/2040/files#diff-4b964ddc83d874094d71c5841cd96dee6863c78d8a6355c760d2702d1a115af3).
> - Adds `pr-8` right padding to toast content when the close button is present to prevent text overlap.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 17d9bd1. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->