### PR TITLE
feat: handle openai prolite plan in UI and spark availability

### DIFF
--- a/apps/server/src/provider/codexAccount.ts
+++ b/apps/server/src/provider/codexAccount.ts
@@ -1,21 +1,21 @@
 import type { ServerProviderModel } from "@t3tools/contracts";
 
 export type CodexPlanType =
-  | "free"
-  | "go"
-  | "plus"
-  | "pro"
-  | "prolite"
-  | "team"
-  | "business"
-  | "enterprise"
-  | "edu"
-  | "unknown";
+    | "free"
+    | "go"
+    | "plus"
+    | "prolite"
+    | "pro"
+    | "team"
+    | "business"
+    | "enterprise"
+    | "edu"
+    | "unknown";
 
 export interface CodexAccountSnapshot {
-  readonly type: "apiKey" | "chatgpt" | "unknown";
-  readonly planType: CodexPlanType | null;
-  readonly sparkEnabled: boolean;
+    readonly type: "apiKey" | "chatgpt" | "unknown";
+    readonly planType: CodexPlanType | null;
+    readonly sparkEnabled: boolean;
 }
 
 export const CODEX_DEFAULT_MODEL = "gpt-5.3-codex";
@@ -23,102 +23,104 @@ export const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
 const CODEX_SPARK_ENABLED_PLAN_TYPES = new Set<CodexPlanType>(["pro", "prolite"]);
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  return value as Record<string, unknown>;
+    if (!value || typeof value !== "object") {
+        return undefined;
+    }
+    return value as Record<string, unknown>;
 }
 
 function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
