### PR TITLE
[codex] Fix Windows release manifest publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,11 @@ jobs:
         run: |
           shopt -s nullglob
           found_windows_manifest=false
-          for x64_manifest in release-assets/latest*-win-x64.yml release-assets/nightly*-win-x64.yml; do
+          for x64_manifest in release-assets/*-win-x64.yml; do
+            if [[ "$(basename "$x64_manifest")" == builder-debug-* ]]; then
+              continue
+            fi
+
             arm64_manifest="${x64_manifest/-x64.yml/-arm64.yml}"
             output_manifest="${x64_manifest/-win-x64.yml/.yml}"
             if [[ ! -f "$arm64_manifest" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,7 @@ jobs:
         run: |
           shopt -s nullglob
           found_windows_manifest=false
-          for x64_manifest in release-assets/latest*-win-x64.yml; do
+          for x64_manifest in release-assets/latest*-win-x64.yml release-assets/nightly*-win-x64.yml; do
             arm64_manifest="${x64_manifest/-x64.yml/-arm64.yml}"
             output_manifest="${x64_manifest/-win-x64.yml/.yml}"
             if [[ ! -f "$arm64_manifest" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,7 @@ jobs:
         run: |
           shopt -s nullglob
           found_windows_manifest=false
-          for x64_manifest in release-assets/*-win-x64.yml; do
+          for x64_manifest in release-assets/latest*-win-x64.yml; do
             arm64_manifest="${x64_manifest/-x64.yml/-arm64.yml}"
             output_manifest="${x64_manifest/-win-x64.yml/.yml}"
             if [[ ! -f "$arm64_manifest" ]]; then

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -78,12 +78,15 @@ releaseDate: '2026-03-08T10:36:07.540Z'
   return { arm64Path, x64Path };
 }
 
-function writeWindowsManifestFixtures(targetRoot: string): { arm64Path: string; x64Path: string } {
+function writeWindowsManifestFixtures(
+  targetRoot: string,
+  channel: "latest" | "nightly",
+): { arm64Path: string; x64Path: string } {
   const assetDirectory = resolve(targetRoot, "release-assets");
   mkdirSync(assetDirectory, { recursive: true });
 
-  const arm64Path = resolve(assetDirectory, "latest-win-arm64.yml");
-  const x64Path = resolve(assetDirectory, "latest-win-x64.yml");
+  const arm64Path = resolve(assetDirectory, `${channel}-win-arm64.yml`);
+  const x64Path = resolve(assetDirectory, `${channel}-win-x64.yml`);
 
   writeFileSync(
     arm64Path,
@@ -253,8 +256,14 @@ try {
     "Merged manifest is missing the x64 asset.",
   );
 
-  const { arm64Path: winArm64Path, x64Path: winX64Path } = writeWindowsManifestFixtures(tempRoot);
+  const { arm64Path: winArm64Path, x64Path: winX64Path } = writeWindowsManifestFixtures(
+    tempRoot,
+    "latest",
+  );
   const mergedWindowsManifestPath = resolve(tempRoot, "release-assets/latest.yml");
+  const { arm64Path: nightlyWinArm64Path, x64Path: nightlyWinX64Path } =
+    writeWindowsManifestFixtures(tempRoot, "nightly");
+  const mergedNightlyWindowsManifestPath = resolve(tempRoot, "release-assets/nightly.yml");
   const { arm64Path: winDebugArm64Path, x64Path: winDebugX64Path } =
     writeWindowsBuilderDebugFixtures(tempRoot);
   execFileSync(
@@ -265,7 +274,7 @@ try {
         release_assets_dir=${JSON.stringify(resolve(tempRoot, "release-assets"))}
         shopt -s nullglob
         found_windows_manifest=false
-        for x64_manifest in "$release_assets_dir"/latest*-win-x64.yml; do
+        for x64_manifest in "$release_assets_dir"/latest*-win-x64.yml "$release_assets_dir"/nightly*-win-x64.yml; do
           arm64_manifest="\${x64_manifest/-x64.yml/-arm64.yml}"
           output_manifest="\${x64_manifest/-win-x64.yml/.yml}"
           if [[ ! -f "$arm64_manifest" ]]; then
@@ -304,11 +313,30 @@ try {
     "T3-Code-9.9.9-smoke.0-x64.exe",
     "Merged Windows manifest is missing the x64 asset.",
   );
+  const mergedNightlyWindowsManifest = readFileSync(mergedNightlyWindowsManifestPath, "utf8");
+  assertContains(
+    mergedNightlyWindowsManifest,
+    "T3-Code-9.9.9-smoke.0-arm64.exe",
+    "Merged nightly Windows manifest is missing the arm64 asset.",
+  );
+  assertContains(
+    mergedNightlyWindowsManifest,
+    "T3-Code-9.9.9-smoke.0-x64.exe",
+    "Merged nightly Windows manifest is missing the x64 asset.",
+  );
   assertMissing(
     winArm64Path,
     "Windows release smoke unexpectedly kept the arm64 updater manifest.",
   );
   assertMissing(winX64Path, "Windows release smoke unexpectedly kept the x64 updater manifest.");
+  assertMissing(
+    nightlyWinArm64Path,
+    "Windows release smoke unexpectedly kept the nightly arm64 updater manifest.",
+  );
+  assertMissing(
+    nightlyWinX64Path,
+    "Windows release smoke unexpectedly kept the nightly x64 updater manifest.",
+  );
   assertExists(
     winDebugArm64Path,
     "Windows release smoke unexpectedly removed the arm64 builder debug fixture.",

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -80,7 +80,7 @@ releaseDate: '2026-03-08T10:36:07.540Z'
 
 function writeWindowsManifestFixtures(
   targetRoot: string,
-  channel: "latest" | "nightly",
+  channel: string,
 ): { arm64Path: string; x64Path: string } {
   const assetDirectory = resolve(targetRoot, "release-assets");
   mkdirSync(assetDirectory, { recursive: true });
@@ -264,6 +264,9 @@ try {
   const { arm64Path: nightlyWinArm64Path, x64Path: nightlyWinX64Path } =
     writeWindowsManifestFixtures(tempRoot, "nightly");
   const mergedNightlyWindowsManifestPath = resolve(tempRoot, "release-assets/nightly.yml");
+  const { arm64Path: previewWinArm64Path, x64Path: previewWinX64Path } =
+    writeWindowsManifestFixtures(tempRoot, "preview");
+  const mergedPreviewWindowsManifestPath = resolve(tempRoot, "release-assets/preview.yml");
   const { arm64Path: winDebugArm64Path, x64Path: winDebugX64Path } =
     writeWindowsBuilderDebugFixtures(tempRoot);
   execFileSync(
@@ -274,7 +277,11 @@ try {
         release_assets_dir=${JSON.stringify(resolve(tempRoot, "release-assets"))}
         shopt -s nullglob
         found_windows_manifest=false
-        for x64_manifest in "$release_assets_dir"/latest*-win-x64.yml "$release_assets_dir"/nightly*-win-x64.yml; do
+        for x64_manifest in "$release_assets_dir"/*-win-x64.yml; do
+          if [[ "$(basename "$x64_manifest")" == builder-debug-* ]]; then
+            continue
+          fi
+
           arm64_manifest="\${x64_manifest/-x64.yml/-arm64.yml}"
           output_manifest="\${x64_manifest/-win-x64.yml/.yml}"
           if [[ ! -f "$arm64_manifest" ]]; then
@@ -324,6 +331,17 @@ try {
     "T3-Code-9.9.9-smoke.0-x64.exe",
     "Merged nightly Windows manifest is missing the x64 asset.",
   );
+  const mergedPreviewWindowsManifest = readFileSync(mergedPreviewWindowsManifestPath, "utf8");
+  assertContains(
+    mergedPreviewWindowsManifest,
+    "T3-Code-9.9.9-smoke.0-arm64.exe",
+    "Merged preview Windows manifest is missing the arm64 asset.",
+  );
+  assertContains(
+    mergedPreviewWindowsManifest,
+    "T3-Code-9.9.9-smoke.0-x64.exe",
+    "Merged preview Windows manifest is missing the x64 asset.",
+  );
   assertMissing(
     winArm64Path,
     "Windows release smoke unexpectedly kept the arm64 updater manifest.",
@@ -336,6 +354,14 @@ try {
   assertMissing(
     nightlyWinX64Path,
     "Windows release smoke unexpectedly kept the nightly x64 updater manifest.",
+  );
+  assertMissing(
+    previewWinArm64Path,
+    "Windows release smoke unexpectedly kept the preview arm64 updater manifest.",
+  );
+  assertMissing(
+    previewWinX64Path,
+    "Windows release smoke unexpectedly kept the preview x64 updater manifest.",
   );
   assertExists(
     winDebugArm64Path,

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -1,5 +1,13 @@
 import { execFileSync } from "node:child_process";
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -112,8 +120,42 @@ releaseDate: '2026-03-08T10:36:07.540Z'
   return { arm64Path, x64Path };
 }
 
+function writeWindowsBuilderDebugFixtures(targetRoot: string): {
+  arm64Path: string;
+  x64Path: string;
+} {
+  const assetDirectory = resolve(targetRoot, "release-assets");
+  mkdirSync(assetDirectory, { recursive: true });
+
+  const arm64Path = resolve(assetDirectory, "builder-debug-win-arm64.yml");
+  const x64Path = resolve(assetDirectory, "builder-debug-win-x64.yml");
+  const debugFixture = `arm64:
+  firstOrDefaultFilePatterns:
+    - '**/*'
+nsis:
+  script: |-
+    !include "example.nsh"
+`;
+
+  writeFileSync(arm64Path, debugFixture);
+  writeFileSync(x64Path, debugFixture);
+
+  return { arm64Path, x64Path };
+}
 function assertContains(haystack: string, needle: string, message: string): void {
   if (!haystack.includes(needle)) {
+    throw new Error(message);
+  }
+}
+
+function assertExists(path: string, message: string): void {
+  if (!existsSync(path)) {
+    throw new Error(message);
+  }
+}
+
+function assertMissing(path: string, message: string): void {
+  if (existsSync(path)) {
     throw new Error(message);
   }
 }
@@ -212,14 +254,38 @@ try {
   );
 
   const { arm64Path: winArm64Path, x64Path: winX64Path } = writeWindowsManifestFixtures(tempRoot);
+  const mergedWindowsManifestPath = resolve(tempRoot, "release-assets/latest.yml");
+  const { arm64Path: winDebugArm64Path, x64Path: winDebugX64Path } =
+    writeWindowsBuilderDebugFixtures(tempRoot);
   execFileSync(
-    process.execPath,
+    "bash",
     [
-      resolve(repoRoot, "scripts/merge-update-manifests.ts"),
-      "--platform",
-      "win",
-      winArm64Path,
-      winX64Path,
+      "-lc",
+      `
+        release_assets_dir=${JSON.stringify(resolve(tempRoot, "release-assets"))}
+        shopt -s nullglob
+        found_windows_manifest=false
+        for x64_manifest in "$release_assets_dir"/latest*-win-x64.yml; do
+          arm64_manifest="\${x64_manifest/-x64.yml/-arm64.yml}"
+          output_manifest="\${x64_manifest/-win-x64.yml/.yml}"
+          if [[ ! -f "$arm64_manifest" ]]; then
+            echo "Missing matching arm64 Windows manifest for $x64_manifest" >&2
+            exit 1
+          fi
+
+          found_windows_manifest=true
+          node ${JSON.stringify(resolve(repoRoot, "scripts/merge-update-manifests.ts"))} --platform win \
+            "$arm64_manifest" \
+            "$x64_manifest" \
+            "$output_manifest"
+          rm -f "$arm64_manifest" "$x64_manifest"
+        done
+
+        if [[ "$found_windows_manifest" != true ]]; then
+          echo "No Windows updater manifests found to merge." >&2
+          exit 1
+        fi
+      `,
     ],
     {
       cwd: repoRoot,
@@ -227,7 +293,7 @@ try {
     },
   );
 
-  const mergedWindowsManifest = readFileSync(winArm64Path, "utf8");
+  const mergedWindowsManifest = readFileSync(mergedWindowsManifestPath, "utf8");
   assertContains(
     mergedWindowsManifest,
     "T3-Code-9.9.9-smoke.0-arm64.exe",
@@ -237,6 +303,19 @@ try {
     mergedWindowsManifest,
     "T3-Code-9.9.9-smoke.0-x64.exe",
     "Merged Windows manifest is missing the x64 asset.",
+  );
+  assertMissing(
+    winArm64Path,
+    "Windows release smoke unexpectedly kept the arm64 updater manifest.",
+  );
+  assertMissing(winX64Path, "Windows release smoke unexpectedly kept the x64 updater manifest.");
+  assertExists(
+    winDebugArm64Path,
+    "Windows release smoke unexpectedly removed the arm64 builder debug fixture.",
+  );
+  assertExists(
+    winDebugX64Path,
+    "Windows release smoke unexpectedly removed the x64 builder debug fixture.",
   );
 
   console.log("Release smoke checks passed.");


### PR DESCRIPTION
## Summary
Fix the Windows release publish step so it only merges real updater manifests, and keep the new Windows ARM release support plus release smoke coverage in place.

## Root cause
The release workflow iterated over `release-assets/*-win-x64.yml`, which matched both updater manifests like `latest-win-x64.yml` and Electron Builder debug files like `builder-debug-win-x64.yml`. The merge step then tried to parse the debug YAML as an updater manifest and failed on the top-level `arm64:` key.

## What changed
- add the Windows ARM release manifest merge support from upstream `main`
- keep updater manifest parsing/merging in the shared `scripts/lib/update-manifest.ts` path with platform-aware merge tests
- narrow the Windows release workflow glob so it only picks `latest*-win-x64.yml`
- extend `scripts/release-smoke.ts` to simulate a mixed `release-assets` directory and verify that builder debug YAML is ignored while updater manifests are merged into `latest.yml`

## Impact
- GitHub Releases can merge Windows x64 + arm64 updater manifests without tripping over builder debug artifacts
- the release smoke test now covers the exact failure mode from Actions

## Validation
- `bun run test --filter=@t3tools/scripts`
- `bun run release:smoke`
- `bun fmt`
- `bun lint`
- `bun typecheck`

`bun lint` still reports existing warnings in unrelated web files, but it exits successfully.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows release manifest publishing to skip builder-debug manifests
> - The release workflow's 'Merge Windows updater manifests' step now skips any `builder-debug-*` files when iterating `release-assets/*-win-x64.yml`, preventing failed merges for debug manifests.
> - The smoke test in [`scripts/release-smoke.ts`](https://github.com/pingdotgg/t3code/pull/2095/files#diff-710e2c3360c77cdcd58afde8d41dac38c929463d0e49b42cb127c157ebf9a918) is reworked to validate multi-channel manifest merging (latest, nightly, preview), confirm removal of per-arch input files after merging, and assert that `builder-debug-*` manifests are ignored and preserved.
> - New helpers `assertExists` and `assertMissing` provide fast-fail checks in the smoke test for expected and unexpected files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 98ef886.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation and manifest merging behavior; a mistake could break Windows release publishing or produce incorrect updater manifests, but changes are small and smoke-tested.
> 
> **Overview**
> Fixes the GitHub Release workflow’s Windows manifest merge so it **skips Electron Builder `builder-debug-*` YAML files** when scanning `*-win-x64.yml`, preventing the updater manifest merge step from trying to parse non-updater YAML.
> 
> Expands `scripts/release-smoke.ts` to generate channel-specific Windows updater manifests (e.g. `latest`, `nightly`, `preview`), add `builder-debug` fixtures, and assert that **only updater manifests are merged into per-channel `*.yml` outputs**, input per-arch manifests are deleted, and debug fixtures remain untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ef886feb0c442e92351117e6bd1ab60ec184bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->