### PR TITLE
Fix changed-file diffs for nested workspaces

### DIFF
--- a/apps/server/src/git/Utils.test.ts
+++ b/apps/server/src/git/Utils.test.ts
@@ -1,0 +1,56 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { isGitRepository } from "./Utils";
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  const directory = mkdtempSync(join(tmpdir(), "t3-git-utils-"));
+  tempDirs.push(directory);
+  return directory;
+}
+
+function initGitRepository(root: string) {
+  execFileSync("git", ["init"], {
+    cwd: root,
+    stdio: "ignore",
+  });
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const directory = tempDirs.pop();
+    if (!directory) {
+      continue;
+    }
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("isGitRepository", () => {
+  it("returns true for a git repository root", () => {
+    const root = makeTempDir();
+    initGitRepository(root);
+
+    expect(isGitRepository(root)).toBe(true);
+  });
+
+  it("returns true for nested directories inside a git repository", () => {
+    const root = makeTempDir();
+    initGitRepository(root);
+    const nestedDirectory = join(root, "apps", "server");
+    mkdirSync(nestedDirectory, { recursive: true });
+
+    expect(isGitRepository(nestedDirectory)).toBe(true);
+  });
+
+  it("returns false outside a git repository", () => {
+    const directory = makeTempDir();
+
+    expect(isGitRepository(directory)).toBe(false);
+  });
+});

--- a/apps/server/src/git/Utils.ts
+++ b/apps/server/src/git/Utils.ts
@@ -7,11 +7,21 @@ import { Schema } from "effect";
 
 import { TextGenerationError } from "@t3tools/contracts";
 
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 export function isGitRepository(cwd: string): boolean {
-  return existsSync(join(cwd, ".git"));
+  if (existsSync(join(cwd, ".git"))) {
+    return true;
+  }
+
+  const result = spawnSync("git", ["rev-parse", "--is-inside-work-tree"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0 && result.stdout.trim() === "true";
 }
 
 /** Convert an Effect Schema to a flat JSON Schema object, inlining `$defs` when present. */


### PR DESCRIPTION
## Summary
- fix git workspace detection for nested project directories like `apps/server`
- restore changed-file diff capture when the active project lives inside a larger git repo but does not contain the `.git` directory itself
- add a regression test for nested directories inside a git repo

## Why this matters
When a thread is opened from a nested workspace such as `apps/server`, Codex can emit real `turn/diff/updated` events for file edits, but T3 Code was silently dropping them because the server only treated the cwd as a git repo if `cwd/.git` existed.

That meant nested workspaces could show the generic `File change` activity row while never rendering the actual `Changed files (...)` card or attaching turn diff state to the assistant message.

In practice, the app looked like it had no file diff information even though the provider had already produced it.

## Verification
- reproduced the failure from a nested workspace (`apps/server`) where `turn/diff/updated` events were present but no changed-files card was stored/rendered
- `bun run --cwd apps/server test src/git/Utils.test.ts`
- `bun run --cwd apps/server test src/orchestration/Layers/ProviderRuntimeIngestion.test.ts`
- `bun fmt`
- `bun lint`
- `bun typecheck` *(still fails on the pre-existing `TS2367` errors in `apps/server/src/provider/Layers/ClaudeAdapter.ts`)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to repository detection plus a regression test; main risk is behavior differences when `git` is unavailable or returns unexpected output.
> 
> **Overview**
> Fixes git-workspace detection so server-side features that depend on git (notably changed-file diff capture) work when the workspace `cwd` is a subdirectory of a larger repository rather than the repo root.
> 
> `isGitRepository` now falls back from checking `cwd/.git` to running `git rev-parse --is-inside-work-tree`, and a new `Utils.test.ts` regression test covers repo root, nested directories, and non-repo directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ff633f617486b67d445c57de214f0127c9767b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isGitRepository` to detect nested directories inside a git work tree
> Previously, `isGitRepository` only returned `true` when a `.git` directory existed directly in the provided `cwd`, so it failed for subdirectories of a repo. Now, if no `.git` is found, it falls back to running `git rev-parse --is-inside-work-tree` via `spawnSync` and returns `true` only when the command exits 0 and prints `"true"`. Tests in [Utils.test.ts](https://github.com/pingdotgg/t3code/pull/2071/files#diff-b5e574130459457782e4d821cfb4f10278b93d73e5f1caabcaf65895df674ecc) cover the root, nested, and outside-repo cases using temporary directories.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0ff633.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->