### PR TITLE
Show symlinks and macOS Finder aliases in folder browser

### DIFF
--- a/apps/server/src/workspace/Layers/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceEntries.test.ts
@@ -444,5 +444,23 @@ it.layer(TestLayer)("WorkspaceEntriesLive", (it) => {
         expect(result).toBe(false);
       }),
     );
+
+    it.effect("rejects files larger than the probe cap without reading magic", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-bookmark-magic-" });
+        const largePath = path.join(cwd, "big-fake-alias.bin");
+        // Starts with the bookmark magic but is larger than the probe cap
+        // (64 KB). Without the size prefilter this would return true; with
+        // it the file is skipped before we open it.
+        const header = Buffer.from("book\x00\x00\x00\x00mark\x00\x00\x00\x00", "binary");
+        const padding = Buffer.alloc(128 * 1024, 0);
+        yield* Effect.promise(() =>
+          fsPromises.writeFile(largePath, Buffer.concat([header, padding])),
+        );
+        const result = yield* Effect.promise(() => isMacOSBookmarkAlias(largePath));
+        expect(result).toBe(false);
+      }),
+    );
   });
 });

--- a/apps/server/src/workspace/Layers/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceEntries.test.ts
@@ -8,7 +8,7 @@ import { ServerConfig } from "../../config.ts";
 import { GitCoreLive } from "../../git/Layers/GitCore.ts";
 import { GitCore } from "../../git/Services/GitCore.ts";
 import { WorkspaceEntries } from "../Services/WorkspaceEntries.ts";
-import { WorkspaceEntriesLive } from "./WorkspaceEntries.ts";
+import { WorkspaceEntriesLive, isMacOSBookmarkAlias } from "./WorkspaceEntries.ts";
 import { WorkspacePathsLive } from "./WorkspacePaths.ts";
 
 const TestLayer = Layer.empty.pipe(
@@ -358,6 +358,90 @@ it.layer(TestLayer)("WorkspaceEntriesLive", (it) => {
           .pipe(Effect.flip);
 
         expect(error.detail).toBe("Relative filesystem browse paths require a current project.");
+      }),
+    );
+
+    it.effect(
+      "includes symlinks that resolve to directories and excludes file/broken symlinks",
+      () =>
+        Effect.gen(function* () {
+          const workspaceEntries = yield* WorkspaceEntries;
+          const path = yield* Path.Path;
+          const cwd = yield* makeTempDir({ prefix: "t3code-workspace-browse-symlink-" });
+          yield* writeTextFile(cwd, "real-dir/index.ts", "export {};\n");
+          yield* writeTextFile(cwd, "real-file.txt", "hello");
+
+          yield* Effect.promise(() =>
+            fsPromises.symlink(path.join(cwd, "real-dir"), path.join(cwd, "linked-dir")),
+          );
+          yield* Effect.promise(() =>
+            fsPromises.symlink(path.join(cwd, "real-file.txt"), path.join(cwd, "linked-file")),
+          );
+          yield* Effect.promise(() =>
+            fsPromises.symlink(path.join(cwd, "missing-target"), path.join(cwd, "broken-link")),
+          );
+
+          const result = yield* workspaceEntries.browse({
+            partialPath: appendSeparator(cwd),
+          });
+
+          expect(result.entries).toEqual([
+            { name: "linked-dir", fullPath: path.join(cwd, "linked-dir"), isSymlink: true },
+            { name: "real-dir", fullPath: path.join(cwd, "real-dir") },
+          ]);
+        }),
+    );
+  });
+
+  describe("isMacOSBookmarkAlias", () => {
+    it.effect("detects files starting with the bookmark magic", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-bookmark-magic-" });
+        const aliasPath = path.join(cwd, "alias.bin");
+        // Minimal header: "book\x00\x00\x00\x00mark\x00\x00\x00\x00" matches
+        // the modern macOS alias format we care about; only the first four
+        // bytes are read.
+        yield* Effect.promise(() =>
+          fsPromises.writeFile(
+            aliasPath,
+            Buffer.from("book\x00\x00\x00\x00mark\x00\x00\x00\x00", "binary"),
+          ),
+        );
+        const result = yield* Effect.promise(() => isMacOSBookmarkAlias(aliasPath));
+        expect(result).toBe(true);
+      }),
+    );
+
+    it.effect("returns false for regular text files", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-bookmark-magic-" });
+        const textPath = path.join(cwd, "note.txt");
+        yield* writeTextFile(cwd, "note.txt", "hello world");
+        const result = yield* Effect.promise(() => isMacOSBookmarkAlias(textPath));
+        expect(result).toBe(false);
+      }),
+    );
+
+    it.effect("returns false for files shorter than the magic", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-bookmark-magic-" });
+        const shortPath = path.join(cwd, "short.bin");
+        yield* Effect.promise(() => fsPromises.writeFile(shortPath, Buffer.from("bo")));
+        const result = yield* Effect.promise(() => isMacOSBookmarkAlias(shortPath));
+        expect(result).toBe(false);
+      }),
+    );
+
+    it.effect("returns false for missing files", () =>
+      Effect.gen(function* () {
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-bookmark-magic-" });
+        const missing = path.join(cwd, "does-not-exist.bin");
+        const result = yield* Effect.promise(() => isMacOSBookmarkAlias(missing));
+        expect(result).toBe(false);
       }),
     );
   });

