### PR TITLE
fix(server): extend negative repository identity cache ttl

### DIFF
--- a/apps/server/src/project/Layers/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/Layers/RepositoryIdentityResolver.test.ts
@@ -112,7 +112,7 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
   );
 
   it.effect(
-    "refreshes cached null identities after the negative TTL when a remote is configured later",
+    "keeps null identities cached across repeated resolves until the negative TTL expires",
     () =>
       Effect.gen(function* () {
         const fileSystem = yield* FileSystem.FileSystem;
@@ -128,8 +128,10 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
 
         yield* git(cwd, ["remote", "add", "origin", "git@github.com:T3Tools/t3code.git"]);
 
-        const cachedIdentity = yield* resolver.resolve(cwd);
-        expect(cachedIdentity).toBeNull();
+        for (const _attempt of [1, 2, 3]) {
+          const cachedIdentity = yield* resolver.resolve(cwd);
+          expect(cachedIdentity).toBeNull();
+        }
 
         yield* TestClock.adjust(Duration.millis(120));
 

--- a/apps/server/src/project/Layers/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/Layers/RepositoryIdentityResolver.ts
@@ -66,7 +66,7 @@ function buildRepositoryIdentity(input: {
 
 const DEFAULT_REPOSITORY_IDENTITY_CACHE_CAPACITY = 512;
 const DEFAULT_POSITIVE_CACHE_TTL = Duration.minutes(1);
-const DEFAULT_NEGATIVE_CACHE_TTL = Duration.seconds(10);
+const DEFAULT_NEGATIVE_CACHE_TTL = Duration.minutes(1);
 
 interface RepositoryIdentityResolverOptions {
   readonly cacheCapacity?: number;


### PR DESCRIPTION
## What Changed

This PR implements Fix 2 proposed by @mei-the-dev in #2037, taking the smallest cache-only slice of that issue. `RepositoryIdentityResolver` now keeps null repository identities for 60 seconds instead of 10 seconds. I also tightened the resolver regression test so repeated resolves continue to reuse the cached null identity until the negative TTL expires.

Validated locally with `bun run test -- src/project/Layers/RepositoryIdentityResolver.test.ts` and `bun run typecheck` in `apps/server`.

## Why

In #2037, @mei-the-dev traced the persistent "Some requests are slow" toast back to replay-time repository identity enrichment and called out the 10-second negative TTL as one of the quick-win fixes. This PR implements that specific Fix 2 only: it stretches the negative cache window to 60 seconds so projects without remotes reuse the same null lookup across reconnect churn instead of refreshing every 10 seconds, while keeping behavior localized to the existing cache. The updated test demonstrates the cached null result is stable across repeated resolves and only refreshes after TTL expiry.

## UI Changes

Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to cache TTL and its test coverage; main behavioral impact is delaying detection of newly-added remotes for up to 1 minute.
> 
> **Overview**
> `RepositoryIdentityResolver` now caches *null* (no identity/no remote) lookups for 1 minute instead of 10 seconds, reducing repeated git-remote resolution work during churn.
> 
> Updates the late-remote regression test to assert repeated `resolve()` calls continue returning the cached null identity until the negative TTL elapses, after which the identity is recomputed and returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f6322196e7ce22647ee0969caa492d4cd0cbac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend negative repository identity cache TTL from 10 seconds to 1 minute
> Increases `DEFAULT_NEGATIVE_CACHE_TTL` in [RepositoryIdentityResolver.ts](https://github.com/pingdotgg/t3code/pull/2083/files#diff-1b09ad6dd44b0f3b908e58ca5c5592d7c74353fb11f53ffab4bb21784b42aa2f) from 10 seconds to 1 minute. The test in [RepositoryIdentityResolver.test.ts](https://github.com/pingdotgg/t3code/pull/2083/files#diff-b534ef78ca4bc5d405686058df2623bfcaa04e738d123cfe27cf3f1daec81fa9) is updated to perform three consecutive resolve calls expecting a null identity before advancing the clock past the new TTL. Behavioral Change: null identities are now cached 6× longer, reducing re-resolution attempts for missing repositories.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54f6322.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->