### PR TITLE
fix(web): reconcile stale approval state after responses

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -68,6 +68,7 @@ import {
 } from "../pendingUserInput";
 import {
   selectProjectsAcrossEnvironments,
+  selectSidebarThreadSummaryByRef,
   selectThreadsAcrossEnvironments,
   useStore,
 } from "../store";
@@ -792,6 +793,12 @@ export default function ChatView(props: ChatViewProps) {
     () => (activeThread ? scopeThreadRef(activeThread.environmentId, activeThread.id) : null),
     [activeThread],
   );
+  const activeThreadSummary = useStore(
+    useMemo(
+      () => (state) => selectSidebarThreadSummaryByRef(state, activeThreadRef) ?? null,
+      [activeThreadRef],
+    ),
+  );
   const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
   const existingOpenTerminalThreadKeys = useMemo(() => {
     const existingThreadKeys = new Set<string>([...serverThreadKeys, ...draftThreadKeys]);
@@ -1059,12 +1066,22 @@ export default function ChatView(props: ChatViewProps) {
     [activeLatestTurn?.turnId, threadActivities],
   );
   const pendingApprovals = useMemo(
-    () => derivePendingApprovals(threadActivities),
-    [threadActivities],
+    () =>
+      derivePendingApprovals(threadActivities, {
+        ...(activeThreadSummary?.hasPendingApprovals !== undefined
+          ? { hasPendingApprovals: activeThreadSummary.hasPendingApprovals }
+          : {}),
+      }),
+    [activeThreadSummary?.hasPendingApprovals, threadActivities],
   );
   const pendingUserInputs = useMemo(
-    () => derivePendingUserInputs(threadActivities),
-    [threadActivities],
+    () =>
+      derivePendingUserInputs(threadActivities, {
+        ...(activeThreadSummary?.hasPendingUserInput !== undefined
+          ? { hasPendingUserInput: activeThreadSummary.hasPendingUserInput }
+          : {}),
+      }),
+    [activeThreadSummary?.hasPendingUserInput, threadActivities],
   );
   const activePendingUserInput = pendingUserInputs[0] ?? null;
   const activePendingDraftAnswers = useMemo(

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -173,6 +173,24 @@ describe("derivePendingApprovals", () => {
 
     expect(derivePendingApprovals(activities)).toEqual([]);
   });
+
+  it("suppresses stale pending approvals when the authoritative shell summary says none remain", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "approval-open-shell-reconciled",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "approval.requested",
+        summary: "Command approval requested",
+        tone: "approval",
+        payload: {
+          requestId: "req-shell-reconciled-1",
+          requestKind: "command",
+        },
+      }),
+    ];
+
+    expect(derivePendingApprovals(activities, { hasPendingApprovals: false })).toEqual([]);
+  });
 });
 
 describe("derivePendingUserInputs", () => {
@@ -304,6 +322,37 @@ describe("derivePendingUserInputs", () => {
     ];
 
     expect(derivePendingUserInputs(activities)).toEqual([]);
+  });
+
+  it("suppresses stale pending user-input prompts when the authoritative shell summary says none remain", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "user-input-open-shell-reconciled",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "user-input.requested",
+        summary: "User input requested",
+        tone: "info",
+        payload: {
+          requestId: "req-user-input-shell-reconciled-1",
+          questions: [
+            {
+              id: "approval",
+              header: "Approval",
+              question: "Continue?",
+              options: [
+                {
+                  label: "yes",
+                  description: "Continue execution",
+                },
+              ],
+              multiSelect: false,
+            },
+          ],
+        },
+      }),
+    ];
+
+    expect(derivePendingUserInputs(activities, { hasPendingUserInput: false })).toEqual([]);
   });
 });
 

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -190,6 +190,9 @@ function isStalePendingRequestFailureDetail(detail: string | undefined): boolean
 
 export function derivePendingApprovals(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
+  options?: {
+    readonly hasPendingApprovals?: boolean;
+  },
 ): PendingApproval[] {
   const openByRequestId = new Map<ApprovalRequestId, PendingApproval>();
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
@@ -239,9 +242,13 @@ export function derivePendingApprovals(
     }
   }
 
