### PR TITLE
Use GitHub App token for release uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,6 +393,14 @@ jobs:
     runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
+      - id: app_token
+        name: Mint release app token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -477,6 +485,7 @@ jobs:
             release-assets/*.blockmap
             release-assets/*.yml
           fail_on_unmatched_files: true
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Publish first release
         if: needs.preflight.outputs.previous_tag == ''
@@ -496,6 +505,7 @@ jobs:
             release-assets/*.blockmap
             release-assets/*.yml
           fail_on_unmatched_files: true
+          token: ${{ steps.app_token.outputs.token }}
 
   finalize:
     name: Finalize release


### PR DESCRIPTION
## Summary
- Mint a GitHub App token at the start of the release job.
- Use that token for Electron release asset uploads instead of the default workflow token.
- Keep upload permissions scoped to the release app credentials configured in repository secrets.

## Testing
- Not run (workflow-only change).
- Verified the release workflow YAML updates the upload steps to pass `steps.app_token.outputs.token`.
- Verified the token is minted before checkout and available to both release upload steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the credentials used by the release workflow; misconfigured app secrets/permissions could cause release creation or asset uploads to fail.
> 
> **Overview**
> The release workflow now **mints a GitHub App installation token** (`actions/create-github-app-token@v2`) at the start of the `release` job.
> 
> Both `softprops/action-gh-release@v2` steps (existing release and first release) are updated to **use that App token** via `token: ${{ steps.app_token.outputs.token }}`, instead of relying on the default workflow token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f158bd810b3297ffc04c5c8e24146b95b2e14a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use GitHub App token for release uploads in the release workflow
> The `Publish GitHub Release` job in [release.yml](.github/workflows/release.yml) now mints a GitHub App token via `actions/create-github-app-token@v2` and passes it explicitly to both release publishing steps, replacing the default workflow token.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f158bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->