+    return typeof value === "string" ? value : undefined;
 }
 
 export function readCodexAccountSnapshot(response: unknown): CodexAccountSnapshot {
-  const record = asObject(response);
-  const account = asObject(record?.account) ?? record;
-  const accountType = asString(account?.type);
+    const record = asObject(response);
+    const account = asObject(record?.account) ?? record;
+    const accountType = asString(account?.type);
 
-  if (accountType === "apiKey") {
+    if (accountType === "apiKey") {
+        return {
+            type: "apiKey",
+            planType: null,
+            sparkEnabled: false,
+        };
+    }
+
+    if (accountType === "chatgpt") {
+        const planType = (account?.planType as CodexPlanType | null) ?? "unknown";
+        return {
+            type: "chatgpt",
+            planType,
+            sparkEnabled: CODEX_SPARK_ENABLED_PLAN_TYPES.has(planType),
+        };
+    }
+
     return {
-      type: "apiKey",
-      planType: null,
-      sparkEnabled: false,
+        type: "unknown",
+        planType: null,
+        sparkEnabled: false,
     };
-  }
-
-  if (accountType === "chatgpt") {
-    const planType = (account?.planType as CodexPlanType | null) ?? "unknown";
-    return {
-      type: "chatgpt",
-      planType,
-      sparkEnabled: CODEX_SPARK_ENABLED_PLAN_TYPES.has(planType),
-    };
-  }
-
-  return {
-    type: "unknown",
-    planType: null,
-    sparkEnabled: false,
-  };
 }
 
 export function codexAuthSubType(account: CodexAccountSnapshot | undefined): string | undefined {
-  if (account?.type === "apiKey") {
-    return "apiKey";
-  }
+    if (account?.type === "apiKey") {
+        return "apiKey";
+    }
 
-  if (account?.type !== "chatgpt") {
-    return undefined;
-  }
+    if (account?.type !== "chatgpt") {
+        return undefined;
+    }
 
-  return account.planType && account.planType !== "unknown" ? account.planType : "chatgpt";
+    return account.planType && account.planType !== "unknown" ? account.planType : "chatgpt";
 }
 
 export function codexAuthSubLabel(account: CodexAccountSnapshot | undefined): string | undefined {
-  switch (codexAuthSubType(account)) {
-    case "apiKey":
-      return "OpenAI API Key";
-    case "chatgpt":
-      return "ChatGPT Subscription";
-    case "free":
-      return "ChatGPT Free Subscription";
-    case "go":
-      return "ChatGPT Go Subscription";
-    case "plus":
-      return "ChatGPT Plus Subscription";
-    case "pro":
-      return "ChatGPT Pro Subscription";
-    case "team":
-      return "ChatGPT Team Subscription";
-    case "business":
-      return "ChatGPT Business Subscription";
-    case "enterprise":
-      return "ChatGPT Enterprise Subscription";
-    case "edu":
-      return "ChatGPT Edu Subscription";
-    default:
-      return undefined;
-  }
+    switch (codexAuthSubType(account)) {
+        case "apiKey":
+            return "OpenAI API Key";
+        case "chatgpt":
+            return "ChatGPT Subscription";
+        case "free":
+            return "ChatGPT Free Subscription";
+        case "go":
+            return "ChatGPT Go Subscription";
+        case "plus":
+            return "ChatGPT Plus Subscription";
+        case "prolite":
+            return "ChatGPT Pro Lite Subscription";
+        case "pro":
+            return "ChatGPT Pro Subscription";
+        case "team":
+            return "ChatGPT Team Subscription";
+        case "business":
+            return "ChatGPT Business Subscription";
+        case "enterprise":
+            return "ChatGPT Enterprise Subscription";
+        case "edu":
+            return "ChatGPT Edu Subscription";
+        default:
+            return undefined;
+    }
 }
 
 export function adjustCodexModelsForAccount(
-  baseModels: ReadonlyArray<ServerProviderModel>,
-  account: CodexAccountSnapshot | undefined,
+    baseModels: ReadonlyArray<ServerProviderModel>,
+    account: CodexAccountSnapshot | undefined,
 ): ReadonlyArray<ServerProviderModel> {
-  if (account?.sparkEnabled !== false) {
-    return baseModels;
-  }
+    if (account?.sparkEnabled !== false) {
+        return baseModels;
+    }
 
-  return baseModels.filter((model) => model.isCustom || model.slug !== CODEX_SPARK_MODEL);
+    return baseModels.filter((model) => model.isCustom || model.slug !== CODEX_SPARK_MODEL);
 }
 
 export function resolveCodexModelForAccount(
-  model: string | undefined,
-  account: CodexAccountSnapshot,
+    model: string | undefined,
+    account: CodexAccountSnapshot,
 ): string | undefined {
-  if (model !== CODEX_SPARK_MODEL || account.sparkEnabled) {
-    return model;
-  }
+    if (model !== CODEX_SPARK_MODEL || account.sparkEnabled) {
+        return model;
+    }
 
-  return CODEX_DEFAULT_MODEL;
+    return CODEX_DEFAULT_MODEL;
 }

--- a/apps/server/src/provider/codexAccount.ts
+++ b/apps/server/src/provider/codexAccount.ts
@@ -1,21 +1,21 @@
 import type { ServerProviderModel } from "@t3tools/contracts";
 
 export type CodexPlanType =
-    | "free"
-    | "go"
-    | "plus"
-    | "prolite"
-    | "pro"
-    | "team"
-    | "business"
-    | "enterprise"
-    | "edu"
-    | "unknown";
+  | "free"
+  | "go"
+  | "plus"
+  | "prolite"
+  | "pro"
+  | "team"
+  | "business"
+  | "enterprise"
+  | "edu"
+  | "unknown";
 
 export interface CodexAccountSnapshot {
-    readonly type: "apiKey" | "chatgpt" | "unknown";
-    readonly planType: CodexPlanType | null;
-    readonly sparkEnabled: boolean;
+  readonly type: "apiKey" | "chatgpt" | "unknown";
+  readonly planType: CodexPlanType | null;
+  readonly sparkEnabled: boolean;
 }
 
 export const CODEX_DEFAULT_MODEL = "gpt-5.3-codex";
