### PR TITLE
Add fetch-latest-origin support for worktree bootstrap

### DIFF
--- a/apps/server/src/git/Layers/GitCore.test.ts
+++ b/apps/server/src/git/Layers/GitCore.test.ts
@@ -40,6 +40,15 @@ function writeTextFile(
   });
 }
 
+function readTextFile(
+  filePath: string,
+): Effect.Effect<string, PlatformError.PlatformError, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fileSystem = yield* FileSystem.FileSystem;
+    return yield* fileSystem.readFileString(filePath);
+  });
+}
+
 function removePath(
   targetPath: string,
 ): Effect.Effect<void, PlatformError.PlatformError, FileSystem.FileSystem> {
@@ -659,7 +668,31 @@ it.layer(TestLayer)("git integration", (it) => {
             "feature/demo",
             "origin/feature/remote-only",
           ]);
+          expect(result.branches.find((branch) => branch.name === "feature/demo")?.originRef).toBe(
+            "origin/feature/demo",
+          );
         }),
+    );
+
+    it.effect("matches branch queries against tracked origin refs for local branches", () =>
+      Effect.gen(function* () {
+        const remote = yield* makeTmpDir();
+        const tmp = yield* makeTmpDir();
+
+        yield* git(remote, ["init", "--bare"]);
+        const { initialBranch } = yield* initRepoWithCommit(tmp);
+        yield* git(tmp, ["remote", "add", "origin", remote]);
+        yield* git(tmp, ["push", "-u", "origin", initialBranch]);
+
+        const result = yield* (yield* GitCore).listBranches({
+          cwd: tmp,
+          query: "origin/",
+          limit: 10,
+        });
+
+        expect(result.branches.map((branch) => branch.name)).toEqual([initialBranch]);
+        expect(result.branches[0]?.originRef).toBe(`origin/${initialBranch}`);
+      }),
     );
   });
 
@@ -1358,6 +1391,40 @@ it.layer(TestLayer)("git integration", (it) => {
         expect(branchOutput).toBe("feature/existing-worktree");
 
         yield* (yield* GitCore).removeWorktree({ cwd: tmp, path: wtPath });
+      }),
+    );
+
+    it.effect("can base a new worktree on the latest fetched origin branch", () =>
+      Effect.gen(function* () {
+        const remote = yield* makeTmpDir();
+        const source = yield* makeTmpDir();
+        const updater = yield* makeTmpDir();
+
+        yield* git(remote, ["init", "--bare"]);
+        const { initialBranch } = yield* initRepoWithCommit(source);
+        yield* git(source, ["remote", "add", "origin", remote]);
+        yield* git(source, ["push", "-u", "origin", initialBranch]);
+
+        yield* git(updater, ["clone", remote, "."]);
+        yield* git(updater, ["config", "user.email", "test@test.com"]);
+        yield* git(updater, ["config", "user.name", "Test"]);
+        yield* writeTextFile(path.join(updater, "README.md"), "latest from origin\n");
+        yield* git(updater, ["add", "README.md"]);
+        yield* git(updater, ["commit", "-m", "advance origin"]);
+        yield* git(updater, ["push", "origin", initialBranch]);
+
+        const wtPath = path.join(source, "wt-origin-latest");
+        yield* (yield* GitCore).createWorktree({
+          cwd: source,
+          branch: initialBranch,
+          newBranch: "wt-origin-latest",
+          fetchLatestOrigin: true,
+          path: wtPath,
+        });
+
+        expect(yield* readTextFile(path.join(wtPath, "README.md"))).toBe("latest from origin\n");
+
+        yield* (yield* GitCore).removeWorktree({ cwd: source, path: wtPath });
       }),
     );
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -213,7 +213,11 @@ function filterBranchesForListQuery(
   }
 
   const normalizedQuery = query.toLowerCase();
-  return branches.filter((branch) => branch.name.toLowerCase().includes(normalizedQuery));
+  return branches.filter(
+    (branch) =>
+      branch.name.toLowerCase().includes(normalizedQuery) ||
+      branch.originRef?.toLowerCase().includes(normalizedQuery) === true,
+  );
 }
 
 function paginateBranches(input: {
@@ -1868,28 +1872,6 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       }
     }
 
-    const localBranches = localBranchResult.stdout
-      .split("\n")
-      .map(parseBranchLine)
-      .filter((branch): branch is { name: string; current: boolean } => branch !== null)
-      .map((branch) => ({
-        name: branch.name,
-        current: branch.current,
-        isRemote: false,
-        isDefault: branch.name === defaultBranch,
-        worktreePath: worktreeMap.get(branch.name) ?? null,
-      }))
-      .toSorted((a, b) => {
-        const aPriority = a.current ? 0 : a.isDefault ? 1 : 2;
-        const bPriority = b.current ? 0 : b.isDefault ? 1 : 2;
-        if (aPriority !== bPriority) return aPriority - bPriority;
-
-        const aLastCommit = branchLastCommit.get(a.name) ?? 0;
-        const bLastCommit = branchLastCommit.get(b.name) ?? 0;
-        if (aLastCommit !== bLastCommit) return bLastCommit - aLastCommit;
-        return a.name.localeCompare(b.name);
-      });
-
     const remoteBranches =
       remoteBranchResult.code === 0
         ? remoteBranchResult.stdout
