### PR TITLE
Codex/sidebar usage refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Before local development, prepare the environment and install dependencies:
 ```bash
 # Optional: only needed if you use mise for dev tool management.
 mise install
-bun install .
+bun install
 ```
 
 Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening an issue or PR.

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -26,6 +26,7 @@ import {
   spawnAndCollect,
   type CommandResult,
 } from "../providerSnapshot";
+import { resolveClaudeUsageSnapshot } from "../claudeUsage";
 import { makeManagedServerProvider } from "../makeManagedServerProvider";
 import { ClaudeProvider } from "../Services/ClaudeProvider";
 import { ServerSettingsService } from "../../serverSettings";
@@ -474,6 +475,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   resolveSlashCommands?: (
     binaryPath: string,
   ) => Effect.Effect<ReadonlyArray<ServerProviderSlashCommand> | undefined>,
+  resolveUsage?: () => Effect.Effect<ServerProvider["usage"] | undefined>,
 ): Effect.fn.Return<
   ServerProvider,
   ServerSettingsError,
@@ -644,12 +646,17 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
 
   const parsed = parseClaudeAuthStatusFromOutput(authProbe.success.value);
   const authMetadata = claudeAuthMetadata({ subscriptionType, authMethod });
+  const usage =
+    parsed.auth.status === "authenticated" && authMetadata?.type !== "apiKey" && resolveUsage
+      ? yield* resolveUsage().pipe(Effect.orElseSucceed(() => undefined))
+      : undefined;
   return buildServerProvider({
     provider: PROVIDER,
     enabled: claudeSettings.enabled,
     checkedAt,
     models,
     slashCommands: dedupedSlashCommands,
+    ...(usage ? { usage } : {}),
     probe: {
       installed: true,
       version: parsedVersion,
@@ -724,6 +731,7 @@ export const ClaudeProviderLive = Layer.effect(
         Cache.get(subscriptionProbeCache, binaryPath).pipe(
           Effect.map((probe) => probe?.slashCommands),
         ),
+      () => Effect.tryPromise(() => resolveClaudeUsageSnapshot()),
     ).pipe(
       Effect.provideService(ServerSettingsService, serverSettings),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -46,6 +46,7 @@ import {
   type CodexAccountSnapshot,
 } from "../codexAccount";
 import { probeCodexDiscovery } from "../codexAppServer";
+import { resolveCodexUsageSnapshot } from "../codexUsage";
 import { CodexProvider } from "../Services/CodexProvider";
 import { ServerSettingsService } from "../../serverSettings";
 import { ServerSettingsError } from "@t3tools/contracts";
@@ -341,6 +342,9 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     readonly homePath?: string;
     readonly cwd: string;
   }) => Effect.Effect<ReadonlyArray<ServerProviderSkill> | undefined>,
+  resolveUsage?: (input: {
+    readonly homePath?: string;
+  }) => Effect.Effect<ServerProvider["usage"] | undefined>,
 ): Effect.fn.Return<
   ServerProvider,
   ServerSettingsError,
@@ -532,12 +536,19 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   const parsed = parseAuthStatusFromOutput(authProbe.success.value);
   const authType = codexAuthSubType(account);
   const authLabel = codexAuthSubLabel(account);
+  const usage =
+    parsed.auth.status === "authenticated" && authType !== "apiKey" && resolveUsage
+      ? yield* resolveUsage({
+          ...(codexSettings.homePath ? { homePath: codexSettings.homePath } : {}),
+        }).pipe(Effect.orElseSucceed(() => undefined))
+      : undefined;
   return buildServerProvider({
     provider: PROVIDER,
     enabled: codexSettings.enabled,
     checkedAt,
     models: resolvedModels,
     skills,
+    ...(usage ? { usage } : {}),
     probe: {
       installed: true,
       version: parsedVersion,
@@ -626,6 +637,7 @@ export const CodexProviderLive = Layer.effect(
           cwd: process.cwd(),
         }).pipe(Effect.map((discovery) => discovery?.account)),
       (input) => getDiscovery(input).pipe(Effect.map((discovery) => discovery?.skills)),
+      (input) => Effect.sync(() => resolveCodexUsageSnapshot(input)),
     ).pipe(
       Effect.provideService(ServerSettingsService, serverSettings),
       Effect.provideService(FileSystem.FileSystem, fileSystem),

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -34,6 +34,7 @@ import { haveProvidersChanged, ProviderRegistryLive } from "./ProviderRegistry";
 import { ServerConfig } from "../../config";
 import { ServerSettingsService, type ServerSettingsShape } from "../../serverSettings";
 import { ProviderRegistry } from "../Services/ProviderRegistry";
+import { ProviderService } from "../Services/ProviderService";
 
 // ── Test helpers ────────────────────────────────────────────────────
 
@@ -123,6 +124,23 @@ function makeMutableServerSettingsService(
     } satisfies ServerSettingsShape;
   });
 }
