### PR TITLE
fix(web): defer command palette filesystem navigation

### DIFF
--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -4,6 +4,7 @@ import type { Thread } from "../types";
 import {
   buildThreadActionItems,
   filterCommandPaletteGroups,
+  getBrowsePrefetchPaths,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -162,5 +163,30 @@ describe("buildThreadActionItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual(["thread:thread-active"]);
+  });
+});
+
+describe("getBrowsePrefetchPaths", () => {
+  it("prefetches the parent path and an exact typed child path", () => {
+    expect(
+      getBrowsePrefetchPaths({
+        browseQuery: "~/Downloads",
+        canBrowseUp: true,
+        exactEntry: {
+          name: "Downloads",
+          fullPath: "/Users/test/Downloads",
+        },
+      }),
+    ).toEqual(["~/", "~/Downloads/"]);
+  });
+
+  it("does not prefetch a child path when the user only has a highlighted browse row", () => {
+    expect(
+      getBrowsePrefetchPaths({
+        browseQuery: "~/Do",
+        canBrowseUp: true,
+        exactEntry: null,
+      }),
+    ).toEqual(["~/"]);
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import type { Thread } from "../types";
 import {
+  buildBrowseGroups,
   buildThreadActionItems,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
@@ -191,5 +192,43 @@ describe("buildThreadActionItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual(["thread:thread-active"]);
+  });
+});
+
+describe("buildBrowseGroups", () => {
+  it("waits for asynchronous browse navigation actions", async () => {
+    let finishNavigation: (() => void) | undefined;
+    const browseTo = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishNavigation = resolve;
+        }),
+    );
+    const groups = buildBrowseGroups({
+      browseEntries: [{ name: "Downloads", fullPath: "/Users/test/Downloads" }],
+      browseQuery: "~/",
+      canBrowseUp: false,
+      upIcon: null,
+      directoryIcon: null,
+      browseUp: vi.fn(),
+      browseTo,
+    });
+    const item = groups[0]?.items[0];
+    if (!item || item.kind !== "action") {
+      throw new Error("Expected a browse action");
+    }
+
+    let actionSettled = false;
+    const action = item.run().then(() => {
+      actionSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(browseTo).toHaveBeenCalledWith("Downloads");
+    expect(actionSettled).toBe(false);
+
+    finishNavigation?.();
+    await action;
+    expect(actionSettled).toBe(true);
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -4,6 +4,8 @@ import type { Thread } from "../types";
 import {
   buildBrowseGroups,
   buildThreadActionItems,
+  canPreloadBrowsePath,
+  createBrowseNavigationCoordinator,
   enumerateCommandPaletteItems,
   filterCommandPaletteGroups,
   type CommandPaletteGroup,
@@ -230,5 +232,67 @@ describe("buildBrowseGroups", () => {
     finishNavigation?.();
     await action;
     expect(actionSettled).toBe(true);
+  });
+});
+
+describe("createBrowseNavigationCoordinator", () => {
+  it("only commits the latest overlapping navigation", async () => {
+    const coordinator = createBrowseNavigationCoordinator();
+    let finishFirst: (() => void) | undefined;
+    let finishSecond: (() => void) | undefined;
+    const commits: string[] = [];
+
+    const first = coordinator.run({
+      load: () =>
+        new Promise<void>((resolve) => {
+          finishFirst = resolve;
+        }),
+      commit: () => {
+        commits.push("first");
+      },
+    });
+    const second = coordinator.run({
+      load: () =>
+        new Promise<void>((resolve) => {
+          finishSecond = resolve;
+        }),
+      commit: () => {
+        commits.push("second");
+      },
+    });
+
+    finishSecond?.();
+    await expect(second).resolves.toBe(true);
+    finishFirst?.();
+    await expect(first).resolves.toBe(false);
+    expect(commits).toEqual(["second"]);
+  });
+
+  it("does not commit after newer user input invalidates the navigation", async () => {
+    const coordinator = createBrowseNavigationCoordinator();
+    let finishNavigation: (() => void) | undefined;
+    const commit = vi.fn();
+    const navigation = coordinator.run({
+      load: () =>
+        new Promise<void>((resolve) => {
+          finishNavigation = resolve;
+        }),
+      commit,
+    });
+
+    coordinator.invalidate();
+    finishNavigation?.();
+
+    await expect(navigation).resolves.toBe(false);
+    expect(commit).not.toHaveBeenCalled();
+  });
+});
+
+describe("canPreloadBrowsePath", () => {
+  it("only preloads paths for connected environments", () => {
+    expect(canPreloadBrowsePath("connected")).toBe(true);
+    expect(canPreloadBrowsePath("offline")).toBe(false);
+    expect(canPreloadBrowsePath("reconnecting")).toBe(false);
+    expect(canPreloadBrowsePath(null)).toBe(false);
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -1,6 +1,7 @@
 import { type KeybindingCommand, type FilesystemBrowseEntry } from "@t3tools/contracts";
 import type { SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import { type ReactNode } from "react";
+import { appendBrowsePathSegment, getBrowseParentPath } from "../lib/projectPaths";
 import { sortThreads } from "../lib/threadSort";
 import { formatRelativeTimeLabel } from "../timestampFormat";
 import { type Project, type SidebarThreadSummary, type Thread } from "../types";
@@ -77,6 +78,27 @@ export function filterBrowseEntries(input: {
       : null;
 
   return { filteredEntries, highlightedEntry, exactEntry };
+}
+
+export function getBrowsePrefetchPaths(input: {
+  browseQuery: string;
+  canBrowseUp: boolean;
+  exactEntry: FilesystemBrowseEntry | null;
+}): string[] {
+  const paths: string[] = [];
+
+  if (input.canBrowseUp) {
+    const parentPath = getBrowseParentPath(input.browseQuery);
+    if (parentPath !== null) {
+      paths.push(parentPath);
+    }
+  }
+
+  if (input.exactEntry) {
+    paths.push(appendBrowsePathSegment(input.browseQuery, input.exactEntry.name));
+  }
+
+  return paths;
 }
 
 export function normalizeSearchText(value: string): string {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -290,8 +290,8 @@ export function buildBrowseGroups(input: {
   canBrowseUp: boolean;
   upIcon: ReactNode;
   directoryIcon: ReactNode;
-  browseUp: () => void;
-  browseTo: (name: string) => void;
+  browseUp: () => void | Promise<void>;
+  browseTo: (name: string) => void | Promise<void>;
 }): CommandPaletteGroup[] {
   const items: CommandPaletteActionItem[] = [];
 

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -73,10 +73,8 @@ export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-b
 export function filterBrowseEntries(input: {
   browseEntries: ReadonlyArray<FilesystemBrowseEntry>;
   browseFilterQuery: string;
-  highlightedItemValue: string | null;
 }): {
   filteredEntries: FilesystemBrowseEntry[];
-  highlightedEntry: FilesystemBrowseEntry | null;
   exactEntry: FilesystemBrowseEntry | null;
 } {
   const lowerFilter = input.browseFilterQuery.toLowerCase();
@@ -88,18 +86,12 @@ export function filterBrowseEntries(input: {
       (showHidden || !entry.name.startsWith(".")),
   );
 
-  let highlightedEntry: FilesystemBrowseEntry | null = null;
-  if (input.highlightedItemValue?.startsWith("browse:")) {
-    const highlightedPath = input.highlightedItemValue.slice("browse:".length);
-    highlightedEntry = filteredEntries.find((entry) => entry.fullPath === highlightedPath) ?? null;
-  }
-
   const exactEntry =
     input.browseFilterQuery.length > 0
       ? (filteredEntries.find((entry) => entry.name === input.browseFilterQuery) ?? null)
       : null;
 
-  return { filteredEntries, highlightedEntry, exactEntry };
+  return { filteredEntries, exactEntry };
 }
 
 export function normalizeSearchText(value: string): string {
@@ -302,8 +294,8 @@ export function buildBrowseGroups(input: {
   canBrowseUp: boolean;
   upIcon: ReactNode;
   directoryIcon: ReactNode;
-  browseUp: () => void;
-  browseTo: (name: string) => void;
+  browseUp: () => void | Promise<void>;
+  browseTo: (name: string) => void | Promise<void>;
 }): CommandPaletteGroup[] {
   const items: CommandPaletteActionItem[] = [];
 
@@ -316,7 +308,7 @@ export function buildBrowseGroups(input: {
       icon: input.upIcon,
       keepOpen: true,
       run: async () => {
-        input.browseUp();
+        await input.browseUp();
       },
     });
   }
@@ -330,7 +322,7 @@ export function buildBrowseGroups(input: {
       icon: input.directoryIcon,
       keepOpen: true,
       run: async () => {
-        input.browseTo(entry.name);
+        await input.browseTo(entry.name);
       },
     });
   }

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -3,6 +3,7 @@ import {
   type FilesystemBrowseEntry,
   THREAD_JUMP_KEYBINDING_COMMANDS,
 } from "@t3tools/contracts";
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
 import type { SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
@@ -14,6 +15,39 @@ import { type Project, type SidebarThreadSummary, type Thread } from "../types";
 export const RECENT_THREAD_LIMIT = 12;
 export const ITEM_ICON_CLASS = "size-4 text-muted-foreground/80";
 export const ADDON_ICON_CLASS = "size-4";
+
+export interface BrowseNavigationCoordinator {
+  readonly invalidate: () => void;
+  readonly run: (input: {
+    readonly load: () => Promise<void>;
+    readonly commit: () => void;
+  }) => Promise<boolean>;
+}
+
+export function createBrowseNavigationCoordinator(): BrowseNavigationCoordinator {
+  let generation = 0;
+
+  return {
+    invalidate: () => {
+      generation += 1;
+    },
+    run: async (input) => {
+      const navigationGeneration = ++generation;
+      await input.load();
+      if (navigationGeneration !== generation) {
+        return false;
+      }
+      input.commit();
+      return true;
+    },
+  };
+}
+
+export function canPreloadBrowsePath(
+  connectionPhase: EnvironmentConnectionPhase | null | undefined,
+): boolean {
+  return connectionPhase === "connected";
+}
 
 export interface CommandPaletteItem {
   readonly kind: "action" | "submenu";

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -81,6 +81,7 @@ import {
   type CommandPaletteView,
   filterBrowseEntries,
   filterCommandPaletteGroups,
+  getBrowsePrefetchPaths,
   getCommandPaletteInputPlaceholder,
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
@@ -367,11 +368,7 @@ function OpenCommandPaletteDialog() {
       !relativePathNeedsActiveProject,
   });
   const browseEntries = browseResult?.entries ?? EMPTY_BROWSE_ENTRIES;
-  const {
-    filteredEntries: filteredBrowseEntries,
-    highlightedEntry: highlightedBrowseEntry,
-    exactEntry: exactBrowseEntry,
-  } = useMemo(
+  const { filteredEntries: filteredBrowseEntries, exactEntry: exactBrowseEntry } = useMemo(
     () => filterBrowseEntries({ browseEntries, browseFilterQuery, highlightedItemValue }),
     [browseEntries, browseFilterQuery, highlightedItemValue],
   );
@@ -392,27 +389,25 @@ function OpenCommandPaletteDialog() {
     [browseEnvironmentId, currentProjectCwdForBrowse, fetchBrowseResult, queryClient],
   );
 
-  // Prefetch the parent and the most likely next child so browse navigation
-  // stays warm without scanning every child directory in large trees.
+  const browsePrefetchPaths = useMemo(
+    () =>
+      getBrowsePrefetchPaths({
+        browseQuery: query,
+        canBrowseUp: canNavigateUp(query),
+        exactEntry: exactBrowseEntry,
+      }),
+    [exactBrowseEntry, query],
+  );
+
+  // Prefetch the parent and only an exact typed child so browse navigation
+  // stays warm without turning pointer hover into a directory read.
   useEffect(() => {
     if (!isBrowsing || filteredBrowseEntries.length === 0) return;
 
-    if (canNavigateUp(query)) {
-      prefetchBrowsePath(getBrowseParentPath(query)!);
+    for (const partialPath of browsePrefetchPaths) {
+      prefetchBrowsePath(partialPath);
     }
-
-    const nextChild = highlightedBrowseEntry ?? exactBrowseEntry;
-    if (nextChild) {
-      prefetchBrowsePath(appendBrowsePathSegment(query, nextChild.name));
-    }
-  }, [
-    exactBrowseEntry,
-    filteredBrowseEntries.length,
-    highlightedBrowseEntry,
-    isBrowsing,
-    prefetchBrowsePath,
-    query,
-  ]);
+  }, [filteredBrowseEntries.length, browsePrefetchPaths, isBrowsing, prefetchBrowsePath]);
 
   const openProjectFromSearch = useMemo(
     () => async (project: (typeof projects)[number]) => {

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -77,6 +77,7 @@ import {
   buildRootGroups,
   buildThreadActionItems,
   type CommandPaletteActionItem,
+  type CommandPaletteGroup,
   type CommandPaletteSubmenuItem,
   type CommandPaletteView,
   filterBrowseEntries,
@@ -333,6 +334,11 @@ function OpenCommandPaletteDialog() {
     browseEnvironmentId && currentProjectEnvironmentId === browseEnvironmentId
       ? currentProjectCwd
       : null;
+  const getBrowseCwdForEnvironment = useCallback(
+    (environmentId: EnvironmentId | null): string | null =>
+      environmentId && currentProjectEnvironmentId === environmentId ? currentProjectCwd : null,
+    [currentProjectCwd, currentProjectEnvironmentId],
+  );
   const relativePathNeedsActiveProject =
     isExplicitRelativeProjectPath(query.trim()) && currentProjectCwdForBrowse === null;
   const browseDirectoryPath = isBrowsing ? getBrowseDirectoryPath(query) : "";
@@ -340,16 +346,20 @@ function OpenCommandPaletteDialog() {
     isBrowsing && !hasTrailingPathSeparator(query) ? getBrowseLeafPathSegment(query) : "";
 
   const fetchBrowseResult = useCallback(
-    async (partialPath: string): Promise<FilesystemBrowseResult | null> => {
-      if (!browseEnvironmentId) return null;
-      const api = readEnvironmentApi(browseEnvironmentId);
+    async (input: {
+      environmentId: EnvironmentId | null;
+      partialPath: string;
+      cwd: string | null;
+    }): Promise<FilesystemBrowseResult | null> => {
+      if (!input.environmentId) return null;
+      const api = readEnvironmentApi(input.environmentId);
       if (!api) return null;
       return api.filesystem.browse({
-        partialPath,
-        ...(currentProjectCwdForBrowse ? { cwd: currentProjectCwdForBrowse } : {}),
+        partialPath: input.partialPath,
+        ...(input.cwd ? { cwd: input.cwd } : {}),
       });
     },
-    [browseEnvironmentId, currentProjectCwdForBrowse],
+    [],
   );
 
   const { data: browseResult, isPending: isBrowsePending } = useQuery({
@@ -359,7 +369,13 @@ function OpenCommandPaletteDialog() {
       browseDirectoryPath,
       currentProjectCwdForBrowse,
     ],
-    queryFn: () => fetchBrowseResult(browseDirectoryPath),
+    queryFn: () =>
+      fetchBrowseResult({
+        environmentId: browseEnvironmentId,
+        partialPath: browseDirectoryPath,
+        cwd: currentProjectCwdForBrowse,
+      }),
+    placeholderData: (previousData) => previousData,
     staleTime: BROWSE_STALE_TIME_MS,
     enabled:
       isBrowsing &&
@@ -374,15 +390,23 @@ function OpenCommandPaletteDialog() {
   );
 
   const prefetchBrowsePath = useCallback(
-    (partialPath: string) => {
-      void queryClient.prefetchQuery({
-        queryKey: [
-          "filesystemBrowse",
-          browseEnvironmentId,
-          partialPath,
-          currentProjectCwdForBrowse,
-        ],
-        queryFn: () => fetchBrowseResult(partialPath),
+    async (
+      partialPath: string,
+      environmentId: EnvironmentId | null = browseEnvironmentId,
+      cwd: string | null = currentProjectCwdForBrowse,
+    ) => {
+      if (!environmentId) {
+        return;
+      }
+
+      await queryClient.prefetchQuery({
+        queryKey: ["filesystemBrowse", environmentId, partialPath, cwd],
+        queryFn: () =>
+          fetchBrowseResult({
+            environmentId,
+            partialPath,
+            cwd,
+          }),
         staleTime: BROWSE_STALE_TIME_MS,
       });
     },
@@ -549,15 +573,23 @@ function OpenCommandPaletteDialog() {
   }
 
   const startAddProjectBrowse = useCallback(
-    (environmentId: EnvironmentId): void => {
+    async (environmentId: EnvironmentId): Promise<void> => {
+      const initialQuery = getAddProjectInitialQueryForEnvironment(environmentId);
+      const initialBrowsePath = getBrowseDirectoryPath(initialQuery);
+      const browseCwd = getBrowseCwdForEnvironment(environmentId);
+
+      if (initialBrowsePath.length > 0) {
+        await prefetchBrowsePath(initialBrowsePath, environmentId, browseCwd);
+      }
+
       setAddProjectEnvironmentId(environmentId);
       pushPaletteView({
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
         groups: [],
-        initialQuery: getAddProjectInitialQueryForEnvironment(environmentId),
+        initialQuery,
       });
     },
-    [getAddProjectInitialQueryForEnvironment],
+    [getAddProjectInitialQueryForEnvironment, getBrowseCwdForEnvironment, prefetchBrowsePath],
   );
 
   const addProjectEnvironmentItems: CommandPaletteActionItem[] = addProjectEnvironmentOptions.map(
@@ -570,7 +602,7 @@ function OpenCommandPaletteDialog() {
       icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
       keepOpen: true,
       run: async () => {
-        startAddProjectBrowse(option.environmentId);
+        await startAddProjectBrowse(option.environmentId);
       },
     }),
   );
@@ -586,7 +618,7 @@ function OpenCommandPaletteDialog() {
     [addProjectEnvironmentItems],
   );
 
-  const openAddProjectFlow = useCallback(() => {
+  const openAddProjectFlow = useCallback(async () => {
     if (addProjectEnvironmentOptions.length > 1) {
       pushPaletteView({
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
@@ -605,7 +637,7 @@ function OpenCommandPaletteDialog() {
       return;
     }
 
-    startAddProjectBrowse(environmentId);
+    await startAddProjectBrowse(environmentId);
   }, [
     addProjectEnvironmentGroups,
     addProjectEnvironmentOptions.length,
@@ -618,7 +650,7 @@ function OpenCommandPaletteDialog() {
       return;
     }
     clearOpenIntent();
-    openAddProjectFlow();
+    void openAddProjectFlow();
   }, [clearOpenIntent, openAddProjectFlow, openIntent]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
@@ -682,7 +714,7 @@ function OpenCommandPaletteDialog() {
       icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
       keepOpen: true,
       run: async () => {
-        openAddProjectFlow();
+        await openAddProjectFlow();
       },
     });
   }
@@ -803,23 +835,28 @@ function OpenCommandPaletteDialog() {
     ],
   );
 
-  function browseTo(name: string): void {
-    const nextQuery = appendBrowsePathSegment(query, name);
-    setHighlightedItemValue(null);
-    setQuery(nextQuery);
-    setBrowseGeneration((generation) => generation + 1);
-  }
+  const browseTo = useCallback(
+    async (name: string): Promise<void> => {
+      const nextQuery = appendBrowsePathSegment(query, name);
+      await prefetchBrowsePath(getBrowseDirectoryPath(nextQuery));
+      setHighlightedItemValue(null);
+      setQuery(nextQuery);
+      setBrowseGeneration((generation) => generation + 1);
+    },
+    [prefetchBrowsePath, query],
+  );
 
-  function browseUp(): void {
+  const browseUp = useCallback(async (): Promise<void> => {
     const parentPath = getBrowseParentPath(query);
     if (parentPath === null) {
       return;
     }
 
+    await prefetchBrowsePath(parentPath);
     setHighlightedItemValue(null);
     setQuery(parentPath);
     setBrowseGeneration((generation) => generation + 1);
-  }
+  }, [prefetchBrowsePath, query]);
 
   // Resolve the add-project path from browse data when available. When the
   // query has a trailing separator (e.g. "~/projects/foo/"), parentPath is the
@@ -842,7 +879,7 @@ function OpenCommandPaletteDialog() {
     browseTo,
   });
 
-  let displayedGroups = filteredGroups;
+  let displayedGroups: ReadonlyArray<CommandPaletteGroup> = filteredGroups;
   if (isBrowsing) {
     displayedGroups = relativePathNeedsActiveProject ? [] : browseGroups;
   }

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -92,6 +92,8 @@ import {
   buildProjectActionItems,
   buildRootGroups,
   buildThreadActionItems,
+  canPreloadBrowsePath,
+  createBrowseNavigationCoordinator,
   enumerateCommandPaletteItems,
   type CommandPaletteActionItem,
   type CommandPaletteSubmenuItem,
@@ -506,6 +508,13 @@ function OpenCommandPaletteDialog(props: {
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
   const [browseGeneration, setBrowseGeneration] = useState(0);
+  const browseNavigationRef = useRef<ReturnType<typeof createBrowseNavigationCoordinator> | null>(
+    null,
+  );
+  if (browseNavigationRef.current === null) {
+    browseNavigationRef.current = createBrowseNavigationCoordinator();
+  }
+  const browseNavigation = browseNavigationRef.current;
   const [addProjectEnvironmentId, setAddProjectEnvironmentId] = useState<EnvironmentId | null>(
     null,
   );
@@ -755,6 +764,12 @@ function OpenCommandPaletteDialog(props: {
       if (!environmentId) {
         return;
       }
+      const environment = environments.find(
+        (candidate) => candidate.environmentId === environmentId,
+      );
+      if (!canPreloadBrowsePath(environment?.connection.phase)) {
+        return;
+      }
 
       await loadBrowsePath({
         environmentId,
@@ -764,7 +779,14 @@ function OpenCommandPaletteDialog(props: {
         },
       });
     },
-    [browseEnvironmentId, currentProjectCwdForBrowse, loadBrowsePath],
+    [browseEnvironmentId, currentProjectCwdForBrowse, environments, loadBrowsePath],
+  );
+
+  useEffect(
+    () => () => {
+      browseNavigation.invalidate();
+    },
+    [browseNavigation],
   );
 
   const openProjectFromSearch = useMemo(
@@ -895,18 +917,22 @@ function OpenCommandPaletteDialog(props: {
   );
   const recentThreadItems = allThreadItems.slice(0, RECENT_THREAD_LIMIT);
 
-  function pushPaletteView(view: CommandPaletteView): void {
-    setViewStack((previousViews) => [
-      ...previousViews,
-      {
-        addonIcon: view.addonIcon,
-        groups: view.groups,
-        ...(view.initialQuery ? { initialQuery: view.initialQuery } : {}),
-      },
-    ]);
-    setHighlightedItemValue(null);
-    setQuery(view.initialQuery ?? "");
-  }
+  const pushPaletteView = useCallback(
+    (view: CommandPaletteView): void => {
+      browseNavigation.invalidate();
+      setViewStack((previousViews) => [
+        ...previousViews,
+        {
+          addonIcon: view.addonIcon,
+          groups: view.groups,
+          ...(view.initialQuery ? { initialQuery: view.initialQuery } : {}),
+        },
+      ]);
+      setHighlightedItemValue(null);
+      setQuery(view.initialQuery ?? "");
+    },
+    [browseNavigation],
+  );
 
   function pushView(item: CommandPaletteSubmenuItem): void {
     pushPaletteView({
@@ -917,6 +943,7 @@ function OpenCommandPaletteDialog(props: {
   }
 
   function popView(): void {
+    browseNavigation.invalidate();
     setAddProjectCloneFlow(null);
     if (viewStack.length <= 1) {
       setAddProjectEnvironmentId(null);
@@ -927,6 +954,7 @@ function OpenCommandPaletteDialog(props: {
   }
 
   function handleQueryChange(nextQuery: string): void {
+    browseNavigation.invalidate();
     setHighlightedItemValue(null);
     setQuery(nextQuery);
     if (nextQuery === "" && currentView?.initialQuery) {
@@ -939,20 +967,31 @@ function OpenCommandPaletteDialog(props: {
       const initialQuery = getAddProjectInitialQueryForEnvironment(environmentId);
       const initialBrowsePath = getBrowseDirectoryPath(initialQuery);
       const browseCwd = getBrowseCwdForEnvironment(environmentId);
-
-      if (initialBrowsePath.length > 0) {
-        await prefetchBrowsePath(initialBrowsePath, environmentId, browseCwd);
-      }
-
-      setAddProjectEnvironmentId(environmentId);
-      setAddProjectCloneFlow(null);
-      pushPaletteView({
+      const view: CommandPaletteView = {
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
         groups: [],
         initialQuery,
+      };
+
+      await browseNavigation.run({
+        load: () =>
+          initialBrowsePath.length > 0
+            ? prefetchBrowsePath(initialBrowsePath, environmentId, browseCwd)
+            : Promise.resolve(),
+        commit: () => {
+          setAddProjectEnvironmentId(environmentId);
+          setAddProjectCloneFlow(null);
+          pushPaletteView(view);
+        },
       });
     },
-    [getAddProjectInitialQueryForEnvironment, getBrowseCwdForEnvironment, prefetchBrowsePath],
+    [
+      browseNavigation,
+      getAddProjectInitialQueryForEnvironment,
+      getBrowseCwdForEnvironment,
+      prefetchBrowsePath,
+      pushPaletteView,
+    ],
   );
 
   const startAddProjectClone = useCallback(
@@ -965,7 +1004,7 @@ function OpenCommandPaletteDialog(props: {
         initialQuery: "",
       });
     },
-    [],
+    [pushPaletteView],
   );
 
   const openSourceControlSettings = useCallback(() => {
@@ -1081,7 +1120,12 @@ function OpenCommandPaletteDialog(props: {
         ),
       });
     },
-    [browseEnvironmentId, buildAddProjectSourceGroups, sourceControlDiscovery.data],
+    [
+      browseEnvironmentId,
+      buildAddProjectSourceGroups,
+      pushPaletteView,
+      sourceControlDiscovery.data,
+    ],
   );
 
   const addProjectEnvironmentItems: CommandPaletteActionItem[] = addProjectEnvironmentOptions.map(
@@ -1136,6 +1180,7 @@ function OpenCommandPaletteDialog(props: {
     addProjectEnvironmentGroups,
     addProjectEnvironmentOptions.length,
     defaultAddProjectEnvironmentId,
+    pushPaletteView,
     startAddProjectSourceSelection,
   ]);
 
@@ -1152,6 +1197,7 @@ function OpenCommandPaletteDialog(props: {
       return;
     }
     clearOpenIntent();
+    browseNavigation.invalidate();
     setAddProjectCloneFlow(null);
     setViewStack([]);
     setQuery("");
@@ -1177,10 +1223,12 @@ function OpenCommandPaletteDialog(props: {
     });
   }, [
     clearOpenIntent,
+    browseNavigation,
     currentProjectEnvironmentId,
     currentProjectId,
     openIntent,
     projectThreadItems,
+    pushPaletteView,
   ]);
 
   const actionItems: Array<CommandPaletteActionItem | CommandPaletteSubmenuItem> = [];
@@ -1582,12 +1630,16 @@ function OpenCommandPaletteDialog(props: {
   const browseTo = useCallback(
     async (name: string): Promise<void> => {
       const nextQuery = appendBrowsePathSegment(query, name);
-      await prefetchBrowsePath(getBrowseDirectoryPath(nextQuery));
-      setHighlightedItemValue(null);
-      setQuery(nextQuery);
-      setBrowseGeneration((generation) => generation + 1);
+      await browseNavigation.run({
+        load: () => prefetchBrowsePath(getBrowseDirectoryPath(nextQuery)),
+        commit: () => {
+          setHighlightedItemValue(null);
+          setQuery(nextQuery);
+          setBrowseGeneration((generation) => generation + 1);
+        },
+      });
     },
-    [prefetchBrowsePath, query],
+    [browseNavigation, prefetchBrowsePath, query],
   );
 
   const browseUp = useCallback(async (): Promise<void> => {
@@ -1596,11 +1648,15 @@ function OpenCommandPaletteDialog(props: {
       return;
     }
 
-    await prefetchBrowsePath(parentPath);
-    setHighlightedItemValue(null);
-    setQuery(parentPath);
-    setBrowseGeneration((generation) => generation + 1);
-  }, [prefetchBrowsePath, query]);
+    await browseNavigation.run({
+      load: () => prefetchBrowsePath(parentPath),
+      commit: () => {
+        setHighlightedItemValue(null);
+        setQuery(parentPath);
+        setBrowseGeneration((generation) => generation + 1);
+      },
+    });
+  }, [browseNavigation, prefetchBrowsePath, query]);
 
   // Resolve the add-project path from browse data when available. When the
   // query has a trailing separator (e.g. "~/projects/foo/"), parentPath is the

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -486,6 +486,10 @@ function OpenCommandPaletteDialog(props: {
   const lookupRepository = useAtomQueryRunner(sourceControlEnvironment.repository, {
     reportFailure: false,
   });
+  const loadBrowsePath = useAtomQueryRunner(filesystemEnvironment.browse, {
+    reportFailure: false,
+    reportDefect: false,
+  });
   const cloneRepository = useAtomCommand(sourceControlEnvironment.cloneRepository, {
     reportFailure: false,
   });
@@ -710,6 +714,11 @@ function OpenCommandPaletteDialog(props: {
     browseEnvironmentId && currentProjectEnvironmentId === browseEnvironmentId
       ? currentProjectCwd
       : null;
+  const getBrowseCwdForEnvironment = useCallback(
+    (environmentId: EnvironmentId | null): string | null =>
+      environmentId && currentProjectEnvironmentId === environmentId ? currentProjectCwd : null,
+    [currentProjectCwd, currentProjectEnvironmentId],
+  );
   const relativePathNeedsActiveProject =
     isExplicitRelativeProjectPath(query.trim()) && currentProjectCwdForBrowse === null;
   const browseDirectoryPath = isBrowsing ? getBrowseDirectoryPath(query) : "";
@@ -733,8 +742,29 @@ function OpenCommandPaletteDialog(props: {
   const isBrowsePending = browseQuery.isPending;
   const browseEntries = browseResult?.entries ?? EMPTY_BROWSE_ENTRIES;
   const { filteredEntries: filteredBrowseEntries, exactEntry: exactBrowseEntry } = useMemo(
-    () => filterBrowseEntries({ browseEntries, browseFilterQuery, highlightedItemValue }),
-    [browseEntries, browseFilterQuery, highlightedItemValue],
+    () => filterBrowseEntries({ browseEntries, browseFilterQuery }),
+    [browseEntries, browseFilterQuery],
+  );
+
+  const prefetchBrowsePath = useCallback(
+    async (
+      partialPath: string,
+      environmentId: EnvironmentId | null = browseEnvironmentId,
+      cwd: string | null = currentProjectCwdForBrowse,
+    ): Promise<void> => {
+      if (!environmentId) {
+        return;
+      }
+
+      await loadBrowsePath({
+        environmentId,
+        input: {
+          partialPath,
+          ...(cwd ? { cwd } : {}),
+        },
+      });
+    },
+    [browseEnvironmentId, currentProjectCwdForBrowse, loadBrowsePath],
   );
 
   const openProjectFromSearch = useMemo(
@@ -905,16 +935,24 @@ function OpenCommandPaletteDialog(props: {
   }
 
   const startAddProjectBrowse = useCallback(
-    (environmentId: EnvironmentId): void => {
+    async (environmentId: EnvironmentId): Promise<void> => {
+      const initialQuery = getAddProjectInitialQueryForEnvironment(environmentId);
+      const initialBrowsePath = getBrowseDirectoryPath(initialQuery);
+      const browseCwd = getBrowseCwdForEnvironment(environmentId);
+
+      if (initialBrowsePath.length > 0) {
+        await prefetchBrowsePath(initialBrowsePath, environmentId, browseCwd);
+      }
+
       setAddProjectEnvironmentId(environmentId);
       setAddProjectCloneFlow(null);
       pushPaletteView({
         addonIcon: <FolderPlusIcon className={ADDON_ICON_CLASS} />,
         groups: [],
-        initialQuery: getAddProjectInitialQueryForEnvironment(environmentId),
+        initialQuery,
       });
     },
-    [getAddProjectInitialQueryForEnvironment],
+    [getAddProjectInitialQueryForEnvironment, getBrowseCwdForEnvironment, prefetchBrowsePath],
   );
 
   const startAddProjectClone = useCallback(
@@ -950,7 +988,7 @@ function OpenCommandPaletteDialog(props: {
           icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
           keepOpen: true,
           run: async () => {
-            startAddProjectBrowse(environmentId);
+            await startAddProjectBrowse(environmentId);
           },
         },
       ];
@@ -1225,7 +1263,7 @@ function OpenCommandPaletteDialog(props: {
       icon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
       keepOpen: true,
       run: async () => {
-        startAddProjectBrowse(wslAddProjectEnvironmentOption.environmentId);
+        await startAddProjectBrowse(wslAddProjectEnvironmentOption.environmentId);
       },
     });
   }
@@ -1541,23 +1579,28 @@ function OpenCommandPaletteDialog(props: {
     await handleAddProject(cloneResult.value.cwd);
   }
 
-  function browseTo(name: string): void {
-    const nextQuery = appendBrowsePathSegment(query, name);
-    setHighlightedItemValue(null);
-    setQuery(nextQuery);
-    setBrowseGeneration((generation) => generation + 1);
-  }
+  const browseTo = useCallback(
+    async (name: string): Promise<void> => {
+      const nextQuery = appendBrowsePathSegment(query, name);
+      await prefetchBrowsePath(getBrowseDirectoryPath(nextQuery));
+      setHighlightedItemValue(null);
+      setQuery(nextQuery);
+      setBrowseGeneration((generation) => generation + 1);
+    },
+    [prefetchBrowsePath, query],
+  );
 
-  function browseUp(): void {
+  const browseUp = useCallback(async (): Promise<void> => {
     const parentPath = getBrowseParentPath(query);
     if (parentPath === null) {
       return;
     }
 
+    await prefetchBrowsePath(parentPath);
     setHighlightedItemValue(null);
     setQuery(parentPath);
     setBrowseGeneration((generation) => generation + 1);
-  }
+  }, [prefetchBrowsePath, query]);
 
   // Resolve the add-project path from browse data when available. When the
   // query has a trailing separator (e.g. "~/projects/foo/"), parentPath is the


### PR DESCRIPTION
## Problem

Command palette filesystem navigation committed the next path before its browse result was available. Moving into a directory, moving up, or opening the initial add-project directory could briefly replace the current results with an empty list.

## Fix

- Load the destination through the current environment-scoped Effect atom query before committing palette state.
- Await asynchronous browse item actions so command execution stays aligned with the navigation.
- Use latest-intent coordination so overlapping navigation or newer query input cannot be overwritten by stale preload completion.
- Skip the preload wait when an environment is not connected so offline project pickers transition immediately.
- Remove the obsolete highlighted-row lookup from browse filtering.
- Preserve the later macOS TCC behavior from #2745: child directories are read only after an explicit navigation action, never from hover or exact-name typing.
- Cover the async action boundary with a focused unit test.

This is the current-architecture port of the original intent behind this PR after the React Query-to-Effect atom migration.

## Surfaces

- Web and desktop share this command palette and receive the fix.
- Mobile does not use this command palette flow.
- Local and remote environments use the same environment-scoped browse atom path.

## Testing

- `vp test run src/components/CommandPalette.logic.test.ts --project unit` from `apps/web` — 9 passed
- `vp run --filter @t3tools/web typecheck`
- `vp lint --report-unused-disable-directives apps/web/src/components/CommandPalette.tsx apps/web/src/components/CommandPalette.logic.ts apps/web/src/components/CommandPalette.logic.test.ts` — passes with two pre-existing nested-component warnings
- `vp fmt --check apps/web/src/components/CommandPalette.tsx apps/web/src/components/CommandPalette.logic.ts apps/web/src/components/CommandPalette.logic.test.ts`
- React Doctor on the three changed files — 92/100, one existing command-palette state-organization warning

Implemented with GPT-5.6 in the Codex harness via T3 Code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/navigation timing change in the shared web/desktop command palette; no auth or data-model changes, with focused unit tests for the new coordinator behavior.
> 
> **Overview**
> Fixes a flash of **empty directory listings** when navigating folders in the command palette by **prefetching browse results before updating path state**.
> 
> `browseTo`, `browseUp`, and opening the add-project local-folder flow now run through a **`BrowseNavigationCoordinator`**: call the environment-scoped filesystem browse query first, then commit query/view changes only if that navigation is still current. Overlapping navigations or query/view changes call **`invalidate()`** so stale loads never commit.
> 
> **`canPreloadBrowsePath`** skips prefetch when the environment is not **`connected`**. Browse item actions **`await`** async navigation handlers. **`filterBrowseEntries`** no longer takes highlight state or returns **`highlightedEntry`**.
> 
> Unit tests cover async browse actions, coordinator ordering/invalidation, and preload gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192da779b7ec3ffbb37460dc0ccb32c5da33b4d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Defer command palette filesystem navigation until directory listings are prefetched
> - Introduces `createBrowseNavigationCoordinator` to serialize in-flight navigations so only the latest navigation commits UI state; earlier or invalidated navigations are discarded.
> - Browse actions (`browseTo`, `browseUp`) now prefetch directory listings before committing view updates, preventing stale or out-of-order UI states.
> - Adds `canPreloadBrowsePath` to gate prefetching on environment connection phase (`'connected'` only).
> - Navigation is invalidated on unmount, view push/pop, and search query changes to prevent stale navigations from committing.
> - Behavioral Change: browse action promises now resolve only after navigation completes, and `filterBrowseEntries` no longer returns `highlightedEntry`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 192da77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->