### PR TITLE
Add an account limit meter to the chat composer

### DIFF
--- a/apps/server/src/codexAppServerManager.ts
+++ b/apps/server/src/codexAppServerManager.ts
@@ -540,6 +540,7 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
           planType: context.account.planType,
           sparkEnabled: context.account.sparkEnabled,
         });
+        await this.refreshRateLimits(context, "session-start");
       } catch (error) {
         console.log("codex account/read failed", error);
       }
@@ -1144,6 +1145,12 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
         activeTurnId: undefined,
         lastError: errorMessage ?? context.session.lastError,
       });
+      void this.refreshRateLimits(context, "turn-completed");
+      return;
+    }
+
+    if (notification.method === "account/updated") {
+      void this.refreshRateLimits(context, "account-updated");
       return;
     }
 
@@ -1324,6 +1331,27 @@ export class CodexAppServerManager extends EventEmitter<CodexAppServerManagerEve
       method,
       message,
     });
+  }
+
+  private async refreshRateLimits(context: CodexSessionContext, reason: string): Promise<void> {
+    try {
+      const response = await this.sendRequest(context, "account/rateLimits/read", {}, 5_000);
+      this.emitEvent({
+        id: EventId.make(randomUUID()),
+        kind: "notification",
+        provider: "codex",
+        threadId: context.session.threadId,
+        createdAt: new Date().toISOString(),
+        method: "account/rateLimits/updated",
+        payload: response,
+      });
+    } catch (error) {
+      await Effect.logDebug("codex app-server rate limits refresh failed", {
+        threadId: context.session.threadId,
+        reason,
+        cause: error instanceof Error ? error.message : String(error),
+      }).pipe(this.runPromise);
+    }
   }
 
   private emitEvent(event: ProviderEvent): void {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -447,6 +447,26 @@ function runtimeEventToActivities(
       ];
     }
 
