### PR TITLE
Default nightly desktop builds to the nightly update channel

### DIFF
--- a/apps/desktop/src/appBranding.ts
+++ b/apps/desktop/src/appBranding.ts
@@ -1,7 +1,8 @@
 import type { DesktopAppBranding, DesktopAppStageLabel } from "@t3tools/contracts";
 
+import { isNightlyDesktopVersion } from "./updateChannels";
+
 const APP_BASE_NAME = "T3 Code";
-const NIGHTLY_VERSION_PATTERN = /-nightly\.\d{8}\.\d+$/;
 
 export function resolveDesktopAppStageLabel(input: {
   readonly isDevelopment: boolean;
@@ -11,7 +12,7 @@ export function resolveDesktopAppStageLabel(input: {
     return "Dev";
   }
 
-  return NIGHTLY_VERSION_PATTERN.test(input.appVersion) ? "Nightly" : "Alpha";
+  return isNightlyDesktopVersion(input.appVersion) ? "Nightly" : "Alpha";
 }
 
 export function resolveDesktopAppBranding(input: {

--- a/apps/desktop/src/desktopSettings.test.ts
+++ b/apps/desktop/src/desktopSettings.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_DESKTOP_SETTINGS,
   readDesktopSettings,
+  resolveDefaultDesktopSettings,
   setDesktopServerExposurePreference,
   setDesktopUpdateChannelPreference,
   writeDesktopSettings,
@@ -28,7 +29,14 @@ function makeSettingsPath() {
 
 describe("desktopSettings", () => {
   it("returns defaults when no settings file exists", () => {
-    expect(readDesktopSettings(makeSettingsPath())).toEqual(DEFAULT_DESKTOP_SETTINGS);
+    expect(readDesktopSettings(makeSettingsPath(), "0.0.17")).toEqual(DEFAULT_DESKTOP_SETTINGS);
+  });
+
+  it("defaults packaged nightly builds to the nightly update channel", () => {
+    expect(resolveDefaultDesktopSettings("0.0.17-nightly.20260415.1")).toEqual({
+      serverExposureMode: "local-only",
+      updateChannel: "nightly",
+    });
   });
 
   it("persists and reloads the configured server exposure mode", () => {
@@ -39,7 +47,7 @@ describe("desktopSettings", () => {
       updateChannel: "latest",
     });
 
-    expect(readDesktopSettings(settingsPath)).toEqual({
+    expect(readDesktopSettings(settingsPath, "0.0.17")).toEqual({
       serverExposureMode: "network-accessible",
       updateChannel: "latest",
     });
@@ -79,6 +87,16 @@ describe("desktopSettings", () => {
     const settingsPath = makeSettingsPath();
     fs.writeFileSync(settingsPath, "{not-json", "utf8");
 
-    expect(readDesktopSettings(settingsPath)).toEqual(DEFAULT_DESKTOP_SETTINGS);
+    expect(readDesktopSettings(settingsPath, "0.0.17")).toEqual(DEFAULT_DESKTOP_SETTINGS);
+  });
+
+  it("falls back to the nightly channel for legacy nightly settings without an update track", () => {
+    const settingsPath = makeSettingsPath();
+    fs.writeFileSync(settingsPath, JSON.stringify({ serverExposureMode: "local-only" }), "utf8");
+
+    expect(readDesktopSettings(settingsPath, "0.0.17-nightly.20260415.1")).toEqual({
+      serverExposureMode: "local-only",
+      updateChannel: "nightly",
+    });
   });
 });

--- a/apps/desktop/src/desktopSettings.test.ts
+++ b/apps/desktop/src/desktopSettings.test.ts
@@ -36,6 +36,7 @@ describe("desktopSettings", () => {
     expect(resolveDefaultDesktopSettings("0.0.17-nightly.20260415.1")).toEqual({
       serverExposureMode: "local-only",
       updateChannel: "nightly",
+      updateChannelConfiguredByUser: false,
     });
   });
 
@@ -45,11 +46,13 @@ describe("desktopSettings", () => {
     writeDesktopSettings(settingsPath, {
       serverExposureMode: "network-accessible",
       updateChannel: "latest",
+      updateChannelConfiguredByUser: true,
     });
 
     expect(readDesktopSettings(settingsPath, "0.0.17")).toEqual({
       serverExposureMode: "network-accessible",
       updateChannel: "latest",
+      updateChannelConfiguredByUser: true,
     });
   });
 
@@ -59,12 +62,14 @@ describe("desktopSettings", () => {
         {
           serverExposureMode: "local-only",
           updateChannel: "latest",
+          updateChannelConfiguredByUser: false,
         },
         "network-accessible",
       ),
     ).toEqual({
       serverExposureMode: "network-accessible",
       updateChannel: "latest",
+      updateChannelConfiguredByUser: false,
     });
   });
 
@@ -74,12 +79,14 @@ describe("desktopSettings", () => {
         {
           serverExposureMode: "local-only",
           updateChannel: "latest",
+          updateChannelConfiguredByUser: false,
         },
         "nightly",
       ),
     ).toEqual({
       serverExposureMode: "local-only",
       updateChannel: "nightly",
+      updateChannelConfiguredByUser: true,
     });
   });
 
@@ -97,6 +104,44 @@ describe("desktopSettings", () => {
     expect(readDesktopSettings(settingsPath, "0.0.17-nightly.20260415.1")).toEqual({
       serverExposureMode: "local-only",
       updateChannel: "nightly",
+      updateChannelConfiguredByUser: false,
+    });
+  });
+
+  it("migrates legacy implicit stable settings to nightly when running a nightly build", () => {
+    const settingsPath = makeSettingsPath();
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        serverExposureMode: "local-only",
+        updateChannel: "latest",
+      }),
+      "utf8",
+    );
+
+    expect(readDesktopSettings(settingsPath, "0.0.17-nightly.20260415.1")).toEqual({
+      serverExposureMode: "local-only",
+      updateChannel: "nightly",
+      updateChannelConfiguredByUser: false,
+    });
+  });
+
+  it("preserves an explicit stable choice on nightly builds", () => {
+    const settingsPath = makeSettingsPath();
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        serverExposureMode: "local-only",
+        updateChannel: "latest",
+        updateChannelConfiguredByUser: true,
+      }),
+      "utf8",
+    );
+
+    expect(readDesktopSettings(settingsPath, "0.0.17-nightly.20260415.1")).toEqual({
+      serverExposureMode: "local-only",
+      updateChannel: "latest",
+      updateChannelConfiguredByUser: true,
     });
   });
 });

