### PR TITLE
Respect installed desktop update channel

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -54,6 +54,11 @@ import { isBackendReadinessAborted, waitForHttpReady } from "./backendReadiness"
 import { showDesktopConfirmDialog } from "./confirmDialog";
 import { resolveDesktopServerExposure } from "./serverExposure";
 import { syncShellEnvironment } from "./syncShellEnvironment";
+import {
+  resolveDesktopUpdateChannel,
+  shouldAcceptDesktopUpdateForCurrentVersion,
+  shouldAllowDesktopPrereleaseUpdates,
+} from "./updateChannel";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
 import { ServerListeningDetector } from "./serverListeningDetector";
 import {
@@ -116,8 +121,6 @@ const APP_RUN_ID = Crypto.randomBytes(6).toString("hex");
 const SERVER_SETTINGS_PATH = Path.join(STATE_DIR, "settings.json");
 const AUTO_UPDATE_STARTUP_DELAY_MS = 15_000;
 const AUTO_UPDATE_POLL_INTERVAL_MS = 4 * 60 * 60 * 1000;
-const DESKTOP_UPDATE_CHANNEL = "latest";
-const DESKTOP_UPDATE_ALLOW_PRERELEASE = false;
 const DESKTOP_LOOPBACK_HOST = "127.0.0.1";
 const DESKTOP_REQUIRED_PORT_PROBE_HOSTS = ["0.0.0.0", "::"] as const;
 const TITLEBAR_HEIGHT = 40;
@@ -1168,6 +1171,9 @@ async function installDownloadedUpdate(): Promise<{ accepted: boolean; completed
 }
 
 function configureAutoUpdater(): void {
+  const currentVersion = app.getVersion();
+  const updateChannel = resolveDesktopUpdateChannel(currentVersion);
+  const allowPrerelease = shouldAllowDesktopPrereleaseUpdates(currentVersion);
   const githubToken =
     process.env.T3CODE_DESKTOP_UPDATE_GITHUB_TOKEN?.trim() || process.env.GH_TOKEN?.trim() || "";
   if (githubToken) {
@@ -1205,12 +1211,14 @@ function configureAutoUpdater(): void {
 
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
-  // Keep alpha branding, but force all installs onto the stable update track.
-  autoUpdater.channel = DESKTOP_UPDATE_CHANNEL;
-  autoUpdater.allowPrerelease = DESKTOP_UPDATE_ALLOW_PRERELEASE;
+  autoUpdater.channel = updateChannel;
+  autoUpdater.allowPrerelease = allowPrerelease;
   autoUpdater.allowDowngrade = false;
   autoUpdater.disableDifferentialDownload = isArm64HostRunningIntelBuild(desktopRuntimeInfo);
   let lastLoggedDownloadMilestone = -1;
+  console.info(
+    `[desktop-updater] Configured update channel=${updateChannel} currentVersion=${currentVersion} allowPrerelease=${allowPrerelease}.`,
+  );
 
   if (isArm64HostRunningIntelBuild(desktopRuntimeInfo)) {
     console.info(
@@ -1222,6 +1230,15 @@ function configureAutoUpdater(): void {
     console.info("[desktop-updater] Looking for updates...");
   });
   autoUpdater.on("update-available", (info) => {
+    if (!shouldAcceptDesktopUpdateForCurrentVersion(currentVersion, info.version)) {
+      setUpdateState(reduceDesktopUpdateStateOnNoUpdate(updateState, new Date().toISOString()));
+      lastLoggedDownloadMilestone = -1;
+      console.info(
+        `[desktop-updater] Ignoring update ${info.version} on channel=${resolveDesktopUpdateChannel(info.version)} while currentVersion=${currentVersion} is on channel=${updateChannel}.`,
+      );
+      return;
+    }
+
     setUpdateState(
       reduceDesktopUpdateStateOnUpdateAvailable(
         updateState,

--- a/apps/desktop/src/updateChannel.test.ts
+++ b/apps/desktop/src/updateChannel.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveDesktopUpdateChannel,
+  shouldAcceptDesktopUpdateForCurrentVersion,
+  shouldAllowDesktopPrereleaseUpdates,
+} from "./updateChannel";
+
+describe("updateChannel", () => {
+  it("uses the stable latest channel for plain versions", () => {
+    expect(resolveDesktopUpdateChannel("0.0.17")).toBe("latest");
+    expect(shouldAllowDesktopPrereleaseUpdates("0.0.17")).toBe(false);
+  });
+
+  it("derives the prerelease channel from the installed version", () => {
+    expect(resolveDesktopUpdateChannel("0.0.18-nightly.20260415")).toBe("nightly");
+    expect(shouldAllowDesktopPrereleaseUpdates("0.0.18-nightly.20260415")).toBe(true);
+  });
+
+  it("accepts updates that stay on the same prerelease track", () => {
+    expect(
+      shouldAcceptDesktopUpdateForCurrentVersion(
+        "0.0.18-nightly.20260415",
+        "0.0.18-nightly.20260416",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects stable releases while running a nightly build", () => {
+    expect(shouldAcceptDesktopUpdateForCurrentVersion("0.0.18-nightly.20260415", "0.0.17")).toBe(
+      false,
+    );
+  });
+
+  it("rejects updates from a different prerelease track", () => {
+    expect(
+      shouldAcceptDesktopUpdateForCurrentVersion("0.0.18-nightly.20260415", "0.0.18-beta.1"),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/updateChannel.ts
+++ b/apps/desktop/src/updateChannel.ts
@@ -1,0 +1,26 @@
+const VERSION_PRERELEASE_CHANNEL_PATTERN =
+  /^\d+\.\d+\.\d+(?:-([0-9A-Za-z-]+)(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+function resolvePrereleaseChannel(version: string): string | null {
+  const normalizedVersion = version.trim();
+  const match = VERSION_PRERELEASE_CHANNEL_PATTERN.exec(normalizedVersion);
+  const channel = match?.[1]?.trim().toLowerCase();
+  return channel && channel.length > 0 ? channel : null;
+}
+
+export function resolveDesktopUpdateChannel(version: string): string {
+  return resolvePrereleaseChannel(version) ?? "latest";
+}
+
+export function shouldAllowDesktopPrereleaseUpdates(version: string): boolean {
+  return resolvePrereleaseChannel(version) !== null;
+}
+
+export function shouldAcceptDesktopUpdateForCurrentVersion(
+  currentVersion: string,
+  candidateVersion: string,
+): boolean {
+  return (
+    resolveDesktopUpdateChannel(currentVersion) === resolveDesktopUpdateChannel(candidateVersion)
+  );
+}

--- a/docs/release.md
+++ b/docs/release.md
@@ -25,6 +25,9 @@ This document covers how to run desktop releases from one tag, first without sig
   - Background checks run on startup delay + interval.
   - No automatic download or install.
   - The desktop UI shows a rocket update button when an update is available; click once to download, click again after download to restart/install.
+- Update channel selection:
+  - Stable builds (`X.Y.Z`) only accept stable updates.
+  - Prerelease builds (for example `X.Y.Z-nightly.N`) stay on that prerelease track and ignore stable or differently-tagged prerelease releases.
 - Provider: GitHub Releases (`provider: github`) configured at build time.
 - Repository slug source:
   - `T3CODE_DESKTOP_UPDATE_REPOSITORY` (format `owner/repo`), if set.


### PR DESCRIPTION
## Summary
- Derives the desktop auto-update channel from the installed app version instead of forcing every build onto `latest`.
- Keeps prerelease installs on their own track and ignores updates from stable or mismatched prerelease channels.
- Adds Vitest coverage for channel resolution and cross-channel update acceptance rules.
- Documents the release behavior for stable vs prerelease desktop builds.

## Testing
- Not run (PR content only).
- Added `apps/desktop/src/updateChannel.test.ts` to cover stable versions, prerelease versions, same-track updates, and rejected cross-track updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes desktop update selection/eligibility logic, which can affect whether users see or apply updates; low code footprint but impacts release/update behavior across channels.
> 
> **Overview**
> Desktop auto-updates now **derive the `electron-updater` channel from the installed app version** instead of forcing all builds onto `latest`, and prerelease builds only accept updates from the same prerelease track.
> 
> This introduces a small `updateChannel` helper (with Vitest coverage) to parse version prerelease tags, configures `autoUpdater.channel`/`allowPrerelease` accordingly, and ignores cross-channel `update-available` events; release docs are updated to describe the stable vs prerelease update behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3291cf83ea6ec038d3744312b6bf9fc89d0084f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Derive desktop auto-update channel from installed version
> - Replaces hardcoded update channel constants with logic that reads the channel from the installed version's semver prerelease tag, implemented in [`updateChannel.ts`](https://github.com/pingdotgg/t3code/pull/2047/files#diff-0dbc68895f7a38456c8ebff1d76a83923e10cee177e6de8d3481aca87bec81b1).
> - Stable installs only accept stable updates; prerelease installs stay on their prerelease track and ignore updates from different tracks.
> - In `configureAutoUpdater`, mismatched updates are rejected in the `update-available` handler, resetting update state and logging the reason.
> - Behavioral Change: previously all installs used a single fixed channel; now each install's channel is determined by its version string at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3291cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->