### PR TITLE
Show thread status in command palette

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -17,6 +17,10 @@ export interface CommandPaletteItem {
   readonly description?: string;
   readonly timestamp?: string;
   readonly icon: ReactNode;
+  /** Optional content rendered inline before the title text. */
+  readonly titleLeadingContent?: ReactNode;
+  /** Optional content rendered inline after the title text (before the timestamp). */
+  readonly titleTrailingContent?: ReactNode;
   readonly shortcutCommand?: KeybindingCommand;
 }
 
@@ -102,20 +106,24 @@ export function buildProjectActionItems(input: {
   }));
 }
 
-export function buildThreadActionItems(input: {
-  threads: ReadonlyArray<
-    Pick<
-      SidebarThreadSummary,
-      "archivedAt" | "branch" | "createdAt" | "environmentId" | "id" | "projectId" | "title"
-    > & {
-      updatedAt?: string | undefined;
-      latestUserMessageAt?: string | null;
-    }
-  >;
+export type BuildThreadActionItemsThread = Pick<
+  SidebarThreadSummary,
+  "archivedAt" | "branch" | "createdAt" | "environmentId" | "id" | "projectId" | "title"
+> & {
+  updatedAt?: string | undefined;
+  latestUserMessageAt?: string | null;
+};
+
+export function buildThreadActionItems<TThread extends BuildThreadActionItemsThread>(input: {
+  threads: ReadonlyArray<TThread>;
   activeThreadId?: Thread["id"];
   projectTitleById: ReadonlyMap<Project["id"], string>;
   sortOrder: SidebarThreadSortOrder;
   icon: ReactNode;
+  /** Optional content rendered inline before the title text per-thread. */
+  renderLeadingContent?: (thread: TThread) => ReactNode;
+  /** Optional content rendered inline after the title text per-thread. */
+  renderTrailingContent?: (thread: TThread) => ReactNode;
   runThread: (thread: Pick<SidebarThreadSummary, "environmentId" | "id">) => Promise<void>;
   limit?: number;
 }): CommandPaletteActionItem[] {
@@ -140,6 +148,9 @@ export function buildThreadActionItems(input: {
       descriptionParts.push("Current thread");
     }
 
+    const leadingContent = input.renderLeadingContent?.(thread);
+    const trailingContent = input.renderTrailingContent?.(thread);
+
     return {
       kind: "action",
       value: `thread:${thread.id}`,
@@ -150,6 +161,8 @@ export function buildThreadActionItems(input: {
         thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt,
       ),
       icon: input.icon,
+      ...(leadingContent ? { titleLeadingContent: leadingContent } : {}),
+      ...(trailingContent ? { titleTrailingContent: trailingContent } : {}),
       run: async () => {
         await input.runThread(thread);
       },

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -89,6 +89,7 @@ import {
 import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
 import { CommandPaletteResults } from "./CommandPaletteResults";
 import { ProjectFavicon } from "./ProjectFavicon";
+import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
 import { useServerKeybindings } from "../rpc/serverState";
 import { resolveShortcutCommand } from "../keybindings";
 import {
@@ -504,6 +505,8 @@ function OpenCommandPaletteDialog() {
         projectTitleById,
         sortOrder: settings.sidebarThreadSortOrder,
         icon: <MessageSquareIcon className={ITEM_ICON_CLASS} />,
+        renderLeadingContent: (thread) => <ThreadRowLeadingStatus thread={thread} />,
+        renderTrailingContent: (thread) => <ThreadRowTrailingStatus thread={thread} />,
         runThread: async (thread) => {
           await navigate({
             to: "/$environmentId/$threadId",

--- a/apps/web/src/components/CommandPaletteResults.tsx
+++ b/apps/web/src/components/CommandPaletteResults.tsx
@@ -86,14 +86,20 @@ function CommandPaletteResultRow(props: {
       {props.item.icon}
       {props.item.description ? (
         <span className="flex min-w-0 flex-1 flex-col">
-          <span className="truncate text-sm text-foreground">{props.item.title}</span>
+          <span className="flex min-w-0 items-center gap-1.5 text-sm text-foreground">
+            {props.item.titleLeadingContent}
+            <span className="truncate">{props.item.title}</span>
+            {props.item.titleTrailingContent}
+          </span>
           <span className="truncate text-muted-foreground/70 text-xs">
             {props.item.description}
           </span>
         </span>
       ) : (
-        <span className="flex min-w-0 items-center gap-1.5 truncate text-sm text-foreground">
+        <span className="flex min-w-0 flex-1 items-center gap-1.5 text-sm text-foreground">
+          {props.item.titleLeadingContent}
           <span className="truncate">{props.item.title}</span>
+          {props.item.titleTrailingContent}
         </span>
       )}
       {props.item.timestamp ? (

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -11,6 +11,12 @@ import {
   TerminalIcon,
   TriangleAlertIcon,
 } from "lucide-react";
+import {
+  prStatusIndicator,
+  resolveThreadPr,
+  terminalStatusFromRunningIds,
+  ThreadStatusLabel,
+} from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { autoAnimate } from "@formkit/auto-animate";
 import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
@@ -38,7 +44,6 @@ import {
   type SidebarProjectGroupingMode,
   type ThreadEnvMode,
   ThreadId,
-  type GitStatusResult,
 } from "@t3tools/contracts";
 import {
   parseScopedThreadKey,
@@ -262,113 +267,6 @@ function buildThreadJumpLabelMap(input: {
     }
   }
   return mapping.size > 0 ? mapping : EMPTY_THREAD_JUMP_LABELS;
-}
-
-interface TerminalStatusIndicator {
-  label: "Terminal process running";
-  colorClass: string;
-  pulse: boolean;
-}
-
-interface PrStatusIndicator {
-  label: "PR open" | "PR closed" | "PR merged";
-  colorClass: string;
-  tooltip: string;
-  url: string;
-}
-
-type ThreadPr = GitStatusResult["pr"];
-
-function ThreadStatusLabel({
-  status,
-  compact = false,
-}: {
-  status: ThreadStatusPill;
-  compact?: boolean;
-}) {
-  if (compact) {
-    return (
-      <span
-        title={status.label}
-        className={`inline-flex size-3.5 shrink-0 items-center justify-center ${status.colorClass}`}
-      >
-        <span
-          className={`size-[9px] rounded-full ${status.dotClass} ${
-            status.pulse ? "animate-pulse" : ""
-          }`}
-        />
-        <span className="sr-only">{status.label}</span>
-      </span>
-    );
-  }
-
-  return (
-    <span
-      title={status.label}
-      className={`inline-flex items-center gap-1 text-[10px] ${status.colorClass}`}
-    >
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${status.dotClass} ${
-          status.pulse ? "animate-pulse" : ""
-        }`}
-      />
-      <span className="hidden md:inline">{status.label}</span>
-    </span>
-  );
-}
-
-function terminalStatusFromRunningIds(
-  runningTerminalIds: string[],
-): TerminalStatusIndicator | null {
-  if (runningTerminalIds.length === 0) {
-    return null;
-  }
-  return {
-    label: "Terminal process running",
-    colorClass: "text-teal-600 dark:text-teal-300/90",
-    pulse: true,
-  };
-}
-
-function prStatusIndicator(pr: ThreadPr): PrStatusIndicator | null {
-  if (!pr) return null;
-
-  if (pr.state === "open") {
-    return {
-      label: "PR open",
-      colorClass: "text-emerald-600 dark:text-emerald-300/90",
-      tooltip: `#${pr.number} PR open: ${pr.title}`,
-      url: pr.url,
-    };
-  }
-  if (pr.state === "closed") {
-    return {
-      label: "PR closed",
-      colorClass: "text-zinc-500 dark:text-zinc-400/80",
-      tooltip: `#${pr.number} PR closed: ${pr.title}`,
-      url: pr.url,
-    };
-  }
-  if (pr.state === "merged") {
-    return {
-      label: "PR merged",
-      colorClass: "text-violet-600 dark:text-violet-300/90",
-      tooltip: `#${pr.number} PR merged: ${pr.title}`,
-      url: pr.url,
-    };
-  }
-  return null;
-}
-
-function resolveThreadPr(
-  threadBranch: string | null,
-  gitStatus: GitStatusResult | null,
-): ThreadPr | null {
-  if (threadBranch === null || gitStatus === null || gitStatus.branch !== threadBranch) {
-    return null;
-  }
-
-  return gitStatus.pr ?? null;
 }
 
 interface SidebarThreadRowProps {

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -175,7 +175,7 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
           <TooltipPopup side="top">{prStatus.tooltip}</TooltipPopup>
         </Tooltip>
       ) : null}
-      {threadStatus ? <ThreadStatusLabel status={threadStatus} compact /> : null}
+      {threadStatus ? <ThreadStatusLabel status={threadStatus} /> : null}
     </span>
   );
 }

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -1,0 +1,241 @@
+import { scopeProjectRef, scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime";
+import type { GitStatusResult } from "@t3tools/contracts";
+import { CloudIcon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
+import { useMemo } from "react";
+import { usePrimaryEnvironmentId } from "../environments/primary";
+import {
+  useSavedEnvironmentRegistryStore,
+  useSavedEnvironmentRuntimeStore,
+} from "../environments/runtime";
+import { useGitStatus } from "../lib/gitStatusState";
+import { type AppState, selectProjectByRef, useStore } from "../store";
+import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
+import { useUiStateStore } from "../uiStateStore";
+import { resolveThreadStatusPill, type ThreadStatusPill } from "./Sidebar.logic";
+import type { SidebarThreadSummary } from "../types";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+
+export interface PrStatusIndicator {
+  label: "PR open" | "PR closed" | "PR merged";
+  colorClass: string;
+  tooltip: string;
+  url: string;
+}
+
+export interface TerminalStatusIndicator {
+  label: "Terminal process running";
+  colorClass: string;
+  pulse: boolean;
+}
+
+export type ThreadPr = GitStatusResult["pr"];
+
+export function prStatusIndicator(pr: ThreadPr): PrStatusIndicator | null {
+  if (!pr) return null;
+
+  if (pr.state === "open") {
+    return {
+      label: "PR open",
+      colorClass: "text-emerald-600 dark:text-emerald-300/90",
+      tooltip: `#${pr.number} PR open: ${pr.title}`,
+      url: pr.url,
+    };
+  }
+  if (pr.state === "closed") {
+    return {
+      label: "PR closed",
+      colorClass: "text-zinc-500 dark:text-zinc-400/80",
+      tooltip: `#${pr.number} PR closed: ${pr.title}`,
+      url: pr.url,
+    };
+  }
+  if (pr.state === "merged") {
+    return {
+      label: "PR merged",
+      colorClass: "text-violet-600 dark:text-violet-300/90",
+      tooltip: `#${pr.number} PR merged: ${pr.title}`,
+      url: pr.url,
+    };
+  }
+  return null;
+}
+
+export function resolveThreadPr(
+  threadBranch: string | null,
+  gitStatus: GitStatusResult | null,
+): ThreadPr | null {
+  if (threadBranch === null || gitStatus === null || gitStatus.branch !== threadBranch) {
+    return null;
+  }
+
+  return gitStatus.pr ?? null;
+}
+
+export function terminalStatusFromRunningIds(
+  runningTerminalIds: string[],
+): TerminalStatusIndicator | null {
+  if (runningTerminalIds.length === 0) {
+    return null;
+  }
+  return {
+    label: "Terminal process running",
+    colorClass: "text-teal-600 dark:text-teal-300/90",
+    pulse: true,
+  };
+}
+
+export function ThreadStatusLabel({
+  status,
+  compact = false,
+}: {
+  status: ThreadStatusPill;
+  compact?: boolean;
+}) {
+  if (compact) {
+    return (
+      <span
+        title={status.label}
+        className={`inline-flex size-3.5 shrink-0 items-center justify-center ${status.colorClass}`}
+      >
+        <span
+          className={`size-[9px] rounded-full ${status.dotClass} ${
+            status.pulse ? "animate-pulse" : ""
+          }`}
+        />
+        <span className="sr-only">{status.label}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      title={status.label}
+      className={`inline-flex items-center gap-1 text-[10px] ${status.colorClass}`}
+    >
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${status.dotClass} ${
+          status.pulse ? "animate-pulse" : ""
+        }`}
+      />
+      <span className="hidden md:inline">{status.label}</span>
+    </span>
+  );
+}
+
+/**
+ * Non-interactive leading status icons for a thread row in compact contexts
+ * like the command palette. Shows the PR state icon (if present) and the
+ * thread status dot, matching the sidebar's leading indicators.
+ */
+export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummary }) {
+  const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+  const lastVisitedAt = useUiStateStore(
+    (state) => state.threadLastVisitedAtById[scopedThreadKey(threadRef)],
+  );
+  const threadProjectCwd = useStore(
+    useMemo(
+      () => (state: AppState) =>
+        selectProjectByRef(state, scopeProjectRef(thread.environmentId, thread.projectId))?.cwd ??
+        null,
+      [thread.environmentId, thread.projectId],
+    ),
+  );
+  const gitCwd = thread.worktreePath ?? threadProjectCwd;
+  const gitStatus = useGitStatus({
+    environmentId: thread.environmentId,
+    cwd: thread.branch != null ? gitCwd : null,
+  });
+  const pr = resolveThreadPr(thread.branch, gitStatus.data);
+  const prStatus = prStatusIndicator(pr);
+  const threadStatus = resolveThreadStatusPill({
+    thread: {
+      ...thread,
+      lastVisitedAt,
+    },
+  });
+
+  if (!prStatus && !threadStatus) {
+    return null;
+  }
+
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1.5">
+      {prStatus ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span
+                aria-label={prStatus.tooltip}
+                className={`inline-flex items-center justify-center ${prStatus.colorClass}`}
+              />
+            }
+          >
+            <GitPullRequestIcon className="size-3" />
+          </TooltipTrigger>
+          <TooltipPopup side="top">{prStatus.tooltip}</TooltipPopup>
+        </Tooltip>
+      ) : null}
+      {threadStatus ? <ThreadStatusLabel status={threadStatus} compact /> : null}
+    </span>
+  );
+}
+
+/**
+ * Non-interactive trailing status icons for a thread row in compact contexts
+ * like the command palette. Shows a terminal-running indicator and a remote
+ * environment indicator, matching the sidebar's trailing indicators.
+ */
+export function ThreadRowTrailingStatus({ thread }: { thread: SidebarThreadSummary }) {
+  const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+  const runningTerminalIds = useTerminalStateStore(
+    (state) =>
+      selectThreadTerminalState(state.terminalStateByThreadKey, threadRef).runningTerminalIds,
+  );
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
+  const isRemoteThread =
+    primaryEnvironmentId !== null && thread.environmentId !== primaryEnvironmentId;
+  const remoteEnvLabel = useSavedEnvironmentRuntimeStore(
+    (state) => state.byId[thread.environmentId]?.descriptor?.label ?? null,
+  );
+  const remoteEnvSavedLabel = useSavedEnvironmentRegistryStore(
+    (state) => state.byId[thread.environmentId]?.label ?? null,
+  );
+  const threadEnvironmentLabel = isRemoteThread
+    ? (remoteEnvLabel ?? remoteEnvSavedLabel ?? "Remote")
+    : null;
+  const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
+
+  if (!terminalStatus && !isRemoteThread) {
+    return null;
+  }
+
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1.5">
+      {terminalStatus ? (
+        <span
+          role="img"
+          aria-label={terminalStatus.label}
+          title={terminalStatus.label}
+          className={`inline-flex items-center justify-center ${terminalStatus.colorClass}`}
+        >
+          <TerminalIcon className={`size-3 ${terminalStatus.pulse ? "animate-pulse" : ""}`} />
+        </span>
+      ) : null}
+      {isRemoteThread ? (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <span
+                aria-label={threadEnvironmentLabel ?? "Remote"}
+                className="inline-flex items-center justify-center"
+              />
+            }
+          >
+            <CloudIcon className="size-3 text-muted-foreground/60" />
+          </TooltipTrigger>
+          <TooltipPopup side="top">{threadEnvironmentLabel}</TooltipPopup>
+        </Tooltip>
+      ) : null}
+    </span>
+  );
+}


### PR DESCRIPTION
## What Changed

- Thread rows in the command palette now display the same status indicators as the sidebar:
  - PR state icon (open / closed / merged) when the thread's branch has an associated PR
  - Thread status pill (Working, Connecting, Pending Approval, Awaiting Input, Plan Ready, Completed)
  - Terminal-running icon when a terminal in that thread has a live subprocess
  - Cloud icon when the thread belongs to a remote environment
- Extracted the shared status UI out of `Sidebar.tsx` into a new `ThreadStatusIndicators.tsx` module (`ThreadStatusLabel`, `prStatusIndicator`, `resolveThreadPr`, `terminalStatusFromRunningIds`), and added two thin components that wrap the per-row hooks so the same indicators can be rendered outside the sidebar without duplicating logic:
  - `ThreadRowLeadingStatus` — PR icon + status pill
  - `ThreadRowTrailingStatus` — terminal icon + remote cloud icon
- Extended `CommandPaletteItem` with optional `titleLeadingContent` and `titleTrailingContent` `ReactNode` fields. `buildThreadActionItems` now accepts `renderLeadingContent` / `renderTrailingContent` callbacks that populate them per-thread, and is generic over the thread shape so callers that pass a richer type (e.g. `SidebarThreadSummary`) keep their fields.
- `CommandPaletteResultRow` renders the leading/trailing content inline around the title text while preserving truncation in both the title-only and title+description layouts.
- `CommandPalette.tsx` wires `ThreadRowLeadingStatus` / `ThreadRowTrailingStatus` into the thread item builder.

## Why

Thread rows in the command palette previously showed only a title, a `project · #branch` description, and a relative timestamp. You could not tell from a palette result whether a thread was still working, waiting on approval, had a PR merged, had a live terminal, or lived on a remote environment — even though the sidebar surfaces all of that. Mirroring the sidebar's indicators gives consistent signal between the two main thread navigation surfaces, at the cost of a small shared module that both entry points now reuse.

## UI Changes

Each thread row in the command palette now renders, from left to right:

`[type icon] [PR icon?] [status dot?] [title]  [terminal icon?] [cloud icon?] [timestamp]`

All new indicators are hidden when they don't apply, so threads with no running work, no PR, no terminal, and on the primary environment look the same as before.

<img width="1208" height="906" alt="image" src="https://github.com/user-attachments/assets/e2b577a1-416c-432f-839d-41a8149fed0b" />

<img width="1266" height="916" alt="image" src="https://github.com/user-attachments/assets/1b0eb6f1-22fb-433e-940c-9f167af88790" />

<img width="643" height="486" alt="image" src="https://github.com/user-attachments/assets/d846d719-7369-46a7-922e-fca520bc879b" />

<img width="651" height="479" alt="image" src="https://github.com/user-attachments/assets/e85cf30c-9d9c-4c2b-815b-37f104563ed2" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show thread status indicators (PR, terminal, environment) in the command palette
> - Adds `ThreadRowLeadingStatus` and `ThreadRowTrailingStatus` components in [`ThreadStatusIndicators.tsx`](https://github.com/pingdotgg/t3code/pull/2107/files#diff-91746549eb55de0a3ac6a473f89804fbe3db8852968122b4b12cebad10625189) that render PR status, thread status pill, terminal-running pulse, and remote environment icon for a thread row.
> - Extends `CommandPaletteItem` with optional `titleLeadingContent` and `titleTrailingContent` fields, and updates `buildThreadActionItems` to accept callbacks that populate these fields.
> - `CommandPaletteResultRow` renders leading/trailing content inline around the item title.
> - Extracts shared status utilities (`prStatusIndicator`, `resolveThreadPr`, `terminalStatusFromRunningIds`) from [`Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/2107/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) into the new shared module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eb38acf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds additional per-thread status hooks (git status/terminal/environment) to command palette rendering and refactors sidebar status logic into a shared module, which could impact performance or introduce subtle UI/layout regressions.
> 
> **Overview**
> Command palette thread results now render the same *status indicators* as the sidebar (PR state, thread status dot, terminal-running, and remote-environment icon) inline around the thread title.
> 
> To enable this, `CommandPaletteItem`/`buildThreadActionItems` were extended to support optional leading/trailing title content, and the sidebar’s PR/terminal/status indicator utilities were extracted into a new shared `ThreadStatusIndicators.tsx` module that also provides compact `ThreadRowLeadingStatus`/`ThreadRowTrailingStatus` components. `CommandPaletteResults` was updated to lay out these new inline elements while preserving truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb38acf8058b364fb6530f5285ef99177b9dee51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->