### PR TITLE
fix(web): add bidirectional text support for RTL languages

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -559,7 +559,10 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
   );
 
   return (
-    <div className="chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80">
+    <div
+      dir="auto"
+      className="chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80"
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={markdownComponents}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1338,6 +1338,7 @@ function ChatMarkdown({
 
   return (
     <div
+      dir="auto"
       className={cn(
         "chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80",
         className,

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1611,7 +1611,7 @@ function ComposerPromptEditorInner({
             <ContentEditable
               dir="auto"
               className={cn(
-                "block max-h-50 min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap wrap-break-word bg-transparent text-[16px] leading-relaxed text-foreground focus:outline-none sm:text-[14px]",
+                "composer-editor-bidi block max-h-50 min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap wrap-break-word bg-transparent text-[16px] leading-relaxed text-foreground focus:outline-none sm:text-[14px]",
                 className,
               )}
               data-testid="composer-editor"

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1623,6 +1623,7 @@ function ComposerPromptEditorInner({
         <PlainTextPlugin
           contentEditable={
             <ContentEditable
+              dir="auto"
               className={cn(
                 "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-[14px] leading-relaxed text-foreground focus:outline-none",
                 className,

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1609,6 +1609,7 @@ function ComposerPromptEditorInner({
         <PlainTextPlugin
           contentEditable={
             <ContentEditable
+              dir="auto"
               className={cn(
                 "block max-h-50 min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap wrap-break-word bg-transparent text-[16px] leading-relaxed text-foreground focus:outline-none sm:text-[14px]",
                 className,

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1625,7 +1625,7 @@ function ComposerPromptEditorInner({
             <ContentEditable
               dir="auto"
               className={cn(
-                "block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-[14px] leading-relaxed text-foreground focus:outline-none",
+                "composer-editor-bidi block max-h-[200px] min-h-17.5 w-full overflow-y-auto whitespace-pre-wrap break-words bg-transparent text-[14px] leading-relaxed text-foreground focus:outline-none",
                 className,
               )}
               data-testid="composer-editor"

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -251,7 +251,10 @@ const PlanSidebar = memo(function PlanSidebar({
                 ) : (
                   <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground/40 transition-transform" />
                 )}
-                <span dir="auto" className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase group-hover:text-muted-foreground/60">
+                <span
+                  dir="auto"
+                  className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase group-hover:text-muted-foreground/60"
+                >
                   {planTitle ?? "Full Plan"}
                 </span>
               </button>

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -246,7 +246,10 @@ const PlanSidebar = memo(function PlanSidebar({
                 ) : (
                   <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground/40 transition-transform" />
                 )}
-                <span dir="auto" className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase group-hover:text-muted-foreground/60">
+                <span
+                  dir="auto"
+                  className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase group-hover:text-muted-foreground/60"
+                >
                   {planTitle ?? "Full Plan"}
                 </span>
               </button>

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -194,7 +194,7 @@ const PlanSidebar = memo(function PlanSidebar({
         <div className="p-3 space-y-4">
           {/* Explanation */}
           {activePlan?.explanation ? (
-            <p className="text-[13px] leading-relaxed text-muted-foreground/80">
+            <p dir="auto" className="text-[13px] leading-relaxed text-muted-foreground/80">
               {activePlan.explanation}
             </p>
           ) : null}
@@ -216,6 +216,7 @@ const PlanSidebar = memo(function PlanSidebar({
                 >
                   <div className="mt-0.5">{stepStatusIcon(step.status)}</div>
                   <p
+                    dir="auto"
                     className={cn(
                       "text-[13px] leading-snug",
                       step.status === "completed"
@@ -237,7 +238,7 @@ const PlanSidebar = memo(function PlanSidebar({
             <div className="space-y-2">
               <button
                 type="button"
-                className="group flex w-full items-center gap-1.5 text-left"
+                className="group flex w-full items-center gap-1.5 text-start"
                 onClick={() => setProposedPlanExpanded((v) => !v)}
               >
                 {proposedPlanExpanded ? (
@@ -245,7 +246,7 @@ const PlanSidebar = memo(function PlanSidebar({
                 ) : (
                   <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground/40 transition-transform" />
                 )}
-                <span className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase group-hover:text-muted-foreground/60">
+                <span dir="auto" className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase group-hover:text-muted-foreground/60">
                   {planTitle ?? "Full Plan"}
                 </span>
               </button>

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -199,7 +199,7 @@ const PlanSidebar = memo(function PlanSidebar({
         <div className="p-3 space-y-4">
           {/* Explanation */}
           {activePlan?.explanation ? (
-            <p className="text-[13px] leading-relaxed text-muted-foreground/80">
+            <p dir="auto" className="text-[13px] leading-relaxed text-muted-foreground/80">
               {activePlan.explanation}
             </p>
           ) : null}
@@ -221,6 +221,7 @@ const PlanSidebar = memo(function PlanSidebar({
                 >
                   {stepStatusIcon(step.status)}
                   <p
+                    dir="auto"
                     className={cn(
                       "text-[13px] leading-snug",
                       step.status === "completed"
@@ -242,7 +243,7 @@ const PlanSidebar = memo(function PlanSidebar({
             <div className="space-y-2">
               <button
                 type="button"
-                className="group flex w-full items-center gap-1.5 text-left"
+                className="group flex w-full items-center gap-1.5 text-start"
                 onClick={() => setProposedPlanExpanded((v) => !v)}
               >
                 {proposedPlanExpanded ? (
@@ -250,7 +251,7 @@ const PlanSidebar = memo(function PlanSidebar({
                 ) : (
                   <ChevronRightIcon className="size-3 shrink-0 text-muted-foreground/40 transition-transform" />
                 )}
-                <span className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase group-hover:text-muted-foreground/60">
+                <span dir="auto" className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase group-hover:text-muted-foreground/60">
                   {planTitle ?? "Full Plan"}
                 </span>
               </button>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -592,6 +592,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
               <TooltipTrigger
                 render={
                   <span
+                    dir="auto"
                     className="min-w-0 flex-1 truncate text-xs"
                     data-testid={`thread-title-${thread.id}`}
                   >

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -641,6 +641,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
               <TooltipTrigger
                 render={
                   <span
+                    dir="auto"
                     className="min-w-0 flex-1 truncate text-xs"
                     data-testid={`thread-title-${thread.id}`}
                   >

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -73,6 +73,7 @@ export const ChatHeader = memo(function ChatHeader({
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
         <SidebarTrigger className="size-7 shrink-0 md:hidden" />
         <h2
+          dir="auto"
           className="min-w-0 shrink truncate text-sm font-medium text-foreground"
           title={activeThreadTitle}
         >

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -79,6 +79,7 @@ export const ChatHeader = memo(function ChatHeader({
           <TooltipTrigger
             render={
               <h2
+                dir="auto"
                 aria-label={activeThreadTitle}
                 className="min-w-0 flex-1 basis-40 truncate text-sm font-medium text-foreground"
               >

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -153,7 +153,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   const customAnswerActive = progress.customAnswer.trim().length > 0;
 
   return (
-    <div dir="auto" className="px-4 py-3 sm:px-5">
+    <div className="px-4 py-3 sm:px-5">
       <div className="mb-2 flex items-center gap-3">
         <span className="text-[11px] font-semibold tracking-widest text-muted-foreground/55 uppercase">
           {activeQuestion.header}

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -124,7 +124,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   }
 
   return (
-    <div dir="auto" className="px-4 py-3 sm:px-5">
+    <div className="px-4 py-3 sm:px-5">
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-2">
           {prompt.questions.length > 1 ? (
@@ -137,9 +137,13 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
           </span>
         </div>
       </div>
-      <p dir="auto" className="mt-1.5 text-sm text-foreground/90">{activeQuestion.question}</p>
+      <p dir="auto" className="mt-1.5 text-sm text-foreground/90">
+        {activeQuestion.question}
+      </p>
       {activeQuestion.multiSelect ? (
-        <p dir="auto" className="mt-1 text-xs text-muted-foreground/65">Select one or more options.</p>
+        <p dir="auto" className="mt-1 text-xs text-muted-foreground/65">
+          Select one or more options.
+        </p>
       ) : null}
       <div className="mt-3 space-y-1">
         {activeQuestion.options.map((option, index) => {
@@ -172,7 +176,9 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
                 </kbd>
               ) : null}
               <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
-                <span dir="auto" className="text-sm font-medium">{option.label}</span>
+                <span dir="auto" className="text-sm font-medium">
+                  {option.label}
+                </span>
                 {option.description && option.description !== option.label ? (
                   <span dir="auto" className="text-xs text-muted-foreground/50">
                     {option.description}

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -124,7 +124,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   }
 
   return (
-    <div className="px-4 py-3 sm:px-5">
+    <div dir="auto" className="px-4 py-3 sm:px-5">
       <div className="flex items-center gap-3">
         <div className="flex items-center gap-2">
           {prompt.questions.length > 1 ? (
@@ -137,9 +137,9 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
           </span>
         </div>
       </div>
-      <p className="mt-1.5 text-sm text-foreground/90">{activeQuestion.question}</p>
+      <p dir="auto" className="mt-1.5 text-sm text-foreground/90">{activeQuestion.question}</p>
       {activeQuestion.multiSelect ? (
-        <p className="mt-1 text-xs text-muted-foreground/65">Select one or more options.</p>
+        <p dir="auto" className="mt-1 text-xs text-muted-foreground/65">Select one or more options.</p>
       ) : null}
       <div className="mt-3 space-y-1">
         {activeQuestion.options.map((option, index) => {
@@ -152,7 +152,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
               disabled={isResponding}
               onClick={() => handleOptionSelection(activeQuestion.id, option.label)}
               className={cn(
-                "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition-all duration-150",
+                "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-start transition-all duration-150",
                 isSelected
                   ? "border-blue-500/40 bg-blue-500/8 text-foreground"
                   : "border-transparent bg-muted/20 text-foreground/80 hover:bg-muted/40 hover:border-border/40",
@@ -171,10 +171,10 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
                   {shortcutKey}
                 </kbd>
               ) : null}
-              <div className="min-w-0 flex-1">
-                <span className="text-sm font-medium">{option.label}</span>
+              <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2">
+                <span dir="auto" className="text-sm font-medium">{option.label}</span>
                 {option.description && option.description !== option.label ? (
-                  <span className="ml-2 text-xs text-muted-foreground/50">
+                  <span dir="auto" className="text-xs text-muted-foreground/50">
                     {option.description}
                   </span>
                 ) : null}

--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -153,7 +153,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
   const customAnswerActive = progress.customAnswer.trim().length > 0;
 
   return (
-    <div className="px-4 py-3 sm:px-5">
+    <div dir="auto" className="px-4 py-3 sm:px-5">
       <div className="mb-2 flex items-center gap-3">
         <span className="text-[11px] font-semibold tracking-widest text-muted-foreground/55 uppercase">
           {activeQuestion.header}
@@ -164,9 +164,13 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
           </span>
         ) : null}
       </div>
-      <p className="text-sm text-foreground/90">{activeQuestion.question}</p>
+      <p dir="auto" className="text-sm text-foreground/90">
+        {activeQuestion.question}
+      </p>
       {activeQuestion.multiSelect ? (
-        <p className="mt-1 text-xs text-muted-foreground/65">Select one or more options.</p>
+        <p dir="auto" className="mt-1 text-xs text-muted-foreground/65">
+          Select one or more options.
+        </p>
       ) : null}
       <div className="mt-3 space-y-1.5">
         {activeQuestion.options.map((option, index) => {
@@ -178,7 +182,7 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
             (!customAnswerActive && progress.selectedOptionLabels.includes(option.label));
           const shortcutKey = index < 9 ? index + 1 : null;
           const className = cn(
-            "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left outline-none transition-all duration-150 focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/25",
+            "group flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-start outline-none transition-all duration-150 focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/25",
             isSelected
               ? "border-primary/30 bg-primary/8 text-foreground"
               : "border-transparent bg-muted/22 text-foreground/85 hover:border-border/45 hover:bg-muted/34",
@@ -188,9 +192,13 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
           const content = (
             <>
               <div className="min-w-0 flex-1 flex flex-col gap-0.5">
-                <span className="text-sm font-medium">{option.label}</span>
+                <span dir="auto" className="text-sm font-medium">
+                  {option.label}
+                </span>
                 {option.description && option.description !== option.label ? (
-                  <span className="text-xs text-muted-foreground/50">{option.description}</span>
+                  <span dir="auto" className="text-xs text-muted-foreground/50">
+                    {option.description}
+                  </span>
                 ) : null}
               </div>
               {isSelected ? (

--- a/apps/web/src/components/chat/ComposerPlanFollowUpBanner.tsx
+++ b/apps/web/src/components/chat/ComposerPlanFollowUpBanner.tsx
@@ -17,7 +17,9 @@ export const ComposerPlanFollowUpBanner = memo(function ComposerPlanFollowUpBann
           Plan Ready
         </Badge>
         {planTitle ? (
-          <span dir="auto" className="min-w-0 flex-1 truncate text-sm font-medium">{planTitle}</span>
+          <span dir="auto" className="min-w-0 flex-1 truncate text-sm font-medium">
+            {planTitle}
+          </span>
         ) : null}
       </div>
       {/* <div className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/chat/ComposerPlanFollowUpBanner.tsx
+++ b/apps/web/src/components/chat/ComposerPlanFollowUpBanner.tsx
@@ -10,7 +10,7 @@ export const ComposerPlanFollowUpBanner = memo(function ComposerPlanFollowUpBann
       <div className="flex flex-wrap items-center gap-2">
         <span className="uppercase text-sm tracking-[0.2em]">Plan ready</span>
         {planTitle ? (
-          <span className="min-w-0 flex-1 truncate text-sm font-medium">{planTitle}</span>
+          <span dir="auto" className="min-w-0 flex-1 truncate text-sm font-medium">{planTitle}</span>
         ) : null}
       </div>
       {/* <div className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/chat/ComposerPlanFollowUpBanner.tsx
+++ b/apps/web/src/components/chat/ComposerPlanFollowUpBanner.tsx
@@ -17,7 +17,7 @@ export const ComposerPlanFollowUpBanner = memo(function ComposerPlanFollowUpBann
           Plan Ready
         </Badge>
         {planTitle ? (
-          <span className="min-w-0 flex-1 truncate text-sm font-medium">{planTitle}</span>
+          <span dir="auto" className="min-w-0 flex-1 truncate text-sm font-medium">{planTitle}</span>
         ) : null}
       </div>
       {/* <div className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/chat/ComposerPlanFollowUpBanner.tsx
+++ b/apps/web/src/components/chat/ComposerPlanFollowUpBanner.tsx
@@ -10,7 +10,9 @@ export const ComposerPlanFollowUpBanner = memo(function ComposerPlanFollowUpBann
       <div className="flex flex-wrap items-center gap-2">
         <span className="uppercase text-sm tracking-[0.2em]">Plan ready</span>
         {planTitle ? (
-          <span dir="auto" className="min-w-0 flex-1 truncate text-sm font-medium">{planTitle}</span>
+          <span dir="auto" className="min-w-0 flex-1 truncate text-sm font-medium">
+            {planTitle}
+          </span>
         ) : null}
       </div>
       {/* <div className="mt-2 text-xs text-muted-foreground">

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -729,7 +729,10 @@ const UserMessageBody = memo(function UserMessageBody(props: {
         }
 
         return (
-          <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
+          <div
+            dir="auto"
+            className="user-message-text whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground"
+          >
             {inlineNodes}
           </div>
         );
@@ -757,7 +760,10 @@ const UserMessageBody = memo(function UserMessageBody(props: {
     }
 
     return (
-      <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
+      <div
+        dir="auto"
+        className="user-message-text whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground"
+      >
         {inlineNodes}
       </div>
     );
@@ -768,7 +774,10 @@ const UserMessageBody = memo(function UserMessageBody(props: {
   }
 
   return (
-    <div className="whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground">
+    <div
+      dir="auto"
+      className="user-message-text whitespace-pre-wrap wrap-break-word text-sm leading-relaxed text-foreground"
+    >
       {props.text}
     </div>
   );

--- a/apps/web/src/components/chat/ProposedPlanCard.tsx
+++ b/apps/web/src/components/chat/ProposedPlanCard.tsx
@@ -143,7 +143,9 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <Badge variant="secondary">Plan</Badge>
-          <p dir="auto" className="truncate text-sm font-medium text-foreground">{title}</p>
+          <p dir="auto" className="truncate text-sm font-medium text-foreground">
+            {title}
+          </p>
         </div>
         <Menu>
           <MenuTrigger

--- a/apps/web/src/components/chat/ProposedPlanCard.tsx
+++ b/apps/web/src/components/chat/ProposedPlanCard.tsx
@@ -143,7 +143,7 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <Badge variant="secondary">Plan</Badge>
-          <p className="truncate text-sm font-medium text-foreground">{title}</p>
+          <p dir="auto" className="truncate text-sm font-medium text-foreground">{title}</p>
         </div>
         <Menu>
           <MenuTrigger

--- a/apps/web/src/components/chat/ProposedPlanCard.tsx
+++ b/apps/web/src/components/chat/ProposedPlanCard.tsx
@@ -135,7 +135,9 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <Badge variant="secondary">Plan</Badge>
-          <p dir="auto" className="truncate text-sm font-medium text-foreground">{title}</p>
+          <p dir="auto" className="truncate text-sm font-medium text-foreground">
+            {title}
+          </p>
         </div>
         <Menu>
           <MenuTrigger

--- a/apps/web/src/components/chat/ProposedPlanCard.tsx
+++ b/apps/web/src/components/chat/ProposedPlanCard.tsx
@@ -135,7 +135,7 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <Badge variant="secondary">Plan</Badge>
-          <p className="truncate text-sm font-medium text-foreground">{title}</p>
+          <p dir="auto" className="truncate text-sm font-medium text-foreground">{title}</p>
         </div>
         <Menu>
           <MenuTrigger

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1484,7 +1484,7 @@ export function ArchivedThreadsPanel() {
                     },
                   );
                 }}
-                title={thread.title}
+                title={<span dir="auto">{thread.title}</span>}
                 description={
                   <>
                     Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1603,7 +1603,7 @@ export function ArchivedThreadsPanel() {
                 }}
               >
                 <div className="min-w-0 flex-1">
-                  <h3 className="truncate text-sm font-medium text-foreground">{thread.title}</h3>
+                  <h3 dir="auto" className="truncate text-sm font-medium text-foreground">{thread.title}</h3>
                   <p className="text-xs text-muted-foreground">
                     Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}
                     {" \u00b7 Created "}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1603,7 +1603,9 @@ export function ArchivedThreadsPanel() {
                 }}
               >
                 <div className="min-w-0 flex-1">
-                  <h3 dir="auto" className="truncate text-sm font-medium text-foreground">{thread.title}</h3>
+                  <h3 dir="auto" className="truncate text-sm font-medium text-foreground">
+                    {thread.title}
+                  </h3>
                   <p className="text-xs text-muted-foreground">
                     Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}
                     {" \u00b7 Created "}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -359,8 +359,8 @@ label:has(> select#reasoning-effort) select {
 
 /* Per-line direction detection for pre-wrap user messages and composer */
 .user-message-text,
-[data-testid="composer-editor"],
-[data-testid="composer-editor"] p {
+.composer-editor-bidi,
+.composer-editor-bidi p {
   unicode-bidi: plaintext;
 }
 
@@ -416,12 +416,12 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown ul {
-  padding-left: 1.25rem;
+  padding-inline-start: 1.25rem;
   list-style-type: disc;
 }
 
 .chat-markdown ol {
-  padding-left: 1.25rem;
+  padding-inline-start: 1.25rem;
   list-style-type: decimal;
 }
 
@@ -481,8 +481,8 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown blockquote {
-  border-left: 2px solid var(--border);
-  padding-left: 0.8rem;
+  border-inline-start: 2px solid var(--border);
+  padding-inline-start: 0.8rem;
   color: var(--muted-foreground);
 }
 
@@ -665,7 +665,7 @@ label:has(> select#reasoning-effort) select {
 .chat-markdown th,
 .chat-markdown td {
   padding: 0.45rem 0.75rem;
-  text-align: left;
+  text-align: start;
 }
 
 .chat-markdown thead th {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -277,8 +277,8 @@ label:has(> select#reasoning-effort) select {
 
 /* Per-line direction detection for pre-wrap user messages and composer */
 .user-message-text,
-[data-testid="composer-editor"],
-[data-testid="composer-editor"] p {
+.composer-editor-bidi,
+.composer-editor-bidi p {
   unicode-bidi: plaintext;
 }
 
@@ -300,12 +300,12 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown ul {
-  padding-left: 1.25rem;
+  padding-inline-start: 1.25rem;
   list-style-type: disc;
 }
 
 .chat-markdown ol {
-  padding-left: 1.25rem;
+  padding-inline-start: 1.25rem;
   list-style-type: decimal;
 }
 
@@ -340,8 +340,8 @@ label:has(> select#reasoning-effort) select {
 }
 
 .chat-markdown blockquote {
-  border-left: 2px solid var(--border);
-  padding-left: 0.8rem;
+  border-inline-start: 2px solid var(--border);
+  padding-inline-start: 0.8rem;
   color: var(--muted-foreground);
 }
 
@@ -487,7 +487,7 @@ label:has(> select#reasoning-effort) select {
 .chat-markdown td {
   border: 1px solid var(--border);
   padding: 0.35rem 0.45rem;
-  text-align: left;
+  text-align: start;
 }
 
 /* Diffs theme bridge (match diff surfaces to app palette) */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -252,6 +252,36 @@ label:has(> select#reasoning-effort) select {
   word-break: break-word;
 }
 
+/* Bidirectional text direction detection for mixed RTL/LTR content */
+.chat-markdown p,
+.chat-markdown li,
+.chat-markdown td,
+.chat-markdown th,
+.chat-markdown h1,
+.chat-markdown h2,
+.chat-markdown h3,
+.chat-markdown h4,
+.chat-markdown h5,
+.chat-markdown h6,
+.chat-markdown blockquote {
+  unicode-bidi: plaintext;
+}
+
+/* Code and tables remain LTR regardless of surrounding text direction */
+.chat-markdown pre,
+.chat-markdown code,
+.chat-markdown table {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+/* Per-line direction detection for pre-wrap user messages and composer */
+.user-message-text,
+[data-testid="composer-editor"],
+[data-testid="composer-editor"] p {
+  unicode-bidi: plaintext;
+}
+
 .chat-markdown > :first-child {
   margin-top: 0;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -334,6 +334,36 @@ label:has(> select#reasoning-effort) select {
   word-break: break-word;
 }
 
+/* Bidirectional text direction detection for mixed RTL/LTR content */
+.chat-markdown p,
+.chat-markdown li,
+.chat-markdown td,
+.chat-markdown th,
+.chat-markdown h1,
+.chat-markdown h2,
+.chat-markdown h3,
+.chat-markdown h4,
+.chat-markdown h5,
+.chat-markdown h6,
+.chat-markdown blockquote {
+  unicode-bidi: plaintext;
+}
+
+/* Code and tables remain LTR regardless of surrounding text direction */
+.chat-markdown pre,
+.chat-markdown code,
+.chat-markdown table {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+/* Per-line direction detection for pre-wrap user messages and composer */
+.user-message-text,
+[data-testid="composer-editor"],
+[data-testid="composer-editor"] p {
+  unicode-bidi: plaintext;
+}
+
 .chat-markdown > :first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
## What Changed

- Added dir="auto" and unicode-bidi: plaintext to chat messages, 
  composer, question panels, thread titles, plan sidebar, and 
  plan cards
- Replaced margin-left, text-left, border-left with logical 
  properties (text-start, gap-x, border-inline-start)
- Code blocks and tables isolated as LTR so they don't flip

## Why

RTL text like Arabic and Hebrew was unreadable when mixed with 
English. Punctuation jumping around, words in wrong order. 
dir="auto" lets the browser figure out direction per element 
from the first strong character, which is the standard fix for this.

Addresses #1771 

## UI Changes

### Before

https://github.com/user-attachments/assets/5b35ccca-5259-45fe-95be-12b3e030a89f



### After

https://github.com/user-attachments/assets/0bfcc85f-29e4-4714-a7d6-f84ee67bc137



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS and HTML attributes with no auth, data, or API changes; main risk is minor layout regressions in edge LTR cases.
> 
> **Overview**
> Improves readability of mixed RTL/LTR content (e.g. Arabic, Hebrew with English) by letting the browser infer text direction per block instead of forcing LTR everywhere.
> 
> **`dir="auto"`** is added on chat markdown, the composer `ContentEditable`, plan sidebar copy (explanations, steps, titles), thread titles in the sidebar and header, pending user-input questions/options, plan banners/cards, and archived thread titles in settings.
> 
> **`index.css`** adds `unicode-bidi: plaintext` on chat markdown prose and on `.user-message-text` / `.composer-editor-bidi` for per-line direction in pre-wrap text; keeps **`pre` / `code` / `table`** LTR with `unicode-bidi: isolate`. List/blockquote/table styling switches to logical properties (`padding-inline-start`, `border-inline-start`, `text-align: start`).
> 
> A few controls use **`text-start`** instead of **`text-left`** so alignment follows layout direction in RTL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc50decb1ae8ab26f7e2f11325a3e911e49c721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bidirectional text support for RTL languages across chat UI components
> - Adds `dir="auto"` to text-bearing elements across chat components (`ChatMarkdown`, `ComposerPromptEditor`, `PlanSidebar`, `ChatHeader`, sidebar thread titles, plan cards, and archived thread settings) so each element auto-detects RTL/LTR direction from its content.
> - Updates [index.css](https://github.com/pingdotgg/t3code/pull/2128/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) with bidi-aware CSS: sets `unicode-bidi: plaintext` on text elements in `.chat-markdown` for per-paragraph direction detection, forces `direction: ltr` on code blocks and tables, and switches list/blockquote spacing to logical CSS properties (`padding-inline-start`, `border-inline-start`).
> - Changes a `text-left` class to `text-start` in `PlanSidebar` for logical alignment in bidi contexts.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3cc50de. 10 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->