### PR TITLE
Feat/chat grid split view

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist-electron/main.cjs",
   "scripts": {
-    "dev": "bun run --parallel dev:bundle dev:electron",
+    "dev": "node scripts/dev-parallel.mjs",
     "dev:bundle": "tsdown --watch",
     "dev:electron": "node scripts/dev-electron.mjs",
     "build": "tsdown",

--- a/apps/desktop/scripts/dev-parallel.mjs
+++ b/apps/desktop/scripts/dev-parallel.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Run tsdown --watch and the Electron dev launcher concurrently.
+ *
+ * Replaces `bun run --parallel dev:bundle dev:electron`, which doesn't work
+ * on bun 1.3.0 (the `--parallel` flag was removed/never-landed and bun silently
+ * treats it as an unknown flag, collapsing the two scripts into one invocation).
+ */
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const desktopDir = resolve(here, "..");
+
+const children = [];
+let shuttingDown = false;
+
+function startChild(label, script) {
+  const child = spawn(process.platform === "win32" ? "bun.exe" : "bun", ["run", script], {
+    cwd: desktopDir,
+    stdio: "inherit",
+    env: process.env,
+  });
+  child.on("exit", (code, signal) => {
+    if (shuttingDown) return;
+    const reason = signal ?? code;
+    console.error(`[dev-parallel] ${label} exited (${reason}); tearing down siblings.`);
+    shutdown(typeof code === "number" ? code : 1);
+  });
+  children.push({ label, child });
+}
+
+function shutdown(exitCode) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const { child } of children) {
+    if (!child.killed) {
+      child.kill(process.platform === "win32" ? undefined : "SIGTERM");
+    }
+  }
+  setTimeout(() => process.exit(exitCode), 500).unref();
+}
+
+process.once("SIGINT", () => shutdown(130));
+process.once("SIGTERM", () => shutdown(143));
+
+startChild("dev:bundle", "dev:bundle");
+startChild("dev:electron", "dev:electron");

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -151,8 +151,10 @@ const buildCmd = Command.make(
           cwd: serverDir,
           stdout: config.verbose ? "inherit" : "ignore",
           stderr: "inherit",
-          // Windows needs shell mode to resolve `.cmd` shims on PATH.
-          shell: process.platform === "win32",
+          // process.execPath is node.exe (not a .cmd shim), so don't go through
+          // cmd.exe — if the path contains spaces (e.g. "C:\Program Files\nodejs")
+          // the shell splits on the space and the spawn fails.
+          shell: false,
         }),
       );
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -138,6 +138,7 @@ import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import { ChatHeader } from "./chat/ChatHeader";
+import { useGridPaneContext } from "./grid/gridPaneContext";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
 import { resolveEffectiveEnvMode, resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -790,7 +791,9 @@ export default function ChatView(props: ChatViewProps) {
     composerInteractionMode ?? activeThread?.interactionMode ?? DEFAULT_INTERACTION_MODE;
   const isLocalDraftThread = !isServerThread && localDraftThread !== undefined;
   const canCheckoutPullRequestIntoThread = isLocalDraftThread;
-  const diffOpen = rawSearch.diff === "1";
+  const diffOpenFromRoute = rawSearch.diff === "1";
+  const gridPaneContext = useGridPaneContext();
+  const diffOpen = gridPaneContext ? gridPaneContext.diffOpen : diffOpenFromRoute;
   const activeThreadId = activeThread?.id ?? null;
   const activeThreadRef = useMemo(
     () => (activeThread ? scopeThreadRef(activeThread.environmentId, activeThread.id) : null),
@@ -1478,6 +1481,10 @@ export default function ChatView(props: ChatViewProps) {
     if (!isServerThread) {
       return;
     }
+    if (gridPaneContext) {
+      gridPaneContext.onRequestDiff({ open: !gridPaneContext.diffOpen });
+      return;
+    }
     if (!diffOpen) {
       onDiffPanelOpen?.();
     }
@@ -1493,7 +1500,15 @@ export default function ChatView(props: ChatViewProps) {
         return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
       },
     });
-  }, [diffOpen, environmentId, isServerThread, navigate, onDiffPanelOpen, threadId]);
+  }, [
+    diffOpen,
+    environmentId,
+    gridPaneContext,
+    isServerThread,
+    navigate,
+    onDiffPanelOpen,
+    threadId,
+  ]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -3166,6 +3181,14 @@ export default function ChatView(props: ChatViewProps) {
       if (!isServerThread) {
         return;
       }
+      if (gridPaneContext) {
+        gridPaneContext.onRequestDiff({
+          open: true,
+          turnId,
+          ...(filePath ? { filePath } : {}),
+        });
+        return;
+      }
       onDiffPanelOpen?.();
       void navigate({
         to: "/$environmentId/$threadId",
@@ -3181,7 +3204,7 @@ export default function ChatView(props: ChatViewProps) {
         },
       });
     },