@@ -1925,6 +1907,38 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
             })
         : [];
 
+    const originRemoteRefs = new Set(
+      remoteBranches
+        .filter((branch) => branch.remoteName === "origin")
+        .map((branch) => branch.name),
+    );
+
+    const localBranches = localBranchResult.stdout
+      .split("\n")
+      .map(parseBranchLine)
+      .filter((branch): branch is { name: string; current: boolean } => branch !== null)
+      .map((branch) => {
+        const originRef = `origin/${branch.name}`;
+        return {
+          name: branch.name,
+          current: branch.current,
+          isRemote: false,
+          originRef: originRemoteRefs.has(originRef) ? originRef : undefined,
+          isDefault: branch.name === defaultBranch,
+          worktreePath: worktreeMap.get(branch.name) ?? null,
+        };
+      })
+      .toSorted((a, b) => {
+        const aPriority = a.current ? 0 : a.isDefault ? 1 : 2;
+        const bPriority = b.current ? 0 : b.isDefault ? 1 : 2;
+        if (aPriority !== bPriority) return aPriority - bPriority;
+
+        const aLastCommit = branchLastCommit.get(a.name) ?? 0;
+        const bLastCommit = branchLastCommit.get(b.name) ?? 0;
+        if (aLastCommit !== bLastCommit) return bLastCommit - aLastCommit;
+        return a.name.localeCompare(b.name);
+      });
+
     const branches = paginateBranches({
       branches: filterBranchesForListQuery(
         dedupeRemoteBranchesWithLocalMatches([...localBranches, ...remoteBranches]),
@@ -1949,9 +1963,29 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
       const sanitizedBranch = targetBranch.replace(/\//g, "-");
       const repoName = path.basename(input.cwd);
       const worktreePath = input.path ?? path.join(worktreesDir, repoName, sanitizedBranch);
+      let baseRef = input.branch;
+
+      if (input.fetchLatestOrigin) {
+        yield* executeGit(
+          "GitCore.createWorktree.fetchLatestOrigin",
+          input.cwd,
+          [
+            "fetch",
+            "--quiet",
+            "--no-tags",
+            "origin",
+            `+refs/heads/${input.branch}:refs/remotes/origin/${input.branch}`,
+          ],
+          {
+            fallbackErrorMessage: `git fetch origin ${input.branch} failed`,
+          },
+        );
+        baseRef = `origin/${input.branch}`;
+      }
+
       const args = input.newBranch
-        ? ["worktree", "add", "-b", input.newBranch, worktreePath, input.branch]
-        : ["worktree", "add", worktreePath, input.branch];
+        ? ["worktree", "add", "-b", input.newBranch, worktreePath, baseRef]
+        : ["worktree", "add", worktreePath, baseRef];
 
       yield* executeGit("GitCore.createWorktree", input.cwd, args, {
         fallbackErrorMessage: "git worktree add failed",

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -3605,6 +3605,69 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("passes fetchLatestOrigin through bootstrap worktree creation when requested", () =>
+    Effect.gen(function* () {
+      const createWorktree = vi.fn((_: Parameters<GitCoreShape["createWorktree"]>[0]) =>
+        Effect.succeed({
+          worktree: {
+            branch: "t3code/bootstrap-branch",
+            path: "/tmp/bootstrap-worktree",
+          },
+        }),
+      );
+
+      yield* buildAppUnderTest({
+        layers: {
+          gitCore: {
+            createWorktree,
+          },
+          orchestrationEngine: {
+            dispatch: () => Effect.succeed({ sequence: 1 }),
+            readEvents: () => Stream.empty,
+          },
+        },
+      });
+
+      const createdAt = new Date().toISOString();
+      const wsUrl = yield* getWsServerUrl("/ws");
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.turn.start",
+            commandId: CommandId.make("cmd-bootstrap-turn-start-fetch-origin"),
+            threadId: ThreadId.make("thread-bootstrap-fetch-origin"),
+            message: {
+              messageId: MessageId.make("msg-bootstrap-fetch-origin"),
+              role: "user",
+              text: "hello",
+              attachments: [],
+            },
+            modelSelection: defaultModelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            bootstrap: {
+              prepareWorktree: {
+                projectCwd: "/tmp/project",
+                baseBranch: "main",
+                branch: "t3code/bootstrap-branch",
+                fetchLatestOrigin: true,
+              },
+            },
+            createdAt,
+          }),
+        ),
+      );
+
+      assert.deepEqual(createWorktree.mock.calls[0]?.[0], {
+        cwd: "/tmp/project",
+        branch: "main",
+        newBranch: "t3code/bootstrap-branch",
+        fetchLatestOrigin: true,
+        path: null,
+      });
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("records setup-script failures without aborting bootstrap turn start", () =>
     Effect.gen(function* () {
       const dispatchedCommands: Array<OrchestrationCommand> = [];

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -457,6 +457,7 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
                 cwd: bootstrap.prepareWorktree.projectCwd,
                 branch: bootstrap.prepareWorktree.baseBranch,
                 newBranch: bootstrap.prepareWorktree.branch,
+                ...(bootstrap.prepareWorktree.fetchLatestOrigin ? { fetchLatestOrigin: true } : {}),
                 path: null,
               });
               targetWorktreePath = worktree.worktree.path;

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -23,6 +23,8 @@ interface BranchToolbarProps {
   effectiveEnvModeOverride?: EnvMode;
   activeThreadBranchOverride?: string | null;
   onActiveThreadBranchOverrideChange?: (branch: string | null) => void;
+  fetchLatestOriginOverride?: boolean;
+  onFetchLatestOriginOverrideChange?: (fetchLatestOrigin: boolean) => void;
   envLocked: boolean;
   onCheckoutPullRequestRequest?: (reference: string) => void;
   onComposerFocusRequest?: () => void;
@@ -38,6 +40,8 @@ export const BranchToolbar = memo(function BranchToolbar({
   effectiveEnvModeOverride,
   activeThreadBranchOverride,
   onActiveThreadBranchOverrideChange,
+  fetchLatestOriginOverride,
+  onFetchLatestOriginOverrideChange,
   envLocked,
   onCheckoutPullRequestRequest,
   onComposerFocusRequest,
@@ -109,6 +113,8 @@ export const BranchToolbar = memo(function BranchToolbar({
         {...(effectiveEnvModeOverride ? { effectiveEnvModeOverride } : {})}
         {...(activeThreadBranchOverride !== undefined ? { activeThreadBranchOverride } : {})}
         {...(onActiveThreadBranchOverrideChange ? { onActiveThreadBranchOverrideChange } : {})}
+        {...(fetchLatestOriginOverride !== undefined ? { fetchLatestOriginOverride } : {})}
+        {...(onFetchLatestOriginOverrideChange ? { onFetchLatestOriginOverrideChange } : {})}
         {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}
         {...(onComposerFocusRequest ? { onComposerFocusRequest } : {})}
       />

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -42,6 +42,7 @@ import {
   ComboboxStatus,
   ComboboxTrigger,
 } from "./ui/combobox";
+import { Switch } from "./ui/switch";
 import { toastManager } from "./ui/toast";
 
 interface BranchToolbarBranchSelectorProps {
@@ -52,6 +53,8 @@ interface BranchToolbarBranchSelectorProps {
   effectiveEnvModeOverride?: "local" | "worktree";
   activeThreadBranchOverride?: string | null;
   onActiveThreadBranchOverrideChange?: (branch: string | null) => void;
+  fetchLatestOriginOverride?: boolean;
+  onFetchLatestOriginOverrideChange?: (fetchLatestOrigin: boolean) => void;
   onCheckoutPullRequestRequest?: (reference: string) => void;
   onComposerFocusRequest?: () => void;
 }
@@ -83,6 +86,8 @@ export function BranchToolbarBranchSelector({
   effectiveEnvModeOverride,
   activeThreadBranchOverride,
   onActiveThreadBranchOverrideChange,
+  fetchLatestOriginOverride,
+  onFetchLatestOriginOverrideChange,
   onCheckoutPullRequestRequest,
   onComposerFocusRequest,
 }: BranchToolbarBranchSelectorProps) {
@@ -118,6 +123,10 @@ export function BranchToolbarBranchSelector({
     activeThreadBranchOverride !== undefined
       ? activeThreadBranchOverride
       : (serverThread?.branch ?? draftThread?.branch ?? null);
+  const fetchLatestOrigin =
+    fetchLatestOriginOverride !== undefined
+      ? fetchLatestOriginOverride
+      : (draftThread?.fetchLatestOriginOnWorktreeCreate ?? false);
   const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const activeProjectCwd = activeProject?.cwd ?? null;
   const branchCwd = activeWorktreePath ?? activeProjectCwd;
@@ -233,7 +242,6 @@ export function BranchToolbarBranchSelector({
     activeThreadBranch,
     currentGitBranch,
   });
-  const branchNames = useMemo(() => branches.map((branch) => branch.name), [branches]);
   const branchByName = useMemo(
     () => new Map(branches.map((branch) => [branch.name, branch] as const)),
     [branches],
@@ -249,6 +257,7 @@ export function BranchToolbarBranchSelector({
   const createBranchItemValue = canCreateBranch
     ? `__create_new_branch__:${trimmedBranchQuery}`
     : null;
+  const branchNames = useMemo(() => branches.map((branch) => branch.name), [branches]);
   const branchPickerItems = useMemo(() => {
     const items = [...branchNames];
     if (createBranchItemValue && !hasExactBranchMatch) {
@@ -285,6 +294,16 @@ export function BranchToolbarBranchSelector({
   const [isBranchActionPending, startBranchActionTransition] = useTransition();
   const shouldVirtualizeBranchList = filteredBranchPickerItems.length > 40;
   const totalBranchCount = branchesSearchData?.pages[0]?.totalCount ?? 0;
+  const hasOriginRemote =
+    branchesSearchData?.pages[0]?.hasOriginRemote ??
+    branchStatusQuery.data?.hasOriginRemote ??
+    false;
+  const selectedBaseBranch = resolvedActiveBranch ? branchByName.get(resolvedActiveBranch) : null;
+  const shouldShowFetchLatestOriginToggle =
+    isSelectingWorktreeBase &&
+    hasOriginRemote &&
+    resolvedActiveBranch !== null &&
+    !(selectedBaseBranch?.isRemote ?? resolvedActiveBranch.startsWith("origin/"));
   const branchStatusText = isBranchesSearchPending
     ? "Loading branches..."
     : isFetchingNextPage
@@ -305,14 +324,32 @@ export function BranchToolbarBranchSelector({
     });
   };
 
+  const selectWorktreeBaseBranch = (branchName: string) => {
+    if (!isSelectingWorktreeBase || isBranchActionPending) return;
+    setThreadBranch(branchName, null);
+    setIsBranchMenuOpen(false);
+    onComposerFocusRequest?.();
+  };
+
+  const setFetchLatestOriginForWorktreeCreate = useCallback(
+    (nextFetchLatestOrigin: boolean) => {
+      if (hasServerThread) {
+        onFetchLatestOriginOverrideChange?.(nextFetchLatestOrigin);
+        return;
+      }
+      setDraftThreadContext(draftId ?? threadRef, {
+        fetchLatestOriginOnWorktreeCreate: nextFetchLatestOrigin,
+      });
+    },
+    [draftId, hasServerThread, onFetchLatestOriginOverrideChange, setDraftThreadContext, threadRef],
+  );
+
   const selectBranch = (branch: GitBranch) => {
     const api = readEnvironmentApi(environmentId);
     if (!api || !branchCwd || !activeProjectCwd || isBranchActionPending) return;
 
     if (isSelectingWorktreeBase) {
-      setThreadBranch(branch.name, null);
-      setIsBranchMenuOpen(false);
-      onComposerFocusRequest?.();
+      selectWorktreeBaseBranch(branch.name);
       return;
     }
 
@@ -591,6 +628,17 @@ export function BranchToolbarBranchSelector({
             onChange={(event) => setBranchQuery(event.target.value)}
           />
         </div>
+        {shouldShowFetchLatestOriginToggle ? (
+          <label className="flex min-w-0 items-center justify-between gap-3 border-b px-3 py-2">
+            <span className="min-w-0 truncate text-sm">Fetch latest origin before creation</span>
+            <Switch
+              className="shrink-0"
+              checked={fetchLatestOrigin}
+              aria-label="Fetch latest origin before creation"
+              onCheckedChange={(checked) => setFetchLatestOriginForWorktreeCreate(Boolean(checked))}
+            />
+          </label>
+        ) : null}
         <ComboboxEmpty>No branches found.</ComboboxEmpty>
 
         {shouldVirtualizeBranchList ? (

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -2605,6 +2605,110 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("can fetch the latest origin ref before creating a worktree", async () => {
+    const snapshot = addThreadToSnapshot(createDraftOnlySnapshot(), THREAD_ID);
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: {
+        ...snapshot,
+        threads: snapshot.threads.map((thread) =>
+          thread.id === THREAD_ID ? Object.assign({}, thread, { session: null }) : thread,
+        ),
+      },
+      resolveRpc: (body) => {
+        if (body._tag === WS_METHODS.gitListBranches) {
+          return {
+            isRepo: true,
+            hasOriginRemote: true,
+            nextCursor: null,
+            totalCount: 1,
+            branches: [
+              {
+                name: "main",
+                originRef: "origin/main",
+                current: true,
+                isDefault: true,
+                worktreePath: null,
+              },
+            ],
+          };
+        }
+        if (body._tag === ORCHESTRATION_WS_METHODS.dispatchCommand) {
+          return {
+            sequence: fixture.snapshot.snapshotSequence + 1,
+          };
+        }
+        return undefined;
+      },
+    });
+
+    try {
+      (await waitForButtonByText("Current checkout")).click();
+      await page.getByText("New worktree", { exact: true }).click();
+      await page.getByText("From main", { exact: true }).click();
+      await page.getByRole("switch", { name: "Fetch latest origin before creation" }).click();
+
+      await vi.waitFor(
+        () => {
+          const turnStartRequest = wsRequests.find(
+            (request) =>
+              request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+              request.type === "thread.turn.start",
+          ) as
+            | {
+                _tag: string;
+                type?: string;
+                bootstrap?: {
+                  prepareWorktree?: {
+                    baseBranch?: string;
+                    fetchLatestOrigin?: boolean;
+                  };
+                };
+              }
+            | undefined;
+
+          expect(findButtonByText("From main")).toBeTruthy();
+          expect(turnStartRequest?.bootstrap?.prepareWorktree?.fetchLatestOrigin).not.toBe(true);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      useComposerDraftStore.getState().setPrompt(THREAD_REF, "Ship it");
+      await waitForLayout();
+
+      const sendButton = await waitForSendButton();
+      expect(sendButton.disabled).toBe(false);
+      sendButton.click();
+
+      await vi.waitFor(
+        () => {
+          const turnStartRequest = wsRequests.find(
+            (request) =>
+              request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+              request.type === "thread.turn.start",
+          ) as
+            | {
+                _tag: string;
+                type?: string;
+                bootstrap?: {
+                  prepareWorktree?: {
+                    baseBranch?: string;
+                    fetchLatestOrigin?: boolean;
+                  };
+                };
+              }
+            | undefined;
+
+          expect(turnStartRequest?.bootstrap?.prepareWorktree?.baseBranch).toBe("main");
+          expect(turnStartRequest?.bootstrap?.prepareWorktree?.fetchLatestOrigin).toBe(true);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("clears pending worktree overrides when switching empty server threads", async () => {
     const secondThreadId = "thread-browser-test-second" as ThreadId;
     const snapshot = addThreadToSnapshot(createDraftOnlySnapshot(), THREAD_ID);

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -700,6 +700,9 @@ export default function ChatView(props: ChatViewProps) {
   const [pendingServerThreadEnvMode, setPendingServerThreadEnvMode] =
     useState<DraftThreadEnvMode | null>(null);
   const [pendingServerThreadBranch, setPendingServerThreadBranch] = useState<string | null>();
+  const [pendingServerThreadFetchLatestOrigin, setPendingServerThreadFetchLatestOrigin] = useState<
+    boolean | null
+  >(null);
   const [lastInvokedScriptByProjectId, setLastInvokedScriptByProjectId] = useLocalStorage(
     LAST_INVOKED_SCRIPT_BY_PROJECT_KEY,
     {},
@@ -2101,6 +2104,11 @@ export default function ChatView(props: ChatViewProps) {
     canOverrideServerThreadEnvMode && pendingServerThreadBranch !== undefined
       ? pendingServerThreadBranch
       : (activeThread?.branch ?? null);
+  const activeThreadFetchLatestOrigin = canOverrideServerThreadEnvMode
+    ? (pendingServerThreadFetchLatestOrigin ?? false)
+    : isLocalDraftThread
+      ? (draftThread?.fetchLatestOriginOnWorktreeCreate ?? false)
+      : false;
   const sendEnvMode = resolveSendEnvMode({
     requestedEnvMode: envMode,
     isGitRepo,
@@ -2109,6 +2117,7 @@ export default function ChatView(props: ChatViewProps) {
   useEffect(() => {
     setPendingServerThreadEnvMode(null);
     setPendingServerThreadBranch(undefined);
+    setPendingServerThreadFetchLatestOrigin(null);
   }, [activeThread?.id]);
 
   useEffect(() => {
@@ -2117,6 +2126,7 @@ export default function ChatView(props: ChatViewProps) {
     }
     setPendingServerThreadEnvMode(null);
     setPendingServerThreadBranch(undefined);
+    setPendingServerThreadFetchLatestOrigin(null);
   }, [canOverrideServerThreadEnvMode]);
 
   useEffect(() => {
@@ -2433,6 +2443,11 @@ export default function ChatView(props: ChatViewProps) {
       isFirstMessage && sendEnvMode === "worktree" && !activeThread.worktreePath
         ? activeThreadBranch
         : null;
+    const fetchLatestOriginForWorktree =
+      isFirstMessage &&
+      sendEnvMode === "worktree" &&
+      !activeThread.worktreePath &&
+      activeThreadFetchLatestOrigin;
 
     // In worktree mode, require an explicit base branch so we don't silently
     // fall back to local execution when branch selection is missing.
@@ -2586,6 +2601,7 @@ export default function ChatView(props: ChatViewProps) {
                       projectCwd: activeProject.cwd,
                       baseBranch: baseBranchForWorktree,
                       branch: buildTemporaryWorktreeBranchName(),
+                      ...(fetchLatestOriginForWorktree ? { fetchLatestOrigin: true } : {}),
                     },
                     runSetupScript: true,
                   }
@@ -3380,6 +3396,9 @@ export default function ChatView(props: ChatViewProps) {
                 ? {
                     activeThreadBranchOverride: activeThreadBranch,
                     onActiveThreadBranchOverrideChange: setPendingServerThreadBranch,
+                    fetchLatestOriginOverride: activeThreadFetchLatestOrigin,
+                    onFetchLatestOriginOverrideChange: (fetchLatestOrigin: boolean) =>
+                      setPendingServerThreadFetchLatestOrigin(fetchLatestOrigin),
                   }
                 : {})}
               envLocked={envLocked}

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -791,6 +791,28 @@ describe("composerDraftStore project draft thread mapping", () => {
     });
   });
 
+  it("stores the fetch-latest-origin flag on an existing draft thread", () => {
+    const store = useComposerDraftStore.getState();
+    store.setProjectDraftThreadId(projectRef, draftId, {
+      threadId,
+      branch: "main",
+      worktreePath: null,
+      envMode: "worktree",
+    });
+    store.setDraftThreadContext(draftId, {
+      fetchLatestOriginOnWorktreeCreate: true,
+    });
+
+    expect(useComposerDraftStore.getState().getDraftThread(draftId)).toMatchObject({
+      environmentId: TEST_ENVIRONMENT_ID,
+      projectId,
+      branch: "main",
+      worktreePath: null,
+      envMode: "worktree",
+      fetchLatestOriginOnWorktreeCreate: true,
+    });
+  });
+
   it("preserves existing branch and worktree when setProjectDraftThreadId receives undefined", () => {
     const store = useComposerDraftStore.getState();
     store.setProjectDraftThreadId(projectRef, draftId, {
@@ -863,6 +885,7 @@ describe("composerDraftStore project draft thread mapping", () => {
       branch: null,
       worktreePath: null,
       envMode: "local",
+      fetchLatestOriginOnWorktreeCreate: false,
     });
   });
 
@@ -885,6 +908,7 @@ describe("composerDraftStore project draft thread mapping", () => {
       branch: null,
       worktreePath: null,
       envMode: "local",
+      fetchLatestOriginOnWorktreeCreate: false,
     });
   });
 });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -165,6 +165,7 @@ const PersistedDraftThreadState = Schema.Struct({
   branch: Schema.NullOr(Schema.String),
   worktreePath: Schema.NullOr(Schema.String),
   envMode: DraftThreadEnvModeSchema,
+  fetchLatestOriginOnWorktreeCreate: Schema.optionalKey(Schema.Boolean),
   promotedTo: Schema.optionalKey(
     Schema.NullOr(
       Schema.Struct({
@@ -225,6 +226,7 @@ export interface DraftSessionState {
   branch: string | null;
   worktreePath: string | null;
   envMode: DraftThreadEnvMode;
+  fetchLatestOriginOnWorktreeCreate?: boolean;
   promotedTo?: ScopedThreadRef | null;
 }
 
@@ -286,6 +288,7 @@ interface ComposerDraftStoreState {
       worktreePath?: string | null;
       createdAt?: string;
       envMode?: DraftThreadEnvMode;
+      fetchLatestOriginOnWorktreeCreate?: boolean;
       runtimeMode?: RuntimeMode;
       interactionMode?: ProviderInteractionMode;
     },
@@ -300,6 +303,7 @@ interface ComposerDraftStoreState {
       worktreePath?: string | null;
       createdAt?: string;
       envMode?: DraftThreadEnvMode;
+      fetchLatestOriginOnWorktreeCreate?: boolean;
       runtimeMode?: RuntimeMode;
       interactionMode?: ProviderInteractionMode;
     },
@@ -313,6 +317,7 @@ interface ComposerDraftStoreState {
       projectRef?: ScopedProjectRef;
       createdAt?: string;
       envMode?: DraftThreadEnvMode;
+      fetchLatestOriginOnWorktreeCreate?: boolean;
       runtimeMode?: RuntimeMode;
       interactionMode?: ProviderInteractionMode;
     },
@@ -1067,6 +1072,7 @@ function createDraftThreadState(
     worktreePath?: string | null;
     createdAt?: string;
     envMode?: DraftThreadEnvMode;
+    fetchLatestOriginOnWorktreeCreate?: boolean;
     runtimeMode?: RuntimeMode;
     interactionMode?: ProviderInteractionMode;
   },
@@ -1087,6 +1093,12 @@ function createDraftThreadState(
         ? null
         : (existingThread?.branch ?? null)
       : (options.branch ?? null);
+  const fetchLatestOriginOnWorktreeCreate =
+    options?.fetchLatestOriginOnWorktreeCreate === undefined
+      ? projectChanged
+        ? false
+        : (existingThread?.fetchLatestOriginOnWorktreeCreate ?? false)
+      : options.fetchLatestOriginOnWorktreeCreate;
   return {
     threadId,
     environmentId: projectRef.environmentId,
@@ -1105,6 +1117,7 @@ function createDraftThreadState(
         : projectChanged
           ? "local"
           : (existingThread?.envMode ?? "local")),
+    fetchLatestOriginOnWorktreeCreate,
     promotedTo: null,
   };
 }
@@ -1136,6 +1149,8 @@ function draftThreadsEqual(left: DraftThreadState | undefined, right: DraftThrea
     left.branch === right.branch &&
     left.worktreePath === right.worktreePath &&
     left.envMode === right.envMode &&
+    (left.fetchLatestOriginOnWorktreeCreate ?? false) ===
+      (right.fetchLatestOriginOnWorktreeCreate ?? false) &&
     scopedThreadRefsEqual(left.promotedTo, right.promotedTo)
   );
 }
@@ -1277,6 +1292,8 @@ function normalizePersistedDraftThreads(
         branch: typeof branch === "string" ? branch : null,
         worktreePath: normalizedWorktreePath,
         envMode: normalizeDraftThreadEnvMode(candidateDraftThread.envMode, normalizedWorktreePath),
+        fetchLatestOriginOnWorktreeCreate:
+          candidateDraftThread.fetchLatestOriginOnWorktreeCreate === true,
         promotedTo,
       };
     }
@@ -1322,6 +1339,7 @@ function normalizePersistedDraftThreads(
           branch: null,
           worktreePath: null,
           envMode: "local",
+          fetchLatestOriginOnWorktreeCreate: false,
           promotedTo: null,
         };
       } else if (
@@ -1826,6 +1844,8 @@ function toHydratedDraftThreadState(
     branch: persistedDraftThread.branch,
     worktreePath: persistedDraftThread.worktreePath,
     envMode: persistedDraftThread.envMode,
+    fetchLatestOriginOnWorktreeCreate:
+      persistedDraftThread.fetchLatestOriginOnWorktreeCreate ?? false,
     promotedTo: persistedDraftThread.promotedTo
       ? scopeThreadRef(
           persistedDraftThread.promotedTo.environmentId as EnvironmentId,
@@ -2031,6 +2051,12 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
                   : projectChanged
                     ? "local"
                     : (existing.envMode ?? "local")),
+              fetchLatestOriginOnWorktreeCreate:
+                options.fetchLatestOriginOnWorktreeCreate === undefined
+                  ? projectChanged
+                    ? false
+                    : (existing.fetchLatestOriginOnWorktreeCreate ?? false)
+                  : options.fetchLatestOriginOnWorktreeCreate,
               promotedTo: existing.promotedTo ?? null,
             };
             const isUnchanged =
@@ -2043,6 +2069,8 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               nextDraftThread.branch === existing.branch &&
               nextDraftThread.worktreePath === existing.worktreePath &&
               nextDraftThread.envMode === existing.envMode &&
+              (nextDraftThread.fetchLatestOriginOnWorktreeCreate ?? false) ===
+                (existing.fetchLatestOriginOnWorktreeCreate ?? false) &&
               scopedThreadRefsEqual(nextDraftThread.promotedTo, existing.promotedTo);
             if (isUnchanged) {
               return state;

--- a/packages/contracts/src/git.test.ts
+++ b/packages/contracts/src/git.test.ts
@@ -2,14 +2,18 @@ import { describe, expect, it } from "vitest";
 import { Schema } from "effect";
 
 import {
+  GitBranch,
   GitCreateWorktreeInput,
+  GitListBranchesResult,
   GitPreparePullRequestThreadInput,
   GitRunStackedActionResult,
   GitRunStackedActionInput,
   GitResolvePullRequestResult,
 } from "./git.ts";
 
+const decodeBranch = Schema.decodeUnknownSync(GitBranch);
 const decodeCreateWorktreeInput = Schema.decodeUnknownSync(GitCreateWorktreeInput);
+const decodeListBranchesResult = Schema.decodeUnknownSync(GitListBranchesResult);
 const decodePreparePullRequestThreadInput = Schema.decodeUnknownSync(
   GitPreparePullRequestThreadInput,
 );
@@ -27,6 +31,31 @@ describe("GitCreateWorktreeInput", () => {
 
     expect(parsed.newBranch).toBeUndefined();
     expect(parsed.branch).toBe("feature/existing");
+  });
+
+  it("accepts an optional fetch-latest-origin flag", () => {
+    const parsed = decodeCreateWorktreeInput({
+      cwd: "/repo",
+      branch: "main",
+      fetchLatestOrigin: true,
+      path: "/tmp/worktree",
+    });
+
+    expect(parsed.fetchLatestOrigin).toBe(true);
+  });
+});
+
+describe("GitBranch", () => {
+  it("accepts optional origin refs for local branches", () => {
+    const parsed = decodeBranch({
+      name: "main",
+      originRef: "origin/main",
+      current: true,
+      isDefault: true,
+      worktreePath: null,
+    });
+
+    expect(parsed.originRef).toBe("origin/main");
   });
 });
 
@@ -58,6 +87,28 @@ describe("GitResolvePullRequestResult", () => {
 
     expect(parsed.pullRequest.number).toBe(42);
     expect(parsed.pullRequest.headBranch).toBe("feature/pr-threads");
+  });
+});
+
+describe("GitListBranchesResult", () => {
+  it("decodes branches that expose an origin tracking ref", () => {
+    const parsed = decodeListBranchesResult({
+      branches: [
+        {
+          name: "main",
+          originRef: "origin/main",
+          current: true,
+          isDefault: true,
+          worktreePath: null,
+        },
+      ],
+      isRepo: true,
+      hasOriginRemote: true,
+      nextCursor: null,
+      totalCount: 1,
+    });
+
+    expect(parsed.branches[0]?.originRef).toBe("origin/main");
   });
 });
 

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -83,6 +83,7 @@ export const GitBranch = Schema.Struct({
   name: TrimmedNonEmptyStringSchema,
   isRemote: Schema.optional(Schema.Boolean),
   remoteName: Schema.optional(TrimmedNonEmptyStringSchema),
+  originRef: Schema.optional(TrimmedNonEmptyStringSchema),
   current: Schema.Boolean,
   isDefault: Schema.Boolean,
   worktreePath: TrimmedNonEmptyStringSchema.pipe(Schema.NullOr),
@@ -141,6 +142,7 @@ export const GitCreateWorktreeInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
   branch: TrimmedNonEmptyStringSchema,
   newBranch: Schema.optional(TrimmedNonEmptyStringSchema),
+  fetchLatestOrigin: Schema.optional(Schema.Boolean),
   path: Schema.NullOr(TrimmedNonEmptyStringSchema),
 });
 export type GitCreateWorktreeInput = typeof GitCreateWorktreeInput.Type;

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -242,6 +242,7 @@ it.effect("accepts bootstrap metadata in thread.turn.start", () =>
           projectCwd: "/tmp/workspace",
           baseBranch: "main",
           branch: "t3code/example",
+          fetchLatestOrigin: true,
         },
         runSetupScript: true,
       },
@@ -249,6 +250,7 @@ it.effect("accepts bootstrap metadata in thread.turn.start", () =>
     });
     assert.strictEqual(parsed.bootstrap?.createThread?.projectId, "project-1");
     assert.strictEqual(parsed.bootstrap?.prepareWorktree?.baseBranch, "main");
+    assert.strictEqual(parsed.bootstrap?.prepareWorktree?.fetchLatestOrigin, true);
     assert.strictEqual(parsed.bootstrap?.runSetupScript, true);
   }),
 );

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -522,6 +522,7 @@ const ThreadTurnStartBootstrapPrepareWorktree = Schema.Struct({
   projectCwd: TrimmedNonEmptyString,
   baseBranch: TrimmedNonEmptyString,
   branch: Schema.optional(TrimmedNonEmptyString),
+  fetchLatestOrigin: Schema.optional(Schema.Boolean),
 });
 
 const ThreadTurnStartBootstrap = Schema.Struct({


### PR DESCRIPTION
## Summary
- Added an optional `fetchLatestOrigin` flag to worktree bootstrap and git worktree creation so new worktrees can be based on the latest remote `origin` ref.
- Thread bootstrap now propagates the flag from the web UI through the WebSocket/server path into `GitCore.createWorktree`.
- Exposed origin-tracking metadata in branch listings so the UI can show and search tracked remote refs for local branches.
- Added a branch selector toggle to let users opt into fetching the latest origin before creating a worktree.
- Persisted the draft-thread fetch preference in composer draft state and covered the new schema/behavior with tests.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`
- Added/updated tests for git worktree creation, branch listing, orchestration contracts, draft store persistence, and browser worktree bootstrap flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes git branch listing/filtering and worktree creation to optionally run an explicit `git fetch` and base new worktrees on `origin/<branch>`, which can affect checkout behavior in real repos. Scope is contained and covered by new server, contract, store, and browser tests.
> 
> **Overview**
> Adds an optional `fetchLatestOrigin` flag for worktree bootstrap/creation so a new worktree can be based on the latest `origin/<baseBranch>` (server now fetches that ref before `git worktree add`).
> 
> Branch listing now annotates local branches with an `originRef` (when an `origin/*` remote-tracking ref exists) and matches list queries against both local names and `originRef`, enabling UI search/selection to account for tracked origin refs.
> 
> Web UI exposes a worktree-base toggle (*Fetch latest origin before creation*), persists the preference on draft threads, and propagates it through websocket bootstrap into `GitCore.createWorktree`; schemas/contracts and tests were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c6025328bc0d83c4fa31cbf6bb22fe59f0d817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fetchLatestOrigin support for worktree bootstrap across contracts, server, and UI
> - Adds an optional `fetchLatestOrigin` flag to `GitCreateWorktreeInput` and `ThreadTurnStartBootstrapPrepareWorktree` contracts, propagated through the WebSocket RPC layer to `createWorktree` in [GitCore.ts](https://github.com/pingdotgg/t3code/pull/2151/files#diff-9e2e5027bebfaa9721be501cd8057c4a36400119ad0ad4797a8d6aca7f3c7865).
> - When `fetchLatestOrigin` is true, `createWorktree` runs `git fetch origin <branch>` and bases the new worktree on `origin/<branch>` instead of the local branch.
> - `listBranches` now populates an optional `originRef` field on local branches and matches list-query filtering against that ref in addition to the branch name.
> - Adds a toggle in [BranchToolbarBranchSelector.tsx](https://github.com/pingdotgg/t3code/pull/2151/files#diff-95e72064c321265e2363abda12fd803f217db7d06a32a076ea7337d942367734) shown when creating a worktree with an origin remote present; state is persisted in `composerDraftStore` via a new `fetchLatestOriginOnWorktreeCreate` field.
> - Risk: `git fetch` during worktree creation adds network latency to the bootstrap path when the flag is enabled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89c6025.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->