### PR TITLE
feat(settings): add UI and code font settings

### DIFF
--- a/apps/desktop/src/clientPersistence.test.ts
+++ b/apps/desktop/src/clientPersistence.test.ts
@@ -3,6 +3,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import {
+  DEFAULT_CODE_FONT_FAMILY,
+  DEFAULT_UI_FONT_FAMILY,
   EnvironmentId,
   type ClientSettings,
   type PersistedSavedEnvironmentRecord,
@@ -52,6 +54,8 @@ const clientSettings: ClientSettings = {
   confirmThreadArchive: true,
   confirmThreadDelete: false,
   diffWordWrap: true,
+  uiFontFamily: DEFAULT_UI_FONT_FAMILY,
+  codeFontFamily: DEFAULT_CODE_FONT_FAMILY,
   sidebarProjectSortOrder: "manual",
   sidebarThreadSortOrder: "created_at",
   timestampFormat: "24-hour",
@@ -71,6 +75,27 @@ describe("clientPersistence", () => {
     const settingsPath = makeTempPath("client-settings.json");
 
     writeClientSettings(settingsPath, clientSettings);
+
+    expect(readClientSettings(settingsPath)).toEqual(clientSettings);
+  });
+
+  it("backfills newly added client settings from legacy files", () => {
+    const settingsPath = makeTempPath("client-settings.json");
+
+    fs.writeFileSync(
+      settingsPath,
+      `${JSON.stringify({
+        settings: {
+          confirmThreadArchive: true,
+          confirmThreadDelete: false,
+          diffWordWrap: true,
+          sidebarProjectSortOrder: "manual",
+          sidebarThreadSortOrder: "created_at",
+          timestampFormat: "24-hour",
+        },
+      })}\n`,
+      "utf8",
+    );
 
     expect(readClientSettings(settingsPath)).toEqual(clientSettings);
   });

--- a/apps/desktop/src/clientPersistence.test.ts
+++ b/apps/desktop/src/clientPersistence.test.ts
@@ -100,6 +100,34 @@ describe("clientPersistence", () => {
     expect(readClientSettings(settingsPath)).toEqual(clientSettings);
   });
 
+  it("falls back only invalid client setting fields to defaults", () => {
+    const settingsPath = makeTempPath("client-settings.json");
+
+    fs.writeFileSync(
+      settingsPath,
+      `${JSON.stringify({
+        settings: {
+          confirmThreadArchive: "invalid",
+          confirmThreadDelete: false,
+          diffWordWrap: true,
+          uiFontFamily: "",
+          codeFontFamily: "",
+          sidebarProjectSortOrder: "manual",
+          sidebarThreadSortOrder: "created_at",
+          timestampFormat: "24-hour",
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    expect(readClientSettings(settingsPath)).toEqual({
+      ...clientSettings,
+      confirmThreadArchive: false,
+      uiFontFamily: "",
+      codeFontFamily: "",
+    });
+  });
+
   it("persists and reloads saved environment metadata", () => {
     const registryPath = makeTempPath("saved-environments.json");
 

--- a/apps/desktop/src/clientPersistence.ts
+++ b/apps/desktop/src/clientPersistence.ts
@@ -1,19 +1,13 @@
 import * as FS from "node:fs";
 import * as Path from "node:path";
 
-import {
-  ClientSettingsSchema,
-  type ClientSettings,
-  type PersistedSavedEnvironmentRecord,
-} from "@t3tools/contracts";
+import { type ClientSettings, type PersistedSavedEnvironmentRecord } from "@t3tools/contracts";
+import { normalizeClientSettings } from "@t3tools/shared/clientSettings";
 import { Predicate } from "effect";
-import * as Schema from "effect/Schema";
 
 interface ClientSettingsDocument {
   readonly settings: ClientSettings;
 }
-
-const decodeClientSettings = Schema.decodeUnknownSync(ClientSettingsSchema);
 
 interface PersistedSavedEnvironmentStorageRecord extends PersistedSavedEnvironmentRecord {
   readonly encryptedBearerToken?: string;
@@ -91,15 +85,7 @@ function toPersistedSavedEnvironmentRecord(
 
 export function readClientSettings(settingsPath: string): ClientSettings | null {
   const rawSettings = readJsonFile<ClientSettingsDocument>(settingsPath)?.settings;
-  if (rawSettings === undefined) {
-    return null;
-  }
-
-  try {
-    return decodeClientSettings(rawSettings);
-  } catch {
-    return null;
-  }
+  return rawSettings === undefined ? null : normalizeClientSettings(rawSettings);
 }
 
 export function writeClientSettings(settingsPath: string, settings: ClientSettings): void {

--- a/apps/desktop/src/clientPersistence.ts
+++ b/apps/desktop/src/clientPersistence.ts
@@ -1,12 +1,19 @@
 import * as FS from "node:fs";
 import * as Path from "node:path";
 
-import type { ClientSettings, PersistedSavedEnvironmentRecord } from "@t3tools/contracts";
+import {
+  ClientSettingsSchema,
+  type ClientSettings,
+  type PersistedSavedEnvironmentRecord,
+} from "@t3tools/contracts";
 import { Predicate } from "effect";
+import * as Schema from "effect/Schema";
 
 interface ClientSettingsDocument {
   readonly settings: ClientSettings;
 }
+
+const decodeClientSettings = Schema.decodeUnknownSync(ClientSettingsSchema);
 
 interface PersistedSavedEnvironmentStorageRecord extends PersistedSavedEnvironmentRecord {
   readonly encryptedBearerToken?: string;
@@ -83,7 +90,16 @@ function toPersistedSavedEnvironmentRecord(
 }
 
 export function readClientSettings(settingsPath: string): ClientSettings | null {
-  return readJsonFile<ClientSettingsDocument>(settingsPath)?.settings ?? null;
+  const rawSettings = readJsonFile<ClientSettingsDocument>(settingsPath)?.settings;
+  if (rawSettings === undefined) {
+    return null;
+  }
+
+  try {
+    return decodeClientSettings(rawSettings);
+  } catch {
+    return null;
+  }
 }
 
 export function writeClientSettings(settingsPath: string, settings: ClientSettings): void {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -20,7 +20,6 @@ import {
 } from "electron";
 import type { MenuItemConstructorOptions, OpenDialogOptions } from "electron";
 import type {
-  ClientSettings,
   DesktopTheme,
   DesktopAppBranding,
   DesktopServerExposureMode,
@@ -34,6 +33,7 @@ import type {
 import { autoUpdater } from "electron-updater";
 
 import type { ContextMenuItem } from "@t3tools/contracts";
+import { parseClientSettings } from "@t3tools/shared/clientSettings";
 import { RotatingFileSink } from "@t3tools/shared/logging";
 import { parsePersistedServerObservabilitySettings } from "@t3tools/shared/serverSettings";
 import { DEFAULT_DESKTOP_BACKEND_PORT, resolveDesktopBackendPort } from "./backendPort";
@@ -1579,11 +1579,12 @@ function registerIpcHandlers(): void {
 
   ipcMain.removeHandler(SET_CLIENT_SETTINGS_CHANNEL);
   ipcMain.handle(SET_CLIENT_SETTINGS_CHANNEL, async (_event, rawSettings: unknown) => {
-    if (typeof rawSettings !== "object" || rawSettings === null) {
+    const settings = parseClientSettings(rawSettings);
+    if (!settings) {
       throw new Error("Invalid client settings payload.");
     }
 
-    writeClientSettings(CLIENT_SETTINGS_PATH, rawSettings as ClientSettings);
+    writeClientSettings(CLIENT_SETTINGS_PATH, settings);
   });
 
   ipcMain.removeHandler(GET_SAVED_ENVIRONMENT_REGISTRY_CHANNEL);

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,7 +12,39 @@
       (() => {
         const LIGHT_BACKGROUND = "#ffffff";
         const DARK_BACKGROUND = "#161616";
+        const CLIENT_SETTINGS_STORAGE_KEY = "t3code:client-settings:v1";
+        const DEFAULT_UI_FONT_FAMILY =
+          '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
+        const DEFAULT_CODE_FONT_FAMILY =
+          '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace';
         const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+        const resolveFontFamily = (value, fallback) => {
+          const trimmedValue = typeof value === "string" ? value.trim() : "";
+          if (!trimmedValue) {
+            return fallback;
+          }
+
+          const probe = document.createElement("span");
+          probe.style.fontFamily = "";
+          probe.style.fontFamily = trimmedValue;
+          return probe.style.fontFamily ? trimmedValue : fallback;
+        };
+
+        const storedClientSettings = window.localStorage.getItem(CLIENT_SETTINGS_STORAGE_KEY);
+        if (storedClientSettings) {
+          try {
+            const clientSettings = JSON.parse(storedClientSettings);
+            document.documentElement.style.setProperty(
+              "--app-font-ui",
+              resolveFontFamily(clientSettings?.uiFontFamily, DEFAULT_UI_FONT_FAMILY),
+            );
+            document.documentElement.style.setProperty(
+              "--app-font-code",
+              resolveFontFamily(clientSettings?.codeFontFamily, DEFAULT_CODE_FONT_FAMILY),
+            );
+          } catch {}
+        }
+
         try {
           const storedTheme = window.localStorage.getItem("t3code:theme");
           const theme =
@@ -44,13 +76,15 @@
       body {
         background: #ffffff;
         color: #262626;
-        font-family:
+        font-family: var(
+          --app-font-ui,
           "DM Sans",
           -apple-system,
           BlinkMacSystemFont,
           "Segoe UI",
           system-ui,
-          sans-serif;
+          sans-serif
+        );
       }
 
       html.dark body {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -13,10 +13,8 @@
         const LIGHT_BACKGROUND = "#ffffff";
         const DARK_BACKGROUND = "#161616";
         const CLIENT_SETTINGS_STORAGE_KEY = "t3code:client-settings:v1";
-        const DEFAULT_UI_FONT_FAMILY =
-          '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
-        const DEFAULT_CODE_FONT_FAMILY =
-          '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace';
+        const DEFAULT_UI_FONT_FAMILY = __T3_DEFAULT_UI_FONT_FAMILY__;
+        const DEFAULT_CODE_FONT_FAMILY = __T3_DEFAULT_CODE_FONT_FAMILY__;
         const themeColorMeta = document.querySelector('meta[name="theme-color"]');
         const resolveFontFamily = (value, fallback) => {
           const trimmedValue = typeof value === "string" ? value.trim() : "";

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -28,9 +28,9 @@
           return probe.style.fontFamily ? trimmedValue : fallback;
         };
 
-        const storedClientSettings = window.localStorage.getItem(CLIENT_SETTINGS_STORAGE_KEY);
-        if (storedClientSettings) {
-          try {
+        try {
+          const storedClientSettings = window.localStorage.getItem(CLIENT_SETTINGS_STORAGE_KEY);
+          if (storedClientSettings) {
             const clientSettings = JSON.parse(storedClientSettings);
             document.documentElement.style.setProperty(
               "--app-font-ui",
@@ -40,8 +40,8 @@
               "--app-font-code",
               resolveFontFamily(clientSettings?.codeFontFamily, DEFAULT_CODE_FONT_FAMILY),
             );
-          } catch {}
-        }
+          }
+        } catch {}
 
         try {
           const storedTheme = window.localStorage.getItem("t3code:theme");

--- a/apps/web/src/clientPersistenceStorage.test.ts
+++ b/apps/web/src/clientPersistenceStorage.test.ts
@@ -1,4 +1,5 @@
 import { EnvironmentId, type PersistedSavedEnvironmentRecord } from "@t3tools/contracts";
+import { DEFAULT_CLIENT_SETTINGS } from "@t3tools/contracts/settings";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const testEnvironmentId = EnvironmentId.make("environment-1");
@@ -49,6 +50,55 @@ afterEach(() => {
 });
 
 describe("clientPersistenceStorage", () => {
+  it("salvages partially invalid browser client settings", async () => {
+    const testWindow = getTestWindow();
+    const { CLIENT_SETTINGS_STORAGE_KEY, readBrowserClientSettings } =
+      await import("./clientPersistenceStorage");
+
+    testWindow.localStorage.setItem(
+      CLIENT_SETTINGS_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_CLIENT_SETTINGS,
+        confirmThreadArchive: "invalid",
+        confirmThreadDelete: false,
+        diffWordWrap: true,
+        sidebarProjectSortOrder: "manual",
+        sidebarThreadSortOrder: "created_at",
+        timestampFormat: "24-hour",
+      }),
+    );
+
+    expect(readBrowserClientSettings()).toEqual({
+      ...DEFAULT_CLIENT_SETTINGS,
+      confirmThreadArchive: false,
+      confirmThreadDelete: false,
+      diffWordWrap: true,
+      sidebarProjectSortOrder: "manual",
+      sidebarThreadSortOrder: "created_at",
+      timestampFormat: "24-hour",
+    });
+    expect(JSON.parse(testWindow.localStorage.getItem(CLIENT_SETTINGS_STORAGE_KEY)!)).toEqual({
+      ...DEFAULT_CLIENT_SETTINGS,
+      confirmThreadArchive: false,
+      confirmThreadDelete: false,
+      diffWordWrap: true,
+      sidebarProjectSortOrder: "manual",
+      sidebarThreadSortOrder: "created_at",
+      timestampFormat: "24-hour",
+    });
+  });
+
+  it("clears corrupt browser client settings payloads", async () => {
+    const testWindow = getTestWindow();
+    const { CLIENT_SETTINGS_STORAGE_KEY, readBrowserClientSettings } =
+      await import("./clientPersistenceStorage");
+
+    testWindow.localStorage.setItem(CLIENT_SETTINGS_STORAGE_KEY, "{");
+
+    expect(readBrowserClientSettings()).toBeNull();
+    expect(testWindow.localStorage.getItem(CLIENT_SETTINGS_STORAGE_KEY)).toBeNull();
+  });
+
   it("stores browser secrets inline with the saved environment record", async () => {
     const testWindow = getTestWindow();
     const {

--- a/apps/web/src/clientPersistenceStorage.ts
+++ b/apps/web/src/clientPersistenceStorage.ts
@@ -1,13 +1,17 @@
 import {
-  ClientSettingsSchema,
   EnvironmentId,
   type ClientSettings,
   type EnvironmentId as EnvironmentIdValue,
   type PersistedSavedEnvironmentRecord,
 } from "@t3tools/contracts";
+import { normalizeClientSettings, parseClientSettings } from "@t3tools/shared/clientSettings";
 import * as Schema from "effect/Schema";
 
-import { getLocalStorageItem, setLocalStorageItem } from "./hooks/useLocalStorage";
+import {
+  getLocalStorageItem,
+  removeLocalStorageItem,
+  setLocalStorageItem,
+} from "./hooks/useLocalStorage";
 
 export const CLIENT_SETTINGS_STORAGE_KEY = "t3code:client-settings:v1";
 export const SAVED_ENVIRONMENT_REGISTRY_STORAGE_KEY = "t3code:saved-environment-registry:v1";
@@ -53,8 +57,25 @@ export function readBrowserClientSettings(): ClientSettings | null {
   }
 
   try {
-    return getLocalStorageItem(CLIENT_SETTINGS_STORAGE_KEY, ClientSettingsSchema);
+    const rawSettings = window.localStorage.getItem(CLIENT_SETTINGS_STORAGE_KEY);
+    if (!rawSettings) {
+      return null;
+    }
+
+    const settings = normalizeClientSettings(JSON.parse(rawSettings));
+    if (!settings) {
+      removeBrowserClientSettings();
+      return null;
+    }
+
+    writeBrowserClientSettings(settings);
+    return settings;
   } catch {
+    try {
+      removeBrowserClientSettings();
+    } catch {
+      // Ignore cleanup errors and fall back to defaults in memory.
+    }
     return null;
   }
 }
@@ -64,7 +85,20 @@ export function writeBrowserClientSettings(settings: ClientSettings): void {
     return;
   }
 
-  setLocalStorageItem(CLIENT_SETTINGS_STORAGE_KEY, settings, ClientSettingsSchema);
+  const validatedSettings = parseClientSettings(settings);
+  if (!validatedSettings) {
+    throw new Error("Invalid browser client settings.");
+  }
+
+  window.localStorage.setItem(CLIENT_SETTINGS_STORAGE_KEY, JSON.stringify(validatedSettings));
+}
+
+export function removeBrowserClientSettings(): void {
+  if (!hasWindow()) {
+    return;
+  }
+
+  removeLocalStorageItem(CLIENT_SETTINGS_STORAGE_KEY);
 }
 
 function readBrowserSavedEnvironmentRegistryDocument(): BrowserSavedEnvironmentRegistryDocument {

--- a/apps/web/src/components/ThreadTerminalDrawer.browser.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.browser.tsx
@@ -1,6 +1,7 @@
 import "../index.css";
 
 import { scopeThreadRef } from "@t3tools/client-runtime";
+import { DEFAULT_CODE_FONT_FAMILY } from "@t3tools/contracts/settings";
 import { ThreadId } from "@t3tools/contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
@@ -43,7 +44,7 @@ vi.mock("@xterm/xterm", () => ({
   Terminal: class MockTerminal {
     cols = 80;
     rows = 24;
-    options: { theme?: unknown } = {};
+    options: { fontFamily?: string; theme?: unknown } = {};
     buffer = {
       active: {
         viewportY: 0,
@@ -52,7 +53,8 @@ vi.mock("@xterm/xterm", () => ({
       },
     };
 
-    constructor(options: unknown) {
+    constructor(options: { fontFamily?: string; theme?: unknown }) {
+      this.options = { ...options };
       terminalConstructorSpy(options);
     }
 
@@ -215,6 +217,7 @@ describe("TerminalViewport", () => {
     terminalDisposeSpy.mockClear();
     fitAddonFitSpy.mockClear();
     fitAddonLoadSpy.mockClear();
+    document.documentElement.style.removeProperty("--app-font-code");
   });
 
   it("does not create a terminal when APIs are unavailable", async () => {
@@ -309,6 +312,54 @@ describe("TerminalViewport", () => {
             background: "rgb(24, 28, 36)",
             foreground: "rgb(228, 232, 240)",
           }),
+        }),
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("uses the configured code font stack for new terminals", async () => {
+    const environment = createEnvironmentApi();
+    environmentApiById.set("environment-a", environment);
+    document.documentElement.style.setProperty("--app-font-code", '"JetBrains Mono", monospace');
+
+    const mounted = await mountTerminalViewport({
+      threadRef: scopeThreadRef("environment-a" as never, THREAD_ID),
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(terminalConstructorSpy).toHaveBeenCalledTimes(1);
+      });
+
+      expect(terminalConstructorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fontFamily: '"JetBrains Mono", monospace',
+        }),
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("falls back to the default code font when the CSS variable is blank", async () => {
+    const environment = createEnvironmentApi();
+    environmentApiById.set("environment-a", environment);
+    document.documentElement.style.setProperty("--app-font-code", "   ");
+
+    const mounted = await mountTerminalViewport({
+      threadRef: scopeThreadRef("environment-a" as never, THREAD_ID),
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(terminalConstructorSpy).toHaveBeenCalledTimes(1);
+      });
+
+      expect(terminalConstructorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fontFamily: DEFAULT_CODE_FONT_FAMILY,
         }),
       );
     } finally {

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -47,6 +47,7 @@ import { selectTerminalEventEntries, useTerminalStateStore } from "../terminalSt
 const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
 const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
+const TERMINAL_FONT_CHANGE_DEBOUNCE_MS = 150;
 
 function maxDrawerHeight(): number {
   if (typeof window === "undefined") return DEFAULT_THREAD_TERMINAL_HEIGHT;
@@ -532,32 +533,52 @@ export function TerminalViewport({
     window.addEventListener("mouseup", handleMouseUp);
     mount.addEventListener("pointerdown", handlePointerDown);
 
-    const themeObserver = new MutationObserver(() => {
+    let pendingFontChangeTimer: number | null = null;
+
+    const applyPendingFontChange = () => {
+      pendingFontChangeTimer = null;
       const activeTerminal = terminalRef.current;
       const activeFitAddon = fitAddonRef.current;
       if (!activeTerminal || !activeFitAddon) return;
 
       const nextFontFamily = getResolvedCodeFontFamily();
-      const hasFontFamilyChanged = activeTerminal.options.fontFamily !== nextFontFamily;
+      if (activeTerminal.options.fontFamily === nextFontFamily) return;
+
+      const wasAtBottom =
+        activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
+      activeTerminal.options.fontFamily = nextFontFamily;
+      activeFitAddon.fit();
+      if (wasAtBottom) {
+        activeTerminal.scrollToBottom();
+      }
+      void api.terminal
+        .resize({
+          threadId,
+          terminalId,
+          cols: activeTerminal.cols,
+          rows: activeTerminal.rows,
+        })
+        .catch(() => undefined);
+    };
+
+    const scheduleFontChange = () => {
+      if (pendingFontChangeTimer !== null) {
+        window.clearTimeout(pendingFontChangeTimer);
+      }
+      pendingFontChangeTimer = window.setTimeout(
+        applyPendingFontChange,
+        TERMINAL_FONT_CHANGE_DEBOUNCE_MS,
+      );
+    };
+
+    const themeObserver = new MutationObserver(() => {
+      const activeTerminal = terminalRef.current;
+      if (!activeTerminal) return;
 
       activeTerminal.options.theme = terminalThemeFromApp(containerRef.current);
 
-      if (hasFontFamilyChanged) {
-        const wasAtBottom =
-          activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
-        activeTerminal.options.fontFamily = nextFontFamily;
-        activeFitAddon.fit();
-        if (wasAtBottom) {
-          activeTerminal.scrollToBottom();
-        }
-        void api.terminal
-          .resize({
-            threadId,
-            terminalId,
-            cols: activeTerminal.cols,
-            rows: activeTerminal.rows,
-          })
-          .catch(() => undefined);
+      if (getResolvedCodeFontFamily() !== activeTerminal.options.fontFamily) {
+        scheduleFontChange();
       }
 
       activeTerminal.refresh(0, activeTerminal.rows - 1);
@@ -745,6 +766,10 @@ export function TerminalViewport({
       window.removeEventListener("mouseup", handleMouseUp);
       mount.removeEventListener("pointerdown", handlePointerDown);
       themeObserver.disconnect();
+      if (pendingFontChangeTimer !== null) {
+        window.clearTimeout(pendingFontChangeTimer);
+        pendingFontChangeTimer = null;
+      }
       terminalRef.current = null;
       fitAddonRef.current = null;
       terminal.dispose();

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -39,6 +39,7 @@ import {
   MAX_TERMINALS_PER_GROUP,
   type ThreadTerminalGroup,
 } from "../types";
+import { getResolvedCodeFontFamily } from "../hooks/useAppFonts";
 import { readEnvironmentApi } from "~/environmentApi";
 import { readLocalApi } from "~/localApi";
 import { selectTerminalEventEntries, useTerminalStateStore } from "../terminalStateStore";
@@ -307,7 +308,7 @@ export function TerminalViewport({
       lineHeight: 1.2,
       fontSize: 12,
       scrollback: 5_000,
-      fontFamily: '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+      fontFamily: getResolvedCodeFontFamily(),
       theme: terminalThemeFromApp(mount),
     });
     terminal.loadAddon(fitAddon);
@@ -533,8 +534,32 @@ export function TerminalViewport({
 
     const themeObserver = new MutationObserver(() => {
       const activeTerminal = terminalRef.current;
-      if (!activeTerminal) return;
+      const activeFitAddon = fitAddonRef.current;
+      if (!activeTerminal || !activeFitAddon) return;
+
+      const nextFontFamily = getResolvedCodeFontFamily();
+      const hasFontFamilyChanged = activeTerminal.options.fontFamily !== nextFontFamily;
+
       activeTerminal.options.theme = terminalThemeFromApp(containerRef.current);
+
+      if (hasFontFamilyChanged) {
+        const wasAtBottom =
+          activeTerminal.buffer.active.viewportY >= activeTerminal.buffer.active.baseY;
+        activeTerminal.options.fontFamily = nextFontFamily;
+        activeFitAddon.fit();
+        if (wasAtBottom) {
+          activeTerminal.scrollToBottom();
+        }
+        void api.terminal
+          .resize({
+            threadId,
+            terminalId,
+            cols: activeTerminal.cols,
+            rows: activeTerminal.rows,
+          })
+          .catch(() => undefined);
+      }
+
       activeTerminal.refresh(0, activeTerminal.rows - 1);
     });
     themeObserver.observe(document.documentElement, {

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -4,7 +4,9 @@ import {
   type AuthAccessStreamEvent,
   type AuthAccessSnapshot,
   AuthSessionId,
+  DEFAULT_CODE_FONT_FAMILY,
   DEFAULT_SERVER_SETTINGS,
+  DEFAULT_UI_FONT_FAMILY,
   EnvironmentId,
   type DesktopBridge,
   type DesktopUpdateChannel,
@@ -451,6 +453,36 @@ describe("GeneralSettingsPanel observability", () => {
         ),
       )
       .toBeInTheDocument();
+  });
+
+  it("lets users edit and reset UI and code font stacks", async () => {
+    setServerConfigSnapshot(createBaseServerConfig());
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <GeneralSettingsPanel />
+      </AppAtomRegistryProvider>,
+    );
+
+    const uiFontInput = page.getByLabelText("UI font family");
+    const codeFontInput = page.getByLabelText("Code font family");
+
+    await expect.element(uiFontInput).toHaveValue(DEFAULT_UI_FONT_FAMILY);
+    await expect.element(codeFontInput).toHaveValue(DEFAULT_CODE_FONT_FAMILY);
+
+    await uiFontInput.fill('"IBM Plex Sans", sans-serif');
+    await codeFontInput.fill('"JetBrains Mono", monospace');
+
+    await expect.element(uiFontInput).toHaveValue('"IBM Plex Sans", sans-serif');
+    await expect.element(codeFontInput).toHaveValue('"JetBrains Mono", monospace');
+    await expect.element(page.getByLabelText("Reset UI font to default")).toBeInTheDocument();
+    await expect.element(page.getByLabelText("Reset code font to default")).toBeInTheDocument();
+
+    await page.getByLabelText("Reset UI font to default").click();
+    await page.getByLabelText("Reset code font to default").click();
+
+    await expect.element(uiFontInput).toHaveValue(DEFAULT_UI_FONT_FAMILY);
+    await expect.element(codeFontInput).toHaveValue(DEFAULT_CODE_FONT_FAMILY);
   });
 
   it("creates and shows a pairing link when network access is enabled", async () => {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -432,6 +432,8 @@ export function useSettingsRestore(onRestored?: () => void) {
   const changedSettingLabels = useMemo(
     () => [
       ...(theme !== "system" ? ["Theme"] : []),
+      ...(settings.uiFontFamily !== DEFAULT_UNIFIED_SETTINGS.uiFontFamily ? ["UI font"] : []),
+      ...(settings.codeFontFamily !== DEFAULT_UNIFIED_SETTINGS.codeFontFamily ? ["Code font"] : []),
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
@@ -461,11 +463,13 @@ export function useSettingsRestore(onRestored?: () => void) {
       isGitWritingModelDirty,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
+      settings.codeFontFamily,
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.diffWordWrap,
       settings.enableAssistantStreaming,
       settings.timestampFormat,
+      settings.uiFontFamily,
       theme,
     ],
   );
@@ -787,6 +791,60 @@ export function GeneralSettingsPanel() {
                 ))}
               </SelectPopup>
             </Select>
+          }
+        />
+
+        <SettingsRow
+          title="UI font"
+          description="CSS font-family stack for navigation, controls, and body text. Leave blank to use the default stack."
+          resetAction={
+            settings.uiFontFamily !== DEFAULT_UNIFIED_SETTINGS.uiFontFamily ? (
+              <SettingResetButton
+                label="UI font"
+                onClick={() =>
+                  updateSettings({
+                    uiFontFamily: DEFAULT_UNIFIED_SETTINGS.uiFontFamily,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Input
+              className="w-full sm:w-[30rem]"
+              value={settings.uiFontFamily}
+              onChange={(event) => updateSettings({ uiFontFamily: event.target.value })}
+              placeholder={DEFAULT_UNIFIED_SETTINGS.uiFontFamily}
+              spellCheck={false}
+              aria-label="UI font family"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Code font"
+          description="CSS font-family stack for code blocks, monospace labels, diffs, and the terminal. Leave blank to use the default stack."
+          resetAction={
+            settings.codeFontFamily !== DEFAULT_UNIFIED_SETTINGS.codeFontFamily ? (
+              <SettingResetButton
+                label="code font"
+                onClick={() =>
+                  updateSettings({
+                    codeFontFamily: DEFAULT_UNIFIED_SETTINGS.codeFontFamily,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Input
+              className="w-full sm:w-[30rem]"
+              value={settings.codeFontFamily}
+              onChange={(event) => updateSettings({ codeFontFamily: event.target.value })}
+              placeholder={DEFAULT_UNIFIED_SETTINGS.codeFontFamily}
+              spellCheck={false}
+              aria-label="Code font family"
+            />
           }
         />
 

--- a/apps/web/src/hooks/useAppFonts.ts
+++ b/apps/web/src/hooks/useAppFonts.ts
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+import {
+  DEFAULT_CODE_FONT_FAMILY,
+  DEFAULT_UI_FONT_FAMILY,
+  type ClientSettings,
+} from "@t3tools/contracts/settings";
+
+import { useSettings } from "./useSettings";
+
+function resolveFontFamily(value: string | null | undefined, fallback: string): string {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue) {
+    return fallback;
+  }
+
+  if (typeof document === "undefined") {
+    return trimmedValue;
+  }
+
+  const probe = document.createElement("span");
+  probe.style.fontFamily = "";
+  probe.style.fontFamily = trimmedValue;
+
+  return probe.style.fontFamily ? trimmedValue : fallback;
+}
+
+export function applyAppFonts(
+  settings: Pick<ClientSettings, "uiFontFamily" | "codeFontFamily">,
+): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.style.setProperty(
+    "--app-font-ui",
+    resolveFontFamily(settings.uiFontFamily, DEFAULT_UI_FONT_FAMILY),
+  );
+  document.documentElement.style.setProperty(
+    "--app-font-code",
+    resolveFontFamily(settings.codeFontFamily, DEFAULT_CODE_FONT_FAMILY),
+  );
+}
+
+export function getResolvedCodeFontFamily(): string {
+  if (typeof document === "undefined") {
+    return DEFAULT_CODE_FONT_FAMILY;
+  }
+
+  return resolveFontFamily(
+    getComputedStyle(document.documentElement).getPropertyValue("--app-font-code"),
+    DEFAULT_CODE_FONT_FAMILY,
+  );
+}
+
+export function useAppFonts(): void {
+  const uiFontFamily = useSettings((settings) => settings.uiFontFamily);
+  const codeFontFamily = useSettings((settings) => settings.codeFontFamily);
+
+  useEffect(() => {
+    applyAppFonts({ uiFontFamily, codeFontFamily });
+  }, [codeFontFamily, uiFontFamily]);
+}

--- a/apps/web/src/hooks/useAppFonts.ts
+++ b/apps/web/src/hooks/useAppFonts.ts
@@ -5,7 +5,7 @@ import {
   type ClientSettings,
 } from "@t3tools/contracts/settings";
 
-import { useSettings } from "./useSettings";
+import { useClientSettingsHydrated, useSettings } from "./useSettings";
 
 function resolveFontFamily(value: string | null | undefined, fallback: string): string {
   const trimmedValue = value?.trim();
@@ -55,8 +55,10 @@ export function getResolvedCodeFontFamily(): string {
 export function useAppFonts(): void {
   const uiFontFamily = useSettings((settings) => settings.uiFontFamily);
   const codeFontFamily = useSettings((settings) => settings.codeFontFamily);
+  const isHydrated = useClientSettingsHydrated();
 
   useEffect(() => {
+    if (!isHydrated) return;
     applyAppFonts({ uiFontFamily, codeFontFamily });
-  }, [codeFontFamily, uiFontFamily]);
+  }, [codeFontFamily, isHydrated, uiFontFamily]);
 }

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -25,6 +25,7 @@ import { applySettingsUpdated, getServerConfig, useServerSettings } from "~/rpc/
 const CLIENT_SETTINGS_PERSISTENCE_ERROR_SCOPE = "[CLIENT_SETTINGS]";
 
 const clientSettingsListeners = new Set<() => void>();
+const clientSettingsHydrationListeners = new Set<() => void>();
 let clientSettingsSnapshot = DEFAULT_CLIENT_SETTINGS;
 let clientSettingsHydrated = false;
 let clientSettingsHydrationPromise: Promise<void> | null = null;
@@ -35,8 +36,18 @@ function emitClientSettingsChange() {
   }
 }
 
+function emitClientSettingsHydrated() {
+  for (const listener of clientSettingsHydrationListeners) {
+    listener();
+  }
+}
+
 function getClientSettingsSnapshot(): ClientSettings {
   return clientSettingsSnapshot;
+}
+
+function getClientSettingsHydratedSnapshot(): boolean {
+  return clientSettingsHydrated;
 }
 
 function replaceClientSettingsSnapshot(settings: ClientSettings): void {
@@ -49,6 +60,14 @@ function subscribeClientSettings(listener: () => void): () => void {
   void hydrateClientSettings();
   return () => {
     clientSettingsListeners.delete(listener);
+  };
+}
+
+function subscribeClientSettingsHydrated(listener: () => void): () => void {
+  clientSettingsHydrationListeners.add(listener);
+  void hydrateClientSettings();
+  return () => {
+    clientSettingsHydrationListeners.delete(listener);
   };
 }
 
@@ -70,6 +89,7 @@ async function hydrateClientSettings(): Promise<void> {
       console.error(`${CLIENT_SETTINGS_PERSISTENCE_ERROR_SCOPE} hydrate failed`, error);
     } finally {
       clientSettingsHydrated = true;
+      emitClientSettingsHydrated();
     }
   })();
 
@@ -121,6 +141,14 @@ function splitPatch(patch: Partial<UnifiedSettings>): {
  * Read merged settings. Selector narrows the subscription so components
  * only re-render when the slice they care about changes.
  */
+
+export function useClientSettingsHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribeClientSettingsHydrated,
+    getClientSettingsHydratedSnapshot,
+    () => false,
+  );
+}
 
 export function useSettings<T = UnifiedSettings>(selector?: (s: UnifiedSettings) => T): T {
   const serverSettings = useServerSettings();
@@ -183,4 +211,5 @@ export function __resetClientSettingsPersistenceForTests(): void {
   clientSettingsHydrated = false;
   clientSettingsHydrationPromise = null;
   clientSettingsListeners.clear();
+  clientSettingsHydrationListeners.clear();
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4,9 +4,12 @@
 /* Window Controls Overlay: active when Electron exposes native titlebar control geometry. */
 @custom-variant wco (&:is(.wco, .wco *));
 
-@theme inline {
+@theme {
   --font-sans: var(--app-font-ui);
   --font-mono: var(--app-font-code);
+}
+
+@theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5,6 +5,8 @@
 @custom-variant wco (&:is(.wco, .wco *));
 
 @theme inline {
+  --font-sans: var(--app-font-ui);
+  --font-mono: var(--app-font-code);
   --animate-skeleton: skeleton 2s -1s infinite linear;
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);
@@ -70,6 +72,8 @@
 :root {
   color-scheme: light;
   --radius: 0.625rem;
+  --app-font-ui: "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --app-font-code: "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
   --background: var(--color-white);
   --app-chrome-background: var(--background);
   --foreground: var(--color-neutral-800);
@@ -129,16 +133,17 @@
 }
 
 body {
-  font-family:
-    "DM Sans",
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    system-ui,
-    sans-serif;
+  font-family: var(--app-font-ui);
   margin: 0;
   padding: 0;
   min-height: 100vh;
+}
+
+button,
+input,
+textarea,
+select {
+  font-family: inherit;
 }
 
 html,
@@ -165,8 +170,10 @@ body::after {
 }
 
 pre,
-code {
-  font-family: "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+code,
+kbd,
+samp {
+  font-family: var(--app-font-code);
 }
 
 /* Window drag region (frameless titlebar) */

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -11,6 +11,7 @@ import {
   type TerminalEvent,
   ThreadId,
 } from "@t3tools/contracts";
+import { DEFAULT_CLIENT_SETTINGS } from "@t3tools/contracts/settings";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ContextMenuItem } from "@t3tools/contracts";
@@ -529,6 +530,7 @@ describe("wsApi", () => {
 
   it("reads and writes persistence through the desktop bridge when available", async () => {
     const getClientSettings = vi.fn().mockResolvedValue({
+      ...DEFAULT_CLIENT_SETTINGS,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
       diffWordWrap: true,
@@ -557,6 +559,7 @@ describe("wsApi", () => {
 
     await api.persistence.getClientSettings();
     await api.persistence.setClientSettings({
+      ...DEFAULT_CLIENT_SETTINGS,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
       diffWordWrap: true,
@@ -575,6 +578,7 @@ describe("wsApi", () => {
 
     expect(getClientSettings).toHaveBeenCalledWith();
     expect(setClientSettings).toHaveBeenCalledWith({
+      ...DEFAULT_CLIENT_SETTINGS,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
       diffWordWrap: true,
@@ -594,6 +598,7 @@ describe("wsApi", () => {
     const api = createLocalApi(rpcClientMock as never);
 
     await api.persistence.setClientSettings({
+      ...DEFAULT_CLIENT_SETTINGS,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
       diffWordWrap: true,
@@ -617,6 +622,7 @@ describe("wsApi", () => {
     );
 
     await expect(api.persistence.getClientSettings()).resolves.toEqual({
+      ...DEFAULT_CLIENT_SETTINGS,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
       diffWordWrap: true,

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -584,6 +584,26 @@ describe("wsApi", () => {
     expect(removeSavedEnvironmentSecret).toHaveBeenCalledWith("environment-local");
   });
 
+  it("clears stale browser client settings when desktop persistence has no settings", async () => {
+    const staleSettings = {
+      ...DEFAULT_CLIENT_SETTINGS,
+      uiFontFamily: '"IBM Plex Sans", sans-serif',
+      codeFontFamily: '"JetBrains Mono", monospace',
+    };
+    const getClientSettings = vi.fn().mockResolvedValue(null);
+    getWindowForTest().desktopBridge = makeDesktopBridge({ getClientSettings });
+
+    const { createLocalApi } = await import("./localApi");
+    const { readBrowserClientSettings, writeBrowserClientSettings } =
+      await import("./clientPersistenceStorage");
+    writeBrowserClientSettings(staleSettings);
+
+    const api = createLocalApi(rpcClientMock as never);
+
+    await expect(api.persistence.getClientSettings()).resolves.toBeNull();
+    expect(readBrowserClientSettings()).toBeNull();
+  });
+
   it("falls back to browser storage for persistence when the desktop bridge is missing", async () => {
     const { createLocalApi } = await import("./localApi");
     const api = createLocalApi(rpcClientMock as never);

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -529,14 +529,17 @@ describe("wsApi", () => {
   });
 
   it("reads and writes persistence through the desktop bridge when available", async () => {
-    const getClientSettings = vi.fn().mockResolvedValue({
+    const clientSettings = {
       ...DEFAULT_CLIENT_SETTINGS,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
       diffWordWrap: true,
-      sidebarProjectSortOrder: "manual",
-      sidebarThreadSortOrder: "created_at",
-      timestampFormat: "24-hour",
+      sidebarProjectSortOrder: "manual" as const,
+      sidebarThreadSortOrder: "created_at" as const,
+      timestampFormat: "24-hour" as const,
+    };
+    const getClientSettings = vi.fn().mockResolvedValue({
+      ...clientSettings,
     });
     const setClientSettings = vi.fn().mockResolvedValue(undefined);
     const getSavedEnvironmentRegistry = vi.fn().mockResolvedValue([]);
@@ -555,18 +558,13 @@ describe("wsApi", () => {
     });
 
     const { createLocalApi } = await import("./localApi");
+    const { readBrowserClientSettings } = await import("./clientPersistenceStorage");
     const api = createLocalApi(rpcClientMock as never);
 
     await api.persistence.getClientSettings();
-    await api.persistence.setClientSettings({
-      ...DEFAULT_CLIENT_SETTINGS,
-      confirmThreadArchive: true,
-      confirmThreadDelete: false,
-      diffWordWrap: true,
-      sidebarProjectSortOrder: "manual",
-      sidebarThreadSortOrder: "created_at",
-      timestampFormat: "24-hour",
-    });
+    expect(readBrowserClientSettings()).toEqual(clientSettings);
+
+    await api.persistence.setClientSettings(clientSettings);
     await api.persistence.getSavedEnvironmentRegistry();
     await api.persistence.setSavedEnvironmentRegistry([]);
     await api.persistence.getSavedEnvironmentSecret(EnvironmentId.make("environment-local"));
@@ -577,15 +575,8 @@ describe("wsApi", () => {
     await api.persistence.removeSavedEnvironmentSecret(EnvironmentId.make("environment-local"));
 
     expect(getClientSettings).toHaveBeenCalledWith();
-    expect(setClientSettings).toHaveBeenCalledWith({
-      ...DEFAULT_CLIENT_SETTINGS,
-      confirmThreadArchive: true,
-      confirmThreadDelete: false,
-      diffWordWrap: true,
-      sidebarProjectSortOrder: "manual",
-      sidebarThreadSortOrder: "created_at",
-      timestampFormat: "24-hour",
-    });
+    expect(setClientSettings).toHaveBeenCalledWith(clientSettings);
+    expect(readBrowserClientSettings()).toEqual(clientSettings);
     expect(getSavedEnvironmentRegistry).toHaveBeenCalledWith();
     expect(setSavedEnvironmentRegistry).toHaveBeenCalledWith([]);
     expect(getSavedEnvironmentSecret).toHaveBeenCalledWith("environment-local");

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -1,4 +1,5 @@
 import type { ContextMenuItem, LocalApi } from "@t3tools/contracts";
+import type { ClientSettings } from "@t3tools/contracts/settings";
 
 import { resetGitStatusStateForTests } from "./lib/gitStatusState";
 import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
@@ -25,6 +26,18 @@ import {
 } from "./clientPersistenceStorage";
 
 let cachedApi: LocalApi | undefined;
+
+function mirrorBrowserClientSettings(settings: ClientSettings | null | undefined): void {
+  if (!settings) {
+    return;
+  }
+
+  try {
+    writeBrowserClientSettings(settings);
+  } catch {
+    // Desktop persistence is authoritative; localStorage is only a bootstrap cache.
+  }
+}
 
 export function createLocalApi(rpcClient: WsRpcClient): LocalApi {
   return {
@@ -68,13 +81,17 @@ export function createLocalApi(rpcClient: WsRpcClient): LocalApi {
     persistence: {
       getClientSettings: async () => {
         if (window.desktopBridge) {
-          return window.desktopBridge.getClientSettings();
+          const settings = await window.desktopBridge.getClientSettings();
+          mirrorBrowserClientSettings(settings);
+          return settings;
         }
         return readBrowserClientSettings();
       },
       setClientSettings: async (settings) => {
         if (window.desktopBridge) {
-          return window.desktopBridge.setClientSettings(settings);
+          await window.desktopBridge.setClientSettings(settings);
+          mirrorBrowserClientSettings(settings);
+          return;
         }
         writeBrowserClientSettings(settings);
       },

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -17,6 +17,7 @@ import { type WsRpcClient } from "./rpc/wsRpcClient";
 import { showContextMenuFallback } from "./contextMenuFallback";
 import {
   readBrowserClientSettings,
+  removeBrowserClientSettings,
   readBrowserSavedEnvironmentRegistry,
   readBrowserSavedEnvironmentSecret,
   removeBrowserSavedEnvironmentSecret,
@@ -27,13 +28,18 @@ import {
 
 let cachedApi: LocalApi | undefined;
 
-function mirrorBrowserClientSettings(settings: ClientSettings | null | undefined): void {
-  if (!settings) {
+function syncBrowserClientSettingsCache(settings: ClientSettings | null | undefined): void {
+  if (settings) {
+    try {
+      writeBrowserClientSettings(settings);
+    } catch {
+      // Desktop persistence is authoritative; localStorage is only a bootstrap cache.
+    }
     return;
   }
 
   try {
-    writeBrowserClientSettings(settings);
+    removeBrowserClientSettings();
   } catch {
     // Desktop persistence is authoritative; localStorage is only a bootstrap cache.
   }
@@ -82,7 +88,7 @@ export function createLocalApi(rpcClient: WsRpcClient): LocalApi {
       getClientSettings: async () => {
         if (window.desktopBridge) {
           const settings = await window.desktopBridge.getClientSettings();
-          mirrorBrowserClientSettings(settings);
+          syncBrowserClientSettingsCache(settings);
           return settings;
         }
         return readBrowserClientSettings();
@@ -90,7 +96,7 @@ export function createLocalApi(rpcClient: WsRpcClient): LocalApi {
       setClientSettings: async (settings) => {
         if (window.desktopBridge) {
           await window.desktopBridge.setClientSettings(settings);
-          mirrorBrowserClientSettings(settings);
+          syncBrowserClientSettingsCache(settings);
           return;
         }
         writeBrowserClientSettings(settings);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -21,6 +21,8 @@ import {
 import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
+import { useAppFonts } from "../hooks/useAppFonts";
+import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import { readLocalApi } from "../localApi";
 import {
   getServerConfigUpdatedNotification,
@@ -32,7 +34,6 @@ import {
 } from "../rpc/serverState";
 import { useStore } from "../store";
 import { useUiStateStore } from "../uiStateStore";
-import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import {
   ensureEnvironmentConnectionBootstrapped,
   getPrimaryEnvironmentConnection,
@@ -65,6 +66,8 @@ export const Route = createRootRouteWithContext<{
 });
 
 function RootRouteView() {
+  useAppFonts();
+
   const pathname = useLocation({ select: (location) => location.pathname });
   const { authGateState } = Route.useRouteContext();
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,8 +2,18 @@ import tailwindcss from "@tailwindcss/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
-import { defineConfig } from "vite";
+import { DEFAULT_CODE_FONT_FAMILY, DEFAULT_UI_FONT_FAMILY } from "@t3tools/contracts/fontDefaults";
+import { defineConfig, type Plugin } from "vite";
 import pkg from "./package.json" with { type: "json" };
+
+const bootstrapConstantsPlugin = (): Plugin => ({
+  name: "t3code:bootstrap-constants",
+  transformIndexHtml(html) {
+    return html
+      .replaceAll("__T3_DEFAULT_UI_FONT_FAMILY__", JSON.stringify(DEFAULT_UI_FONT_FAMILY))
+      .replaceAll("__T3_DEFAULT_CODE_FONT_FAMILY__", JSON.stringify(DEFAULT_CODE_FONT_FAMILY));
+  },
+});
 
 const port = Number(process.env.PORT ?? 5733);
 const host = process.env.HOST?.trim() || "localhost";
@@ -54,6 +64,7 @@ export default defineConfig({
       presets: [reactCompilerPreset()],
     }),
     tailwindcss(),
+    bootstrapConstantsPlugin(),
   ],
   optimizeDeps: {
     include: ["@pierre/diffs", "@pierre/diffs/react", "@pierre/diffs/worker/worker.js"],

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -10,6 +10,11 @@
   "module": "./dist/index.mjs",
   "types": "./src/index.ts",
   "exports": {
+    "./fontDefaults": {
+      "types": "./src/fontDefaults.ts",
+      "import": "./src/fontDefaults.ts",
+      "require": "./src/fontDefaults.ts"
+    },
     "./settings": {
       "types": "./src/settings.ts",
       "import": "./src/settings.ts",

--- a/packages/contracts/src/fontDefaults.ts
+++ b/packages/contracts/src/fontDefaults.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_UI_FONT_FAMILY =
+  '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
+
+export const DEFAULT_CODE_FONT_FAMILY =
+  '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace';

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -2,12 +2,15 @@ import { Effect } from "effect";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 import { TrimmedNonEmptyString, TrimmedString } from "./baseSchemas";
+import { DEFAULT_CODE_FONT_FAMILY, DEFAULT_UI_FONT_FAMILY } from "./fontDefaults";
 import {
   ClaudeModelOptions,
   CodexModelOptions,
   DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER,
 } from "./model";
 import { ModelSelection } from "./orchestration";
+
+export { DEFAULT_CODE_FONT_FAMILY, DEFAULT_UI_FONT_FAMILY };
 
 // ── Client Settings (local-only) ───────────────────────────────
 
@@ -22,11 +25,6 @@ export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "upda
 export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
-
-export const DEFAULT_UI_FONT_FAMILY =
-  '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
-export const DEFAULT_CODE_FONT_FAMILY =
-  '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace';
 
 export const ClientSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -23,10 +23,21 @@ export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 
+export const DEFAULT_UI_FONT_FAMILY =
+  '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif';
+export const DEFAULT_CODE_FONT_FAMILY =
+  '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace';
+
 export const ClientSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  uiFontFamily: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_UI_FONT_FAMILY)),
+  ),
+  codeFontFamily: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_CODE_FONT_FAMILY)),
+  ),
   sidebarProjectSortOrder: SidebarProjectSortOrder.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_SORT_ORDER)),
   ),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,6 +44,10 @@
       "types": "./src/serverSettings.ts",
       "import": "./src/serverSettings.ts"
     },
+    "./clientSettings": {
+      "types": "./src/clientSettings.ts",
+      "import": "./src/clientSettings.ts"
+    },
     "./String": {
       "types": "./src/String.ts",
       "import": "./src/String.ts"

--- a/packages/shared/src/clientSettings.ts
+++ b/packages/shared/src/clientSettings.ts
@@ -1,0 +1,44 @@
+import { ClientSettingsSchema, type ClientSettings } from "@t3tools/contracts/settings";
+import * as Schema from "effect/Schema";
+
+const decodeClientSettings = Schema.decodeUnknownSync(ClientSettingsSchema);
+
+const clientSettingsFieldDecoders = Object.fromEntries(
+  Object.entries(ClientSettingsSchema.fields).map(([key, schema]) => [
+    key,
+    Schema.decodeUnknownSync(schema),
+  ]),
+) as Record<keyof ClientSettings, (value: unknown) => unknown>;
+
+export function parseClientSettings(raw: unknown): ClientSettings | null {
+  try {
+    return decodeClientSettings(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeClientSettings(raw: unknown): ClientSettings | null {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return null;
+  }
+
+  const rawRecord = raw as Record<string, unknown>;
+  const partialSettings: Partial<Record<keyof ClientSettings, unknown>> = {};
+  for (const [key, decode] of Object.entries(clientSettingsFieldDecoders) as Array<
+    [keyof ClientSettings, (value: unknown) => unknown]
+  >) {
+    const value = rawRecord[key];
+    if (value === undefined) {
+      continue;
+    }
+
+    try {
+      partialSettings[key] = decode(value);
+    } catch {
+      // Drop invalid fields so schema defaults can recover them.
+    }
+  }
+
+  return parseClientSettings(partialSettings);
+}


### PR DESCRIPTION
## Summary
- add two client-side settings for the UI font stack and code font stack
- apply those settings through global CSS variables, including boot-time font initialization
- update the embedded terminal so the code font setting also affects xterm
- backfill legacy desktop client settings files and add regression coverage for migration + terminal font behavior

## Notes
- both settings are local-only client preferences, matching the existing settings architecture
- blank or invalid font stacks fall back to the current project defaults
- malformed stored font settings no longer affect theme bootstrap

## Validation
- bun fmt
- bun lint
- bun typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client settings persistence/validation and early page bootstrap behavior, so bugs could cause settings resets or incorrect fonts/theme at startup, but changes are localized and covered by new tests.
> 
> **Overview**
> Adds two new client-only settings, `uiFontFamily` and `codeFontFamily`, with shared defaults and a settings UI to edit/reset them; fonts are applied globally via `--app-font-ui`/`--app-font-code` and wired into Tailwind/base styles.
> 
> Updates web bootstrapping to read cached client settings from `localStorage` before React renders (and injects default font constants at build time), plus adds a `useAppFonts` hook that applies fonts after settings hydration.
> 
> Hardens persistence/validation: desktop now normalizes legacy/partially invalid `client-settings.json` on read and validates IPC payloads; web storage now normalizes/salvages invalid fields, clears corrupt payloads, and mirrors desktop settings into browser storage for next-load bootstrap. Terminal creation now uses the resolved code font and debounces live font changes via a `MutationObserver`, with added regression tests for migrations, storage salvage, and terminal font behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d12fe9c0adf8e6748f403d67fadff0cbfb700bf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add UI and code font family settings with CSS variable-based application
> - Adds `uiFontFamily` and `codeFontFamily` fields to `ClientSettingsSchema` with defaults exported from a new `contracts/fontDefaults` module.
> - Adds settings UI rows in `GeneralSettingsPanel` to edit and reset both font stacks; the restore-defaults prompt includes font changes.
> - Applies fonts via CSS variables `--app-font-ui` and `--app-font-code` at boot (via an inline script in `index.html`) and at runtime via a new `useAppFonts` hook, reducing flash of unstyled fonts.
> - Terminal in `ThreadTerminalDrawer` now initializes with the configured code font and dynamically refits when the font changes, preserving scroll position.
> - Client settings persistence (both desktop and browser) now validates and normalizes payloads on read and write, salvaging partially invalid settings and coercing missing fields to defaults.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d12fe9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->