### PR TITLE
Revert to Github Runner for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
             target: AppImage
             arch: x64
           - label: Windows x64
-            runner: blacksmith-32vcpu-windows-2025
+            runner: windows-2022 # blacksmith-32vcpu-windows-2025
             platform: win
             target: nsis
             arch: x64


### PR DESCRIPTION
Blacksmith misses `Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre` which causes node-pty rebuild to fail

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Windows portion of the release pipeline; runner environment differences could affect build/signing behavior, but the change is a single runner selection.
> 
> **Overview**
> Updates the release workflow to build the **Windows x64** desktop artifact on GitHub-hosted `windows-2022` rather than the Blacksmith Windows runner (left as a comment), to prevent Windows build failures caused by missing Visual Studio runtime components during `node-pty` rebuilds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54407b54f1401269d1d6bc00291b766f2d22650e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert Windows x64 CI runner from Blacksmith to `windows-2022`
> Switches the Windows x64 matrix entry in [release.yml](.github/workflows/release.yml) back to the standard GitHub-hosted `windows-2022` runner. The previous `blacksmith-32vcpu-windows-2025` value is preserved as an inline comment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54407b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->