### PR TITLE
fix: fall back to local mode for empty repos with no commits

### DIFF
--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -185,13 +185,31 @@ describe("getStartedThreadModelChangeBlockReason", () => {
 });
 
 describe("resolveSendEnvMode", () => {
-  it("keeps worktree mode for git repositories", () => {
-    expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true })).toBe("worktree");
+  it("keeps worktree mode for git repositories with a branch", () => {
+    expect(
+      resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true, branch: "main" }),
+    ).toBe("worktree");
   });
 
   it("forces local mode for non-git repositories", () => {
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: false })).toBe("local");
     expect(resolveSendEnvMode({ requestedEnvMode: "local", isGitRepo: false })).toBe("local");
+  });
+
+  it("falls back to local mode for empty repos with no branch (no commits)", () => {
+    expect(
+      resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true, branch: null }),
+    ).toBe("local");
+  });
+
+  it("keeps local mode for empty repos when local was requested", () => {
+    expect(resolveSendEnvMode({ requestedEnvMode: "local", isGitRepo: true, branch: null })).toBe(
+      "local",
+    );
+  });
+
+  it("keeps worktree mode when branch is not provided (backward compat)", () => {
+    expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true })).toBe("worktree");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -84,13 +84,31 @@ describe("buildExpiredTerminalContextToastCopy", () => {
 });
 
 describe("resolveSendEnvMode", () => {
-  it("keeps worktree mode for git repositories", () => {
-    expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true })).toBe("worktree");
+  it("keeps worktree mode for git repositories with a branch", () => {
+    expect(
+      resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true, branch: "main" }),
+    ).toBe("worktree");
   });
 
   it("forces local mode for non-git repositories", () => {
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: false })).toBe("local");
     expect(resolveSendEnvMode({ requestedEnvMode: "local", isGitRepo: false })).toBe("local");
