### PR TITLE
fix(server): kill managed probe opencode processes (mem leak)

### DIFF
--- a/apps/server/src/git/Layers/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/OpenCodeTextGeneration.test.ts
@@ -46,7 +46,7 @@ vi.mock("../../provider/opencodeRuntime.ts", async () => {
       return {
         url,
         process: {} as ChildProcess,
-        close: () => {
+        close: async () => {
           runtimeMock.state.closeCalls.push(url);
         },
       };

--- a/apps/server/src/git/Layers/OpenCodeTextGeneration.ts
+++ b/apps/server/src/git/Layers/OpenCodeTextGeneration.ts
@@ -56,13 +56,14 @@ const makeOpenCodeTextGeneration = Effect.gen(function* () {
     idleCloseFiber: null,
   };
 
-  const closeSharedServer = (server: OpenCodeServerProcess) => {
-    if (sharedServerState.server === server) {
-      sharedServerState.server = null;
-      sharedServerState.binaryPath = null;
-    }
-    server.close();
-  };
+  const closeSharedServer = (server: OpenCodeServerProcess) =>
+    Effect.promise(async () => {
+      if (sharedServerState.server === server) {
+        sharedServerState.server = null;
+        sharedServerState.binaryPath = null;
+      }
+      await server.close();
+    });
 
   const cancelIdleCloseFiber = Effect.fn("cancelIdleCloseFiber")(function* () {
     const idleCloseFiber = sharedServerState.idleCloseFiber;
@@ -79,12 +80,12 @@ const makeOpenCodeTextGeneration = Effect.gen(function* () {
     const fiber = yield* Effect.sleep(Duration.millis(OPENCODE_TEXT_GENERATION_IDLE_TTL_MS)).pipe(
       Effect.andThen(
         sharedServerMutex.withPermit(
-          Effect.sync(() => {
+          Effect.gen(function* () {
             if (sharedServerState.server !== server || sharedServerState.activeRequests > 0) {
               return;
             }
             sharedServerState.idleCloseFiber = null;
-            closeSharedServer(server);
+            yield* closeSharedServer(server);
           }),
         ),
       ),
@@ -111,7 +112,7 @@ const makeOpenCodeTextGeneration = Effect.gen(function* () {
             sharedServerState.binaryPath !== input.binaryPath &&
             sharedServerState.activeRequests === 0
           ) {
-            closeSharedServer(existingServer);
+            yield* closeSharedServer(existingServer);
           } else {
             if (sharedServerState.binaryPath !== input.binaryPath) {
               yield* Effect.logWarning(
@@ -166,7 +167,7 @@ const makeOpenCodeTextGeneration = Effect.gen(function* () {
         sharedServerState.binaryPath = null;
         sharedServerState.activeRequests = 0;
         if (server !== null) {
-          server.close();
+          yield* Effect.promise(() => server.close());
         }
       }),
     ),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -70,14 +70,14 @@ vi.mock("../opencodeRuntime.ts", async () => {
         process: {
           once() {},
         },
-        close() {},
+        close: async () => {},
       };
     }),
     connectToOpenCodeServer: vi.fn(async ({ serverUrl }: { serverUrl?: string }) => ({
       url: serverUrl ?? "http://127.0.0.1:4301",
       process: null,
       external: Boolean(serverUrl),
-      close() {
+      close: async () => {
         runtimeMock.state.closeCalls.push(serverUrl ?? "http://127.0.0.1:4301");
         if (runtimeMock.state.closeError) {
           throw runtimeMock.state.closeError;
@@ -480,7 +480,7 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
 
       assert.equal(sessions.length, 1);
       assert.equal(sessions[0]?.threadId, "thread-native-log-failure");
-      assert.deepEqual(runtimeMock.state.closeCalls, []);
+      assert.deepEqual(runtimeMock.state.closeCalls, ["http://127.0.0.1:9999"]);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -377,7 +377,7 @@ async function stopOpenCodeContext(context: OpenCodeSessionContext): Promise<voi
       .abort({ sessionID: context.openCodeSessionId })
       .catch(() => undefined);
   } catch {}
-  context.server.close();
+  await context.server.close();
 }
 
 export function makeOpenCodeAdapterLive(_options?: OpenCodeAdapterLiveOptions) {
@@ -425,7 +425,7 @@ export function makeOpenCodeAdapterLive(_options?: OpenCodeAdapterLiveOptions) {
         }
         context.stopped = true;
         sessions.delete(context.session.threadId);
-        context.server.close();
+        void context.server.close().catch(() => undefined);
         const turnId = context.activeTurnId;
         void emitPromise({
           ...buildEventBase({ threadId: context.session.threadId, turnId }),
@@ -924,7 +924,10 @@ export function makeOpenCodeAdapterLive(_options?: OpenCodeAdapterLiveOptions) {
                   .catch(() => undefined),
               catch: () => undefined,
             }).pipe(Effect.ignore);
-            started.server.close();
+            yield* Effect.tryPromise({
+              try: () => started.server.close(),
+              catch: () => undefined,
+            }).pipe(Effect.ignore);
             return raceWinner.session;
           }
 
@@ -1316,6 +1319,10 @@ export function makeOpenCodeAdapterLive(_options?: OpenCodeAdapterLiveOptions) {
               cause,
             }),
         });
+
+      yield* Effect.addFinalizer(() =>
+        stopAll().pipe(Effect.ignore, Effect.andThen(Queue.shutdown(runtimeEvents))),
+      );
 
       return {
         provider: PROVIDER,

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -41,7 +41,7 @@ vi.mock("../opencodeRuntime.ts", async () => {
       url: serverUrl ?? "http://127.0.0.1:4301",
       process: null,
       external: Boolean(serverUrl),
-      close() {},
+      close: async () => {},
     })),
     createOpenCodeSdkClient: vi.fn(() => ({})),
     loadOpenCodeInventory: vi.fn(async () => {

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -270,7 +270,7 @@ export function checkOpenCodeProviderStatus(input: {
             },
             catch: toOpenCodeProbeError,
           }),
-        (server) => Effect.sync(() => server.close()),
+        (server) => Effect.promise(() => server.close()),
       ),
     );
     if (inventoryExit._tag === "Failure") {

--- a/apps/server/src/provider/opencodeRuntime.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 
 import { describe, it, vi } from "vitest";
 
@@ -34,5 +35,72 @@ describe("resolveOpenCodeBinaryPath", () => {
         timeout: 3_000,
       },
     ]);
+  });
+});
+
+describe("startOpenCodeServerProcess", () => {
+  it("swallows close rejections when startup times out", async () => {
+    vi.useFakeTimers();
+
+    class MockStream extends EventEmitter {
+      setEncoding(_encoding: string) {}
+    }
+
+    class MockChild extends EventEmitter {
+      readonly stdout = new MockStream();
+      readonly stderr = new MockStream();
+      readonly pid = 123;
+      readonly exitCode = null;
+      readonly signalCode = null;
+
+      kill(_signal?: NodeJS.Signals | number): boolean {
+        queueMicrotask(() => {
+          this.emit("error", new Error("shutdown failed"));
+        });
+        return true;
+      }
+    }
+
+    const child = new MockChild();
+    childProcessMock.spawn.mockReturnValueOnce(child as never);
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      const error = new Error("missing process") as NodeJS.ErrnoException;
+      error.code = "ESRCH";
+      throw error;
+    });
+
+    const unhandledRejections: Array<unknown> = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const { startOpenCodeServerProcess } = await import("./opencodeRuntime.ts");
+      const startup = startOpenCodeServerProcess({
+        binaryPath: "/opt/homebrew/bin/opencode",
+        timeoutMs: 10,
+      });
+      const startupResult = startup.then(
+        () => ({ ok: true as const }),
+        (error) => ({ ok: false as const, error }),
+      );
+
+      await vi.advanceTimersByTimeAsync(10);
+      const result = await startupResult;
+      await Promise.resolve();
+
+      assert.equal(result.ok, false);
+      assert.match(
+        result.error instanceof Error ? result.error.message : String(result.error),
+        /Timed out waiting for OpenCode server start after 10ms\./,
+      );
+      assert.deepEqual(unhandledRejections, []);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+      killSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/server/src/provider/opencodeRuntime.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.test.ts
@@ -1,6 +1,4 @@
 import assert from "node:assert/strict";
-import { EventEmitter } from "node:events";
-
 import { describe, it, vi } from "vitest";
 
 const childProcessMock = vi.hoisted(() => ({
@@ -35,72 +33,5 @@ describe("resolveOpenCodeBinaryPath", () => {
         timeout: 3_000,
       },
     ]);
-  });
-});
-
-describe("startOpenCodeServerProcess", () => {
-  it("swallows close rejections when startup times out", async () => {
-    vi.useFakeTimers();
-
-    class MockStream extends EventEmitter {
-      setEncoding(_encoding: string) {}
-    }
-
-    class MockChild extends EventEmitter {
-      readonly stdout = new MockStream();
-      readonly stderr = new MockStream();
-      readonly pid = 123;
-      readonly exitCode = null;
-      readonly signalCode = null;
-
-      kill(_signal?: NodeJS.Signals | number): boolean {
-        queueMicrotask(() => {
-          this.emit("error", new Error("shutdown failed"));
-        });
-        return true;
-      }
-    }
-
-    const child = new MockChild();
-    childProcessMock.spawn.mockReturnValueOnce(child as never);
-
-    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
-      const error = new Error("missing process") as NodeJS.ErrnoException;
-      error.code = "ESRCH";
-      throw error;
-    });
-
-    const unhandledRejections: Array<unknown> = [];
-    const onUnhandledRejection = (reason: unknown) => {
-      unhandledRejections.push(reason);
-    };
-    process.on("unhandledRejection", onUnhandledRejection);
-
-    try {
-      const { startOpenCodeServerProcess } = await import("./opencodeRuntime.ts");
-      const startup = startOpenCodeServerProcess({
-        binaryPath: "/opt/homebrew/bin/opencode",
-        timeoutMs: 10,
-      });
-      const startupResult = startup.then(
-        () => ({ ok: true as const }),
-        (error) => ({ ok: false as const, error }),
-      );
-
-      await vi.advanceTimersByTimeAsync(10);
-      const result = await startupResult;
-      await Promise.resolve();
-
-      assert.equal(result.ok, false);
-      assert.match(
-        result.error instanceof Error ? result.error.message : String(result.error),
-        /Timed out waiting for OpenCode server start after 10ms\./,
-      );
-      assert.deepEqual(unhandledRejections, []);
-    } finally {
-      process.off("unhandledRejection", onUnhandledRejection);
-      killSpy.mockRestore();
-      vi.useRealTimers();
-    }
   });
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, spawnSync, type ChildProcess } from "node:child_process";
 import * as FS from "node:fs";
 import { createServer, type AddressInfo } from "node:net";
 import * as OS from "node:os";
@@ -42,14 +42,14 @@ export const DEFAULT_OPENCODE_MODEL_CAPABILITIES: ModelCapabilities = {
 export interface OpenCodeServerProcess {
   readonly url: string;
   readonly process: ChildProcess;
-  close(): void;
+  close(): Promise<void>;
 }
 
 export interface OpenCodeServerConnection {
   readonly url: string;
   readonly process: ChildProcess | null;
   readonly external: boolean;
-  close(): void;
+  close(): Promise<void>;
 }
 
 function buildOpenCodeBasicAuthorizationHeader(password: string): string {
@@ -349,6 +349,103 @@ export function detectMacosSigkillHint(binaryPath: string): string | null {
   return null;
 }
 
+class OpenCodeServerExitTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenCodeServerExitTimeoutError";
+  }
+}
+
+function hasChildExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+function signalOpenCodeServerProcess(
+  child: ChildProcess,
+  signal: NodeJS.Signals = "SIGTERM",
+): void {
+  if (child.pid === undefined) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    try {
+      spawnSync("taskkill", ["/pid", String(child.pid), "/T", "/F"], { stdio: "ignore" });
+      return;
+    } catch {
+      child.kill(signal);
+      return;
+    }
+  }
+
+  try {
+    process.kill(-child.pid, signal);
+    return;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ESRCH" && code !== "EINVAL" && code !== "EPERM") {
+      throw error;
+    }
+  }
+
+  child.kill(signal);
+}
+
+function waitForOpenCodeServerExit(child: ChildProcess, timeoutMs: number): Promise<void> {
+  if (hasChildExited(child)) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(
+        new OpenCodeServerExitTimeoutError(
+          `Timed out waiting for OpenCode server process ${child.pid ?? "unknown"} to exit.`,
+        ),
+      );
+    }, timeoutMs);
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off("close", onClose);
+      child.off("error", onError);
+    };
+
+    const onClose = () => {
+      cleanup();
+      resolve();
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    child.once("close", onClose);
+    child.once("error", onError);
+  });
+}
+
+async function stopOpenCodeServerProcess(child: ChildProcess): Promise<void> {
+  if (hasChildExited(child)) {
+    return;
+  }
+
+  signalOpenCodeServerProcess(child, "SIGTERM");
+  try {
+    await waitForOpenCodeServerExit(child, 1_000);
+    return;
+  } catch (error) {
+    if (!(error instanceof OpenCodeServerExitTimeoutError)) {
+      throw error;
+    }
+  }
+
+  signalOpenCodeServerProcess(child, "SIGKILL");
+  await waitForOpenCodeServerExit(child, 4_000);
+}
+
 export async function startOpenCodeServerProcess(input: {
   readonly binaryPath: string;
   readonly port?: number;
@@ -361,6 +458,7 @@ export async function startOpenCodeServerProcess(input: {
   const args = ["serve", `--hostname=${hostname}`, `--port=${port}`];
   const child = spawn(input.binaryPath, args, {
     stdio: ["ignore", "pipe", "pipe"],
+    detached: process.platform !== "win32",
     env: {
       ...process.env,
       OPENCODE_CONFIG_CONTENT: JSON.stringify({}),
@@ -372,18 +470,16 @@ export async function startOpenCodeServerProcess(input: {
 
   let stdout = "";
   let stderr = "";
-  let closed = false;
+  let closePromise: Promise<void> | undefined;
   const close = () => {
-    if (closed) {
-      return;
-    }
-    closed = true;
-    child.kill();
+    closePromise ??= stopOpenCodeServerProcess(child);
+    return closePromise;
   };
 
   const url = await new Promise<string>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      close();
+      cleanup();
+      void close().catch(() => undefined);
       reject(new Error(`Timed out waiting for OpenCode server start after ${timeoutMs}ms.`));
     }, timeoutMs);
 
@@ -461,7 +557,7 @@ export async function connectToOpenCodeServer(input: {
       url: serverUrl,
       process: null,
       external: true,
-      close() {},
+      close: async () => {},
     };
   }
 
@@ -476,7 +572,7 @@ export async function connectToOpenCodeServer(input: {
     url: server.url,
     process: server.process,
     external: false,
-    close: () => server.close(),
+    close: async () => server.close(),
   };
 }
 


### PR DESCRIPTION
Closes #2157

AI disclosure: Used GPT 5.4 high in Codex CLI to create this PR. Made it add logs everywhere and made sure it understood the root cause before asking it for options to resolve this issue and discussing all of the options before making a decision. Went with this option because it was the most targeted. Reviewed the code and ensured it looked good and fit the repo's established practices before creating the PR.

## What Changed

This change fixes managed OpenCode server cleanup so local `opencode serve` processes that are used for probing do not remain orphaned after shutdown.

Short AI summary:
  - Make managed OpenCode server shutdown await real process exit
  - Terminate the managed OpenCode process tree instead of relying on a single child kill
  - Add shutdown finalization in the OpenCode adapter so active managed servers are cleaned up on adapter teardown
  - Update affected call sites to use the async close path

<img height="500" alt="c62bc42717b27b96b484dbcdfb1d1a228fc66af448534ce8ae6940ff51a2b4ac" src="https://github.com/user-attachments/assets/d2d454ef-216f-467b-bc08-41acb77235cd" />

## Why
 
OpenCode was being spawned successfully, but the local managed server process was not always being cleaned up reliably. That could leave `opencode serve` processes running after provider checks, shutdown, or restart flows.

It completely crashed my 64gb macbook after few hours of leaving T3code running.
 
## Suggestion

@juliusmarminge Btw, I would recommend just adding a reload button in the settings or in the model picker for opencode to run this probe ondemand instead of spinning it up every 60 seconds. Launching open code takes 300mb so it's a waste to keep launching and killing it IMO. I didn't do this in this PR to keep it focused and just to address the current nightly blocker. But please let me know if you want me to do this.

## Validation (by Human not AI)
 
- I tested adding openrouter as a new provider to opencode and all the new models appeared right away without needing a restart.
- Tests passed
- Formatting and typechecking passed
- Lint completed successfully (aside from unrelated existing warnings)

## Checklist

- [x] This PR is small and focused 
- [x] I explained what changed and why 
- [x] I included before/after screenshots for any UI changes <- Not applicable
- [x] I included a video for animation/interaction changes <- Not applicable



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenCode process lifecycle to use async, staged shutdown (including killing process groups) and adds additional finalizers; mistakes could cause longer shutdowns or leave sessions/events in unexpected states.
> 
> **Overview**
> Fixes leaked/orphaned managed `opencode serve` processes by making `OpenCodeServerProcess`/`OpenCodeServerConnection` `close()` asynchronous and awaiting shutdown across text generation, provider probing, and adapter session cleanup.
> 
> Updates the OpenCode runtime to spawn managed servers as process groups (non-Windows) and implements staged termination (`SIGTERM` + wait, then `SIGKILL` with timeouts, with Windows `taskkill` fallback), ensuring the process tree actually exits before continuing.
> 
> Adds adapter layer finalization to stop all active OpenCode sessions and shut down the runtime event queue on teardown, and adjusts tests to reflect async close behavior and expected close calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3a161c99052cb3feb68e9f0f273fa797ce1d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix memory leak by killing managed OpenCode probe processes on shutdown
> - Changes `close` on `OpenCodeServerProcess` and `OpenCodeServerConnection` interfaces from synchronous to `Promise<void>`, requiring all callers to await shutdown.
> - Adds `stopOpenCodeServerProcess` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/2178/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) with graceful SIGTERM → SIGKILL escalation (1s then 4s timeout) and process-group signaling on POSIX / `taskkill` on Windows to ensure child processes are killed.
> - Spawns the server process with `detached: true` on POSIX so it leads its own process group, making group-wide termination reliable.
> - Updates all shutdown call sites in `OpenCodeTextGeneration`, `OpenCodeAdapter`, and `OpenCodeProvider` layers to await the async close via `Effect.promise`.
> - Adds a layer finalizer to `makeOpenCodeAdapterLive` that stops all sessions and shuts down the events queue on layer release.
> - Risk: Shutdown paths that previously returned immediately now block until the process exits or the kill timeout elapses (up to ~5s).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c3a161.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->