### PR TITLE
Add Claude Opus 4.5 to built-in Claude models

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -87,6 +87,23 @@ const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
     } satisfies ModelCapabilities,
   },
   {
+    slug: "claude-opus-4-5",
+    name: "Claude Opus 4.5",
+    isCustom: false,
+    capabilities: {
+      reasoningEffortLevels: [
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" },
+        { value: "high", label: "High", isDefault: true },
+        { value: "max", label: "Max" },
+      ],
+      supportsFastMode: true,
+      supportsThinkingToggle: false,
+      contextWindowOptions: [],
+      promptInjectedEffortLevels: [],
+    } satisfies ModelCapabilities,
+  },
+  {
     slug: "claude-sonnet-4-6",
     name: "Claude Sonnet 4.6",
     isCustom: false,


### PR DESCRIPTION
## Summary

- Registers `claude-opus-4-5` as a built-in Claude model in `ClaudeProvider` with display name **Claude Opus 4.5**.
- Configures capabilities: reasoning effort levels (low / medium / high default / max), fast mode enabled, no thinking toggle, no extra context-window options, no prompt-injected effort levels.

## Testing

- `bun fmt`, `bun lint`, and `bun typecheck` (not run in this session).
- In the app, open model selection for Claude and confirm **Claude Opus 4.5** appears and can be selected.
- Optional: start a short session with the new model and confirm requests succeed against your Anthropic setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only extends the built-in model registry/metadata for Claude without changing auth, execution, or request logic.
> 
> **Overview**
> Adds **Claude Opus 4.5** (`claude-opus-4-5`) to the built-in Claude model list in `ClaudeProvider`, including its advertised capabilities (reasoning effort levels with `high` default, `supportsFastMode: true`, and no context-window or prompt-injected effort options).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf3edd8dc9cde3045c1bd813cfe94559a9964a31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Claude Opus 4.5 to built-in Claude models
> Adds a new entry for `claude-opus-4-5` (Claude Opus 4.5) to the `BUILT_IN_MODELS` array in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/2143/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3). The model supports reasoning effort levels (low, medium, high, max) with `high` as the default, and has fast mode enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf3edd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->