### PR TITLE
try out blacksmith for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   quality:
     name: Format, Lint, Typecheck, Test, Browser Test, Build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -76,7 +76,7 @@ jobs:
 
   release_smoke:
     name: Release Smoke
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,11 +160,11 @@ jobs:
             platform: win
             target: nsis
             arch: x64
-          - label: Windows arm64
-            runner: windows-11-arm
-            platform: win
-            target: nsis
-            arch: arm64
+          # - label: Windows arm64
+          #   runner: windows-11-arm
+          #   platform: win
+          #   target: nsis
+          #   arch: arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -277,16 +277,17 @@ jobs:
             done
           fi
 
+          # Enable if Windows arm64 builds are enabled.
           # Windows updater metadata is channel-specific (for example
           # "latest.yml" or "nightly.yml"). Suffix each per-arch copy so the
           # release job can merge matching arm64/x64 manifests back into one
           # canonical manifest per channel.
-          if [[ "${{ matrix.platform }}" == "win" ]]; then
-            shopt -s nullglob
-            for manifest in release-publish/*.yml; do
-              mv "$manifest" "${manifest%.yml}-win-${{ matrix.arch }}.yml"
-            done
-          fi
+          # if [[ "${{ matrix.platform }}" == "win" ]]; then
+          #   shopt -s nullglob
+          #   for manifest in release-publish/*.yml; do
+          #     mv "$manifest" "${manifest%.yml}-win-${{ matrix.arch }}.yml"
+          #   done
+          # fi
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
@@ -363,34 +364,34 @@ jobs:
             fi
           done
 
-      - name: Merge Windows updater manifests
-        run: |
-          shopt -s nullglob
-          found_windows_manifest=false
-          for x64_manifest in release-assets/*-win-x64.yml; do
-            if [[ "$(basename "$x64_manifest")" == builder-debug-* ]]; then
-              continue
-            fi
+      # - name: Merge Windows updater manifests
+      #   run: |
+      #     shopt -s nullglob
+      #     found_windows_manifest=false
+      #     for x64_manifest in release-assets/*-win-x64.yml; do
+      #       if [[ "$(basename "$x64_manifest")" == builder-debug-* ]]; then
+      #         continue
+      #       fi
 
-            arm64_manifest="${x64_manifest/-x64.yml/-arm64.yml}"
-            output_manifest="${x64_manifest/-win-x64.yml/.yml}"
-            if [[ ! -f "$arm64_manifest" ]]; then
-              echo "Missing matching arm64 Windows manifest for $x64_manifest" >&2
-              exit 1
-            fi
+      #       arm64_manifest="${x64_manifest/-x64.yml/-arm64.yml}"
+      #       output_manifest="${x64_manifest/-win-x64.yml/.yml}"
+      #       if [[ ! -f "$arm64_manifest" ]]; then
+      #         echo "Missing matching arm64 Windows manifest for $x64_manifest" >&2
+      #         exit 1
+      #       fi
 
-            found_windows_manifest=true
-            node scripts/merge-update-manifests.ts --platform win \
-              "$arm64_manifest" \
-              "$x64_manifest" \
-              "$output_manifest"
-            rm -f "$arm64_manifest" "$x64_manifest"
-          done
+      #       found_windows_manifest=true
+      #       node scripts/merge-update-manifests.ts --platform win \
+      #         "$arm64_manifest" \
+      #         "$x64_manifest" \
+      #         "$output_manifest"
+      #       rm -f "$arm64_manifest" "$x64_manifest"
+      #     done
 
-          if [[ "$found_windows_manifest" != true ]]; then
-            echo "No Windows updater manifests found to merge." >&2
-            exit 1
-          fi
+      #     if [[ "$found_windows_manifest" != true ]]; then
+      #       echo "No Windows updater manifests found to merge." >&2
+      #       exit 1
+      #     fi
 
       - name: Publish release
         if: needs.preflight.outputs.previous_tag != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   preflight:
     name: Preflight
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:
       release_channel: ${{ steps.release_meta.outputs.release_channel }}
@@ -141,7 +141,7 @@ jobs:
       matrix:
         include:
           - label: macOS arm64
-            runner: macos-14
+            runner: blacksmith-12vcpu-macos-26
             platform: mac
             target: dmg
             arch: arm64
@@ -151,12 +151,12 @@ jobs:
             target: dmg
             arch: x64
           - label: Linux x64
-            runner: ubuntu-24.04
+            runner: blacksmith-32vcpu-ubuntu-2404
             platform: linux
             target: AppImage
             arch: x64
           - label: Windows x64
-            runner: windows-2022
+            runner: blacksmith-32vcpu-windows-2025
             platform: win
             target: nsis
             arch: x64
@@ -298,7 +298,7 @@ jobs:
   publish_cli:
     name: Publish CLI to npm
     needs: [preflight, build]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -332,7 +332,7 @@ jobs:
   release:
     name: Publish GitHub Release
     needs: [preflight, build, publish_cli]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -435,7 +435,7 @@ jobs:
     name: Finalize release
     if: needs.preflight.outputs.release_channel == 'stable'
     needs: [preflight, release]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - id: app_token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
             target: dmg
             arch: arm64
           - label: macOS x64
-            runner: macos-15-intel
+            runner: blacksmith-12vcpu-macos-26
             platform: mac
             target: dmg
             arch: x64


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow-only changes, but they affect CI and the release build/publish pipeline; misconfigured runner images or disabled Windows arm64/manifest steps could break releases or artifact packaging.
> 
> **Overview**
> Moves CI `quality` and `release_smoke` jobs, plus all `release.yml` jobs, from GitHub-hosted runners to Blacksmith runner images with increased CPU sizing.
> 
> Updates the release build matrix to use Blacksmith runners for macOS/Linux/Windows builds, and comments out the Windows arm64 build as well as the Windows updater-manifest renaming/merge steps (left as opt-in if arm64 builds are re-enabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35af9a9a3b5ad18e679c7fbeddf05fbef20611a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch release and CI workflow jobs to Blacksmith runners
> - Migrates all Ubuntu jobs in [ci.yml](https://github.com/pingdotgg/t3code/pull/2101/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) and [release.yml](https://github.com/pingdotgg/t3code/pull/2101/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) from standard GitHub-hosted runners to `blacksmith-8vcpu-ubuntu-2404` and `blacksmith-32vcpu-ubuntu-2404`.
> - Updates macOS build runners from `macos-14`/`macos-15-intel` to `blacksmith-12vcpu-macos-26`, and Windows x64 from `windows-2022` to `blacksmith-32vcpu-windows-2025`.
> - Disables the Windows arm64 build matrix entry and comments out per-arch Windows updater manifest renaming and merging steps.
> - Behavioral Change: Windows arm64 releases are no longer built, and Windows updater manifest handling is disabled for this run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35af9a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->