### PR TITLE
Modernize release workflow runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
             target: AppImage
             arch: x64
           - label: Windows x64
-            runner: windows-2022 # blacksmith-32vcpu-windows-2025
+            runner: blacksmith-32vcpu-windows-2025
             platform: win
             target: nsis
             arch: x64
@@ -187,6 +187,18 @@ jobs:
 
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
+
+      - name: Install Spectre-mitigated MSVC libs
+        if: matrix.platform == 'win'
+        shell: bash
+        run: |
+          vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          installPath = & $vswhere -products * -latest -property installationPath
+          setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+          Start-Process -FilePath $setupExe `   
+           -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `               
+           "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre", "--quiet", "--norestart" `
+           -Wait -PassThru -NoNewWindow
 
       - name: Build desktop artifact
         shell: bash
@@ -333,7 +345,7 @@ jobs:
   release:
     name: Publish GitHub Release
     needs: [preflight, build, publish_cli]
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -341,10 +353,18 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.ref }}
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Download all desktop artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,10 +195,15 @@ jobs:
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
              $installPath = & $vswhere -products * -latest -property installationPath
              $setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
-             Start-Process -FilePath $setupExe `
+             $proc = Start-Process -FilePath $setupExe `
               -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `
               "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre", "--quiet", "--norestart" `
               -Wait -PassThru -NoNewWindow
+             if ($null -eq $proc -or $proc.ExitCode -ne 0) {
+               $code = if ($null -ne $proc) { $proc.ExitCode } else { 1 }
+               Write-Error "Visual Studio Installer failed with exit code $code"
+               exit $code
+             }
 
       - name: Build desktop artifact
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,8 +195,8 @@ jobs:
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
              $installPath = & $vswhere -products * -latest -property installationPath
              $setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
-             Start-Process -FilePath $setupExe `   
-              -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `               
+             Start-Process -FilePath $setupExe `
+              -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `
               "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre", "--quiet", "--norestart" `
               -Wait -PassThru -NoNewWindow
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,15 +190,15 @@ jobs:
 
       - name: Install Spectre-mitigated MSVC libs
         if: matrix.platform == 'win'
-        shell: bash
+        shell: pwsh
         run: |
-          vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          installPath = & $vswhere -products * -latest -property installationPath
-          setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
-          Start-Process -FilePath $setupExe `   
-           -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `               
-           "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre", "--quiet", "--norestart" `
-           -Wait -PassThru -NoNewWindow
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+             $installPath = & $vswhere -products * -latest -property installationPath
+             $setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+             Start-Process -FilePath $setupExe `   
+              -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `               
+              "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre", "--quiet", "--norestart" `
+              -Wait -PassThru -NoNewWindow
 
       - name: Build desktop artifact
         shell: bash


### PR DESCRIPTION
## Summary
- Switched the Windows build job to `blacksmith-32vcpu-windows-2025` for the release matrix.
- Added a Windows step to install Spectre-mitigated MSVC libraries before building desktop artifacts.
- Moved the release publishing job to GitHub-hosted `ubuntu-24.04` and set up Bun there.
- Installed dependencies in the release job before downloading artifacts and publishing the release.

## Testing
- Not run (workflow-only change).
- Expected validation: release workflow should build Windows artifacts successfully with the Spectre-mitigated toolchain.
- Expected validation: publish job should complete on `ubuntu-24.04` after `bun install --frozen-lockfile`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow-only changes, but they modify CI runner environments and Windows toolchain installation; failures would block releases rather than affect runtime behavior.
> 
> **Overview**
> Modernizes the `release.yml` workflow by moving the Windows x64 build to `blacksmith-32vcpu-windows-2025` and adding a pre-build PowerShell step to install Spectre-mitigated MSVC components.
> 
> Switches the GitHub Release publishing job to GitHub-hosted `ubuntu-24.04` and adds Bun setup plus `bun install --frozen-lockfile` in that job before downloading artifacts and publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2c1cb0f38e1c6b0790d9c1e03c7dad79a76646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Modernize release workflow runners and add Spectre-mitigated MSVC libs for Windows builds
> Updates [release.yml](.github/workflows/release.yml) to use updated runners and toolchain setup:
> - Switches the Windows x64 build runner from `windows-2022` to `blacksmith-32vcpu-windows-2025`
> - Adds a Windows-only step to install Spectre-mitigated MSVC libraries via the Visual Studio Installer before building
> - Switches the release job runner from `blacksmith-8vcpu-ubuntu-2404` to the GitHub-hosted `ubuntu-24.04`
> - Adds Bun setup and `bun install --frozen-lockfile` steps to the release job
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba2c1cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->