### PR TITLE
Add dismissible thread notifications

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -402,6 +402,8 @@ describe("resolveThreadStatusPill", () => {
     interactionMode: "plan" as const,
     latestTurn: null,
     lastVisitedAt: undefined,
+    dismissedStatusKey: undefined,
+    updatedAt: "2026-03-09T10:05:00.000Z",
     session: {
       provider: "codex" as const,
       status: "running" as const,
@@ -491,6 +493,25 @@ describe("resolveThreadStatusPill", () => {
         },
       }),
     ).toMatchObject({ label: "Completed", pulse: false });
+  });
+
+  it("hides a dismissible status when its dismissal key matches", () => {
+    expect(
+      resolveThreadStatusPill({
+        thread: {
+          ...baseThread,
+          hasActionableProposedPlan: true,
+          latestTurn: makeLatestTurn(),
+          dismissedStatusKey:
+            "Plan Ready:2026-03-09T10:05:00.000Z:turn-1:2026-03-09T10:05:00.000Z:2026-03-09T10:00:00.000Z",
+          session: {
+            ...baseThread.session,
+            status: "ready",
+            orchestrationStatus: "ready",
+          },
+        },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -31,6 +31,8 @@ export interface ThreadStatusPill {
   colorClass: string;
   dotClass: string;
   pulse: boolean;
+  dismissible?: boolean;
+  dismissalKey?: string;
 }
 
 const THREAD_STATUS_PRIORITY: Record<ThreadStatusPill["label"], number> = {
@@ -50,9 +52,32 @@ type ThreadStatusInput = Pick<
   | "interactionMode"
   | "latestTurn"
   | "session"
+  | "updatedAt"
 > & {
   lastVisitedAt?: string | undefined;
+  dismissedStatusKey?: string | undefined;
 };
+
+function createThreadStatusDismissalKey(
+  label: Extract<ThreadStatusPill["label"], "Pending Approval" | "Awaiting Input" | "Plan Ready">,
+  thread: ThreadStatusInput,
+): string {
+  return [
+    label,
+    thread.updatedAt ?? "",
+    thread.latestTurn?.turnId ?? "",
+    thread.latestTurn?.completedAt ?? "",
+    thread.session?.updatedAt ?? "",
+  ].join(":");
+}
+
+function createCompletedDismissalKey(thread: ThreadStatusInput): string | null {
+  if (!thread.latestTurn?.completedAt) {
+    return null;
+  }
+
+  return ["Completed", thread.latestTurn.turnId, thread.latestTurn.completedAt].join(":");
+}
 
 export interface ThreadJumpHintVisibilityController {
   sync: (shouldShow: boolean) => void;
@@ -314,20 +339,32 @@ export function resolveThreadStatusPill(input: {
   const { thread } = input;
 
   if (thread.hasPendingApprovals) {
+    const dismissalKey = createThreadStatusDismissalKey("Pending Approval", thread);
+    if (thread.dismissedStatusKey === dismissalKey) {
+      return null;
+    }
     return {
       label: "Pending Approval",
       colorClass: "text-amber-600 dark:text-amber-300/90",
       dotClass: "bg-amber-500 dark:bg-amber-300/90",
       pulse: false,
+      dismissible: true,
+      dismissalKey,
     };
   }
 
   if (thread.hasPendingUserInput) {
+    const dismissalKey = createThreadStatusDismissalKey("Awaiting Input", thread);
+    if (thread.dismissedStatusKey === dismissalKey) {
+      return null;
+    }
     return {
       label: "Awaiting Input",
       colorClass: "text-indigo-600 dark:text-indigo-300/90",
       dotClass: "bg-indigo-500 dark:bg-indigo-300/90",
       pulse: false,
+      dismissible: true,
+      dismissalKey,
     };
   }
 
@@ -337,6 +374,7 @@ export function resolveThreadStatusPill(input: {
       colorClass: "text-sky-600 dark:text-sky-300/80",
       dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: true,
+      dismissible: false,
     };
   }
 
@@ -346,6 +384,7 @@ export function resolveThreadStatusPill(input: {
       colorClass: "text-sky-600 dark:text-sky-300/80",
       dotClass: "bg-sky-500 dark:bg-sky-300/80",
       pulse: true,
+      dismissible: false,
     };
   }
 
@@ -355,20 +394,32 @@ export function resolveThreadStatusPill(input: {
     isLatestTurnSettled(thread.latestTurn, thread.session) &&
     thread.hasActionableProposedPlan;
   if (hasPlanReadyPrompt) {
+    const dismissalKey = createThreadStatusDismissalKey("Plan Ready", thread);
+    if (thread.dismissedStatusKey === dismissalKey) {
+      return null;
+    }
     return {
       label: "Plan Ready",
       colorClass: "text-violet-600 dark:text-violet-300/90",
       dotClass: "bg-violet-500 dark:bg-violet-300/90",
       pulse: false,
+      dismissible: true,
+      dismissalKey,
     };
   }
 
   if (hasUnseenCompletion(thread)) {
+    const dismissalKey = createCompletedDismissalKey(thread);
+    if (dismissalKey && thread.dismissedStatusKey === dismissalKey) {
+      return null;
+    }
     return {
       label: "Completed",
       colorClass: "text-emerald-600 dark:text-emerald-300/90",
       dotClass: "bg-emerald-500 dark:bg-emerald-300/90",
       pulse: false,
+      dismissible: true,
+      ...(dismissalKey ? { dismissalKey } : {}),
     };
   }
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   SquarePenIcon,
   TerminalIcon,
   TriangleAlertIcon,
+  XIcon,
 } from "lucide-react";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { autoAnimate } from "@formkit/auto-animate";
@@ -285,6 +286,7 @@ interface SidebarThreadRowProps {
     position: { x: number; y: number },
   ) => Promise<void>;
   clearSelection: () => void;
+  clearThreadNotification: (threadId: ThreadId) => void;
   commitRename: (threadId: ThreadId, newTitle: string, originalTitle: string) => Promise<void>;
   cancelRename: () => void;
   attemptArchiveThread: (threadId: ThreadId) => Promise<void>;
@@ -294,6 +296,9 @@ interface SidebarThreadRowProps {
 function SidebarThreadRow(props: SidebarThreadRowProps) {
   const thread = useSidebarThreadSummaryById(props.threadId);
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[props.threadId]);
+  const dismissedStatusKey = useUiStateStore(
+    (state) => state.threadDismissedStatusKeyById[props.threadId],
+  );
   const runningTerminalIds = useTerminalStateStore(
     (state) =>
       selectThreadTerminalState(state.terminalStateByThreadId, props.threadId).runningTerminalIds,
@@ -313,6 +318,7 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
   const threadStatus = resolveThreadStatusPill({
     thread: {
       ...thread,
+      dismissedStatusKey,
       lastVisitedAt,
     },
   });
@@ -320,9 +326,10 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
   const prStatus = prStatusIndicator(pr);
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const isConfirmingArchive = props.confirmingArchiveThreadId === thread.id && !isThreadRunning;
+  const hasHoverThreadActions = threadStatus?.dismissible || !isThreadRunning;
   const threadMetaClassName = isConfirmingArchive
     ? "pointer-events-none opacity-0"
-    : !isThreadRunning
+    : hasHoverThreadActions
       ? "pointer-events-none transition-opacity duration-150 group-hover/menu-sub-item:opacity-0 group-focus-within/menu-sub-item:opacity-0"
       : "pointer-events-none";
 
@@ -398,7 +405,7 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
               <TooltipPopup side="top">{prStatus.tooltip}</TooltipPopup>
             </Tooltip>
           )}
-          {threadStatus && <ThreadStatusLabel status={threadStatus} />}
+          {threadStatus ? <ThreadStatusLabel status={threadStatus} /> : null}
           {props.renamingThreadId === thread.id ? (
             <input
               ref={props.onRenamingInputMount}
@@ -468,58 +475,84 @@ function SidebarThreadRow(props: SidebarThreadRowProps) {
               >
                 Confirm
               </button>
-            ) : !isThreadRunning ? (
-              props.appSettingsConfirmThreadArchive ? (
-                <div className="pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity duration-150 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100">
-                  <button
-                    type="button"
-                    data-thread-selection-safe
-                    data-testid={`thread-archive-${thread.id}`}
-                    aria-label={`Archive ${thread.title}`}
-                    className="inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-                    onPointerDown={(event) => {
-                      event.stopPropagation();
-                    }}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      event.stopPropagation();
-                      props.setConfirmingArchiveThreadId(thread.id);
-                      requestAnimationFrame(() => {
-                        props.confirmArchiveButtonRefs.current.get(thread.id)?.focus();
-                      });
-                    }}
-                  >
-                    <ArchiveIcon className="size-3.5" />
-                  </button>
+            ) : hasHoverThreadActions ? (
+              <div className="pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity duration-150 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100">
+                <div className="inline-flex items-center gap-0.5">
+                  {threadStatus?.dismissible ? (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            data-thread-selection-safe
+                            data-testid={`thread-clear-notification-${thread.id}`}
+                            aria-label={`Clear notification for ${thread.title}`}
+                            className="inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+                            onPointerDown={(event) => {
+                              event.stopPropagation();
+                            }}
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              props.clearThreadNotification(thread.id);
+                            }}
+                          >
+                            <XIcon className="size-3" />
+                          </button>
+                        }
+                      />
+                      <TooltipPopup side="top">Clear notification</TooltipPopup>
+                    </Tooltip>
+                  ) : null}
+                  {!isThreadRunning && props.appSettingsConfirmThreadArchive ? (
+                    <button
+                      type="button"
+                      data-thread-selection-safe
+                      data-testid={`thread-archive-${thread.id}`}
+                      aria-label={`Archive ${thread.title}`}
+                      className="inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+                      onPointerDown={(event) => {
+                        event.stopPropagation();
+                      }}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        props.setConfirmingArchiveThreadId(thread.id);
+                        requestAnimationFrame(() => {
+                          props.confirmArchiveButtonRefs.current.get(thread.id)?.focus();
+                        });
+                      }}
+                    >
+                      <ArchiveIcon className="size-3.5" />
+                    </button>
+                  ) : !isThreadRunning ? (
+                    <Tooltip>
+                      <TooltipTrigger
+                        render={
+                          <button
+                            type="button"
+                            data-thread-selection-safe
+                            data-testid={`thread-archive-${thread.id}`}
+                            aria-label={`Archive ${thread.title}`}
+                            className="inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
+                            onPointerDown={(event) => {
+                              event.stopPropagation();
+                            }}
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                              void props.attemptArchiveThread(thread.id);
+                            }}
+                          >
+                            <ArchiveIcon className="size-3.5" />
+                          </button>
+                        }
+                      />
+                      <TooltipPopup side="top">Archive</TooltipPopup>
+                    </Tooltip>
+                  ) : null}
                 </div>
