### PR TITLE
feat: strip provider prefix from OpenCode model names in chat composer

### DIFF
--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -106,7 +106,7 @@ function createBaseServerConfig(): ServerConfig {
           serverUrl: "",
           serverPassword: "",
           customModels: [],
-          showProviderInModelName: false,
+          showProviderComposer: false,
         },
       },
     },

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -106,6 +106,7 @@ function createBaseServerConfig(): ServerConfig {
           serverUrl: "",
           serverPassword: "",
           customModels: [],
+          showProviderInModelName: false,
         },
       },
     },

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1926,8 +1926,8 @@ export const ChatComposer = memo(
                     lockedProvider={lockedProvider}
                     providers={providerStatuses}
                     modelOptionsByProvider={modelOptionsByProvider}
-                    showOpenCodeProviderInModelName={
-                      settings.providers.opencode.showProviderInModelName
+                    showOpenCodeProviderComposer={
+                      settings.providers.opencode.showProviderComposer
                     }
                     {...(composerProviderState.modelPickerIconClassName
                       ? {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1926,6 +1926,9 @@ export const ChatComposer = memo(
                     lockedProvider={lockedProvider}
                     providers={providerStatuses}
                     modelOptionsByProvider={modelOptionsByProvider}
+                    showOpenCodeProviderInModelName={
+                      settings.providers.opencode.showProviderInModelName
+                    }
                     {...(composerProviderState.modelPickerIconClassName
                       ? {
                           activeProviderIconClassName:

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -22,6 +22,13 @@ import { ClaudeAI, CursorIcon, Gemini, Icon, OpenAI, OpenCodeIcon } from "../Ico
 import { cn } from "~/lib/utils";
 import { getProviderSnapshot } from "../../providerModels";
 
+function stripOpenCodeProviderPrefix(name: string): string {
+  const separator = " · ";
+  const index = name.indexOf(separator);
+  if (index < 0) return name;
+  return name.slice(index + separator.length);
+}
+
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {
   value: ProviderKind;
   label: string;
@@ -59,6 +66,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   disabled?: boolean;
   triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   triggerClassName?: string;
+  showOpenCodeProviderInModelName?: boolean;
   onProviderModelChange: (provider: ProviderKind, model: string) => void;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -66,6 +74,10 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   const selectedProviderOptions = props.modelOptionsByProvider[activeProvider];
   const selectedModelLabel =
     selectedProviderOptions.find((option) => option.slug === props.model)?.name ?? props.model;
+  const displayModelLabel =
+    activeProvider === "opencode" && !props.showOpenCodeProviderInModelName
+      ? stripOpenCodeProviderPrefix(selectedModelLabel)
+      : selectedModelLabel;
   const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[activeProvider];
   const handleModelChange = (provider: ProviderKind, value: string) => {
     if (props.disabled) return;
@@ -120,7 +132,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
               props.activeProviderIconClassName,
             )}
           />
-          <span className="min-w-0 flex-1 truncate">{selectedModelLabel}</span>
+          <span className="min-w-0 flex-1 truncate">{displayModelLabel}</span>
           <ChevronDownIcon aria-hidden="true" className="size-3 shrink-0 opacity-60" />
         </span>
       </MenuTrigger>

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -66,7 +66,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   disabled?: boolean;
   triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   triggerClassName?: string;
-  showOpenCodeProviderInModelName?: boolean;
+  showOpenCodeProviderComposer?: boolean;
   onProviderModelChange: (provider: ProviderKind, model: string) => void;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -75,7 +75,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   const selectedModelLabel =
     selectedProviderOptions.find((option) => option.slug === props.model)?.name ?? props.model;
   const displayModelLabel =
-    activeProvider === "opencode" && !props.showOpenCodeProviderInModelName
+    activeProvider === "opencode" && !props.showOpenCodeProviderComposer
       ? stripOpenCodeProviderPrefix(selectedModelLabel)
       : selectedModelLabel;
   const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[activeProvider];

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1383,21 +1383,21 @@ export function GeneralSettingsPanel() {
                       <div className="border-t border-border/60 px-4 py-3 sm:px-5">
                         <div className="flex items-center justify-between gap-3">
                           <label
-                            htmlFor="provider-install-opencode-show-provider-in-composer"
+                            htmlFor="opencode-show-provider-composer"
                             className="text-xs font-medium text-foreground"
                           >
                             Show provider in model name in composer
                           </label>
                           <Switch
-                            id="provider-install-opencode-show-provider-in-composer"
-                            checked={settings.providers.opencode.showProviderInModelName}
+                            id="opencode-show-provider-composer"
+                            checked={settings.providers.opencode.showProviderComposer}
                             onCheckedChange={(checked) =>
                               updateSettings({
                                 providers: {
                                   ...settings.providers,
                                   opencode: {
                                     ...settings.providers.opencode,
-                                    showProviderInModelName: checked,
+                                    showProviderComposer: checked,
                                   },
                                 },
                               })

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1379,6 +1379,38 @@ export function GeneralSettingsPanel() {
                       </div>
                     ) : null}
 
+                    {providerCard.provider === "opencode" ? (
+                      <div className="border-t border-border/60 px-4 py-3 sm:px-5">
+                        <div className="flex items-center justify-between gap-3">
+                          <label
+                            htmlFor="provider-install-opencode-show-provider"
+                            className="text-xs font-medium text-foreground"
+                          >
+                            Show provider in model name
+                          </label>
+                          <Switch
+                            id="provider-install-opencode-show-provider"
+                            checked={settings.providers.opencode.showProviderInModelName}
+                            onCheckedChange={(checked) =>
+                              updateSettings({
+                                providers: {
+                                  ...settings.providers,
+                                  opencode: {
+                                    ...settings.providers.opencode,
+                                    showProviderInModelName: checked,
+                                  },
+                                },
+                              })
+                            }
+                          />
+                        </div>
+                        <span className="mt-1 block text-xs text-muted-foreground">
+                          Prefix the model name with its upstream provider (e.g. &quot;Anthropic ·
+                          Claude Sonnet 4.5&quot;).
+                        </span>
+                      </div>
+                    ) : null}
+
                     {providerCard.homePathKey ? (
                       <div className="border-t border-border/60 px-4 py-3 sm:px-5">
                         <label

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1383,13 +1383,13 @@ export function GeneralSettingsPanel() {
                       <div className="border-t border-border/60 px-4 py-3 sm:px-5">
                         <div className="flex items-center justify-between gap-3">
                           <label
-                            htmlFor="provider-install-opencode-show-provider"
+                            htmlFor="provider-install-opencode-show-provider-in-composer"
                             className="text-xs font-medium text-foreground"
                           >
-                            Show provider in model name
+                            Show provider in model name in composer
                           </label>
                           <Switch
-                            id="provider-install-opencode-show-provider"
+                            id="provider-install-opencode-show-provider-in-composer"
                             checked={settings.providers.opencode.showProviderInModelName}
                             onCheckedChange={(checked) =>
                               updateSettings({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -104,6 +104,7 @@ export const OpenCodeSettings = Schema.Struct({
   serverUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   serverPassword: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  showProviderInModelName: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
 });
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
@@ -238,6 +239,7 @@ const OpenCodeSettingsPatch = Schema.Struct({
   serverUrl: Schema.optionalKey(Schema.String),
   serverPassword: Schema.optionalKey(Schema.String),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+  showProviderInModelName: Schema.optionalKey(Schema.Boolean),
 });
 
 export const ServerSettingsPatch = Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -104,7 +104,7 @@ export const OpenCodeSettings = Schema.Struct({
   serverUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   serverPassword: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
-  showProviderInModelName: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  showProviderComposer: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
 });
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
@@ -239,7 +239,7 @@ const OpenCodeSettingsPatch = Schema.Struct({
   serverUrl: Schema.optionalKey(Schema.String),
   serverPassword: Schema.optionalKey(Schema.String),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
-  showProviderInModelName: Schema.optionalKey(Schema.Boolean),
+  showProviderComposer: Schema.optionalKey(Schema.Boolean),
 });
 
 export const ServerSettingsPatch = Schema.Struct({


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed
Instead of showing the full provider and name for opencode models it only shows the model name. The model selector is unaffected and this can be reverted with a setting. 
<!-- Describe the change clearly and keep scope tight. -->

## Why
For long provider names (e.g GLM coding plan, etc) you can't really see which model you are using.  
<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->
Before: 
<img width="818" height="161" alt="image" src="https://github.com/user-attachments/assets/5edd936b-ac23-474d-b2d1-86815e0aa5d2" />
After: 
<img width="850" height="154" alt="image" src="https://github.com/user-attachments/assets/31abe374-24dd-416b-a73d-2fcb08b7ddc7" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/settings change that adds a new persisted boolean and tweaks only the displayed OpenCode model label in the composer; main risk is minor settings migration/default behavior differences.
> 
> **Overview**
> **OpenCode model labels in the chat composer are now shortened by default.** When the active provider is `opencode`, the composer’s model button strips the leading `<provider> · ` prefix from the displayed model name.
> 
> This introduces a new persisted setting (`settings.providers.opencode.showProviderComposer`, default `false`) and surfaces it as a toggle in the OpenCode provider settings panel to restore the previous prefixed display. The new flag is also threaded through `ChatComposer` into `ProviderModelPicker`, and test fixtures/default snapshots are updated to include the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce7e1f2a2a3041b09500d068f36a3e9fa189c577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Strip provider prefix from OpenCode model names in the chat composer
> - Adds a `showProviderComposer` boolean to `OpenCodeSettings` (default `false`) in [settings.ts](https://github.com/pingdotgg/t3code/pull/2171/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), controlling whether the upstream provider prefix (e.g. "Anthropic · ") is shown in the composer model picker.
> - Introduces `stripOpenCodeProviderPrefix` in [ProviderModelPicker.tsx](https://github.com/pingdotgg/t3code/pull/2171/files#diff-01e915fe10bb55b513fb511c18383cd09199ea82c807cdf1fa405ba3261b0a40) that strips the prefix up to and including the " · " separator when the active provider is `opencode` and the flag is `false`.
> - Adds a toggle in the General settings panel under the OpenCode section so users can opt into showing the full prefixed model name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce7e1f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->