### PR TITLE
feat: surface provider rate limit usage in composer

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -447,6 +447,21 @@ function runtimeEventToActivities(
       ];
     }
 
+    case "account.rate-limits.updated": {
+      return [
+        {
+          id: event.eventId,
+          createdAt: event.createdAt,
+          tone: "info",
+          kind: "account.rate-limits.updated",
+          summary: "Account rate limits updated",
+          payload: event.payload.rateLimits,
+          turnId: toTurnId(event.turnId) ?? null,
+          ...maybeSequence,
+        },
+      ];
+    }
+
     case "item.updated": {
       if (!isToolLifecycleItemType(event.payload.itemType)) {
         return [];

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -76,6 +76,7 @@ import {
   renderProviderTraitsPicker,
 } from "./composerProviderRegistry";
 import { ContextWindowMeter } from "./ContextWindowMeter";
+import { ProviderUsageMeter } from "./ProviderUsageMeter";
 import { buildExpandedImagePreview, type ExpandedImagePreview } from "./ExpandedImagePreview";
 import { basenameOfPath } from "../../vscode-icons";
 import { cn, randomUUID } from "~/lib/utils";
@@ -101,6 +102,7 @@ import type { SessionPhase, Thread } from "../../types";
 import type { PendingUserInputDraftAnswer } from "../../pendingUserInput";
 import type { PendingApproval, PendingUserInput } from "../../session-logic";
 import { deriveLatestContextWindowSnapshot } from "../../lib/contextWindow";
+import { deriveLatestProviderUsageSnapshot } from "../../lib/providerUsage";
 import { formatProviderSkillDisplayName } from "../../providerSkillPresentation";
 import { searchProviderSkills } from "../../providerSkillSearch";
 
@@ -268,6 +270,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
 const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(props: {
   compact: boolean;
   activeContextWindow: ReturnType<typeof deriveLatestContextWindowSnapshot>;
+  activeProviderUsage: ReturnType<typeof deriveLatestProviderUsageSnapshot>;
   isPreparingWorktree: boolean;
   pendingAction: {
     questionIndex: number;
@@ -288,6 +291,9 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
 }) {
   return (
     <>
+      {props.activeProviderUsage ? (
+        <ProviderUsageMeter usage={props.activeProviderUsage} />
+      ) : null}
       {props.activeContextWindow ? <ContextWindowMeter usage={props.activeContextWindow} /> : null}
       {props.isPreparingWorktree ? (
         <span className="text-muted-foreground/70 text-xs">Preparing worktree...</span>
@@ -645,6 +651,14 @@ export const ChatComposer = memo(
     // ------------------------------------------------------------------
     const activeContextWindow = useMemo(
       () => deriveLatestContextWindowSnapshot(activeThreadActivities ?? []),
+      [activeThreadActivities],
+    );
+
+    // ------------------------------------------------------------------
+    // Provider usage (rate limits / session %)
+    // ------------------------------------------------------------------
+    const activeProviderUsage = useMemo(
+      () => deriveLatestProviderUsageSnapshot(activeThreadActivities ?? []),
       [activeThreadActivities],
     );
 
@@ -1987,6 +2001,7 @@ export const ChatComposer = memo(
                   <ComposerFooterPrimaryActions
                     compact={isComposerPrimaryActionsCompact}
                     activeContextWindow={activeContextWindow}
+                    activeProviderUsage={activeProviderUsage}
                     pendingAction={pendingPrimaryAction}
                     isRunning={phase === "running"}
                     showPlanFollowUpPrompt={

--- a/apps/web/src/components/chat/ProviderUsageMeter.tsx
+++ b/apps/web/src/components/chat/ProviderUsageMeter.tsx
@@ -1,0 +1,106 @@
+import { type ProviderUsageSnapshot } from "~/lib/providerUsage";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+
+function formatResetTime(resetsAt: number | null): string | null {
+  if (resetsAt === null) {
+    return null;
+  }
+  const date = new Date(resetsAt * 1000);
+  return `Resets ${date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  })}, ${date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  })}`;
+}
+
+function UsageBar(props: { percent: number; status: "ok" | "warning" | "rejected" }) {
+  const barColor =
+    props.status === "rejected" || props.percent >= 90
+      ? "bg-red-500"
+      : props.status === "warning" || props.percent >= 70
+        ? "bg-amber-500"
+        : "bg-rose-500";
+
+  return (
+    <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-muted/50">
+      <div
+        className={`absolute inset-y-0 left-0 rounded-full transition-[width] duration-500 ease-out ${barColor}`}
+        style={{ width: `${Math.min(100, Math.max(0, props.percent))}%` }}
+      />
+    </div>
+  );
+}
+
+function BarGraphIcon(props: { status: "ok" | "warning" | "rejected" }) {
+  const barColor =
+    props.status === "rejected"
+      ? "var(--color-destructive)"
+      : props.status === "warning"
+        ? "var(--color-warning, #f59e0b)"
+        : "var(--color-muted-foreground)";
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      className="h-4 w-4"
+      aria-hidden="true"
+    >
+      <rect x="4" y="13" width="4" height="7" rx="1" fill={barColor} opacity={0.6} />
+      <rect x="10" y="8" width="4" height="12" rx="1" fill={barColor} opacity={0.8} />
+      <rect x="16" y="4" width="4" height="16" rx="1" fill={barColor} />
+    </svg>
+  );
+}
+
+export function ProviderUsageMeter(props: { usage: ProviderUsageSnapshot }) {
+  const { usage } = props;
+  const maxPercent = Math.max(...usage.windows.map((w) => w.usedPercent), 0);
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        openOnHover
+        delay={150}
+        closeDelay={0}
+        render={
+          <button
+            type="button"
+            className="group inline-flex items-center justify-center rounded-full p-0.5 transition-opacity hover:opacity-85"
+            aria-label={`${usage.providerLabel} usage: ${Math.round(maxPercent)}%`}
+          >
+            <BarGraphIcon status={usage.status} />
+          </button>
+        }
+      />
+      <PopoverPopup tooltipStyle side="top" align="end" className="w-64 max-w-none px-4 py-3">
+        <div className="space-y-3">
+          <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+            {usage.providerLabel}
+          </div>
+
+          {usage.windows.map((window) => {
+            const resetText = formatResetTime(window.resetsAt);
+            return (
+              <div key={window.label} className="space-y-1.5">
+                <div className="flex items-baseline justify-between">
+                  <span className="text-xs font-semibold text-foreground">{window.label}</span>
+                  <span className="text-xs font-semibold text-foreground">
+                    {Math.round(window.usedPercent)}%
+                  </span>
+                </div>
+                <UsageBar percent={window.usedPercent} status={usage.status} />
+                {resetText ? (
+                  <div className="text-[11px] text-muted-foreground">{resetText}</div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </PopoverPopup>
+    </Popover>
+  );
+}

--- a/apps/web/src/lib/providerUsage.ts
+++ b/apps/web/src/lib/providerUsage.ts
@@ -12,6 +12,10 @@ function asString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function asBoolean(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
 export interface RateLimitWindow {
   /** Label for this window, e.g. "Session (5 hrs)" or "Weekly" */
   readonly label: string;
@@ -34,6 +38,22 @@ export interface ProviderUsageSnapshot {
 
 // ---------------------------------------------------------------------------
 // Claude rate_limit_event normalization
+//
+// Real payload shape (from native event logs):
+// {
+//   type: "rate_limit_event",
+//   rate_limit_info: {
+//     status: "allowed" | "allowed_warning" | "rejected",
+//     resetsAt: 1776582000,           // camelCase, unix seconds
+//     rateLimitType: "five_hour",     // camelCase
+//     overageStatus: "rejected",
+//     overageDisabledReason: "...",
+//     isUsingOverage: false,
+//     utilization?: number,           // 0-1, may be absent
+//   },
+//   uuid: "...",
+//   session_id: "...",
+// }
 // ---------------------------------------------------------------------------
 
 const CLAUDE_WINDOW_LABELS: Record<string, string> = {
@@ -47,30 +67,58 @@ const CLAUDE_WINDOW_LABELS: Record<string, string> = {
 function normalizeClaudeRateLimitEvent(
   payload: Record<string, unknown>,
 ): Omit<ProviderUsageSnapshot, "updatedAt"> | null {
-  // Claude SDK sends: { type: "rate_limit_event", rate_limit_info: { ... }, ... }
   const info = asRecord(payload.rate_limit_info) ?? asRecord(payload);
   if (!info) {
     return null;
   }
 
-  const utilization = asFiniteNumber(info.utilization);
-  if (utilization === null) {
-    return null;
-  }
-
-  const rateLimitType = asString(info.rate_limit_type);
+  // The SDK may use camelCase or snake_case depending on version.
+  const rateLimitType =
+    asString(info.rateLimitType) ?? asString(info.rate_limit_type);
   const statusRaw = asString(info.status);
+  const resetsAt =
+    asFiniteNumber(info.resetsAt) ?? asFiniteNumber(info.resets_at);
+
+  // utilization (0-1) may or may not be present.
+  const utilization = asFiniteNumber(info.utilization);
+
+  const label = (rateLimitType && CLAUDE_WINDOW_LABELS[rateLimitType]) ?? "Session";
 
   const windows: RateLimitWindow[] = [];
 
-  windows.push({
-    label: (rateLimitType && CLAUDE_WINDOW_LABELS[rateLimitType]) ?? "Session",
-    usedPercent: Math.min(100, Math.max(0, utilization * 100)),
-    resetsAt: asFiniteNumber(info.resets_at),
-  });
+  if (utilization !== null) {
+    // We have a utilization value — use it directly.
+    windows.push({
+      label,
+      usedPercent: Math.min(100, Math.max(0, utilization * 100)),
+      resetsAt,
+    });
+  } else if (rateLimitType || resetsAt !== null) {
+    // No utilization, but we still know which window and its reset time.
+    // Show a placeholder — the status field tells us whether we're OK or not.
+    const estimatedPercent =
+      statusRaw === "rejected"
+        ? 100
+        : statusRaw === "allowed_warning"
+          ? 80
+          : 0;
+    windows.push({
+      label,
+      usedPercent: estimatedPercent,
+      resetsAt,
+    });
+  }
+
+  if (windows.length === 0) {
+    return null;
+  }
 
   const status: ProviderUsageSnapshot["status"] =
-    statusRaw === "rejected" ? "rejected" : statusRaw === "allowed_warning" ? "warning" : "ok";
+    statusRaw === "rejected"
+      ? "rejected"
+      : statusRaw === "allowed_warning"
+        ? "warning"
+        : "ok";
 
   return {
     providerLabel: "Claude",
@@ -81,14 +129,33 @@ function normalizeClaudeRateLimitEvent(
 
 // ---------------------------------------------------------------------------
 // Codex rate limit normalization
+//
+// Real payload shape (from native event logs):
+// The activity payload is the full rateLimits object. Due to adapter nesting,
+// it may arrive as:
+//   { rateLimits: { limitId, primary: {...}, secondary: {...}, ... } }
+// or directly as:
+//   { limitId, primary: {...}, secondary: {...}, ... }
+// We handle both.
+//
+// primary/secondary shape:
+//   { usedPercent: 1, windowDurationMins: 300, resetsAt: 1776587601 }
 // ---------------------------------------------------------------------------
 
 function normalizeCodexRateLimits(
   payload: Record<string, unknown>,
 ): Omit<ProviderUsageSnapshot, "updatedAt"> | null {
-  // Codex sends: { primary: { usedPercent, windowDurationMins, resetsAt }, secondary: ..., ... }
-  const primary = asRecord(payload.primary);
-  const secondary = asRecord(payload.secondary);
+  // Handle double-nesting: payload might be { rateLimits: { primary, ... } }
+  let data = payload;
+  if (!data.primary && !data.secondary) {
+    const nested = asRecord(data.rateLimits);
+    if (nested) {
+      data = nested;
+    }
+  }
+
+  const primary = asRecord(data.primary);
+  const secondary = asRecord(data.secondary);
 
   if (!primary && !secondary) {
     return null;
@@ -164,13 +231,23 @@ function normalizeRateLimitPayload(
     return normalizeClaudeRateLimitEvent(record);
   }
 
-  // Codex: has primary/secondary windows
+  // Codex: has primary/secondary windows (possibly nested under rateLimits)
   if (record.primary || record.secondary) {
     return normalizeCodexRateLimits(record);
   }
 
-  // Unknown format — try Claude-style (flat utilization field)
-  if (asFiniteNumber(record.utilization) !== null) {
+  // Codex double-nested: { rateLimits: { primary, secondary, ... } }
+  const nested = asRecord(record.rateLimits);
+  if (nested && (nested.primary || nested.secondary || nested.limitId !== undefined)) {
+    return normalizeCodexRateLimits(record);
+  }
+
+  // Unknown format — try Claude-style (flat fields with rateLimitType or utilization)
+  if (
+    asFiniteNumber(record.utilization) !== null ||
+    asString(record.rateLimitType) !== null ||
+    asString(record.rate_limit_type) !== null
+  ) {
     return normalizeClaudeRateLimitEvent(record);
   }
 

--- a/apps/web/src/lib/providerUsage.ts
+++ b/apps/web/src/lib/providerUsage.ts
@@ -1,0 +1,247 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export interface RateLimitWindow {
+  /** Label for this window, e.g. "Session (5 hrs)" or "Weekly" */
+  readonly label: string;
+  /** Percentage used, 0-100 */
+  readonly usedPercent: number;
+  /** Unix timestamp (seconds) when this window resets, or null if unknown */
+  readonly resetsAt: number | null;
+}
+
+export interface ProviderUsageSnapshot {
+  /** The provider name to show in the tooltip header */
+  readonly providerLabel: string;
+  /** Rate limit windows (e.g. session + weekly) */
+  readonly windows: ReadonlyArray<RateLimitWindow>;
+  /** Overall status */
+  readonly status: "ok" | "warning" | "rejected";
+  /** When this snapshot was last updated */
+  readonly updatedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Claude rate_limit_event normalization
+// ---------------------------------------------------------------------------
+
+const CLAUDE_WINDOW_LABELS: Record<string, string> = {
+  five_hour: "Session (5 hrs)",
+  seven_day: "Weekly",
+  seven_day_opus: "Weekly (Opus)",
+  seven_day_sonnet: "Weekly (Sonnet)",
+  overage: "Overage",
+};
+
+function normalizeClaudeRateLimitEvent(
+  payload: Record<string, unknown>,
+): Omit<ProviderUsageSnapshot, "updatedAt"> | null {
+  // Claude SDK sends: { type: "rate_limit_event", rate_limit_info: { ... }, ... }
+  const info = asRecord(payload.rate_limit_info) ?? asRecord(payload);
+  if (!info) {
+    return null;
+  }
+
+  const utilization = asFiniteNumber(info.utilization);
+  if (utilization === null) {
+    return null;
+  }
+
+  const rateLimitType = asString(info.rate_limit_type);
+  const statusRaw = asString(info.status);
+
+  const windows: RateLimitWindow[] = [];
+
+  windows.push({
+    label: (rateLimitType && CLAUDE_WINDOW_LABELS[rateLimitType]) ?? "Session",
+    usedPercent: Math.min(100, Math.max(0, utilization * 100)),
+    resetsAt: asFiniteNumber(info.resets_at),
+  });
+
+  const status: ProviderUsageSnapshot["status"] =
+    statusRaw === "rejected" ? "rejected" : statusRaw === "allowed_warning" ? "warning" : "ok";
+
+  return {
+    providerLabel: "Claude",
+    windows,
+    status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Codex rate limit normalization
+// ---------------------------------------------------------------------------
+
+function normalizeCodexRateLimits(
+  payload: Record<string, unknown>,
+): Omit<ProviderUsageSnapshot, "updatedAt"> | null {
+  // Codex sends: { primary: { usedPercent, windowDurationMins, resetsAt }, secondary: ..., ... }
+  const primary = asRecord(payload.primary);
+  const secondary = asRecord(payload.secondary);
+
+  if (!primary && !secondary) {
+    return null;
+  }
+
+  const windows: RateLimitWindow[] = [];
+
+  if (primary) {
+    const usedPercent = asFiniteNumber(primary.usedPercent);
+    if (usedPercent !== null) {
+      const durationMins = asFiniteNumber(primary.windowDurationMins);
+      let label = "Session";
+      if (durationMins !== null) {
+        const hours = Math.round(durationMins / 60);
+        label = hours > 0 ? `Session (${hours} hrs)` : `Session (${durationMins} min)`;
+      }
+      windows.push({
+        label,
+        usedPercent: Math.min(100, Math.max(0, usedPercent)),
+        resetsAt: asFiniteNumber(primary.resetsAt),
+      });
+    }
+  }
+
+  if (secondary) {
+    const usedPercent = asFiniteNumber(secondary.usedPercent);
+    if (usedPercent !== null) {
+      const durationMins = asFiniteNumber(secondary.windowDurationMins);
+      let label = "Weekly";
+      if (durationMins !== null) {
+        const days = Math.round(durationMins / (60 * 24));
+        if (days >= 2) {
+          label = `Weekly`;
+        }
+      }
+      windows.push({
+        label,
+        usedPercent: Math.min(100, Math.max(0, usedPercent)),
+        resetsAt: asFiniteNumber(secondary.resetsAt),
+      });
+    }
+  }
+
+  if (windows.length === 0) {
+    return null;
+  }
+
+  const maxPercent = Math.max(...windows.map((w) => w.usedPercent));
+  const status: ProviderUsageSnapshot["status"] =
+    maxPercent >= 100 ? "rejected" : maxPercent >= 80 ? "warning" : "ok";
+
+  return {
+    providerLabel: "Codex",
+    windows,
+    status,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Detect provider and normalize
+// ---------------------------------------------------------------------------
+
+function normalizeRateLimitPayload(
+  payload: unknown,
+): Omit<ProviderUsageSnapshot, "updatedAt"> | null {
+  const record = asRecord(payload);
+  if (!record) {
+    return null;
+  }
+
+  // Claude: has rate_limit_info or type === "rate_limit_event"
+  if (record.rate_limit_info || record.type === "rate_limit_event") {
+    return normalizeClaudeRateLimitEvent(record);
+  }
+
+  // Codex: has primary/secondary windows
+  if (record.primary || record.secondary) {
+    return normalizeCodexRateLimits(record);
+  }
+
+  // Unknown format — try Claude-style (flat utilization field)
+  if (asFiniteNumber(record.utilization) !== null) {
+    return normalizeClaudeRateLimitEvent(record);
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Derives a merged provider usage snapshot from the activity stream.
+ *
+ * Claude emits one `rate_limit_event` per rate-limit window (e.g. a `five_hour`
+ * event and a separate `seven_day` event), so we merge the most recent event
+ * for each distinct window label into a single snapshot.  Codex emits both
+ * primary and secondary in a single event, so merging is a no-op for it.
+ */
+export function deriveLatestProviderUsageSnapshot(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ProviderUsageSnapshot | null {
+  const windowsByLabel = new Map<string, RateLimitWindow>();
+  let providerLabel: string | null = null;
+  let latestStatus: ProviderUsageSnapshot["status"] = "ok";
+  let latestUpdatedAt: string | null = null;
+
+  // Walk backwards so the first match for each label wins (most recent).
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    const activity = activities[index];
+    if (!activity || activity.kind !== "account.rate-limits.updated") {
+      continue;
+    }
+
+    const result = normalizeRateLimitPayload(activity.payload);
+    if (!result) {
+      continue;
+    }
+
+    if (providerLabel === null) {
+      providerLabel = result.providerLabel;
+      latestStatus = result.status;
+      latestUpdatedAt = activity.createdAt;
+    }
+
+    // Only merge events from the same provider.
+    if (result.providerLabel !== providerLabel) {
+      continue;
+    }
+
+    for (const window of result.windows) {
+      if (!windowsByLabel.has(window.label)) {
+        windowsByLabel.set(window.label, window);
+      }
+    }
+
+    // Escalate status if a worse status was seen in an older event.
+    if (result.status === "rejected") {
+      latestStatus = "rejected";
+    } else if (result.status === "warning" && latestStatus === "ok") {
+      latestStatus = "warning";
+    }
+  }
+
+  if (providerLabel === null || windowsByLabel.size === 0 || latestUpdatedAt === null) {
+    return null;
+  }
+
+  return {
+    providerLabel,
+    windows: Array.from(windowsByLabel.values()),
+    status: latestStatus,
+    updatedAt: latestUpdatedAt,
+  };
+}

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -477,6 +477,7 @@ export function deriveWorkLogEntries(
     .filter((activity) => activity.kind !== "tool.started")
     .filter((activity) => activity.kind !== "task.started")
     .filter((activity) => activity.kind !== "context-window.updated")
+    .filter((activity) => activity.kind !== "account.rate-limits.updated")
     .filter((activity) => activity.summary !== "Checkpoint captured")
     .filter((activity) => !isPlanBoundaryToolActivity(activity))
     .map(toDerivedWorkLogEntry);


### PR DESCRIPTION
## Summary

Closes #673

Wires the `account.rate-limits.updated` events — already emitted by the Claude and Codex provider adapters — through the orchestration layer to the frontend. Previously these events were silently dropped because `ProviderRuntimeIngestion` had no `case` for them.

Adds a bar graph icon to the left of the existing context window meter in the composer footer. Hovering shows a tooltip with session % and weekly % usage bars plus reset times, matching the style shown in #673.

- **Codex**: Displays both Session (5 hrs) and Weekly windows with accurate `usedPercent`, `windowDurationMins`, and `resetsAt` from the `account/rateLimits/updated` JSON-RPC notification (`primary` + `secondary` buckets).
- **Claude**: Displays Session (5 hrs) window from the SDK's `rate_limit_event`. Weekly quota is not exposed by the Claude Agent SDK, and `utilization` is absent — usage is estimated from the `status` field (`allowed` → 0%, `allowed_warning` → ~80%, `rejected` → 100%).

### Files changed

| File | Change |
|------|--------|
| `ProviderRuntimeIngestion.ts` | Add `account.rate-limits.updated` case to create thread activities |
| `session-logic.ts` | Filter rate limit activities from the work log |
| `providerUsage.ts` *(new)* | Parse + normalize rate limit data from both providers |
| `ProviderUsageMeter.tsx` *(new)* | Bar graph icon + hover tooltip component |
| `ChatComposer.tsx` | Wire new meter into the composer footer |

### Known limitations

- **Claude** only reports `five_hour` (session) rate limits via the SDK — the weekly quota is not exposed in `rate_limit_event`. Codex reports both session and weekly.
- **Claude** does not include a `utilization` field, so usage percentage is estimated from the `status` field rather than showing gradual progress.

<img width="849" height="185" alt="Screenshot 2026-04-18 at 5 53 33 PM" src="https://github.com/user-attachments/assets/a8b06fa3-8dc1-4f1f-bb2f-21e86762a755" />

<img width="770" height="228" alt="Screenshot 2026-04-18 at 5 54 44 PM" src="https://github.com/user-attachments/assets/fcb08cf7-aa06-42be-9cfe-3d7a4408310b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new orchestration activity type and frontend parsing/merging of provider rate-limit payloads; incorrect normalization could surface misleading usage or break the composer footer display but doesn’t touch auth or data writes.
> 
> **Overview**
> Surfaces provider rate-limit updates end-to-end by converting `account.rate-limits.updated` runtime events into thread activities in `ProviderRuntimeIngestion`.
> 
> On the web app, derives a `ProviderUsageSnapshot` from those activities (normalizing Claude and Codex payload shapes and merging per-window updates) and displays it in the composer footer via a new `ProviderUsageMeter` hover tooltip. Rate-limit activities are also excluded from the work log list so they don’t add noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21162586b21f409da4d798c6aa0e08960ef3a6ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->