+    case "account.rate-limits.updated": {
+      const payload = event.payload.normalized;
+      if (!payload) {
+        return [];
+      }
+
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "account-rate-limits.updated",
+          summary: "Account limit updated",
+          payload,
+          turnId: null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
     case "item.updated": {
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -19,6 +19,7 @@ import {
   type SDKUserMessage,
   type ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
+import { normalizeAccountRateLimits } from "@t3tools/shared/accountLimits";
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
 import {
   ApprovalRequestId,
@@ -2276,11 +2277,13 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (message.type === "rate_limit_event") {
+      const normalized = normalizeAccountRateLimits(message);
       yield* offerRuntimeEvent({
         ...base,
         type: "account.rate-limits.updated",
         payload: {
           rateLimits: message,
+          ...(normalized ? { normalized } : {}),
         },
       });
       return;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -22,6 +22,7 @@ import {
   TurnId,
   ProviderSendTurnInput,
 } from "@t3tools/contracts";
+import { normalizeAccountRateLimits } from "@t3tools/shared/accountLimits";
 import { Effect, FileSystem, Layer, Queue, Schema, Context, Stream } from "effect";
 
 import {
@@ -1166,12 +1167,14 @@ function mapToRuntimeEvents(
   }
 
   if (event.method === "account/rateLimits/updated") {
+    const normalized = normalizeAccountRateLimits(event.payload);
     return [
       {
         type: "account.rate-limits.updated",
         ...runtimeEventBase(event, canonicalThreadId),
         payload: {
           rateLimits: event.payload ?? {},
+          ...(normalized ? { normalized } : {}),
         },
       },
     ];

--- a/apps/web/src/components/chat/AccountLimitMeter.tsx
+++ b/apps/web/src/components/chat/AccountLimitMeter.tsx
@@ -1,0 +1,133 @@
+import type { AccountRateLimitsSnapshot } from "@t3tools/contracts";
+import { cn } from "~/lib/utils";
+import { formatRelativeTimeUntilLabel } from "../../timestampFormat";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+
+type AccountLimitWindow = NonNullable<AccountRateLimitsSnapshot["buckets"][number]["primary"]>;
+
+const formatPercentage = (value: number) =>
+  value < 10 ? `${value.toFixed(1).replace(/\.0$/, "")}%` : `${Math.round(value)}%`;
+
+function formatResetCopy(resetsAtIso: string | undefined): string | null {
+  if (!resetsAtIso) return null;
+  const label = formatRelativeTimeUntilLabel(resetsAtIso);
+  return label.endsWith(" left")
+    ? `Resets in ${label.slice(0, -" left".length)}`
+    : `Resets ${label.toLowerCase()}`;
+}
+
+function displayBucket(snapshot: AccountRateLimitsSnapshot) {
+  return (
+    (snapshot.selected
+      ? snapshot.buckets.find((bucket) => bucket.limitId === snapshot.selected?.limitId)
+      : undefined) ??
+    snapshot.buckets.find((bucket) => bucket.primary) ??
+    snapshot.buckets[0]
+  );
+}
+
+function limitColor(remainingPercent: number): string {
+  return remainingPercent <= 10
+    ? "text-destructive"
+    : remainingPercent <= 25
+      ? "text-amber-700 dark:text-amber-400"
+      : "text-emerald-700 dark:text-emerald-400";
+}
+
+function AccountLimitWindowRow(props: { label: string; window: AccountLimitWindow }) {
+  const resetCopy = formatResetCopy(props.window.resetsAtIso);
+  return (
+    <div className="grid gap-0.5">
+      <div className="flex items-center justify-between gap-4 text-xs">
+        <span className="text-muted-foreground">{props.label}</span>
+        <span className="font-medium text-foreground">
+          {formatPercentage(props.window.remainingPercent)} remaining
+        </span>
+      </div>
+      <div className="text-[11px] text-muted-foreground">
+        {formatPercentage(props.window.usedPercent)} used{resetCopy ? ` · ${resetCopy}` : ""}
+      </div>
+    </div>
+  );
+}
+
+export function AccountLimitMeter(props: { snapshot: AccountRateLimitsSnapshot }) {
+  const bucket = displayBucket(props.snapshot);
+  const primaryWindow = bucket?.primary;
+  if (!primaryWindow) return null;
+
+  const rows = [
+    ...(bucket.primary ? [{ label: "Session", window: bucket.primary }] : []),
+    ...(bucket.secondary ? [{ label: "Weekly", window: bucket.secondary }] : []),
+  ];
+  const usedLabel = formatPercentage(primaryWindow.usedPercent);
+  const remainingLabel = formatPercentage(primaryWindow.remainingPercent);
+  const radius = 9.75;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset =
+    circumference - (Math.max(0, Math.min(100, primaryWindow.usedPercent)) / 100) * circumference;
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        openOnHover
+        delay={150}
+        closeDelay={0}
+        render={
+          <button
+            type="button"
+            className={cn(
+              "group inline-flex items-center justify-center rounded-full transition-opacity hover:opacity-85",
+              limitColor(primaryWindow.remainingPercent),
+            )}
+            aria-label={`Account limit ${usedLabel} used, ${remainingLabel} remaining`}
+          >
+            <span className="relative flex h-6 w-6 items-center justify-center">
+              <svg
+                viewBox="0 0 24 24"
+                className="-rotate-90 absolute inset-0 h-full w-full transform-gpu"
+                aria-hidden="true"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r={radius}
+                  fill="none"
+                  stroke="color-mix(in oklab, currentColor 25%, transparent)"
+                  strokeWidth="3"
+                />
+                <circle
+                  cx="12"
+                  cy="12"
+                  r={radius}
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                  strokeDasharray={circumference}
+                  strokeDashoffset={dashOffset}
+                  className="transition-[stroke-dashoffset] duration-500 ease-out motion-reduce:transition-none"
+                />
+              </svg>
+              <span className="relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium">
+                {Math.round(primaryWindow.usedPercent)}
+              </span>
+            </span>
+          </button>
+        }
+      />
+      <PopoverPopup tooltipStyle side="top" align="end" className="w-max max-w-none px-3 py-2">
+        <div className="space-y-1.5 leading-tight">
+          <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            Account limit
+          </div>
+          <div className="grid min-w-36 gap-2">
+            {rows.map((row) => (
+              <AccountLimitWindowRow key={row.label} {...row} />
+            ))}
+          </div>
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -75,6 +75,7 @@ import {
   renderProviderTraitsMenuContent,
   renderProviderTraitsPicker,
 } from "./composerProviderRegistry";
+import { AccountLimitMeter } from "./AccountLimitMeter";
 import { ContextWindowMeter } from "./ContextWindowMeter";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../vscode-icons";
@@ -100,6 +101,7 @@ import type { UnifiedSettings } from "@t3tools/contracts/settings";
 import type { SessionPhase, Thread } from "../../types";
 import type { PendingUserInputDraftAnswer } from "../../pendingUserInput";
 import type { PendingApproval, PendingUserInput } from "../../session-logic";
+import { deriveLatestAccountLimitSnapshot } from "../../lib/accountLimits";
 import { deriveLatestContextWindowSnapshot } from "../../lib/contextWindow";
 import { formatProviderSkillDisplayName } from "../../providerSkillPresentation";
 import { searchProviderSkills } from "../../providerSkillSearch";
@@ -268,6 +270,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
 const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(props: {
   compact: boolean;
   activeContextWindow: ReturnType<typeof deriveLatestContextWindowSnapshot>;
+  activeAccountLimit: ReturnType<typeof deriveLatestAccountLimitSnapshot>;
   isPreparingWorktree: boolean;
   pendingAction: {
     questionIndex: number;
@@ -289,6 +292,7 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
   return (
     <>
       {props.activeContextWindow ? <ContextWindowMeter usage={props.activeContextWindow} /> : null}
+      {props.activeAccountLimit ? <AccountLimitMeter snapshot={props.activeAccountLimit} /> : null}
       {props.isPreparingWorktree ? (
         <span className="text-muted-foreground/70 text-xs">Preparing worktree...</span>
       ) : null}
@@ -645,6 +649,10 @@ export const ChatComposer = memo(
     // ------------------------------------------------------------------
     const activeContextWindow = useMemo(
       () => deriveLatestContextWindowSnapshot(activeThreadActivities ?? []),
+      [activeThreadActivities],
+    );
+    const activeAccountLimit = useMemo(
+      () => deriveLatestAccountLimitSnapshot(activeThreadActivities ?? []),
       [activeThreadActivities],
     );
 
@@ -1987,6 +1995,7 @@ export const ChatComposer = memo(
                   <ComposerFooterPrimaryActions
                     compact={isComposerPrimaryActionsCompact}
                     activeContextWindow={activeContextWindow}
+                    activeAccountLimit={activeAccountLimit}
                     pendingAction={pendingPrimaryAction}
                     isRunning={phase === "running"}
                     showPlanFollowUpPrompt={

--- a/apps/web/src/lib/accountLimits.ts
+++ b/apps/web/src/lib/accountLimits.ts
@@ -1,0 +1,20 @@
+import type { AccountRateLimitsSnapshot, OrchestrationThreadActivity } from "@t3tools/contracts";
+import { normalizeAccountRateLimits } from "@t3tools/shared/accountLimits";
+
+export function deriveLatestAccountLimitSnapshot(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): AccountRateLimitsSnapshot | null {
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    const activity = activities[index];
+    if (!activity || activity.kind !== "account-rate-limits.updated") {
+      continue;
+    }
+
+    const snapshot = normalizeAccountRateLimits(activity.payload);
+    if (snapshot?.selected) {
+      return snapshot;
+    }
+  }
+
+  return null;
+}

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -477,6 +477,7 @@ export function deriveWorkLogEntries(
     .filter((activity) => activity.kind !== "tool.started")
     .filter((activity) => activity.kind !== "task.started")
     .filter((activity) => activity.kind !== "context-window.updated")
+    .filter((activity) => activity.kind !== "account-rate-limits.updated")
     .filter((activity) => activity.summary !== "Checkpoint captured")
     .filter((activity) => !isPlanBoundaryToolActivity(activity))
     .map(toDerivedWorkLogEntry);

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -528,8 +528,39 @@ const AccountUpdatedPayload = Schema.Struct({
 });
 export type AccountUpdatedPayload = typeof AccountUpdatedPayload.Type;
 
+export const AccountRateLimitWindow = Schema.Struct({
+  usedPercent: Schema.Number,
+  remainingPercent: Schema.Number,
+  windowDurationMins: Schema.optional(NonNegativeInt),
+  resetsAt: Schema.optional(NonNegativeInt),
+  resetsAtIso: Schema.optional(IsoDateTime),
+});
+export type AccountRateLimitWindow = typeof AccountRateLimitWindow.Type;
+
+export const AccountRateLimitBucket = Schema.Struct({
+  limitId: TrimmedNonEmptyStringSchema,
+  limitName: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
+  primary: Schema.optional(Schema.NullOr(AccountRateLimitWindow)),
+  secondary: Schema.optional(Schema.NullOr(AccountRateLimitWindow)),
+});
+export type AccountRateLimitBucket = typeof AccountRateLimitBucket.Type;
+
+export const AccountRateLimitsSnapshot = Schema.Struct({
+  buckets: Schema.Array(AccountRateLimitBucket),
+  selected: Schema.NullOr(
+    Schema.Struct({
+      limitId: TrimmedNonEmptyStringSchema,
+      limitName: Schema.optional(Schema.NullOr(TrimmedNonEmptyStringSchema)),
+      windowKind: Schema.Literals(["primary", "secondary"]),
+      window: AccountRateLimitWindow,
+    }),
+  ),
+});
+export type AccountRateLimitsSnapshot = typeof AccountRateLimitsSnapshot.Type;
+
 const AccountRateLimitsUpdatedPayload = Schema.Struct({
   rateLimits: Schema.Unknown,
+  normalized: Schema.optional(AccountRateLimitsSnapshot),
 });
 export type AccountRateLimitsUpdatedPayload = typeof AccountRateLimitsUpdatedPayload.Type;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -71,6 +71,10 @@
     "./path": {
       "types": "./src/path.ts",
       "import": "./src/path.ts"
+    },
+    "./accountLimits": {
+      "types": "./src/accountLimits.ts",
+      "import": "./src/accountLimits.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/accountLimits.ts
+++ b/packages/shared/src/accountLimits.ts
@@ -1,0 +1,138 @@
+import type {
+  AccountRateLimitBucket,
+  AccountRateLimitWindow,
+  AccountRateLimitsSnapshot,
+} from "@t3tools/contracts";
+
+type WindowKind = "primary" | "secondary";
+type Candidate = {
+  bucket: AccountRateLimitBucket;
+  kind: WindowKind;
+  window: AccountRateLimitWindow;
+  index: number;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object" && !Array.isArray(value);
+
+const numberValue = (value: unknown) => {
+  const parsed = typeof value === "string" && value.trim() ? Number(value) : value;
+  return typeof parsed === "number" && Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const stringValue = (value: unknown) => (typeof value === "string" && value.trim()) || undefined;
+
+const firstNumber = (record: Record<string, unknown>, keys: string[]) => {
+  for (const key of keys) {
+    const value = numberValue(record[key]);
+    if (value !== undefined) return value;
+  }
+};
+
+const oneOrNone = <T>(value: T | undefined): T[] => (value ? [value] : []);
+
+function parseWindow(value: unknown): AccountRateLimitWindow | undefined {
+  if (!isRecord(value)) return;
+  const rawUsedPercent = firstNumber(value, ["usedPercent", "used_percent"]);
+  if (rawUsedPercent === undefined) return;
+
+  const usedPercent = Math.max(0, Math.min(100, rawUsedPercent));
+  const duration = firstNumber(value, [
+    "windowDurationMins",
+    "window_duration_mins",
+    "windowDurationMinutes",
+    "window_duration_minutes",
+  ]);
+  const rawResetsAt = firstNumber(value, ["resetsAt", "resets_at", "resetAt", "reset_at"]);
+  const resetsAt =
+    rawResetsAt !== undefined && rawResetsAt >= 0 ? Math.floor(rawResetsAt) : undefined;
+  const resetsAtIso =
+    resetsAt !== undefined && Number.isFinite(new Date(resetsAt * 1000).getTime())
+      ? new Date(resetsAt * 1000).toISOString()
+      : undefined;
+
+  return {
+    usedPercent,
+    remainingPercent: 100 - usedPercent,
+    ...(duration !== undefined && duration >= 0
+      ? { windowDurationMins: Math.floor(duration) }
+      : {}),
+    ...(resetsAt !== undefined ? { resetsAt } : {}),
+    ...(resetsAtIso ? { resetsAtIso } : {}),
+  };
+}
+
+function parseBucket(value: unknown, fallbackLimitId?: string): AccountRateLimitBucket | undefined {
+  if (!isRecord(value)) return;
+  const limitId =
+    stringValue(value.limitId) ?? stringValue(value.limit_id) ?? stringValue(fallbackLimitId);
+  if (!limitId) return;
+
+  const primary = parseWindow(value.primary);
+  const secondary = parseWindow(value.secondary);
+  if (!primary && !secondary) return;
+
+  const limitName =
+    value.limitName === null || value.limit_name === null
+      ? null
+      : (stringValue(value.limitName) ?? stringValue(value.limit_name));
+
+  return {
+    limitId,
+    ...(limitName !== undefined ? { limitName } : {}),
+    ...(primary ? { primary } : {}),
+    ...(secondary ? { secondary } : {}),
+  };
+}
+
+function parseBuckets(value: unknown): AccountRateLimitBucket[] {
+  if (!isRecord(value)) return [];
+  if (Array.isArray(value.buckets))
+    return value.buckets.flatMap((bucket) => oneOrNone(parseBucket(bucket)));
+
+  const byId = value.rateLimitsByLimitId ?? value.rate_limits_by_limit_id;
+  if (isRecord(byId)) {
+    const buckets = Object.entries(byId).flatMap(([id, bucket]) =>
+      oneOrNone(parseBucket(bucket, id)),
+    );
+    if (buckets.length) return buckets;
+  }
+
+  return oneOrNone(parseBucket(value.rateLimits ?? value.rate_limits ?? value));
+}
+
+function compareCandidates(left: Candidate, right: Candidate) {
+  return (
+    left.window.remainingPercent - right.window.remainingPercent ||
+    (left.window.resetsAt ?? Infinity) - (right.window.resetsAt ?? Infinity) ||
+    (left.kind === right.kind ? 0 : left.kind === "primary" ? -1 : 1) ||
+    left.index - right.index
+  );
+}
+
+function selectWindow(buckets: AccountRateLimitBucket[]): AccountRateLimitsSnapshot["selected"] {
+  const candidates = buckets.flatMap((bucket, index): Candidate[] => [
+    ...(bucket.primary
+      ? [{ bucket, kind: "primary" as const, window: bucket.primary, index }]
+      : []),
+    ...(bucket.secondary
+      ? [{ bucket, kind: "secondary" as const, window: bucket.secondary, index }]
+      : []),
+  ]);
+  const selected = candidates.toSorted(compareCandidates)[0];
+  return selected
+    ? {
+        limitId: selected.bucket.limitId,
+        ...(selected.bucket.limitName !== undefined
+          ? { limitName: selected.bucket.limitName }
+          : {}),
+        windowKind: selected.kind,
+        window: selected.window,
+      }
+    : null;
+}
+
+export function normalizeAccountRateLimits(value: unknown): AccountRateLimitsSnapshot | undefined {
+  const buckets = parseBuckets(value);
+  return buckets.length ? { buckets, selected: selectWindow(buckets) } : undefined;
+}


### PR DESCRIPTION
## What Changed
Added a small UI element using the same UI as the context remaining display (just using different color). With a hover tooltip for details
As it is now, this is codex-only. I didn't look into implementing into other harnesses because I don't have an active sub on those. 

## Why
This is a useful way to see the account limits at a glance (instead of having to open a terminal, run codex, type /status). Courtesy of @iPixelGalaxy for bullying me into using my codex subscription to make this

## UI Changes
|A table just to make this look nicer|   |  |
|---|---|---|
|  <img width="267" height="206" alt="Screenshot 2026-04-18 043527" src="https://github.com/user-attachments/assets/0ce82635-31d8-4b0d-9bee-dd310260b500" /> |  <img width="211" height="142" alt="Screenshot 2026-04-18 043604" src="https://github.com/user-attachments/assets/162c9ef4-35dc-40cf-a3fd-5e98042ab746" /> | <img width="265" height="210" alt="Screenshot 2026-04-18 043630" src="https://github.com/user-attachments/assets/acf552e9-30f1-44eb-a1ee-456171971824" /> |
| <img width="238" height="192" alt="Screenshot 2026-04-18 043651" src="https://github.com/user-attachments/assets/b300eb48-e633-4bb8-a288-ce2d8fd4eb5f" /> | <img width="217" height="154" alt="Screenshot 2026-04-18 043704" src="https://github.com/user-attachments/assets/68620668-d6d1-4ca3-a520-86af35155550" /> | <img width="181" height="117" alt="Screenshot 2026-04-18 043729" src="https://github.com/user-attachments/assets/4d4182f7-ad64-4933-a978-ae295cde8499" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new cross-layer runtime event and normalization schema for account rate limits, plus new UI driven off activity ingestion; mistakes could cause missing/incorrect limits or extra event noise but does not touch auth or persistence.
> 
> **Overview**
> Adds end-to-end support for displaying **account rate limits** in the chat composer.
> 
> On the server, Codex now proactively fetches `account/rateLimits/read` on session start and after `turn/completed`/`account/updated`, emitting `account/rateLimits/updated`; provider adapters (Codex + Claude) attach a new `normalized` snapshot to `account.rate-limits.updated`, and orchestration ingestion converts that into an `account-rate-limits.updated` thread activity.
> 
> On the web, introduces `AccountLimitMeter` and wires it into `ChatComposer`, deriving the latest limit snapshot from activities and hiding these activities from the work log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b537c0503ec256859ff3210613bc8a8226a7164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add an account limit meter to the chat composer
> - Adds a circular meter UI ([AccountLimitMeter.tsx](https://github.com/pingdotgg/t3code/pull/2155/files#diff-46e79d4b05338c1b6da1808325d17af1eb63c35e03bb9b6ec022d0037844f1d1)) to the chat composer footer that displays current account rate-limit usage with a popover showing session/weekly reset windows.
> - Introduces a `normalizeAccountRateLimits` utility ([packages/shared/src/accountLimits.ts](https://github.com/pingdotgg/t3code/pull/2155/files#diff-c34e8b3a09c745c7dd53d0a5eea5b5ed89f23877bcac46ee24f96c5be191090a)) that parses provider-specific rate-limit payloads into a consistent `AccountRateLimitsSnapshot`, selecting the most constrained window.
> - Refreshes rate limits on session start, turn completion, and `account/updated` notifications via a new `refreshRateLimits` method in [CodexAppServerManager.ts](https://github.com/pingdotgg/t3code/pull/2155/files#diff-e9a7d9ee65eff27f28522b5e9f0c7676c04de7c11dcca64f017fffd46cdedde9); failures are non-fatal and logged at debug level.
> - Both the Codex and Claude adapters now attach a normalized snapshot to `account.rate-limits.updated` runtime events, which the ingestion layer converts to `account-rate-limits.updated` activities.
> - Filters `account-rate-limits.updated` activities out of work log entries in [session-logic.ts](https://github.com/pingdotgg/t3code/pull/2155/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b537c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->