### PR TITLE
ci(release): install deps before finalize version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,6 +474,9 @@ jobs:
         with:
           node-version-file: package.json
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - id: update_versions
         name: Update version strings
         env:


### PR DESCRIPTION
## Summary

The `Finalize release` job in `.github/workflows/release.yml` failed on the latest stable release ([run #24543937441](https://github.com/pingdotgg/t3code/actions/runs/24543937441/job/71756741742)) with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@t3tools/shared' imported from /home/runner/work/t3code/t3code/scripts/update-release-package-versions.ts
```

`scripts/update-release-package-versions.ts` imports `@t3tools/shared/cliArgs` (a workspace package), but the `finalize` job only set up Bun and Node — it never ran `bun install`, so the workspace symlink in `node_modules` did not exist and Node 24's native TS loader failed module resolution.

This adds the missing `bun install --frozen-lockfile` step before `Update version strings`, matching the pattern already used by `preflight`, `build`, and `publish_cli` in the same workflow.

## Test plan

- [ ] Re-run the failed release workflow (or wait for the next stable tag) and confirm the `Finalize release` job passes the `Update version strings` step.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a missing `bun install --frozen-lockfile` step to the CI workflow, affecting only the release pipeline execution order.
> 
> **Overview**
> Fixes the `Finalize release` GitHub Actions job by **installing dependencies before running** `scripts/update-release-package-versions.ts`, ensuring workspace packages resolve correctly.
> 
> This inserts `bun install --frozen-lockfile` after Node/Bun setup and before the version update/format/commit steps, aligning `finalize` with the other release jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c3208dc3adc7917b3c37e0457488a4dd7c02fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install dependencies before version bump step in release preflight job
> Adds a `bun install --frozen-lockfile` step to the preflight job in [release.yml](.github/workflows/release.yml) before the version bump finalization runs. This fixes a missing dependency setup that caused the subsequent step to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c3208d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->