+
+function makeProviderServiceTestLayer(streamEvents: Stream.Stream<any> = Stream.empty) {
+  return Layer.succeed(ProviderService, {
+    startSession: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    sendTurn: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    interruptTurn: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    respondToRequest: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    respondToUserInput: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    stopSession: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    listSessions: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    getCapabilities: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    rollbackConversation: () => Effect.die(new Error("not used in ProviderRegistry tests")),
+    streamEvents,
+  });
+}
+
+const providerServiceTestLayer = makeProviderServiceTestLayer();
 
 /**
  * Create a temporary CODEX_HOME scoped to the current Effect test.
@@ -571,6 +589,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const providerRegistryLayer = ProviderRegistryLive.pipe(
             Layer.provideMerge(Layer.succeed(ServerSettingsService, serverSettings)),
+            Layer.provideMerge(providerServiceTestLayer),
             Layer.provideMerge(
               ServerConfig.layerTest(process.cwd(), {
                 prefix: "t3-provider-registry-",
@@ -625,6 +644,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
           yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
           const providerRegistryLayer = ProviderRegistryLive.pipe(
             Layer.provideMerge(Layer.succeed(ServerSettingsService, serverSettings)),
+            Layer.provideMerge(providerServiceTestLayer),
             Layer.provideMerge(
               ServerConfig.layerTest(process.cwd(), {
                 prefix: "t3-provider-registry-",
@@ -686,6 +706,91 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
               updated.find((status) => status.provider === "codex")?.status,
               "error",
             );
+          }).pipe(Effect.provide(runtimeServices));
+        }),
+      );
+
+      it.effect("merges runtime rate-limit events into provider snapshots", () =>
+        Effect.gen(function* () {
+          const serverSettings = yield* makeMutableServerSettingsService();
+          const runtimeEvents = yield* PubSub.unbounded<any>();
+          const scope = yield* Scope.make();
+          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+          const providerRegistryLayer = ProviderRegistryLive.pipe(
+            Layer.provideMerge(Layer.succeed(ServerSettingsService, serverSettings)),
+            Layer.provideMerge(makeProviderServiceTestLayer(Stream.fromPubSub(runtimeEvents))),
+            Layer.provideMerge(
+              ServerConfig.layerTest(process.cwd(), {
+                prefix: "t3-provider-registry-",
+              }),
+            ),
+            Layer.provideMerge(
+              mockCommandSpawnerLayer((command, args) => {
+                const joined = args.join(" ");
+                if (joined === "--version") {
+                  if (command === "codex") {
+                    return { stdout: "codex 1.0.0\n", stderr: "", code: 0 };
+                  }
+                  return { stdout: "", stderr: "spawn ENOENT", code: 1 };
+                }
+                if (joined === "login status") {
+                  return { stdout: "Logged in\n", stderr: "", code: 0 };
+                }
+                throw new Error(`Unexpected args: ${joined}`);
+              }),
+            ),
+          );
+          const runtimeServices = yield* Layer.build(
+            Layer.mergeAll(
+              Layer.succeed(ServerSettingsService, serverSettings),
+              providerRegistryLayer,
+            ),
+          ).pipe(Scope.provide(scope));
+
+          yield* Effect.gen(function* () {
+            const registry = yield* ProviderRegistry;
+            yield* registry.refresh("codex");
+
+            yield* PubSub.publish(runtimeEvents, {
+              type: "account.rate-limits.updated",
+              eventId: "evt-rate-limits-1",
+              provider: "codex",
+              createdAt: "2026-04-17T02:00:00.000Z",
+              threadId: "thread-1",
+              payload: {
+                rateLimits: {
+                  five_hour: {
+                    utilization: 0.42,
+                    resets_at: "2026-04-17T05:00:00.000Z",
+                  },
+                },
+              },
+            });
+
+            for (let attempt = 0; attempt < 20; attempt += 1) {
+              const providers = yield* registry.getProviders;
+              const codex = providers.find((provider) => provider.provider === "codex");
+              if (codex?.usage) {
+                assert.deepStrictEqual(codex.usage, {
+                  state: "available",
+                  checkedAt: "2026-04-17T02:00:00.000Z",
+                  windows: [
+                    {
+                      id: "five-hour",
+                      label: "5h",
+                      percentUsed: 42,
+                      resetsAt: "2026-04-17T05:00:00.000Z",
+                      level: "normal",
+                      exhausted: false,
+                    },
+                  ],
+                });
+                return;
+              }
+              yield* Effect.sleep("10 millis");
+            }
+
+            assert.fail("expected codex provider usage to update from runtime event");
           }).pipe(Effect.provide(runtimeServices));
         }),
       );
@@ -1019,6 +1124,59 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
               input: { hint: "pr-or-branch" },
             },
           ]);
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"claude.ai"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("includes direct claude usage in the provider snapshot when available", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            () => Effect.succeed("pro"),
+            undefined,
+            () =>
+              Effect.succeed({
+                state: "available",
+                checkedAt: "2026-04-17T04:00:00.000Z",
+                windows: [
+                  {
+                    id: "five-hour",
+                    label: "5h",
+                    percentUsed: 64,
+                    resetsAt: "2026-04-17T05:00:00.000Z",
+                    level: "normal",
+                    exhausted: false,
+                  },
+                ],
+              }),
+          );
+
+          assert.deepStrictEqual(status.usage, {
+            state: "available",
+            checkedAt: "2026-04-17T04:00:00.000Z",
+            windows: [
+              {
+                id: "five-hour",
+                label: "5h",
+                percentUsed: 64,
+                resetsAt: "2026-04-17T05:00:00.000Z",
+                level: "normal",
+                exhausted: false,
+              },
+            ],
+          });
         }).pipe(
           Effect.provide(
             mockSpawnerLayer((args) => {

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -14,6 +14,7 @@ import { ClaudeProvider } from "../Services/ClaudeProvider";
 import type { CodexProviderShape } from "../Services/CodexProvider";
 import { CodexProvider } from "../Services/CodexProvider";
 import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry";
+import { ProviderService } from "../Services/ProviderService";
 import {
   hydrateCachedProvider,
   PROVIDER_CACHE_IDS,
@@ -22,6 +23,7 @@ import {
   resolveProviderStatusCachePath,
   writeProviderStatusCache,
 } from "../providerStatusCache";
+import { mergeProviderRuntimeEventIntoSnapshot } from "../providerUsage";
 
 const loadProviders = (
   codexProvider: CodexProviderShape,
@@ -41,6 +43,7 @@ export const ProviderRegistryLive = Layer.effect(
   Effect.gen(function* () {
     const codexProvider = yield* CodexProvider;
     const claudeProvider = yield* ClaudeProvider;
+    const providerService = yield* ProviderService;
     const config = yield* ServerConfig;
     const fileSystem = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -146,6 +149,15 @@ export const ProviderRegistryLive = Layer.effect(
       return yield* upsertProviders([provider], options);
     });
 
+    const applyRuntimeProviderEvent = Effect.fn("applyRuntimeProviderEvent")(function* (
+      provider: ServerProvider,
+      options?: {
+        readonly publish?: boolean;
+      },
+    ) {
+      return yield* syncProvider(provider, options);
+    });
+
     const refresh = Effect.fn("refresh")(function* (provider?: ProviderKind) {
       switch (provider) {
         case "codex":
@@ -179,6 +191,26 @@ export const ProviderRegistryLive = Layer.effect(
     ).pipe(Effect.forkScoped);
     yield* Stream.runForEach(claudeProvider.streamChanges, (provider) =>
       syncProvider(provider),
+    ).pipe(Effect.forkScoped);
+    yield* Stream.runForEach(providerService.streamEvents, (event) =>
+      Effect.gen(function* () {
+        if (event.type !== "account.updated" && event.type !== "account.rate-limits.updated") {
+          return;
+        }
+
+        const providers = yield* Ref.get(providersRef);
+        const currentProvider = providers.find((provider) => provider.provider === event.provider);
+        if (!currentProvider) {
+          return;
+        }
+
+        const nextProvider = mergeProviderRuntimeEventIntoSnapshot(currentProvider, event);
+        if (Equal.equals(currentProvider, nextProvider)) {
+          return;
+        }
+
+        yield* applyRuntimeProviderEvent(nextProvider);
+      }),
     ).pipe(Effect.forkScoped);
 
     return {

--- a/apps/server/src/provider/claudeUsage.test.ts
+++ b/apps/server/src/provider/claudeUsage.test.ts
@@ -1,0 +1,143 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { resolveClaudeUsageSnapshot } from "./claudeUsage";
+
+const tempDirs = new Set<string>();
+
+function makeTempHomeDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "t3-claude-usage-"));
+  tempDirs.add(dir);
+  return dir;
+}
+
+function writeClaudeCredentials(
+  homeDir: string,
+  overrides?: Partial<{ accessToken: string; expiresAt: number; subscriptionType: string }>,
+): void {
+  const configDir = path.join(homeDir, ".claude");
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(configDir, ".credentials.json"),
+    JSON.stringify({
+      claudeAiOauth: {
+        accessToken: overrides?.accessToken ?? "token-123",
+        expiresAt: overrides?.expiresAt ?? Date.UTC(2027, 0, 1, 0, 0, 0),
+        subscriptionType: overrides?.subscriptionType ?? "pro",
+      },
+    }),
+    "utf8",
+  );
+}
+
+function mockFetch(response: Response) {
+  return async () => response;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
+
+describe("resolveClaudeUsageSnapshot", () => {
+  it("normalizes direct Claude usage responses into provider usage windows", async () => {
+    const homeDir = makeTempHomeDir();
+    writeClaudeCredentials(homeDir);
+
+    const usage = await resolveClaudeUsageSnapshot({
+      homeDir: () => homeDir,
+      now: () => Date.UTC(2026, 3, 17, 2, 0, 0),
+      fetchImpl: mockFetch(
+        new Response(
+          JSON.stringify({
+            five_hour: {
+              utilization: 42,
+              resets_at: "2026-04-17T05:00:00.000Z",
+            },
+            seven_day: {
+              utilization: 88,
+              resets_at: "2026-04-24T00:00:00.000Z",
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    });
+
+    expect(usage).toEqual({
+      state: "available",
+      checkedAt: "2026-04-17T02:00:00.000Z",
+      windows: [
+        {
+          id: "five-hour",
+          label: "5h",
+          percentUsed: 42,
+          resetsAt: "2026-04-17T05:00:00.000Z",
+          level: "normal",
+          exhausted: false,
+        },
+        {
+          id: "seven-day",
+          label: "7d",
+          percentUsed: 88,
+          resetsAt: "2026-04-24T00:00:00.000Z",
+          level: "critical",
+          exhausted: false,
+        },
+      ],
+    });
+  });
+
+  it("serves the last synced usage during rate limiting", async () => {
+    const homeDir = makeTempHomeDir();
+    writeClaudeCredentials(homeDir);
+    const firstNow = Date.UTC(2026, 3, 17, 2, 0, 0);
+
+    await resolveClaudeUsageSnapshot({
+      homeDir: () => homeDir,
+      now: () => firstNow,
+      fetchImpl: mockFetch(
+        new Response(
+          JSON.stringify({
+            five_hour: {
+              utilization: 40,
+              resets_at: "2026-04-17T05:00:00.000Z",
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    });
+
+    const usage = await resolveClaudeUsageSnapshot({
+      homeDir: () => homeDir,
+      now: () => firstNow + 6 * 60_000,
+      fetchImpl: mockFetch(
+        new Response(null, {
+          status: 429,
+          headers: { "retry-after": "120" },
+        }),
+      ),
+    });
+
+    expect(usage).toEqual({
+      state: "syncing",
+      checkedAt: "2026-04-17T02:06:00.000Z",
+      windows: [
+        {
+          id: "five-hour",
+          label: "5h",
+          percentUsed: 40,
+          resetsAt: "2026-04-17T05:00:00.000Z",
+          level: "normal",
+          exhausted: false,
+        },
+      ],
+      message: "Claude usage is temporarily rate limited; showing the last synced values.",
+    });
+  });
+});

--- a/apps/server/src/provider/claudeUsage.ts
+++ b/apps/server/src/provider/claudeUsage.ts
@@ -249,9 +249,7 @@ function parseIsoDate(value: unknown): string | null {
   return parsed.toISOString();
 }
 
-function levelFromPercent(
-  percentUsed: number | null,
-): ServerProviderUsageWindow["level"] {
+function levelFromPercent(percentUsed: number | null): ServerProviderUsageWindow["level"] {
   if ((percentUsed ?? 0) >= 100) return "exhausted";
   if ((percentUsed ?? 0) >= 85) return "critical";
   if ((percentUsed ?? 0) >= 70) return "warning";

--- a/apps/server/src/provider/claudeUsage.ts
+++ b/apps/server/src/provider/claudeUsage.ts
@@ -1,0 +1,392 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ServerProvider, ServerProviderUsageWindow } from "@t3tools/contracts";
+
+const CLAUDE_USAGE_CACHE_TTL_MS = 5 * 60_000;
+const CLAUDE_USAGE_FAILURE_TTL_MS = 15_000;
+const CLAUDE_USAGE_RATE_LIMIT_BASE_MS = 60_000;
+const CLAUDE_USAGE_RATE_LIMIT_MAX_MS = 5 * 60_000;
+const CLAUDE_USAGE_API_URL = "https://api.anthropic.com/api/oauth/usage";
+const CLAUDE_USAGE_API_BETA = "oauth-2025-04-20";
+const CLAUDE_USAGE_USER_AGENT = "t3code/desktop";
+
+interface ClaudeOauthCredentials {
+  readonly accessToken: string;
+  readonly expiresAt?: number;
+  readonly subscriptionType?: string;
+}
+
+interface ClaudeUsageCacheRecord {
+  readonly usage: ServerProvider["usage"];
+  readonly timestamp: number;
+  readonly retryAfterUntil?: number;
+  readonly rateLimitedCount?: number;
+  readonly lastGoodUsage?: ServerProvider["usage"];
+}
+
+export interface ClaudeUsageDependencies {
+  readonly homeDir?: () => string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly now?: () => number;
+  readonly fetchImpl?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+}
+
+function getClaudeConfigDir(homeDir: string, env: NodeJS.ProcessEnv): string {
+  const configured = env.CLAUDE_CONFIG_DIR?.trim();
+  return configured && configured.length > 0 ? configured : path.join(homeDir, ".claude");
+}
+
+function getClaudeUsageCachePath(homeDir: string): string {
+  return path.join(homeDir, ".t3code", "cache", "claude-usage.json");
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isUsingCustomAnthropicEndpoint(env: NodeJS.ProcessEnv): boolean {
+  const baseUrl = env.ANTHROPIC_BASE_URL?.trim() || env.ANTHROPIC_API_BASE_URL?.trim();
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    return new URL(baseUrl).origin !== "https://api.anthropic.com";
+  } catch {
+    return true;
+  }
+}
+
+function readClaudeOauthCredentials(
+  configDir: string,
+  now: number,
+): ClaudeOauthCredentials | undefined {
+  const credentialsPath = path.join(configDir, ".credentials.json");
+  if (!fs.existsSync(credentialsPath)) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(credentialsPath, "utf8")) as unknown;
+  const oauth = asRecord(asRecord(parsed)?.claudeAiOauth);
+  const accessToken = asString(oauth?.accessToken);
+
+  if (!accessToken) {
+    return undefined;
+  }
+
+  const expiresAt = asNumber(oauth?.expiresAt);
+  if (expiresAt !== undefined && expiresAt <= now) {
+    return undefined;
+  }
+  const subscriptionType = asString(oauth?.subscriptionType);
+
+  return {
+    accessToken,
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
+    ...(subscriptionType ? { subscriptionType } : {}),
+  };
+}
+
+function readUsageCache(cachePath: string, now: number): ServerProvider["usage"] | undefined {
+  if (!fs.existsSync(cachePath)) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8")) as ClaudeUsageCacheRecord;
+  if (!parsed.usage) {
+    return undefined;
+  }
+
+  if (parsed.retryAfterUntil && parsed.retryAfterUntil > now) {
+    return parsed.usage;
+  }
+
+  const ttl =
+    parsed.usage.state === "unavailable" ? CLAUDE_USAGE_FAILURE_TTL_MS : CLAUDE_USAGE_CACHE_TTL_MS;
+  return now - parsed.timestamp < ttl ? parsed.usage : undefined;
+}
+
+function ensureCacheDir(cachePath: string): void {
+  const dir = path.dirname(cachePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function writeUsageCache(cachePath: string, record: ClaudeUsageCacheRecord): void {
+  ensureCacheDir(cachePath);
+  fs.writeFileSync(cachePath, JSON.stringify(record), "utf8");
+}
+
+function readPreviousCache(cachePath: string): ClaudeUsageCacheRecord | undefined {
+  if (!fs.existsSync(cachePath)) {
+    return undefined;
+  }
+
+  return JSON.parse(fs.readFileSync(cachePath, "utf8")) as ClaudeUsageCacheRecord;
+}
+
+function getRateLimitedBackoffMs(count: number): number {
+  return Math.min(
+    CLAUDE_USAGE_RATE_LIMIT_BASE_MS * 2 ** Math.max(0, count - 1),
+    CLAUDE_USAGE_RATE_LIMIT_MAX_MS,
+  );
+}
+
+function parseRetryAfterMs(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric * 1000;
+  }
+
+  const date = Date.parse(value);
+  if (!Number.isNaN(date)) {
+    return Math.max(0, date - Date.now());
+  }
+
+  return undefined;
+}
+
+async function fetchClaudeUsageApi(
+  accessToken: string,
+  fetchImpl: NonNullable<ClaudeUsageDependencies["fetchImpl"]>,
+): Promise<
+  | { readonly ok: true; readonly data: unknown }
+  | { readonly ok: false; readonly error: string; readonly retryAfterMs?: number }
+> {
+  const response = await fetchImpl(CLAUDE_USAGE_API_URL, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "anthropic-beta": CLAUDE_USAGE_API_BETA,
+      "User-Agent": CLAUDE_USAGE_USER_AGENT,
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!response.ok) {
+    const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
+    return {
+      ok: false,
+      error: response.status === 429 ? "rate-limited" : `http-${response.status}`,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    };
+  }
+
+  return {
+    ok: true,
+    data: (await response.json()) as unknown,
+  };
+}
+
+function buildUnavailableUsage(
+  checkedAt: string,
+  message: string,
+  windows?: ReadonlyArray<NonNullable<ServerProvider["usage"]>["windows"][number]>,
+): NonNullable<ServerProvider["usage"]> {
+  return {
+    state: windows && windows.length > 0 ? "syncing" : "unavailable",
+    checkedAt,
+    windows: windows ? [...windows] : [],
+    message,
+  };
+}
+
+// ── Claude OAuth usage response parser ─────────────────────────────
+//
+// The Anthropic OAuth usage endpoint returns `utilization` as a 0–100
+// percentage (NOT a 0–1 ratio) and may include many extra fields beyond
+// the two windows the sidebar surfaces (e.g. seven_day_omelette,
+// extra_usage). We only extract `five_hour` and `seven_day` and treat
+// their `utilization` as an already-scaled percentage, matching the
+// claude-hud reference implementation.
+
+interface ClaudeUsageWindowResponse {
+  readonly utilization?: number;
+  readonly resets_at?: string | null;
+}
+
+interface ClaudeUsageResponse {
+  readonly five_hour?: ClaudeUsageWindowResponse | null;
+  readonly seven_day?: ClaudeUsageWindowResponse | null;
+}
+
+function parseUtilizationPercent(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.max(0, Math.min(100, value));
+}
+
+function parseIsoDate(value: unknown): string | null {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+function levelFromPercent(
+  percentUsed: number | null,
+): ServerProviderUsageWindow["level"] {
+  if ((percentUsed ?? 0) >= 100) return "exhausted";
+  if ((percentUsed ?? 0) >= 85) return "critical";
+  if ((percentUsed ?? 0) >= 70) return "warning";
+  return "normal";
+}
+
+function buildClaudeWindow(
+  id: string,
+  label: string,
+  raw: ClaudeUsageWindowResponse | null | undefined,
+): ServerProviderUsageWindow | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const percentUsed = parseUtilizationPercent(raw.utilization);
+  const resetsAt = parseIsoDate(raw.resets_at);
+  if (percentUsed === null && !resetsAt) {
+    return undefined;
+  }
+  const exhausted = percentUsed !== null && percentUsed >= 100;
+  return {
+    id,
+    label,
+    percentUsed,
+    resetsAt,
+    exhausted,
+    level: levelFromPercent(percentUsed),
+  };
+}
+
+function parseClaudeUsageSnapshot(
+  value: unknown,
+  checkedAt: string,
+): ServerProvider["usage"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const response = value as ClaudeUsageResponse;
+  const windows: ServerProviderUsageWindow[] = [];
+  const fiveHour = buildClaudeWindow("five-hour", "5h", response.five_hour);
+  if (fiveHour) windows.push(fiveHour);
+  const sevenDay = buildClaudeWindow("seven-day", "7d", response.seven_day);
+  if (sevenDay) windows.push(sevenDay);
+
+  if (windows.length === 0) {
+    return undefined;
+  }
+
+  return {
+    state: "available",
+    checkedAt,
+    windows,
+  };
+}
+
+export async function resolveClaudeUsageSnapshot(
+  dependencies: ClaudeUsageDependencies = {},
+): Promise<ServerProvider["usage"] | undefined> {
+  const homeDir = dependencies.homeDir?.() ?? os.homedir();
+  const env = dependencies.env ?? process.env;
+  const now = dependencies.now?.() ?? Date.now();
+  const fetchImpl = dependencies.fetchImpl ?? fetch;
+  const cachePath = getClaudeUsageCachePath(homeDir);
+
+  if (isUsingCustomAnthropicEndpoint(env)) {
+    return undefined;
+  }
+
+  const cachedUsage = readUsageCache(cachePath, now);
+  if (cachedUsage) {
+    return cachedUsage;
+  }
+
+  const credentials = readClaudeOauthCredentials(getClaudeConfigDir(homeDir, env), now);
+  if (!credentials?.subscriptionType) {
+    return undefined;
+  }
+
+  const checkedAt = new Date(now).toISOString();
+
+  try {
+    const result = await fetchClaudeUsageApi(credentials.accessToken, fetchImpl);
+    if (!result.ok) {
+      const previous = readPreviousCache(cachePath);
+      const rateLimitedCount =
+        result.error === "rate-limited" ? (previous?.rateLimitedCount ?? 0) + 1 : 0;
+      const fallbackUsage =
+        result.error === "rate-limited" ? (previous?.lastGoodUsage ?? previous?.usage) : undefined;
+      const usage = buildUnavailableUsage(
+        checkedAt,
+        result.error === "rate-limited"
+          ? "Claude usage is temporarily rate limited; showing the last synced values."
+          : "Claude usage telemetry is temporarily unavailable.",
+        fallbackUsage?.windows,
+      );
+
+      writeUsageCache(cachePath, {
+        usage,
+        timestamp: now,
+        rateLimitedCount,
+        ...(result.error === "rate-limited"
+          ? {
+              retryAfterUntil:
+                now + (result.retryAfterMs ?? getRateLimitedBackoffMs(rateLimitedCount)),
+            }
+          : {}),
+        ...(fallbackUsage ? { lastGoodUsage: fallbackUsage } : {}),
+      });
+
+      return usage;
+    }
+
+    const usage = parseClaudeUsageSnapshot(result.data, checkedAt);
+    if (!usage) {
+      return undefined;
+    }
+
+    writeUsageCache(cachePath, {
+      usage,
+      timestamp: now,
+      lastGoodUsage: usage,
+    });
+    return usage;
+  } catch {
+    const previous = readPreviousCache(cachePath);
+    const usage = buildUnavailableUsage(
+      checkedAt,
+      "Claude usage telemetry is temporarily unavailable.",
+      previous?.lastGoodUsage?.windows,
+    );
+    writeUsageCache(cachePath, {
+      usage,
+      timestamp: now,
+      ...(previous?.lastGoodUsage ? { lastGoodUsage: previous.lastGoodUsage } : {}),
+    });
+    return usage;
+  }
+}

--- a/apps/server/src/provider/codexUsage.ts
+++ b/apps/server/src/provider/codexUsage.ts
@@ -1,10 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type {
-  ServerProvider,
-  ServerProviderUsageWindow,
-} from "@t3tools/contracts";
+import type { ServerProvider, ServerProviderUsageWindow } from "@t3tools/contracts";
 
 export interface CodexUsageDependencies {
   readonly homePath?: string;
@@ -66,11 +63,7 @@ function findLatestRollout(codexHome: string): string | undefined {
         stack.push(full);
         continue;
       }
-      if (
-        !entry.isFile() ||
-        !entry.name.startsWith("rollout-") ||
-        !entry.name.endsWith(".jsonl")
-      ) {
+      if (!entry.isFile() || !entry.name.startsWith("rollout-") || !entry.name.endsWith(".jsonl")) {
         continue;
       }
       try {

--- a/apps/server/src/provider/codexUsage.ts
+++ b/apps/server/src/provider/codexUsage.ts
@@ -1,0 +1,221 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type {
+  ServerProvider,
+  ServerProviderUsageWindow,
+} from "@t3tools/contracts";
+
+export interface CodexUsageDependencies {
+  readonly homePath?: string;
+  readonly homeDir?: () => string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly now?: () => number;
+}
+
+interface RolloutLine {
+  readonly timestamp?: string;
+  readonly type?: string;
+  readonly payload?: unknown;
+}
+
+interface RawWindow {
+  readonly used_percent?: unknown;
+  readonly resets_at?: unknown;
+  readonly window_minutes?: unknown;
+}
+
+interface RawRateLimits {
+  readonly limit_id?: unknown;
+  readonly limit_name?: unknown;
+  readonly primary?: RawWindow;
+  readonly secondary?: RawWindow;
+}
+
+function getCodexHome(deps: CodexUsageDependencies): string {
+  if (deps.homePath && deps.homePath.trim().length > 0) return deps.homePath;
+  const env = deps.env ?? process.env;
+  const fromEnv = env.CODEX_HOME?.trim();
+  if (fromEnv) return fromEnv;
+  const homeDir = deps.homeDir?.() ?? os.homedir();
+  return path.join(homeDir, ".codex");
+}
+
+function findLatestRollout(codexHome: string): string | undefined {
+  const sessionsDir = path.join(codexHome, "sessions");
+  if (!fs.existsSync(sessionsDir)) return undefined;
+
+  let latestPath: string | undefined;
+  let latestMtime = 0;
+
+  const stack = [sessionsDir];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    if (!dir) continue;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (
+        !entry.isFile() ||
+        !entry.name.startsWith("rollout-") ||
+        !entry.name.endsWith(".jsonl")
+      ) {
+        continue;
+      }
+      try {
+        const stat = fs.statSync(full);
+        if (stat.mtimeMs > latestMtime) {
+          latestMtime = stat.mtimeMs;
+          latestPath = full;
+        }
+      } catch {
+        // ignore stat errors
+      }
+    }
+  }
+
+  return latestPath;
+}
+
+function toNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function resetsAtIso(value: unknown): string | null {
+  const num = toNumber(value);
+  if (num !== undefined) {
+    // Rollout files use unix seconds.
+    return new Date(num * 1000).toISOString();
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+  }
+  return null;
+}
+
+function windowLabel(windowMinutes: number | undefined, fallback: string): string {
+  if (windowMinutes === undefined) return fallback;
+  if (windowMinutes >= 60 * 24) {
+    const days = Math.round(windowMinutes / (60 * 24));
+    return `${days}d`;
+  }
+  if (windowMinutes >= 60) {
+    const hours = Math.round(windowMinutes / 60);
+    return `${hours}h`;
+  }
+  return `${windowMinutes}m`;
+}
+
+function levelFromPercent(
+  percentUsed: number,
+  exhausted: boolean,
+): ServerProviderUsageWindow["level"] {
+  if (exhausted || percentUsed >= 100) return "exhausted";
+  if (percentUsed >= 85) return "critical";
+  if (percentUsed >= 70) return "warning";
+  return "normal";
+}
+
+function toUsageWindow(
+  id: string,
+  fallbackLabel: string,
+  raw: RawWindow | undefined,
+): ServerProviderUsageWindow | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const percent = toNumber(raw.used_percent);
+  if (percent === undefined) return undefined;
+  const clamped = Math.max(0, Math.min(100, percent));
+  const windowMinutes = toNumber(raw.window_minutes);
+  const label = windowLabel(windowMinutes, fallbackLabel);
+  const exhausted = clamped >= 100;
+  return {
+    id,
+    label,
+    percentUsed: clamped,
+    resetsAt: resetsAtIso(raw.resets_at),
+    exhausted,
+    level: levelFromPercent(clamped, exhausted),
+  };
+}
+
+function findLastTokenCountRateLimits(
+  rolloutPath: string,
+): { readonly rateLimits: RawRateLimits; readonly at: string } | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(rolloutPath, "utf8");
+  } catch {
+    return undefined;
+  }
+
+  const lines = raw.split("\n");
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (!line || !line.trim()) continue;
+    let parsed: RolloutLine;
+    try {
+      parsed = JSON.parse(line) as RolloutLine;
+    } catch {
+      continue;
+    }
+    if (parsed.type !== "event_msg" || !parsed.payload || typeof parsed.payload !== "object") {
+      continue;
+    }
+    const event = parsed.payload as Record<string, unknown>;
+    if (event.type !== "token_count") continue;
+    const rateLimits = event.rate_limits;
+    if (!rateLimits || typeof rateLimits !== "object") continue;
+    return {
+      rateLimits: rateLimits as RawRateLimits,
+      at: typeof parsed.timestamp === "string" ? parsed.timestamp : new Date().toISOString(),
+    };
+  }
+
+  return undefined;
+}
+
+export function readCodexUsageFromRollout(
+  rolloutPath: string,
+): ServerProvider["usage"] | undefined {
+  const found = findLastTokenCountRateLimits(rolloutPath);
+  if (!found) return undefined;
+
+  const primary = toUsageWindow("primary", "Primary", found.rateLimits.primary);
+  const secondary = toUsageWindow("secondary", "Secondary", found.rateLimits.secondary);
+  const windows = [primary, secondary].filter(
+    (entry): entry is ServerProviderUsageWindow => entry !== undefined,
+  );
+  if (windows.length === 0) return undefined;
+
+  return {
+    state: "available",
+    checkedAt: found.at,
+    windows,
+  };
+}
+
+export function resolveCodexUsageSnapshot(
+  dependencies: CodexUsageDependencies = {},
+): ServerProvider["usage"] | undefined {
+  const codexHome = getCodexHome(dependencies);
+  const rollout = findLatestRollout(codexHome);
+  if (!rollout) return undefined;
+  return readCodexUsageFromRollout(rollout);
+}

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -6,6 +6,7 @@ import type {
   ServerProviderSlashCommand,
   ServerProviderModel,
   ServerProviderState,
+  ServerProviderUsage,
 } from "@t3tools/contracts";
 import { Effect, Stream } from "effect";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -134,6 +135,7 @@ export function buildServerProvider(input: {
   models: ReadonlyArray<ServerProviderModel>;
   slashCommands?: ReadonlyArray<ServerProviderSlashCommand>;
   skills?: ReadonlyArray<ServerProviderSkill>;
+  usage?: ServerProviderUsage;
   probe: ProviderProbeResult;
 }): ServerProvider {
   return {
@@ -148,6 +150,7 @@ export function buildServerProvider(input: {
     models: input.models,
     slashCommands: [...(input.slashCommands ?? [])],
     skills: [...(input.skills ?? [])],
+    ...(input.usage ? { usage: input.usage } : {}),
   };
 }
 

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -65,6 +65,20 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
       checkedAt: "2026-04-10T12:00:00.000Z",
       models: [],
       message: "Cached message",
+      usage: {
+        state: "available",
+        checkedAt: "2026-04-10T12:00:00.000Z",
+        windows: [
+          {
+            id: "5h",
+            label: "5h",
+            percentUsed: 42,
+            resetsAt: "2026-04-10T17:00:00.000Z",
+            level: "normal",
+            exhausted: false,
+          },
+        ],
+      },
       skills: [
         {
           name: "github:gh-fix-ci",
@@ -106,6 +120,7 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
         checkedAt: cachedCodex.checkedAt,
         slashCommands: cachedCodex.slashCommands,
         skills: cachedCodex.skills,
+        usage: cachedCodex.usage,
         message: cachedCodex.message,
       },
     );

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -43,6 +43,7 @@ export const hydrateCachedProvider = (input: {
     checkedAt: input.cachedProvider.checkedAt,
     slashCommands: input.cachedProvider.slashCommands,
     skills: input.cachedProvider.skills,
+    ...(input.cachedProvider.usage ? { usage: input.cachedProvider.usage } : {}),
   };
 
   return input.cachedProvider.message

--- a/apps/server/src/provider/providerUsage.test.ts
+++ b/apps/server/src/provider/providerUsage.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderRuntimeEvent, ServerProvider } from "@t3tools/contracts";
+
+import {
+  mergeProviderRuntimeEventIntoSnapshot,
+  normalizeProviderUsageSnapshot,
+} from "./providerUsage";
+
+function makeProvider(
+  provider: ServerProvider["provider"],
+  overrides?: Partial<ServerProvider>,
+): ServerProvider {
+  return {
+    provider,
+    enabled: true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: "2026-04-17T00:00:00.000Z",
+    models: [],
+    slashCommands: [],
+    skills: [],
+    ...overrides,
+  };
+}
+
+describe("providerUsage", () => {
+  it("normalizes named usage windows from runtime rate-limit payloads", () => {
+    const usage = normalizeProviderUsageSnapshot(
+      {
+        five_hour: {
+          utilization: 0.42,
+          resets_at: "2026-04-17T05:00:00.000Z",
+        },
+        seven_day: {
+          utilization: 0.88,
+          resets_at: "2026-04-24T00:00:00.000Z",
+        },
+      },
+      "2026-04-17T01:00:00.000Z",
+    );
+
+    expect(usage).toEqual({
+      state: "available",
+      checkedAt: "2026-04-17T01:00:00.000Z",
+      windows: [
+        {
+          id: "five-hour",
+          label: "5h",
+          percentUsed: 42,
+          resetsAt: "2026-04-17T05:00:00.000Z",
+          level: "normal",
+          exhausted: false,
+        },
+        {
+          id: "seven-day",
+          label: "7d",
+          percentUsed: 88,
+          resetsAt: "2026-04-24T00:00:00.000Z",
+          level: "critical",
+          exhausted: false,
+        },
+      ],
+    });
+  });
+
+  it("merges runtime rate-limit updates into provider snapshots", () => {
+    const provider = makeProvider("codex");
+    const event: ProviderRuntimeEvent = {
+      type: "account.rate-limits.updated",
+      eventId: "evt-rate-limits-1" as never,
+      provider: "codex",
+      createdAt: "2026-04-17T02:00:00.000Z",
+      threadId: "thread-1" as never,
+      payload: {
+        rateLimits: {
+          windows: [
+            {
+              id: "tokens",
+              label: "Tokens",
+              percentUsed: 72,
+              resetsAt: "2026-04-17T03:00:00.000Z",
+            },
+          ],
+        },
+      },
+    };
+
+    expect(mergeProviderRuntimeEventIntoSnapshot(provider, event)).toMatchObject({
+      usage: {
+        state: "available",
+        checkedAt: "2026-04-17T02:00:00.000Z",
+        windows: [
+          {
+            id: "tokens",
+            label: "Tokens",
+            percentUsed: 72,
+            resetsAt: "2026-04-17T03:00:00.000Z",
+            level: "warning",
+            exhausted: false,
+          },
+        ],
+      },
+    });
+  });
+
+  it("updates codex auth metadata from account updates and clears stale usage for api keys", () => {
+    const provider = makeProvider("codex", {
+      usage: {
+        state: "available",
+        checkedAt: "2026-04-17T02:00:00.000Z",
+        windows: [],
+      },
+    });
+    const event: ProviderRuntimeEvent = {
+      type: "account.updated",
+      eventId: "evt-account-1" as never,
+      provider: "codex",
+      createdAt: "2026-04-17T03:00:00.000Z",
+      threadId: "thread-1" as never,
+      payload: {
+        account: {
+          type: "apiKey",
+        },
+      },
+    };
+
+    expect(mergeProviderRuntimeEventIntoSnapshot(provider, event)).toMatchObject({
+      auth: {
+        status: "authenticated",
+        type: "apiKey",
+        label: "OpenAI API Key",
+      },
+    });
+    expect(mergeProviderRuntimeEventIntoSnapshot(provider, event).usage).toBeUndefined();
+  });
+});

--- a/apps/server/src/provider/providerUsage.ts
+++ b/apps/server/src/provider/providerUsage.ts
@@ -1,0 +1,360 @@
+import type {
+  ProviderRuntimeEvent,
+  ServerProvider,
+  ServerProviderUsage,
+  ServerProviderUsageWindow,
+} from "@t3tools/contracts";
+
+import { codexAuthSubLabel, codexAuthSubType, readCodexAccountSnapshot } from "./codexAccount.ts";
+
+type UnknownRecord = Record<string, unknown>;
+
+const WINDOW_CONTAINER_KEYS = ["windows", "limits", "rateLimits", "rate_limits"] as const;
+const WINDOW_PERCENT_KEYS = [
+  "percentUsed",
+  "usedPercent",
+  "percentageUsed",
+  "used_percentage",
+  "used_percent",
+  "percentage",
+  "percent",
+  "pct",
+  "currentPercent",
+  "current_percent",
+] as const;
+const WINDOW_RATIO_KEYS = [
+  "utilization",
+  "utilisation",
+  "ratio",
+  "usageRatio",
+  "usedRatio",
+] as const;
+const WINDOW_RESET_KEYS = [
+  "resetsAt",
+  "resetAt",
+  "resets_at",
+  "reset_at",
+  "retryAt",
+  "retry_at",
+] as const;
+const WINDOW_MESSAGE_KEYS = ["message", "detail", "error", "reason"] as const;
+const WINDOW_STATE_KEYS = ["state", "status"] as const;
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as UnknownRecord;
+}
+
+function asArray(value: unknown): ReadonlyArray<unknown> | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+function toPercent(value: number, fractional: boolean): number {
+  return clampPercent(fractional ? value * 100 : value);
+}
+
+function normalizeUsageState(value: unknown): ServerProviderUsage["state"] | undefined {
+  const normalized = asString(value)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized.includes("sync")) {
+    return "syncing";
+  }
+  if (
+    normalized.includes("unavailable") ||
+    normalized.includes("error") ||
+    normalized.includes("failed")
+  ) {
+    return "unavailable";
+  }
+  if (
+    normalized.includes("available") ||
+    normalized.includes("ready") ||
+    normalized.includes("ok")
+  ) {
+    return "available";
+  }
+  return undefined;
+}
+
+function levelFromPercent(
+  percentUsed: number | null,
+  exhausted: boolean,
+): ServerProviderUsageWindow["level"] {
+  if (exhausted || (percentUsed ?? 0) >= 100) {
+    return "exhausted";
+  }
+  if ((percentUsed ?? 0) >= 85) {
+    return "critical";
+  }
+  if ((percentUsed ?? 0) >= 70) {
+    return "warning";
+  }
+  return "normal";
+}
+
+function formatKeyLabel(key: string): string {
+  const normalized = key.replace(/[\s_-]+/g, "").toLowerCase();
+  switch (normalized) {
+    case "fivehour":
+    case "5hour":
+    case "5h":
+      return "5h";
+    case "sevenday":
+    case "7day":
+    case "7d":
+      return "7d";
+    case "hourly":
+    case "onehour":
+    case "1hour":
+    case "1h":
+      return "1h";
+    case "daily":
+    case "oneday":
+    case "1day":
+    case "1d":
+      return "1d";
+    default:
+      return key
+        .replace(/([a-z])([A-Z])/g, "$1 $2")
+        .replace(/[_-]+/g, " ")
+        .trim();
+  }
+}
+
+function sanitizeWindowId(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "usage"
+  );
+}
+
+function parseIsoDate(value: unknown): string | null {
+  const raw = asString(value);
+  if (!raw) {
+    return null;
+  }
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+function readPercent(record: UnknownRecord): number | null {
+  for (const key of WINDOW_PERCENT_KEYS) {
+    const value = asNumber(record[key]);
+    if (value !== undefined) {
+      return toPercent(value, false);
+    }
+  }
+  for (const key of WINDOW_RATIO_KEYS) {
+    const value = asNumber(record[key]);
+    if (value !== undefined) {
+      return toPercent(value, true);
+    }
+  }
+  return null;
+}
+
+function readWindowLabel(record: UnknownRecord, fallbackKey?: string): string {
+  const explicit =
+    asString(record.label) ??
+    asString(record.name) ??
+    asString(record.window) ??
+    asString(record.id);
+  if (explicit) {
+    return explicit;
+  }
+  return fallbackKey ? formatKeyLabel(fallbackKey) : "Usage";
+}
+
+function hasWindowShape(record: UnknownRecord): boolean {
+  return (
+    WINDOW_PERCENT_KEYS.some((key) => asNumber(record[key]) !== undefined) ||
+    WINDOW_RATIO_KEYS.some((key) => asNumber(record[key]) !== undefined) ||
+    WINDOW_RESET_KEYS.some((key) => parseIsoDate(record[key]) !== null) ||
+    asBoolean(record.exhausted) === true ||
+    asBoolean(record.is_exhausted) === true
+  );
+}
+
+function collectWindowCandidates(
+  value: unknown,
+): ReadonlyArray<{ readonly key?: string; readonly record: UnknownRecord }> {
+  const directArray = asArray(value);
+  if (directArray) {
+    return directArray
+      .map((entry) => asRecord(entry))
+      .filter((entry): entry is UnknownRecord => entry !== undefined)
+      .map((record) => ({ record }));
+  }
+
+  const root = asRecord(value);
+  if (!root) {
+    return [];
+  }
+
+  const candidates: Array<{ readonly key?: string; readonly record: UnknownRecord }> = [];
+
+  if (hasWindowShape(root)) {
+    candidates.push({ record: root });
+  }
+
+  for (const key of WINDOW_CONTAINER_KEYS) {
+    const nestedArray = asArray(root[key]);
+    if (!nestedArray) {
+      continue;
+    }
+    for (const entry of nestedArray) {
+      const record = asRecord(entry);
+      if (record && hasWindowShape(record)) {
+        candidates.push({ record });
+      }
+    }
+  }
+
+  for (const [key, nested] of Object.entries(root)) {
+    const record = asRecord(nested);
+    if (!record || !hasWindowShape(record)) {
+      continue;
+    }
+    candidates.push({ key, record });
+  }
+
+  return candidates;
+}
+
+export function normalizeProviderUsageSnapshot(
+  value: unknown,
+  checkedAt: string,
+): ServerProvider["usage"] | undefined {
+  const root = asRecord(value);
+  const windows = new Map<string, ServerProviderUsageWindow>();
+
+  for (const candidate of collectWindowCandidates(value)) {
+    const label = readWindowLabel(candidate.record, candidate.key);
+    const id = sanitizeWindowId(candidate.key ?? label);
+    const percentUsed = readPercent(candidate.record);
+    const exhausted =
+      asBoolean(candidate.record.exhausted) ??
+      asBoolean(candidate.record.is_exhausted) ??
+      (percentUsed !== null ? percentUsed >= 100 : false);
+    const resetsAt =
+      WINDOW_RESET_KEYS.map((key) => parseIsoDate(candidate.record[key])).find(
+        (entry) => entry !== null,
+      ) ?? null;
+
+    windows.set(id, {
+      id,
+      label,
+      percentUsed,
+      resetsAt,
+      exhausted,
+      level: levelFromPercent(percentUsed, exhausted),
+    });
+  }
+
+  const message = root
+    ? WINDOW_MESSAGE_KEYS.map((key) => asString(root[key])).find((entry) => entry !== undefined)
+    : undefined;
+  const state =
+    (root
+      ? WINDOW_STATE_KEYS.map((key) => normalizeUsageState(root[key])).find(
+          (entry) => entry !== undefined,
+        )
+      : undefined) ?? (windows.size > 0 ? "available" : undefined);
+
+  if (windows.size === 0 && !message && !state) {
+    return undefined;
+  }
+
+  return {
+    state: state ?? "available",
+    checkedAt,
+    windows: [...windows.values()],
+    ...(message ? { message } : {}),
+  };
+}
+
+function mergeCodexAccount(provider: ServerProvider, payload: unknown): ServerProvider {
+  if (provider.provider !== "codex") {
+    return provider;
+  }
+
+  const account = readCodexAccountSnapshot(payload);
+  const nextAuthType = codexAuthSubType(account);
+  const nextAuthLabel = codexAuthSubLabel(account);
+  const shouldClearUsage = account.type !== "chatgpt";
+
+  return {
+    ...provider,
+    auth: {
+      ...provider.auth,
+      status: "authenticated",
+      ...(nextAuthType ? { type: nextAuthType } : {}),
+      ...(nextAuthLabel ? { label: nextAuthLabel } : {}),
+    },
+    ...(shouldClearUsage ? { usage: undefined } : {}),
+  };
+}
+
+export function mergeProviderRuntimeEventIntoSnapshot(
+  provider: ServerProvider,
+  event: ProviderRuntimeEvent,
+): ServerProvider {
+  if (provider.provider !== event.provider) {
+    return provider;
+  }
+
+  switch (event.type) {
+    case "account.updated":
+      return mergeCodexAccount(provider, event.payload.account);
+
+    case "account.rate-limits.updated": {
+      const usage = normalizeProviderUsageSnapshot(event.payload.rateLimits, event.createdAt);
+      if (!usage) {
+        return provider;
+      }
+      return {
+        ...provider,
+        usage,
+      };
+    }
+
+    default:
+      return provider;
+  }
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -163,6 +163,8 @@ const ProviderLayerLive = Layer.unwrap(
   }),
 );
 
+const ProviderRegistryRuntimeLive = ProviderRegistryLive.pipe(Layer.provide(ProviderLayerLive));
+
 const PersistenceLayerLive = Layer.empty.pipe(Layer.provideMerge(SqlitePersistenceLayerLive));
 
 const GitManagerLayerLive = GitManagerLive.pipe(
@@ -203,7 +205,7 @@ const RuntimeDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(TerminalLayerLive),
   Layer.provideMerge(PersistenceLayerLive),
   Layer.provideMerge(KeybindingsLive),
-  Layer.provideMerge(ProviderRegistryLive),
+  Layer.provideMerge(ProviderRegistryRuntimeLive),
   Layer.provideMerge(ServerSettingsLive),
   Layer.provideMerge(WorkspaceLayerLive),
   Layer.provideMerge(ProjectFaviconResolverLive),

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -140,6 +140,7 @@ import {
 } from "./Sidebar.logic";
 import { sortThreads } from "../lib/threadSort";
 import { SidebarUpdatePill } from "./sidebar/SidebarUpdatePill";
+import { SidebarProviderUsageCard } from "./sidebar/SidebarProviderUsageCard";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { CommandDialogTrigger } from "./ui/command";
 import { readEnvironmentApi } from "../environmentApi";
@@ -2008,6 +2009,7 @@ const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   return (
     <SidebarFooter className="p-2">
       <SidebarUpdatePill />
+      <SidebarProviderUsageCard />
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton

--- a/apps/web/src/components/sidebar/SidebarProviderUsageCard.browser.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUsageCard.browser.tsx
@@ -1,0 +1,316 @@
+import {
+  DEFAULT_SERVER_SETTINGS,
+  EnvironmentId,
+  type LocalApi,
+  type ServerConfig,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { page } from "vitest/browser";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { __resetLocalApiForTests } from "../../localApi";
+import { AppAtomRegistryProvider } from "../../rpc/atomRegistry";
+import { resetServerStateForTests, setServerConfigSnapshot } from "../../rpc/serverState";
+import { SidebarProviderUsageCard } from "./SidebarProviderUsageCard";
+
+const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
+const NOW_ISO = "2026-04-19T00:00:00.000Z";
+
+function makeProvider(
+  provider: ServerProvider["provider"],
+  overrides?: Partial<ServerProvider>,
+): ServerProvider {
+  return {
+    provider,
+    enabled: true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: NOW_ISO,
+    models: [],
+    slashCommands: [],
+    skills: [],
+    ...overrides,
+  };
+}
+
+function createServerConfig(providers: ReadonlyArray<ServerProvider>): ServerConfig {
+  return {
+    environment: {
+      environmentId: LOCAL_ENVIRONMENT_ID,
+      label: "Local environment",
+      platform: { os: "darwin", arch: "arm64" },
+      serverVersion: "0.0.0-test",
+      capabilities: { repositoryIdentity: true },
+    },
+    auth: {
+      policy: "loopback-browser",
+      bootstrapMethods: ["one-time-token"],
+      sessionMethods: ["browser-session-cookie", "bearer-session-token"],
+      sessionCookieName: "t3_session",
+    },
+    cwd: "/repo/project",
+    keybindingsConfigPath: "/repo/project/.t3code-keybindings.json",
+    keybindings: [],
+    issues: [],
+    providers: [...providers],
+    availableEditors: [],
+    observability: {
+      logsDirectoryPath: "/repo/project/.t3/logs",
+      localTracingEnabled: false,
+      otlpTracesEnabled: false,
+      otlpMetricsEnabled: false,
+    },
+    settings: DEFAULT_SERVER_SETTINGS,
+  };
+}
+
+describe("SidebarProviderUsageCard", () => {
+  let mounted:
+    | (Awaited<ReturnType<typeof render>> & {
+        cleanup?: () => Promise<void>;
+        unmount?: () => Promise<void>;
+      })
+    | null = null;
+
+  beforeEach(async () => {
+    resetServerStateForTests();
+    await __resetLocalApiForTests();
+  });
+
+  afterEach(async () => {
+    if (mounted) {
+      const teardown = mounted.cleanup ?? mounted.unmount;
+      await teardown?.call(mounted).catch(() => {});
+    }
+    mounted = null;
+    Reflect.deleteProperty(window, "nativeApi");
+    document.body.innerHTML = "";
+    resetServerStateForTests();
+    await __resetLocalApiForTests();
+  });
+
+  it("renders both providers and keeps 5h above 7d with extra windows afterward", async () => {
+    setServerConfigSnapshot(
+      createServerConfig([
+        makeProvider("codex", {
+          auth: { status: "authenticated", label: "ChatGPT Pro Subscription" },
+          usage: {
+            state: "available",
+            checkedAt: NOW_ISO,
+            windows: [
+              {
+                id: "monthly",
+                label: "Monthly",
+                percentUsed: 12,
+                resetsAt: null,
+                level: "normal",
+                exhausted: false,
+              },
+              {
+                id: "secondary",
+                label: "7d",
+                percentUsed: 68,
+                resetsAt: "2026-04-26T00:00:00.000Z",
+                level: "normal",
+                exhausted: false,
+              },
+              {
+                id: "primary",
+                label: "5h",
+                percentUsed: 41,
+                resetsAt: "2026-04-19T05:00:00.000Z",
+                level: "normal",
+                exhausted: false,
+              },
+            ],
+          },
+        }),
+        makeProvider("claudeAgent", {
+          auth: { status: "authenticated", label: "Claude Max Subscription" },
+          usage: {
+            state: "available",
+            checkedAt: NOW_ISO,
+            windows: [
+              {
+                id: "seven-day",
+                label: "7d",
+                percentUsed: 77,
+                resetsAt: "2026-04-26T00:00:00.000Z",
+                level: "warning",
+                exhausted: false,
+              },
+              {
+                id: "five-hour",
+                label: "5h",
+                percentUsed: 22,
+                resetsAt: "2026-04-19T05:00:00.000Z",
+                level: "normal",
+                exhausted: false,
+              },
+            ],
+          },
+        }),
+      ]),
+    );
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <SidebarProviderUsageCard />
+      </AppAtomRegistryProvider>,
+    );
+
+    await expect.element(page.getByText("Usage limits")).toBeInTheDocument();
+    await expect.element(page.getByText("Codex")).toBeInTheDocument();
+    await expect.element(page.getByText("Claude")).toBeInTheDocument();
+
+    const codexSection = document.querySelector('[data-provider-usage="codex"]');
+    if (!(codexSection instanceof HTMLElement)) {
+      throw new Error("Expected the Codex usage section to render.");
+    }
+
+    const codexWindowLabels = Array.from(
+      codexSection.querySelectorAll<HTMLElement>("[data-provider-usage-window-label]"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(codexWindowLabels).toEqual(["5h", "7d", "Monthly"]);
+  });
+
+  it("refreshes provider usage from the sidebar header button", async () => {
+    const refreshControl: { finish?: () => void } = {};
+    const refreshProviders = vi.fn<LocalApi["server"]["refreshProviders"]>().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          refreshControl.finish = () => resolve({ providers: [] });
+        }),
+    );
+    window.nativeApi = {
+      server: {
+        refreshProviders,
+      },
+    } as unknown as LocalApi;
+
+    setServerConfigSnapshot(
+      createServerConfig([
+        makeProvider("codex", {
+          usage: {
+            state: "available",
+            checkedAt: NOW_ISO,
+            windows: [
+              {
+                id: "primary",
+                label: "5h",
+                percentUsed: 41,
+                resetsAt: "2026-04-19T05:00:00.000Z",
+                level: "normal",
+                exhausted: false,
+              },
+            ],
+          },
+        }),
+      ]),
+    );
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <SidebarProviderUsageCard />
+      </AppAtomRegistryProvider>,
+    );
+
+    await page.getByRole("button", { name: "Refresh usage limits" }).click();
+
+    await vi.waitFor(() => {
+      expect(refreshProviders).toHaveBeenCalledTimes(1);
+    });
+    await expect
+      .element(page.getByRole("button", { name: "Refreshing usage limits" }))
+      .toBeDisabled();
+
+    refreshControl.finish?.();
+
+    await vi.waitFor(async () => {
+      await expect
+        .element(page.getByRole("button", { name: "Refresh usage limits" }))
+        .toBeEnabled();
+    });
+  });
+
+  it("shows syncing copy inline while provider limits refresh", async () => {
+    setServerConfigSnapshot(
+      createServerConfig([
+        makeProvider("codex", {
+          usage: {
+            state: "syncing",
+            checkedAt: NOW_ISO,
+            windows: [
+              {
+                id: "primary",
+                label: "5h",
+                percentUsed: 41,
+                resetsAt: "2026-04-19T05:00:00.000Z",
+                level: "normal",
+                exhausted: false,
+              },
+              {
+                id: "secondary",
+                label: "7d",
+                percentUsed: 62,
+                resetsAt: "2026-04-26T00:00:00.000Z",
+                level: "normal",
+                exhausted: false,
+              },
+            ],
+          },
+        }),
+        makeProvider("claudeAgent", {
+          usage: {
+            state: "available",
+            checkedAt: NOW_ISO,
+            windows: [],
+          },
+        }),
+      ]),
+    );
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <SidebarProviderUsageCard />
+      </AppAtomRegistryProvider>,
+    );
+
+    await expect
+      .element(page.getByText("Refreshing the latest account limits."))
+      .toBeInTheDocument();
+  });
+
+  it("shows compact unavailable and missing-usage fallback messages", async () => {
+    setServerConfigSnapshot(
+      createServerConfig([
+        makeProvider("codex"),
+        makeProvider("claudeAgent", {
+          usage: {
+            state: "unavailable",
+            checkedAt: NOW_ISO,
+            windows: [],
+            message: "Claude usage telemetry is temporarily unavailable.",
+          },
+        }),
+      ]),
+    );
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <SidebarProviderUsageCard />
+      </AppAtomRegistryProvider>,
+    );
+
+    await expect
+      .element(page.getByText("Usage telemetry has not been reported yet."))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText("Claude usage telemetry is temporarily unavailable."))
+      .toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx
@@ -1,0 +1,245 @@
+import { PROVIDER_DISPLAY_NAMES, type ProviderKind, type ServerProvider } from "@t3tools/contracts";
+
+import {
+  formatProviderUsagePercent,
+  formatProviderUsageResetAt,
+  selectPrimaryProviderUsageWindow,
+  shortProviderPlanLabel,
+} from "~/lib/providerUsage";
+import { cn } from "~/lib/utils";
+import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
+import { useServerProviders } from "../../rpc/serverState";
+
+const SIDEBAR_PROVIDER_ORDER: readonly ProviderKind[] = ["codex", "claudeAgent"];
+
+function progressToneClasses(provider: ServerProvider): string {
+  const primaryWindow = selectPrimaryProviderUsageWindow(provider);
+  const usageState = provider.usage?.state;
+
+  if (usageState === "syncing") {
+    return "bg-sky-500/65";
+  }
+
+  switch (primaryWindow?.level) {
+    case "warning":
+      return "bg-amber-500";
+    case "critical":
+    case "exhausted":
+      return "bg-red-500";
+    default:
+      return "bg-emerald-500";
+  }
+}
+
+function barWidth(provider: ServerProvider): string {
+  const usageState = provider.usage?.state;
+  const primaryWindow = selectPrimaryProviderUsageWindow(provider);
+  if (typeof primaryWindow?.percentUsed === "number") {
+    return `${Math.max(4, Math.min(primaryWindow.percentUsed, 100))}%`;
+  }
+  if (usageState === "syncing") {
+    return "35%";
+  }
+  return "0%";
+}
+
+function summaryLabel(provider: ServerProvider): string {
+  const usage = provider.usage;
+  const primaryWindow = selectPrimaryProviderUsageWindow(provider);
+
+  if (!usage) {
+    return "No data";
+  }
+
+  if (!primaryWindow) {
+    if (usage.state === "syncing") {
+      return "Syncing";
+    }
+    if (usage.state === "unavailable") {
+      return "Unavailable";
+    }
+    return "Usage";
+  }
+
+  const percent = formatProviderUsagePercent(primaryWindow.percentUsed) ?? "--";
+  return `${primaryWindow.label} ${percent}`;
+}
+
+function detailLabel(provider: ServerProvider): string {
+  const usage = provider.usage;
+  const primaryWindow = selectPrimaryProviderUsageWindow(provider);
+  if (!usage) {
+    return "Usage telemetry has not been reported yet.";
+  }
+  if (!primaryWindow) {
+    if (usage.state === "syncing") {
+      return "Refreshing the latest account limits.";
+    }
+    if (usage.state === "unavailable") {
+      return usage.message ?? "Limit telemetry is currently unavailable.";
+    }
+    return usage.message ?? "Usage telemetry is available.";
+  }
+
+  const resetsIn = formatProviderUsageResetAt(primaryWindow.resetsAt);
+  if (resetsIn) {
+    return `Resets in ${resetsIn}`;
+  }
+  return usage.message ?? "Latest account usage snapshot.";
+}
+
+function ProviderUsageDetails(props: { provider: ServerProvider }) {
+  const { provider } = props;
+  const usage = provider.usage;
+  const providerLabel =
+    provider.auth.label ?? PROVIDER_DISPLAY_NAMES[provider.provider] ?? provider.provider;
+
+  if (!usage) {
+    return (
+      <div className="space-y-1.5">
+        <div className="text-sm font-medium text-foreground">{providerLabel}</div>
+        <div className="text-xs text-muted-foreground">
+          Usage telemetry has not been reported yet for this provider.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 leading-tight">
+      <div className="space-y-0.5">
+        <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+          Usage limits
+        </div>
+        <div className="text-sm font-medium text-foreground">{providerLabel}</div>
+      </div>
+
+      {usage.message ? <div className="text-xs text-muted-foreground">{usage.message}</div> : null}
+
+      {usage.state === "syncing" ? (
+        <div className="text-xs text-muted-foreground">Refreshing the latest account limits.</div>
+      ) : null}
+
+      {usage.state === "unavailable" && usage.windows.length === 0 ? (
+        <div className="text-xs text-muted-foreground">
+          Limit telemetry is currently unavailable for this provider session.
+        </div>
+      ) : null}
+
+      {usage.windows.length > 0 ? (
+        <div className="space-y-1.5">
+          {usage.windows.map((window) => {
+            const percent = formatProviderUsagePercent(window.percentUsed) ?? "--";
+            const resetsIn = formatProviderUsageResetAt(window.resetsAt);
+            return (
+              <div key={window.id} className="flex items-center justify-between gap-3 text-xs">
+                <div className="min-w-0">
+                  <div className="font-medium text-foreground">{window.label}</div>
+                  {resetsIn ? (
+                    <div className="text-muted-foreground">Resets in {resetsIn}</div>
+                  ) : null}
+                </div>
+                <div
+                  className={cn(
+                    "shrink-0 rounded-full px-2 py-0.5 font-medium",
+                    window.level === "warning" &&
+                      "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+                    (window.level === "critical" || window.level === "exhausted") &&
+                      "bg-red-500/10 text-red-700 dark:text-red-300",
+                    window.level === "normal" && "bg-muted text-foreground",
+                  )}
+                >
+                  {percent}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SidebarProviderUsageRow(props: { provider: ServerProvider }) {
+  const { provider } = props;
+  const providerName = PROVIDER_DISPLAY_NAMES[provider.provider] ?? provider.provider;
+  const compactPlanLabel = shortProviderPlanLabel(provider);
+  const usage = provider.usage;
+  const summary = summaryLabel(provider);
+  const detail = detailLabel(provider);
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        openOnHover
+        delay={150}
+        closeDelay={0}
+        render={
+          <button
+            type="button"
+            className="w-full rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent/60"
+            aria-label={`${providerName} limits ${summary}`.trim()}
+          >
+            <div className="flex items-center justify-between gap-2 text-[11px]">
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <span className="truncate font-medium text-foreground">{providerName}</span>
+                  {compactPlanLabel ? (
+                    <span className="truncate text-muted-foreground/75">{compactPlanLabel}</span>
+                  ) : null}
+                </div>
+              </div>
+              <span className="shrink-0 text-muted-foreground">{summary}</span>
+            </div>
+            <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-sidebar-border/80">
+              <div
+                className={cn(
+                  "h-full rounded-full transition-[width] duration-300",
+                  progressToneClasses(provider),
+                  usage?.state === "syncing" && "animate-pulse",
+                )}
+                style={{ width: barWidth(provider) }}
+              />
+            </div>
+            <div className="mt-1 truncate text-[11px] text-muted-foreground/80">{detail}</div>
+          </button>
+        }
+      />
+      <PopoverPopup
+        tooltipStyle
+        side="right"
+        align="end"
+        className="w-72 max-w-[calc(100vw-2rem)] px-3 py-2"
+      >
+        <ProviderUsageDetails provider={provider} />
+      </PopoverPopup>
+    </Popover>
+  );
+}
+
+export function SidebarProviderUsageCard() {
+  const providers = useServerProviders();
+  const usageProviders = SIDEBAR_PROVIDER_ORDER.flatMap((providerKind) => {
+    const provider = providers.find((candidate) => candidate.provider === providerKind);
+    return provider ? [provider] : [];
+  });
+
+  if (usageProviders.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="group-data-[collapsible=icon]:hidden">
+      <div className="rounded-xl border border-sidebar-border/70 bg-sidebar-accent/25 p-1.5">
+        <div className="px-2 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+          Usage limits
+        </div>
+        <div className="space-y-1">
+          {usageProviders.map((provider) => (
+            <SidebarProviderUsageRow key={provider.provider} provider={provider} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx
@@ -1,26 +1,31 @@
 import { PROVIDER_DISPLAY_NAMES, type ProviderKind, type ServerProvider } from "@t3tools/contracts";
+import { LoaderIcon, RefreshCwIcon } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
 
+import { ensureLocalApi } from "~/localApi";
 import {
   formatProviderUsagePercent,
   formatProviderUsageResetAt,
-  selectPrimaryProviderUsageWindow,
+  orderProviderUsageWindows,
   shortProviderPlanLabel,
 } from "~/lib/providerUsage";
 import { cn } from "~/lib/utils";
-import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 import { useServerProviders } from "../../rpc/serverState";
+import { Button } from "../ui/button";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 const SIDEBAR_PROVIDER_ORDER: readonly ProviderKind[] = ["codex", "claudeAgent"];
+type ProviderUsageState = NonNullable<ServerProvider["usage"]>["state"];
 
-function progressToneClasses(provider: ServerProvider): string {
-  const primaryWindow = selectPrimaryProviderUsageWindow(provider);
-  const usageState = provider.usage?.state;
-
+function windowToneClasses(
+  window: NonNullable<ServerProvider["usage"]>["windows"][number],
+  usageState: ProviderUsageState,
+): string {
   if (usageState === "syncing") {
     return "bg-sky-500/65";
   }
 
-  switch (primaryWindow?.level) {
+  switch (window.level) {
     case "warning":
       return "bg-amber-500";
     case "critical":
@@ -31,131 +36,77 @@ function progressToneClasses(provider: ServerProvider): string {
   }
 }
 
-function barWidth(provider: ServerProvider): string {
-  const usageState = provider.usage?.state;
-  const primaryWindow = selectPrimaryProviderUsageWindow(provider);
-  if (typeof primaryWindow?.percentUsed === "number") {
-    return `${Math.max(4, Math.min(primaryWindow.percentUsed, 100))}%`;
+function windowBarWidth(
+  window: NonNullable<ServerProvider["usage"]>["windows"][number],
+  usageState: ProviderUsageState,
+): string {
+  if (typeof window.percentUsed === "number") {
+    return `${Math.max(4, Math.min(window.percentUsed, 100))}%`;
   }
+
   if (usageState === "syncing") {
     return "35%";
   }
+
   return "0%";
 }
 
-function summaryLabel(provider: ServerProvider): string {
+function providerStatusMessage(provider: ServerProvider): string | null {
   const usage = provider.usage;
-  const primaryWindow = selectPrimaryProviderUsageWindow(provider);
-
-  if (!usage) {
-    return "No data";
-  }
-
-  if (!primaryWindow) {
-    if (usage.state === "syncing") {
-      return "Syncing";
-    }
-    if (usage.state === "unavailable") {
-      return "Unavailable";
-    }
-    return "Usage";
-  }
-
-  const percent = formatProviderUsagePercent(primaryWindow.percentUsed) ?? "--";
-  return `${primaryWindow.label} ${percent}`;
-}
-
-function detailLabel(provider: ServerProvider): string {
-  const usage = provider.usage;
-  const primaryWindow = selectPrimaryProviderUsageWindow(provider);
   if (!usage) {
     return "Usage telemetry has not been reported yet.";
   }
-  if (!primaryWindow) {
-    if (usage.state === "syncing") {
-      return "Refreshing the latest account limits.";
-    }
-    if (usage.state === "unavailable") {
-      return usage.message ?? "Limit telemetry is currently unavailable.";
-    }
-    return usage.message ?? "Usage telemetry is available.";
+
+  if (usage.state === "syncing") {
+    return usage.message ?? "Refreshing the latest account limits.";
   }
 
-  const resetsIn = formatProviderUsageResetAt(primaryWindow.resetsAt);
-  if (resetsIn) {
-    return `Resets in ${resetsIn}`;
+  if (usage.state === "unavailable") {
+    return usage.message ?? "Limit telemetry is currently unavailable.";
   }
-  return usage.message ?? "Latest account usage snapshot.";
+
+  return usage.message ?? null;
 }
 
-function ProviderUsageDetails(props: { provider: ServerProvider }) {
-  const { provider } = props;
-  const usage = provider.usage;
-  const providerLabel =
-    provider.auth.label ?? PROVIDER_DISPLAY_NAMES[provider.provider] ?? provider.provider;
-
-  if (!usage) {
-    return (
-      <div className="space-y-1.5">
-        <div className="text-sm font-medium text-foreground">{providerLabel}</div>
-        <div className="text-xs text-muted-foreground">
-          Usage telemetry has not been reported yet for this provider.
-        </div>
-      </div>
-    );
-  }
+function ProviderUsageWindowRow(props: {
+  provider: ServerProvider;
+  usageState: NonNullable<ServerProvider["usage"]>["state"];
+  window: NonNullable<ServerProvider["usage"]>["windows"][number];
+}) {
+  const { provider, usageState, window } = props;
+  const percent = formatProviderUsagePercent(window.percentUsed) ?? "--";
+  const resetsIn = formatProviderUsageResetAt(window.resetsAt);
 
   return (
-    <div className="space-y-2 leading-tight">
-      <div className="space-y-0.5">
-        <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-          Usage limits
+    <div
+      className="space-y-1"
+      data-provider-usage-window={window.id}
+      aria-label={`${PROVIDER_DISPLAY_NAMES[provider.provider] ?? provider.provider} ${window.label} ${percent}`}
+    >
+      <div className="flex items-center justify-between gap-2 text-[11px] leading-none">
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span
+            className="shrink-0 font-medium text-foreground/90"
+            data-provider-usage-window-label
+          >
+            {window.label}
+          </span>
+          {resetsIn ? (
+            <span className="truncate text-muted-foreground/75">Resets in {resetsIn}</span>
+          ) : null}
         </div>
-        <div className="text-sm font-medium text-foreground">{providerLabel}</div>
+        <span className="shrink-0 text-muted-foreground">{percent}</span>
       </div>
-
-      {usage.message ? <div className="text-xs text-muted-foreground">{usage.message}</div> : null}
-
-      {usage.state === "syncing" ? (
-        <div className="text-xs text-muted-foreground">Refreshing the latest account limits.</div>
-      ) : null}
-
-      {usage.state === "unavailable" && usage.windows.length === 0 ? (
-        <div className="text-xs text-muted-foreground">
-          Limit telemetry is currently unavailable for this provider session.
-        </div>
-      ) : null}
-
-      {usage.windows.length > 0 ? (
-        <div className="space-y-1.5">
-          {usage.windows.map((window) => {
-            const percent = formatProviderUsagePercent(window.percentUsed) ?? "--";
-            const resetsIn = formatProviderUsageResetAt(window.resetsAt);
-            return (
-              <div key={window.id} className="flex items-center justify-between gap-3 text-xs">
-                <div className="min-w-0">
-                  <div className="font-medium text-foreground">{window.label}</div>
-                  {resetsIn ? (
-                    <div className="text-muted-foreground">Resets in {resetsIn}</div>
-                  ) : null}
-                </div>
-                <div
-                  className={cn(
-                    "shrink-0 rounded-full px-2 py-0.5 font-medium",
-                    window.level === "warning" &&
-                      "bg-amber-500/10 text-amber-700 dark:text-amber-300",
-                    (window.level === "critical" || window.level === "exhausted") &&
-                      "bg-red-500/10 text-red-700 dark:text-red-300",
-                    window.level === "normal" && "bg-muted text-foreground",
-                  )}
-                >
-                  {percent}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
+      <div className="h-1 overflow-hidden rounded-full bg-sidebar-border/80">
+        <div
+          className={cn(
+            "h-full rounded-full transition-[width] duration-300",
+            windowToneClasses(window, usageState),
+            usageState === "syncing" && "animate-pulse",
+          )}
+          style={{ width: windowBarWidth(window, usageState) }}
+        />
+      </div>
     </div>
   );
 }
@@ -165,80 +116,105 @@ function SidebarProviderUsageRow(props: { provider: ServerProvider }) {
   const providerName = PROVIDER_DISPLAY_NAMES[provider.provider] ?? provider.provider;
   const compactPlanLabel = shortProviderPlanLabel(provider);
   const usage = provider.usage;
-  const summary = summaryLabel(provider);
-  const detail = detailLabel(provider);
+  const orderedWindows = usage ? orderProviderUsageWindows(usage.windows) : [];
+  const statusMessage = providerStatusMessage(provider);
 
   return (
-    <Popover>
-      <PopoverTrigger
-        openOnHover
-        delay={150}
-        closeDelay={0}
-        render={
-          <button
-            type="button"
-            className="w-full rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent/60"
-            aria-label={`${providerName} limits ${summary}`.trim()}
-          >
-            <div className="flex items-center justify-between gap-2 text-[11px]">
-              <div className="min-w-0">
-                <div className="flex items-center gap-1.5">
-                  <span className="truncate font-medium text-foreground">{providerName}</span>
-                  {compactPlanLabel ? (
-                    <span className="truncate text-muted-foreground/75">{compactPlanLabel}</span>
-                  ) : null}
-                </div>
-              </div>
-              <span className="shrink-0 text-muted-foreground">{summary}</span>
-            </div>
-            <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-sidebar-border/80">
-              <div
-                className={cn(
-                  "h-full rounded-full transition-[width] duration-300",
-                  progressToneClasses(provider),
-                  usage?.state === "syncing" && "animate-pulse",
-                )}
-                style={{ width: barWidth(provider) }}
-              />
-            </div>
-            <div className="mt-1 truncate text-[11px] text-muted-foreground/80">{detail}</div>
-          </button>
-        }
-      />
-      <PopoverPopup
-        tooltipStyle
-        side="right"
-        align="end"
-        className="w-72 max-w-[calc(100vw-2rem)] px-3 py-2"
-      >
-        <ProviderUsageDetails provider={provider} />
-      </PopoverPopup>
-    </Popover>
+    <section className="space-y-1.5 py-2" data-provider-usage={provider.provider}>
+      <div className="flex items-center gap-1.5 px-1 text-[11px] leading-none">
+        <span className="font-medium text-foreground">{providerName}</span>
+        {compactPlanLabel ? (
+          <span className="truncate text-muted-foreground/75">{compactPlanLabel}</span>
+        ) : null}
+      </div>
+
+      {statusMessage ? (
+        <div className="px-1 text-[11px] text-muted-foreground">{statusMessage}</div>
+      ) : null}
+
+      {orderedWindows.length > 0 ? (
+        <div className="space-y-1.5 px-1">
+          {orderedWindows.map((window) => (
+            <ProviderUsageWindowRow
+              key={window.id}
+              provider={provider}
+              usageState={usage?.state ?? "available"}
+              window={window}
+            />
+          ))}
+        </div>
+      ) : null}
+    </section>
   );
 }
 
 export function SidebarProviderUsageCard() {
+  const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
+  const refreshingRef = useRef(false);
   const providers = useServerProviders();
   const usageProviders = SIDEBAR_PROVIDER_ORDER.flatMap((providerKind) => {
     const provider = providers.find((candidate) => candidate.provider === providerKind);
     return provider ? [provider] : [];
   });
 
+  const refreshProviders = useCallback(() => {
+    if (refreshingRef.current) {
+      return;
+    }
+
+    refreshingRef.current = true;
+    setIsRefreshingProviders(true);
+    void ensureLocalApi()
+      .server.refreshProviders()
+      .catch((error: unknown) => {
+        console.warn("Failed to refresh provider usage", error);
+      })
+      .finally(() => {
+        refreshingRef.current = false;
+        setIsRefreshingProviders(false);
+      });
+  }, []);
+
   if (usageProviders.length === 0) {
     return null;
   }
 
   return (
-    <div className="group-data-[collapsible=icon]:hidden">
-      <div className="rounded-xl border border-sidebar-border/70 bg-sidebar-accent/25 p-1.5">
-        <div className="px-2 pb-1 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+    <div className="group-data-[collapsible=icon]:hidden px-2 pb-1">
+      <div className="flex items-center justify-between gap-2 px-1 pb-1">
+        <div className="text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
           Usage limits
         </div>
-        <div className="space-y-1">
-          {usageProviders.map((provider) => (
-            <SidebarProviderUsageRow key={provider.provider} provider={provider} />
-          ))}
-        </div>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                size="icon-xs"
+                variant="ghost"
+                className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                disabled={isRefreshingProviders}
+                onClick={() => void refreshProviders()}
+                aria-label={
+                  isRefreshingProviders ? "Refreshing usage limits" : "Refresh usage limits"
+                }
+              >
+                {isRefreshingProviders ? (
+                  <LoaderIcon className="size-3 animate-spin" />
+                ) : (
+                  <RefreshCwIcon className="size-3" />
+                )}
+              </Button>
+            }
+          />
+          <TooltipPopup side="top">
+            {isRefreshingProviders ? "Refreshing usage limits" : "Refresh usage limits"}
+          </TooltipPopup>
+        </Tooltip>
+      </div>
+      <div className="divide-y divide-sidebar-border/60">
+        {usageProviders.map((provider) => (
+          <SidebarProviderUsageRow key={provider.provider} provider={provider} />
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/lib/providerUsage.test.ts
+++ b/apps/web/src/lib/providerUsage.test.ts
@@ -4,6 +4,7 @@ import type { ServerProvider } from "@t3tools/contracts";
 import {
   formatProviderUsagePercent,
   formatProviderUsageResetAt,
+  orderProviderUsageWindows,
   selectPrimaryProviderUsageWindow,
   shortProviderPlanLabel,
 } from "./providerUsage";
@@ -74,5 +75,36 @@ describe("providerUsage", () => {
     expect(formatProviderUsageResetAt("2026-04-17T01:30:00.000Z")).toBe("1h 30m");
 
     vi.useRealTimers();
+  });
+
+  it("orders sidebar usage windows with 5h first and 7d second", () => {
+    const ordered = orderProviderUsageWindows([
+      {
+        id: "monthly",
+        label: "Monthly",
+        percentUsed: 12,
+        resetsAt: null,
+        level: "normal",
+        exhausted: false,
+      },
+      {
+        id: "secondary",
+        label: "7d",
+        percentUsed: 84,
+        resetsAt: null,
+        level: "warning",
+        exhausted: false,
+      },
+      {
+        id: "primary",
+        label: "5h",
+        percentUsed: 41,
+        resetsAt: null,
+        level: "normal",
+        exhausted: false,
+      },
+    ]);
+
+    expect(ordered.map((window) => window.label)).toEqual(["5h", "7d", "Monthly"]);
   });
 });

--- a/apps/web/src/lib/providerUsage.test.ts
+++ b/apps/web/src/lib/providerUsage.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ServerProvider } from "@t3tools/contracts";
+
+import {
+  formatProviderUsagePercent,
+  formatProviderUsageResetAt,
+  selectPrimaryProviderUsageWindow,
+  shortProviderPlanLabel,
+} from "./providerUsage";
+
+function makeProvider(overrides?: Partial<ServerProvider>): ServerProvider {
+  return {
+    provider: "codex",
+    enabled: true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: { status: "authenticated", label: "ChatGPT Pro Subscription" },
+    checkedAt: "2026-04-17T00:00:00.000Z",
+    models: [],
+    slashCommands: [],
+    skills: [],
+    ...overrides,
+  };
+}
+
+describe("providerUsage", () => {
+  it("chooses the highest-usage window for compact display", () => {
+    const provider = makeProvider({
+      usage: {
+        state: "available",
+        checkedAt: "2026-04-17T00:05:00.000Z",
+        windows: [
+          {
+            id: "5h",
+            label: "5h",
+            percentUsed: 41,
+            resetsAt: null,
+            level: "normal",
+            exhausted: false,
+          },
+          {
+            id: "7d",
+            label: "7d",
+            percentUsed: 84,
+            resetsAt: null,
+            level: "warning",
+            exhausted: false,
+          },
+        ],
+      },
+    });
+
+    expect(selectPrimaryProviderUsageWindow(provider)?.id).toBe("7d");
+  });
+
+  it("shortens provider plan labels for compact HUD chips", () => {
+    expect(shortProviderPlanLabel(makeProvider())).toBe("Pro");
+    expect(
+      shortProviderPlanLabel(
+        makeProvider({
+          auth: { status: "authenticated", label: "Claude Max Subscription" },
+        }),
+      ),
+    ).toBe("Max");
+  });
+
+  it("formats percentages and reset timers for hover details", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-17T00:00:00.000Z"));
+
+    expect(formatProviderUsagePercent(9.4)).toBe("9.4%");
+    expect(formatProviderUsagePercent(42)).toBe("42%");
+    expect(formatProviderUsageResetAt("2026-04-17T01:30:00.000Z")).toBe("1h 30m");
+
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/lib/providerUsage.ts
+++ b/apps/web/src/lib/providerUsage.ts
@@ -1,5 +1,45 @@
 import type { ServerProvider, ServerProviderUsageWindow } from "@t3tools/contracts";
 
+const FIVE_HOUR_WINDOW_KEYS = new Set(["5h", "5-hour", "five-hour", "fivehour"]);
+const SEVEN_DAY_WINDOW_KEYS = new Set(["7d", "7-day", "seven-day", "sevenday"]);
+
+function normalizeWindowKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function canonicalWindowOrder(window: ServerProviderUsageWindow): number {
+  const keys = [window.id, window.label].map(normalizeWindowKey);
+
+  if (keys.some((key) => FIVE_HOUR_WINDOW_KEYS.has(key))) {
+    return 0;
+  }
+
+  if (keys.some((key) => SEVEN_DAY_WINDOW_KEYS.has(key))) {
+    return 1;
+  }
+
+  return 2;
+}
+
+export function orderProviderUsageWindows(
+  windows: ReadonlyArray<ServerProviderUsageWindow>,
+): ServerProviderUsageWindow[] {
+  return windows
+    .map((window, index) => ({ window, index }))
+    .toSorted((left, right) => {
+      const rankDifference = canonicalWindowOrder(left.window) - canonicalWindowOrder(right.window);
+      if (rankDifference !== 0) {
+        return rankDifference;
+      }
+      return left.index - right.index;
+    })
+    .map(({ window }) => window);
+}
+
 export function selectPrimaryProviderUsageWindow(
   provider: Pick<ServerProvider, "usage">,
 ): ServerProviderUsageWindow | null {

--- a/apps/web/src/lib/providerUsage.ts
+++ b/apps/web/src/lib/providerUsage.ts
@@ -1,0 +1,75 @@
+import type { ServerProvider, ServerProviderUsageWindow } from "@t3tools/contracts";
+
+export function selectPrimaryProviderUsageWindow(
+  provider: Pick<ServerProvider, "usage">,
+): ServerProviderUsageWindow | null {
+  const windows = provider.usage?.windows ?? [];
+  if (windows.length === 0) {
+    return null;
+  }
+
+  const ranked = windows.toSorted((left, right) => {
+    const leftPercent = left.percentUsed ?? -1;
+    const rightPercent = right.percentUsed ?? -1;
+    return rightPercent - leftPercent;
+  });
+
+  return ranked[0] ?? null;
+}
+
+export function shortProviderPlanLabel(provider: Pick<ServerProvider, "auth">): string | null {
+  const label = provider.auth.label?.trim();
+  if (!label) {
+    return null;
+  }
+
+  return label
+    .replace(/^ChatGPT\s+/i, "")
+    .replace(/^Claude\s+/i, "")
+    .replace(/\s+Subscription$/i, "")
+    .trim();
+}
+
+export function formatProviderUsagePercent(value: number | null): string | null {
+  if (value === null || !Number.isFinite(value)) {
+    return null;
+  }
+  if (value < 10) {
+    return `${value.toFixed(1).replace(/\.0$/, "")}%`;
+  }
+  return `${Math.round(value)}%`;
+}
+
+export function formatProviderUsageResetAt(
+  value: string | null,
+  now: Date = new Date(),
+): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const resetAt = new Date(value);
+  if (Number.isNaN(resetAt.getTime())) {
+    return null;
+  }
+
+  const diffMs = resetAt.getTime() - now.getTime();
+  if (diffMs <= 0) {
+    return null;
+  }
+
+  const diffMins = Math.ceil(diffMs / 60_000);
+  if (diffMins < 60) {
+    return `${diffMins}m`;
+  }
+
+  const hours = Math.floor(diffMins / 60);
+  const minutes = diffMins % 60;
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const remainingHours = hours % 24;
+    return remainingHours > 0 ? `${days}d ${remainingHours}h` : `${days}d`;
+  }
+
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -182,6 +182,7 @@
     },
   },
   "trustedDependencies": [
+    "electron",
     "node-pty",
   ],
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     ]
   },
   "trustedDependencies": [
-    "node-pty"
+    "node-pty",
+    "electron"
   ]
 }

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -22,5 +22,46 @@ describe("ServerProvider", () => {
 
     expect(parsed.slashCommands).toEqual([]);
     expect(parsed.skills).toEqual([]);
+    expect(parsed.usage).toBeUndefined();
+  });
+
+  it("decodes provider usage windows with defaults", () => {
+    const parsed = decodeServerProvider({
+      provider: "codex",
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: {
+        status: "authenticated",
+      },
+      checkedAt: "2026-04-10T00:00:00.000Z",
+      models: [],
+      usage: {
+        state: "available",
+        checkedAt: "2026-04-10T00:05:00.000Z",
+        windows: [
+          {
+            id: "5h",
+            label: "5h",
+          },
+        ],
+      },
+    });
+
+    expect(parsed.usage).toEqual({
+      state: "available",
+      checkedAt: "2026-04-10T00:05:00.000Z",
+      windows: [
+        {
+          id: "5h",
+          label: "5h",
+          percentUsed: null,
+          resetsAt: null,
+          level: "normal",
+          exhausted: false,
+        },
+      ],
+    });
   });
 });

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -81,6 +81,37 @@ export const ServerProviderSkill = Schema.Struct({
 });
 export type ServerProviderSkill = typeof ServerProviderSkill.Type;
 
+export const ServerProviderUsageState = Schema.Literals(["available", "syncing", "unavailable"]);
+export type ServerProviderUsageState = typeof ServerProviderUsageState.Type;
+
+export const ServerProviderUsageLevel = Schema.Literals([
+  "normal",
+  "warning",
+  "critical",
+  "exhausted",
+]);
+export type ServerProviderUsageLevel = typeof ServerProviderUsageLevel.Type;
+
+export const ServerProviderUsageWindow = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  label: TrimmedNonEmptyString,
+  percentUsed: Schema.NullOr(Schema.Number).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
+  resetsAt: Schema.NullOr(IsoDateTime).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
+  level: ServerProviderUsageLevel.pipe(Schema.withDecodingDefault(Effect.succeed("normal"))),
+  exhausted: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+});
+export type ServerProviderUsageWindow = typeof ServerProviderUsageWindow.Type;
+
+export const ServerProviderUsage = Schema.Struct({
+  state: ServerProviderUsageState,
+  checkedAt: IsoDateTime,
+  windows: Schema.Array(ServerProviderUsageWindow).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
+  message: Schema.optional(TrimmedNonEmptyString),
+});
+export type ServerProviderUsage = typeof ServerProviderUsage.Type;
+
 export const ServerProvider = Schema.Struct({
   provider: ProviderKind,
   enabled: Schema.Boolean,
@@ -95,6 +126,7 @@ export const ServerProvider = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed([])),
   ),
   skills: Schema.Array(ServerProviderSkill).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  usage: Schema.optional(ServerProviderUsage),
 });
 export type ServerProvider = typeof ServerProvider.Type;
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new provider usage telemetry (including an external Claude OAuth API call and local Codex log parsing) and wires it into the provider registry/UI; changes affect runtime snapshot state and caching but are scoped to usage display/refresh paths.
> 
> **Overview**
> **Provider snapshots now optionally include usage/limit telemetry.** Contracts add `ServerProvider.usage` with normalized windows/states, `buildServerProvider`/cache hydration persist it, and both `CodexProvider`/`ClaudeProvider` conditionally attach usage when authenticated (excluding API-key auth).
> 
> **Usage data sources and live updates were added.** Codex usage is derived from the latest `rollout-*.jsonl` token-count rate-limit event, while Claude usage is fetched from Anthropic’s OAuth usage endpoint with on-disk caching and rate-limit backoff; `ProviderRegistry` now listens to `ProviderService.streamEvents` to merge runtime `account.updated` / `account.rate-limits.updated` events into existing provider snapshots.
> 
> **UI: new sidebar card for usage limits.** `SidebarProviderUsageCard` displays per-provider windows (ordered with 5h/7d first), shows syncing/unavailable states, and provides a button that triggers `server.refreshProviders()`; tests were added for server normalization/merging and the new sidebar behavior. Also updates dev docs (`bun install`) and adds `electron` as a trusted dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b208e62f1e9bcc158841e9eae633919ce2aa2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider usage display to sidebar for Codex and Claude accounts
> - Introduces a `SidebarProviderUsageCard` in the sidebar footer showing usage windows (5h and 7d limits), progress bars, reset timers, and a manual refresh button for Codex and Claude providers.
> - Adds `resolveCodexUsageSnapshot` (from rollout session logs) and `resolveClaudeUsageSnapshot` (via Claude OAuth API with caching and rate-limit fallback) to populate usage data on provider snapshots.
> - Extends `ProviderRegistry` to subscribe to `ProviderService.streamEvents` and merge `account.updated` and `account.rate-limits.updated` runtime events into provider snapshots in near-real-time.
> - Adds `ServerProviderUsage` schemas to the contracts package with sensible defaults, and threads the optional `usage` field through provider snapshot building and cache hydration.
> - Behavioral Change: Codex and Claude providers authenticated via OAuth (not API key) will now fetch and cache usage data; Claude usage fetches hit the Anthropic API with a TTL cache and degrade gracefully on rate limits by serving last-known values.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c2b208e. 15 files reviewed, 7 issues evaluated, 2 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 43](https://github.com/pingdotgg/t3code/blob/c2b208e62f1e9bcc158841e9eae633919ce2aa2f/apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx#L43): In `windowBarWidth`, the check `typeof window.percentUsed === "number"` returns true for `NaN`, causing the function to return `"NaN%"` (an invalid CSS width). The related function `formatProviderUsagePercent` in `providerUsage.ts` guards against non-finite values using `Number.isFinite(value)`, suggesting NaN is a realistic data concern. The check should be `typeof window.percentUsed === "number" && Number.isFinite(window.percentUsed)`. <b>[ Failed validation ]</b>
> - [line 167](https://github.com/pingdotgg/t3code/blob/c2b208e62f1e9bcc158841e9eae633919ce2aa2f/apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx#L167): If `ensureLocalApi()` throws synchronously (when local API is not found), the exception is not caught by the `.catch()` handler since the promise chain never starts. This leaves `refreshingRef.current = true` permanently (blocking future refresh attempts) and `isRefreshingProviders = true` (stuck loading state), and the error propagates uncaught. The `.catch()` only handles promise rejections, not synchronous throws before the promise is created. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->