### PR TITLE
feat(web): attach images dragged from another browser tab

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -37,8 +37,11 @@ import {
   collapseExpandedComposerCursor,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
+  extractDraggedImageUrls,
+  isComposerAttachmentDrag,
   replaceTextRange,
 } from "../../composer-logic";
+import { fetchDroppedImageAsFile } from "../../lib/fetchDroppedImage";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
 import {
   type ComposerImageAttachment,
@@ -1572,21 +1575,21 @@ export const ChatComposer = memo(
     };
 
     const onComposerDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
-      if (!event.dataTransfer.types.includes("Files")) return;
+      if (!isComposerAttachmentDrag(event.dataTransfer.types)) return;
       event.preventDefault();
       dragDepthRef.current += 1;
       setIsDragOverComposer(true);
     };
 
     const onComposerDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-      if (!event.dataTransfer.types.includes("Files")) return;
+      if (!isComposerAttachmentDrag(event.dataTransfer.types)) return;
       event.preventDefault();
       event.dataTransfer.dropEffect = "copy";
       setIsDragOverComposer(true);
     };
 
     const onComposerDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
-      if (!event.dataTransfer.types.includes("Files")) return;
+      if (!isComposerAttachmentDrag(event.dataTransfer.types)) return;
       event.preventDefault();
       const nextTarget = event.relatedTarget;
       if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) return;
