### PR TITLE
Guard release workflow jobs from upstream failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,7 @@ jobs:
   build:
     name: Build ${{ matrix.label }}
     needs: preflight
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
@@ -353,6 +354,7 @@ jobs:
   publish_cli:
     name: Publish CLI to npm
     needs: [preflight, build]
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
@@ -387,6 +389,7 @@ jobs:
   release:
     name: Publish GitHub Release
     needs: [preflight, build, publish_cli]
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
@@ -496,7 +499,7 @@ jobs:
 
   finalize:
     name: Finalize release
-    if: needs.preflight.outputs.release_channel == 'stable'
+    if: ${{ !failure() && !cancelled() && needs.preflight.outputs.release_channel == 'stable' }}
     needs: [preflight, release]
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Add failure and cancellation guards to the release workflow jobs so downstream publish steps do not run after an upstream job has already failed.
- Apply the same guard to the final release gate while preserving the stable-channel condition.
- Reduce the chance of partial or inconsistent release activity when the workflow is already in a failed state.

## Testing
- Not run (workflow-only change).
- Reviewed the `.github/workflows/release.yml` diff to confirm the new `if` conditions were applied to `build`, `publish_cli`, `release`, and `finalize`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that tightens job gating to prevent publish/release steps from running after upstream failures or cancellations. Low risk, with the main potential impact being inadvertently skipping jobs if conditions are mis-specified.
> 
> **Overview**
> Adds explicit `if: ${{ !failure() && !cancelled() }}` guards to the release workflow’s downstream jobs (`build`, `publish_cli`, and `release`) so publish steps don’t run when an earlier job has already failed or the run was cancelled.
> 
> Updates the `finalize` gate to keep the *stable-channel-only* behavior while also requiring the overall workflow to be neither failed nor cancelled, reducing chances of partial/inconsistent release side effects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510350a7d865333d43428cf9477af12c2cec9b15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard release workflow jobs from upstream failures and cancellations
> Adds `if: ${{ !failure() && !cancelled() }}` conditions to the `build`, `publish_cli`, and `release` jobs in [release.yml](.github/workflows/release.yml), and extends the existing condition on the `finalize` job with the same guards. Without these conditions, GitHub Actions can run downstream jobs even when upstream jobs fail or the workflow is cancelled.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 510350a. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->