-    [environmentId, isServerThread, navigate, onDiffPanelOpen, threadId],
+    [environmentId, gridPaneContext, isServerThread, navigate, onDiffPanelOpen, threadId],
   );
   // Both the Map and the revert handler are read from refs at call-time so
   // the callback reference is fully stable and never busts context identity.

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -3,7 +3,9 @@ import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/reac
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { scopeThreadRef } from "@t3tools/client-runtime";
-import type { TurnId } from "@t3tools/contracts";
+import type { ScopedThreadRef, TurnId } from "@t3tools/contracts";
+
+import type { DiffRouteSearch } from "../diffRouteSearch";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -162,11 +164,26 @@ function buildFileDiffRenderKey(fileDiff: FileDiffMetadata): string {
 
 interface DiffPanelProps {
   mode?: DiffPanelMode;
+  /**
+   * Optional thread-ref override. When provided, DiffPanel uses this instead
+   * of reading the thread from the current route params. Used by grid panes
+   * where the route doesn't contain the thread.
+   */
+  threadRefOverride?: ScopedThreadRef | null;
+  /** Optional override for diff search state (diff open, turn id, file path). */
+  diffSearchOverride?: DiffRouteSearch;
+  /** Called when the user picks a turn in the strip — overrides route navigate. */
+  onSelectTurnOverride?: (turnId: TurnId | null) => void;
 }
 
 export { DiffWorkerPoolProvider } from "./DiffWorkerPoolProvider";
 
-export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
+export default function DiffPanel({
+  mode = "inline",
+  threadRefOverride,
+  diffSearchOverride,
+  onSelectTurnOverride,
+}: DiffPanelProps) {
   const navigate = useNavigate();
   const { resolvedTheme } = useTheme();
   const settings = useSettings();
@@ -177,11 +194,17 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const previousDiffOpenRef = useRef(false);
   const [canScrollTurnStripLeft, setCanScrollTurnStripLeft] = useState(false);
   const [canScrollTurnStripRight, setCanScrollTurnStripRight] = useState(false);
-  const routeThreadRef = useParams({
+  const routeThreadRefFromParams = useParams({
     strict: false,
     select: (params) => resolveThreadRouteRef(params),
   });
-  const diffSearch = useSearch({ strict: false, select: (search) => parseDiffRouteSearch(search) });
+  const routeThreadRef =
+    threadRefOverride !== undefined ? threadRefOverride : routeThreadRefFromParams;
+  const routeDiffSearch = useSearch({
+    strict: false,
+    select: (search) => parseDiffRouteSearch(search),
+  });
+  const diffSearch = diffSearchOverride ?? routeDiffSearch;
   const diffOpen = diffSearch.diff === "1";
   const activeThreadId = routeThreadRef?.threadId ?? null;
   const activeThread = useStore(
@@ -345,6 +368,10 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
 
   const selectTurn = (turnId: TurnId) => {
     if (!activeThread) return;
+    if (onSelectTurnOverride) {
+      onSelectTurnOverride(turnId);
+      return;
+    }
     void navigate({
       to: "/$environmentId/$threadId",
       params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
@@ -356,6 +383,10 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   };
   const selectWholeConversation = () => {
     if (!activeThread) return;
+    if (onSelectTurnOverride) {
+      onSelectTurnOverride(null);
+      return;
+    }
     void navigate({
       to: "/$environmentId/$threadId",
       params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -6,15 +6,18 @@ import {
   type ThreadId,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime";
-import { memo } from "react";
+import { memo, useCallback } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import GitActionsControl from "../GitActionsControl";
 import { type DraftId } from "~/composerDraftStore";
-import { DiffIcon, TerminalSquareIcon } from "lucide-react";
+import { DiffIcon, Grid2X2Icon, TerminalSquareIcon, XIcon } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
 import { Toggle } from "../ui/toggle";
+import { Button } from "../ui/button";
 import { SidebarTrigger } from "../ui/sidebar";
+import { useGridPaneContext } from "../grid/gridPaneContext";
 import { OpenInPicker } from "./OpenInPicker";
 
 interface ChatHeaderProps {
@@ -68,10 +71,18 @@ export const ChatHeader = memo(function ChatHeader({
   onToggleTerminal,
   onToggleDiff,
 }: ChatHeaderProps) {
+  const navigate = useNavigate();
+  const gridPane = useGridPaneContext();
+  const openGridView = useCallback(() => {
+    void navigate({
+      to: "/$environmentId/grid",
+      params: { environmentId: activeThreadEnvironmentId },
+    });
+  }, [activeThreadEnvironmentId, navigate]);
   return (
     <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
-        <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+        {gridPane ? null : <SidebarTrigger className="size-7 shrink-0 md:hidden" />}
         <h2
           className="min-w-0 shrink truncate text-sm font-medium text-foreground"
           title={activeThreadTitle}
@@ -158,11 +169,51 @@ export const ChatHeader = memo(function ChatHeader({
           <TooltipPopup side="bottom">
             {!isGitRepo
               ? "Diff panel is unavailable because this project is not a git repository."
-              : diffToggleShortcutLabel
-                ? `Toggle diff panel (${diffToggleShortcutLabel})`
-                : "Toggle diff panel"}
+              : gridPane
+                ? "Open diff (switches this pane to full-thread view)"
+                : diffToggleShortcutLabel
+                  ? `Toggle diff panel (${diffToggleShortcutLabel})`
+                  : "Toggle diff panel"}
           </TooltipPopup>
         </Tooltip>
+        {gridPane ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  className="shrink-0"
+                  variant="outline"
+                  size="icon-xs"
+                  aria-label="Remove this pane from the grid"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    gridPane.onClosePane();
+                  }}
+                >
+                  <XIcon className="size-3" />
+                </Button>
+              }
+            />
+            <TooltipPopup side="bottom">Remove pane from grid</TooltipPopup>
+          </Tooltip>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  className="shrink-0"
+                  variant="outline"
+                  size="icon-xs"
+                  aria-label="Open grid split view"
+                  onClick={openGridView}
+                >
+                  <Grid2X2Icon className="size-3" />
+                </Button>
+              }
+            />
+            <TooltipPopup side="bottom">Open grid split view</TooltipPopup>
+          </Tooltip>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/grid/GridEmptyPane.tsx
+++ b/apps/web/src/components/grid/GridEmptyPane.tsx
@@ -1,0 +1,49 @@
+import { type EnvironmentId } from "@t3tools/contracts";
+import { SquarePenIcon } from "lucide-react";
+
+import { Button } from "../ui/button";
+
+import { GridThreadPicker } from "./GridThreadPicker";
+
+interface GridEmptyPaneProps {
+  environmentId: EnvironmentId;
+  excludedThreadKeys: ReadonlySet<string>;
+  onSelectThread: (threadKey: string) => void;
+  onRequestNewThread: () => void;
+  densityClass: string;
+}
+
+export function GridEmptyPane({
+  environmentId,
+  excludedThreadKeys,
+  onSelectThread,
+  onRequestNewThread,
+  densityClass,
+}: GridEmptyPaneProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-background p-3 text-center">
+      <div className="text-xs text-muted-foreground">Empty pane</div>
+      <div className={`flex flex-col items-center gap-2 ${densityClass}`}>
+        <GridThreadPicker
+          environmentId={environmentId}
+          excludedThreadKeys={excludedThreadKeys}
+          onSelect={onSelectThread}
+          triggerLabel="Pick thread"
+        />
+        <Button
+          variant="outline"
+          size="xs"
+          className="gap-1.5"
+          onClick={onRequestNewThread}
+          aria-label="Start a new thread in this cell"
+        >
+          <SquarePenIcon className="size-3" />
+          New thread
+        </Button>
+      </div>
+      <div className="text-[10px] text-muted-foreground">
+        Click a thread from the sidebar, or use "New thread".
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/grid/GridPane.tsx
+++ b/apps/web/src/components/grid/GridPane.tsx
@@ -1,0 +1,250 @@
+import { type EnvironmentId, type ThreadId, type TurnId } from "@t3tools/contracts";
+import { parseScopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime";
+import { Suspense, lazy, memo, useCallback, useMemo, useState } from "react";
+import { XIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import ChatView from "../ChatView";
+import { Button } from "../ui/button";
+import { type DraftId, useComposerDraftStore } from "../../composerDraftStore";
+import {
+  DiffPanelHeaderSkeleton,
+  DiffPanelLoadingState,
+  DiffPanelShell,
+  type DiffPanelMode,
+} from "../DiffPanelShell";
+import { DiffWorkerPoolProvider } from "../DiffWorkerPoolProvider";
+import type { DiffRouteSearch } from "../../diffRouteSearch";
+import { selectThreadByRef, useStore } from "../../store";
+
+import { GridEmptyPane } from "./GridEmptyPane";
+import type { GridLayoutCell } from "./gridLayout";
+import { GridPaneProvider, type GridPaneDiffRequest } from "./gridPaneContext";
+
+const DiffPanel = lazy(() => import("../DiffPanel"));
+
+interface GridPaneProps {
+  cell: GridLayoutCell;
+  cellIndex: number;
+  environmentId: EnvironmentId;
+  focused: boolean;
+  excludedThreadKeys: ReadonlySet<string>;
+  onFocus: (cellIndex: number) => void;
+  onAssignThread: (cellIndex: number, threadKey: string) => void;
+  onClearCell: (cellIndex: number) => void;
+  onRequestNewThread: (cellIndex: number) => void;
+  densityClass: string;
+  compactness: "normal" | "compact" | "ultra";
+}
+
+export const GridPane = memo(function GridPane({
+  cell,
+  cellIndex,
+  environmentId,
+  focused,
+  excludedThreadKeys,
+  onFocus,
+  onAssignThread,
+  onClearCell,
+  onRequestNewThread,
+  densityClass,
+  compactness,
+}: GridPaneProps) {
+  return (
+    <div
+      className={cn(
+        "@container/grid-pane relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border bg-card transition-[border-color]",
+        focused ? "border-primary/35" : "border-border",
+      )}
+      onMouseDown={() => onFocus(cellIndex)}
+      onFocus={() => onFocus(cellIndex)}
+      data-grid-pane-index={cellIndex}
+      data-grid-pane-focused={focused ? "true" : undefined}
+    >
+      {cell.threadKey ? (
+        <PopulatedPane
+          threadKey={cell.threadKey}
+          environmentId={environmentId}
+          onClearCell={() => onClearCell(cellIndex)}
+          compactness={compactness}
+        />
+      ) : (
+        <GridEmptyPane
+          environmentId={environmentId}
+          excludedThreadKeys={excludedThreadKeys}
+          onSelectThread={(threadKey) => onAssignThread(cellIndex, threadKey)}
+          onRequestNewThread={() => onRequestNewThread(cellIndex)}
+          densityClass={densityClass}
+        />
+      )}
+    </div>
+  );
+});
+
+interface PopulatedPaneProps {
+  threadKey: string;
+  environmentId: EnvironmentId;
+  onClearCell: () => void;
+  compactness: "normal" | "compact" | "ultra";
+}
+
+interface PaneDiffState {
+  open: boolean;
+  turnId?: TurnId;
+  filePath?: string;
+}
+
+function PopulatedPane({ threadKey, environmentId, onClearCell, compactness }: PopulatedPaneProps) {
+  const threadRef = useMemo(() => parseScopedThreadKey(threadKey), [threadKey]);
+  const threadId = threadRef?.threadId ?? null;
+  const threadEnvId = threadRef?.environmentId ?? null;
+  const serverThread = useStore((store) => selectThreadByRef(store, threadRef));
+  const draftId = useComposerDraftStore((store) => {
+    if (!threadRef) return null;
+    for (const [key, draft] of Object.entries(store.draftThreadsByThreadKey)) {
+      if (
+        draft.environmentId === threadRef.environmentId &&
+        draft.threadId === threadRef.threadId
+      ) {
+        return key as DraftId;
+      }
+    }
+    return null;
+  });
+  const [paneDiff, setPaneDiff] = useState<PaneDiffState>({ open: false });
+  const handleClosePane = useCallback(() => {
+    onClearCell();
+  }, [onClearCell]);
+  const handleRequestDiff = useCallback((request: GridPaneDiffRequest) => {
+    setPaneDiff((previous) => {
+      if (!request.open) {
+        return previous.open ? { open: false } : previous;
+      }
+      return {
+        open: true,
+        ...(request.turnId ? { turnId: request.turnId } : {}),
+        ...(request.filePath ? { filePath: request.filePath } : {}),
+      };
+    });
+  }, []);
+  const handleCloseDiff = useCallback(() => {
+    setPaneDiff({ open: false });
+  }, []);
+  const handleSelectTurn = useCallback((turnId: TurnId | null) => {
+    setPaneDiff((previous) => {
+      if (!previous.open) return previous;
+      return turnId ? { open: true, turnId } : { open: true };
+    });
+  }, []);
+  const diffSearchOverride = useMemo<DiffRouteSearch>(
+    () => ({
+      diff: paneDiff.open ? "1" : undefined,
+      ...(paneDiff.turnId ? { diffTurnId: paneDiff.turnId } : {}),
+      ...(paneDiff.filePath ? { diffFilePath: paneDiff.filePath } : {}),
+    }),
+    [paneDiff.filePath, paneDiff.open, paneDiff.turnId],
+  );
+  const scopedThreadRefForDiff = useMemo(
+    () =>
+      threadRef && threadId && threadEnvId
+        ? scopeThreadRef(threadEnvId, threadId as ThreadId)
+        : null,
+    [threadEnvId, threadId, threadRef],
+  );
+
+  const isCurrentEnvironment = threadEnvId === environmentId;
+
+  if (!threadRef || !threadId || !isCurrentEnvironment) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 bg-background p-3 text-center text-xs text-muted-foreground">
+        <p>This cell references a thread that is not in the current environment.</p>
+        <Button variant="outline" size="xs" onClick={onClearCell}>
+          Clear cell
+        </Button>
+      </div>
+    );
+  }
+
+  const hasServerThread = Boolean(serverThread);
+  const routeKind = hasServerThread ? "server" : draftId ? "draft" : null;
+
+  if (routeKind === null) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 bg-background p-3 text-center text-xs text-muted-foreground">
+        <p>Thread not found. It may have been archived or deleted.</p>
+        <Button variant="outline" size="xs" onClick={onClearCell}>
+          Clear cell
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative flex h-full min-h-0 flex-1 flex-col overflow-hidden",
+        compactness === "compact" && "text-[13px]",
+        compactness === "ultra" && "text-[12px]",
+      )}
+      data-grid-pane-content="true"
+    >
+      <GridPaneProvider
+        onClosePane={handleClosePane}
+        onRequestDiff={handleRequestDiff}
+        diffOpen={paneDiff.open}
+      >
+        {routeKind === "server" ? (
+          <ChatView
+            environmentId={threadEnvId as EnvironmentId}
+            threadId={threadId as ThreadId}
+            reserveTitleBarControlInset={false}
+            routeKind="server"
+          />
+        ) : draftId ? (
+          <ChatView
+            environmentId={threadEnvId as EnvironmentId}
+            threadId={threadId as ThreadId}
+            reserveTitleBarControlInset={false}
+            routeKind="draft"
+            draftId={draftId}
+          />
+        ) : null}
+      </GridPaneProvider>
+      {paneDiff.open && scopedThreadRefForDiff ? (
+        <div className="absolute inset-0 z-30 flex flex-col overflow-hidden bg-background/80 backdrop-blur">
+          <div className="flex items-center justify-between border-b border-border bg-card px-3 py-1.5">
+            <div className="text-xs font-medium text-foreground">Diff</div>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={handleCloseDiff}
+              aria-label="Close diff panel"
+            >
+              <XIcon className="size-3" />
+            </Button>
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <DiffWorkerPoolProvider>
+              <Suspense fallback={<GridPaneDiffLoading mode="inline" />}>
+                <DiffPanel
+                  mode="inline"
+                  threadRefOverride={scopedThreadRefForDiff}
+                  diffSearchOverride={diffSearchOverride}
+                  onSelectTurnOverride={handleSelectTurn}
+                />
+              </Suspense>
+            </DiffWorkerPoolProvider>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function GridPaneDiffLoading({ mode }: { mode: DiffPanelMode }) {
+  return (
+    <DiffPanelShell mode={mode} header={<DiffPanelHeaderSkeleton />}>
+      <DiffPanelLoadingState label="Loading diff viewer..." />
+    </DiffPanelShell>
+  );
+}

--- a/apps/web/src/components/grid/GridSizePicker.tsx
+++ b/apps/web/src/components/grid/GridSizePicker.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useRef, useState } from "react";
+import { Grid2X2Icon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { Button } from "../ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+
+import { GRID_MAX_DIM, GRID_MIN_DIM } from "./gridLayout";
+
+interface GridSizePickerProps {
+  currentRows: number;
+  currentCols: number;
+  onSelect: (rows: number, cols: number) => void;
+  triggerLabel?: string;
+  className?: string;
+  align?: "start" | "center" | "end";
+}
+
+/**
+ * Google Docs-style 6x6 hover picker. Hovering the dots selects the preview
+ * rows/cols; clicking confirms.
+ */
+export function GridSizePicker({
+  currentRows,
+  currentCols,
+  onSelect,
+  triggerLabel,
+  className,
+  align = "start",
+}: GridSizePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [hoveredRow, setHoveredRow] = useState<number | null>(null);
+  const [hoveredCol, setHoveredCol] = useState<number | null>(null);
+  const gridRef = useRef<HTMLDivElement | null>(null);
+
+  const previewRows = hoveredRow !== null ? hoveredRow + 1 : currentRows;
+  const previewCols = hoveredCol !== null ? hoveredCol + 1 : currentCols;
+
+  const handleOpenChange = useCallback((next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setHoveredRow(null);
+      setHoveredCol(null);
+    }
+  }, []);
+
+  const handleSelect = useCallback(
+    (row: number, col: number) => {
+      onSelect(row + 1, col + 1);
+      setOpen(false);
+      setHoveredRow(null);
+      setHoveredCol(null);
+    },
+    [onSelect],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            size="xs"
+            className={cn("gap-1.5", className)}
+            aria-label="Pick grid dimensions"
+          >
+            <Grid2X2Icon className="size-3" />
+            <span className="tabular-nums">
+              {currentRows}×{currentCols}
+            </span>
+            {triggerLabel ? (
+              <span className="ml-1 text-muted-foreground">{triggerLabel}</span>
+            ) : null}
+          </Button>
+        }
+      />
+      <PopoverPopup align={align} sideOffset={4} className="w-auto">
+        <div className="flex flex-col gap-2" data-grid-size-picker-root>
+          <div className="text-center text-[11px] font-medium tabular-nums text-muted-foreground">
+            {previewRows} × {previewCols}
+          </div>
+          <div
+            ref={gridRef}
+            className="grid select-none gap-1"
+            style={{
+              gridTemplateColumns: `repeat(${GRID_MAX_DIM}, 1rem)`,
+              gridTemplateRows: `repeat(${GRID_MAX_DIM}, 1rem)`,
+            }}
+            onMouseLeave={() => {
+              setHoveredRow(null);
+              setHoveredCol(null);
+            }}
+          >
+            {Array.from({ length: GRID_MAX_DIM * GRID_MAX_DIM }, (_, index) => {
+              const row = Math.floor(index / GRID_MAX_DIM);
+              const col = index - row * GRID_MAX_DIM;
+              const rowsToHighlight = hoveredRow ?? currentRows - 1;
+              const colsToHighlight = hoveredCol ?? currentCols - 1;
+              const isHighlighted = row <= rowsToHighlight && col <= colsToHighlight;
+              const isHovered = hoveredRow === row && hoveredCol === col;
+              return (
+                <button
+                  key={`${row}-${col}`}
+                  type="button"
+                  aria-label={`Select ${row + 1} rows by ${col + 1} columns`}
+                  className={cn(
+                    "size-4 rounded-sm border transition-colors",
+                    isHighlighted
+                      ? "border-primary bg-primary/60"
+                      : "border-border bg-background hover:border-primary/50",
+                    isHovered ? "ring-1 ring-primary" : undefined,
+                  )}
+                  onMouseEnter={() => {
+                    setHoveredRow(row);
+                    setHoveredCol(col);
+                  }}
+                  onFocus={() => {
+                    setHoveredRow(row);
+                    setHoveredCol(col);
+                  }}
+                  onClick={() => handleSelect(row, col)}
+                />
+              );
+            })}
+          </div>
+          <div className="text-center text-[10px] text-muted-foreground">
+            {GRID_MIN_DIM}–{GRID_MAX_DIM} rows × {GRID_MIN_DIM}–{GRID_MAX_DIM} cols
+          </div>
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/apps/web/src/components/grid/GridThreadPicker.tsx
+++ b/apps/web/src/components/grid/GridThreadPicker.tsx
@@ -1,0 +1,116 @@
+import { type EnvironmentId } from "@t3tools/contracts";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime";
+import { useMemo, useState } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { LayersIcon, SearchIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { Button } from "../ui/button";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { selectSidebarThreadsAcrossEnvironments, useStore } from "../../store";
+import type { SidebarThreadSummary } from "../../types";
+
+interface GridThreadPickerProps {
+  environmentId: EnvironmentId;
+  excludedThreadKeys: ReadonlySet<string>;
+  onSelect: (threadKey: string) => void;
+  triggerClassName?: string;
+  triggerLabel?: string;
+}
+
+export function GridThreadPicker({
+  environmentId,
+  excludedThreadKeys,
+  onSelect,
+  triggerClassName,
+  triggerLabel,
+}: GridThreadPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const threads = useStore(
+    useShallow((store) =>
+      selectSidebarThreadsAcrossEnvironments(store).filter(
+        (thread) => thread.environmentId === environmentId && thread.archivedAt === null,
+      ),
+    ),
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const available = threads.filter((thread) => {
+      const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+      return !excludedThreadKeys.has(key);
+    });
+    if (q.length === 0) return available;
+    return available.filter((thread) => thread.title.toLowerCase().includes(q));
+  }, [threads, query, excludedThreadKeys]);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="outline"
+            size="xs"
+            className={cn("gap-1.5", triggerClassName)}
+            aria-label="Pick a thread to assign to this cell"
+          >
+            <LayersIcon className="size-3" />
+            {triggerLabel ?? "Pick thread"}
+          </Button>
+        }
+      />
+      <PopoverPopup align="start" sideOffset={4} className="w-80">
+        <div className="flex flex-col gap-2" data-grid-thread-picker-root>
+          <div className="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1">
+            <SearchIcon className="size-3.5 shrink-0 opacity-50" />
+            <input
+              type="text"
+              value={query}
+              placeholder="Search threads..."
+              onChange={(event) => setQuery(event.target.value)}
+              className="flex-1 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+          <div className="flex max-h-80 flex-col gap-0.5 overflow-y-auto">
+            {filtered.length === 0 ? (
+              <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+                No threads available.
+              </div>
+            ) : (
+              filtered.map((thread) => (
+                <PickerItem
+                  key={thread.id}
+                  thread={thread}
+                  onSelect={() => {
+                    const key = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+                    onSelect(key);
+                    setOpen(false);
+                    setQuery("");
+                  }}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}
+
+function PickerItem({ thread, onSelect }: { thread: SidebarThreadSummary; onSelect: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="flex flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left text-xs hover:bg-accent focus:bg-accent focus:outline-none"
+    >
+      <span className="line-clamp-1 font-medium">{thread.title || "Untitled thread"}</span>
+      {thread.latestUserMessageAt ? (
+        <span className="text-[10px] text-muted-foreground">
+          Last activity: {new Date(thread.latestUserMessageAt).toLocaleString()}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/web/src/components/grid/GridToolbar.tsx
+++ b/apps/web/src/components/grid/GridToolbar.tsx
@@ -1,0 +1,87 @@
+import { type EnvironmentId } from "@t3tools/contracts";
+import { memo, useCallback } from "react";
+import { Grid2X2Icon, XIcon } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+
+import { cn } from "~/lib/utils";
+import { isElectron } from "../../env";
+import { useGridLayoutStore } from "../../gridLayoutStore";
+import { Button } from "../ui/button";
+import { SidebarTrigger } from "../ui/sidebar";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+import { GridSizePicker } from "./GridSizePicker";
+
+interface GridToolbarProps {
+  environmentId: EnvironmentId;
+  rows: number;
+  cols: number;
+  populatedCount: number;
+  totalCellCount: number;
+  onChangeSize: (rows: number, cols: number) => void;
+  onResetLayout: () => void;
+}
+
+export const GridToolbar = memo(function GridToolbar({
+  environmentId,
+  rows,
+  cols,
+  populatedCount,
+  totalCellCount,
+  onChangeSize,
+  onResetLayout,
+}: GridToolbarProps) {
+  const navigate = useNavigate();
+  const exitGrid = useCallback(() => {
+    useGridLayoutStore.getState().setLastView(environmentId, "thread");
+    void navigate({ to: "/", search: {} });
+  }, [environmentId, navigate]);
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b border-border bg-card px-3",
+        isElectron
+          ? "drag-region h-[52px] wco:h-[env(titlebar-area-height)] wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]"
+          : "py-2",
+      )}
+    >
+      <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+      <div className="flex items-center gap-1.5 text-xs font-medium">
+        <Grid2X2Icon className="size-3.5" />
+        <span>Grid view</span>
+      </div>
+      <div className="hidden text-[11px] text-muted-foreground sm:block">
+        {populatedCount} / {totalCellCount} panes populated · env {environmentId.slice(0, 8)}
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <GridSizePicker currentRows={rows} currentCols={cols} onSelect={onChangeSize} align="end" />
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button variant="outline" size="xs" onClick={onResetLayout}>
+                Reset layout
+              </Button>
+            }
+          />
+          <TooltipPopup side="bottom">Clear every pane in this grid.</TooltipPopup>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="outline"
+                size="icon-xs"
+                onClick={exitGrid}
+                aria-label="Exit grid view"
+              >
+                <XIcon className="size-3" />
+              </Button>
+            }
+          />
+          <TooltipPopup side="bottom">Exit grid view</TooltipPopup>
+        </Tooltip>
+      </div>
+    </div>
+  );
+});

--- a/apps/web/src/components/grid/GridView.tsx
+++ b/apps/web/src/components/grid/GridView.tsx
@@ -1,0 +1,221 @@
+import { type EnvironmentId, type ProjectId } from "@t3tools/contracts";
+import {
+  parseScopedThreadKey,
+  scopedProjectKey,
+  scopedThreadKey,
+  scopeProjectRef,
+  scopeThreadRef,
+} from "@t3tools/client-runtime";
+import { useCallback, useEffect, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+
+import { toastManager } from "../ui/toast";
+import { SidebarInset } from "../ui/sidebar";
+import { useGridLayoutStore } from "../../gridLayoutStore";
+import { selectThreadsForEnvironment, useStore } from "../../store";
+import { useComposerDraftStore } from "../../composerDraftStore";
+import { newDraftId, newThreadId } from "../../lib/utils";
+
+import { GridPane } from "./GridPane";
+import { GridToolbar } from "./GridToolbar";
+import { cellIndexToCoord, populatedCellThreadKeys, type GridLayoutState } from "./gridLayout";
+
+interface GridViewProps {
+  environmentId: EnvironmentId;
+}
+
+export function GridView({ environmentId }: GridViewProps) {
+  const layout = useGridLayoutStore((store) => store.getState(environmentId));
+  const assignCell = useGridLayoutStore((store) => store.assignCell);
+  const clearCell = useGridLayoutStore((store) => store.clearCell);
+  const setSize = useGridLayoutStore((store) => store.setSize);
+  const setFocusedCell = useGridLayoutStore((store) => store.setFocusedCell);
+  const setActive = useGridLayoutStore((store) => store.setActive);
+  const setLastView = useGridLayoutStore((store) => store.setLastView);
+  const resetEnvironment = useGridLayoutStore((store) => store.resetEnvironment);
+
+  useEffect(() => {
+    setActive(environmentId, true);
+    setLastView(environmentId, "grid");
+    return () => {
+      setActive(environmentId, false);
+    };
+  }, [environmentId, setActive, setLastView]);
+
+  const serverThreads = useStore(
+    useShallow((store) => selectThreadsForEnvironment(store, environmentId)),
+  );
+  const setLogicalProjectDraftThreadId = useComposerDraftStore(
+    (store) => store.setLogicalProjectDraftThreadId,
+  );
+  const applyStickyState = useComposerDraftStore((store) => store.applyStickyState);
+
+  // Prune cells pointing to threads that have been archived or deleted.
+  useEffect(() => {
+    const aliveServerKeys = new Set(
+      serverThreads.map((thread) =>
+        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+      ),
+    );
+    const draftSessionsByThreadKey = useComposerDraftStore.getState().draftThreadsByThreadKey;
+    for (let index = 0; index < layout.cells.length; index += 1) {
+      const cell = layout.cells[index];
+      if (!cell || cell.threadKey === null) continue;
+      const threadRef = parseScopedThreadKey(cell.threadKey);
+      if (!threadRef) {
+        clearCell(environmentId, index);
+        continue;
+      }
+      if (threadRef.environmentId !== environmentId) continue;
+      if (aliveServerKeys.has(cell.threadKey)) continue;
+      const hasDraft = Object.values(draftSessionsByThreadKey).some(
+        (draft) =>
+          draft.environmentId === threadRef.environmentId && draft.threadId === threadRef.threadId,
+      );
+      if (!hasDraft) {
+        clearCell(environmentId, index);
+      }
+    }
+  }, [clearCell, environmentId, layout.cells, serverThreads]);
+
+  const populatedThreadKeys = useMemo(() => populatedCellThreadKeys(layout), [layout]);
+  const excludedThreadKeys = useMemo(() => new Set(populatedThreadKeys), [populatedThreadKeys]);
+
+  const handleAssignThread = useCallback(
+    (cellIndex: number, threadKey: string) => {
+      assignCell(environmentId, cellIndex, threadKey);
+      setFocusedCell(environmentId, cellIndex);
+    },
+    [assignCell, environmentId, setFocusedCell],
+  );
+
+  const handleClearCell = useCallback(
+    (cellIndex: number) => {
+      clearCell(environmentId, cellIndex);
+    },
+    [clearCell, environmentId],
+  );
+
+  const handleFocusCell = useCallback(
+    (cellIndex: number) => {
+      setFocusedCell(environmentId, cellIndex);
+    },
+    [environmentId, setFocusedCell],
+  );
+
+  const handleRequestNewThread = useCallback(
+    (cellIndex: number) => {
+      const envState = useStore.getState().environmentStateById[environmentId];
+      const projectId = envState?.projectIds[0] as ProjectId | undefined;
+      if (!projectId) {
+        toastManager.add({
+          type: "warning",
+          title: "No project available",
+          description: "Add a project to this environment before creating new grid threads.",
+        });
+        return;
+      }
+      const draftId = newDraftId();
+      const threadId = newThreadId();
+      const createdAt = new Date().toISOString();
+      const projectRef = scopeProjectRef(environmentId, projectId);
+      // Each grid-created draft lives under its own unique logical-project mapping
+      // so creating a new pane doesn't evict a sibling pane's draft via the
+      // "one draft per logical project" deletion inside setLogicalProjectDraftThreadId.
+      const gridLogicalProjectKey = `grid:${scopedProjectKey(projectRef)}:${draftId}`;
+      setLogicalProjectDraftThreadId(gridLogicalProjectKey, projectRef, draftId, {
+        threadId,
+        createdAt,
+        envMode: "local",
+      });
+      applyStickyState(draftId);
+      const threadKey = scopedThreadKey(scopeThreadRef(environmentId, threadId));
+      assignCell(environmentId, cellIndex, threadKey);
+      setFocusedCell(environmentId, cellIndex);
+    },
+    [applyStickyState, assignCell, environmentId, setFocusedCell, setLogicalProjectDraftThreadId],
+  );
+
+  const handleChangeSize = useCallback(
+    (rows: number, cols: number) => {
+      setSize(environmentId, rows, cols);
+    },
+    [environmentId, setSize],
+  );
+
+  const handleResetLayout = useCallback(() => {
+    resetEnvironment(environmentId);
+  }, [environmentId, resetEnvironment]);
+
+  const compactness = resolveCompactness(layout.cols);
+  const densityClass =
+    compactness === "ultra" ? "scale-95" : compactness === "compact" ? "scale-100" : "scale-100";
+
+  const gridStyle: React.CSSProperties = {
+    gridTemplateColumns: `repeat(${layout.cols}, minmax(0, 1fr))`,
+    gridTemplateRows: `repeat(${layout.rows}, minmax(0, 1fr))`,
+  };
+
+  const cells = layout.cells;
+
+  return (
+    <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
+      <GridToolbar
+        environmentId={environmentId}
+        rows={layout.rows}
+        cols={layout.cols}
+        populatedCount={populatedThreadKeys.length}
+        totalCellCount={cells.length}
+        onChangeSize={handleChangeSize}
+        onResetLayout={handleResetLayout}
+      />
+      <div
+        className="grid min-h-0 flex-1 gap-2 overflow-hidden p-2"
+        style={gridStyle}
+        role="grid"
+        aria-label="Chat split grid"
+        data-grid-view-root
+      >
+        {cells.map((cell, index) => {
+          const coord = cellIndexToCoord(index, layout.cols);
+          const paneKey = `r${coord.row}c${coord.col}`;
+          return (
+            <div
+              key={paneKey}
+              className="contents"
+              data-grid-row={coord.row}
+              data-grid-col={coord.col}
+            >
+              <GridPane
+                cell={cell}
+                cellIndex={index}
+                environmentId={environmentId}
+                focused={layout.focusedCellIndex === index}
+                excludedThreadKeys={excludedThreadKeys}
+                onFocus={handleFocusCell}
+                onAssignThread={handleAssignThread}
+                onClearCell={handleClearCell}
+                onRequestNewThread={handleRequestNewThread}
+                densityClass={densityClass}
+                compactness={compactness}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </SidebarInset>
+  );
+}
+
+function resolveCompactness(cols: number): "normal" | "compact" | "ultra" {
+  if (cols <= 2) return "normal";
+  if (cols <= 4) return "compact";
+  return "ultra";
+}
+
+/** Exposed for tests. */
+export function _testableResolveCompactness(cols: number): "normal" | "compact" | "ultra" {
+  return resolveCompactness(cols);
+}
+
+export type { GridLayoutState };

--- a/apps/web/src/components/grid/gridLayout.test.ts
+++ b/apps/web/src/components/grid/gridLayout.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assignCellThread,
+  cellIndexToCoord,
+  clampCellIndex,
+  clampGridDim,
+  clearCellThread,
+  coordToCellIndex,
+  createDefaultGridLayoutState,
+  createEmptyCells,
+  gridHasPopulatedCells,
+  populatedCellThreadKeys,
+  removeThreadFromGridLayout,
+  resizeGridLayout,
+  setFocusedCell,
+  setGridActive,
+  setLastView,
+  GRID_MAX_DIM,
+  GRID_MIN_DIM,
+} from "./gridLayout";
+
+describe("gridLayout", () => {
+  describe("clampGridDim", () => {
+    it("clamps below minimum", () => {
+      expect(clampGridDim(0)).toBe(GRID_MIN_DIM);
+      expect(clampGridDim(-3)).toBe(GRID_MIN_DIM);
+    });
+
+    it("clamps above maximum", () => {
+      expect(clampGridDim(10)).toBe(GRID_MAX_DIM);
+      expect(clampGridDim(7)).toBe(GRID_MAX_DIM);
+    });
+
+    it("truncates fractional values", () => {
+      expect(clampGridDim(2.9)).toBe(2);
+    });
+
+    it("returns minimum for non-finite", () => {
+      expect(clampGridDim(Number.NaN)).toBe(GRID_MIN_DIM);
+      // POSITIVE_INFINITY is not finite, so falls through the guard and clamps to min.
+      expect(clampGridDim(Number.POSITIVE_INFINITY)).toBe(GRID_MIN_DIM);
+    });
+  });
+
+  describe("createEmptyCells", () => {
+    it("creates the requested number of empty cells", () => {
+      const cells = createEmptyCells(6);
+      expect(cells.length).toBe(6);
+      for (const cell of cells) {
+        expect(cell.threadKey).toBeNull();
+      }
+    });
+
+    it("creates unique cell objects (not shared reference)", () => {
+      const cells = createEmptyCells(2);
+      expect(cells[0]).not.toBe(cells[1]);
+    });
+  });
+
+  describe("createDefaultGridLayoutState", () => {
+    it("defaults to 2x2 with 4 empty cells, focused on index 0", () => {
+      const state = createDefaultGridLayoutState();
+      expect(state.rows).toBe(2);
+      expect(state.cols).toBe(2);
+      expect(state.cells.length).toBe(4);
+      expect(state.focusedCellIndex).toBe(0);
+      expect(state.active).toBe(false);
+      expect(state.lastView).toBeNull();
+    });
+  });
+
+  describe("resizeGridLayout", () => {
+    it("returns same state when dimensions unchanged", () => {
+      const state = createDefaultGridLayoutState();
+      const next = resizeGridLayout(state, 2, 2);
+      expect(next).toBe(state);
+    });
+
+    it("grows the grid, preserving existing cells at their coordinates", () => {
+      const initial = assignCellThread(createDefaultGridLayoutState(), 3, "env:thread-a");
+      const next = resizeGridLayout(initial, 3, 3);
+      expect(next.rows).toBe(3);
+      expect(next.cols).toBe(3);
+      expect(next.cells.length).toBe(9);
+      // Original cell (1,1) in a 2x2 → index 3; in new 3x3 → index 1*3+1 = 4
+      expect(next.cells[4]?.threadKey).toBe("env:thread-a");
+      expect(next.cells[3]?.threadKey).toBeNull();
+    });
+
+    it("shrinks the grid, dropping cells outside the new rectangle", () => {
+      let state = createDefaultGridLayoutState();
+      state = resizeGridLayout(state, 3, 3);
+      state = assignCellThread(state, 0, "env:thread-a");
+      state = assignCellThread(state, 8, "env:thread-b"); // (2,2)
+      const next = resizeGridLayout(state, 2, 2);
+      expect(next.rows).toBe(2);
+      expect(next.cols).toBe(2);
+      expect(next.cells.length).toBe(4);
+      // (0,0) preserved
+      expect(next.cells[0]?.threadKey).toBe("env:thread-a");
+      // (2,2) dropped
+      for (const cell of next.cells) {
+        expect(cell.threadKey).not.toBe("env:thread-b");
+      }
+    });
+
+    it("clamps focused cell index to fit new cell count", () => {
+      let state = createDefaultGridLayoutState();
+      state = resizeGridLayout(state, 3, 3);
+      state = setFocusedCell(state, 8);
+      expect(state.focusedCellIndex).toBe(8);
+      const next = resizeGridLayout(state, 2, 2);
+      expect(next.focusedCellIndex).toBeLessThan(next.cells.length);
+    });
+
+    it("clamps requested dimensions to grid bounds", () => {
+      const state = createDefaultGridLayoutState();
+      const next = resizeGridLayout(state, 99, 0);
+      expect(next.rows).toBe(GRID_MAX_DIM);
+      expect(next.cols).toBe(GRID_MIN_DIM);
+      expect(next.cells.length).toBe(GRID_MAX_DIM * GRID_MIN_DIM);
+    });
+  });
+
+  describe("assignCellThread", () => {
+    it("sets the thread key on the target cell", () => {
+      const state = createDefaultGridLayoutState();
+      const next = assignCellThread(state, 2, "env:thread-x");
+      expect(next.cells[2]?.threadKey).toBe("env:thread-x");
+      expect(next).not.toBe(state);
+    });
+
+    it("returns same reference when thread already assigned", () => {
+      let state = createDefaultGridLayoutState();
+      state = assignCellThread(state, 2, "env:thread-x");
+      const next = assignCellThread(state, 2, "env:thread-x");
+      expect(next).toBe(state);
+    });
+
+    it("clamps out-of-range cell indices", () => {
+      const state = createDefaultGridLayoutState();
+      const next = assignCellThread(state, 99, "env:thread-x");
+      // Clamped to last cell (index 3 in 2x2)
+      expect(next.cells[3]?.threadKey).toBe("env:thread-x");
+    });
+  });
+
+  describe("clearCellThread", () => {
+    it("clears a populated cell", () => {
+      const populated = assignCellThread(createDefaultGridLayoutState(), 1, "env:thread-x");
+      const cleared = clearCellThread(populated, 1);
+      expect(cleared.cells[1]?.threadKey).toBeNull();
+    });
+
+    it("returns same reference if cell already empty", () => {
+      const state = createDefaultGridLayoutState();
+      const next = clearCellThread(state, 0);
+      expect(next).toBe(state);
+    });
+  });
+
+  describe("removeThreadFromGridLayout", () => {
+    it("removes the thread from every matching cell", () => {
+      let state = createDefaultGridLayoutState();
+      state = assignCellThread(state, 0, "env:thread-x");
+      state = assignCellThread(state, 2, "env:thread-x");
+      state = assignCellThread(state, 3, "env:thread-y");
+      const next = removeThreadFromGridLayout(state, "env:thread-x");
+      expect(next.cells[0]?.threadKey).toBeNull();
+      expect(next.cells[2]?.threadKey).toBeNull();
+      expect(next.cells[3]?.threadKey).toBe("env:thread-y");
+    });
+
+    it("returns same reference when thread key is not present", () => {
+      const state = createDefaultGridLayoutState();
+      const next = removeThreadFromGridLayout(state, "env:thread-absent");
+      expect(next).toBe(state);
+    });
+  });
+
+  describe("setFocusedCell", () => {
+    it("clamps to valid index", () => {
+      const state = createDefaultGridLayoutState();
+      expect(setFocusedCell(state, -5).focusedCellIndex).toBe(0);
+      expect(setFocusedCell(state, 99).focusedCellIndex).toBe(state.cells.length - 1);
+    });
+
+    it("returns same reference when unchanged", () => {
+      const state = createDefaultGridLayoutState();
+      const next = setFocusedCell(state, 0);
+      expect(next).toBe(state);
+    });
+  });
+
+  describe("setGridActive", () => {
+    it("toggles active", () => {
+      const state = createDefaultGridLayoutState();
+      const active = setGridActive(state, true);
+      expect(active.active).toBe(true);
+      expect(setGridActive(active, true)).toBe(active);
+    });
+  });
+
+  describe("setLastView", () => {
+    it("records the last-active view kind", () => {
+      const state = createDefaultGridLayoutState();
+      const grid = setLastView(state, "grid");
+      expect(grid.lastView).toBe("grid");
+      const thread = setLastView(grid, "thread");
+      expect(thread.lastView).toBe("thread");
+    });
+
+    it("returns same reference when unchanged", () => {
+      const state = setLastView(createDefaultGridLayoutState(), "grid");
+      expect(setLastView(state, "grid")).toBe(state);
+    });
+  });
+
+  describe("gridHasPopulatedCells / populatedCellThreadKeys", () => {
+    it("returns false/empty for fresh grid", () => {
+      const state = createDefaultGridLayoutState();
+      expect(gridHasPopulatedCells(state)).toBe(false);
+      expect(populatedCellThreadKeys(state)).toEqual([]);
+    });
+
+    it("collects unique populated thread keys in order", () => {
+      let state = createDefaultGridLayoutState();
+      state = assignCellThread(state, 0, "env:thread-a");
+      state = assignCellThread(state, 1, "env:thread-b");
+      state = assignCellThread(state, 2, "env:thread-a");
+      expect(gridHasPopulatedCells(state)).toBe(true);
+      expect(populatedCellThreadKeys(state)).toEqual(["env:thread-a", "env:thread-b"]);
+    });
+  });
+
+  describe("cellIndexToCoord / coordToCellIndex", () => {
+    it("round-trips row-major coordinates", () => {
+      const cols = 4;
+      for (let row = 0; row < 3; row += 1) {
+        for (let col = 0; col < cols; col += 1) {
+          const index = coordToCellIndex(row, col, cols);
+          expect(cellIndexToCoord(index, cols)).toEqual({ row, col });
+        }
+      }
+    });
+  });
+
+  describe("clampCellIndex", () => {
+    it("handles empty cell lists", () => {
+      expect(clampCellIndex(5, 0)).toBe(0);
+    });
+
+    it("clamps negative indices to 0", () => {
+      expect(clampCellIndex(-3, 5)).toBe(0);
+    });
+
+    it("clamps to cellCount - 1", () => {
+      expect(clampCellIndex(7, 4)).toBe(3);
+    });
+  });
+});

--- a/apps/web/src/components/grid/gridLayout.ts
+++ b/apps/web/src/components/grid/gridLayout.ts
@@ -1,0 +1,192 @@
+/**
+ * Pure grid-layout logic for the chat-split-grid feature.
+ *
+ * A grid is an N x M matrix of cells indexed row-major. Each cell references a
+ * scoped thread key (populated) or `null` (empty). All functions here are pure
+ * reducers — state lives in `gridLayoutStore` and the React tree; this module
+ * owns the math.
+ */
+
+export const GRID_MIN_DIM = 1;
+export const GRID_MAX_DIM = 6;
+
+export interface GridLayoutCell {
+  readonly threadKey: string | null;
+}
+
+/**
+ * Which view this environment was last in. Used on app reopen to restore
+ * the user's most-recent context (grid or single-thread) per-environment.
+ */
+export type LastViewKind = "grid" | "thread" | null;
+
+export interface GridLayoutState {
+  readonly rows: number;
+  readonly cols: number;
+  readonly cells: ReadonlyArray<GridLayoutCell>;
+  readonly focusedCellIndex: number;
+  readonly active: boolean;
+  readonly lastView: LastViewKind;
+}
+
+export function createEmptyCells(count: number): GridLayoutCell[] {
+  return Array.from({ length: count }, () => ({ threadKey: null }));
+}
+
+export function createDefaultGridLayoutState(): GridLayoutState {
+  return {
+    rows: 2,
+    cols: 2,
+    cells: createEmptyCells(4),
+    focusedCellIndex: 0,
+    active: false,
+    lastView: null,
+  };
+}
+
+export function clampGridDim(value: number): number {
+  if (!Number.isFinite(value)) return GRID_MIN_DIM;
+  return Math.max(GRID_MIN_DIM, Math.min(GRID_MAX_DIM, Math.trunc(value)));
+}
+
+/**
+ * Resize the grid while preserving populated cells that still fit within the
+ * new dimensions. Cells that fall outside the new (rows, cols) rectangle are
+ * dropped. Newly introduced cells are empty.
+ *
+ * Row-major indexing: index = row * oldCols + col.
+ */
+export function resizeGridLayout(
+  state: GridLayoutState,
+  nextRows: number,
+  nextCols: number,
+): GridLayoutState {
+  const rows = clampGridDim(nextRows);
+  const cols = clampGridDim(nextCols);
+
+  if (rows === state.rows && cols === state.cols) {
+    return state;
+  }
+
+  const nextCells = createEmptyCells(rows * cols);
+  const copyRows = Math.min(rows, state.rows);
+  const copyCols = Math.min(cols, state.cols);
+
+  for (let row = 0; row < copyRows; row += 1) {
+    for (let col = 0; col < copyCols; col += 1) {
+      const oldIndex = row * state.cols + col;
+      const newIndex = row * cols + col;
+      const sourceCell = state.cells[oldIndex];
+      if (sourceCell) {
+        nextCells[newIndex] = sourceCell;
+      }
+    }
+  }
+
+  const focusedCellIndex = clampCellIndex(state.focusedCellIndex, rows * cols);
+
+  return {
+    ...state,
+    rows,
+    cols,
+    cells: nextCells,
+    focusedCellIndex,
+  };
+}
+
+export function clampCellIndex(index: number, cellCount: number): number {
+  if (cellCount <= 0) return 0;
+  if (!Number.isFinite(index)) return 0;
+  const truncated = Math.trunc(index);
+  if (truncated < 0) return 0;
+  if (truncated >= cellCount) return cellCount - 1;
+  return truncated;
+}
+
+export function assignCellThread(
+  state: GridLayoutState,
+  cellIndex: number,
+  threadKey: string,
+): GridLayoutState {
+  const index = clampCellIndex(cellIndex, state.cells.length);
+  const existing = state.cells[index];
+  if (existing && existing.threadKey === threadKey) {
+    return state;
+  }
+  const cells = state.cells.slice();
+  cells[index] = { threadKey };
+  return { ...state, cells };
+}
+
+export function clearCellThread(state: GridLayoutState, cellIndex: number): GridLayoutState {
+  const index = clampCellIndex(cellIndex, state.cells.length);
+  const existing = state.cells[index];
+  if (!existing || existing.threadKey === null) {
+    return state;
+  }
+  const cells = state.cells.slice();
+  cells[index] = { threadKey: null };
+  return { ...state, cells };
+}
+
+/**
+ * Remove a thread key from every cell it appears in. Used when a thread is
+ * deleted externally so we don't hold a dangling reference.
+ */
+export function removeThreadFromGridLayout(
+  state: GridLayoutState,
+  threadKey: string,
+): GridLayoutState {
+  let changed = false;
+  const cells = state.cells.map((cell) => {
+    if (cell.threadKey === threadKey) {
+      changed = true;
+      return { threadKey: null } satisfies GridLayoutCell;
+    }
+    return cell;
+  });
+  return changed ? { ...state, cells } : state;
+}
+
+export function setFocusedCell(state: GridLayoutState, cellIndex: number): GridLayoutState {
+  const next = clampCellIndex(cellIndex, state.cells.length);
+  if (next === state.focusedCellIndex) return state;
+  return { ...state, focusedCellIndex: next };
+}
+
+export function setGridActive(state: GridLayoutState, active: boolean): GridLayoutState {
+  if (state.active === active) return state;
+  return { ...state, active };
+}
+
+export function setLastView(state: GridLayoutState, lastView: LastViewKind): GridLayoutState {
+  if (state.lastView === lastView) return state;
+  return { ...state, lastView };
+}
+
+/**
+ * Returns true if at least one cell holds a thread key.
+ */
+export function gridHasPopulatedCells(state: GridLayoutState): boolean {
+  return state.cells.some((cell) => cell.threadKey !== null);
+}
+
+export function populatedCellThreadKeys(state: GridLayoutState): string[] {
+  const out: string[] = [];
+  for (const cell of state.cells) {
+    if (cell.threadKey !== null && !out.includes(cell.threadKey)) {
+      out.push(cell.threadKey);
+    }
+  }
+  return out;
+}
+
+export function cellIndexToCoord(index: number, cols: number): { row: number; col: number } {
+  const row = Math.floor(index / cols);
+  const col = index - row * cols;
+  return { row, col };
+}
+
+export function coordToCellIndex(row: number, col: number, cols: number): number {
+  return row * cols + col;
+}

--- a/apps/web/src/components/grid/gridPaneContext.tsx
+++ b/apps/web/src/components/grid/gridPaneContext.tsx
@@ -1,0 +1,52 @@
+/**
+ * React context used by GridPane to coordinate with the ChatView it renders.
+ *
+ * When inside a grid pane:
+ *   - ChatHeader swaps the "open grid split view" button for a × close-pane
+ *     button; the × calls `onClosePane` which clears the grid cell.
+ *   - ChatView routes diff toggles through `onRequestDiff` so the diff opens
+ *     as a pane-local sheet instead of navigating away from the grid.
+ *   - `diffOpen` reflects whether the pane-local diff sheet is currently open.
+ */
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { TurnId } from "@t3tools/contracts";
+
+export interface GridPaneDiffRequest {
+  /** When true, open the diff. When false, close it. */
+  open: boolean;
+  /** Scope the diff to a single turn. */
+  turnId?: TurnId;
+  /** Scope the diff to a single file within the turn. */
+  filePath?: string;
+}
+
+export interface GridPaneContextValue {
+  readonly inGridPane: true;
+  readonly onClosePane: () => void;
+  readonly onRequestDiff: (request: GridPaneDiffRequest) => void;
+  readonly diffOpen: boolean;
+}
+
+const GridPaneContext = createContext<GridPaneContextValue | null>(null);
+
+export function GridPaneProvider({
+  onClosePane,
+  onRequestDiff,
+  diffOpen,
+  children,
+}: {
+  onClosePane: () => void;
+  onRequestDiff: (request: GridPaneDiffRequest) => void;
+  diffOpen: boolean;
+  children: ReactNode;
+}) {
+  const value = useMemo<GridPaneContextValue>(
+    () => ({ inGridPane: true, onClosePane, onRequestDiff, diffOpen }),
+    [onClosePane, onRequestDiff, diffOpen],
+  );
+  return <GridPaneContext.Provider value={value}>{children}</GridPaneContext.Provider>;
+}
+
+export function useGridPaneContext(): GridPaneContextValue | null {
+  return useContext(GridPaneContext);
+}

--- a/apps/web/src/components/grid/gridShortcut.test.ts
+++ b/apps/web/src/components/grid/gridShortcut.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { gridSplitViewShortcutLabel, isGridSplitViewShortcut } from "./gridShortcut";
+
+function keyDown(overrides: Partial<KeyboardEvent>) {
+  return {
+    type: "keydown",
+    key: "g",
+    code: "KeyG",
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides,
+  } as unknown as KeyboardEvent;
+}
+
+describe("isGridSplitViewShortcut", () => {
+  it("matches Ctrl+Shift+G on non-mac", () => {
+    const event = keyDown({ ctrlKey: true, shiftKey: true });
+    expect(isGridSplitViewShortcut(event, "Win32")).toBe(true);
+  });
+
+  it("matches Cmd+Shift+G on mac", () => {
+    const event = keyDown({ metaKey: true, shiftKey: true });
+    expect(isGridSplitViewShortcut(event, "MacIntel")).toBe(true);
+  });
+
+  it("does not match without shift", () => {
+    const event = keyDown({ ctrlKey: true });
+    expect(isGridSplitViewShortcut(event, "Win32")).toBe(false);
+  });
+
+  it("does not match alt modifier", () => {
+    const event = keyDown({ ctrlKey: true, shiftKey: true, altKey: true });
+    expect(isGridSplitViewShortcut(event, "Win32")).toBe(false);
+  });
+
+  it("does not match cross-platform modifier", () => {
+    const event = keyDown({ metaKey: true, shiftKey: true });
+    expect(isGridSplitViewShortcut(event, "Win32")).toBe(false);
+    const event2 = keyDown({ ctrlKey: true, shiftKey: true });
+    expect(isGridSplitViewShortcut(event2, "MacIntel")).toBe(false);
+  });
+
+  it("ignores non-keydown event types", () => {
+    const event = keyDown({ type: "keyup", ctrlKey: true, shiftKey: true });
+    expect(isGridSplitViewShortcut(event, "Win32")).toBe(false);
+  });
+});
+
+describe("gridSplitViewShortcutLabel", () => {
+  it("returns mac symbols on mac", () => {
+    const label = gridSplitViewShortcutLabel("MacIntel");
+    expect(label).toContain("\u2318");
+    expect(label).toContain("\u21e7");
+  });
+
+  it("returns text label on non-mac", () => {
+    expect(gridSplitViewShortcutLabel("Win32")).toBe("Ctrl+Shift+G");
+  });
+});

--- a/apps/web/src/components/grid/gridShortcut.ts
+++ b/apps/web/src/components/grid/gridShortcut.ts
@@ -1,0 +1,38 @@
+/**
+ * Local keyboard shortcut for toggling grid split view.
+ *
+ * We don't route this through the centralized `KeybindingsConfig` because that
+ * requires contract + server changes. Grid view is a client-only concern, so a
+ * local matcher keeps the plumbing tight. Default shortcut: Ctrl/Cmd+Shift+G.
+ */
+import { isMacPlatform } from "../../lib/utils";
+import type { ShortcutEventLike } from "../../keybindings";
+
+export function isGridSplitViewShortcut(
+  event: ShortcutEventLike,
+  platform: string = typeof navigator !== "undefined" ? navigator.platform : "",
+): boolean {
+  if (event.type !== undefined && event.type !== "keydown") {
+    return false;
+  }
+  const key = (event.key ?? "").toLowerCase();
+  if (key !== "g") return false;
+  if (!event.shiftKey) return false;
+  if (event.altKey) return false;
+  const useMeta = isMacPlatform(platform);
+  if (useMeta) {
+    return event.metaKey && !event.ctrlKey;
+  }
+  return event.ctrlKey && !event.metaKey;
+}
+
+export const GRID_SPLIT_VIEW_SHORTCUT_LABEL = "Ctrl+Shift+G";
+export const GRID_SPLIT_VIEW_SHORTCUT_LABEL_MAC = "\u2318\u21e7G";
+
+export function gridSplitViewShortcutLabel(
+  platform: string = typeof navigator !== "undefined" ? navigator.platform : "",
+): string {
+  return isMacPlatform(platform)
+    ? GRID_SPLIT_VIEW_SHORTCUT_LABEL_MAC
+    : GRID_SPLIT_VIEW_SHORTCUT_LABEL;
+}

--- a/apps/web/src/gridLayoutStore.test.ts
+++ b/apps/web/src/gridLayoutStore.test.ts
@@ -1,0 +1,90 @@
+import { type EnvironmentId } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { resetGridLayoutStoreForTests, useGridLayoutStore } from "./gridLayoutStore";
+
+const ENV_A = "env_a" as EnvironmentId;
+const ENV_B = "env_b" as EnvironmentId;
+
+function read(envId: EnvironmentId) {
+  return useGridLayoutStore.getState().getState(envId);
+}
+
+describe("gridLayoutStore", () => {
+  beforeEach(() => {
+    resetGridLayoutStoreForTests();
+  });
+
+  it("returns a default layout for an unknown environment", () => {
+    const state = read(ENV_A);
+    expect(state.rows).toBe(2);
+    expect(state.cols).toBe(2);
+    expect(state.cells).toHaveLength(4);
+    expect(state.active).toBe(false);
+  });
+
+  it("keeps per-environment state isolated", () => {
+    useGridLayoutStore.getState().setSize(ENV_A, 3, 3);
+    useGridLayoutStore.getState().setSize(ENV_B, 2, 4);
+    expect(read(ENV_A).rows).toBe(3);
+    expect(read(ENV_A).cols).toBe(3);
+    expect(read(ENV_B).rows).toBe(2);
+    expect(read(ENV_B).cols).toBe(4);
+  });
+
+  it("assigns and clears cells", () => {
+    useGridLayoutStore.getState().assignCell(ENV_A, 1, "env:thread-x");
+    expect(read(ENV_A).cells[1]?.threadKey).toBe("env:thread-x");
+    useGridLayoutStore.getState().clearCell(ENV_A, 1);
+    expect(read(ENV_A).cells[1]?.threadKey).toBeNull();
+  });
+
+  it("resizes while preserving cells that fit in the new rectangle", () => {
+    useGridLayoutStore.getState().assignCell(ENV_A, 0, "env:t-a");
+    useGridLayoutStore.getState().setSize(ENV_A, 3, 3);
+    expect(read(ENV_A).cells[0]?.threadKey).toBe("env:t-a");
+    expect(read(ENV_A).cells).toHaveLength(9);
+  });
+
+  it("tracks active flag", () => {
+    useGridLayoutStore.getState().setActive(ENV_A, true);
+    const state = read(ENV_A);
+    expect(state.active).toBe(true);
+  });
+
+  it("tracks last view per environment", () => {
+    useGridLayoutStore.getState().setLastView(ENV_A, "grid");
+    useGridLayoutStore.getState().setLastView(ENV_B, "thread");
+    expect(read(ENV_A).lastView).toBe("grid");
+    expect(read(ENV_B).lastView).toBe("thread");
+  });
+
+  it("removes a thread from all cells that reference it", () => {
+    useGridLayoutStore.getState().assignCell(ENV_A, 0, "env:t-x");
+    useGridLayoutStore.getState().assignCell(ENV_A, 2, "env:t-x");
+    useGridLayoutStore.getState().assignCell(ENV_A, 3, "env:t-y");
+    useGridLayoutStore.getState().removeThread(ENV_A, "env:t-x");
+    const state = read(ENV_A);
+    expect(state.cells[0]?.threadKey).toBeNull();
+    expect(state.cells[2]?.threadKey).toBeNull();
+    expect(state.cells[3]?.threadKey).toBe("env:t-y");
+  });
+
+  it("clamps requested grid dimensions to bounds", () => {
+    useGridLayoutStore.getState().setSize(ENV_A, 99, 0);
+    const state = read(ENV_A);
+    expect(state.rows).toBe(6);
+    expect(state.cols).toBe(1);
+    expect(state.cells).toHaveLength(6);
+  });
+
+  it("resets an environment to defaults", () => {
+    useGridLayoutStore.getState().setSize(ENV_A, 4, 4);
+    useGridLayoutStore.getState().assignCell(ENV_A, 5, "env:t-x");
+    useGridLayoutStore.getState().resetEnvironment(ENV_A);
+    const state = read(ENV_A);
+    expect(state.rows).toBe(2);
+    expect(state.cols).toBe(2);
+    expect(state.cells.every((cell) => cell.threadKey === null)).toBe(true);
+  });
+});

--- a/apps/web/src/gridLayoutStore.ts
+++ b/apps/web/src/gridLayoutStore.ts
@@ -1,0 +1,230 @@
+/**
+ * Zustand store for the chat-split-grid feature.
+ *
+ * Holds per-environment grid layouts persisted to localStorage. The grid is a
+ * separate view mode: when a user enters grid mode for an environment, we
+ * render an N x M matrix of panes, each bound to its own thread.
+ *
+ * Per-env isolation: each environment gets its own layout so switching
+ * projects doesn't blow away the grid configuration of the one you left.
+ */
+import type { EnvironmentId } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+import {
+  assignCellThread,
+  clampCellIndex,
+  clearCellThread,
+  createDefaultGridLayoutState,
+  createEmptyCells,
+  GRID_MAX_DIM,
+  GRID_MIN_DIM,
+  gridHasPopulatedCells,
+  type GridLayoutCell,
+  type GridLayoutState,
+  type LastViewKind,
+  populatedCellThreadKeys,
+  removeThreadFromGridLayout,
+  resizeGridLayout,
+  setFocusedCell,
+  setGridActive,
+  setLastView as setLastViewOnState,
+} from "./components/grid/gridLayout";
+
+export const GRID_LAYOUT_STORAGE_KEY = "t3code:grid-layout:v1";
+
+const GridLayoutCellSchema = Schema.Struct({
+  threadKey: Schema.NullOr(Schema.String),
+});
+
+const LastViewSchema = Schema.NullOr(
+  Schema.Union([Schema.Literal("grid"), Schema.Literal("thread")]),
+);
+
+const GridLayoutStateSchema = Schema.Struct({
+  rows: Schema.Number,
+  cols: Schema.Number,
+  cells: Schema.Array(GridLayoutCellSchema),
+  focusedCellIndex: Schema.Number,
+  active: Schema.Boolean,
+  lastView: LastViewSchema,
+});
+
+const PersistedGridLayoutDocumentSchema = Schema.Struct({
+  version: Schema.Literal(1),
+  stateByEnvironmentId: Schema.Record(Schema.String, GridLayoutStateSchema),
+});
+type PersistedGridLayoutDocument = typeof PersistedGridLayoutDocumentSchema.Type;
+
+interface GridLayoutStoreState {
+  stateByEnvironmentId: Record<string, GridLayoutState>;
+}
+
+interface GridLayoutStoreActions {
+  getState: (environmentId: EnvironmentId) => GridLayoutState;
+  setActive: (environmentId: EnvironmentId, active: boolean) => void;
+  setSize: (environmentId: EnvironmentId, rows: number, cols: number) => void;
+  assignCell: (environmentId: EnvironmentId, cellIndex: number, threadKey: string) => void;
+  clearCell: (environmentId: EnvironmentId, cellIndex: number) => void;
+  setFocusedCell: (environmentId: EnvironmentId, cellIndex: number) => void;
+  setLastView: (environmentId: EnvironmentId, view: LastViewKind) => void;
+  removeThread: (environmentId: EnvironmentId, threadKey: string) => void;
+  resetEnvironment: (environmentId: EnvironmentId) => void;
+}
+
+export type GridLayoutStore = GridLayoutStoreState & GridLayoutStoreActions;
+
+function normalizeEnvState(raw: unknown): GridLayoutState {
+  if (!raw || typeof raw !== "object") {
+    return createDefaultGridLayoutState();
+  }
+  const candidate = raw as Partial<GridLayoutState>;
+  const rows = clampDim(candidate.rows);
+  const cols = clampDim(candidate.cols);
+  const cellCount = rows * cols;
+  const rawCells = Array.isArray(candidate.cells) ? candidate.cells : [];
+  const cells: GridLayoutCell[] = createEmptyCells(cellCount);
+  for (let i = 0; i < cellCount; i += 1) {
+    const cell = rawCells[i];
+    const threadKey =
+      cell && typeof cell === "object" && typeof cell.threadKey === "string" && cell.threadKey
+        ? cell.threadKey
+        : null;
+    cells[i] = { threadKey };
+  }
+  const focusedCellIndex = clampCellIndex(candidate.focusedCellIndex ?? 0, cellCount);
+  const rawLastView = (candidate as { lastView?: unknown }).lastView;
+  const lastView: LastViewKind =
+    rawLastView === "grid" || rawLastView === "thread" ? rawLastView : null;
+  return {
+    rows,
+    cols,
+    cells,
+    focusedCellIndex,
+    active: Boolean(candidate.active),
+    lastView,
+  };
+}
+
+function clampDim(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 2;
+  const truncated = Math.trunc(value);
+  if (truncated < GRID_MIN_DIM) return GRID_MIN_DIM;
+  if (truncated > GRID_MAX_DIM) return GRID_MAX_DIM;
+  return truncated;
+}
+
+function getOrInit(state: GridLayoutStoreState, environmentId: EnvironmentId): GridLayoutState {
+  return state.stateByEnvironmentId[environmentId] ?? createDefaultGridLayoutState();
+}
+
+function patch(
+  state: GridLayoutStoreState,
+  environmentId: EnvironmentId,
+  next: GridLayoutState,
+): GridLayoutStoreState {
+  const prev = state.stateByEnvironmentId[environmentId];
+  if (prev && prev === next) return state;
+  return {
+    stateByEnvironmentId: {
+      ...state.stateByEnvironmentId,
+      [environmentId]: next,
+    },
+  };
+}
+
+export const useGridLayoutStore = create<GridLayoutStore>()(
+  persist(
+    (set, get) => ({
+      stateByEnvironmentId: {},
+      getState: (environmentId) => getOrInit(get(), environmentId),
+      setActive: (environmentId, active) => {
+        set((state) =>
+          patch(state, environmentId, setGridActive(getOrInit(state, environmentId), active)),
+        );
+      },
+      setSize: (environmentId, rows, cols) => {
+        set((state) =>
+          patch(
+            state,
+            environmentId,
+            resizeGridLayout(getOrInit(state, environmentId), rows, cols),
+          ),
+        );
+      },
+      assignCell: (environmentId, cellIndex, threadKey) => {
+        set((state) =>
+          patch(
+            state,
+            environmentId,
+            assignCellThread(getOrInit(state, environmentId), cellIndex, threadKey),
+          ),
+        );
+      },
+      clearCell: (environmentId, cellIndex) => {
+        set((state) =>
+          patch(state, environmentId, clearCellThread(getOrInit(state, environmentId), cellIndex)),
+        );
+      },
+      setFocusedCell: (environmentId, cellIndex) => {
+        set((state) =>
+          patch(state, environmentId, setFocusedCell(getOrInit(state, environmentId), cellIndex)),
+        );
+      },
+      setLastView: (environmentId, view) => {
+        set((state) =>
+          patch(state, environmentId, setLastViewOnState(getOrInit(state, environmentId), view)),
+        );
+      },
+      removeThread: (environmentId, threadKey) => {
+        set((state) =>
+          patch(
+            state,
+            environmentId,
+            removeThreadFromGridLayout(getOrInit(state, environmentId), threadKey),
+          ),
+        );
+      },
+      resetEnvironment: (environmentId) => {
+        set((state) => patch(state, environmentId, createDefaultGridLayoutState()));
+      },
+    }),
+    {
+      name: GRID_LAYOUT_STORAGE_KEY,
+      version: 1,
+      storage: createJSONStorage(() =>
+        typeof window === "undefined"
+          ? {
+              getItem: () => null,
+              setItem: () => undefined,
+              removeItem: () => undefined,
+            }
+          : window.localStorage,
+      ),
+      partialize: (state) => ({ stateByEnvironmentId: state.stateByEnvironmentId }),
+      merge: (persisted, current) => {
+        if (!persisted || typeof persisted !== "object") return current;
+        const candidate = persisted as Partial<PersistedGridLayoutDocument> & {
+          stateByEnvironmentId?: Record<string, unknown>;
+        };
+        const mapping = candidate.stateByEnvironmentId ?? {};
+        const restored: Record<string, GridLayoutState> = {};
+        for (const [envId, raw] of Object.entries(mapping)) {
+          restored[envId] = normalizeEnvState(raw);
+        }
+        return { ...current, stateByEnvironmentId: restored };
+      },
+    },
+  ),
+);
+
+/**
+ * Standalone test hook for resetting the store between tests.
+ */
+export function resetGridLayoutStoreForTests(): void {
+  useGridLayoutStore.setState({ stateByEnvironmentId: {} });
+}
+
+export { gridHasPopulatedCells, populatedCellThreadKeys };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as SettingsGeneralRouteImport } from './routes/settings.general'
 import { Route as SettingsConnectionsRouteImport } from './routes/settings.connections'
 import { Route as SettingsArchivedRouteImport } from './routes/settings.archived'
 import { Route as ChatDraftDraftIdRouteImport } from './routes/_chat.draft.$draftId'
+import { Route as ChatEnvironmentIdGridRouteImport } from './routes/_chat.$environmentId.grid'
 import { Route as ChatEnvironmentIdThreadIdRouteImport } from './routes/_chat.$environmentId.$threadId'
 
 const SettingsRoute = SettingsRouteImport.update({
@@ -58,6 +59,11 @@ const ChatDraftDraftIdRoute = ChatDraftDraftIdRouteImport.update({
   path: '/draft/$draftId',
   getParentRoute: () => ChatRoute,
 } as any)
+const ChatEnvironmentIdGridRoute = ChatEnvironmentIdGridRouteImport.update({
+  id: '/$environmentId/grid',
+  path: '/$environmentId/grid',
+  getParentRoute: () => ChatRoute,
+} as any)
 const ChatEnvironmentIdThreadIdRoute =
   ChatEnvironmentIdThreadIdRouteImport.update({
     id: '/$environmentId/$threadId',
@@ -73,6 +79,7 @@ export interface FileRoutesByFullPath {
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
+  '/$environmentId/grid': typeof ChatEnvironmentIdGridRoute
   '/draft/$draftId': typeof ChatDraftDraftIdRoute
 }
 export interface FileRoutesByTo {
@@ -83,6 +90,7 @@ export interface FileRoutesByTo {
   '/settings/general': typeof SettingsGeneralRoute
   '/': typeof ChatIndexRoute
   '/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
+  '/$environmentId/grid': typeof ChatEnvironmentIdGridRoute
   '/draft/$draftId': typeof ChatDraftDraftIdRoute
 }
 export interface FileRoutesById {
@@ -95,6 +103,7 @@ export interface FileRoutesById {
   '/settings/general': typeof SettingsGeneralRoute
   '/_chat/': typeof ChatIndexRoute
   '/_chat/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
+  '/_chat/$environmentId/grid': typeof ChatEnvironmentIdGridRoute
   '/_chat/draft/$draftId': typeof ChatDraftDraftIdRoute
 }
 export interface FileRouteTypes {
@@ -107,6 +116,7 @@ export interface FileRouteTypes {
     | '/settings/connections'
     | '/settings/general'
     | '/$environmentId/$threadId'
+    | '/$environmentId/grid'
     | '/draft/$draftId'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -117,6 +127,7 @@ export interface FileRouteTypes {
     | '/settings/general'
     | '/'
     | '/$environmentId/$threadId'
+    | '/$environmentId/grid'
     | '/draft/$draftId'
   id:
     | '__root__'
@@ -128,6 +139,7 @@ export interface FileRouteTypes {
     | '/settings/general'
     | '/_chat/'
     | '/_chat/$environmentId/$threadId'
+    | '/_chat/$environmentId/grid'
     | '/_chat/draft/$draftId'
   fileRoutesById: FileRoutesById
 }
@@ -195,6 +207,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ChatDraftDraftIdRouteImport
       parentRoute: typeof ChatRoute
     }
+    '/_chat/$environmentId/grid': {
+      id: '/_chat/$environmentId/grid'
+      path: '/$environmentId/grid'
+      fullPath: '/$environmentId/grid'
+      preLoaderRoute: typeof ChatEnvironmentIdGridRouteImport
+      parentRoute: typeof ChatRoute
+    }
     '/_chat/$environmentId/$threadId': {
       id: '/_chat/$environmentId/$threadId'
       path: '/$environmentId/$threadId'
@@ -208,12 +227,14 @@ declare module '@tanstack/react-router' {
 interface ChatRouteChildren {
   ChatIndexRoute: typeof ChatIndexRoute
   ChatEnvironmentIdThreadIdRoute: typeof ChatEnvironmentIdThreadIdRoute
+  ChatEnvironmentIdGridRoute: typeof ChatEnvironmentIdGridRoute
   ChatDraftDraftIdRoute: typeof ChatDraftDraftIdRoute
 }
 
 const ChatRouteChildren: ChatRouteChildren = {
   ChatIndexRoute: ChatIndexRoute,
   ChatEnvironmentIdThreadIdRoute: ChatEnvironmentIdThreadIdRoute,
+  ChatEnvironmentIdGridRoute: ChatEnvironmentIdGridRoute,
   ChatDraftDraftIdRoute: ChatDraftDraftIdRoute,
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import { APP_DISPLAY_NAME } from "../branding";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
+import { useGridLayoutStore } from "../gridLayoutStore";
 import {
   SlowRpcAckToastCoordinator,
   WebSocketConnectionCoordinator,
@@ -255,14 +256,25 @@ function EventRouter() {
       if (handledBootstrapThreadIdRef.current === payload.bootstrapThreadId) {
         return;
       }
-      await navigate({
-        to: "/$environmentId/$threadId",
-        params: {
-          environmentId: payload.environment.environmentId,
-          threadId: payload.bootstrapThreadId,
-        },
-        replace: true,
-      });
+      const lastView = useGridLayoutStore
+        .getState()
+        .getState(payload.environment.environmentId).lastView;
+      if (lastView === "grid") {
+        await navigate({
+          to: "/$environmentId/grid",
+          params: { environmentId: payload.environment.environmentId },
+          replace: true,
+        });
+      } else {
+        await navigate({
+          to: "/$environmentId/$threadId",
+          params: {
+            environmentId: payload.environment.environmentId,
+            threadId: payload.bootstrapThreadId,
+          },
+          replace: true,
+        });
+      }
       handledBootstrapThreadIdRef.current = payload.bootstrapThreadId;
     })().catch(() => undefined);
   });

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -4,6 +4,7 @@ import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react
 import ChatView from "../components/ChatView";
 import { threadHasStarted } from "../components/ChatView.logic";
 import { DiffWorkerPoolProvider } from "../components/DiffWorkerPoolProvider";
+import { useGridLayoutStore } from "../gridLayoutStore";
 import {
   DiffPanelHeaderSkeleton,
   DiffPanelLoadingState,
@@ -221,6 +222,12 @@ function ChatThreadRouteView() {
       void navigate({ to: "/", replace: true });
     }
   }, [bootstrapComplete, environmentHasAnyThreads, navigate, routeThreadExists, threadRef]);
+
+  useEffect(() => {
+    if (threadRef) {
+      useGridLayoutStore.getState().setLastView(threadRef.environmentId, "thread");
+    }
+  }, [threadRef]);
 
   useEffect(() => {
     if (!threadRef || !serverThreadStarted || !draftThread?.promotedTo) {

--- a/apps/web/src/routes/_chat.$environmentId.grid.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.grid.tsx
@@ -1,0 +1,13 @@
+import { type EnvironmentId } from "@t3tools/contracts";
+import { createFileRoute } from "@tanstack/react-router";
+
+import { GridView } from "../components/grid/GridView";
+
+function GridRouteView() {
+  const { environmentId } = Route.useParams();
+  return <GridView environmentId={environmentId as EnvironmentId} />;
+}
+
+export const Route = createFileRoute("/_chat/$environmentId/grid")({
+  component: GridRouteView,
+});

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,4 +1,4 @@
-import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
+import { Outlet, createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
 
 import { useCommandPaletteStore } from "../commandPaletteStore";
@@ -9,11 +9,13 @@ import {
 } from "../lib/chatThreadActions";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { resolveShortcutCommand } from "../keybindings";
+import { isGridSplitViewShortcut } from "../components/grid/gridShortcut";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { resolveSidebarNewThreadEnvMode } from "~/components/Sidebar.logic";
 import { useSettings } from "~/hooks/useSettings";
 import { useServerKeybindings } from "~/rpc/serverState";
+import { usePrimaryEnvironmentId } from "~/environments/primary";
 
 function ChatRouteGlobalShortcuts() {
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
@@ -27,6 +29,8 @@ function ChatRouteGlobalShortcuts() {
       : false,
   );
   const appSettings = useSettings();
+  const navigate = useNavigate();
+  const primaryEnvironmentId = usePrimaryEnvironmentId();
 
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
@@ -45,6 +49,19 @@ function ChatRouteGlobalShortcuts() {
       if (event.key === "Escape" && selectedThreadKeysSize > 0) {
         event.preventDefault();
         clearSelection();
+        return;
+      }
+
+      if (isGridSplitViewShortcut(event)) {
+        const environmentId = routeThreadRef?.environmentId ?? primaryEnvironmentId;
+        if (environmentId) {
+          event.preventDefault();
+          event.stopPropagation();
+          void navigate({
+            to: "/$environmentId/grid",
+            params: { environmentId },
+          });
+        }
         return;
       }
 
@@ -89,6 +106,9 @@ function ChatRouteGlobalShortcuts() {
     handleNewThread,
     keybindings,
     defaultProjectRef,
+    navigate,
+    primaryEnvironmentId,
+    routeThreadRef,
     selectedThreadKeysSize,
     terminalOpen,
     appSettings.defaultThreadEnvMode,

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@t3tools/monorepo",
@@ -200,6 +199,7 @@
     },
   },
   "trustedDependencies": [
+    "electron",
     "node-pty",
   ],
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     ]
   },
   "trustedDependencies": [
+    "electron",
     "node-pty"
   ]
 }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

  ## What Changed
  Adds an opt-in grid split view at `/$environmentId/grid`:

  - New route rendering a configurable N×M grid (1×1 up to 6×6) of chat panes.
  - Each pane hosts a full `ChatView`; empty cells offer "Pick thread" or "New thread".
  - Layout, chosen threads, and last-active view (grid vs single-thread) persist per environment via a new zustand
   store backed by localStorage.
  - Inside a pane, the diff toggle stays visible but opens an **in-pane diff sheet** (via new optional props on
  `DiffPanel`) instead of navigating away — the rest of the grid stays on screen.
  - Entry points: grid icon in `ChatHeader`, `Ctrl/Cmd+Shift+G`, or direct URL.
  - Also includes a small Windows dev-runner fix (drop `shell:true` on Node spawn; replace broken `bun run
  --parallel` with a tiny orchestrator; trust Electron's postinstall) — happy to split into a separate PR if
  preferred.

  47 new unit tests (`gridLayout`, `gridLayoutStore`, `gridShortcut`), full suite green.

  ## Why

  Today comparing output across threads means tab-switching one thread at a time. A grid view lets N sessions run
  in parallel — useful for A/B-ing model outputs, running the same task across threads, or just watching several
  agents work side-by-side. The single-thread flow is untouched; grid is a separate route reached from a new icon,
   so users who don't want it never see it.

  ## UI Changes

https://github.com/user-attachments/assets/cbab7cd5-9162-410f-a5e4-cf8815a0f8e6

  ### Before (single thread, unchanged)
 
<img width="2558" height="1384" alt="image" src="https://github.com/user-attachments/assets/d044e5c5-733f-44e2-9384-c8ac94c89200" />


  ### After (2×2 grid,)
<img width="2557" height="1397" alt="image" src="https://github.com/user-attachments/assets/5c6968ac-1a96-496c-a681-cc00d990b4b1" />


## Checklist

- [x] ] This PR is small and focused
- [ x]] I explained what changed and why
- [ x]] I included before/after screenshots for any UI changes
- [ x]] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a substantial new UI mode with new routing and persisted local state, and changes diff-toggle behavior to support both route-driven and pane-local diff state; regressions could affect navigation and thread/diff UX. Also adjusts Windows process spawning and desktop dev orchestration, which could impact developer workflows on those platforms.
> 
> **Overview**
> Adds a new **grid split view** route at `/$environmentId/grid` that renders an N×M (1–6) matrix of chat panes, including UI for picking threads/creating new draft threads per cell, resizing/resetting the grid, and tracking focus.
> 
> Persists grid layout and last-view-per-environment via a new `gridLayoutStore` (localStorage-backed), wires entry points from `ChatHeader`, a new Ctrl/Cmd+Shift+G shortcut, and boot navigation now restores the last view (*grid vs thread*).
> 
> Updates `ChatView` and `DiffPanel` so diff toggling/turn selection can be controlled by a grid-pane context (pane-local diff sheet with override props) instead of always navigating via route search params.
> 
> Separately fixes dev/build ergonomics: replaces broken `bun run --parallel` in desktop dev with a node orchestrator script, disables `shell` spawning for the server `build` CLI on Windows to avoid space-in-path issues, and marks `electron` as a trusted dependency in lock/package config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed1e15b7e63405a0a856e28b3e58e90d0bd711e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add chat grid split view for arranging multiple threads in a resizable grid
> - Adds a new `/:environmentId/grid` route rendering `GridView`, where users can arrange multiple chat threads in a CSS grid, assign threads to cells, create drafts, and resize the layout.
> - Introduces a persisted Zustand store ([gridLayoutStore.ts](https://github.com/pingdotgg/t3code/pull/2177/files#diff-943cc72397bc0a82f99d0f3772b6fa6c9a40c333ff72b98657f837809c06c847)) that tracks per-environment grid state (rows, cols, cells, focus, active flag, last view) in localStorage, with normalization on restore.
> - Adds grid layout primitives in [gridLayout.ts](https://github.com/pingdotgg/t3code/pull/2177/files#diff-908675ff1d825f8e05340aa5d92729fb453a4a4fa060839e1cce05bcce4f2d93): dimension clamping, resize (preserving in-bounds cells), cell assignment/clearing, thread removal, and coordinate helpers.
> - Adds `GridPane`, `GridEmptyPane`, `GridToolbar`, `GridSizePicker`, and `GridThreadPicker` components to compose the grid UI; each pane renders a full `ChatView` or an empty-state picker.
> - Extends `ChatView` and `DiffPanel` with a `GridPaneContext` so diff state and turn selection are scoped to the pane without mutating the URL.
> - Adds a global keyboard shortcut (`Cmd/Ctrl+Shift+G`) in `ChatRouteGlobalShortcuts` to navigate to the grid view, and restores the grid route on app start if `lastView` was `'grid'`.
> - Risk: grid layout is stored in localStorage under `t3code:grid-layout:v1`; schema changes will require migration or normalization updates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed1e15b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->