### PR TITLE
Extract backend startup readiness coordination

### DIFF
--- a/apps/desktop/src/backendStartupReadiness.test.ts
+++ b/apps/desktop/src/backendStartupReadiness.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BackendReadinessAbortedError } from "./backendReadiness.ts";
+import { waitForBackendStartupReady } from "./backendStartupReadiness.ts";
+
+describe("waitForBackendStartupReady", () => {
+  it("falls back to the HTTP probe when no listening signal exists", async () => {
+    const waitForHttpReady = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const cancelHttpWait = vi.fn();
+
+    await expect(
+      waitForBackendStartupReady({
+        waitForHttpReady,
+        cancelHttpWait,
+      }),
+    ).resolves.toBe("http");
+
+    expect(waitForHttpReady).toHaveBeenCalledTimes(1);
+    expect(cancelHttpWait).not.toHaveBeenCalled();
+  });
+
+  it("uses the listening signal and cancels the HTTP probe", async () => {
+    let rejectHttpWait: ((error: unknown) => void) | null = null;
+    const waitForHttpReady = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectHttpWait = reject;
+        }),
+    );
+    const cancelHttpWait = vi.fn(() => {
+      rejectHttpWait?.(new BackendReadinessAbortedError());
+    });
+
+    await expect(
+      waitForBackendStartupReady({
+        listeningPromise: Promise.resolve(),
+        waitForHttpReady,
+        cancelHttpWait,
+      }),
+    ).resolves.toBe("listening");
+
+    expect(waitForHttpReady).toHaveBeenCalledTimes(1);
+    expect(cancelHttpWait).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the listening signal fails before HTTP readiness", async () => {
+    const error = new Error("backend exited");
+    const waitForHttpReady = vi.fn(() => new Promise<void>(() => {}));
+
+    await expect(
+      waitForBackendStartupReady({
+        listeningPromise: Promise.reject(error),
+        waitForHttpReady,
+        cancelHttpWait: vi.fn(),
+      }),
+    ).rejects.toBe(error);
+  });
+});

--- a/apps/desktop/src/backendStartupReadiness.ts
+++ b/apps/desktop/src/backendStartupReadiness.ts
@@ -1,0 +1,56 @@
+import { isBackendReadinessAborted } from "./backendReadiness.ts";
+
+export interface WaitForBackendStartupReadyOptions {
+  readonly listeningPromise?: Promise<void> | null;
+  readonly waitForHttpReady: () => Promise<void>;
+  readonly cancelHttpWait: () => void;
+}
+
+export async function waitForBackendStartupReady(
+  options: WaitForBackendStartupReadyOptions,
+): Promise<"listening" | "http"> {
+  const httpReadyPromise = options.waitForHttpReady();
+  const listeningPromise = options.listeningPromise;
+
+  if (!listeningPromise) {
+    await httpReadyPromise;
+    return "http";
+  }
+
+  return await new Promise<"listening" | "http">((resolve, reject) => {
+    let settled = false;
+
+    const settleResolve = (source: "listening" | "http") => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (source === "listening") {
+        options.cancelHttpWait();
+      }
+      resolve(source);
+    };
+
+    const settleReject = (error: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(error);
+    };
+
+    listeningPromise.then(
+      () => settleResolve("listening"),
+      (error) => settleReject(error),
+    );
+    httpReadyPromise.then(
+      () => settleResolve("http"),
+      (error) => {
+        if (settled && isBackendReadinessAborted(error)) {
+          return;
+        }
+        settleReject(error);
+      },
+    );
+  });
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -57,6 +57,7 @@ import { isBackendReadinessAborted, waitForHttpReady } from "./backendReadiness.
 import { showDesktopConfirmDialog } from "./confirmDialog.ts";
 import { resolveDesktopServerExposure } from "./serverExposure.ts";
 import { syncShellEnvironment } from "./syncShellEnvironment.ts";
+import { waitForBackendStartupReady } from "./backendStartupReadiness.ts";
 import { getAutoUpdateDisabledReason, shouldBroadcastDownloadProgress } from "./updateState.ts";
 import { doesVersionMatchDesktopUpdateChannel } from "./updateChannels.ts";
 import { ServerListeningDetector } from "./serverListeningDetector.ts";