@@ -1597,13 +1600,43 @@ export const ChatComposer = memo(
     };
 
     const onComposerDrop = (event: React.DragEvent<HTMLDivElement>) => {
-      if (!event.dataTransfer.types.includes("Files")) return;
+      if (!isComposerAttachmentDrag(event.dataTransfer.types)) return;
       event.preventDefault();
       dragDepthRef.current = 0;
       setIsDragOverComposer(false);
+
       const files = Array.from(event.dataTransfer.files);
-      addComposerImages(files);
-      focusComposer();
+      if (files.length > 0) {
+        addComposerImages(files);
+        focusComposer();
+        return;
+      }
+
+      // No real files — likely an image dragged from another browser tab
+      // (e.g. the ChatGPT web UI). Snapshot the URLs synchronously because
+      // `event.dataTransfer` is inert outside this handler, then fetch the
+      // bytes asynchronously.
+      const urls = extractDraggedImageUrls(event.dataTransfer);
+      if (urls.length === 0) return;
+
+      void (async () => {
+        const results = await Promise.all(urls.map((url) => fetchDroppedImageAsFile(url)));
+        const fetched = results.filter((file): file is File => file !== null);
+        if (fetched.length > 0) {
+          addComposerImages(fetched);
+          focusComposer();
+          return;
+        }
+        // We saw image-shaped URLs but couldn't turn any into a file — usually
+        // a CORS block on the source host. Let the user know so they know to
+        // fall back to the Finder round-trip that already works.
+        toastManager.add({
+          type: "error",
+          title: "Couldn't attach dragged image.",
+          description:
+            "The source blocked a direct download. Save the image to your computer first, then drop the file.",
+        });
+      })();
     };
     const handleInterruptPrimaryAction = useCallback(() => {
       void onInterrupt();

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   clampCollapsedComposerCursor,
   collapseExpandedComposerCursor,
+  deriveImageFilenameFromUrl,
   detectComposerTrigger,
   expandCollapsedComposerCursor,
+  extractDraggedImageUrls,
   isCollapsedCursorAdjacentToInlineToken,
+  isComposerAttachmentDrag,
   parseStandaloneComposerSlashCommand,
   replaceTextRange,
 } from "./composer-logic";
@@ -285,6 +288,151 @@ describe("isCollapsedCursorAdjacentToInlineToken", () => {
 
     expect(isCollapsedCursorAdjacentToInlineToken(text, tokenEnd, "left")).toBe(true);
     expect(isCollapsedCursorAdjacentToInlineToken(text, tokenStart, "right")).toBe(true);
+  });
+});
+
+describe("isComposerAttachmentDrag", () => {
+  it("accepts real File drags (Finder, other apps)", () => {
+    expect(isComposerAttachmentDrag(["Files"])).toBe(true);
+  });
+
+  it("accepts browser image/link drags that carry text/uri-list", () => {
+    expect(isComposerAttachmentDrag(["text/uri-list", "text/html", "text/plain"])).toBe(true);
+  });
+
+  it("ignores plain-text drags so Lexical keeps handling them", () => {
+    expect(isComposerAttachmentDrag(["text/plain"])).toBe(false);
+    expect(isComposerAttachmentDrag(["text/plain", "text/html"])).toBe(false);
+  });
+
+  it("ignores an empty type list", () => {
+    expect(isComposerAttachmentDrag([])).toBe(false);
+  });
+});
+
+const makeDraggedData = (entries: Record<string, string>) => ({
+  types: Object.keys(entries),
+  getData: (type: string) => entries[type] ?? "",
+});
+
+describe("extractDraggedImageUrls", () => {
+  it("parses a single URL from text/uri-list", () => {
+    const data = makeDraggedData({
+      "text/uri-list": "https://files.oaiusercontent.com/example.png",
+    });
+    expect(extractDraggedImageUrls(data)).toEqual(["https://files.oaiusercontent.com/example.png"]);
+  });
+
+  it("ignores comment lines in text/uri-list per RFC 2483", () => {
+    const data = makeDraggedData({
+      "text/uri-list": "# dragged from ChatGPT\nhttps://cdn.example.com/a.png",
+    });
+    expect(extractDraggedImageUrls(data)).toEqual(["https://cdn.example.com/a.png"]);
+  });
+
+  it("falls back to <img src> in text/html when uri-list is missing", () => {
+    const data = makeDraggedData({
+      "text/html": '<meta charset="utf-8"><img src="https://cdn.example.com/b.webp" alt="dragged">',
+    });
+    expect(extractDraggedImageUrls(data)).toEqual(["https://cdn.example.com/b.webp"]);
+  });
+
+  it("accepts single-quoted src attributes", () => {
+    const data = makeDraggedData({
+      "text/html": "<img src='https://cdn.example.com/c.gif'>",
+    });
+    expect(extractDraggedImageUrls(data)).toEqual(["https://cdn.example.com/c.gif"]);
+  });
+
+  it("deduplicates the same URL appearing in both uri-list and html", () => {
+    const data = makeDraggedData({
+      "text/uri-list": "https://cdn.example.com/d.png",
+      "text/html": '<img src="https://cdn.example.com/d.png">',
+    });
+    expect(extractDraggedImageUrls(data)).toEqual(["https://cdn.example.com/d.png"]);
+  });
+
+  it("accepts data:image/ and blob: URLs", () => {
+    const data = makeDraggedData({
+      "text/uri-list": "data:image/png;base64,AAAA",
+      "text/html": '<img src="blob:https://example.com/abc-123">',
+    });
+    expect(extractDraggedImageUrls(data)).toEqual([
+      "data:image/png;base64,AAAA",
+      "blob:https://example.com/abc-123",
+    ]);
+  });
+
+  it("rejects non-http schemes and non-image data URLs", () => {
+    const data = makeDraggedData({
+      "text/uri-list": "file:///Users/alice/secret.txt\nabout:blank\ndata:text/plain,hello",
+    });
+    expect(extractDraggedImageUrls(data)).toEqual([]);
+  });
+
+  it("uses text/plain as a last-resort fallback", () => {
+    const data = makeDraggedData({ "text/plain": "https://cdn.example.com/e.png" });
+    expect(extractDraggedImageUrls(data)).toEqual(["https://cdn.example.com/e.png"]);
+  });
+
+  it("does not fall back to text/plain when uri-list/html already yielded URLs", () => {
+    // Guards against an optional-fallthrough bug: the fallback branch must
+    // only fire when uri-list AND html produced nothing.
+    const data = makeDraggedData({
+      "text/uri-list": "https://cdn.example.com/f.png",
+      "text/plain": "totally unrelated text that happens to mention https://example.com",
+    });
+    expect(extractDraggedImageUrls(data)).toEqual(["https://cdn.example.com/f.png"]);
+  });
+
+  it("returns an empty array when nothing is extractable", () => {
+    expect(extractDraggedImageUrls(makeDraggedData({ "text/plain": "just some text" }))).toEqual(
+      [],
+    );
+    expect(extractDraggedImageUrls(makeDraggedData({}))).toEqual([]);
+  });
+});
+
+describe("deriveImageFilenameFromUrl", () => {
+  it("preserves the original filename when the URL has one", () => {
+    expect(deriveImageFilenameFromUrl("https://cdn.example.com/path/photo.png", "image/png")).toBe(
+      "photo.png",
+    );
+  });
+
+  it("strips the query string before extracting the filename", () => {
+    expect(
+      deriveImageFilenameFromUrl(
+        "https://cdn.example.com/path/photo.jpg?token=abc&v=2",
+        "image/jpeg",
+      ),
+    ).toBe("photo.jpg");
+  });
+
+  it("adds an extension when the URL path has none", () => {
+    expect(deriveImageFilenameFromUrl("https://cdn.example.com/resource/12345", "image/webp")).toBe(
+      "12345.webp",
+    );
+  });
+
+  it("falls back to a generic name when the URL has no usable path", () => {
+    expect(deriveImageFilenameFromUrl("https://cdn.example.com/", "image/png")).toBe(
+      "dropped-image.png",
+    );
+  });
+
+  it("falls back to png when the MIME subtype is missing", () => {
+    expect(deriveImageFilenameFromUrl("https://cdn.example.com/", "")).toBe("dropped-image.png");
+  });
+
+  it("decodes percent-encoded names", () => {
+    expect(
+      deriveImageFilenameFromUrl("https://cdn.example.com/path/my%20photo.png", "image/png"),
+    ).toBe("my photo.png");
+  });
+
+  it("handles invalid URLs without throwing", () => {
+    expect(deriveImageFilenameFromUrl("not a url", "image/png")).toBe("dropped-image.png");
   });
 });
 

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -296,3 +296,102 @@ export function replaceTextRange(
   const nextText = `${text.slice(0, safeStart)}${replacement}${text.slice(safeEnd)}`;
   return { text: nextText, cursor: safeStart + replacement.length };
 }
