### PR TITLE
Expose grouped sidebar state for desktop embedding

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2625,6 +2625,7 @@ export default function Sidebar() {
   const projectExpandedById = useUiStateStore((store) => store.projectExpandedById);
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const reorderProjects = useUiStateStore((store) => store.reorderProjects);
+  const toggleProject = useUiStateStore((store) => store.toggleProject);
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const isOnSettings = pathname.startsWith("/settings");
@@ -3281,6 +3282,117 @@ export default function Sidebar() {
       return next;
     });
   }, []);
+
+  const nuaSidebarSnapshot = useMemo<NuaT3SidebarSnapshot>(
+    () => ({
+      projects: sortedProjects.map((project) => {
+        const projectThreads = sortThreads(
+          (threadsByProjectKey.get(project.projectKey) ?? []).filter(
+            (thread) => thread.archivedAt === null,
+          ),
+          sidebarThreadSortOrder,
+        );
+
+        return {
+          id: `project:${project.projectKey}`,
+          kind: "project",
+          title: project.displayName,
+          isActive: activeRouteProjectKey === project.projectKey,
+          isExpanded: projectExpandedById[project.projectKey] ?? true,
+          threadCount: projectThreads.length,
+          ...(project.groupedProjectCount > 1
+            ? { subtitle: `${project.groupedProjectCount} linked projects` }
+            : {}),
+          threads: projectThreads.map((thread) => ({
+            id: `thread:${scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))}`,
+            kind: "thread",
+            title: thread.title,
+            isActive:
+              routeThreadKey === scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+          })),
+        };
+      }),
+    }),
+    [
+      activeRouteProjectKey,
+      projectExpandedById,
+      routeThreadKey,
+      sidebarThreadSortOrder,
+      sortedProjects,
+      threadsByProjectKey,
+    ],
+  );
+
+  const selectSidebarEntry = useCallback(
+    (entryId: string) => {
+      if (entryId.startsWith("project:")) {
+        const projectKey = entryId.slice("project:".length);
+        if (!projectKey) {
+          return false;
+        }
+        toggleProject(projectKey);
+        return true;
+      }
+
+      if (!entryId.startsWith("thread:")) {
+        return false;
+      }
+
+      const threadKey = entryId.slice("thread:".length);
+      const threadRef = parseScopedThreadKey(threadKey);
+      if (!threadRef) {
+        return false;
+      }
+
+      navigateToThread(threadRef);
+      return true;
+    },
+    [navigateToThread, toggleProject],
+  );
+
+  useEffect(() => {
+    const hooks: NuaT3Hooks = {
+      ...window.__NUA_T3_HOOKS__,
+      getSidebarSnapshot: () => nuaSidebarSnapshot,
+      selectSidebarEntry,
+    };
+
+    window.__NUA_T3_HOOKS__ = hooks;
+    window.__NUA_T3_HOOKS = hooks;
+
+    return () => {
+      const removeSidebarHooks = (key: "__NUA_T3_HOOKS__" | "__NUA_T3_HOOKS") => {
+        const currentHooks = window[key];
+        if (!currentHooks) {
+          return;
+        }
+        if (
+          currentHooks.getSidebarSnapshot !== hooks.getSidebarSnapshot &&
+          currentHooks.selectSidebarEntry !== hooks.selectSidebarEntry
+        ) {
+          return;
+        }
+
+        const nextHooks = { ...currentHooks };
+        if (nextHooks.getSidebarSnapshot === hooks.getSidebarSnapshot) {
+          delete nextHooks.getSidebarSnapshot;
+        }
+        if (nextHooks.selectSidebarEntry === hooks.selectSidebarEntry) {
+          delete nextHooks.selectSidebarEntry;
+        }
+
+        if (Object.keys(nextHooks).length === 0) {
+          delete window[key];
+          return;
+        }
+
+        window[key] = nextHooks;
+      };
+
+      removeSidebarHooks("__NUA_T3_HOOKS__");
+      removeSidebarHooks("__NUA_T3_HOOKS");
+    };
+  }, [nuaSidebarSnapshot, selectSidebarEntry]);
 
   return (
     <>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -49,6 +49,7 @@ import {
   resolveInitialServerAuthGateState,
   updatePrimaryEnvironmentDescriptor,
 } from "../environments/primary";
+import { hasNuaFreshThreadRequest } from "../lib/nuaFreshThread";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -215,6 +216,7 @@ function EventRouter() {
   }));
   const readPathname = useEffectEvent(() => pathname);
   const handledBootstrapThreadIdRef = useRef<string | null>(null);
+  const suppressNextBootstrapThreadRestoreRef = useRef(false);
   const seenServerConfigUpdateIdRef = useRef(getServerConfigUpdatedNotification()?.id ?? 0);
   const disposedRef = useRef(false);
   const serverConfig = useServerConfig();