@@ -459,51 +460,13 @@ function cancelBackendReadinessWait(): void {
 }
 
 async function waitForBackendWindowReady(baseUrl: string): Promise<"listening" | "http"> {
-  const httpReadyPromise = waitForBackendHttpReady(baseUrl, {
-    timeoutMs: 60_000,
-  });
-  const listeningPromise = backendListeningDetector?.promise;
-
-  if (!listeningPromise) {
-    await httpReadyPromise;
-    return "http";
-  }
-
-  return await new Promise<"listening" | "http">((resolve, reject) => {
-    let settled = false;
-
-    const settleResolve = (source: "listening" | "http") => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      if (source === "listening") {
-        cancelBackendReadinessWait();
-      }
-      resolve(source);
-    };
-
-    const settleReject = (error: unknown) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      reject(error);
-    };
-
-    listeningPromise.then(
-      () => settleResolve("listening"),
-      (error) => settleReject(error),
-    );
-    httpReadyPromise.then(
-      () => settleResolve("http"),
-      (error) => {
-        if (settled && isBackendReadinessAborted(error)) {
-          return;
-        }
-        settleReject(error);
-      },
-    );
+  return await waitForBackendStartupReady({
+    listeningPromise: backendListeningDetector?.promise ?? null,
+    waitForHttpReady: () =>
+      waitForBackendHttpReady(baseUrl, {
+        timeoutMs: 60_000,
+      }),
+    cancelHttpWait: cancelBackendReadinessWait,
   });
 }
 
@@ -2119,9 +2082,9 @@ async function bootstrap(): Promise<void> {
   if (isDevelopment) {
     mainWindow = createWindow();
     writeDesktopLogHeader("bootstrap main window created");
-    void waitForBackendHttpReady(backendHttpUrl)
-      .then(() => {
-        writeDesktopLogHeader("bootstrap backend ready");
+    void waitForBackendWindowReady(backendHttpUrl)
+      .then((source) => {
+        writeDesktopLogHeader(`bootstrap backend ready source=${source}`);
       })
       .catch((error) => {
         if (isBackendReadinessAborted(error)) {


### PR DESCRIPTION
## Summary
- Extract backend startup readiness orchestration into `backendStartupReadiness.ts` to centralize the race between the backend listening signal and HTTP readiness probe.
- Preserve the cancellation path so an early listening signal still aborts the HTTP wait cleanly.
- Update desktop bootstrap logging to record which readiness source won.
- Add unit coverage for the startup readiness helper, including fallback, listening-first, and failure cases.

## Testing
- `bun run test` for `apps/desktop/src/backendStartupReadiness.test.ts`
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that moves existing readiness orchestration into a helper and adds tests; behavioral changes are limited to readiness selection/cancellation and log output.
> 
> **Overview**
> Centralizes backend startup readiness coordination into a new `waitForBackendStartupReady` helper that races a backend *listening* signal against the existing HTTP readiness probe, preserving the abort/cancellation behavior when listening wins.
> 
> Updates desktop bootstrap (`main.ts`) to use the new helper instead of inline promise-race logic, and enhances logging to record which readiness source (`listening` vs `http`) determined readiness. Adds focused Vitest coverage for fallback, listening-first cancellation, and listening-failure cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afed1d79efd7004cbcf64947fb8c51f3290692c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract backend startup readiness coordination into `waitForBackendStartupReady`
> - Moves the backend readiness race logic from `main.ts` into a standalone `waitForBackendStartupReady` utility in [backendStartupReadiness.ts](https://github.com/pingdotgg/t3code/pull/2133/files#diff-4011d3775e51bf13440e6bd86c9ccac12194c1eefaf2ba9d923b0418c989f8ae), covered by a new test suite.
> - The utility races an optional `listeningPromise` against an HTTP readiness probe, resolves with whichever wins (`"listening"` or `"http"`), and cancels the HTTP probe when the listening signal arrives first.
> - Late HTTP rejections caused by an intentional abort are suppressed if the promise is already settled; other rejections propagate normally.
> - In the development bootstrap path, `main.ts` now calls `waitForBackendWindowReady` (instead of `waitForBackendHttpReady` directly) and logs the winning readiness source.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afed1d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->