### PR TITLE
Security: Session identifiers appear to be persisted as raw bearer secrets

### DIFF
--- a/apps/server/src/persistence/Migrations/020_AuthAccessManagement.ts
+++ b/apps/server/src/persistence/Migrations/020_AuthAccessManagement.ts
@@ -25,7 +25,7 @@ export default Effect.gen(function* () {
 
   yield* sql`
     CREATE TABLE IF NOT EXISTS auth_sessions (
-      session_id TEXT PRIMARY KEY,
+      session_fingerprint TEXT PRIMARY KEY CHECK(length(session_fingerprint) = 64),
       subject TEXT NOT NULL,
       role TEXT NOT NULL,
       method TEXT NOT NULL,


### PR DESCRIPTION
## Problem

The `auth_sessions` table uses `session_id TEXT PRIMARY KEY`, which suggests session bearer tokens are stored directly. Database compromise would allow immediate session hijacking by replaying IDs.

**Severity**: `high`
**File**: `apps/server/src/persistence/Migrations/020_AuthAccessManagement.ts`

## Solution

Persist a hash/fingerprint of session tokens instead of raw token values, rotate compromised sessions, and ensure token comparisons are constant-time.

## Changes

- `apps/server/src/persistence/Migrations/020_AuthAccessManagement.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `auth_sessions` primary key column from `session_id` to a fixed-length `session_fingerprint`, which can break queries/code expecting `session_id` and requires coordinated rollout/migration handling. Security impact is positive (reduces session replay risk on DB compromise) but schema mismatch risk is non-trivial.
> 
> **Overview**
> Updates the `auth_sessions` table schema to **stop persisting raw session identifiers**, replacing `session_id` with `session_fingerprint` as the primary key and enforcing a `length(...) = 64` check.
> 
> This shifts session lookup/storage semantics to be based on a hashed/fingerprinted token value rather than a replayable bearer secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0a1974dbe10bb7e85b05745758984651b76a77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Store session fingerprints instead of raw bearer secrets in `auth_sessions`
> Renames the primary key column in the `auth_sessions` table from `session_id` to `session_fingerprint` and adds a `CHECK` constraint enforcing exactly 64 characters, as defined in [020_AuthAccessManagement.ts](https://github.com/pingdotgg/t3code/pull/2145/files#diff-769f6c9683bdfa154fe70f4f58d31aef62c0e2d206898981d6279258b6d99c30). Risk: any existing code that inserts or queries by `session_id` will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa0a197.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->