@@ -252,6 +254,13 @@ function EventRouter() {
       if (readPathname() !== "/") {
         return;
       }
+      if (hasNuaFreshThreadRequest()) {
+        return;
+      }
+      if (suppressNextBootstrapThreadRestoreRef.current) {
+        suppressNextBootstrapThreadRestoreRef.current = false;
+        return;
+      }
       if (handledBootstrapThreadIdRef.current === payload.bootstrapThreadId) {
         return;
       }
@@ -266,6 +275,32 @@ function EventRouter() {
       handledBootstrapThreadIdRef.current = payload.bootstrapThreadId;
     })().catch(() => undefined);
   });
+
+  useEffect(() => {
+    const onSuppressNextBootstrapThreadRestore = () => {
+      suppressNextBootstrapThreadRestoreRef.current = true;
+    };
+
+    window.__NUA_T3_HOOKS__ = {
+      ...window.__NUA_T3_HOOKS__,
+      suppressNextBootstrapThreadRestore: onSuppressNextBootstrapThreadRestore,
+    };
+
+    return () => {
+      if (
+        window.__NUA_T3_HOOKS__?.suppressNextBootstrapThreadRestore ===
+        onSuppressNextBootstrapThreadRestore
+      ) {
+        const nextHooks = { ...window.__NUA_T3_HOOKS__ };
+        delete nextHooks.suppressNextBootstrapThreadRestore;
+        if (Object.keys(nextHooks).length === 0) {
+          delete window.__NUA_T3_HOOKS__;
+        } else {
+          window.__NUA_T3_HOOKS__ = nextHooks;
+        }
+      }
+    };
+  }, []);
 
   const handleServerConfigUpdated = useEffectEvent(
     (notification: ServerConfigUpdatedNotification | null) => {

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,12 +1,14 @@
 import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { useEffect, useEffectEvent, useRef } from "react";
 
 import { useCommandPaletteStore } from "../commandPaletteStore";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import {
+  startFreshThreadFromContext,
   startNewLocalThreadFromContext,
   startNewThreadFromContext,
 } from "../lib/chatThreadActions";
+import { clearNuaFreshThreadRequest, hasNuaFreshThreadRequest } from "../lib/nuaFreshThread";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { resolveShortcutCommand } from "../keybindings";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
@@ -18,8 +20,14 @@ import { useServerKeybindings } from "~/rpc/serverState";
 function ChatRouteGlobalShortcuts() {
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
-  const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
-    useHandleNewThread();
+  const {
+    activeDraftThread,
+    activeThread,
+    defaultProjectRef,
+    handleFreshThread,
+    handleNewThread,
+    routeThreadRef,
+  } = useHandleNewThread();
   const keybindings = useServerKeybindings();
   const terminalOpen = useTerminalStateStore((state) =>
     routeThreadRef
@@ -27,6 +35,40 @@ function ChatRouteGlobalShortcuts() {
       : false,
   );
   const appSettings = useSettings();
+  const defaultThreadEnvMode = resolveSidebarNewThreadEnvMode({
+    defaultEnvMode: appSettings.defaultThreadEnvMode,
+  });
+  const didHandleUrlFreshThreadRef = useRef(false);
+  const createThreadActionContext = useEffectEvent(() => ({
+    activeDraftThread,
+    activeThread,
+    defaultProjectRef,
+    defaultThreadEnvMode,
+    handleFreshThread,
+    handleNewThread,
+  }));
+
+  useEffect(() => {
+    if (didHandleUrlFreshThreadRef.current) {
+      return;
+    }
+    if (!hasNuaFreshThreadRequest()) {
+      return;
+    }
+    if (!defaultProjectRef) {
+      return;
+    }
+
+    didHandleUrlFreshThreadRef.current = true;
+    void startFreshThreadFromContext(createThreadActionContext()).then((didStart) => {
+      if (!didStart) {
+        didHandleUrlFreshThreadRef.current = false;
+        return;
+      }
+
+      clearNuaFreshThreadRequest();
+    });
+  }, [createThreadActionContext, defaultProjectRef]);
 
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
@@ -51,47 +93,44 @@ function ChatRouteGlobalShortcuts() {
       if (command === "chat.newLocal") {
         event.preventDefault();
         event.stopPropagation();
-        void startNewLocalThreadFromContext({
-          activeDraftThread,
-          activeThread,
-          defaultProjectRef,
-          defaultThreadEnvMode: resolveSidebarNewThreadEnvMode({
-            defaultEnvMode: appSettings.defaultThreadEnvMode,
-          }),
-          handleNewThread,
-        });
+        void startNewLocalThreadFromContext(createThreadActionContext());
         return;
       }
 
       if (command === "chat.new") {
         event.preventDefault();
         event.stopPropagation();
-        void startNewThreadFromContext({
-          activeDraftThread,
-          activeThread,
-          defaultProjectRef,
-          defaultThreadEnvMode: resolveSidebarNewThreadEnvMode({
-            defaultEnvMode: appSettings.defaultThreadEnvMode,
-          }),
-          handleNewThread,
-        });
+        void startNewThreadFromContext(createThreadActionContext());
       }
     };
 
+    const onFreshThreadRequest = () => {
+      void startFreshThreadFromContext(createThreadActionContext());
+    };
+
     window.addEventListener("keydown", onWindowKeyDown);
+    window.__NUA_T3_HOOKS__ = {
+      ...window.__NUA_T3_HOOKS__,
+      openFreshThread: onFreshThreadRequest,
+    };
     return () => {
       window.removeEventListener("keydown", onWindowKeyDown);
+      if (window.__NUA_T3_HOOKS__?.openFreshThread === onFreshThreadRequest) {
+        const nextHooks = { ...window.__NUA_T3_HOOKS__ };
+        delete nextHooks.openFreshThread;
+        if (Object.keys(nextHooks).length === 0) {
+          delete window.__NUA_T3_HOOKS__;
+        } else {
+          window.__NUA_T3_HOOKS__ = nextHooks;
+        }
+      }
     };
   }, [
-    activeDraftThread,
-    activeThread,
     clearSelection,
-    handleNewThread,
+    createThreadActionContext,
     keybindings,
-    defaultProjectRef,
     selectedThreadKeysSize,
     terminalOpen,
-    appSettings.defaultThreadEnvMode,
   ]);
 
   return null;

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -11,8 +11,40 @@ interface ImportMeta {
 }
 
 declare global {
+  interface NuaT3SidebarThreadSnapshot {
+    id: string;
+    kind: "thread";
+    title: string;
+    subtitle?: string;
+    isActive?: boolean;
+  }
+
+  interface NuaT3SidebarProjectSnapshot {
+    id: string;
+    kind: "project";
+    title: string;
+    subtitle?: string;
+    isActive?: boolean;
+    isExpanded: boolean;
+    threadCount: number;
+    threads: NuaT3SidebarThreadSnapshot[];
+  }
+
+  interface NuaT3SidebarSnapshot {
+    projects: NuaT3SidebarProjectSnapshot[];
+  }
+
+  interface NuaT3Hooks {
+    openFreshThread?: () => void;
+    suppressNextBootstrapThreadRestore?: () => void;
+    getSidebarSnapshot?: () => NuaT3SidebarSnapshot;
+    selectSidebarEntry?: (entryId: string) => boolean;
+  }
+
   interface Window {
     nativeApi?: LocalApi;
     desktopBridge?: DesktopBridge;
+    __NUA_T3_HOOKS__?: NuaT3Hooks;
+    __NUA_T3_HOOKS?: NuaT3Hooks;
   }
 }


### PR DESCRIPTION
## Summary
- expose grouped project/thread sidebar snapshots for desktop embedding hooks
- allow desktop shells to select project folders and thread rows through hook callbacks
- publish the hook types on `window` so embedded clients can integrate without DOM scraping

## Verification
- bun turbo run typecheck --filter=@t3tools/web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new `window.__NUA_T3_HOOKS__` integration points that can trigger navigation/thread creation and alters bootstrap thread-restore behavior, which could affect initial routing and sidebar interactions if misused or if hook cleanup/order is wrong.
> 
> **Overview**
> Exposes a structured, grouped sidebar snapshot (projects + threads, active/expanded state, counts) via new `window.__NUA_T3_HOOKS__` hooks, and adds a `selectSidebarEntry` callback so embedded desktop shells can toggle projects or navigate to threads without DOM scraping.
> 
> Introduces a "fresh thread" flow controlled via hooks/URL state: `_chat` can open a fresh thread on demand and consume pending requests, while `__root` can suppress the default bootstrap thread restore (and exposes a hook to suppress it) to avoid fighting with the fresh-thread navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97545950a6fa87a359dcac4fc7a4ec80d1a175c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose sidebar state and fresh-thread controls to desktop embedding via `window.__NUA_T3_HOOKS__`
> - Publishes `getSidebarSnapshot` and `selectSidebarEntry` on `window.__NUA_T3_HOOKS__` from [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2169/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), allowing external callers to read the grouped sidebar model and toggle project expansion or navigate to a thread.
> - Registers `openFreshThread` on `window.__NUA_T3_HOOKS__` from [_chat.tsx](https://github.com/pingdotgg/t3code/pull/2169/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691), and auto-initiates a fresh thread on mount when a pending fresh-thread request is detected.
> - Adds `suppressNextBootstrapThreadRestore` hook in [__root.tsx](https://github.com/pingdotgg/t3code/pull/2169/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) to skip automatic navigation to the bootstrap thread, also skipped when `hasNuaFreshThreadRequest()` returns true.
> - Declares TypeScript types for all new hook surface area in [vite-env.d.ts](https://github.com/pingdotgg/t3code/pull/2169/files#diff-4ccec8944b4c17b983119e99acea29e34f2bee9f0be80b9038a2f36303bea6f1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9754595.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->