### PR TITLE
Guard release workflow jobs on upstream success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
   build:
     name: Build ${{ matrix.label }}
     needs: preflight
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
@@ -354,7 +354,7 @@ jobs:
   publish_cli:
     name: Publish CLI to npm
     needs: [preflight, build]
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.build.result == 'success' }}
     runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
@@ -389,7 +389,7 @@ jobs:
   release:
     name: Publish GitHub Release
     needs: [preflight, build, publish_cli]
-    if: ${{ !failure() && !cancelled() }}
+    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.build.result == 'success' && needs.publish_cli.result == 'success' }}
     runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
@@ -499,7 +499,7 @@ jobs:
 
   finalize:
     name: Finalize release
-    if: ${{ !failure() && !cancelled() && needs.preflight.outputs.release_channel == 'stable' }}
+    if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.release.result == 'success' && needs.preflight.outputs.release_channel == 'stable' }}
     needs: [preflight, release]
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10


### PR DESCRIPTION
## Summary
- Add explicit job guards to the release workflow so downstream jobs only run when upstream jobs succeed.
- Prevent `build`, `publish_cli`, `release`, and `finalize` from continuing after failures or cancellations.
- Keep the stable-channel finalization step gated behind a successful release.

## Testing
- Not run (workflow-only change).
- Reviewed `.github/workflows/release.yml` job conditions for `build`, `publish_cli`, `release`, and `finalize`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but it can alter release automation behavior by preventing `build`/publish/release/finalize steps from running after upstream failures or skips.
> 
> **Overview**
> Tightens `.github/workflows/release.yml` job conditions so `build`, `publish_cli`, and `release` only execute when their upstream dependencies completed *successfully* (in addition to not being cancelled/failing).
> 
> Also gates `finalize` on both a successful `preflight` and `release`, while keeping the existing *stable-channel only* restriction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37485cc7e048f47acc8114b38ababf6db9ebdee9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard release workflow jobs on explicit upstream job success
> The `build`, `publish_cli`, `release`, and `finalize` jobs in [release.yml](.github/workflows/release.yml) previously ran whenever the workflow had not failed or been cancelled, even if upstream jobs were skipped. Each job now also requires all upstream jobs to have `result == 'success'`, ensuring the pipeline stops if any earlier step does not complete successfully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37485cc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->