+
+// ---------------------------------------------------------------------------
+// Drag-and-drop helpers (images dragged from other browser tabs / apps).
+//
+// Background: dropping an image straight from another browser tab (e.g. the
+// ChatGPT web UI) into the composer does nothing today because the composer's
+// drop handler only accepts `DataTransfer.files`. Browser drag sources expose
+// the image via `text/uri-list` / `text/html` instead — the destination has
+// to fetch the bytes itself.
+// ---------------------------------------------------------------------------
+
+/**
+ * True when the dragged payload looks attachable — either a real file list
+ * (Finder, other apps) or a URL/image reference (another browser tab).
+ *
+ * Gating on `text/uri-list` (rather than any text/*) keeps plain-text drags
+ * from flipping the drop-zone highlight and from being hijacked away from
+ * the Lexical editor's native text-drop behavior.
+ */
+export function isComposerAttachmentDrag(types: ReadonlyArray<string>): boolean {
+  return types.includes("Files") || types.includes("text/uri-list");
+}
+
+/**
+ * Extract candidate image URLs from a DataTransfer-like payload. Used when a
+ * drop carried no real `Files` (image dragged from another browser window).
+ *
+ * Preference order mirrors what browsers actually populate for image drags:
+ *   1. `text/uri-list` — the standard; one URL per non-comment line.
+ *   2. `text/html`     — parse `<img src>` attributes for cases where the
+ *                        source only populated rich HTML.
+ *   3. `text/plain`    — last-resort fallback; some sources put the URL here.
+ *
+ * Only `http(s):`, `data:image/*`, and `blob:` URLs are returned — everything
+ * else (chrome://, about:, file:, arbitrary text) is filtered out so the
+ * caller can safely `fetch()` the result.
+ */
+export function extractDraggedImageUrls(data: {
+  getData: (type: string) => string;
+  types: ReadonlyArray<string>;
+}): string[] {
+  const urls: string[] = [];
+  const push = (value: string | null | undefined) => {
+    if (!value) return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    if (!/^(?:https?:|data:image\/|blob:)/i.test(trimmed)) return;
+    if (!urls.includes(trimmed)) urls.push(trimmed);
+  };
+
+  if (data.types.includes("text/uri-list")) {
+    const raw = data.getData("text/uri-list");
+    if (raw) {
+      for (const line of raw.split(/\r?\n/)) {
+        if (line.startsWith("#")) continue;
+        push(line);
+      }
+    }
+  }
+  if (data.types.includes("text/html")) {
+    const html = data.getData("text/html");
+    if (html) {
+      // Match <img ... src="..."> or src='...'; tolerate other attrs in between.
+      const pattern = /<img\b[^>]*\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)')/gi;
+      for (const match of html.matchAll(pattern)) {
+        push(match[1] ?? match[2]);
+      }
+    }
+  }
+  if (urls.length === 0 && data.types.includes("text/plain")) {
+    push(data.getData("text/plain"));
+  }
+  return urls;
+}
+
+/**
+ * Derive a reasonable filename for a File fetched from a URL.
+ *
+ * - Strips the query string and takes the last non-empty path segment.
+ * - Falls back to `dropped-image.<ext>` when the URL has no usable name.
+ * - Infers extension from the MIME type when the derived name has none.
+ */
+export function deriveImageFilenameFromUrl(url: string, mimeType: string): string {
+  let pathname = "";
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    pathname = "";
+  }
+  const last = pathname.split("/").findLast((segment) => segment.length > 0) ?? "";
+  const cleaned = decodeURIComponent(last)
+    .replace(/[\r\n\t]/g, "")
+    .trim();
+  const subtype = mimeType.split("/")[1]?.split(";")[0]?.trim() || "png";
+  const ext = subtype || "png";
+  if (cleaned && /\.[a-z0-9]{1,6}$/i.test(cleaned)) return cleaned;
+  if (cleaned) return `${cleaned}.${ext}`;
+  return `dropped-image.${ext}`;
+}

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -389,9 +389,8 @@ export function deriveImageFilenameFromUrl(url: string, mimeType: string): strin
   const cleaned = decodeURIComponent(last)
     .replace(/[\r\n\t]/g, "")
     .trim();