--- a/apps/desktop/src/desktopSettings.ts
+++ b/apps/desktop/src/desktopSettings.ts
@@ -7,11 +7,13 @@ import { resolveDefaultDesktopUpdateChannel } from "./updateChannels";
 export interface DesktopSettings {
   readonly serverExposureMode: DesktopServerExposureMode;
   readonly updateChannel: DesktopUpdateChannel;
+  readonly updateChannelConfiguredByUser: boolean;
 }
 
 export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   serverExposureMode: "local-only",
   updateChannel: "latest",
+  updateChannelConfiguredByUser: false,
 };
 
 export function resolveDefaultDesktopSettings(appVersion: string): DesktopSettings {
@@ -37,12 +39,11 @@ export function setDesktopUpdateChannelPreference(
   settings: DesktopSettings,
   requestedChannel: DesktopUpdateChannel,
 ): DesktopSettings {
-  return settings.updateChannel === requestedChannel
-    ? settings
-    : {
-        ...settings,
-        updateChannel: requestedChannel,
-      };
+  return {
+    ...settings,
+    updateChannel: requestedChannel,
+    updateChannelConfiguredByUser: true,
+  };
 }
 
 export function readDesktopSettings(settingsPath: string, appVersion: string): DesktopSettings {
@@ -57,15 +58,22 @@ export function readDesktopSettings(settingsPath: string, appVersion: string): D
     const parsed = JSON.parse(raw) as {
       readonly serverExposureMode?: unknown;
       readonly updateChannel?: unknown;
+      readonly updateChannelConfiguredByUser?: unknown;
     };
+    const parsedUpdateChannel =
+      parsed.updateChannel === "nightly" || parsed.updateChannel === "latest"
+        ? parsed.updateChannel
+        : null;
+    const updateChannelConfiguredByUser = parsed.updateChannelConfiguredByUser === true;
 
     return {
       serverExposureMode:
         parsed.serverExposureMode === "network-accessible" ? "network-accessible" : "local-only",
       updateChannel:
-        parsed.updateChannel === "nightly" || parsed.updateChannel === "latest"
-          ? parsed.updateChannel
+        updateChannelConfiguredByUser && parsedUpdateChannel !== null
+          ? parsedUpdateChannel
           : defaultSettings.updateChannel,
+      updateChannelConfiguredByUser,
     };
   } catch {
     return defaultSettings;

--- a/apps/desktop/src/desktopSettings.ts
+++ b/apps/desktop/src/desktopSettings.ts
@@ -64,7 +64,10 @@ export function readDesktopSettings(settingsPath: string, appVersion: string): D
       parsed.updateChannel === "nightly" || parsed.updateChannel === "latest"
         ? parsed.updateChannel
         : null;
-    const updateChannelConfiguredByUser = parsed.updateChannelConfiguredByUser === true;
+    const isLegacySettings = parsed.updateChannelConfiguredByUser === undefined;
+    const updateChannelConfiguredByUser =
+      parsed.updateChannelConfiguredByUser === true ||
+      (isLegacySettings && parsedUpdateChannel === "nightly");
 
     return {
       serverExposureMode:

--- a/apps/desktop/src/desktopSettings.ts
+++ b/apps/desktop/src/desktopSettings.ts
@@ -2,6 +2,8 @@ import * as FS from "node:fs";
 import * as Path from "node:path";
 import type { DesktopServerExposureMode, DesktopUpdateChannel } from "@t3tools/contracts";
 
+import { resolveDefaultDesktopUpdateChannel } from "./updateChannels";
+
 export interface DesktopSettings {
   readonly serverExposureMode: DesktopServerExposureMode;
   readonly updateChannel: DesktopUpdateChannel;
@@ -11,6 +13,13 @@ export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
   serverExposureMode: "local-only",
   updateChannel: "latest",
 };
+
+export function resolveDefaultDesktopSettings(appVersion: string): DesktopSettings {
+  return {
+    ...DEFAULT_DESKTOP_SETTINGS,
+    updateChannel: resolveDefaultDesktopUpdateChannel(appVersion),
+  };
+}
 
 export function setDesktopServerExposurePreference(
   settings: DesktopSettings,
@@ -36,10 +45,12 @@ export function setDesktopUpdateChannelPreference(
       };
 }
 
-export function readDesktopSettings(settingsPath: string): DesktopSettings {
+export function readDesktopSettings(settingsPath: string, appVersion: string): DesktopSettings {
+  const defaultSettings = resolveDefaultDesktopSettings(appVersion);
+
   try {
     if (!FS.existsSync(settingsPath)) {
-      return DEFAULT_DESKTOP_SETTINGS;
+      return defaultSettings;
     }
 
     const raw = FS.readFileSync(settingsPath, "utf8");
@@ -51,10 +62,13 @@ export function readDesktopSettings(settingsPath: string): DesktopSettings {
     return {
       serverExposureMode:
         parsed.serverExposureMode === "network-accessible" ? "network-accessible" : "local-only",
-      updateChannel: parsed.updateChannel === "nightly" ? "nightly" : "latest",
+      updateChannel:
+        parsed.updateChannel === "nightly" || parsed.updateChannel === "latest"
+          ? parsed.updateChannel
+          : defaultSettings.updateChannel,
     };
   } catch {
-    return DEFAULT_DESKTOP_SETTINGS;
+    return defaultSettings;
   }
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1802,12 +1802,13 @@ function registerIpcHandlers(): void {
     }
 
     const nextChannel = rawChannel as DesktopUpdateChannel;
-    if (nextChannel === desktopSettings.updateChannel) {
-      return updateState;
-    }
 
     desktopSettings = setDesktopUpdateChannelPreference(desktopSettings, nextChannel);
     writeDesktopSettings(DESKTOP_SETTINGS_PATH, desktopSettings);
+
+    if (nextChannel === updateState.channel) {
+      return updateState;
+    }
 
     const enabled = shouldEnableAutoUpdates();
     setUpdateState(createBaseUpdateState(nextChannel, enabled));

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -58,6 +58,7 @@ import { showDesktopConfirmDialog } from "./confirmDialog";
 import { resolveDesktopServerExposure } from "./serverExposure";
 import { syncShellEnvironment } from "./syncShellEnvironment";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState";
+import { doesVersionMatchDesktopUpdateChannel } from "./updateChannels";
 import { ServerListeningDetector } from "./serverListeningDetector";
 import {
   createInitialDesktopUpdateState,
@@ -190,7 +191,7 @@ let desktopLogSink: RotatingFileSink | null = null;
 let backendLogSink: RotatingFileSink | null = null;
 let restoreStdIoCapture: (() => void) | null = null;
 let backendObservabilitySettings = readPersistedBackendObservabilitySettings();
-let desktopSettings = readDesktopSettings(DESKTOP_SETTINGS_PATH);
+let desktopSettings = readDesktopSettings(DESKTOP_SETTINGS_PATH, app.getVersion());
 let desktopServerExposureMode: DesktopServerExposureMode = desktopSettings.serverExposureMode;
 
 let destructiveMenuIconCache: Electron.NativeImage | null | undefined;
@@ -1138,9 +1139,9 @@ function createBaseUpdateState(
 function applyAutoUpdaterChannel(channel: DesktopUpdateChannel): void {
   autoUpdater.channel = channel;
   autoUpdater.allowPrerelease = channel === "nightly";
-  autoUpdater.allowDowngrade = channel === "nightly";
+  autoUpdater.allowDowngrade = false;
   console.info(
-    `[desktop-updater] Using update channel '${channel}' (allowPrerelease=${channel === "nightly"}).`,
+    `[desktop-updater] Using update channel '${channel}' (allowPrerelease=${channel === "nightly"}, allowDowngrade=false).`,
   );
 }
 
@@ -1285,6 +1286,15 @@ function configureAutoUpdater(): void {
     console.info("[desktop-updater] Looking for updates...");
   });
   autoUpdater.on("update-available", (info) => {
+    if (!doesVersionMatchDesktopUpdateChannel(info.version, updateState.channel)) {
+      console.info(
+        `[desktop-updater] Ignoring ${info.version} because it does not match the selected '${updateState.channel}' channel.`,
+      );
+      setUpdateState(reduceDesktopUpdateStateOnNoUpdate(updateState, new Date().toISOString()));
+      lastLoggedDownloadMilestone = -1;
+      return;
+    }
+
     setUpdateState(
       reduceDesktopUpdateStateOnUpdateAvailable(
         updateState,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1139,9 +1139,9 @@ function createBaseUpdateState(
 function applyAutoUpdaterChannel(channel: DesktopUpdateChannel): void {
   autoUpdater.channel = channel;
   autoUpdater.allowPrerelease = channel === "nightly";
-  autoUpdater.allowDowngrade = false;
+  autoUpdater.allowDowngrade = channel === "nightly";
   console.info(
-    `[desktop-updater] Using update channel '${channel}' (allowPrerelease=${channel === "nightly"}, allowDowngrade=false).`,
+    `[desktop-updater] Using update channel '${channel}' (allowPrerelease=${channel === "nightly"}, allowDowngrade=${channel === "nightly"}).`,
   );
 }
 

--- a/apps/desktop/src/updateChannels.test.ts
+++ b/apps/desktop/src/updateChannels.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  doesVersionMatchDesktopUpdateChannel,
+  isNightlyDesktopVersion,
+  resolveDefaultDesktopUpdateChannel,
+} from "./updateChannels";
+
+describe("isNightlyDesktopVersion", () => {
+  it("detects packaged nightly versions", () => {
+    expect(isNightlyDesktopVersion("0.0.17-nightly.20260415.1")).toBe(true);
+  });
+
+  it("does not flag stable versions as nightly", () => {
+    expect(isNightlyDesktopVersion("0.0.17")).toBe(false);
+  });
+});
+
+describe("resolveDefaultDesktopUpdateChannel", () => {
+  it("defaults stable builds to latest", () => {
+    expect(resolveDefaultDesktopUpdateChannel("0.0.17")).toBe("latest");
+  });
+
+  it("defaults nightly builds to nightly", () => {
+    expect(resolveDefaultDesktopUpdateChannel("0.0.17-nightly.20260415.1")).toBe("nightly");
+  });
+});
+
+describe("doesVersionMatchDesktopUpdateChannel", () => {
+  it("accepts nightly releases on the nightly channel", () => {
+    expect(doesVersionMatchDesktopUpdateChannel("0.0.17-nightly.20260416.1", "nightly")).toBe(true);
+  });
+
+  it("rejects stable releases on the nightly channel", () => {
+    expect(doesVersionMatchDesktopUpdateChannel("0.0.17", "nightly")).toBe(false);
+  });
+
+  it("rejects nightly releases on the stable channel", () => {
+    expect(doesVersionMatchDesktopUpdateChannel("0.0.17-nightly.20260416.1", "latest")).toBe(false);
+  });
+});

--- a/apps/desktop/src/updateChannels.ts
+++ b/apps/desktop/src/updateChannels.ts
@@ -1,0 +1,18 @@
+import type { DesktopUpdateChannel } from "@t3tools/contracts";
+
+const NIGHTLY_VERSION_PATTERN = /-nightly\.\d{8}\.\d+$/;
+
+export function isNightlyDesktopVersion(version: string): boolean {
+  return NIGHTLY_VERSION_PATTERN.test(version);
+}
+
+export function resolveDefaultDesktopUpdateChannel(appVersion: string): DesktopUpdateChannel {
+  return isNightlyDesktopVersion(appVersion) ? "nightly" : "latest";
+}
+
+export function doesVersionMatchDesktopUpdateChannel(
+  version: string,
+  channel: DesktopUpdateChannel,
+): boolean {
+  return resolveDefaultDesktopUpdateChannel(version) === channel;
+}

--- a/docs/release.md
+++ b/docs/release.md
@@ -37,7 +37,7 @@ This document covers the unified release workflow for stable and nightly desktop
   - tag format: `nightly-vX.Y.Z-nightly.YYYYMMDD.<run_number>`
   - release name includes the short commit SHA
   - `make_latest` is always `false`
-- Uses the current `apps/desktop/package.json` semver core (`X.Y.Z`) as the nightly base, then appends a nightly prerelease suffix.
+- Uses the next stable patch version as the nightly base. For example, `0.0.17` produces nightlies on `0.0.18-nightly.*`.
 - Publishes Electron auto-update metadata to the dedicated `nightly` updater channel, so desktop users can opt into that track independently from stable.
 - Publishes the CLI package (`apps/server`, npm package `t3`) to the `nightly` npm dist-tag using the same nightly version.
 - Does not commit version bumps back to `main`.

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -127,17 +127,17 @@ try {
   );
   assertContains(
     nightlyReleaseMetadata,
-    "version=9.9.9-nightly.20260413.321",
+    "version=9.9.10-nightly.20260413.321",
     "Expected nightly metadata to contain the derived nightly version.",
   );
   assertContains(
     nightlyReleaseMetadata,
-    "tag=nightly-v9.9.9-nightly.20260413.321",
+    "tag=nightly-v9.9.10-nightly.20260413.321",
     "Expected nightly metadata to contain the derived nightly tag.",
   );
   assertContains(
     nightlyReleaseMetadata,
-    "name=T3 Code Nightly 9.9.9-nightly.20260413.321 (abcdef123456)",
+    "name=T3 Code Nightly 9.9.10-nightly.20260413.321 (abcdef123456)",
     "Expected nightly metadata to include the short commit SHA in the release name.",
   );
 

--- a/scripts/resolve-nightly-release.test.ts
+++ b/scripts/resolve-nightly-release.test.ts
@@ -3,6 +3,7 @@ import { assert, it } from "@effect/vitest";
 import {
   resolveNightlyBaseVersion,
   resolveNightlyReleaseMetadata,
+  resolveNightlyTargetVersion,
 } from "./resolve-nightly-release.ts";
 
 it("strips prerelease and build metadata when deriving the nightly base version", () => {
@@ -11,14 +12,20 @@ it("strips prerelease and build metadata when deriving the nightly base version"
   assert.equal(resolveNightlyBaseVersion("1.2.3-beta.4+build.9"), "1.2.3");
 });
 
+it("bumps the patch version before deriving nightly prerelease versions", () => {
+  assert.equal(resolveNightlyTargetVersion("0.0.17"), "0.0.18");
+  assert.equal(resolveNightlyTargetVersion("9.9.9-smoke.0"), "9.9.10");
+  assert.equal(resolveNightlyTargetVersion("1.2.3-beta.4+build.9"), "1.2.4");
+});
+
 it("derives nightly metadata including the short commit sha in the release name", () => {
   assert.deepStrictEqual(
-    resolveNightlyReleaseMetadata("9.9.9", "20260413", 321, "abcdef1234567890"),
+    resolveNightlyReleaseMetadata("9.9.10", "20260413", 321, "abcdef1234567890"),
     {
-      baseVersion: "9.9.9",
-      version: "9.9.9-nightly.20260413.321",
-      tag: "nightly-v9.9.9-nightly.20260413.321",
-      name: "T3 Code Nightly 9.9.9-nightly.20260413.321 (abcdef123456)",
+      baseVersion: "9.9.10",
+      version: "9.9.10-nightly.20260413.321",
+      tag: "nightly-v9.9.10-nightly.20260413.321",
+      name: "T3 Code Nightly 9.9.10-nightly.20260413.321 (abcdef123456)",
       shortSha: "abcdef123456",
     },
   );

--- a/scripts/resolve-nightly-release.ts
+++ b/scripts/resolve-nightly-release.ts
@@ -32,6 +32,17 @@ const decodeDesktopPackageJson = Schema.decodeUnknownEffect(
 
 export const resolveNightlyBaseVersion = (version: string) => version.replace(/[-+].*$/, "");
 
+export const resolveNightlyTargetVersion = (version: string) => {
+  const stableCore = resolveNightlyBaseVersion(version);
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(stableCore);
+  if (!match) {
+    throw new Error(`Invalid desktop package version '${version}'.`);
+  }
+
+  const [, major, minor, patch] = match;
+  return `${major}.${minor}.${Number(patch) + 1}`;
+};
+
 export const resolveNightlyReleaseMetadata = (
   baseVersion: string,
   date: string,
@@ -59,7 +70,7 @@ const readDesktopBaseVersion = Effect.fn("readDesktopBaseVersion")(function* (
   const packageJson = yield* fs
     .readFileString(packageJsonPath)
     .pipe(Effect.flatMap(decodeDesktopPackageJson));
-  return resolveNightlyBaseVersion(packageJson.version);
+  return resolveNightlyTargetVersion(packageJson.version);
 });
 
 const writeOutput = Effect.fn("writeOutput")(function* (


### PR DESCRIPTION
## Summary
- Added shared update-channel helpers to पहचान nightly desktop versions and match incoming update artifacts to the selected channel.
- Defaulted packaged nightly builds to the `nightly` update channel while keeping stable builds on `latest`.
- Hardened desktop auto-update handling so `update-available` events are ignored when the published version does not match the active channel.
- Updated desktop settings loading to preserve legacy nightly settings and added coverage for the new defaults and channel matching logic.

## Testing
- Added Vitest coverage in `apps/desktop/src/updateChannels.test.ts` for nightly version detection, default channel resolution, and channel/version matching.
- Added Vitest coverage in `apps/desktop/src/desktopSettings.test.ts` for nightly defaults and legacy nightly settings without an explicit update track.
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`
- Not run: `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect update-channel selection, settings migration, and auto-update event handling, which can alter upgrade/downgrade behavior for existing users (especially legacy nightly installs).
> 
> **Overview**
> Nightly desktop builds now **default to the `nightly` update channel** based on the packaged version string, via new shared helpers in `updateChannels.ts` (also used for stage labeling in `appBranding.ts`).
> 
> Desktop settings loading is now version-aware (`readDesktopSettings(settingsPath, appVersion)`) and persists a new `updateChannelConfiguredByUser` flag to distinguish explicit user choice from defaults; legacy settings are migrated so nightly builds without an explicit choice roll onto `nightly` while explicit stable picks are preserved.
> 
> The auto-updater in `main.ts` is hardened to **ignore `update-available` events** whose `info.version` doesn’t match the currently selected channel, preventing stable/nightly cross-channel prompts; nightly release tooling/docs are also updated so nightly versions are derived from the *next patch* (e.g., `0.0.17` -> `0.0.18-nightly.*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ce4e82cf1f7de5bf3ba019ce1f79aedc3eacd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default nightly desktop builds to the nightly update channel
> - Nightly app versions (matching `-nightly.YYYYMMDD.N` suffix) now default to the `nightly` update channel; stable builds continue to default to `latest`. Logic is centralized in [updateChannels.ts](https://github.com/pingdotgg/t3code/pull/2049/files#diff-9216dcb97727ed0834c650824931cdf1ccfa7fb4b6d8eec23e42b3b801d8433b).
> - Adds `updateChannelConfiguredByUser` to `DesktopSettings` to distinguish explicit user preference from the version-derived default. Legacy settings without this flag are treated as user-configured only if they previously selected `nightly`.
> - The auto-updater now ignores available releases that don't match the selected channel, preventing cross-channel updates from surfacing.
> - Nightly release scripts now use the next patch version as the semver base (e.g. `0.0.17` → `0.0.18-nightly.*`) via the new `resolveNightlyTargetVersion` function.
> - Behavioral Change: existing nightly users with a persisted `latest` channel and no explicit `updateChannelConfiguredByUser` flag will be migrated to the `nightly` channel on next launch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93ce4e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->