-              ) : (
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <div className="pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity duration-150 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100">
-                        <button
-                          type="button"
-                          data-thread-selection-safe
-                          data-testid={`thread-archive-${thread.id}`}
-                          aria-label={`Archive ${thread.title}`}
-                          className="inline-flex size-5 cursor-pointer items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring"
-                          onPointerDown={(event) => {
-                            event.stopPropagation();
-                          }}
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            void props.attemptArchiveThread(thread.id);
-                          }}
-                        >
-                          <ArchiveIcon className="size-3.5" />
-                        </button>
-                      </div>
-                    }
-                  />
-                  <TooltipPopup side="top">Archive</TooltipPopup>
-                </Tooltip>
-              )
+              </div>
             ) : null}
             <span className={threadMetaClassName}>
               {props.showThreadJumpHints && props.jumpLabel ? (
@@ -677,13 +710,21 @@ export default function Sidebar() {
   const projects = useStore((store) => store.projects);
   const sidebarThreadsById = useStore((store) => store.sidebarThreadsById);
   const threadIdsByProjectId = useStore((store) => store.threadIdsByProjectId);
-  const { projectExpandedById, projectOrder, threadLastVisitedAtById } = useUiStateStore(
+  const {
+    projectExpandedById,
+    projectOrder,
+    threadDismissedStatusKeyById,
+    threadLastVisitedAtById,
+  } = useUiStateStore(
     useShallow((store) => ({
       projectExpandedById: store.projectExpandedById,
       projectOrder: store.projectOrder,
+      threadDismissedStatusKeyById: store.threadDismissedStatusKeyById,
       threadLastVisitedAtById: store.threadLastVisitedAtById,
     })),
   );
+  const dismissThreadStatus = useUiStateStore((store) => store.dismissThreadStatus);
+  const markThreadVisited = useUiStateStore((store) => store.markThreadVisited);
   const markThreadUnread = useUiStateStore((store) => store.markThreadUnread);
   const toggleProject = useUiStateStore((store) => store.toggleProject);
   const reorderProjects = useUiStateStore((store) => store.reorderProjects);
@@ -1088,6 +1129,30 @@ export default function Sidebar() {
       });
     },
   });
