### PR TITLE
chore(turbo): pass through PATHEXT

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,7 @@
     "T3CODE_OTLP_EXPORT_INTERVAL_MS",
     "T3CODE_OTLP_SERVICE_NAME"
   ],
+  "globalPassThroughEnv": ["PATHEXT"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Add `PATHEXT` to `globalPassThroughEnv` in turbo.json.

## Why

On Windows with `bun dev:desktop` or `bun start:desktop`, Turbo strict mode omits `PATHEXT`, so terminal-drawer commands cannot resolve executables in PATH without explicit file extensions.

**Expected:**
```powershell
echo "$env:PATHEXT"  
# .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL

cd C:\temp
$env:PATH = "C:\temp;$env:PATH"
'@echo hello world' > testshim.cmd  
testshim
# hello world
```

**Actual:**
`bun dev:desktop`
<img width="795" height="363" alt="image" src="https://github.com/user-attachments/assets/4c736cf0-56f1-48c9-888b-8f03ffc0e0cc" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] ~I included before/after screenshots for any UI changes~ -- no UI changes
- [x] ~I included a video for animation/interaction changes~ -- no animation changes

## Validation

- [x] `bun fmt`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun dev:desktop` (on Windows)
- [x] `bun start:desktop` (on Windows)

**After fix:**
`bun dev:desktop`
<img width="844" height="332" alt="image" src="https://github.com/user-attachments/assets/062545d8-8f4c-424d-a449-ad1327f6f02e" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects how Turborepo forwards environment variables, primarily impacting Windows command resolution.
> 
> **Overview**
> Adds `PATHEXT` to Turborepo’s `globalPassThroughEnv` in `turbo.json`, ensuring all tasks inherit this variable from the invoking shell (notably fixing Windows executable resolution in strict env mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f36b31c5681a9a2de8cd766d63fa1bf1fdd5231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pass `PATHEXT` through to all Turborepo tasks via `globalPassThroughEnv`
> Adds `PATHEXT` to `globalPassThroughEnv` in [turbo.json](https://github.com/pingdotgg/t3code/pull/2184/files#diff-f8de965273949793edc0fbfe249bb458c0becde39b2e141db087bcbf5d4ad5e3) so all Turborepo tasks inherit the `PATHEXT` environment variable from the invoking shell. This is primarily relevant on Windows, where `PATHEXT` controls which file extensions are treated as executable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f36b31.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->