### PR TITLE
Throttle nightly release workflow to every 3 hours

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*.*.*"
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "0 */3 * * *"
   workflow_dispatch:
     inputs:
       channel:
@@ -26,8 +26,45 @@ permissions:
   id-token: write
 
 jobs:
+  check_changes:
+    name: Check for changes since last nightly
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: check
+        name: Compare HEAD to last nightly tag
+        run: |
+          last_nightly_tag=$(git tag --list 'nightly-v*' --sort=-creatordate | head -n 1)
+          if [[ -z "$last_nightly_tag" ]]; then
+            echo "No previous nightly tag found. Proceeding with release."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          last_nightly_sha=$(git rev-parse "$last_nightly_tag^{commit}")
+          head_sha=$(git rev-parse HEAD)
+
+          if [[ "$last_nightly_sha" == "$head_sha" ]]; then
+            echo "No changes on main since last nightly release ($last_nightly_tag). Skipping."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changes detected on main since $last_nightly_tag ($last_nightly_sha → $head_sha). Proceeding."
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
   preflight:
     name: Preflight
+    needs: [check_changes]
+    if: |
+      !failure() && !cancelled() &&
+      (github.event_name != 'schedule' || needs.check_changes.outputs.has_changes == 'true')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:


### PR DESCRIPTION
## Summary
- Changed the scheduled release cadence from once daily at 9:00 UTC to every 3 hours.
- Added a preflight change check for scheduled runs so nightly releases only proceed when `main` has advanced since the last `nightly-v*` tag.
- Skips redundant scheduled releases when there are no new commits, while still allowing manual dispatch and tag-triggered releases.

## Testing
- Not run (workflow-only change).
- Reviewed the updated GitHub Actions logic for scheduled runs, tag releases, and manual dispatch paths.
- Confirmed the new `check_changes` job gates `preflight` only for scheduled runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that adjust schedule and add a simple git-tag/commit comparison gate; main risk is inadvertently skipping/triggering scheduled nightlies if tagging or fetch behavior differs from expectations.
> 
> **Overview**
> Nightly releases are now scheduled to run every 3 hours instead of once daily.
> 
> For scheduled runs, a new `check_changes` job compares `HEAD` to the most recent `nightly-v*` tag and gates `preflight` so the workflow skips publishing when there are no new commits since the last nightly (manual dispatch and tag-triggered releases still proceed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e944ba9b7e2b6d6617b463504ada9680f18098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Throttle nightly release workflow to every 3 hours and skip runs with no changes
> - Changes the cron schedule in [release.yml](.github/workflows/release.yml) from once daily (`0 9 * * *`) to every 3 hours (`0 */3 * * *`).
> - Adds a `check_changes` job that compares HEAD to the last `nightly-v*` tag and sets a `has_changes` output.
> - The `preflight` job now depends on `check_changes` and skips on scheduled runs when no new commits exist since the last nightly tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10e944b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->