+  const clearThreadNotification = useCallback(
+    (threadId: ThreadId) => {
+      const thread = sidebarThreadsById[threadId];
+      if (!thread) {
+        return;
+      }
+      const threadStatus = resolveThreadStatusPill({
+        thread: {
+          ...thread,
+          dismissedStatusKey: useUiStateStore.getState().threadDismissedStatusKeyById[threadId],
+          lastVisitedAt: useUiStateStore.getState().threadLastVisitedAtById[threadId],
+        },
+      });
+      if (!threadStatus?.dismissible) {
+        return;
+      }
+      if (threadStatus.label === "Completed") {
+        markThreadVisited(threadId, thread.latestTurn?.completedAt ?? undefined);
+        return;
+      }
+      dismissThreadStatus(threadId, threadStatus.dismissalKey);
+    },
+    [dismissThreadStatus, markThreadVisited, sidebarThreadsById],
+  );
   const handleThreadContextMenu = useCallback(
     async (threadId: ThreadId, position: { x: number; y: number }) => {
       const api = readNativeApi();
@@ -1096,9 +1161,19 @@ export default function Sidebar() {
       if (!thread) return;
       const threadWorkspacePath =
         thread.worktreePath ?? projectCwdById.get(thread.projectId) ?? null;
+      const threadStatus = resolveThreadStatusPill({
+        thread: {
+          ...thread,
+          dismissedStatusKey: useUiStateStore.getState().threadDismissedStatusKeyById[threadId],
+          lastVisitedAt: useUiStateStore.getState().threadLastVisitedAtById[threadId],
+        },
+      });
       const clicked = await api.contextMenu.show(
         [
           { id: "rename", label: "Rename thread" },
+          ...(threadStatus?.dismissible
+            ? [{ id: "clear-notification", label: "Clear notification" }]
+            : []),
           { id: "mark-unread", label: "Mark unread" },
           { id: "copy-path", label: "Copy Path" },
           { id: "copy-thread-id", label: "Copy Thread ID" },
@@ -1118,6 +1193,10 @@ export default function Sidebar() {
 
       if (clicked === "mark-unread") {
         markThreadUnread(threadId, thread.latestTurn?.completedAt);
+        return;
+      }
+      if (clicked === "clear-notification") {
+        clearThreadNotification(threadId);
         return;
       }
       if (clicked === "copy-path") {
@@ -1152,6 +1231,7 @@ export default function Sidebar() {
     },
     [
       appSettings.confirmThreadDelete,
+      clearThreadNotification,
       copyPathToClipboard,
       copyThreadIdToClipboard,
       deleteThread,
@@ -1440,6 +1520,7 @@ export default function Sidebar() {
           resolveThreadStatusPill({
             thread: {
               ...thread,
+              dismissedStatusKey: threadDismissedStatusKeyById[thread.id],
               lastVisitedAt: threadLastVisitedAtById[thread.id],
             },
           });
@@ -1497,6 +1578,7 @@ export default function Sidebar() {
       routeThreadId,
       sortedProjects,
       sidebarThreadsById,
+      threadDismissedStatusKeyById,
       threadIdsByProjectId,
       threadLastVisitedAtById,
     ],
@@ -1817,6 +1899,7 @@ export default function Sidebar() {
                 handleMultiSelectContextMenu={handleMultiSelectContextMenu}
                 handleThreadContextMenu={handleThreadContextMenu}
                 clearSelection={clearSelection}
+                clearThreadNotification={clearThreadNotification}
                 commitRename={commitRename}
                 cancelRename={cancelRename}
                 attemptArchiveThread={attemptArchiveThread}

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   clearThreadUi,
+  dismissThreadStatus,
   markThreadUnread,
   reorderProjects,
   setProjectExpanded,
@@ -16,6 +17,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectExpandedById: {},
     projectOrder: [],
     threadLastVisitedAtById: {},
+    threadDismissedStatusKeyById: {},
     ...overrides,
   };
 }
@@ -46,6 +48,17 @@ describe("uiStateStore pure functions", () => {
     const next = markThreadUnread(initialState, threadId, null);
 
     expect(next).toBe(initialState);
+  });
+
+  it("dismissThreadStatus stores the active dismissal key per thread", () => {
+    const threadId = ThreadId.makeUnsafe("thread-1");
+    const initialState = makeUiState();
+
+    const next = dismissThreadStatus(initialState, threadId, "Plan Ready:turn-1");
+
+    expect(next.threadDismissedStatusKeyById).toEqual({
+      [threadId]: "Plan Ready:turn-1",
+    });
   });
 
   it("reorderProjects moves a project to a target index", () => {
@@ -137,12 +150,19 @@ describe("uiStateStore pure functions", () => {
         [thread1]: "2026-02-25T12:35:00.000Z",
         [thread2]: "2026-02-25T12:36:00.000Z",
       },
+      threadDismissedStatusKeyById: {
+        [thread1]: "Plan Ready:turn-1",
+        [thread2]: "Pending Approval:turn-2",
+      },
     });
 
     const next = syncThreads(initialState, [{ id: thread1 }]);
 
     expect(next.threadLastVisitedAtById).toEqual({
       [thread1]: "2026-02-25T12:35:00.000Z",
+    });
+    expect(next.threadDismissedStatusKeyById).toEqual({
+      [thread1]: "Plan Ready:turn-1",
     });
   });
 
@@ -183,10 +203,14 @@ describe("uiStateStore pure functions", () => {
       threadLastVisitedAtById: {
         [thread1]: "2026-02-25T12:35:00.000Z",
       },
+      threadDismissedStatusKeyById: {
+        [thread1]: "Plan Ready:turn-1",
+      },
     });
 
     const next = clearThreadUi(initialState, thread1);
 
     expect(next.threadLastVisitedAtById).toEqual({});
+    expect(next.threadDismissedStatusKeyById).toEqual({});
   });
 });

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -19,6 +19,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 interface PersistedUiState {
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
+  threadDismissedStatusKeyById?: Record<string, string>;
 }
 
 export interface UiProjectState {
@@ -28,6 +29,7 @@ export interface UiProjectState {
 
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
+  threadDismissedStatusKeyById: Record<string, string>;
 }
 
 export interface UiState extends UiProjectState, UiThreadState {}
@@ -46,6 +48,7 @@ const initialState: UiState = {
   projectExpandedById: {},
   projectOrder: [],
   threadLastVisitedAtById: {},
+  threadDismissedStatusKeyById: {},
 };
 
 const persistedExpandedProjectCwds = new Set<string>();
@@ -70,11 +73,35 @@ function readPersistedState(): UiState {
       }
       return initialState;
     }
-    hydratePersistedProjectState(JSON.parse(raw) as PersistedUiState);
-    return initialState;
+    const parsed = JSON.parse(raw) as PersistedUiState;
+    hydratePersistedProjectState(parsed);
+    return {
+      ...initialState,
+      threadDismissedStatusKeyById: sanitizePersistedThreadDismissedStatusKeys(
+        parsed.threadDismissedStatusKeyById,
+      ),
+    };
   } catch {
     return initialState;
   }
+}
+
+function sanitizePersistedThreadDismissedStatusKeys(
+  value: PersistedUiState["threadDismissedStatusKeyById"],
+): Record<string, string> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      ([threadId, statusKey]) =>
+        typeof threadId === "string" &&
+        threadId.length > 0 &&
+        typeof statusKey === "string" &&
+        statusKey.length > 0,
+    ),
+  );
 }
 
 function hydratePersistedProjectState(parsed: PersistedUiState): void {
@@ -107,11 +134,17 @@ function persistState(state: UiState): void {
       const cwd = currentProjectCwdById.get(projectId);
       return cwd ? [cwd] : [];
     });
