### PR TITLE
fix(web): use capture-phase keydown listener so CTRL+J toggles terminal from terminal focus on Windows (#2113)

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2290,8 +2290,8 @@ export default function ChatView(props: ChatViewProps) {
       event.stopPropagation();
       void runProjectScript(script);
     };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
   }, [
     activeProject,
     terminalState.terminalOpen,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -131,6 +131,15 @@ describe("isTerminalToggleShortcut", () => {
       isTerminalToggleShortcut(event({ ctrlKey: true }), DEFAULT_BINDINGS, { platform: "Win32" }),
     );
   });
+
+  it("matches Ctrl+J on non-macOS while terminalFocus is true", () => {
+    assert.isTrue(
+      isTerminalToggleShortcut(event({ ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Win32",
+        context: { terminalFocus: true },
+      }),
+    );
+  });
 });
 
 describe("split/new/close terminal shortcuts", () => {


### PR DESCRIPTION
## What Changed

The window keydown listener in `ChatView.tsx` now runs in the capture phase instead of the default bubble phase.

## Why

On Windows, CTRL+J opens the terminal but pressing it again while the terminal has focus does not close it. Clicking back into chat and pressing CTRL+J closes it fine. macOS CMD+J is unaffected.

PR #1580 added `terminal.attachCustomKeyEventHandler` inside `ThreadTerminalDrawer.tsx` that returns `false` for terminal shortcuts, with the intent of letting the event bubble up to the global keydown listener in `ChatView.tsx`. On Windows, xterm.js still processes the event before it reaches the bubble-phase listener (ctrlKey combinations that map to control characters like LF get consumed), so the toggle never fires.

Flipping the listener to capture phase makes it fire before xterm.js has a chance to touch the event. The handler already calls `event.preventDefault()` and `event.stopPropagation()` when a terminal command matches, so xterm never sees those events at all. macOS stays unaffected because CMD+J was already working via the same code path.

Added a regression test for `isTerminalToggleShortcut` with `terminalFocus: true` on Win32.

## UI Changes

No visual change. Keyboard behavior only: CTRL+J now consistently toggles the terminal regardless of which pane has focus on Windows.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (N/A, no visual change)
- [ ] I included a video for animation/interaction changes (N/A, requires Windows to reproduce)

Fixes #2113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global `keydown` handling to run in the capture phase, which can subtly affect shortcut/event propagation ordering across the app, though the change is localized and guarded by command matching.
> 
> **Overview**
> Ensures the terminal toggle shortcut works consistently on Windows even when focus is inside the terminal by registering the `ChatView` global `window` `keydown` listener in the **capture phase** (and removing it with matching options).
> 
> Adds a regression test confirming `Ctrl+J` still matches `terminal.toggle` on non-macOS when `terminalFocus: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ffb946d89d921fb6780dfa92797a3e6b94bc281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CTRL+J terminal toggle from terminal focus on Windows by using capture-phase keydown listener
> The global `keydown` listener in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2142/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) is now registered with `{ capture: true }` so it intercepts events before they reach the focused terminal element, which was previously consuming the event during the bubble phase. A test is added to confirm `isTerminalToggleShortcut` matches Ctrl+J when `context.terminalFocus` is true on non-macOS.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ffb946.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->