### PR TITLE
fix: guard against missing sidebarProjectGroupingOverrides in client settings

### DIFF
--- a/apps/desktop/src/clientPersistence.ts
+++ b/apps/desktop/src/clientPersistence.ts
@@ -1,8 +1,13 @@
 import * as FS from "node:fs";
 import * as Path from "node:path";
 
-import type { ClientSettings, PersistedSavedEnvironmentRecord } from "@t3tools/contracts";
+import {
+  ClientSettingsSchema,
+  type ClientSettings,
+  type PersistedSavedEnvironmentRecord,
+} from "@t3tools/contracts";
 import { Predicate } from "effect";
+import * as Schema from "effect/Schema";
 
 interface ClientSettingsDocument {
   readonly settings: ClientSettings;
@@ -83,7 +88,15 @@ function toPersistedSavedEnvironmentRecord(
 }
 
 export function readClientSettings(settingsPath: string): ClientSettings | null {
-  return readJsonFile<ClientSettingsDocument>(settingsPath)?.settings ?? null;
+  const raw = readJsonFile<ClientSettingsDocument>(settingsPath)?.settings;
+  if (!raw) {
+    return null;
+  }
+  try {
+    return Schema.decodeUnknownSync(ClientSettingsSchema)(raw);
+  } catch {
+    return null;
+  }
 }
 
 export function writeClientSettings(settingsPath: string, settings: ClientSettings): void {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1379,7 +1379,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       const overrideKey = deriveProjectGroupingOverrideKey(member);
       setProjectGroupingTarget(member);
       setProjectGroupingSelection(
-        projectGroupingSettings.sidebarProjectGroupingOverrides[overrideKey] ?? "inherit",
+        projectGroupingSettings.sidebarProjectGroupingOverrides?.[overrideKey] ?? "inherit",
       );
     },
     [projectGroupingSettings.sidebarProjectGroupingOverrides],

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -64,7 +64,7 @@ async function hydrateClientSettings(): Promise<void> {
     try {
       const persistedSettings = await ensureLocalApi().persistence.getClientSettings();
       if (persistedSettings) {
-        replaceClientSettingsSnapshot(persistedSettings);
+        replaceClientSettingsSnapshot({ ...DEFAULT_CLIENT_SETTINGS, ...persistedSettings });
       }
     } catch (error) {
       console.error(`${CLIENT_SETTINGS_PERSISTENCE_ERROR_SCOPE} hydrate failed`, error);

--- a/apps/web/src/logicalProject.ts
+++ b/apps/web/src/logicalProject.ts
@@ -70,7 +70,7 @@ export function resolveProjectGroupingMode(
   settings: ProjectGroupingSettings,
 ): SidebarProjectGroupingMode {
   return (
-    settings.sidebarProjectGroupingOverrides[deriveProjectGroupingOverrideKey(project)] ??
+    settings.sidebarProjectGroupingOverrides?.[deriveProjectGroupingOverrideKey(project)] ??
     settings.sidebarProjectGroupingMode
   );
 }


### PR DESCRIPTION
## Summary

Fixes a runtime crash:

```
TypeError: Cannot read properties of undefined (reading '<environmentId>:/path/to/project')
```

Persisted client settings created before #2055 omit `sidebarProjectGroupingOverrides`. Reading that field as a raw object then crashed whenever `resolveProjectGroupingMode` (or the Sidebar override dialog) tried to look up a project's override using the physical project key.

The composite `<environmentId>:/path` shape in the error message is the physical project key from `derivePhysicalProjectKey`, which V8 surfaces verbatim because the failing access is `undefined[physicalKey]`.

## Changes

- `apps/web/src/hooks/useSettings.ts`: hydration now merges persisted snapshots with `DEFAULT_CLIENT_SETTINGS`, so any field added after a user last persisted their settings falls back to its default instead of leaving a hole in the snapshot.
- `apps/desktop/src/clientPersistence.ts`: `readClientSettings` decodes the on-disk JSON through `ClientSettingsSchema` (`Schema.decodeUnknownSync`) so `withDecodingDefault` applies for missing fields. Previously it was a raw cast, which is what allowed the missing-field shape to reach React.
- `apps/web/src/logicalProject.ts` and `apps/web/src/components/Sidebar.tsx`: defensive optional chaining at the two override lookup sites so a future regression of this kind degrades gracefully rather than throwing.

## Test plan

- [x] `bun typecheck`
- [x] `bun lint` (no new warnings)
- [x] `bun fmt`
- [ ] Manual: load app with a pre-existing client settings file that omits `sidebarProjectGroupingOverrides` and confirm the sidebar renders without throwing.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client settings hydration/decoding and sidebar grouping override resolution; low complexity but could affect how persisted settings are interpreted across upgrades.
> 
> **Overview**
> Prevents crashes when older persisted client settings are missing `sidebarProjectGroupingOverrides` by **making settings hydration/decoding fill defaults instead of leaving `undefined` holes**.
> 
> Desktop `readClientSettings` now decodes the on-disk JSON via `ClientSettingsSchema` (returning `null` on decode failure), web settings hydration merges persisted values over `DEFAULT_CLIENT_SETTINGS`, and the sidebar/grouping lookup sites use optional chaining so missing overrides degrade gracefully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf875c368cfb62efe17cde7780dd4a8708c282a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard against missing `sidebarProjectGroupingOverrides` in client settings
> - Adds optional chaining in `resolveProjectGroupingMode` ([logicalProject.ts](https://github.com/pingdotgg/t3code/pull/2099/files#diff-9fa781592e3ea36ce218eab738bf15d811679cc104ed2394cf764b2cc58bf684)) and the `SidebarProjectItem.openProjectGroupingDialog` callback ([Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2099/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1)) to avoid runtime errors when `sidebarProjectGroupingOverrides` is undefined.
> - `readClientSettings` in [clientPersistence.ts](https://github.com/pingdotgg/t3code/pull/2099/files#diff-884652b3de3dbc1d4540512589385b162cf7dc192aa2195e2f8ca2e66516ff6e) now validates persisted data against `ClientSettingsSchema`, returning `null` if validation fails instead of returning an arbitrary object.
> - `hydrateClientSettings` in [useSettings.ts](https://github.com/pingdotgg/t3code/pull/2099/files#diff-e989c3ad63c7359b2af1c2873a7ffbfea1639454ea1053c98da7f68d6946fbda) merges persisted settings with `DEFAULT_CLIENT_SETTINGS` so missing fields always have defaults.
> - Behavioral Change: previously persisted client settings that fail schema validation will now be discarded and replaced with defaults on load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf875c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->