+    const threadDismissedStatusKeyById = Object.fromEntries(
+      Object.entries(state.threadDismissedStatusKeyById).filter(
+        ([threadId, statusKey]) => threadId.length > 0 && statusKey.length > 0,
+      ),
+    );
     window.localStorage.setItem(
       PERSISTED_STATE_KEY,
       JSON.stringify({
         expandedProjectCwds,
         projectOrderCwds,
+        threadDismissedStatusKeyById,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -261,12 +294,21 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
       nextThreadLastVisitedAtById[thread.id] = thread.seedVisitedAt;
     }
   }
-  if (recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById)) {
+  const nextThreadDismissedStatusKeyById = Object.fromEntries(
+    Object.entries(state.threadDismissedStatusKeyById).filter(([threadId]) =>
+      retainedThreadIds.has(threadId as ThreadId),
+    ),
+  );
+  if (
+    recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById) &&
+    recordsEqual(state.threadDismissedStatusKeyById, nextThreadDismissedStatusKeyById)
+  ) {
     return state;
   }
   return {
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
+    threadDismissedStatusKeyById: nextThreadDismissedStatusKeyById,
   };
 }
 
@@ -307,24 +349,53 @@ export function markThreadUnread(
   if (state.threadLastVisitedAtById[threadId] === unreadVisitedAt) {
     return state;
   }
+  const nextThreadDismissedStatusKeyById = { ...state.threadDismissedStatusKeyById };
+  delete nextThreadDismissedStatusKeyById[threadId];
   return {
     ...state,
     threadLastVisitedAtById: {
       ...state.threadLastVisitedAtById,
       [threadId]: unreadVisitedAt,
     },
+    threadDismissedStatusKeyById: nextThreadDismissedStatusKeyById,
+  };
+}
+
+export function dismissThreadStatus(
+  state: UiState,
+  threadId: ThreadId,
+  statusKey: string | null | undefined,
+): UiState {
+  if (!statusKey) {
+    return state;
+  }
+  if (state.threadDismissedStatusKeyById[threadId] === statusKey) {
+    return state;
+  }
+  return {
+    ...state,
+    threadDismissedStatusKeyById: {
+      ...state.threadDismissedStatusKeyById,
+      [threadId]: statusKey,
+    },
   };
 }
 
 export function clearThreadUi(state: UiState, threadId: ThreadId): UiState {
-  if (!(threadId in state.threadLastVisitedAtById)) {
+  if (
+    !(threadId in state.threadLastVisitedAtById) &&
+    !(threadId in state.threadDismissedStatusKeyById)
+  ) {
     return state;
   }
   const nextThreadLastVisitedAtById = { ...state.threadLastVisitedAtById };
+  const nextThreadDismissedStatusKeyById = { ...state.threadDismissedStatusKeyById };
   delete nextThreadLastVisitedAtById[threadId];
+  delete nextThreadDismissedStatusKeyById[threadId];
   return {
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
+    threadDismissedStatusKeyById: nextThreadDismissedStatusKeyById,
   };
 }
 
@@ -386,6 +457,7 @@ interface UiStateStore extends UiState {
   syncThreads: (threads: readonly SyncThreadInput[]) => void;
   markThreadVisited: (threadId: ThreadId, visitedAt?: string) => void;
   markThreadUnread: (threadId: ThreadId, latestTurnCompletedAt: string | null | undefined) => void;
+  dismissThreadStatus: (threadId: ThreadId, statusKey: string | null | undefined) => void;
   clearThreadUi: (threadId: ThreadId) => void;
   toggleProject: (projectId: ProjectId) => void;
   setProjectExpanded: (projectId: ProjectId, expanded: boolean) => void;
@@ -400,6 +472,8 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => markThreadVisited(state, threadId, visitedAt)),
   markThreadUnread: (threadId, latestTurnCompletedAt) =>
     set((state) => markThreadUnread(state, threadId, latestTurnCompletedAt)),
+  dismissThreadStatus: (threadId, statusKey) =>
+    set((state) => dismissThreadStatus(state, threadId, statusKey)),
   clearThreadUi: (threadId) => set((state) => clearThreadUi(state, threadId)),
   toggleProject: (projectId) => set((state) => toggleProject(state, projectId)),
   setProjectExpanded: (projectId, expanded) =>


### PR DESCRIPTION
## Summary

- add a clear-notification action for dismissible thread statuses in the sidebar
- persist dismissed status keys so cleared notifications stay cleared until the underlying status changes
- cover the new dismissal behavior in sidebar logic and UI state tests

## Why

Plan and approval notifications can show up in one thread while the user continues work in another. This adds a thread-level way to clear those notifications without affecting thread state.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test --filter=@t3tools/web -- --run src/uiStateStore.test.ts src/components/Sidebar.logic.test.ts`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add dismissible thread status notifications to the Sidebar
> - Adds a 'Clear notification' button and context menu item to each sidebar thread row for dismissible statuses ('Pending Approval', 'Awaiting Input', 'Plan Ready', 'Completed').
> - Introduces `dismissThreadStatus` in [`uiStateStore.ts`](https://github.com/pingdotgg/t3code/pull/2166/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8) to persist dismissed status keys to localStorage, keyed by a composite identifier derived from turn and session metadata.
> - Updates [`Sidebar.logic.ts`](https://github.com/pingdotgg/t3code/pull/2166/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to compute dismissal keys and return `null` from `resolveThreadStatusPill` when the stored key matches, hiding already-dismissed pills.
> - Clearing a 'Completed' notification marks the thread visited; clearing others stores a dismissal key. Marking a thread unread also clears its dismissed notification state.
> - Dismissed keys for threads removed from the dataset are pruned during `syncThreads`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 75e81f9. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds persisted UI state and new dismissal logic for thread status indicators; bugs could cause notifications to hide incorrectly or persist longer than intended across sessions.
> 
> **Overview**
> Adds **dismissible sidebar thread status notifications** with a new “Clear notification” action (hover button + context-menu item) for actionable thread pills.
> 
> `resolveThreadStatusPill` now computes per-status dismissal keys and returns `null` when the stored `dismissedStatusKey` matches, so cleared statuses stay hidden until underlying thread/session/turn metadata changes; “Completed” clearing marks the thread visited instead of storing a dismissal.
> 
> `uiStateStore` persists `threadDismissedStatusKeyById` to localStorage (with sanitization), prunes it during `syncThreads`, and clears it when marking a thread unread or clearing thread UI; tests were updated/added to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e81f914f0ac0a042c26de22c06b7359dac4953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->