### PR TITLE
fix(release): use v<semver> tag format for nightly releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "!v*-nightly.*"
   schedule:
     - cron: "0 */3 * * *"
   workflow_dispatch:
@@ -41,7 +42,7 @@ jobs:
       - id: check
         name: Compare HEAD to last nightly tag
         run: |
-          last_nightly_tag=$(git tag --list 'nightly-v*' --sort=-creatordate | head -n 1)
+          last_nightly_tag=$(git tag --list 'v*-nightly.*' 'nightly-v*' --sort=-creatordate | head -n 1)
           if [[ -z "$last_nightly_tag" ]]; then
             echo "No previous nightly tag found. Proceeding with release."
             echo "has_changes=true" >> "$GITHUB_OUTPUT"

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -220,7 +220,7 @@ try {
   );
   assertContains(
     nightlyReleaseMetadata,
-    "tag=nightly-v9.9.10-nightly.20260413.321",
+    "tag=v9.9.10-nightly.20260413.321",
     "Expected nightly metadata to contain the derived nightly tag.",
   );
   assertContains(

--- a/scripts/resolve-nightly-release.test.ts
+++ b/scripts/resolve-nightly-release.test.ts
@@ -24,7 +24,7 @@ it("derives nightly metadata including the short commit sha in the release name"
     {
       baseVersion: "9.9.10",
       version: "9.9.10-nightly.20260413.321",
-      tag: "nightly-v9.9.10-nightly.20260413.321",
+      tag: "v9.9.10-nightly.20260413.321",
       name: "T3 Code Nightly 9.9.10-nightly.20260413.321 (abcdef123456)",
       shortSha: "abcdef123456",
     },

--- a/scripts/resolve-nightly-release.ts
+++ b/scripts/resolve-nightly-release.ts
@@ -54,7 +54,7 @@ export const resolveNightlyReleaseMetadata = (
   return {
     baseVersion,
     version,
-    tag: `nightly-v${version}`,
+    tag: `v${version}`,
     name: `T3 Code Nightly ${version} (${shortSha})`,
     shortSha,
   };

--- a/scripts/resolve-previous-release-tag.ts
+++ b/scripts/resolve-previous-release-tag.ts
@@ -75,11 +75,17 @@ const parseStableTag = (tag: string): StableVersion | undefined => {
   const [, major, minor, patch, prerelease] = match;
   if (!major || !minor || !patch) return undefined;
 
+  const prereleaseIdentifiers = prerelease ? prerelease.split(".") : [];
+  // Nightly tags also start with `v` and carry a `nightly.*` prerelease
+  // identifier. They must not be considered stable candidates when resolving
+  // the previous stable tag.
+  if (prereleaseIdentifiers[0] === "nightly") return undefined;
+
   return {
     major: Number(major),
     minor: Number(minor),
     patch: Number(patch),
-    prerelease: prerelease ? prerelease.split(".") : [],
+    prerelease: prereleaseIdentifiers,
   };
 };
 
@@ -92,7 +98,9 @@ const compareNightlyVersions = (left: NightlyVersion, right: NightlyVersion): nu
 };
 
 const parseNightlyTag = (tag: string): NightlyVersion | undefined => {
-  const match = /^nightly-v(\d+)\.(\d+)\.(\d+)-nightly\.(\d{8})\.(\d+)$/.exec(tag);
+  // Accept both the current `v<semver>` format and the legacy `nightly-v<semver>`
+  // format so release note diffs keep working across the tag-format transition.
+  const match = /^(?:nightly-)?v(\d+)\.(\d+)\.(\d+)-nightly\.(\d{8})\.(\d+)$/.exec(tag);
   if (!match) return undefined;
 
   const [, major, minor, patch, date, runNumber] = match;


### PR DESCRIPTION
Closes #2181

## What

Drop the `nightly-` prefix from nightly release tags so they become valid semver that electron-updater can parse.

- Before: `nightly-v0.0.21-nightly.20260417.58`
- After:  `v0.0.21-nightly.20260417.58`

Stable tags (`v<semver>`) are unchanged. Existing `nightly-v*` tags stay in the repo as inert history — no retagging.

## Why

The nightly update track has never actually worked. #2181 reports it, and you can reproduce it on 0.0.20: switch to the Nightly channel → "Check for updates" → `Error: No published versions on GitHub`.

Root cause is in `electron-updater`'s `GitHubProvider`, which uses the [`semver`](https://www.npmjs.com/package/semver) package to parse tags from `releases.atom`. Two places, same problem:

**1. Channel matching** — [`providers/GitHubProvider.js:68`](https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/providers/GitHubProvider.ts):

```js
const hrefChannel = semver.prerelease(hrefTag)?.[0] || null;
```

With `autoUpdater.channel = 'nightly'` and `allowPrerelease = true`, a release is selected only when `hrefChannel === 'nightly'`. For that to hold, the tag must be valid semver with a prerelease identifier `nightly`.

- `semver.prerelease('v0.0.21-nightly.20260417.58')` → `['nightly', '20260417', 58]` ✅
- `semver.prerelease('nightly-v0.0.21-nightly.20260417.58')` → `null` ❌ (the leading `nightly-v` breaks semver's grammar, which requires either a digit or an optional `v` + digit)

So no entry in the atom feed matches and the loop exits with `tag == null`, throwing `No published versions on GitHub`.

**2. Release notes computation** — `providers/GitHubProvider.js:189`:

```js
const versionRelease = /\/tag\/v?([^/]+)$/.exec(...)[1];
if (semver.valid(versionRelease) && semver.lt(currentVersion, versionRelease)) { ... }
```

The optional `v?` strip doesn't help either — the remainder (`nightly-v0.0.21-...`) still isn't `semver.valid()`, so nightlies never show up in release notes either.

## Fix

The minimal, library-aligned fix: make the tag valid semver. Dropping the `nightly-` prefix yields `v<base>-nightly.<date>.<run>`, which:

- Is `semver.valid()` ✅
- Has prerelease identifier `nightly` — matches `autoUpdater.channel = 'nightly'` ✅
- Is ordered correctly relative to stable (`0.0.21-nightly.20260417.58 < 0.0.21 < 0.0.22`) ✅

## Changes

- `scripts/resolve-nightly-release.ts` — emit `v<version>` instead of `nightly-v<version>`.
- `scripts/resolve-nightly-release.test.ts`, `scripts/release-smoke.ts` — fixtures updated for the new tag.
- `scripts/resolve-previous-release-tag.ts`:
  - `parseStableTag` now rejects tags whose first prerelease identifier is `nightly` (the new nightly tags also start with `v`, so the stable resolver has to skip them explicitly).
  - `parseNightlyTag` accepts both the new `v<version>` format **and** the legacy `nightly-v<version>` format so the "previous nightly" release-note diff keeps working across the transition.
- `.github/workflows/release.yml`:
  - `last_nightly_tag` lookup matches `v*-nightly.*` in addition to legacy `nightly-v*`.
  - `push.tags` trigger excludes `v*-nightly.*` so creating a new nightly tag doesn't accidentally re-trigger the stable release path.

No runtime code (`apps/desktop/*`) is touched. No library patches, no workarounds — just aligning the tag we publish with the format `electron-updater` already expects.

## Why not a runtime workaround in `main.ts`?

I considered a desktop-side workaround (fetch recent releases via GitHub API, pick the latest nightly ourselves, point `autoUpdater.setFeedURL` at that release as a `generic` provider). Decided against it because:

- It creates two parallel update-resolution paths (stable uses `GitHubProvider`, nightly uses custom logic) that need to stay in sync forever.
- It commits us to the oddball `nightly-v*` tag format indefinitely, with client-side logic whose only job is to work around that format.
- The tag format was introduced 3 days ago in #2012 and has never worked end-to-end, so "don't break existing behavior" doesn't really apply here.

The tag-format change is 5 files, 15 insertions, 6 deletions — all in release tooling, none in runtime.

## Testing

- `bun fmt`, `bun lint`, `bun typecheck`, `bun run test` all pass.
- `scripts/resolve-nightly-release.test.ts` asserts the new tag shape.
- Manually ran `node scripts/resolve-nightly-release.ts` and `node scripts/resolve-previous-release-tag.ts` for both channels against the current repo tags — `previous_tag` resolution correctly finds `v0.0.19` for stable and the last `nightly-v*` legacy tag for nightly.
- End-to-end verification (installing the resulting build and updating) requires the CI pipeline to publish — happy to iterate if you want additional coverage before merge.

## Risks / compatibility

- **Old `nightly-v*` tags**: untouched, no rename. They remain in git history and on the Releases page.
- **Users currently on a `nightly-v*` build**: they cannot update today anyway (that's the bug). After this PR the next nightly will be `v<semver>`, `semver.gt` picks it up correctly, and they transition forward. No "stuck user" scenario.
- **Stable release flow**: unchanged. Stable tags are still `v<semver>` without a `-nightly.*` prerelease.
- **`push.tags` trigger**: the added `!v*-nightly.*` exclusion prevents the stable path from firing when the nightly job creates the new-format tag.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nightly release tag format to use `v<semver>-nightly.<date>.<run>`
> - Changes `resolveNightlyReleaseMetadata` in [resolve-nightly-release.ts](https://github.com/pingdotgg/t3code/pull/2186/files#diff-908efcd86c90341a4fcec11bc6327f78b5b1fada44e1dd8802dfd10ea628e618) to generate tags as `v<semver>-nightly.<date>.<run>` instead of `nightly-v<semver>-nightly.<date>.<run>`.
> - Updates `parseNightlyTag` in [resolve-previous-release-tag.ts](https://github.com/pingdotgg/t3code/pull/2186/files#diff-7a8a5b092210685ad9f73b267b7c772922541c68b703084bf0573acd46d92633) to accept both the new `v*-nightly.*` format and the legacy `nightly-v*` format.
> - Fixes `parseStableTag` to exclude nightly-tagged versions from being treated as stable releases.
> - Updates the release workflow to exclude `v*-nightly.*` tags from triggering the stable release job, and to search both tag formats when finding the last nightly.
> - Behavioral Change: nightly tags created going forward will use the new `v*-nightly.*` format; old `nightly-v*` tags remain recognized for backward compatibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a0162d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->