### PR TITLE
fix: updated UI "add project" icon to match the command pallete icon

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import {
   ChevronRightIcon,
   CloudIcon,
   GitPullRequestIcon,
-  PlusIcon,
+  FolderPlusIcon,
   SearchIcon,
   SettingsIcon,
   SquarePenIcon,
@@ -2587,7 +2587,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                   />
                 }
               >
-                <PlusIcon className="size-3.5" />
+                <FolderPlusIcon className="size-3.5" />
               </TooltipTrigger>
               <TooltipPopup side="right">Add project</TooltipPopup>
             </Tooltip>


### PR DESCRIPTION
## What Changed

Changed the icon for "add project" on the sidebar from "Plus Icon" to "Folder Plus Icon" 

## Why

Currently there are two icons representing "add project". In the sidebar it is "PlusIcon" and in the command pallet it is "FolderPlusIcon". In addition, personally I keep hitting the "PlusIcon" button because my brain associate the plus icon with a new thread. 

I believe "FolderPlusIcon" is the better option because it make it clear that a folder is being added. In addition, it unifies the UI to have on universal icon which represents "add project".

## UI Changes

### Before

<img width="303" height="217" alt="Before Icon t3" src="https://github.com/user-attachments/assets/d5639980-e787-4acd-920c-f84bb8f98124" />

### After

<img width="319" height="225" alt="After Icon t3" src="https://github.com/user-attachments/assets/84793dca-8abc-413d-b6ac-fae6d273e574" />

As seen below the UI is now unify under one "add project" icon
<img width="574" height="679" alt="After UI unity" src="https://github.com/user-attachments/assets/77de8034-88c8-451a-866e-3f2808e380ee" />

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change: swaps the sidebar "Add project" icon component with no behavior, state, or data-flow changes.
> 
> **Overview**
> Updates the sidebar "Add project" button to use `FolderPlusIcon` instead of `PlusIcon`, aligning the iconography with the command palette and improving UI consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f1c941415274b8bb1745fabfe48351a2c5eca2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace 'Add project' sidebar icon with `FolderPlusIcon` to match command palette
> Swaps the `PlusIcon` for `FolderPlusIcon` in the sidebar's 'Add project' tooltip button in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2176/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), making it consistent with the command palette icon.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f1c941.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->