### PR TITLE
fix(web): use atomic bootstrap for plan implementation in new thread

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2997,39 +2997,36 @@ export default function ChatView(props: ChatViewProps) {
 
     await api.orchestration
       .dispatchCommand({
-        type: "thread.create",
+        type: "thread.turn.start",
         commandId: newCommandId(),
         threadId: nextThreadId,
-        projectId: activeProject.id,
-        title: nextThreadTitle,
-        modelSelection: nextThreadModelSelection,
+        message: {
+          messageId: newMessageId(),
+          role: "user",
+          text: outgoingImplementationPrompt,
+          attachments: [],
+        },
+        modelSelection: ctxSelectedModelSelection,
+        titleSeed: nextThreadTitle,
         runtimeMode,
         interactionMode: "default",
-        branch: activeThreadBranch,
-        worktreePath: activeThread.worktreePath,
+        bootstrap: {
+          createThread: {
+            projectId: activeProject.id,
+            title: nextThreadTitle,
+            modelSelection: nextThreadModelSelection,
+            runtimeMode,
+            interactionMode: "default",
+            branch: activeThreadBranch,
+            worktreePath: activeThread.worktreePath,
+            createdAt,
+          },
+        },
+        sourceProposedPlan: {
+          threadId: activeThread.id,
+          planId: activeProposedPlan.id,
+        },
         createdAt,
-      })
-      .then(() => {
-        return api.orchestration.dispatchCommand({
-          type: "thread.turn.start",
-          commandId: newCommandId(),
-          threadId: nextThreadId,
-          message: {
-            messageId: newMessageId(),
-            role: "user",
-            text: outgoingImplementationPrompt,
-            attachments: [],
-          },
-          modelSelection: ctxSelectedModelSelection,
-          titleSeed: nextThreadTitle,
-          runtimeMode,
-          interactionMode: "default",
-          sourceProposedPlan: {
-            threadId: activeThread.id,
-            planId: activeProposedPlan.id,
-          },
-          createdAt,
-        });
       })
       .then(() => {
         return waitForStartedServerThread(scopeThreadRef(activeThread.environmentId, nextThreadId));
@@ -3046,13 +3043,6 @@ export default function ChatView(props: ChatViewProps) {
         });
       })
       .catch(async (err: unknown) => {
-        await api.orchestration
-          .dispatchCommand({
-            type: "thread.delete",
-            commandId: newCommandId(),
-            threadId: nextThreadId,
-          })
-          .catch(() => undefined);
         toastManager.add({
           type: "error",
           title: "Could not start implementation thread",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3042,7 +3042,7 @@ export default function ChatView(props: ChatViewProps) {
           },
         });
       })
-      .catch(async (err: unknown) => {
+      .catch((err: unknown) => {
         toastManager.add({
           type: "error",
           title: "Could not start implementation thread",


### PR DESCRIPTION
## Problem

When using **"Implement in a new thread"** from a worktree-based planning thread, the provider session could start in the **main workspace directory** instead of the worktree, causing the LLM to make changes on the wrong branch.

### Root Cause

`onImplementPlanInNewThread` was the **only code path** that created a thread and started a turn as **two separate RPC commands**:

```
1. thread.create  (with worktreePath)  → RPC 1
2. thread.turn.start (without bootstrap) → RPC 2
```

Every other thread+turn creation in the codebase uses the **atomic bootstrap pattern** — a single `thread.turn.start` with an embedded `bootstrap.createThread`. The two-command approach relies on external timing guarantees between separate RPC calls to propagate worktree context (`worktreePath`, `branch`) to the provider session.

### How the Bootstrap Pattern Works

The server's `dispatchBootstrapTurnStart` (`ws.ts`) processes both operations **atomically within the same Effect generator**:

1. Dispatches `thread.create` (with `worktreePath`) → read model updated
2. Dispatches `thread.turn.start` → `ProviderCommandReactor` reads thread with correct `worktreePath`
3. Provider session starts with `cwd = worktreePath` ✓

With the two-command approach, there is a window where the turn start can execute before the thread creation is fully reflected in the read model, causing `resolveThreadWorkspaceCwd` to fall back to `project.workspaceRoot` (the main branch directory).

## Fix

Consolidated the two separate commands into a single `thread.turn.start` with `bootstrap.createThread`, matching the canonical pattern used by the normal send flow (`ChatView.tsx:2545-2589`).

**Changes:**
- Replaced separate `thread.create` + `thread.turn.start` with single atomic `thread.turn.start` + `bootstrap.createThread`
- Removed manual `thread.delete` cleanup in the error path — the server's bootstrap error handler (`ws.ts:478-486`) already handles cleanup automatically
- No schema or server changes needed — uses existing `ThreadTurnStartBootstrap` infrastructure

**Before:** 2 RPCs, manual cleanup, timing-dependent context propagation
**After:** 1 RPC, automatic cleanup, guaranteed context propagation

## Test plan

- [ ] Type-check passes (`tsc --noEmit` on `apps/web`) ✅ verified locally
- [ ] Create a plan in a worktree-based thread
- [ ] Click "Implement in a new thread" from the dropdown
- [ ] Verify the new thread starts with provider session in the **worktree directory** (not main workspace)
- [ ] Verify plan sidebar opens on the new thread
- [ ] Verify error handling: if the turn start fails, the thread is cleaned up by the server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the client orchestration path for creating and starting implementation threads; mistakes could cause thread creation/start failures or incorrect workspace/branch context when launching the provider session.
> 
> **Overview**
> Fixes "Implement in a new thread" to start the new thread via a single atomic `thread.turn.start` call that embeds `bootstrap.createThread` (instead of separate `thread.create` then `thread.turn.start`).
> 
> This ensures the new implementation thread inherits the correct `branch`/`worktreePath` at provider-session start, and removes the client-side error cleanup that deleted the thread on failure (relying on server-side bootstrap cleanup instead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c7bb08407cf2fa51aec7f1686618b2ad9ec7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use atomic bootstrap to create thread and start turn in a single command
> In [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2050/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), starting a plan implementation thread previously required two sequential commands: `thread.create` followed by `thread.turn.start`, with a `thread.delete` cleanup call on failure. Now a single `thread.turn.start` command is dispatched with an embedded `bootstrap.createThread` payload, making thread creation atomic with the first turn. The failure handler is simplified to show an error toast only, since no partial thread exists to clean up.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6c7bb0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->