### PR TITLE
fix: prevent user-input activities from leaking into pending approvals projection

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -1284,6 +1284,14 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             }
             return;
           }
+          // Only approval-requested activities should create pending-approval
+          // rows.  Other activity kinds that happen to carry a requestId
+          // (e.g. user-input.requested / user-input.resolved) must not
+          // pollute this projection — they have their own accounting via
+          // derivePendingUserInputCountFromActivities.
+          if (event.payload.activity.kind !== "approval.requested") {
+            return;
+          }
           if (Option.isSome(existingRow) && existingRow.value.status === "resolved") {
             return;
           }


### PR DESCRIPTION
## Summary

Threads that used **user-input prompts** (structured questions to the user) permanently display **"Pending Approval"** in the sidebar even after all inputs have been answered and the turn has completed.

## Root cause

`applyPendingApprovalsProjection` in `ProjectionPipeline.ts` does not filter by `activity.kind` before creating pending-approval rows. The logic:

1. Extracts `requestId` from **any** activity payload via `extractActivityRequestId`
2. Checks if the activity is `approval.resolved` → skip
3. Checks if the activity is `provider.approval.respond.failed` → skip
4. **Default**: creates a row with `status = "pending"` for **any** remaining activity with a `requestId`

Activities like `user-input.requested` and `user-input.resolved` carry a `requestId` in their payload, so they fall through to the default branch and create orphan pending-approval rows. When `user-input.resolved` arrives, it also falls through and **overwrites** the row with `status = "pending"` again (since it's not `approval.resolved`).

These orphan rows are never cleaned up because only `approval.resolved` can resolve them.

### Contrast with backfill migration

The backfill migration `024_BackfillProjectionThreadShellSummary.ts` correctly filters by `kind = 'approval.requested'` when seeding pending-approval rows (line 36). The live projection was missing this same guard.

| Operation | Migration 024 (backfill) | Live projection (before fix) |
|---|---|---|
| Create pending row | `WHERE kind = 'approval.requested'` ✅ | Any activity with `requestId` ❌ |
| Resolve row | `WHERE kind = 'approval.resolved'` ✅ | `kind === "approval.resolved"` ✅ |
| Stale cleanup | `WHERE kind = 'provider.approval.respond.failed'` ✅ | Matching stale detail strings ✅ |

## Fix

Add a `kind !== "approval.requested"` guard before the pending-row creation path, so only actual approval requests create entries in `projection_pending_approvals`. User-input activities already have their own accounting via `derivePendingUserInputCountFromActivities`.

## Verified with real data

A thread with 11 answered user-input prompts had 11 orphan `pending` rows in `projection_pending_approvals`, all with `status = "pending"` and `resolved_at = null`, even though every single one had a matching `user-input.resolved` event in the event store. The thread's session was `status = "ready"` with `active_turn_id = null`.

## Test plan

- [x] All 18 `ProjectionPipeline.test.ts` tests pass
- [x] All 82 related orchestration tests pass (ProjectionPipeline, ProviderRuntimeIngestion, ProviderCommandReactor, projector)
- [ ] Verify sidebar no longer shows "Pending Approval" for threads with only answered user-input prompts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to projection logic that narrows when pending-approval rows are created; risk is limited to approval sidebar/count behavior.
> 
> **Overview**
> Fixes an issue where `user-input.*` activities that include a `requestId` could incorrectly create/overwrite `projection_pending_approvals` rows, leaving threads stuck showing *Pending Approval*.
> 
> `applyPendingApprovalsProjection` now **only** creates `status="pending"` rows for `activity.kind === "approval.requested"`, while keeping existing resolve/stale-failure handling intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ea2b1f6624617564969f822a1a4986974ccae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pending approvals projection to only process `approval.requested` activities
> Previously, any activity event carrying a `requestId` could upsert a row into the pending-approval repository, causing user-input activities to leak into the pending approvals projection. A guard is added in [`ProjectionPipeline.ts`](https://github.com/pingdotgg/t3code/pull/2051/files#diff-fd69e677e48d4705b0235085da8402910510d529ec5a507d804037a88fca07f4) that returns early unless `event.payload.activity.kind === 'approval.requested'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51ea2b1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->