### PR TITLE
feat(diff-viewer): collapsible files and per-file viewed state

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -1,3 +1,4 @@
+// Component for displaying unified diff view with collapsible files and syntax highlighting
 import { parsePatchFiles } from "@pierre/diffs";
 import { FileDiff, type FileDiffMetadata, Virtualizer } from "@pierre/diffs/react";
 import { useQuery } from "@tanstack/react-query";
@@ -5,6 +6,8 @@ import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { scopeThreadRef } from "@t3tools/client-runtime";
 import type { TurnId } from "@t3tools/contracts";
 import {
+  CheckIcon,
+  ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   Columns2Icon,
@@ -35,6 +38,7 @@ import { createThreadSelectorByRef } from "../storeSelectors";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { useSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
+import { CONVERSATION_DIFF_TURN_KEY, useUiStateStore } from "../uiStateStore";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
@@ -87,6 +91,13 @@ const DIFF_PANEL_UNSAFE_CSS = `
   z-index: 4;
   background-color: color-mix(in srgb, var(--card) 94%, var(--foreground)) !important;
   border-bottom: 1px solid var(--border) !important;
+}
+
+/* The default @pierre/diffs header renders a coloured "change type" dot on
+   the left. We hide it so the collapse/expand chevron injected via
+   renderHeaderPrefix can take its place, matching GitHub's diff header. */
+[data-change-icon] {
+  display: none !important;
 }
 
 [data-title] {
@@ -172,6 +183,12 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const settings = useSettings();
   const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("stacked");
   const [diffWordWrap, setDiffWordWrap] = useState(settings.diffWordWrap);
+  const diffFilesCollapsedByThread = useUiStateStore(
+    (store) => store.threadDiffFilesCollapsedById,
+  );
+  const diffFilesViewedByThread = useUiStateStore((store) => store.threadDiffFilesViewedById);
+  const setDiffFileCollapsed = useUiStateStore((store) => store.setDiffFileCollapsed);
+  const setDiffFileViewed = useUiStateStore((store) => store.setDiffFileViewed);
   const patchViewportRef = useRef<HTMLDivElement>(null);
   const turnStripRef = useRef<HTMLDivElement>(null);
   const previousDiffOpenRef = useRef(false);
@@ -313,6 +330,74 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       }),
     );
   }, [renderablePatch]);
+
+  // Key identifying which slice of the thread's diff state we're looking at.
+  // Either a specific turn, or the aggregate "all turns" sentinel.
+  const activeDiffTurnKey = selectedTurn?.turnId ?? CONVERSATION_DIFF_TURN_KEY;
+  const diffFileFlagsForActiveView = useMemo(() => {
+    if (!activeThreadId) {
+      return { collapsed: {} as Record<string, boolean>, viewed: {} as Record<string, boolean> };
+    }
+    return {
+      collapsed: diffFilesCollapsedByThread[activeThreadId]?.[activeDiffTurnKey] ?? {},
+      viewed: diffFilesViewedByThread[activeThreadId]?.[activeDiffTurnKey] ?? {},
+    };
+  }, [
+    activeDiffTurnKey,
+    activeThreadId,
+    diffFilesCollapsedByThread,
+    diffFilesViewedByThread,
+  ]);
+  const viewedFileCount = useMemo(
+    () =>
+      renderableFiles.reduce(
+        (total, fileDiff) =>
+          total + (diffFileFlagsForActiveView.viewed[resolveFileDiffPath(fileDiff)] ? 1 : 0),
+        0,
+      ),
+    [diffFileFlagsForActiveView.viewed, renderableFiles],
+  );
+  const anyDiffFileCollapsed = useMemo(
+    () =>
+      renderableFiles.some(
+        (fileDiff) => diffFileFlagsForActiveView.collapsed[resolveFileDiffPath(fileDiff)] === true,
+      ),
+    [diffFileFlagsForActiveView.collapsed, renderableFiles],
+  );
+
+  const handleToggleDiffFileCollapsed = useCallback(
+    (filePath: string, collapsed: boolean) => {
+      if (!activeThreadId) return;
+      setDiffFileCollapsed(activeThreadId, activeDiffTurnKey, filePath, collapsed);
+    },
+    [activeDiffTurnKey, activeThreadId, setDiffFileCollapsed],
+  );
+  const handleToggleDiffFileViewed = useCallback(
+    (filePath: string, viewed: boolean, alreadyCollapsed: boolean) => {
+      if (!activeThreadId) return;
+      setDiffFileViewed(activeThreadId, activeDiffTurnKey, filePath, viewed);
+      // Auto-collapse when marking as viewed — mirrors the standard PR review UX so
+      // the reviewer can keep scrolling without manually collapsing the file too.
+      if (viewed && !alreadyCollapsed) {
+        setDiffFileCollapsed(activeThreadId, activeDiffTurnKey, filePath, true);
+      }
+    },
+    [activeDiffTurnKey, activeThreadId, setDiffFileCollapsed, setDiffFileViewed],
+  );
+  const handleCollapseAllDiffFiles = useCallback(
+    (collapsed: boolean) => {
+      if (!activeThreadId) return;
+      for (const fileDiff of renderableFiles) {
+        setDiffFileCollapsed(
+          activeThreadId,
+          activeDiffTurnKey,
+          resolveFileDiffPath(fileDiff),
+          collapsed,
+        );
+      }
+    },
+    [activeDiffTurnKey, activeThreadId, renderableFiles, setDiffFileCollapsed],
+  );
 
   useEffect(() => {
     if (diffOpen && !previousDiffOpenRef.current) {
@@ -520,6 +605,24 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+        {renderableFiles.length > 0 && viewedFileCount > 0 && (
+          <span
+            className="hidden text-[10px] font-medium text-muted-foreground/80 tabular-nums sm:inline"
+            title="Files marked as viewed"
+          >
+            {viewedFileCount}/{renderableFiles.length} viewed
+          </span>
+        )}
+        {renderableFiles.length > 0 && (
+          <button
+            type="button"
+            onClick={() => handleCollapseAllDiffFiles(!anyDiffFileCollapsed)}
+            className="inline-flex h-6 items-center rounded-md border border-input bg-transparent px-2 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            title={anyDiffFileCollapsed ? "Expand all files" : "Collapse all files"}
+          >
+            {anyDiffFileCollapsed ? "Expand all" : "Collapse all"}
+          </button>
+        )}
         <ToggleGroup
           className="shrink-0"
           variant="outline"
@@ -604,11 +707,18 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                   const filePath = resolveFileDiffPath(fileDiff);
                   const fileKey = buildFileDiffRenderKey(fileDiff);
                   const themedFileKey = `${fileKey}:${resolvedTheme}`;
+                  const isCollapsed = diffFileFlagsForActiveView.collapsed[filePath] === true;
+                  const isViewed = diffFileFlagsForActiveView.viewed[filePath] === true;
                   return (
                     <div
                       key={themedFileKey}
                       data-diff-file-path={filePath}
-                      className="diff-render-file mb-2 rounded-md first:mt-2 last:mb-0"
+                      className={cn(
+                        "diff-render-file mb-2 rounded-md first:mt-2 last:mb-0",
+                        isViewed &&
+                          !isCollapsed &&
+                          "opacity-75 transition-opacity hover:opacity-100",
+                      )}
                       onClickCapture={(event) => {
                         const nativeEvent = event.nativeEvent as MouseEvent;
                         const composedPath = nativeEvent.composedPath?.() ?? [];
@@ -622,7 +732,27 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                     >
                       <FileDiff
                         fileDiff={fileDiff}
+                        renderHeaderPrefix={() => (
+                          <DiffFileChevronButton
+                            collapsed={isCollapsed}
+                            onClick={() =>
+                              handleToggleDiffFileCollapsed(filePath, !isCollapsed)
+                            }
+                          />
+                        )}
+                        renderHeaderMetadata={() => (
+                          <DiffFileViewedButton
+                            viewed={isViewed}
+                            onClick={() =>
+                              handleToggleDiffFileViewed(filePath, !isViewed, isCollapsed)
+                            }
+                          />
+                        )}
                         options={{
+                          // Native library collapse — hides the diff body while
+                          // keeping the real (shadow-DOM) header, so expanded and
+                          // collapsed rows share identical typography & layout.
+                          collapsed: isCollapsed,
                           diffStyle: diffRenderMode === "split" ? "split" : "unified",
                           lineDiffType: "none",
                           overflow: diffWordWrap ? "wrap" : "scroll",
@@ -658,3 +788,69 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     </DiffPanelShell>
   );
 }
+
+/**
+ * Chevron toggle injected into the `FileDiff` header's prefix slot via
+ * `renderHeaderPrefix`. Replaces the library's coloured change-type dot (hidden
+ * via `unsafeCSS`) and flips direction based on the library's
+ * `options.collapsed` state.
+ */
+function DiffFileChevronButton({
+  collapsed,
+  onClick,
+}: {
+  collapsed: boolean;
+  onClick: () => void;
+}) {
+  const Icon = collapsed ? ChevronRightIcon : ChevronDownIcon;
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      className="-ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      aria-expanded={!collapsed}
+      aria-label={collapsed ? "Expand file" : "Collapse file"}
+      title={collapsed ? "Expand file" : "Collapse file"}
+    >
+      <Icon className="size-4" />
+    </button>
+  );
+}
+
+/**
+ * "Viewed" pill injected into the `FileDiff` header's metadata slot via
+ * `renderHeaderMetadata`. Renders after the built-in `+/-` counts and mirrors
+ * GitHub's per-file viewed checkbox without requiring a real `<input>`.
+ */
+function DiffFileViewedButton({
+  viewed,
+  onClick,
+}: {
+  viewed: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      className={cn(
+        "inline-flex h-6 shrink-0 items-center gap-1 rounded-md border px-2 text-[11px] font-medium transition-colors",
+        viewed
+          ? "border-emerald-500/40 bg-emerald-500/15 text-emerald-600 hover:bg-emerald-500/25 dark:text-emerald-400"
+          : "border-border bg-background/70 text-muted-foreground hover:bg-accent hover:text-foreground",
+      )}
+      aria-pressed={viewed}
+      title={viewed ? "Mark as not viewed" : "Mark as viewed"}
+    >
+      <CheckIcon className="size-3" />
+      Viewed
+    </button>
+  );
+}
+

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -1,3 +1,4 @@
+// Tests for UI state store functionality
 import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
@@ -5,6 +6,8 @@ import {
   clearThreadUi,
   markThreadUnread,
   reorderProjects,
+  setDiffFileCollapsed,
+  setDiffFileViewed,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
   syncProjects,
@@ -18,6 +21,8 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
+    threadDiffFilesCollapsedById: {},
+    threadDiffFilesViewedById: {},
     ...overrides,
   };
 }
@@ -143,7 +148,7 @@ describe("uiStateStore pure functions", () => {
 
     const next = reorderProjects(initialState, [keyALocal, keyARemote], [keyBLocal, keyBRemote]);
 
-    // Target members may become non-contiguous; this is fine because the
+    // Target members may end up non-contiguous; that's fine because the
     // sidebar groups by logical key using first-occurrence positioning.
     expect(next.projectOrder).toEqual([keyBLocal, keyALocal, keyARemote, keyBRemote]);
   });
@@ -344,5 +349,75 @@ describe("uiStateStore pure functions", () => {
     const next = setThreadChangedFilesExpanded(initialState, thread1, "turn-1", true);
 
     expect(next.threadChangedFilesExpandedById).toEqual({});
+  });
+
+  it("setDiffFileCollapsed records per-file collapse state nested by turn", () => {
+    const thread1 = ThreadId.make("thread-1");
+    const initialState = makeUiState();
+
+    const next = setDiffFileCollapsed(initialState, thread1, "turn-1", "src/foo.ts", true);
+
+    expect(next.threadDiffFilesCollapsedById).toEqual({
+      [thread1]: {
+        "turn-1": {
+          "src/foo.ts": true,
+        },
+      },
+    });
+  });
+
+  it("setDiffFileCollapsed prunes empty branches when a file is expanded again", () => {
+    const thread1 = ThreadId.make("thread-1");
+    const initialState = makeUiState({
+      threadDiffFilesCollapsedById: {
+        [thread1]: {
+          "turn-1": {
+            "src/foo.ts": true,
+          },
+        },
+      },
+    });
+
+    const next = setDiffFileCollapsed(initialState, thread1, "turn-1", "src/foo.ts", false);
+
+    expect(next.threadDiffFilesCollapsedById).toEqual({});
+  });
+
+  it("setDiffFileViewed is a no-op when toggling to the current value", () => {
+    const thread1 = ThreadId.make("thread-1");
+    const initialState = makeUiState({
+      threadDiffFilesViewedById: {
+        [thread1]: {
+          "turn-1": {
+            "src/foo.ts": true,
+          },
+        },
+      },
+    });
+
+    const next = setDiffFileViewed(initialState, thread1, "turn-1", "src/foo.ts", true);
+
+    expect(next).toBe(initialState);
+  });
+
+  it("clearThreadUi wipes diff viewer state for the thread", () => {
+    const thread1 = ThreadId.make("thread-1");
+    const thread2 = ThreadId.make("thread-2");
+    const initialState = makeUiState({
+      threadDiffFilesCollapsedById: {
+        [thread1]: { "turn-1": { "src/foo.ts": true } },
+        [thread2]: { "turn-2": { "src/bar.ts": true } },
+      },
+      threadDiffFilesViewedById: {
+        [thread1]: { "turn-1": { "src/foo.ts": true } },
+      },
+    });
+
+    const next = clearThreadUi(initialState, thread1);
+
+    expect(next.threadDiffFilesCollapsedById).toEqual({
+      [thread2]: { "turn-2": { "src/bar.ts": true } },
+    });
+    expect(next.threadDiffFilesViewedById).toEqual({});
   });
 });

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -1,3 +1,4 @@
+// Zustand store for managing UI state including project expansion and diff file visibility
 import { Debouncer } from "@tanstack/react-pacer";
 import { create } from "zustand";
 
@@ -19,6 +20,8 @@ interface PersistedUiState {
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
+  threadDiffFilesCollapsedById?: Record<string, Record<string, Record<string, boolean>>>;
+  threadDiffFilesViewedById?: Record<string, Record<string, Record<string, boolean>>>;
 }
 
 export interface UiProjectState {
@@ -29,7 +32,27 @@ export interface UiProjectState {
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
+  /**
+   * Per-file collapsed state in the diff viewer.
+   * Shape: threadId -> turnKey -> filePath -> true.
+   * `turnKey` is the selected turn id or `CONVERSATION_DIFF_TURN_KEY` for the
+   * "all turns" aggregate view. Only `true` (collapsed) entries are tracked;
+   * missing entries mean the file is expanded by default.
+   */
+  threadDiffFilesCollapsedById: Record<string, Record<string, Record<string, boolean>>>;
+  /**
+   * Per-file "viewed" state in the diff viewer. Same shape as
+   * `threadDiffFilesCollapsedById`. Only `true` (viewed) entries are tracked.
+   */
+  threadDiffFilesViewedById: Record<string, Record<string, Record<string, boolean>>>;
 }
+
+/**
+ * Sentinel `turnKey` used when the diff panel is showing the aggregate
+ * "all turns" patch rather than a specific turn. Kept as a constant so
+ * consumers import it instead of hard-coding the string.
+ */
+export const CONVERSATION_DIFF_TURN_KEY = "__conversation__";
 
 export interface UiState extends UiProjectState, UiThreadState {}
 
@@ -48,6 +71,8 @@ const initialState: UiState = {
   projectOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
+  threadDiffFilesCollapsedById: {},
+  threadDiffFilesViewedById: {},
 };
 
 const persistedExpandedProjectCwds = new Set<string>();
@@ -79,10 +104,61 @@ function readPersistedState(): UiState {
       threadChangedFilesExpandedById: sanitizePersistedThreadChangedFilesExpanded(
         parsed.threadChangedFilesExpandedById,
       ),
+      threadDiffFilesCollapsedById: sanitizePersistedThreadDiffFileFlags(
+        parsed.threadDiffFilesCollapsedById,
+      ),
+      threadDiffFilesViewedById: sanitizePersistedThreadDiffFileFlags(
+        parsed.threadDiffFilesViewedById,
+      ),
     };
   } catch {
     return initialState;
   }
+}
+
+/**
+ * Shared sanitizer for persisted per-file boolean flags (collapsed / viewed)
+ * keyed by threadId -> turnKey -> filePath. Drops entries whose values are not
+ * strictly `true` since both stored flags use the convention that a missing
+ * entry means the default state, and only `true` is persisted.
+ */
+function sanitizePersistedThreadDiffFileFlags(
+  value: PersistedUiState["threadDiffFilesCollapsedById"],
+): Record<string, Record<string, Record<string, boolean>>> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const nextState: Record<string, Record<string, Record<string, boolean>>> = {};
+  for (const [threadId, turns] of Object.entries(value)) {
+    if (!threadId || !turns || typeof turns !== "object") {
+      continue;
+    }
+
+    const nextTurns: Record<string, Record<string, boolean>> = {};
+    for (const [turnKey, files] of Object.entries(turns)) {
+      if (!turnKey || !files || typeof files !== "object") {
+        continue;
+      }
+
+      const nextFiles: Record<string, boolean> = {};
+      for (const [filePath, flag] of Object.entries(files)) {
+        if (filePath && typeof flag === "boolean" && flag === true) {
+          nextFiles[filePath] = true;
+        }
+      }
+
+      if (Object.keys(nextFiles).length > 0) {
+        nextTurns[turnKey] = nextFiles;
+      }
+    }
+
+    if (Object.keys(nextTurns).length > 0) {
+      nextState[threadId] = nextTurns;
+    }
+  }
+
+  return nextState;
 }
 
 function sanitizePersistedThreadChangedFilesExpanded(
@@ -151,12 +227,20 @@ function persistState(state: UiState): void {
         return Object.keys(nextTurns).length > 0 ? [[threadId, nextTurns]] : [];
       }),
     );
+    const threadDiffFilesCollapsedById = serializeThreadDiffFileFlags(
+      state.threadDiffFilesCollapsedById,
+    );
+    const threadDiffFilesViewedById = serializeThreadDiffFileFlags(
+      state.threadDiffFilesViewedById,
+    );
     window.localStorage.setItem(
       PERSISTED_STATE_KEY,
       JSON.stringify({
         expandedProjectCwds,
         projectOrderCwds,
         threadChangedFilesExpandedById,
+        threadDiffFilesCollapsedById,
+        threadDiffFilesViewedById,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -166,8 +250,26 @@ function persistState(state: UiState): void {
       }
     }
   } catch {
-    // Ignore quota/storage errors to avoid breaking chat UX.
+    // Swallow quota/storage errors so they don't break the chat UX.
   }
+}
+
+function serializeThreadDiffFileFlags(
+  value: Record<string, Record<string, Record<string, boolean>>>,
+): Record<string, Record<string, Record<string, boolean>>> {
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([threadId, turns]) => {
+      const nextTurns = Object.fromEntries(
+        Object.entries(turns).flatMap(([turnKey, files]) => {
+          const nextFiles = Object.fromEntries(
+            Object.entries(files).filter(([, flag]) => flag === true),
+          );
+          return Object.keys(nextFiles).length > 0 ? [[turnKey, nextFiles]] : [];
+        }),
+      );
+      return Object.keys(nextTurns).length > 0 ? [[threadId, nextTurns]] : [];
+    }),
+  );
 }
 
 const debouncedPersistState = new Debouncer(persistState, { wait: 500 });
@@ -203,6 +305,23 @@ function nestedBooleanRecordsEqual(
   }
   for (const [key, value] of leftEntries) {
     if (!(key in right) || !recordsEqual(value, right[key]!)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function deeplyNestedBooleanRecordsEqual(
+  left: Record<string, Record<string, Record<string, boolean>>>,
+  right: Record<string, Record<string, Record<string, boolean>>>,
+): boolean {
+  const leftEntries = Object.entries(left);
+  const rightEntries = Object.entries(right);
+  if (leftEntries.length !== rightEntries.length) {
+    return false;
+  }
+  for (const [key, value] of leftEntries) {
+    if (!(key in right) || !nestedBooleanRecordsEqual(value, right[key]!)) {
       return false;
     }
   }
@@ -328,11 +447,29 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
       retainedThreadIds.has(threadId),
     ),
   );
+  const nextThreadDiffFilesCollapsedById = Object.fromEntries(
+    Object.entries(state.threadDiffFilesCollapsedById).filter(([threadId]) =>
+      retainedThreadIds.has(threadId),
+    ),
+  );
+  const nextThreadDiffFilesViewedById = Object.fromEntries(
+    Object.entries(state.threadDiffFilesViewedById).filter(([threadId]) =>
+      retainedThreadIds.has(threadId),
+    ),
+  );
   if (
     recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById) &&
     nestedBooleanRecordsEqual(
       state.threadChangedFilesExpandedById,
       nextThreadChangedFilesExpandedById,
+    ) &&
+    deeplyNestedBooleanRecordsEqual(
+      state.threadDiffFilesCollapsedById,
+      nextThreadDiffFilesCollapsedById,
+    ) &&
+    deeplyNestedBooleanRecordsEqual(
+      state.threadDiffFilesViewedById,
+      nextThreadDiffFilesViewedById,
     )
   ) {
     return state;
@@ -341,6 +478,8 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
     threadChangedFilesExpandedById: nextThreadChangedFilesExpandedById,
+    threadDiffFilesCollapsedById: nextThreadDiffFilesCollapsedById,
+    threadDiffFilesViewedById: nextThreadDiffFilesViewedById,
   };
 }
 
@@ -393,17 +532,30 @@ export function markThreadUnread(
 export function clearThreadUi(state: UiState, threadId: string): UiState {
   const hasVisitedState = threadId in state.threadLastVisitedAtById;
   const hasChangedFilesState = threadId in state.threadChangedFilesExpandedById;
-  if (!hasVisitedState && !hasChangedFilesState) {
+  const hasDiffCollapsedState = threadId in state.threadDiffFilesCollapsedById;
+  const hasDiffViewedState = threadId in state.threadDiffFilesViewedById;
+  if (
+    !hasVisitedState &&
+    !hasChangedFilesState &&
+    !hasDiffCollapsedState &&
+    !hasDiffViewedState
+  ) {
     return state;
   }
   const nextThreadLastVisitedAtById = { ...state.threadLastVisitedAtById };
   const nextThreadChangedFilesExpandedById = { ...state.threadChangedFilesExpandedById };
+  const nextThreadDiffFilesCollapsedById = { ...state.threadDiffFilesCollapsedById };
+  const nextThreadDiffFilesViewedById = { ...state.threadDiffFilesViewedById };
   delete nextThreadLastVisitedAtById[threadId];
   delete nextThreadChangedFilesExpandedById[threadId];
+  delete nextThreadDiffFilesCollapsedById[threadId];
+  delete nextThreadDiffFilesViewedById[threadId];
   return {
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
     threadChangedFilesExpandedById: nextThreadChangedFilesExpandedById,
+    threadDiffFilesCollapsedById: nextThreadDiffFilesCollapsedById,
+    threadDiffFilesViewedById: nextThreadDiffFilesViewedById,
   };
 }
 
@@ -454,6 +606,94 @@ export function setThreadChangedFilesExpanded(
       },
     },
   };
+}
+
+function setThreadDiffFileFlag(
+  state: UiState,
+  selector: (state: UiState) => Record<string, Record<string, Record<string, boolean>>>,
+  apply: (
+    state: UiState,
+    next: Record<string, Record<string, Record<string, boolean>>>,
+  ) => UiState,
+  threadId: string,
+  turnKey: string,
+  filePath: string,
+  flag: boolean,
+): UiState {
+  if (!threadId || !turnKey || !filePath) {
+    return state;
+  }
+  const root = selector(state);
+  const threadState = root[threadId] ?? {};
+  const turnState = threadState[turnKey] ?? {};
+  const current = turnState[filePath] === true;
+  if (current === flag) {
+    return state;
+  }
+
+  if (flag) {
+    const nextTurnState = { ...turnState, [filePath]: true };
+    const nextThreadState = { ...threadState, [turnKey]: nextTurnState };
+    return apply(state, { ...root, [threadId]: nextThreadState });
+  }
+
+  if (!(filePath in turnState)) {
+    return state;
+  }
+  const nextTurnState = { ...turnState };
+  delete nextTurnState[filePath];
+
+  if (Object.keys(nextTurnState).length === 0) {
+    const nextThreadState = { ...threadState };
+    delete nextThreadState[turnKey];
+    if (Object.keys(nextThreadState).length === 0) {
+      const nextRoot = { ...root };
+      delete nextRoot[threadId];
+      return apply(state, nextRoot);
+    }
+    return apply(state, { ...root, [threadId]: nextThreadState });
+  }
+
+  return apply(state, {
+    ...root,
+    [threadId]: { ...threadState, [turnKey]: nextTurnState },
+  });
+}
+
+export function setDiffFileCollapsed(
+  state: UiState,
+  threadId: string,
+  turnKey: string,
+  filePath: string,
+  collapsed: boolean,
+): UiState {
+  return setThreadDiffFileFlag(
+    state,
+    (current) => current.threadDiffFilesCollapsedById,
+    (current, next) => ({ ...current, threadDiffFilesCollapsedById: next }),
+    threadId,
+    turnKey,
+    filePath,
+    collapsed,
+  );
+}
+
+export function setDiffFileViewed(
+  state: UiState,
+  threadId: string,
+  turnKey: string,
+  filePath: string,
+  viewed: boolean,
+): UiState {
+  return setThreadDiffFileFlag(
+    state,
+    (current) => current.threadDiffFilesViewedById,
+    (current, next) => ({ ...current, threadDiffFilesViewedById: next }),
+    threadId,
+    turnKey,
+    filePath,
+    viewed,
+  );
 }
 
 export function toggleProject(state: UiState, projectId: string): UiState {
@@ -530,6 +770,18 @@ interface UiStateStore extends UiState {
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
   clearThreadUi: (threadId: string) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
+  setDiffFileCollapsed: (
+    threadId: string,
+    turnKey: string,
+    filePath: string,
+    collapsed: boolean,
+  ) => void;
+  setDiffFileViewed: (
+    threadId: string,
+    turnKey: string,
+    filePath: string,
+    viewed: boolean,
+  ) => void;
   toggleProject: (projectId: string) => void;
   setProjectExpanded: (projectId: string, expanded: boolean) => void;
   reorderProjects: (
@@ -549,6 +801,10 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
   clearThreadUi: (threadId) => set((state) => clearThreadUi(state, threadId)),
   setThreadChangedFilesExpanded: (threadId, turnId, expanded) =>
     set((state) => setThreadChangedFilesExpanded(state, threadId, turnId, expanded)),
+  setDiffFileCollapsed: (threadId, turnKey, filePath, collapsed) =>
+    set((state) => setDiffFileCollapsed(state, threadId, turnKey, filePath, collapsed)),
+  setDiffFileViewed: (threadId, turnKey, filePath, viewed) =>
+    set((state) => setDiffFileViewed(state, threadId, turnKey, filePath, viewed)),
   toggleProject: (projectId) => set((state) => toggleProject(state, projectId)),
   setProjectExpanded: (projectId, expanded) =>
     set((state) => setProjectExpanded(state, projectId, expanded)),


### PR DESCRIPTION
## Summary

- Adds a chevron toggle to each file header in the diff panel so individual files can be collapsed/expanded; replaces the library's change-type dot with this control
- Adds a "Viewed" pill button per file (mirrors GitHub's PR review UX); marking a file viewed auto-collapses it
- Adds "Collapse all / Expand all" toolbar button and a `N/M viewed` counter that appears once at least one file is marked viewed
- Persists collapsed and viewed state in `localStorage` keyed by `threadId → turnKey → filePath`; state is scoped to the selected turn or the `__conversation__` sentinel for the aggregate view
- Extends `uiStateStore` with `threadDiffFilesCollapsedById` and `threadDiffFilesViewedById`; both follow a sparse-`true`-only convention so expanded/unviewed files produce no storage entries
- Prunes empty branches on collapse removal and wipes both maps in `clearThreadUi` and `syncThreads`

## Testing

- Open the diff panel for a conversation and verify each file header shows a chevron that collapses/expands the diff body on click
- Mark a file as viewed; confirm it auto-collapses and the header opacity dims, and hovering restores full opacity
- Click "Collapse all" — all files should collapse; button label should flip to "Expand all"; clicking again expands all
- Verify the `N/M viewed` counter appears only after the first file is marked viewed and increments correctly
- Reload the page and confirm collapsed/viewed state is restored from `localStorage`
- Switch between a specific turn and the "all turns" aggregate view; confirm state is tracked independently per view
- Run unit tests: `pnpm vitest run apps/web/src/uiStateStore.test.ts`


https://github.com/user-attachments/assets/0184c629-6e97-4571-9006-523017d286da



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new persisted UI state (collapsed/viewed flags) and integrates it into diff rendering logic, which could cause regressions in diff panel interactions or localStorage hydration/serialization.
> 
> **Overview**
> Adds GitHub-like per-file diff controls: each file header now includes a chevron to collapse/expand and a *Viewed* toggle (marking viewed auto-collapses), plus a top-bar `Collapse all / Expand all` action and an optional `N/M viewed` counter.
> 
> Extends `uiStateStore` to persist per-thread, per-turn (or `CONVERSATION_DIFF_TURN_KEY` aggregate) collapsed/viewed flags in `localStorage`, including sanitization, sparse `true`-only serialization, pruning empty branches, and clearing/pruning state via `clearThreadUi` and `syncThreads` (with new unit tests covering these behaviors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071269130424886a032420bbaf40faa06bf59bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add collapsible files and per-file viewed state to the diff viewer
> - Each file header in the diff panel gains a chevron button to collapse/expand and a 'Viewed' pill button to mark the file as reviewed. Marking a file as viewed auto-collapses it.
> - A viewed counter (X/Y) and a Collapse all / Expand all button are added to the diff panel header.
> - Per-file collapsed and viewed state is stored in the Zustand UI store, scoped per thread and per selected turn (or the aggregate conversation view via `CONVERSATION_DIFF_TURN_KEY`), and persisted to localStorage with empty-branch pruning.
> - The library's built-in change-type icon is hidden via `[data-change-icon]` CSS to make room for the custom chevron.
> - Behavioral Change: viewed/collapsed flags are loaded from localStorage on startup and cleared when a thread's UI state is reset.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0712691.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->