+  });
+
+  it("falls back to local mode for empty repos with no branch (no commits)", () => {
+    expect(
+      resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true, branch: null }),
+    ).toBe("local");
+  });
+
+  it("keeps local mode for empty repos when local was requested", () => {
+    expect(resolveSendEnvMode({ requestedEnvMode: "local", isGitRepo: true, branch: null })).toBe(
+      "local",
+    );
+  });
+
+  it("keeps worktree mode when branch is not provided (backward compat)", () => {
+    expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true })).toBe("worktree");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -178,8 +178,14 @@ export function readFileAsDataUrl(file: File): Promise<string> {
 export function resolveSendEnvMode(input: {
   requestedEnvMode: DraftThreadEnvMode;
   isGitRepo: boolean;
+  /** Current branch name — null for empty repos with no commits. */
+  branch?: string | null;
 }): DraftThreadEnvMode {
-  return input.isGitRepo ? input.requestedEnvMode : "local";
+  if (!input.isGitRepo) return "local";
+  // Empty repos (git init, no commits) report isRepo=true but branch=null.
+  // Worktree mode requires at least one commit, so fall back to local.
+  if (input.requestedEnvMode === "worktree" && input.branch === null) return "local";
+  return input.requestedEnvMode;
 }
 
 export function cloneComposerImageForRetry(

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -178,12 +178,17 @@ export function readFileAsDataUrl(file: File): Promise<string> {
 export function resolveSendEnvMode(input: {
   requestedEnvMode: DraftThreadEnvMode;
   isGitRepo: boolean;
-  /** Current branch name — null for empty repos with no commits. */
-  branch?: string | null;
+  /**
+   * Current branch name.
+   * - `null` → empty repo with no commits (fall back to local for worktree mode).
+   * - `undefined` → git status query still loading (keep requested mode).
+   */
+  branch?: string | null | undefined;
 }): DraftThreadEnvMode {
   if (!input.isGitRepo) return "local";
   // Empty repos (git init, no commits) report isRepo=true but branch=null.
   // Worktree mode requires at least one commit, so fall back to local.
+  // undefined means the query is still loading — don't downgrade yet.
   if (input.requestedEnvMode === "worktree" && input.branch === null) return "local";
   return input.requestedEnvMode;
 }

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -159,8 +159,14 @@ export function readFileAsDataUrl(file: File): Promise<string> {
 export function resolveSendEnvMode(input: {
   requestedEnvMode: DraftThreadEnvMode;
   isGitRepo: boolean;
+  /** Current branch name — null for empty repos with no commits. */
+  branch?: string | null;
 }): DraftThreadEnvMode {
-  return input.isGitRepo ? input.requestedEnvMode : "local";
+  if (!input.isGitRepo) return "local";
+  // Empty repos (git init, no commits) report isRepo=true but branch=null.
+  // Worktree mode requires at least one commit, so fall back to local.
+  if (input.requestedEnvMode === "worktree" && input.branch === null) return "local";
+  return input.requestedEnvMode;
 }
 
 export function cloneComposerImageForRetry(

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -159,12 +159,17 @@ export function readFileAsDataUrl(file: File): Promise<string> {
 export function resolveSendEnvMode(input: {
   requestedEnvMode: DraftThreadEnvMode;
   isGitRepo: boolean;
-  /** Current branch name — null for empty repos with no commits. */
-  branch?: string | null;
+  /**
+   * Current branch name.
+   * - `null` → empty repo with no commits (fall back to local for worktree mode).
+   * - `undefined` → git status query still loading (keep requested mode).
+   */
+  branch?: string | null | undefined;
 }): DraftThreadEnvMode {
   if (!input.isGitRepo) return "local";
   // Empty repos (git init, no commits) report isRepo=true but branch=null.
   // Worktree mode requires at least one commit, so fall back to local.
+  // undefined means the query is still loading — don't downgrade yet.
   if (input.requestedEnvMode === "worktree" && input.branch === null) return "local";
   return input.requestedEnvMode;
 }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3332,7 +3332,7 @@ function ChatViewContent(props: ChatViewProps) {
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
     isGitRepo,
-    branch: gitStatusQuery.data?.branch ?? null,
+    branch: gitStatusQuery.data?.refName,
   });
 
   useEffect(() => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3332,6 +3332,7 @@ function ChatViewContent(props: ChatViewProps) {
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
     isGitRepo,
+    branch: gitStatusQuery.data?.branch ?? null,
   });
 
   useEffect(() => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2104,7 +2104,7 @@ export default function ChatView(props: ChatViewProps) {
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
     isGitRepo,
-    branch: gitStatusQuery.data?.branch ?? null,
+    branch: gitStatusQuery.data?.branch,
   });
 
   useEffect(() => {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2104,6 +2104,7 @@ export default function ChatView(props: ChatViewProps) {
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
     isGitRepo,
+    branch: gitStatusQuery.data?.branch ?? null,
   });
 
   useEffect(() => {


### PR DESCRIPTION
## What Changed

`resolveSendEnvMode()` now checks branch availability alongside `isGitRepo`. When the user's default env mode is `"worktree"` but the repo has no branch (i.e. an empty repo with zero commits), it falls back to `"local"` mode instead of proceeding into a guaranteed crash.

Three files changed, 28 lines added, 3 removed:

- **`ChatView.logic.ts`** — added optional `branch` param to `resolveSendEnvMode`; returns `"local"` when worktree is requested but `branch === null`
- **`ChatView.tsx`** — passes `gitStatusQuery.data?.branch` at the call site
- **`ChatView.logic.test.ts`** — 3 new test cases (empty repo fallback, local-on-empty, backward compat when branch not provided)

## Why

Empty git repositories (`git init`, no commits) report `isRepo: true` but `branch: null` — the status line reads `# branch.head (initial)`, parsed as `null` in `GitCore.ts`. In worktree mode this triggers a crash:

1. `resolveSendEnvMode` sees `isGitRepo=true` → keeps `"worktree"` mode
2. Bootstrap calls `git worktree add` → fails (no commits to branch from)
3. Error handler dispatches `thread.delete` → draft is cleared
4. User is stranded on a dead route: "Select an existing thread or create a new one"

The fix is the smallest correct change: detect the missing branch client-side and fall back to local mode before the bootstrap ever runs. No server changes needed.

Fixes #2148

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes — N/A (no UI changes, behavioral fix only)
- [x] I included a video for animation/interaction changes — N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, client-only guard around env mode resolution with explicit loading (`undefined`) vs empty (`null`) semantics and tests; no auth or server changes.
> 
> **Overview**
> **Prevents worktree bootstrap from running on empty repos** (`git init`, zero commits) where git still reports a repo but no branch head.
> 
> `resolveSendEnvMode` in `ChatView.logic.ts` now accepts an optional `branch`: when the user wants **worktree** and `branch === null`, it returns **`local`** instead of keeping worktree (which would fail on `git worktree add`). If `branch` is **`undefined`** (VCS status still loading), the requested mode is unchanged so the UI does not flicker to local prematurely.
> 
> `ChatView.tsx` wires this by passing `gitStatusQuery.data?.refName` into `resolveSendEnvMode`. Unit tests cover empty-repo fallback, local-on-empty, and backward compatibility when `branch` is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a8126d6e62961597a0ac63c28ea960bebc6093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to local mode in `resolveSendEnvMode` for git repos with no commits
> When a git repo has no commits, `gitStatusQuery` reports `refName` as `null`. Previously, `resolveSendEnvMode` would still return the requested mode (e.g. `worktree`) in this case, which is invalid for an empty repo.
>
> - Updates `resolveSendEnvMode` in [ChatView.logic.ts](https://github.com/pingdotgg/t3code/pull/2150/files#diff-464e876afd6be3800453dd8cc94d805066953bed62ffd825bbd6fdfd86f4d114) to accept an optional `branch` field and return `"local"` when `branch === null` and the requested mode is `"worktree"`
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2150/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to pass `gitStatusQuery.data?.refName` as `branch`
> - When `branch` is `undefined` (e.g. still loading), the requested mode is preserved unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e8a8126.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->