-  return [...openByRequestId.values()].toSorted((left, right) =>
+  const pendingApprovals = [...openByRequestId.values()].toSorted((left, right) =>
     left.createdAt.localeCompare(right.createdAt),
   );
+  if (options?.hasPendingApprovals === false) {
+    return [];
+  }
+  return pendingApprovals;
 }
 
 function parseUserInputQuestions(
@@ -296,6 +303,9 @@ function parseUserInputQuestions(
 
 export function derivePendingUserInputs(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
+  options?: {
+    readonly hasPendingUserInput?: boolean;
+  },
 ): PendingUserInput[] {
   const openByRequestId = new Map<ApprovalRequestId, PendingUserInput>();
   const ordered = [...activities].toSorted(compareActivitiesByOrder);
@@ -338,9 +348,13 @@ export function derivePendingUserInputs(
     }
   }
 
-  return [...openByRequestId.values()].toSorted((left, right) =>
+  const pendingUserInputs = [...openByRequestId.values()].toSorted((left, right) =>
     left.createdAt.localeCompare(right.createdAt),
   );
+  if (options?.hasPendingUserInput === false) {
+    return [];
+  }
+  return pendingUserInputs;
 }
 
 export function deriveActivePlanState(

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -1,5 +1,6 @@
 import { scopeThreadRef } from "@t3tools/client-runtime";
 import {
+  ApprovalRequestId,
   CheckpointRef,
   DEFAULT_MODEL_BY_PROVIDER,
   EnvironmentId,
@@ -24,6 +25,7 @@ import {
   type AppState,
   type EnvironmentState,
 } from "./store";
+import { derivePendingApprovals, derivePendingUserInputs } from "./session-logic";
 import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type Thread } from "./types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
@@ -364,6 +366,174 @@ describe("thread selection memoization", () => {
       ),
     ).toBe(false);
     expect(selectThreadExistsByRef(state, null)).toBe(false);
+  });
+});
+
+describe("optimistic request responses", () => {
+  it("clears pending approvals as soon as an approval response is requested", () => {
+    const state = makeState(
+      makeThread({
+        activities: [
+          {
+            id: EventId.make("activity-approval-requested"),
+            createdAt: "2026-02-27T00:00:01.000Z",
+            kind: "approval.requested",
+            summary: "Command approval requested",
+            tone: "approval",
+            payload: {
+              requestId: "req-approval-1",
+              requestKind: "command",
+            },
+            turnId: null,
+          },
+        ],
+      }),
+    );
+
+    const nextState = applyOrchestrationEvent(
+      state,
+      makeEvent("thread.approval-response-requested", {
+        threadId: ThreadId.make("thread-1"),
+        requestId: ApprovalRequestId.make("req-approval-1"),
+        decision: "accept",
+        createdAt: "2026-02-27T00:00:02.000Z",
+      }),
+      localEnvironmentId,
+    );
+
+    const nextThread = selectThreadByRef(
+      nextState,
+      scopeThreadRef(localEnvironmentId, ThreadId.make("thread-1")),
+    );
+    expect(nextThread).not.toBeNull();
+    expect(derivePendingApprovals(nextThread?.activities ?? [])).toEqual([]);
+    expect(
+      nextThread?.activities.filter((activity) => activity.kind === "approval.resolved"),
+    ).toHaveLength(1);
+  });
+
+  it("replaces optimistic approval resolutions once the provider emits the real activity", () => {
+    const state = makeState(
+      makeThread({
+        activities: [
+          {
+            id: EventId.make("activity-approval-requested"),
+            createdAt: "2026-02-27T00:00:01.000Z",
+            kind: "approval.requested",
+            summary: "Command approval requested",
+            tone: "approval",
+            payload: {
+              requestId: "req-approval-2",
+              requestKind: "command",
+            },
+            turnId: null,
+          },
+        ],
+      }),
+    );
+
+    const afterResponseRequested = applyOrchestrationEvent(
+      state,
+      makeEvent("thread.approval-response-requested", {
+        threadId: ThreadId.make("thread-1"),
+        requestId: ApprovalRequestId.make("req-approval-2"),
+        decision: "accept",
+        createdAt: "2026-02-27T00:00:02.000Z",
+      }),
+      localEnvironmentId,
+    );
+
+    const afterProviderResolution = applyOrchestrationEvent(
+      afterResponseRequested,
+      makeEvent("thread.activity-appended", {
+        threadId: ThreadId.make("thread-1"),
+        activity: {
+          id: EventId.make("activity-approval-resolved"),
+          createdAt: "2026-02-27T00:00:02.100Z",
+          kind: "approval.resolved",
+          summary: "Approval resolved",
+          tone: "approval",
+          payload: {
+            requestId: "req-approval-2",
+            requestKind: "command",
+            decision: "accept",
+          },
+          turnId: null,
+        },
+      }),
+      localEnvironmentId,
+    );
+
+    const nextThread = selectThreadByRef(
+      afterProviderResolution,
+      scopeThreadRef(localEnvironmentId, ThreadId.make("thread-1")),
+    );
+    expect(nextThread).not.toBeNull();
+    expect(derivePendingApprovals(nextThread?.activities ?? [])).toEqual([]);
+    expect(
+      nextThread?.activities.filter(
+        (activity) =>
+          activity.kind === "approval.resolved" &&
+          (activity.payload as { requestId?: string }).requestId === "req-approval-2",
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("clears pending user input as soon as a response is requested", () => {
+    const state = makeState(
+      makeThread({
+        activities: [
+          {
+            id: EventId.make("activity-user-input-requested"),
+            createdAt: "2026-02-27T00:00:01.000Z",
+            kind: "user-input.requested",
+            summary: "User input requested",
+            tone: "info",
+            payload: {
+              requestId: "req-user-input-1",
+              questions: [
+                {
+                  id: "sandbox",
+                  header: "Sandbox",
+                  question: "Choose a mode",
+                  options: [
+                    {
+                      label: "workspace-write",
+                      description: "Allow writes inside the workspace",
+                    },
+                  ],
+                  multiSelect: false,
+                },
+              ],
+            },
+            turnId: null,
+          },
+        ],
+      }),
+    );
+
+    const nextState = applyOrchestrationEvent(
+      state,
+      makeEvent("thread.user-input-response-requested", {
+        threadId: ThreadId.make("thread-1"),
+        requestId: ApprovalRequestId.make("req-user-input-1"),
+        answers: {
+          sandbox: "workspace-write",
+        },
+        createdAt: "2026-02-27T00:00:02.000Z",
+      }),
+      localEnvironmentId,
+    );
+
+    const nextThread = selectThreadByRef(
+      nextState,
+      scopeThreadRef(localEnvironmentId, ThreadId.make("thread-1")),
+    );
+    expect(nextThread).not.toBeNull();
+    expect(derivePendingUserInputs(nextThread?.activities ?? [])).toEqual([]);
+    expect(
+      nextThread?.activities.filter((activity) => activity.kind === "user-input.resolved"),
+    ).toHaveLength(1);
   });
 });
 

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -461,6 +461,58 @@ function buildActivitySlice(thread: Thread): {
   };
 }
 
+function getActivityPayloadRecord(
+  activity: OrchestrationThreadActivity,
+): Record<string, unknown> | null {
+  return activity.payload && typeof activity.payload === "object"
+    ? (activity.payload as Record<string, unknown>)
+    : null;
+}
+
+function getActivityRequestId(activity: OrchestrationThreadActivity): string | null {
+  const payload = getActivityPayloadRecord(activity);
+  return typeof payload?.requestId === "string" ? payload.requestId : null;
+}
+
+function isOptimisticResponseActivity(activity: OrchestrationThreadActivity): boolean {
+  return getActivityPayloadRecord(activity)?.optimistic === true;
+}
+
+function appendThreadActivity(
+  thread: Thread,
+  activity: OrchestrationThreadActivity,
+  updatedAt: string,
+): Thread {
+  const requestId = getActivityRequestId(activity);
+  const existingActivities = [...thread.activities].filter((entry) => {
+    if (entry.id === activity.id) {
+      return false;
+    }
+
+    if (
+      requestId !== null &&
+      (activity.kind === "approval.resolved" || activity.kind === "user-input.resolved") &&
+      entry.kind === activity.kind &&
+      isOptimisticResponseActivity(entry) &&
+      getActivityRequestId(entry) === requestId
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+
+  const activities = [...existingActivities, activity]
+    .toSorted(compareActivities)
+    .slice(-MAX_THREAD_ACTIVITIES);
+
+  return {
+    ...thread,
+    activities,
+    updatedAt,
+  };
+}
+
 function buildProposedPlanSlice(thread: Thread): {
   ids: string[];
   byId: Record<string, ProposedPlan>;
@@ -1607,23 +1659,51 @@ function applyEnvironmentOrchestrationEvent(
       });
 
     case "thread.activity-appended":
-      return updateThreadState(state, event.payload.threadId, (thread) => {
-        const activities = [
-          ...thread.activities.filter((activity) => activity.id !== event.payload.activity.id),
-          { ...event.payload.activity },
-        ]
-          .toSorted(compareActivities)
-          .slice(-MAX_THREAD_ACTIVITIES);
-        return {
-          ...thread,
-          activities,
-          updatedAt: event.occurredAt,
-        };
-      });
+      return updateThreadState(state, event.payload.threadId, (thread) =>
+        appendThreadActivity(thread, { ...event.payload.activity }, event.occurredAt),
+      );
 
     case "thread.approval-response-requested":
+      return updateThreadState(state, event.payload.threadId, (thread) =>
+        appendThreadActivity(
+          thread,
+          {
+            id: event.eventId,
+            createdAt: event.payload.createdAt,
+            kind: "approval.resolved",
+            summary: "Approval resolved",
+            tone: "approval",
+            payload: {
+              requestId: event.payload.requestId,
+              decision: event.payload.decision,
+              optimistic: true,
+            },
+            turnId: null,
+          },
+          event.occurredAt,
+        ),
+      );
+
     case "thread.user-input-response-requested":
-      return state;
+      return updateThreadState(state, event.payload.threadId, (thread) =>
+        appendThreadActivity(
+          thread,
+          {
+            id: event.eventId,
+            createdAt: event.payload.createdAt,
+            kind: "user-input.resolved",
+            summary: "User input submitted",
+            tone: "info",
+            payload: {
+              requestId: event.payload.requestId,
+              answers: event.payload.answers,
+              optimistic: true,
+            },
+            turnId: null,
+          },
+          event.occurredAt,
+        ),
+      );
   }
 
   return state;


### PR DESCRIPTION
## Summary
- clear pending approval and pending user-input state immediately when the client sends the corresponding response command
- reconcile thread detail against the shell summary so previously approved Windows chats stop showing stale pending state after reload
- add regression tests for optimistic response handling and shell-summary reconciliation

## Windows issues addressed
- approvals could stay stuck on `Pending Approval` in existing chats even after the action had already been approved
- newly approved requests could remain visible until a later provider lifecycle event arrived, which made the Windows desktop app look inconsistent
- validated a fresh local Windows NSIS build (`release/T3-Code-0.0.20-x64.exe`) after the fix; the installer artifact was generated successfully and did not reproduce a blank embedded icon in the rebuilt package

## Verification
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run --cwd apps/web test -- src/store.test.ts src/session-logic.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client state derivation for pending approvals/user-inputs and injects optimistic activities into the thread store, which could affect approval gating and UI consistency if the reconciliation flags are wrong.
> 
> **Overview**
> Fixes stale "Pending approval" / "Pending user input" UI by **reconciling thread detail activities against the shell/sidebar summary**: `ChatView` now passes `hasPendingApprovals`/`hasPendingUserInput` into `derivePendingApprovals`/`derivePendingUserInputs`, and those derivations can now suppress all pending items when the shell says none remain.
> 
> Adds **optimistic resolution handling** in the store: when `thread.approval-response-requested` or `thread.user-input-response-requested` fires, the reducer appends an `approval.resolved` / `user-input.resolved` activity (flagged `optimistic`) immediately, and `appendThreadActivity` replaces that optimistic entry once the provider emits the real resolution activity. Regression tests cover both the shell-summary suppression and the optimistic response behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4877f2e08cd167046f6a33440fbb3c97901be982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale pending approvals and user-input prompts by adding optimistic resolution activities
> - When the user responds to an approval or user-input prompt, an optimistic `approval.resolved` or `user-input.resolved` activity is immediately appended to the thread, clearing the pending state before the provider confirms.
> - `derivePendingApprovals` and `derivePendingUserInputs` in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/2116/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) accept an optional options parameter; when the sidebar thread summary reports no pending items, they return an empty array to suppress stale UI state.
> - A new `appendThreadActivity` helper in [store.ts](https://github.com/pingdotgg/t3code/pull/2116/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82) handles deduplication and replaces optimistic activities with real ones when the provider emits the canonical resolved event for the same `requestId`.
> - Behavioral Change: pending approvals and user-input prompts now disappear immediately on response rather than waiting for the next provider event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4877f2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->