### PR TITLE
Insert non-image file references on drop/paste

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import type { DesktopBridge } from "@t3tools/contracts";
 
 const PICK_FOLDER_CHANNEL = "desktop:pick-folder";
@@ -53,6 +53,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
     ipcRenderer.invoke(REMOVE_SAVED_ENVIRONMENT_SECRET_CHANNEL, environmentId),
   getServerExposureState: () => ipcRenderer.invoke(GET_SERVER_EXPOSURE_STATE_CHANNEL),
   setServerExposureMode: (mode) => ipcRenderer.invoke(SET_SERVER_EXPOSURE_MODE_CHANNEL, mode),
+  getPathForFile: (file) => webUtils.getPathForFile(file),
   pickFolder: (options) => ipcRenderer.invoke(PICK_FOLDER_CHANNEL, options),
   confirm: (message) => ipcRenderer.invoke(CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),

--- a/apps/web/src/components/ChatMarkdown.browser.tsx
+++ b/apps/web/src/components/ChatMarkdown.browser.tsx
@@ -8,7 +8,10 @@ const { openInPreferredEditorMock, readLocalApiMock } = vi.hoisted(() => ({
   openInPreferredEditorMock: vi.fn(async () => "vscode"),
   readLocalApiMock: vi.fn(() => ({
     server: { getConfig: vi.fn(async () => ({ availableEditors: ["vscode"] })) },
-    shell: { openInEditor: vi.fn(async () => undefined) },
+    shell: {
+      openInEditor: vi.fn(async () => undefined),
+      getPathForFile: vi.fn(async () => null),
+    },
   })),
 }));
 

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -876,6 +876,7 @@ export interface ComposerPromptEditorHandle {
   focus: () => void;
   focusAt: (cursor: number) => void;
   focusAtEnd: () => void;
+  insertTextAndFocus: (text: string) => void;
   readSnapshot: () => {
     value: string;
     cursor: number;
@@ -1548,6 +1549,29 @@ function ComposerPromptEditorInner({
     return snapshot;
   }, [editor]);
 
+  const insertTextAndFocus = useCallback(
+    (text: string) => {
+      const rootElement = editor.getRootElement();
+      if (rootElement) {
+        rootElement.focus();
+      }
+      editor.update(
+        () => {
+          let selection = $getSelection();
+          if (!$isRangeSelection(selection)) {
+            $setSelectionAtComposerOffset(snapshotRef.current.cursor);
+            selection = $getSelection();
+          }
+          if ($isRangeSelection(selection)) {
+            selection.insertText(text);
+          }
+        },
+        { tag: HISTORY_MERGE_TAG },
+      );
+    },
+    [editor],
+  );
+
   useImperativeHandle(
     editorRef,
     () => ({
@@ -1563,9 +1587,10 @@ function ComposerPromptEditorInner({
           ),
         );
       },
+      insertTextAndFocus,
       readSnapshot,
     }),
-    [focusAt, readSnapshot],
+    [focusAt, insertTextAndFocus, readSnapshot],
   );
 
   const handleEditorChange = useCallback((editorState: EditorState) => {

--- a/apps/web/src/components/ThreadTerminalDrawer.browser.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.browser.tsx
@@ -24,12 +24,18 @@ const {
     () =>
       | {
           contextMenu: { show: ReturnType<typeof vi.fn> };
-          shell: { openExternal: ReturnType<typeof vi.fn> };
+          shell: {
+            openExternal: ReturnType<typeof vi.fn>;
+            getPathForFile: ReturnType<typeof vi.fn>;
+          };
         }
       | undefined
   >(() => ({
     contextMenu: { show: vi.fn(async () => null) },
-    shell: { openExternal: vi.fn(async () => undefined) },
+    shell: {
+      openExternal: vi.fn(async () => undefined),
+      getPathForFile: vi.fn(async () => null),
+    },
   })),
 }));
 

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1556,7 +1556,7 @@ export const ChatComposer = memo(
           nonImageFiles.map(async (file) => {
             try {
               const resolvedPath = await localApi?.shell.getPathForFile(file);
-              return formatComposerFileReference(resolvedPath ?? file.name);
+              return formatComposerFileReference(resolvedPath || file.name);
             } catch {
               return formatComposerFileReference(file.name);
             }

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -38,6 +38,7 @@ import {
   collapseExpandedComposerCursor,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
+  formatComposerFileReference,
   replaceTextRange,
 } from "../../composer-logic";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
@@ -80,6 +81,7 @@ import { ContextWindowMeter } from "./ContextWindowMeter";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../vscode-icons";
 import { cn, randomUUID } from "~/lib/utils";
+import { readLocalApi } from "~/localApi";
 import { Separator } from "../ui/separator";
 import { Button } from "../ui/button";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
@@ -106,6 +108,7 @@ import { formatProviderSkillDisplayName } from "../../providerSkillPresentation"
 import { searchProviderSkills } from "../../providerSkillSearch";
 
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
+const COMPOSER_FILE_REFERENCE_SEPARATOR = " ";
 
 const runtimeModeConfig: Record<
   RuntimeMode,
@@ -1471,50 +1474,98 @@ export const ChatComposer = memo(
     // ------------------------------------------------------------------
     // Callbacks: images
     // ------------------------------------------------------------------
-    const addComposerImages = (files: File[]) => {
-      if (!activeThreadId || files.length === 0) return;
-      if (pendingUserInputs.length > 0) {
-        toastManager.add({
-          type: "error",
-          title: "Attach images after answering plan questions.",
-        });
-        return;
-      }
-      const nextImages: ComposerImageAttachment[] = [];
-      let nextImageCount = composerImagesRef.current.length;
-      let error: string | null = null;
-      for (const file of files) {
-        if (!file.type.startsWith("image/")) {
-          error = `Unsupported file type for '${file.name}'. Please attach image files only.`;
-          continue;
+    const addComposerImages = useCallback(
+      (files: File[]) => {
+        if (!activeThreadId || files.length === 0) return;
+        if (pendingUserInputs.length > 0) {
+          toastManager.add({
+            type: "error",
+            title: "Attach images after answering plan questions.",
+          });
+          return;
         }
-        if (file.size > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
-          error = `'${file.name}' exceeds the ${IMAGE_SIZE_LIMIT_LABEL} attachment limit.`;
-          continue;
+        const nextImages: ComposerImageAttachment[] = [];
+        let nextImageCount = composerImagesRef.current.length;
+        let error: string | null = null;
+        for (const file of files) {
+          if (!file.type.startsWith("image/")) {
+            error = `Unsupported file type for '${file.name}'. Please attach image files only.`;
+            continue;
+          }
+          if (file.size > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+            error = `'${file.name}' exceeds the ${IMAGE_SIZE_LIMIT_LABEL} attachment limit.`;
+            continue;
+          }
+          if (nextImageCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
+            error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} images per message.`;
+            break;
+          }
+          const previewUrl = URL.createObjectURL(file);
+          nextImages.push({
+            type: "image",
+            id: randomUUID(),
+            name: file.name || "image",
+            mimeType: file.type,
+            sizeBytes: file.size,
+            previewUrl,
+            file,
+          });
+          nextImageCount += 1;
         }
-        if (nextImageCount >= PROVIDER_SEND_TURN_MAX_ATTACHMENTS) {
-          error = `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} images per message.`;
-          break;
+        if (nextImages.length === 1 && nextImages[0]) {
+          addComposerImage(nextImages[0]);
+        } else if (nextImages.length > 1) {
+          addComposerImagesToDraft(nextImages);
         }
-        const previewUrl = URL.createObjectURL(file);
-        nextImages.push({
-          type: "image",
-          id: randomUUID(),
-          name: file.name || "image",
-          mimeType: file.type,
-          sizeBytes: file.size,
-          previewUrl,
-          file,
-        });
-        nextImageCount += 1;
-      }
-      if (nextImages.length === 1 && nextImages[0]) {
-        addComposerImage(nextImages[0]);
-      } else if (nextImages.length > 1) {
-        addComposerImagesToDraft(nextImages);
-      }
-      setThreadError(activeThreadId, error);
-    };
+        setThreadError(activeThreadId, error);
+      },
+      [
+        activeThreadId,
+        addComposerImage,
+        addComposerImagesToDraft,
+        composerImagesRef,
+        pendingUserInputs,
+        setThreadError,
+      ],
+    );
+
+    const insertComposerFileReferences = useCallback((references: readonly string[]) => {
+      if (references.length === 0) return;
+      composerEditorRef.current?.insertTextAndFocus(
+        references.join(COMPOSER_FILE_REFERENCE_SEPARATOR),
+      );
+    }, []);
+
+    const addComposerAttachments = useCallback(
+      async (files: File[]) => {
+        if (files.length === 0) return;
+
+        const imageFiles = files.filter((file) => file.type.startsWith("image/"));
+        const nonImageFiles = files.filter((file) => !file.type.startsWith("image/"));
+
+        if (imageFiles.length > 0) {
+          addComposerImages(imageFiles);
+        }
+
+        if (nonImageFiles.length === 0) {
+          return;
+        }
+
+        const localApi = readLocalApi();
+        const references = await Promise.all(
+          nonImageFiles.map(async (file) => {
+            try {
+              const resolvedPath = await localApi?.shell.getPathForFile(file);
+              return formatComposerFileReference(resolvedPath ?? file.name);
+            } catch {
+              return formatComposerFileReference(file.name);
+            }
+          }),
+        );
+        insertComposerFileReferences(references);
+      },
+      [addComposerImages, insertComposerFileReferences],
+    );
 
     const removeComposerImage = (imageId: string) => {
       removeComposerImageFromDraft(imageId);
@@ -1526,10 +1577,8 @@ export const ChatComposer = memo(
     const onComposerPaste = (event: React.ClipboardEvent<HTMLElement>) => {
       const files = Array.from(event.clipboardData.files);
       if (files.length === 0) return;
-      const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-      if (imageFiles.length === 0) return;
       event.preventDefault();
-      addComposerImages(imageFiles);
+      void addComposerAttachments(files);
     };
 
     const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
@@ -1563,8 +1612,11 @@ export const ChatComposer = memo(
       dragDepthRef.current = 0;
       setIsDragOverComposer(false);
       const files = Array.from(event.dataTransfer.files);
-      addComposerImages(files);
-      focusComposer();
+      const hasNonImageFiles = files.some((file) => !file.type.startsWith("image/"));
+      void addComposerAttachments(files);
+      if (!hasNonImageFiles) {
+        focusComposer();
+      }
     };
     const handleInterruptPrimaryAction = useCallback(() => {
       void onInterrupt();

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -307,6 +307,7 @@ const createDesktopBridgeStub = (overrides?: {
         endpointUrl: mode === "network-accessible" ? "http://192.168.1.44:3773" : null,
         advertisedHost: mode === "network-accessible" ? "192.168.1.44" : null,
       })),
+    getPathForFile: vi.fn().mockReturnValue(null),
     pickFolder: vi.fn().mockResolvedValue(null),
     confirm: vi.fn().mockResolvedValue(false),
     setTheme: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -5,6 +5,7 @@ import {
   collapseExpandedComposerCursor,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
+  formatComposerFileReference,
   isCollapsedCursorAdjacentToInlineToken,
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
@@ -241,6 +242,22 @@ describe("replaceTextRange trailing space consumption", () => {
     const extendedEnd = text[rangeEnd] === " " ? rangeEnd + 1 : rangeEnd;
     const withConsume = replaceTextRange(text, rangeStart, extendedEnd, "@AGENTS.md ");
     expect(withConsume.text).toBe("and then @AGENTS.md summarize");
+  });
+});
+
+describe("formatComposerFileReference", () => {
+  it("leaves simple paths unquoted", () => {
+    expect(formatComposerFileReference("/tmp/input.json")).toBe("/tmp/input.json");
+  });
+
+  it("quotes paths containing whitespace", () => {
+    expect(formatComposerFileReference("/tmp/input data.json")).toBe('"/tmp/input data.json"');
+  });
+
+  it("falls back to single quotes when the path already contains double quotes", () => {
+    expect(formatComposerFileReference('/tmp/"quoted" name.json')).toBe(
+      "'/tmp/\"quoted\" name.json'",
+    );
   });
 });
 

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -42,6 +42,19 @@ function tokenStartForCursor(text: string, cursor: number): number {
   return index + 1;
 }
 
+export function formatComposerFileReference(path: string): string {
+  if (!/[\s"'`]/.test(path)) {
+    return path;
+  }
+  if (!path.includes('"')) {
+    return `"${path}"`;
+  }
+  if (!path.includes("'")) {
+    return `'${path}'`;
+  }
+  return JSON.stringify(path);
+}
+
 export function expandCollapsedComposerCursor(text: string, cursorInput: number): number {
   const collapsedCursor = clampCursor(text, cursorInput);
   const segments = splitPromptIntoComposerSegments(text);

--- a/apps/web/src/environments/runtime/connection.test.ts
+++ b/apps/web/src/environments/runtime/connection.test.ts
@@ -83,6 +83,7 @@ function createTestClient() {
     },
     shell: {
       openInEditor: vi.fn(async () => undefined),
+      getPathForFile: vi.fn(async () => null),
     },
     git: {
       pull: vi.fn(async () => undefined),

--- a/apps/web/src/lib/gitStatusState.test.ts
+++ b/apps/web/src/lib/gitStatusState.test.ts
@@ -88,6 +88,7 @@ function createRegisteredGitStatusClient(environmentId: EnvironmentId) {
     },
     shell: {
       openInEditor: vi.fn(async () => undefined),
+      getPathForFile: vi.fn(async () => null),
     },
     git: {
       pull: vi.fn(async () => undefined),

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -56,6 +56,7 @@ const rpcClientMock = {
   },
   shell: {
     openInEditor: vi.fn(),
+    getPathForFile: vi.fn(async () => null),
   },
   git: {
     pull: vi.fn(),
@@ -179,6 +180,7 @@ function makeDesktopBridge(overrides: Partial<DesktopBridge> = {}): DesktopBridg
       endpointUrl: null,
       advertisedHost: null,
     }),
+    getPathForFile: () => null,
     pickFolder: async () => null,
     confirm: async () => true,
     setTheme: async () => undefined,
@@ -514,6 +516,26 @@ describe("wsApi", () => {
       "/tmp/project",
     );
     expect(pickFolder).toHaveBeenCalledWith({ initialPath: "/tmp/workspace" });
+  });
+
+  it("forwards dropped-file path resolution to the desktop bridge", async () => {
+    const getPathForFile = vi.fn().mockReturnValue("/tmp/workspace/data/input.json");
+    getWindowForTest().desktopBridge = makeDesktopBridge({ getPathForFile });
+
+    const { createLocalApi } = await import("./localApi");
+    const api = createLocalApi(rpcClientMock as never);
+    const file = new File(['{"hello":"world"}'], "input.json", { type: "application/json" });
+
+    await expect(api.shell.getPathForFile(file)).resolves.toBe("/tmp/workspace/data/input.json");
+    expect(getPathForFile).toHaveBeenCalledWith(file);
+  });
+
+  it("returns null for dropped-file path resolution when the desktop bridge is missing", async () => {
+    const { createLocalApi } = await import("./localApi");
+    const api = createLocalApi(rpcClientMock as never);
+    const file = new File(['{"hello":"world"}'], "input.json", { type: "application/json" });
+
+    await expect(api.shell.getPathForFile(file)).resolves.toBeNull();
   });
 
   it("falls back to the browser context menu helper when the desktop bridge is missing", async () => {

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -538,6 +538,18 @@ describe("wsApi", () => {
     await expect(api.shell.getPathForFile(file)).resolves.toBeNull();
   });
 
+  it("normalizes empty dropped-file paths from the desktop bridge to null", async () => {
+    const getPathForFile = vi.fn().mockReturnValue("");
+    getWindowForTest().desktopBridge = makeDesktopBridge({ getPathForFile });
+
+    const { createLocalApi } = await import("./localApi");
+    const api = createLocalApi(rpcClientMock as never);
+    const file = new File(['{"hello":"world"}'], "input.json", { type: "application/json" });
+
+    await expect(api.shell.getPathForFile(file)).resolves.toBeNull();
+    expect(getPathForFile).toHaveBeenCalledWith(file);
+  });
+
   it("falls back to the browser context menu helper when the desktop bridge is missing", async () => {
     showContextMenuFallbackMock.mockResolvedValue("rename");
     const { createLocalApi } = await import("./localApi");

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -53,7 +53,10 @@ export function createLocalApi(rpcClient: WsRpcClient): LocalApi {
 
         window.open(url, "_blank", "noopener,noreferrer");
       },
-      getPathForFile: async (file) => window.desktopBridge?.getPathForFile(file) ?? null,
+      getPathForFile: async (file) => {
+        const resolvedPath = window.desktopBridge?.getPathForFile(file);
+        return resolvedPath || null;
+      },
     },
     contextMenu: {
       show: async <T extends string>(

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -53,6 +53,7 @@ export function createLocalApi(rpcClient: WsRpcClient): LocalApi {
 
         window.open(url, "_blank", "noopener,noreferrer");
       },
+      getPathForFile: async (file) => window.desktopBridge?.getPathForFile(file) ?? null,
     },
     contextMenu: {
       show: async <T extends string>(

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -160,6 +160,7 @@ export interface DesktopBridge {
   removeSavedEnvironmentSecret: (environmentId: EnvironmentId) => Promise<void>;
   getServerExposureState: () => Promise<DesktopServerExposureState>;
   setServerExposureMode: (mode: DesktopServerExposureMode) => Promise<DesktopServerExposureState>;
+  getPathForFile: (file: File) => string | null;
   pickFolder: (options?: PickFolderOptions) => Promise<string | null>;
   confirm: (message: string) => Promise<boolean>;
   setTheme: (theme: DesktopTheme) => Promise<void>;
@@ -195,6 +196,7 @@ export interface LocalApi {
   shell: {
     openInEditor: (cwd: string, editor: EditorId) => Promise<void>;
     openExternal: (url: string) => Promise<void>;
+    getPathForFile: (file: File) => Promise<string | null>;
   };
   contextMenu: {
     show: <T extends string>(


### PR DESCRIPTION
## Summary

This changes composer file ingestion so that dropping or pasting non-image files inserts file references into the prompt instead of rejecting them.

Images keep the existing attachment flow.
Non-image files now resolve to local file references:

- on desktop, the composer inserts the native file system path
- outside the desktop shell, it falls back to the file name

## Related issues

- Fixes #557
- Fixes #2139

## Prior art / related PRs

- Supersedes #885 for the current codebase shape.

#885 is directionally the same user-facing fix, but it targets the older composer structure. The current implementation path now runs through `ChatComposer`, the current `LocalApi` surface, and the current `ComposerPromptEditor` handle rather than the older `ChatView`-centric flow.

This PR keeps the same product intent, but re-implements it against the current architecture so it is actually mergeable on top of today's code.

- Complementary to #2108, not a duplicate.

#2108 expands the drag/drop surface for URL-backed image drags from other browser tabs. This PR covers the `File`-backed non-image path and paste/drop insertion of local file references. They touch adjacent composer code, but solve different cases.

## Before / After

### Before

Dropping a non-image file into the composer is rejected with:

> Please attach image files only.

<img width="2198" height="1386" alt="image" src="https://github.com/user-attachments/assets/50046495-967b-432f-ae00-235ce4a86300" />

### After: non-image file drop

Dropping a non-image file inserts its local file reference into the composer.

<img width="2286" height="1472" alt="image" src="https://github.com/user-attachments/assets/d4e795f8-76d2-4bca-ac1c-007f12a532f8" />

### After: mixed drop

Mixed drops keep image attachments and insert non-image file references into the prompt.

<img width="2286" height="1472" alt="image" src="https://github.com/user-attachments/assets/e8329237-39c2-41ab-a135-2557307652d8" />

## Problem

Today the composer only accepts `image/*` files.
If a user drops or pastes a `.json`, `.csv`, `.txt`, or other non-image file into the chat box, the action is rejected with:

> Please attach image files only.

That is a poor fit for the actual developer workflow here.
In practice, users often want to reference a local file in their prompt rather than upload it as binary message content.

Examples:

- `look at /Users/alice/project/output.json`
- `compare this against ./fixtures/request.txt`
- `inspect the CSV I just dropped`

## Why this approach

I intentionally did **not** implement arbitrary non-image attachments.

That would expand the product contract significantly:

- new attachment semantics for non-image files
- persistence and preview rules
- payload size and MIME policy questions
- provider/runtime expectations for how local files should be interpreted

For this UX, that is unnecessary.
The cleaner behavior is:

- keep `image/*` as true attachments
- treat non-image files as prompt references

This matches how coding-agent users actually work and keeps the existing send contract unchanged.

## What changed

### Desktop bridge support

Added `getPathForFile(file)` to the desktop bridge contract and preload layer.

On Electron desktop this uses `webUtils.getPathForFile(file)`, which is the supported replacement for the removed nonstandard `File.path` behavior.

### App-level local API

Exposed file path resolution through `LocalApi.shell.getPathForFile(...)` so the composer does not need to talk to `window.desktopBridge` directly.

This keeps the platform-specific behavior behind the same local-shell abstraction already used for other desktop/browser capabilities.

### Composer ingestion behavior

Unified paste/drop handling so both paths now:

- keep images on the current attachment flow
- resolve non-image files into prompt text references
- insert those references at the current cursor position in the prompt editor

Mixed drops work as expected:

- images are attached
- non-image file references are inserted into the prompt

### Editor insertion behavior

Added an editor handle method for text insertion at the active composer cursor so file references are inserted into the real prompt state rather than reconstructed from a stale plain-text snapshot.

### Reference formatting

Added a small formatter for prompt-safe file references:

- plain paths are inserted as-is
- paths with spaces are quoted
- paths containing quotes fall back to the next-safe quoting form

## User impact

This removes a frustrating dead end in the composer.

After this change:

- dropping a config/data/text file into the composer is useful instead of rejected
- desktop users get the real native path
- browser users still get a reasonable fallback (`file.name`)
- image attachments continue to work exactly as before

## Validation

Ran:

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test src/localApi.test.ts src/composer-logic.test.ts` in `apps/web`

Also manually validated the desktop behavior:

- dropping non-image files inserts file references into the prompt
- mixed image + non-image drops keep image attachments and insert file references
- pasting non-image files uses the same path insertion behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat composer paste/drop handling and adds a new Electron desktop bridge surface (`getPathForFile`), which could affect attachment ingestion and desktop/browser parity if path resolution behaves unexpectedly.
> 
> **Overview**
> Dropping or pasting *non-image* files into the chat composer now inserts formatted file references into the prompt (while `image/*` files continue to be added as image attachments, including mixed drops).
> 
> Adds `shell.getPathForFile` to `LocalApi`/`DesktopBridge` and wires desktop resolution via Electron `webUtils.getPathForFile`; the composer uses this when available (falling back to `file.name`) and quotes/escapes references via new `formatComposerFileReference`. The prompt editor ref gains `insertTextAndFocus` to insert references at the current cursor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 852431fe562d6ae8b9a485bc1196b0c939d48991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Insert non-image file references into the composer prompt on drop or paste
> - Non-image files dropped or pasted into the composer are now resolved to their local filesystem paths and inserted as formatted references in the prompt text; image files continue to attach as before.
> - Adds `formatComposerFileReference` in [composer-logic.ts](https://github.com/pingdotgg/t3code/pull/2091/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6) to quote paths containing whitespace or special characters.
> - Adds `getPathForFile(file)` to the `DesktopBridge` interface, `localApi.shell`, and the Electron preload bridge to resolve a `File` object to an absolute path; returns `null` in non-desktop environments.
> - Adds `insertTextAndFocus` to the `ComposerPromptEditorHandle` imperative API so callers can insert text at the current cursor position without separate focus management.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 852431f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->