### PR TITLE
Support spark for ChatGPT Pro Lite accounts

### DIFF
--- a/apps/server/src/codexAppServerManager.test.ts
+++ b/apps/server/src/codexAppServerManager.test.ts
@@ -310,6 +310,20 @@ describe("readCodexAccountSnapshot", () => {
     });
   });
 
+  it("keeps spark enabled for chatgpt pro-lite accounts", () => {
+    expect(
+      readCodexAccountSnapshot({
+        type: "chatgpt",
+        email: "pro-lite@example.com",
+        planType: "pro-lite",
+      }),
+    ).toEqual({
+      type: "chatgpt",
+      planType: "pro-lite",
+      sparkEnabled: true,
+    });
+  });
+
   it("disables spark for api key accounts", () => {
     expect(
       readCodexAccountSnapshot({
@@ -352,6 +366,16 @@ describe("resolveCodexModelForAccount", () => {
       resolveCodexModelForAccount("gpt-5.3-codex-spark", {
         type: "chatgpt",
         planType: "pro",
+        sparkEnabled: true,
+      }),
+    ).toBe("gpt-5.3-codex-spark");
+  });
+
+  it("keeps spark for pro-lite plans", () => {
+    expect(
+      resolveCodexModelForAccount("gpt-5.3-codex-spark", {
+        type: "chatgpt",
+        planType: "pro-lite",
         sparkEnabled: true,
       }),
     ).toBe("gpt-5.3-codex-spark");

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -242,6 +242,38 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
         ),
       );
 
+      it.effect("returns the codex pro-lite plan type in auth and keeps spark enabled", () =>
+        Effect.gen(function* () {
+          yield* withTempCodexHome();
+          const status = yield* checkCodexProviderStatus(() =>
+            Effect.succeed({
+              type: "chatgpt" as const,
+              planType: "pro-lite" as const,
+              sparkEnabled: true,
+            }),
+          );
+
+          assert.strictEqual(status.provider, "codex");
+          assert.strictEqual(status.status, "ready");
+          assert.strictEqual(status.auth.status, "authenticated");
+          assert.strictEqual(status.auth.type, "pro-lite");
+          assert.strictEqual(status.auth.label, "ChatGPT Pro Lite Subscription");
+          assert.deepStrictEqual(
+            status.models.some((model) => model.slug === "gpt-5.3-codex-spark"),
+            true,
+          );
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
+              if (joined === "login status") return { stdout: "Logged in\n", stderr: "", code: 0 };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
       it.effect("includes probed codex skills in the provider snapshot", () =>
         Effect.gen(function* () {
           yield* withTempCodexHome();

--- a/apps/server/src/provider/codexAccount.ts
+++ b/apps/server/src/provider/codexAccount.ts
@@ -5,6 +5,7 @@ export type CodexPlanType =
   | "go"
   | "plus"
   | "pro"
+  | "pro-lite"
   | "team"
   | "business"
   | "enterprise"
@@ -19,7 +20,7 @@ export interface CodexAccountSnapshot {
 
 export const CODEX_DEFAULT_MODEL = "gpt-5.3-codex";
 export const CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
-const CODEX_SPARK_ENABLED_PLAN_TYPES = new Set<CodexPlanType>(["pro"]);
+const CODEX_SPARK_ENABLED_PLAN_TYPES = new Set<CodexPlanType>(["pro", "pro-lite"]);
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object") {
@@ -87,6 +88,8 @@ export function codexAuthSubLabel(account: CodexAccountSnapshot | undefined): st
       return "ChatGPT Plus Subscription";
     case "pro":
       return "ChatGPT Pro Subscription";
+    case "pro-lite":
+      return "ChatGPT Pro Lite Subscription";
     case "team":
       return "ChatGPT Team Subscription";
     case "business":


### PR DESCRIPTION
- Treat `pro-lite` as a Codex plan with Spark enabled
- Update auth labels and provider snapshot tests accordingly

Closes #2194 

## What Changed

Added `pro-lite` plan to `CODEX_SPARK_ENABLED_PLAN_TYPES` and `CodexPlanType`

## Why

Codex Spark is also available for Pro Lite accounts

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, additive change to plan-type gating and labels, with tests updated to cover the new `pro-lite` branch.
> 
> **Overview**
> Adds support for the `pro-lite` ChatGPT subscription tier in Codex account handling.
> 
> `pro-lite` is added to `CodexPlanType`, treated as Spark-enabled (so `gpt-5.3-codex-spark` is kept/selected), and given a new auth label (`ChatGPT Pro Lite Subscription`). Tests are extended to assert Spark enablement and provider snapshots for `pro-lite` accounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909620cc79fc936e7fbe5de551d972d0a81e6200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support spark model for ChatGPT Pro Lite accounts
> - Adds `'pro-lite'` to the `CodexPlanType` union and to `CODEX_SPARK_ENABLED_PLAN_TYPES` in [`codexAccount.ts`](https://github.com/pingdotgg/t3code/pull/2195/files#diff-e2ef69363c008d96643fd58096e4e796cf3703e9ec85028a5b1e3b3f57b249a6), so Pro Lite accounts retain the spark model (`gpt-5.3-codex-spark`) instead of falling back.
> - Adds a `'pro-lite'` case to `codexAuthSubLabel`, returning `'ChatGPT Pro Lite Subscription'` as the display label.
> - Updates [`ProviderRegistry`](https://github.com/pingdotgg/t3code/pull/2195/files#diff-28b6372c54d8310c6909678b338ea3a67f48ea13b57386544bfe5ffdfa742b6f) and [`codexAppServerManager`](https://github.com/pingdotgg/t3code/pull/2195/files#diff-e0b57ec17b32e60d14081ebeb4bcfb13db511905869ef4ffbd669b229c0bb2c1) tests to cover Pro Lite plan behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 909620c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->