--- a/apps/server/src/workspace/Layers/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceEntries.ts
@@ -1,6 +1,7 @@
 import * as OS from "node:os";
 import fsPromises from "node:fs/promises";
 import type { Dirent } from "node:fs";
+import { execFile } from "node:child_process";
 
 import { Cache, Duration, Effect, Exit, Layer, Option, Path } from "effect";
 
@@ -140,6 +141,121 @@ function directoryAncestorsOf(relativePath: string): string[] {
     directories.push(segments.slice(0, index).join("/"));
   }
   return directories;
+}
+
+// Cap parallelism when probing directory entries for Finder-alias magic
+// bytes. Each probe opens a file and reads 4 bytes, so on huge directories
+// unbounded parallelism can saturate file descriptors and the kernel's I/O
+// queue. Sixteen is a good middle ground — small enough to stay polite,
+// large enough to overlap I/O latency.
+const ALIAS_PROBE_CONCURRENCY = 16;
+
+async function mapWithConcurrency<A, B>(
+  items: readonly A[],
+  concurrency: number,
+  fn: (item: A, index: number) => Promise<B>,
+): Promise<B[]> {
+  if (items.length === 0) return [];
+  const results: B[] = Array.from({ length: items.length });
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      const item = items[index];
+      if (item === undefined) continue;
+      results[index] = await fn(item, index);
+    }
+  };
+  const workerCount = Math.max(1, Math.min(concurrency, items.length));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+// macOS Finder aliases are binary files (not symlinks). Modern ones (10.5+)
+// are bookmark-format NSURL data and start with magic bytes "book". Pre-10.5
+// "alis"-format aliases stored their type/creator metadata in the HFS
+// FinderInfo extended attribute rather than the file body; detecting those
+// would require reading `com.apple.FinderInfo`, which has no native Node API
+// and is essentially extinct on modern installs. We intentionally only
+// support modern bookmark aliases here.
+const MACOS_BOOKMARK_ALIAS_MAGIC = "book";
+// The script emits one resolved path per alias in argv order, using NUL as
+// the terminator. POSIX paths cannot contain NUL bytes, so this is the only
+// delimiter that is guaranteed to be unambiguous; tabs and newlines are legal
+// in filenames and would break simpler formats.
+const MACOS_ALIAS_RESOLVE_SCRIPT = `on run argv
+  set results to ""
+  set nul to ASCII character 0
+  repeat with rawPath in argv
+    set p to rawPath as string
+    try
+      tell application "Finder"
+        set theTarget to original item of (POSIX file p as alias)
+        set resolved to POSIX path of (theTarget as alias)
+      end tell
+      set results to results & resolved & nul
+    on error
+      set results to results & nul
+    end try
+  end repeat
+  return results
+end run`;
+
+export async function isMacOSBookmarkAlias(filePath: string): Promise<boolean> {
+  let handle: fsPromises.FileHandle | undefined;
+  try {
+    handle = await fsPromises.open(filePath, "r");
+    const buffer = Buffer.alloc(4);
+    const { bytesRead } = await handle.read(buffer, 0, 4, 0);
+    if (bytesRead < 4) return false;
+    return buffer.toString("ascii") === MACOS_BOOKMARK_ALIAS_MAGIC;
+  } catch {
+    return false;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function resolveMacOSAliasTargets(
+  aliasPaths: readonly string[],
+): Promise<Map<string, string>> {
+  if (process.platform !== "darwin" || aliasPaths.length === 0) {
+    return new Map();
+  }
+  // The first osascript invocation on a given install triggers macOS's TCC
+  // prompt to "control Finder". If the user doesn't click Allow immediately,
+  // osascript blocks waiting for their response. A short timeout would kill
+  // the subprocess before they can react and leave aliases silently missing
+  // from the picker, so we use a generous ceiling. Subsequent calls are
+  // effectively instantaneous.
+  const stdout = await new Promise<string>((resolve) => {
+    execFile(
+      "osascript",
+      ["-e", MACOS_ALIAS_RESOLVE_SCRIPT, "--", ...aliasPaths],
+      { timeout: 30_000, maxBuffer: 1_024 * 1_024 },
+      (error, out) => {
+        if (error) {
+          resolve("");
+          return;
+        }
+        resolve(out);
+      },
+    );
+  });
+  const map = new Map<string, string>();
+  // The script emits `<resolved>\0` for each argv entry (empty chunk for
+  // unresolvable aliases). Split on NUL and match positionally to aliasPaths.
+  const chunks = stdout.split("\0");
+  for (let i = 0; i < aliasPaths.length; i += 1) {
+    const aliasPath = aliasPaths[i];
+    const resolved = chunks[i]?.replace(/\/$/, "") ?? "";
+    if (aliasPath && resolved) {
+      map.set(aliasPath, resolved);
+    }
+  }
+  return map;
 }
 
 const resolveBrowseTarget = (
@@ -426,8 +542,37 @@ export const makeWorkspaceEntries = Effect.gen(function* () {
     function* (input) {
       const resolvedInputPath = yield* resolveBrowseTarget(input, path);
       const endsWithSeparator = /[\\/]$/.test(input.partialPath) || input.partialPath === "~";
-      const parentPath = endsWithSeparator ? resolvedInputPath : path.dirname(resolvedInputPath);
+      const initialParentPath = endsWithSeparator
+        ? resolvedInputPath
+        : path.dirname(resolvedInputPath);
       const prefix = endsWithSeparator ? "" : path.basename(resolvedInputPath);
+
+      // If the user typed a path whose last component is a macOS Finder alias
+      // (e.g. `~/mongodb-test-alis/`), the entry is a regular file on disk and
+      // readdir would fail. Resolve it to its target directory first so the
+      // listing works and the returned parentPath reflects the real location.
+      const parentPath = yield* Effect.promise(async () => {
+        try {
+          if (process.platform !== "darwin" || !endsWithSeparator) {
+            return initialParentPath;
+          }
+          try {
+            const stats = await fsPromises.lstat(initialParentPath);
+            if (!stats.isFile()) return initialParentPath;
+          } catch {
+            return initialParentPath;
+          }
+          if (!(await isMacOSBookmarkAlias(initialParentPath))) {
+            return initialParentPath;
+          }
+          const resolved = await resolveMacOSAliasTargets([initialParentPath]);
+          return resolved.get(initialParentPath) ?? initialParentPath;
+        } catch {
+          // Defense in depth: alias resolution is best-effort; never let an
+          // unexpected rejection here become an Effect defect.
+          return initialParentPath;
+        }
+      });
 
       const dirents = yield* Effect.tryPromise({
         try: () => fsPromises.readdir(parentPath, { withFileTypes: true }),
@@ -444,19 +589,106 @@ export const makeWorkspaceEntries = Effect.gen(function* () {
       const showHidden = endsWithSeparator || prefix.startsWith(".");
       const lowerPrefix = prefix.toLowerCase();
 
+      const isDarwin = process.platform === "darwin";
+
+      const candidates = dirents.filter((dirent) => {
+        if (!dirent.name.toLowerCase().startsWith(lowerPrefix)) return false;
+        if (!showHidden && dirent.name.startsWith(".")) return false;
+        if (dirent.isDirectory() || dirent.isSymbolicLink()) return true;
+        // On macOS, regular files can be Finder aliases (binary bookmark
+        // files). We detect them by magic bytes below before resolving.
+        if (isDarwin && dirent.isFile()) return true;
+        return false;
+      });
+
+      // Follow symlinks (e.g. ~/Dropbox -> ~/Library/CloudStorage/Dropbox) and
+      // macOS Finder aliases so they show up in the picker alongside real
+      // directories. Aliases are resolved in a single batched osascript call.
+      const { resolved, aliasTargets } = yield* Effect.promise(async () => {
+        try {
+          const initial = await mapWithConcurrency(
+            candidates,
+            ALIAS_PROBE_CONCURRENCY,
+            async (dirent) => {
+              if (dirent.isDirectory()) {
+                return { dirent, pointsToDirectory: true, isAlias: false };
+              }
+              if (dirent.isSymbolicLink()) {
+                try {
+                  const stats = await fsPromises.stat(path.join(parentPath, dirent.name));
+                  return { dirent, pointsToDirectory: stats.isDirectory(), isAlias: false };
+                } catch {
+                  return { dirent, pointsToDirectory: false, isAlias: false };
+                }
+              }
+              if (isDarwin && dirent.isFile()) {
+                const fullPath = path.join(parentPath, dirent.name);
+                if (await isMacOSBookmarkAlias(fullPath)) {
+                  return { dirent, pointsToDirectory: false, isAlias: true };
+                }
+              }
+              return { dirent, pointsToDirectory: false, isAlias: false };
+            },
+          );
+
+          const aliasCandidatePaths = initial
+            .filter((item) => item.isAlias)
+            .map((item) => path.join(parentPath, item.dirent.name));
+          const aliasTargets = await resolveMacOSAliasTargets(aliasCandidatePaths);
+
+          const finalItems = await mapWithConcurrency(
+            initial,
+            ALIAS_PROBE_CONCURRENCY,
+            async (item) => {
+              if (!item.isAlias) return item;
+              const aliasPath = path.join(parentPath, item.dirent.name);
+              const target = aliasTargets.get(aliasPath);
+              if (!target) return item;
+              try {
+                const stats = await fsPromises.stat(target);
+                return { ...item, pointsToDirectory: stats.isDirectory() };
+              } catch {
+                return item;
+              }
+            },
+          );
+
+          return { resolved: finalItems, aliasTargets };
+        } catch {
+          // Defense in depth: alias/symlink resolution is best-effort. Fall
+          // back to the raw dirent list without any target-directory
+          // promotion rather than letting an unexpected rejection surface as
+          // an Effect defect.
+          return {
+            resolved: candidates.map((dirent) => ({
+              dirent,
+              pointsToDirectory: dirent.isDirectory(),
+              isAlias: false,
+            })),
+            aliasTargets: new Map<string, string>(),
+          };
+        }
+      });
+
       return {
         parentPath,
-        entries: dirents
-          .filter(
-            (dirent) =>
-              dirent.isDirectory() &&
-              dirent.name.toLowerCase().startsWith(lowerPrefix) &&
-              (showHidden || !dirent.name.startsWith(".")),
-          )
-          .map((dirent) => ({
-            name: dirent.name,
-            fullPath: path.join(parentPath, dirent.name),
-          }))
+        entries: resolved
+          .filter((item) => item.pointsToDirectory)
+          .map(({ dirent, isAlias }) => {
+            const joined = path.join(parentPath, dirent.name);
+            const entry: {
+              name: string;
+              fullPath: string;
+              isSymlink?: boolean;
+              isAlias?: boolean;
+            } = {
+              name: dirent.name,
+              fullPath: isAlias ? (aliasTargets.get(joined) ?? joined) : joined,
+            };
+            if (dirent.isSymbolicLink() || isAlias) entry.isSymlink = true;
+            if (isAlias) entry.isAlias = true;
+            return entry;
+          })
           .toSorted((left, right) => left.name.localeCompare(right.name)),
       };
     },

--- a/apps/server/src/workspace/Layers/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceEntries.ts
@@ -181,6 +181,11 @@ async function mapWithConcurrency<A, B>(
 // and is essentially extinct on modern installs. We intentionally only
 // support modern bookmark aliases here.
 const MACOS_BOOKMARK_ALIAS_MAGIC = "book";
+// Real Finder bookmark files are tiny (typically well under 2 KB). Capping
+// the probe at 64 KB lets us skip media, archives, binaries, etc. with a
+// single cheap `stat` syscall in directories like ~/Downloads, instead of
+// paying for an `open + read + close` on every file matching the prefix.
+const MACOS_ALIAS_MAX_PROBE_BYTES = 64 * 1024;
 // The script emits one resolved path per alias in argv order, using NUL as
 // the terminator. POSIX paths cannot contain NUL bytes, so this is the only
 // delimiter that is guaranteed to be unambiguous; tabs and newlines are legal
@@ -204,6 +209,14 @@ const MACOS_ALIAS_RESOLVE_SCRIPT = `on run argv
 end run`;
 
 export async function isMacOSBookmarkAlias(filePath: string): Promise<boolean> {
+  // Cheap stat prefilter: bookmark files are small, so anything outside the
+  // plausible range can't be one and isn't worth opening.
+  try {
+    const stats = await fsPromises.stat(filePath);
+    if (stats.size < 4 || stats.size > MACOS_ALIAS_MAX_PROBE_BYTES) return false;
+  } catch {
+    return false;
+  }
   let handle: fsPromises.FileHandle | undefined;
   try {
     handle = await fsPromises.open(filePath, "r");

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
+import { EnvironmentId, type FilesystemBrowseEntry, ProjectId, ThreadId } from "@t3tools/contracts";
 import type { Thread } from "../types";
 import {
+  buildBrowseGroups,
   buildThreadActionItems,
   filterCommandPaletteGroups,
   type CommandPaletteGroup,
@@ -162,5 +163,97 @@ describe("buildThreadActionItems", () => {
     });
 
     expect(items.map((item) => item.value)).toEqual(["thread:thread-active"]);
+  });
+});
+
+describe("buildBrowseGroups", () => {
+  const makeEntry = (overrides: Partial<FilesystemBrowseEntry>): FilesystemBrowseEntry => ({
+    name: "entry",
+    fullPath: "/entry",
+    ...overrides,
+  });
+
+  const makeInput = (
+    entries: FilesystemBrowseEntry[],
+    handlers: {
+      browseTo?: (name: string) => void;
+      browseToPath?: (fullPath: string) => void;
+    } = {},
+  ) => ({
+    browseEntries: entries,
+    browseQuery: "~/",
+    canBrowseUp: false,
+    upIcon: "up-icon",
+    directoryIcon: "dir-icon",
+    symlinkIcon: "symlink-icon",
+    browseUp: () => undefined,
+    browseTo: handlers.browseTo ?? (() => undefined),
+    browseToPath: handlers.browseToPath ?? (() => undefined),
+  });
+
+  it("uses the symlink icon for symlinked and aliased entries", () => {
+    const groups = buildBrowseGroups(
+      makeInput([
+        makeEntry({ name: "real", fullPath: "/p/real" }),
+        makeEntry({ name: "linked", fullPath: "/p/linked", isSymlink: true }),
+        makeEntry({ name: "aliased", fullPath: "/target", isSymlink: true, isAlias: true }),
+      ]),
+    );
+
+    const icons = groups[0]?.items.map((item) => item.kind === "action" && item.icon);
+    expect(icons).toEqual(["dir-icon", "symlink-icon", "symlink-icon"]);
+  });
+
+  it("produces unique values for aliases that share a resolved target", () => {
+    const groups = buildBrowseGroups(
+      makeInput([
+        makeEntry({ name: "alias-a", fullPath: "/shared/target", isSymlink: true, isAlias: true }),
+        makeEntry({ name: "alias-b", fullPath: "/shared/target", isSymlink: true, isAlias: true }),
+      ]),
+    );
+
+    const values = groups[0]?.items.map((item) => item.value) ?? [];
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("routes alias navigation to browseToPath with the resolved fullPath", async () => {
+    const browseTo = vi.fn();
+    const browseToPath = vi.fn();
+    const groups = buildBrowseGroups(
+      makeInput(
+        [makeEntry({ name: "alias", fullPath: "/target", isSymlink: true, isAlias: true })],
+        { browseTo, browseToPath },
+      ),
+    );
+
+    const action = groups[0]?.items[0];
+    if (action?.kind !== "action") throw new Error("expected action item");
+    await action.run();
+
+    expect(browseToPath).toHaveBeenCalledWith("/target");
+    expect(browseTo).not.toHaveBeenCalled();
+  });
+
+  it("routes directory and symlink navigation to browseTo with the entry name", async () => {
+    const browseTo = vi.fn();
+    const browseToPath = vi.fn();
+    const groups = buildBrowseGroups(
+      makeInput(
+        [
+          makeEntry({ name: "dir", fullPath: "/p/dir" }),
+          makeEntry({ name: "symlink", fullPath: "/p/symlink", isSymlink: true }),
+        ],
+        { browseTo, browseToPath },
+      ),
+    );
+
+    const items = groups[0]?.items ?? [];
+    for (const item of items) {
+      if (item.kind !== "action") throw new Error("expected action item");
+      await item.run();
+    }
+
+    expect(browseTo.mock.calls).toEqual([["dir"], ["symlink"]]);
+    expect(browseToPath).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -7,7 +7,6 @@ import {
   buildThreadActionItems,
   filterBrowseEntries,
   filterCommandPaletteGroups,
-  parseBrowseItemValue,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -261,33 +260,6 @@ describe("buildBrowseGroups", () => {
   });
 });
 
-describe("browse item value encoding", () => {
-  it("round-trips plain entries through parse/build", () => {
-    const value = buildBrowseItemValue({ name: "dir", fullPath: "/p/dir" });
-    expect(value).toBe("browse:/p/dir");
-    expect(parseBrowseItemValue(value)).toEqual({ kind: "entry", fullPath: "/p/dir" });
-  });
-
-  it("round-trips aliases through parse/build", () => {
-    const value = buildBrowseItemValue({
-      name: "alias",
-      fullPath: "/target/dir",
-      isAlias: true,
-    });
-    expect(value).toBe("browse:alias:alias:/target/dir");
-    expect(parseBrowseItemValue(value)).toEqual({
-      kind: "alias",
-      name: "alias",
-      fullPath: "/target/dir",
-    });
-  });
-
-  it("returns null for non-browse values", () => {
-    expect(parseBrowseItemValue("thread:thread-1")).toBeNull();
-    expect(parseBrowseItemValue("browse:alias:")).toBeNull();
-  });
-});
-
 describe("filterBrowseEntries", () => {
   const makeEntry = (overrides: Partial<FilesystemBrowseEntry>): FilesystemBrowseEntry => ({
     name: "entry",
@@ -305,8 +277,8 @@ describe("filterBrowseEntries", () => {
     expect(result.highlightedEntry).toBe(entry);
   });
 
-  it("resolves highlightedEntry for alias entries (regression: #2136)", () => {
-    // Two aliases in the same listing sharing a resolved target — the
+  it("resolves highlightedEntry for alias entries sharing a resolved target", () => {
+    // Two aliases in the same listing pointing at the same target; the
     // filename is what disambiguates them.
     const aliasA = makeEntry({
       name: "alias-a",
@@ -328,5 +300,26 @@ describe("filterBrowseEntries", () => {
     });
 
     expect(result.highlightedEntry).toBe(aliasB);
+  });
+
+  it("resolves highlightedEntry when the alias name contains a colon", () => {
+    // POSIX allows `:` in filenames. A stringy parser that splits on the
+    // first `:` after `alias:` would misread the name/fullPath boundary
+    // and fail to match. The consumer recomputes the value instead, so
+    // the round-trip is robust.
+    const alias = makeEntry({
+      name: "weird:name",
+      fullPath: "/real/target",
+      isSymlink: true,
+      isAlias: true,
+    });
+
+    const result = filterBrowseEntries({
+      browseEntries: [alias],
+      browseFilterQuery: "",
+      highlightedItemValue: buildBrowseItemValue(alias),
+    });
+
+    expect(result.highlightedEntry).toBe(alias);
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -3,8 +3,11 @@ import { EnvironmentId, type FilesystemBrowseEntry, ProjectId, ThreadId } from "
 import type { Thread } from "../types";
 import {
   buildBrowseGroups,
+  buildBrowseItemValue,
   buildThreadActionItems,
+  filterBrowseEntries,
   filterCommandPaletteGroups,
+  parseBrowseItemValue,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -255,5 +258,75 @@ describe("buildBrowseGroups", () => {
 
     expect(browseTo.mock.calls).toEqual([["dir"], ["symlink"]]);
     expect(browseToPath).not.toHaveBeenCalled();
+  });
+});
+
+describe("browse item value encoding", () => {
+  it("round-trips plain entries through parse/build", () => {
+    const value = buildBrowseItemValue({ name: "dir", fullPath: "/p/dir" });
+    expect(value).toBe("browse:/p/dir");
+    expect(parseBrowseItemValue(value)).toEqual({ kind: "entry", fullPath: "/p/dir" });
+  });
+
+  it("round-trips aliases through parse/build", () => {
+    const value = buildBrowseItemValue({
+      name: "alias",
+      fullPath: "/target/dir",
+      isAlias: true,
+    });
+    expect(value).toBe("browse:alias:alias:/target/dir");
+    expect(parseBrowseItemValue(value)).toEqual({
+      kind: "alias",
+      name: "alias",
+      fullPath: "/target/dir",
+    });
+  });
+
+  it("returns null for non-browse values", () => {
+    expect(parseBrowseItemValue("thread:thread-1")).toBeNull();
+    expect(parseBrowseItemValue("browse:alias:")).toBeNull();
+  });
+});
+
+describe("filterBrowseEntries", () => {
+  const makeEntry = (overrides: Partial<FilesystemBrowseEntry>): FilesystemBrowseEntry => ({
+    name: "entry",
+    fullPath: "/entry",
+    ...overrides,
+  });
+
+  it("resolves highlightedEntry for non-alias entries", () => {
+    const entry = makeEntry({ name: "dir", fullPath: "/p/dir" });
+    const result = filterBrowseEntries({
+      browseEntries: [entry],
+      browseFilterQuery: "",
+      highlightedItemValue: buildBrowseItemValue(entry),
+    });
+    expect(result.highlightedEntry).toBe(entry);
+  });
+
+  it("resolves highlightedEntry for alias entries (regression: #2136)", () => {
+    // Two aliases in the same listing sharing a resolved target — the
+    // filename is what disambiguates them.
+    const aliasA = makeEntry({
+      name: "alias-a",
+      fullPath: "/shared/target",
+      isSymlink: true,
+      isAlias: true,
+    });
+    const aliasB = makeEntry({
+      name: "alias-b",
+      fullPath: "/shared/target",
+      isSymlink: true,
+      isAlias: true,
+    });
+
+    const result = filterBrowseEntries({
+      browseEntries: [aliasA, aliasB],
+      browseFilterQuery: "",
+      highlightedItemValue: buildBrowseItemValue(aliasB),
+    });
+
+    expect(result.highlightedEntry).toBe(aliasB);
   });
 });

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -51,6 +51,42 @@ export interface CommandPaletteView {
 
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
+// Browse palette values have two shapes:
+//   - `browse:${fullPath}` for regular directories and symlinks
+//   - `browse:alias:${name}:${fullPath}` for macOS Finder aliases, where two
+//     aliases in the same listing can resolve to the same target and we need
+//     the visible name to disambiguate them.
+// Both the producer (buildBrowseGroups) and the consumer (filterBrowseEntries)
+// must agree on the format, so the encode/decode pair lives here.
+export function buildBrowseItemValue(
+  entry: Pick<FilesystemBrowseEntry, "name" | "fullPath" | "isAlias">,
+): string {
+  return entry.isAlias
+    ? `browse:alias:${entry.name}:${entry.fullPath}`
+    : `browse:${entry.fullPath}`;
+}
+
+export function parseBrowseItemValue(
+  value: string,
+):
+  | { readonly kind: "entry"; readonly fullPath: string }
+  | { readonly kind: "alias"; readonly name: string; readonly fullPath: string }
+  | null {
+  if (!value.startsWith("browse:")) return null;
+  const rest = value.slice("browse:".length);
+  if (rest.startsWith("alias:")) {
+    const afterAlias = rest.slice("alias:".length);
+    const separatorIndex = afterAlias.indexOf(":");
+    if (separatorIndex <= 0) return null;
+    return {
+      kind: "alias",
+      name: afterAlias.slice(0, separatorIndex),
+      fullPath: afterAlias.slice(separatorIndex + 1),
+    };
+  }
+  return { kind: "entry", fullPath: rest };
+}
+
 export function filterBrowseEntries(input: {
   browseEntries: ReadonlyArray<FilesystemBrowseEntry>;
   browseFilterQuery: string;
@@ -70,9 +106,16 @@ export function filterBrowseEntries(input: {
   );
 
   let highlightedEntry: FilesystemBrowseEntry | null = null;
-  if (input.highlightedItemValue?.startsWith("browse:")) {
-    const highlightedPath = input.highlightedItemValue.slice("browse:".length);
-    highlightedEntry = filteredEntries.find((entry) => entry.fullPath === highlightedPath) ?? null;
+  const parsed = input.highlightedItemValue
+    ? parseBrowseItemValue(input.highlightedItemValue)
+    : null;
+  if (parsed) {
+    highlightedEntry =
+      filteredEntries.find((entry) =>
+        parsed.kind === "alias"
+          ? entry.name === parsed.name && entry.fullPath === parsed.fullPath
+          : entry.fullPath === parsed.fullPath,
+      ) ?? null;
   }
 
   const exactEntry =
@@ -303,16 +346,9 @@ export function buildBrowseGroups(input: {
   }
 
   for (const entry of input.browseEntries) {
-    // For Finder aliases, `fullPath` is the resolved target and two aliases
-    // in the same directory can resolve to the same place. Fold the visible
-    // name into the value so each row has a distinct identifier for React
-    // keys and keyboard navigation.
-    const value = entry.isAlias
-      ? `browse:alias:${entry.name}:${entry.fullPath}`
-      : `browse:${entry.fullPath}`;
     items.push({
       kind: "action",
-      value,
+      value: buildBrowseItemValue(entry),
       searchTerms: [input.browseQuery, entry.fullPath, entry.name],
       title: entry.name,
       icon: entry.isSymlink ? input.symlinkIcon : input.directoryIcon,

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -281,8 +281,10 @@ export function buildBrowseGroups(input: {
   canBrowseUp: boolean;
   upIcon: ReactNode;
   directoryIcon: ReactNode;
+  symlinkIcon: ReactNode;
   browseUp: () => void;
   browseTo: (name: string) => void;
+  browseToPath: (fullPath: string) => void;
 }): CommandPaletteGroup[] {
   const items: CommandPaletteActionItem[] = [];
 
@@ -301,15 +303,29 @@ export function buildBrowseGroups(input: {
   }
 
   for (const entry of input.browseEntries) {
+    // For Finder aliases, `fullPath` is the resolved target and two aliases
+    // in the same directory can resolve to the same place. Fold the visible
+    // name into the value so each row has a distinct identifier for React
+    // keys and keyboard navigation.
+    const value = entry.isAlias
+      ? `browse:alias:${entry.name}:${entry.fullPath}`
+      : `browse:${entry.fullPath}`;
     items.push({
       kind: "action",
-      value: `browse:${entry.fullPath}`,
+      value,
       searchTerms: [input.browseQuery, entry.fullPath, entry.name],
       title: entry.name,
-      icon: input.directoryIcon,
+      icon: entry.isSymlink ? input.symlinkIcon : input.directoryIcon,
       keepOpen: true,
       run: async () => {
-        input.browseTo(entry.name);
+        // Finder aliases resolve to a target elsewhere on disk. Appending the
+        // alias file name to the current path would fail to readdir, so we
+        // jump straight to the resolved fullPath.
+        if (entry.isAlias) {
+          input.browseToPath(entry.fullPath);
+        } else {
+          input.browseTo(entry.name);
+        }
       },
     });
   }

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -56,35 +56,15 @@ export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-b
 //   - `browse:alias:${name}:${fullPath}` for macOS Finder aliases, where two
 //     aliases in the same listing can resolve to the same target and we need
 //     the visible name to disambiguate them.
-// Both the producer (buildBrowseGroups) and the consumer (filterBrowseEntries)
-// must agree on the format, so the encode/decode pair lives here.
+// The consumer never parses this string — it recomputes the value via
+// buildBrowseItemValue(entry) and compares. That way filename characters
+// (colons, spaces, …) never collide with the `:` delimiter.
 export function buildBrowseItemValue(
   entry: Pick<FilesystemBrowseEntry, "name" | "fullPath" | "isAlias">,
 ): string {
   return entry.isAlias
     ? `browse:alias:${entry.name}:${entry.fullPath}`
     : `browse:${entry.fullPath}`;
-}
-
-export function parseBrowseItemValue(
-  value: string,
-):
-  | { readonly kind: "entry"; readonly fullPath: string }
-  | { readonly kind: "alias"; readonly name: string; readonly fullPath: string }
-  | null {
-  if (!value.startsWith("browse:")) return null;
-  const rest = value.slice("browse:".length);
-  if (rest.startsWith("alias:")) {
-    const afterAlias = rest.slice("alias:".length);
-    const separatorIndex = afterAlias.indexOf(":");
-    if (separatorIndex <= 0) return null;
-    return {
-      kind: "alias",
-      name: afterAlias.slice(0, separatorIndex),
-      fullPath: afterAlias.slice(separatorIndex + 1),
-    };
-  }
-  return { kind: "entry", fullPath: rest };
 }
 
 export function filterBrowseEntries(input: {
@@ -106,16 +86,10 @@ export function filterBrowseEntries(input: {
   );
 
   let highlightedEntry: FilesystemBrowseEntry | null = null;
-  const parsed = input.highlightedItemValue
-    ? parseBrowseItemValue(input.highlightedItemValue)
-    : null;
-  if (parsed) {
+  const highlighted = input.highlightedItemValue;
+  if (highlighted && highlighted.startsWith("browse:")) {
     highlightedEntry =
-      filteredEntries.find((entry) =>
-        parsed.kind === "alias"
-          ? entry.name === parsed.name && entry.fullPath === parsed.fullPath
-          : entry.fullPath === parsed.fullPath,
-      ) ?? null;
+      filteredEntries.find((entry) => buildBrowseItemValue(entry) === highlighted) ?? null;
   }
 
   const exactEntry =

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -16,6 +16,7 @@ import {
   CornerLeftUpIcon,
   FolderIcon,
   FolderPlusIcon,
+  FolderSymlinkIcon,
   MessageSquareIcon,
   SettingsIcon,
   SquarePenIcon,
@@ -404,7 +405,11 @@ function OpenCommandPaletteDialog() {
 
     const nextChild = highlightedBrowseEntry ?? exactBrowseEntry;
     if (nextChild) {
-      prefetchBrowsePath(appendBrowsePathSegment(query, nextChild.name));
+      prefetchBrowsePath(
+        nextChild.isAlias
+          ? ensureBrowseDirectoryPath(nextChild.fullPath)
+          : appendBrowsePathSegment(query, nextChild.name),
+      );
     }
   }, [
     exactBrowseEntry,
@@ -818,6 +823,13 @@ function OpenCommandPaletteDialog() {
     setBrowseGeneration((generation) => generation + 1);
   }
 
+  function browseToPath(fullPath: string): void {
+    const nextQuery = ensureBrowseDirectoryPath(fullPath);
+    setHighlightedItemValue(null);
+    setQuery(nextQuery);
+    setBrowseGeneration((generation) => generation + 1);
+  }
+
   function browseUp(): void {
     const parentPath = getBrowseParentPath(query);
     if (parentPath === null) {
@@ -846,8 +858,10 @@ function OpenCommandPaletteDialog() {
     canBrowseUp,
     upIcon: <CornerLeftUpIcon className={ITEM_ICON_CLASS} />,
     directoryIcon: <FolderIcon className={ITEM_ICON_CLASS} />,
+    symlinkIcon: <FolderSymlinkIcon className={ITEM_ICON_CLASS} />,
     browseUp,
     browseTo,
+    browseToPath,
   });
 
   let displayedGroups = filteredGroups;

--- a/packages/contracts/src/filesystem.ts
+++ b/packages/contracts/src/filesystem.ts
@@ -12,6 +12,12 @@ export type FilesystemBrowseInput = typeof FilesystemBrowseInput.Type;
 export const FilesystemBrowseEntry = Schema.Struct({
   name: TrimmedNonEmptyString,
   fullPath: TrimmedNonEmptyString,
+  isSymlink: Schema.optional(Schema.Boolean),
+  // True when `fullPath` is the resolved target of something that isn't a
+  // directory at the visible name (e.g. a macOS Finder alias file). In that
+  // case navigation must jump to `fullPath` directly rather than appending
+  // the visible name to the current browse path.
+  isAlias: Schema.optional(Schema.Boolean),
 });
 export type FilesystemBrowseEntry = typeof FilesystemBrowseEntry.Type;
 


### PR DESCRIPTION
Fixes #2135

## What Changed

The command-palette folder browser silently dropped symlinks and Finder aliases that point to directories, even though Electron's native picker resolves both. This PR brings the type-to-browse path to parity.

- Symbolic links that resolve to a directory (e.g. `~/Dropbox`) are shown and navigable.
- Modern bookmark-format macOS Finder aliases are detected by magic bytes and resolved to their targets via a single batched `osascript` call (30s timeout to cover the first-run TCC "control Finder" prompt).
- An alias that appears mid-path (e.g. `~/my-alias/`) is resolved before `readdir`, so the listing works.
- Both kinds use a distinct `FolderSymlinkIcon`, get unique palette values so two aliases to the same target don't collide, and navigate to the resolved path directly via `browseToPath`.
- Probe concurrency is bounded, the `Effect.promise` bodies have outer fallbacks, and the `osascript` output is NUL-delimited so filenames containing tabs or newlines parse correctly.

## Why

`readdir({ withFileTypes: true })` uses `lstat` semantics, so symlinks to directories don't report `isDirectory()` and Finder aliases are regular files, not symlinks at all. The picker therefore silently hid common locations like `~/Dropbox` and any Finder alias dragged into the home directory. Electron's native folder dialog already resolves both transparently, so this brings the type-to-browse path to parity with the native picker.

## Smaller-scope alternative

If the alias half feels out of scope, the symlink half alone is a much smaller bug fix (**~+65 / −4 across 5–6 files**, cross-platform, no `osascript`, no TCC prompt, no new helpers). Happy to reduce this PR to symlink-only and leave Finder alias support as a follow-up — just let me know.

## UI Changes

BEFORE:
<img width="646" height="268" alt="before" src="https://github.com/user-attachments/assets/c0e19a7e-c936-4553-94fb-8fcf3baea628" />

AFTER:
<img width="646" height="264" alt="after" src="https://github.com/user-attachments/assets/f5b9cd56-c1f1-4e79-b8b1-ce3120223fa6" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core filesystem browsing behavior and adds macOS-specific alias resolution via `osascript` (including timeouts/permissions), which could introduce latency or edge-case failures despite best-effort fallbacks.
> 
> **Overview**
> The filesystem browse API now returns directory candidates that are *symlinks* and (on macOS) Finder *bookmark aliases*, marking them via new `FilesystemBrowseEntry.isSymlink`/`isAlias` flags and excluding symlinks that point to files or are broken.
> 
> On macOS, alias entries are detected by probing magic bytes (`isMacOSBookmarkAlias`) and then resolved in a single batched `osascript` call; browsing also resolves a trailing-path alias to its target before calling `readdir` so listings work when the user types an alias path.
> 
> The command palette browse UI is updated to show a symlink folder icon, generate stable unique item values for aliases (even when multiple aliases resolve to the same target), navigate aliases via a new `browseToPath` flow, and prefetch the resolved target path instead of appending the alias filename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15e373452e6f047176518527d75175873e1e380. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show symlinks and macOS Finder aliases as folders in the workspace folder browser
> - Extends `WorkspaceEntries.browse` to include symlinked directories and macOS Finder aliases alongside regular directories, annotating entries with `isSymlink` and `isAlias` flags in [`FilesystemBrowseEntry`](https://github.com/pingdotgg/t3code/pull/2136/files#diff-80a6cb4180ec3fb0a1c336a148b6ad7313a759f0abf07941a4faf3019d6bf553).
> - Detects macOS Finder aliases by probing the first 4 bytes for the `book` magic and resolving targets via AppleScript (`osascript`) with a 30s timeout.
> - Updates the command palette to display a symlink icon for symlinks/aliases and navigate to the resolved `fullPath` for aliases rather than appending the visible name.
> - Adds `buildBrowseItemValue` to generate stable, unique item values that disambiguate aliases sharing the same resolved target or names containing colons.
> - Risk: alias resolution invokes a subprocess (`osascript`) per browse call on macOS, which may add latency for directories containing many aliases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b15e373.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->