@@ -23,104 +23,104 @@ export const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
 const CODEX_SPARK_ENABLED_PLAN_TYPES = new Set<CodexPlanType>(["pro", "prolite"]);
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
-    if (!value || typeof value !== "object") {
-        return undefined;
-    }
-    return value as Record<string, unknown>;
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
 }
 
 function asString(value: unknown): string | undefined {
-    return typeof value === "string" ? value : undefined;
+  return typeof value === "string" ? value : undefined;
 }
 
 export function readCodexAccountSnapshot(response: unknown): CodexAccountSnapshot {
-    const record = asObject(response);
-    const account = asObject(record?.account) ?? record;
-    const accountType = asString(account?.type);
+  const record = asObject(response);
+  const account = asObject(record?.account) ?? record;
+  const accountType = asString(account?.type);
 
-    if (accountType === "apiKey") {
-        return {
-            type: "apiKey",
-            planType: null,
-            sparkEnabled: false,
-        };
-    }
-
-    if (accountType === "chatgpt") {
-        const planType = (account?.planType as CodexPlanType | null) ?? "unknown";
-        return {
-            type: "chatgpt",
-            planType,
-            sparkEnabled: CODEX_SPARK_ENABLED_PLAN_TYPES.has(planType),
-        };
-    }
-
+  if (accountType === "apiKey") {
     return {
-        type: "unknown",
-        planType: null,
-        sparkEnabled: false,
+      type: "apiKey",
+      planType: null,
+      sparkEnabled: false,
     };
+  }
+
+  if (accountType === "chatgpt") {
+    const planType = (account?.planType as CodexPlanType | null) ?? "unknown";
+    return {
+      type: "chatgpt",
+      planType,
+      sparkEnabled: CODEX_SPARK_ENABLED_PLAN_TYPES.has(planType),
+    };
+  }
+
+  return {
+    type: "unknown",
+    planType: null,
+    sparkEnabled: false,
+  };
 }
 
 export function codexAuthSubType(account: CodexAccountSnapshot | undefined): string | undefined {
-    if (account?.type === "apiKey") {
-        return "apiKey";
-    }
+  if (account?.type === "apiKey") {
+    return "apiKey";
+  }
 
-    if (account?.type !== "chatgpt") {
-        return undefined;
-    }
+  if (account?.type !== "chatgpt") {
+    return undefined;
+  }
 
-    return account.planType && account.planType !== "unknown" ? account.planType : "chatgpt";
+  return account.planType && account.planType !== "unknown" ? account.planType : "chatgpt";
 }
 
 export function codexAuthSubLabel(account: CodexAccountSnapshot | undefined): string | undefined {
-    switch (codexAuthSubType(account)) {
-        case "apiKey":
-            return "OpenAI API Key";
-        case "chatgpt":
-            return "ChatGPT Subscription";
-        case "free":
-            return "ChatGPT Free Subscription";
-        case "go":
-            return "ChatGPT Go Subscription";
-        case "plus":
-            return "ChatGPT Plus Subscription";
-        case "prolite":
-            return "ChatGPT Pro Lite Subscription";
-        case "pro":
-            return "ChatGPT Pro Subscription";
-        case "team":
-            return "ChatGPT Team Subscription";
-        case "business":
-            return "ChatGPT Business Subscription";
-        case "enterprise":
-            return "ChatGPT Enterprise Subscription";
-        case "edu":
-            return "ChatGPT Edu Subscription";
-        default:
-            return undefined;
-    }
+  switch (codexAuthSubType(account)) {
+    case "apiKey":
+      return "OpenAI API Key";
+    case "chatgpt":
+      return "ChatGPT Subscription";
+    case "free":
+      return "ChatGPT Free Subscription";
+    case "go":
+      return "ChatGPT Go Subscription";
+    case "plus":
+      return "ChatGPT Plus Subscription";
+    case "prolite":
+      return "ChatGPT Pro Lite Subscription";
+    case "pro":
+      return "ChatGPT Pro Subscription";
+    case "team":
+      return "ChatGPT Team Subscription";
+    case "business":
+      return "ChatGPT Business Subscription";
+    case "enterprise":
+      return "ChatGPT Enterprise Subscription";
+    case "edu":
+      return "ChatGPT Edu Subscription";
+    default:
+      return undefined;
+  }
 }
 
 export function adjustCodexModelsForAccount(
-    baseModels: ReadonlyArray<ServerProviderModel>,
-    account: CodexAccountSnapshot | undefined,
+  baseModels: ReadonlyArray<ServerProviderModel>,
+  account: CodexAccountSnapshot | undefined,
 ): ReadonlyArray<ServerProviderModel> {
-    if (account?.sparkEnabled !== false) {
-        return baseModels;
-    }
+  if (account?.sparkEnabled !== false) {
+    return baseModels;
+  }
 
-    return baseModels.filter((model) => model.isCustom || model.slug !== CODEX_SPARK_MODEL);
+  return baseModels.filter((model) => model.isCustom || model.slug !== CODEX_SPARK_MODEL);
 }
 
 export function resolveCodexModelForAccount(
-    model: string | undefined,
-    account: CodexAccountSnapshot,
+  model: string | undefined,
+  account: CodexAccountSnapshot,
 ): string | undefined {
-    if (model !== CODEX_SPARK_MODEL || account.sparkEnabled) {
-        return model;
-    }
+  if (model !== CODEX_SPARK_MODEL || account.sparkEnabled) {
+    return model;
+  }
 
-    return CODEX_DEFAULT_MODEL;
+  return CODEX_DEFAULT_MODEL;
 }

