### PR TITLE
Update workflow to use ubuntu-24.04 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,7 +299,7 @@ jobs:
   publish_cli:
     name: Publish CLI to npm
     needs: [preflight, build]
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
trusted publishing requires github runners

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the environment used for the npm publishing step, which could surface differences in tooling/permissions during releases.
> 
> **Overview**
> Updates the release workflow so the **npm CLI publish** job (`publish_cli`) runs on the GitHub-hosted `ubuntu-24.04` runner rather than `blacksmith-8vcpu-ubuntu-2404`, aligning with trusted publishing requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b438368398fae589cfd2c89606ff8100aa59fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch 'Publish CLI to npm' job to ubuntu-24.04 runner
> Updates [release.yml](.github/workflows/release.yml) to use the GitHub-hosted `ubuntu-24.04` runner instead of `blacksmith-8vcpu-ubuntu-2404` for the `publish_cli` job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17b4383.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->