### PR TITLE
Add max-height scroll to changed files list

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -648,14 +648,16 @@ function AssistantChangedFilesSectionInner({
           </Button>
         </div>
       </div>
-      <ChangedFilesTree
-        key={`changed-files-tree:${turnSummary.turnId}`}
-        turnId={turnSummary.turnId}
-        files={checkpointFiles}
-        allDirectoriesExpanded={allDirectoriesExpanded}
-        resolvedTheme={resolvedTheme}
-        onOpenTurnDiff={onOpenTurnDiff}
-      />
+      <div className="max-h-80 overflow-y-auto">
+        <ChangedFilesTree
+          key={`changed-files-tree:${turnSummary.turnId}`}
+          turnId={turnSummary.turnId}
+          files={checkpointFiles}
+          allDirectoriesExpanded={allDirectoriesExpanded}
+          resolvedTheme={resolvedTheme}
+          onOpenTurnDiff={onOpenTurnDiff}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap the `ChangedFilesTree` in a scrollable container (`max-h-80` / 320px) so large file lists no longer force excessive scrolling in the chat timeline
- The header (file count, "Collapse all", "View diff" buttons) stays pinned above the scroll area
- No behavior changes — just adds overflow containment

Fixes #1927

## Test plan
- [x] Trigger a turn that modifies 20+ files
- [x] Verify the file list caps at ~320px and shows a scrollbar
- [x] Verify the "Changed files (N)" header and buttons remain visible above the scroll
- [x] Verify small file lists (<15 files) render normally without a scrollbar
- [x] Verify "Collapse all" / "Expand all" still works within the scrollable area

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI layout change (adds a scroll container) with no changes to data flow or diff/open actions.
> 
> **Overview**
> Adds overflow containment to the assistant “Changed files” section by wrapping `ChangedFilesTree` in a `max-h-80 overflow-y-auto` container, preventing large file lists from expanding the chat timeline.
> 
> The header (file count/stats and the “Collapse all”/“View diff” buttons) remains outside the scroll area so it stays visible while scrolling the file list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5ebd5acb8ebd366a0f91b395a7c746180878c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add max-height and vertical scroll to changed files list
> Wraps `ChangedFilesTree` in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/2041/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) with a `max-h-80 overflow-y-auto` div so the list no longer expands unboundedly when many files are changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c5ebd5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->