--- a/apps/server/src/provider/codexAccount.ts
+++ b/apps/server/src/provider/codexAccount.ts
@@ -5,6 +5,7 @@ export type CodexPlanType =
   | "go"
   | "plus"
   | "pro"
+  | "prolite"
   | "team"
   | "business"
   | "enterprise"
@@ -19,7 +20,7 @@ export interface CodexAccountSnapshot {
 
 export const CODEX_DEFAULT_MODEL = "gpt-5.3-codex";
 export const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
-const CODEX_SPARK_ENABLED_PLAN_TYPES = new Set<CodexPlanType>(["pro"]);
+const CODEX_SPARK_ENABLED_PLAN_TYPES = new Set<CodexPlanType>(["pro", "prolite"]);
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object") {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Enable Spark for ProLite Plans (100$ plan) and add the proper UI labels for it.

I saw the other prolite implementation #2006, but its way more extensive and I saw that this small change would already fix the issue I had :)

## Why

The plan allows to use the spark model but at the moment the model is only shown for pro plan users.

## UI Changes
Left you see the current nightly build, on the right the dev build. My account is on the 100$ plan.

<img width="1726" height="1082" alt="image" src="https://github.com/user-attachments/assets/4fd51448-ef91-4ffa-a970-697a065046d6" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to plan-type parsing/labeling and Spark model gating; minimal chance of impacting other accounts beyond plan classification.
> 
> **Overview**
> Extends Codex account plan handling to recognize a new ChatGPT `prolite` plan.
> 
> Updates Spark eligibility so `gpt-5.3-codex-spark` is treated as enabled for both `pro` and `prolite` accounts, and adds a corresponding subscription label (`ChatGPT Pro Lite Subscription`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a2034b42ca693c3070a967345fbe64b3d733e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable Spark for the `prolite` plan type in Codex
> Adds `"prolite"` to `CODEX_SPARK_ENABLED_PLAN_TYPES` in [codexAccount.ts](https://github.com/pingdotgg/t3code/pull/2064/files#diff-e2ef69363c008d96643fd58096e4e796cf3703e9ec85028a5b1e3b3f57b249a6), so membership checks return `true` for that plan. Also adds a `codexAuthSubLabel` case for `"prolite"` returning `"ChatGPT Pro Lite Subscription"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54fd572.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->