### PR TITLE
fix(server): drop stale text generation options when resetting text-gen model selection

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -142,6 +142,35 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("drops stale text generation options when resetting model selection", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsService;
+
+      yield* serverSettings.updateSettings({
+        textGenerationModelSelection: {
+          provider: "codex",
+          model: DEFAULT_SERVER_SETTINGS.textGenerationModelSelection.model,
+          options: {
+            reasoningEffort: "high",
+            fastMode: true,
+          },
+        },
+      });
+
+      const next = yield* serverSettings.updateSettings({
+        textGenerationModelSelection: {
+          provider: DEFAULT_SERVER_SETTINGS.textGenerationModelSelection.provider,
+          model: DEFAULT_SERVER_SETTINGS.textGenerationModelSelection.model,
+        },
+      });
+
+      assert.deepEqual(next.textGenerationModelSelection, {
+        provider: DEFAULT_SERVER_SETTINGS.textGenerationModelSelection.provider,
+        model: DEFAULT_SERVER_SETTINGS.textGenerationModelSelection.model,
+      });
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("trims provider path settings when updates are applied", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsService;

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -79,12 +79,13 @@ export class ServerSettingsService extends Context.Service<
           start: Effect.void,
           ready: Effect.void,
           getSettings: Ref.get(currentSettingsRef),
-          updateSettings: (patch) =>
+updateSettings: (patch) =>
             Ref.get(currentSettingsRef).pipe(
               Effect.flatMap((currentSettings) =>
-                applyServerSettingsPatch(currentSettings, patch),
+                Schema.decodeEffect(ServerSettings)(
+                  applyServerSettingsPatch(currentSettings, patch),
+                ),
               ),
-              Schema.decodeEffect(ServerSettings),
               Effect.tap((nextSettings) => Ref.set(currentSettingsRef, nextSettings)),
             ),
           streamChanges: Stream.empty,

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -81,7 +81,8 @@ export class ServerSettingsService extends Context.Service<
           getSettings: Ref.get(currentSettingsRef),
           updateSettings: (patch) =>
             Ref.get(currentSettingsRef).pipe(
-              Effect.map((currentSettings) => deepMerge(currentSettings, patch)),
+              Effect.map((currentSettings) => applyServerSettingsPatch(currentSettings, patch)),
+              Effect.map((next) => Schema.decodeSync(ServerSettings)(next)),
               Effect.tap((nextSettings) => Ref.set(currentSettingsRef, nextSettings)),
             ),
           streamChanges: Stream.empty,

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -42,6 +42,7 @@ import * as Semaphore from "effect/Semaphore";
 import { ServerConfig } from "./config";
 import { type DeepPartial, deepMerge } from "@t3tools/shared/Struct";
 import { fromLenientJson } from "@t3tools/shared/schemaJson";
+import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
 
 export interface ServerSettingsShape {
   /** Start the settings runtime and attach file watching. */
@@ -314,7 +315,9 @@ const makeServerSettings = Effect.gen(function* () {
       writeSemaphore.withPermits(1)(
         Effect.gen(function* () {
           const current = yield* getSettingsFromCache;
-          const next = yield* Schema.decodeEffect(ServerSettings)(deepMerge(current, patch)).pipe(
+          const next = yield* Schema.decodeEffect(ServerSettings)(
+            applyServerSettingsPatch(current, patch),
+          ).pipe(
             Effect.mapError(
               (cause) =>
                 new ServerSettingsError({

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -81,8 +81,10 @@ export class ServerSettingsService extends Context.Service<
           getSettings: Ref.get(currentSettingsRef),
           updateSettings: (patch) =>
             Ref.get(currentSettingsRef).pipe(
-              Effect.map((currentSettings) => applyServerSettingsPatch(currentSettings, patch)),
-              Effect.map((next) => Schema.decodeSync(ServerSettings)(next)),
+              Effect.flatMap((currentSettings) =>
+                applyServerSettingsPatch(currentSettings, patch),
+              ),
+              Schema.decodeEffect(ServerSettings),
               Effect.tap((nextSettings) => Ref.set(currentSettingsRef, nextSettings)),
             ),
           streamChanges: Stream.empty,

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -79,11 +79,20 @@ export class ServerSettingsService extends Context.Service<
           start: Effect.void,
           ready: Effect.void,
           getSettings: Ref.get(currentSettingsRef),
-updateSettings: (patch) =>
+          updateSettings: (patch) =>
             Ref.get(currentSettingsRef).pipe(
               Effect.flatMap((currentSettings) =>
                 Schema.decodeEffect(ServerSettings)(
                   applyServerSettingsPatch(currentSettings, patch),
+                ).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new ServerSettingsError({
+                        settingsPath: "<memory>",
+                        detail: `failed to normalize server settings: ${SchemaIssue.makeFormatterDefault()(cause.issue)}`,
+                        cause,
+                      }),
+                  ),
                 ),
               ),
               Effect.tap((nextSettings) => Ref.set(currentSettingsRef, nextSettings)),

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -19,7 +19,7 @@ import {
 } from "@t3tools/contracts/settings";
 import { ensureLocalApi } from "~/localApi";
 import { Struct } from "effect";
-import { deepMerge } from "@t3tools/shared/Struct";
+import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
 import { applySettingsUpdated, getServerConfig, useServerSettings } from "~/rpc/serverState";
 
 const CLIENT_SETTINGS_PERSISTENCE_ERROR_SCOPE = "[CLIENT_SETTINGS]";
@@ -154,7 +154,7 @@ export function useUpdateSettings() {
     if (Object.keys(serverPatch).length > 0) {
       const currentServerConfig = getServerConfig();
       if (currentServerConfig) {
-        applySettingsUpdated(deepMerge(currentServerConfig.settings, serverPatch));
+        applySettingsUpdated(applyServerSettingsPatch(currentServerConfig.settings, serverPatch));
       }
       // Fire-and-forget RPC — push will reconcile on success
       void ensureLocalApi().server.updateSettings(serverPatch);

--- a/packages/shared/src/serverSettings.test.ts
+++ b/packages/shared/src/serverSettings.test.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_SERVER_SETTINGS } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 import {
+  applyServerSettingsPatch,
   extractPersistedServerObservabilitySettings,
   normalizePersistedServerSettingString,
   parsePersistedServerObservabilitySettings,
@@ -48,6 +50,63 @@ describe("serverSettings helpers", () => {
     expect(parsePersistedServerObservabilitySettings("{")).toEqual({
       otlpTracesUrl: undefined,
       otlpMetricsUrl: undefined,
+    });
+  });
+
+  it("replaces text generation selection when provider/model are provided", () => {
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      textGenerationModelSelection: {
+        provider: "codex" as const,
+        model: "gpt-5.4-mini",
+        options: {
+          reasoningEffort: "high" as const,
+          fastMode: true,
+        },
+      },
+    };
+
+    expect(
+      applyServerSettingsPatch(current, {
+        textGenerationModelSelection: {
+          provider: "codex",
+          model: "gpt-5.4-mini",
+        },
+      }).textGenerationModelSelection,
+    ).toEqual({
+      provider: "codex",
+      model: "gpt-5.4-mini",
+    });
+  });
+
+  it("still deep merges text generation selection when only options are provided", () => {
+    const current = {
+      ...DEFAULT_SERVER_SETTINGS,
+      textGenerationModelSelection: {
+        provider: "codex" as const,
+        model: "gpt-5.4-mini",
+        options: {
+          reasoningEffort: "high" as const,
+          fastMode: true,
+        },
+      },
+    };
+
+    expect(
+      applyServerSettingsPatch(current, {
+        textGenerationModelSelection: {
+          options: {
+            fastMode: false,
+          },
+        },
+      }).textGenerationModelSelection,
+    ).toEqual({
+      provider: "codex",
+      model: "gpt-5.4-mini",
+      options: {
+        reasoningEffort: "high",
+        fastMode: false,
+      },
     });
   });
 });

--- a/packages/shared/src/serverSettings.ts
+++ b/packages/shared/src/serverSettings.ts
@@ -1,5 +1,6 @@
-import { ServerSettings } from "@t3tools/contracts";
+import { ServerSettings, type ServerSettingsPatch } from "@t3tools/contracts";
 import { Schema } from "effect";
+import { deepMerge } from "./Struct";
 import { fromLenientJson } from "./schemaJson";
 
 const ServerSettingsJson = fromLenientJson(ServerSettings);
@@ -37,4 +38,35 @@ export function parsePersistedServerObservabilitySettings(
   } catch {
     return { otlpTracesUrl: undefined, otlpMetricsUrl: undefined };
   }
+}
+
+function shouldReplaceTextGenerationModelSelection(
+  patch: ServerSettingsPatch["textGenerationModelSelection"] | undefined,
+): boolean {
+  return Boolean(patch && (patch.provider !== undefined || patch.model !== undefined));
+}
+
+/**
+ * Applies a server settings patch while treating textGenerationModelSelection as
+ * replace-on-provider/model updates. This prevents stale nested options from
+ * surviving a reset patch that intentionally omits options.
+ */
+export function applyServerSettingsPatch(
+  current: ServerSettings,
+  patch: ServerSettingsPatch,
+): ServerSettings {
+  const selectionPatch = patch.textGenerationModelSelection;
+  const next = deepMerge(current, patch);
+  if (!selectionPatch || !shouldReplaceTextGenerationModelSelection(selectionPatch)) {
+    return next;
+  }
+
+  return {
+    ...next,
+    textGenerationModelSelection: {
+      provider: selectionPatch.provider ?? current.textGenerationModelSelection.provider,
+      model: selectionPatch.model ?? current.textGenerationModelSelection.model,
+      ...(selectionPatch.options ? { options: selectionPatch.options } : {}),
+    },
+  };
 }


### PR DESCRIPTION
## What Changed

Introduced applyServerSettingsPatch function in packages/shared/src/serverSettings.ts to handle server settings patches with atomic replacement for textGenerationModelSelection. When provider or model is updated in the patch, the entire textGenerationModelSelection object is rebuilt instead of deep-merged, ensuring stale nested options are dropped. Updated apps/server/src/serverSettings.ts and apps/web/src/hooks/useSettings.ts to use this new patch logic. Added comprehensive tests in packages/shared/src/serverSettings.test.ts and apps/server/src/serverSettings.test.ts to verify correct behavior.

## Why

Previously, resetting the text generation model selection didn't work. Stale options from prior configurations would persist. The atomic replacement ensures clean resets while maintaining options when explicitly provided.

## UI Changes

-

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to settings merge semantics plus tests; main risk is subtle behavior change for callers relying on old deep-merge of `textGenerationModelSelection` when updating provider/model.
> 
> **Overview**
> Fixes server settings patching so resetting `textGenerationModelSelection` no longer preserves stale nested `options`. Introduces shared helper `applyServerSettingsPatch` that deep-merges normally but *replaces* `textGenerationModelSelection` when a patch specifies `provider` and/or `model`, dropping omitted options.
> 
> Both server-side `updateSettings` (in-memory test layer and persisted path) and the web client’s optimistic settings update now use this helper, and new unit/integration tests cover replacement vs option-only merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d147712365f454594465e600fd9c5bd7446381d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop stale `textGenerationModelSelection` options when resetting text-gen model selection
> - Introduces `applyServerSettingsPatch` in [`packages/shared/src/serverSettings.ts`](https://github.com/pingdotgg/t3code/pull/2076/files#diff-043ca428f05b5295b6161cdcb2c48bd97c3985f21faa3a8214057decca51518f) that replaces `textGenerationModelSelection` (dropping stale `options`) when `provider` or `model` are present in the patch, while still deep-merging when only `options` are provided.
> - Replaces `deepMerge` with `applyServerSettingsPatch` in the server settings update handler and the test layer in [`apps/server/src/serverSettings.ts`](https://github.com/pingdotgg/t3code/pull/2076/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e).
> - Applies the same fix to the optimistic client-side update in [`apps/web/src/hooks/useSettings.ts`](https://github.com/pingdotgg/t3code/pull/2076/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) so the UI stays consistent with server behavior.
> - Behavioral Change: changing `provider` or `model` in a settings patch now discards previously stored `options`; patches that only update `options` continue to deep-merge as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d14771.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->