### PR TITLE
Install Spectre MSVC libs for Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,60 @@ jobs:
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
 
+      - name: Install VS 2022 Spectre-mitigated MSVC libraries
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $setup = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+          $spectreComponent = "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre"
+
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe not found at $vswhere"
+          }
+
+          if (-not (Test-Path $setup)) {
+            throw "Visual Studio installer setup.exe not found at $setup"
+          }
+
+          $existingSpectreInstall = & $vswhere -products * -requires $spectreComponent -property installationPath
+          if ($LASTEXITCODE -ne 0) {
+            throw "vswhere failed while checking for $spectreComponent"
+          }
+
+          if ($existingSpectreInstall) {
+            Write-Host "Spectre-mitigated MSVC libraries already installed at $existingSpectreInstall"
+            exit 0
+          }
+
+          $installPath = & $vswhere -products * -requires Microsoft.Component.MSBuild -property installationPath
+          if ($LASTEXITCODE -ne 0) {
+            throw "vswhere failed while locating the Visual Studio Build Tools installation"
+          }
+
+          if (-not $installPath) {
+            throw "Could not find a Visual Studio Build Tools installation to modify"
+          }
+
+          Write-Host "Installing $spectreComponent into $installPath"
+          & $setup modify `
+            --installPath $installPath `
+            --add $spectreComponent `
+            --quiet `
+            --wait `
+            --norestart
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Visual Studio installer failed with exit code $LASTEXITCODE"
+          }
+
+          $verifiedInstall = & $vswhere -products * -requires $spectreComponent -property installationPath
+          if (-not $verifiedInstall) {
+            throw "$spectreComponent was not detected after installation"
+          }
+
+          Write-Host "Installed Spectre-mitigated MSVC libraries at $verifiedInstall"
+
       - name: Build desktop artifact
         shell: bash
         env:


### PR DESCRIPTION
## Summary
- Add a Windows-only release step to install the VS 2022 Spectre-mitigated MSVC runtime libraries.
- Detect existing Spectre components first to avoid redundant installer changes.
- Verify the component is available after modification before continuing the release build.

## Testing
- Not run (workflow-only change).
- Reviewed the updated `.github/workflows/release.yml` step logic for Windows installation and post-install verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Windows release build environment by mutating the Visual Studio Build Tools installation during CI; failures here can block Windows artifact generation even though no app code changes.
> 
> **Overview**
> Adds a Windows-only step in `release.yml` to install the VS 2022 *Spectre-mitigated* MSVC runtime component (`Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre`) before the desktop artifact build.
> 
> The step uses `vswhere.exe` to detect whether the component is already present, runs `setup.exe modify --add ...` to install it when missing, and then re-checks via `vswhere` to fail fast if installation/verification does not succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3631d0a8ee908bdfb8690bb0cf230b235e007a27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install Spectre-mitigated MSVC libraries for Windows release builds
> Adds a conditional step in [release.yml](.github/workflows/release.yml) that runs before the desktop artifact build on Windows runners. The step uses `vswhere.exe` to locate a Visual Studio Build Tools installation, checks if `Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre` is already present, and installs it via `setup.exe` in quiet mode if absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3631d0a. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->