### PR TITLE
fix: resolve Windows dev environment failure with bun pty

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -75,7 +75,7 @@ import {
 
 const PtyAdapterLive = Layer.unwrap(
   Effect.gen(function* () {
-    if (typeof Bun !== "undefined") {
+	if (typeof Bun !== "undefined" && process.platform !== "win32") {
       const BunPTY = yield* Effect.promise(() => import("./terminal/Layers/BunPTY"));
       return BunPTY.layer;
     } else {


### PR DESCRIPTION
## What Changed

Modified the command/script in `apps\server\src\server.ts` to properly handle `bun pty` execution on Windows environments.

## Why

Currently, starting the development environment fails on Windows machines due to `bun pty` incompatibilities. This single-line fix resolves the local execution failure for Windows contributors while maintaining the intended behavior and compatibility for UNIX-like systems. 

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change affecting only PTY adapter selection; impact is limited to terminal runtime behavior on Windows under Bun.
> 
> **Overview**
> Updates `PtyAdapterLive` selection in `apps/server/src/server.ts` to only use `BunPTY` when running under Bun on non-Windows platforms, and to fall back to `NodePTY` on Windows.
> 
> This avoids `bun pty` incompatibilities that break local server startup for Windows contributors while preserving existing behavior on Unix-like systems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f450d67a7f27a69242b36cf7f81df2076c4109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows dev environment failure by skipping `BunPTY` on win32
> In [server.ts](https://github.com/pingdotgg/t3code/pull/2063/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd), the `PtyAdapterLive` layer selection previously used `BunPTY` whenever Bun was detected. On Windows, this caused the dev environment to fail. The fix adds a `process.platform !== 'win32'` check so `NodePTY.layer` is used on Windows regardless of Bun's presence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82f450d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->