-  const subtype = mimeType.split("/")[1]?.split(";")[0]?.trim() || "png";
-  const ext = subtype || "png";
   if (cleaned && /\.[a-z0-9]{1,6}$/i.test(cleaned)) return cleaned;
+  const ext = mimeType.split("/")[1]?.split(";")[0]?.trim() || "png";
   if (cleaned) return `${cleaned}.${ext}`;
   return `dropped-image.${ext}`;
 }

--- a/apps/web/src/lib/fetchDroppedImage.test.ts
+++ b/apps/web/src/lib/fetchDroppedImage.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { fetchDroppedImageAsFile } from "./fetchDroppedImage";
+
+describe("fetchDroppedImageAsFile", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  const mockFetch = () => globalThis.fetch as ReturnType<typeof vi.fn>;
+
+  it("returns a File when the URL resolves to image bytes", async () => {
+    const blob = new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" });
+    mockFetch().mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.resolve(blob),
+    } as unknown as Response);
+
+    const result = await fetchDroppedImageAsFile(
+      "https://cdn.example.com/path/photo.png?token=abc",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe("photo.png");
+    expect(result?.type).toBe("image/png");
+    expect(result?.size).toBe(3);
+  });
+
+  it("returns null on a network / CORS failure (fetch rejects)", async () => {
+    mockFetch().mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    const result = await fetchDroppedImageAsFile("https://blocked.example.com/x.png");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for non-2xx responses — never trusts body on error status", async () => {
+    // Pattern: response.ok must be checked. fetch() resolves on 4xx/5xx,
+    // and reading the body would otherwise wrap an HTML error page as a "file".
+    mockFetch().mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      blob: () => Promise.resolve(new Blob(["forbidden"], { type: "text/html" })),
+    } as unknown as Response);
+
+    const result = await fetchDroppedImageAsFile("https://cdn.example.com/forbidden.png");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the response body is not an image", async () => {
+    mockFetch().mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(["<html>"], { type: "text/html" })),
+    } as unknown as Response);
+
+    const result = await fetchDroppedImageAsFile("https://example.com/page");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when reading the body throws", async () => {
+    mockFetch().mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.reject(new Error("body stream closed")),
+    } as unknown as Response);
+
+    const result = await fetchDroppedImageAsFile("https://cdn.example.com/a.png");
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/src/lib/fetchDroppedImage.ts
+++ b/apps/web/src/lib/fetchDroppedImage.ts
@@ -1,0 +1,39 @@
+import { deriveImageFilenameFromUrl } from "../composer-logic";
+
+/**
+ * Fetch a URL that was dropped onto the composer and return it as a `File`
+ * suitable for the existing image-attachment pipeline.
+ *
+ * Returns `null` (instead of throwing) for every failure mode so the caller
+ * can aggregate results across a batch of URLs without a single bad URL
+ * poisoning the whole drop:
+ *
+ *   - network / CORS failure  → `null`
+ *   - non-2xx response         → `null`
+ *   - non-image content type   → `null`
+ *
+ * Note: `response.ok` is checked explicitly. `fetch` only rejects on network
+ * errors — 4xx/5xx resolve successfully and would otherwise silently return
+ * an error-page body wrapped as a "file".
+ */
+export async function fetchDroppedImageAsFile(url: string): Promise<File | null> {
+  let response: Response;
+  try {
+    response = await fetch(url, { credentials: "omit" });
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+
+  let blob: Blob;
+  try {
+    blob = await response.blob();
+  } catch {
+    return null;
+  }
+
+  if (!blob.type.startsWith("image/")) return null;
+
+  const name = deriveImageFilenameFromUrl(url, blob.type);
+  return new File([blob], name, { type: blob.type });
+}


### PR DESCRIPTION
## What Changed

Dropping an image straight from another browser tab onto the composer now works. Today, dragging an image from e.g. the ChatGPT web UI onto the composer silently does nothing — you have to drop the image into Finder first, then drop the file from Finder into T3 Code.

## Why

The composer's drop handler in [`ChatComposer.tsx`](https://github.com/pingdotgg/t3code/blob/main/apps/web/src/components/chat/ChatComposer.tsx) short-circuits on the very first line of every drag handler:

```ts
if (!event.dataTransfer.types.includes("Files")) return;
```

That gate is correct for Finder drops (which expose a real `File`), but wrong for cross-tab browser drags. When a browser is the drag source, it puts the image into `DataTransfer` as `text/uri-list` + `text/html` (an `<img src="…">`). There is no `File` — the destination has to fetch the bytes itself.

The drop zone never even highlighted, so the user couldn't tell whether the gesture was recognized.

## Why not existing PRs

- **#2091** (Insert non-image file references on drop/paste) — extends non-image file drops to insert native paths; still gated on `dataTransfer.files`.
- **#885** (Insert native file path when dropping or pasting non-image files) — same mechanism, earlier attempt.

Neither touches the "Files" gate, and neither helps a drag that contains no `File` at all. The two surfaces are complementary.

## How it works

Three small pure helpers in `composer-logic.ts`, one async helper in `lib/fetchDroppedImage.ts`, and a ~30-line change to the existing drop handler.

1. **`isComposerAttachmentDrag(types)`** — accepts `Files` (as before) **or** `text/uri-list`. Gating on `text/uri-list` rather than any text type is deliberate: plain-text drags (e.g. selecting and dragging text from another input) don't include `text/uri-list`, so the Lexical editor's native text-drop behavior is preserved.

2. **`extractDraggedImageUrls(dataTransfer)`** — extracts candidate URLs in priority order:
   - `text/uri-list` (the standard; strips `#` comment lines per RFC 2483)
   - `text/html` (`<img src>` parsed for the URL)
   - `text/plain` (last-resort fallback, only used if the two above yielded nothing)

   Only `http(s):`, `data:image/*`, and `blob:` URLs pass — everything else (`file:`, `about:`, random text) is dropped so the caller can safely `fetch()` the result.

3. **`deriveImageFilenameFromUrl(url, mime)`** — strips query strings, takes the last path segment, falls back to `dropped-image.<ext>` when the URL has no usable name, and infers the extension from the MIME type when missing.

4. **`fetchDroppedImageAsFile(url)`** — downloads the URL and returns it as a `File` suitable for the existing attachment pipeline. Explicitly handles every failure mode (network/CORS reject, non-2xx status, non-image MIME, body read error) by returning `null` so a single bad URL can't poison a batch.

5. **Drop handler update** — when `dataTransfer.files` is empty but image-shaped URLs are present, fetch them asynchronously and feed the results through the existing `addComposerImages(...)` path. If every fetch fails (typically a CORS block on the source host), a single toast tells the user to fall back to the Finder round-trip that already works.

Order of preservation:

- Finder / app drop → unchanged sync path.
- Text-only drag → still handled by Lexical as before (no `text/uri-list`, handler bails).
- Link / image drag from browser → new path.

## Defensive coding notes

This PR was written with explicit attention to three patterns that have bitten me (and been caught by bots) on recent PRs:

1. **Optional fallthrough in ternary / guarded fallback chain** — the `text/plain` fallback only fires when both `text/uri-list` and `text/html` produced zero URLs. There's a dedicated test (`does not fall back to text/plain when uri-list/html already yielded URLs`) that would fail if the guard regressed to something like `if (uris.length === 0 || ...)`.
2. **Check return values before signaling success** — `fetchDroppedImageAsFile` explicitly checks `response.ok` (fetch resolves on 4xx/5xx; treating a 403 HTML error page as image bytes would otherwise wrap it as a "file"), explicitly checks `blob.type.startsWith("image/")`, and the caller gates the toast + `addComposerImages` on `fetched.length > 0`. A dedicated test covers the 403 case.
3. **DOM cleanup** — not applicable here (no temporary DOM elements created), but noted in case future reviewers expect it.

## Tests

**`apps/web/src/composer-logic.test.ts`** — new coverage for all three pure helpers:

- uri-list single URL
- uri-list with RFC 2483 `#` comment lines
- `<img src>` extraction from html, both `"` and `'` quoted
- dedup across uri-list and html
- `data:image/` and `blob:` URL acceptance
- rejection of `file:`, `about:`, and `data:text/plain`
- text/plain last-resort fallback
- no-fall-through guard (see above)
- filename derivation: passthrough, query-string stripping, extension inference, generic fallback, percent-decoding, invalid URL

**`apps/web/src/lib/fetchDroppedImage.test.ts`** — all four failure modes covered:

- happy path (returns File with derived name/MIME)
- fetch rejects (network/CORS)
- response.ok false (403)
- non-image blob type
- blob read throws

Full suite: 897/897 tests pass.

## UI Changes

None when no image is dragged. New behavior only activates when `dataTransfer.files` is empty and image-shaped URLs are present.

Error path (image URL but fetch blocked, typically CORS on the source host):

> **Couldn't attach dragged image.**
> The source blocked a direct download. Save the image to your computer first, then drop the file.

## Validation

- `bun fmt` — clean
- `bun lint` — zero new warnings from the changed files (pre-existing warnings unrelated)
- `bun typecheck` — clean across `@t3tools/scripts`, `@t3tools/web`, `@t3tools/desktop`, root
- `bun run test` — 897/897

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Tests cover both pure logic and the async fetch helper
- [x] No overlap with #2091 or #885 (different surface — they extend the Files-present path, this handles the Files-absent path)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new drag/drop behavior that triggers client-side `fetch()`es of dropped URLs and alters event gating, which could introduce edge-case UX regressions or unexpected network requests (though failures are handled and surfaced to users).
> 
> **Overview**
> Enables attaching images by dragging them from another browser tab into the chat composer, not just dropping local files.
> 
> Updates composer drag handlers to recognize URL-based drags (`text/uri-list`), extract image URLs from `DataTransfer`, and asynchronously download them into `File`s via a new `fetchDroppedImageAsFile` helper; if all downloads fail (commonly due to CORS), the user gets an error toast.
> 
> Adds tested helpers in `composer-logic.ts` for drag-type gating, URL extraction/deduping, and deriving filenames from URLs, plus unit tests for the new fetch helper’s success and failure modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e330f5957f29604b03b1ec26b4361faefe8418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support attaching images dragged from another browser tab in the chat composer
> - Extends `onComposerDrop` in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/2108/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to handle URL-based drags (e.g. dragging an image from another tab) in addition to file drags.
> - Adds `extractDraggedImageUrls` to parse image URLs from `text/uri-list`, `text/html` `<img src>`, and `text/plain` in the drag payload, and `isComposerAttachmentDrag` to gate drag-over highlighting on both `Files` and `text/uri-list` drags.
> - Adds `fetchDroppedImageAsFile` in [lib/fetchDroppedImage.ts](https://github.com/pingdotgg/t3code/pull/2108/files#diff-be7e157a57cc34640d19974794877c9141422e9f5ac9f996016f861aa4a3fcbb) to fetch each extracted URL and convert it to a `File`; non-image, failed, or non-OK responses return `null`.
> - If all URL fetches fail, a toast error is shown suggesting the user save the image locally first.
> - Behavioral Change: drag-over highlighting and copy `dropEffect` now activates for `text/uri-list` drags but not for plain-text drags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 68e330f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->