### PR TITLE
Update Electron to 41.2.1

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "effect": "catalog:",
-    "electron": "40.6.0",
+    "electron": "41.2.1",
     "electron-updater": "^6.6.2"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
       "version": "0.0.20",
       "dependencies": {
         "effect": "catalog:",
-        "electron": "40.6.0",
+        "electron": "41.2.1",
         "electron-updater": "^6.6.2",
       },
       "devDependencies": {
@@ -1058,7 +1058,7 @@
 
     "effect": ["effect@4.0.0-beta.45", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.5.3", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.8", "multipasta": "^0.2.7", "toml": "^3.0.0", "uuid": "^13.0.0", "yaml": "^2.8.2" } }, "sha512-vvNrUWqnzBIW1hRMa+zw0CLRW6HLgdu7hQ6K7PT/rS+UY/73Ma11O+Oi9oc9zwL8KcN37M47UDseAdlF0bGNWw=="],
 
-    "electron": ["electron@40.6.0", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-ett8W+yOFGDuM0vhJMamYSkrbV3LoaffzJd9GfjI96zRAxyrNqUSKqBpf/WGbQCweDxX2pkUCUfrv4wwKpsFZA=="],
+    "electron": ["electron@41.2.1", "", { "dependencies": { "@electron/get": "^2.0.0", "@types/node": "^24.9.0", "extract-zip": "^2.0.1" }, "bin": { "electron": "cli.js" } }, "sha512-teeRThiYGTPKf/2yOW7zZA1bhb91KEQ4yLBPOg7GxpmnkLFLugKgQaAKOrCgdzwsXh/5mFIfmkm+4+wACJKwaA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.313", "", {}, "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA=="],
 


### PR DESCRIPTION

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Bump the desktop app Electron runtime
- Refresh the lockfile to match the new version

## Why

Better Wayland desktop support. See:

https://www.electronjs.org/blog/tech-talk-wayland
https://www.electronjs.org/blog/electron-41-0#improved-wayland-support

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update Electron to 41.2.1 in the desktop app
> Bumps the `electron` dependency in [package.json](https://github.com/pingdotgg/t3code/pull/2117/files#diff-f260cda9a89e97068b04d6627600f3e650fcff63642da2f62c7b9412a2da2646) from 40.6.0 to 41.2.1 and updates the lockfile accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5de7705.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the desktop runtime dependency; while the code diff is small, Electron major-version bumps can introduce platform-specific regressions and packaging/runtime behavior changes.
> 
> **Overview**
> Updates the desktop app to run on **Electron 41.2.1** (from 40.6.0) by bumping the `electron` dependency in `apps/desktop/package.json`.
> 
> Refreshes `bun.lock` to align the lockfile with the new Electron version and integrity hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de7705b23492c02d09cacf20d2666d520045e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->