### PR TITLE
fix(server): handle OpenCode text response format in commit message g…

### DIFF
--- a/apps/server/src/git/Layers/CursorTextGeneration.ts
+++ b/apps/server/src/git/Layers/CursorTextGeneration.ts
@@ -16,7 +16,12 @@ import {
   buildPrContentPrompt,
   buildThreadTitlePrompt,
 } from "../Prompts.ts";
-import { sanitizeCommitSubject, sanitizePrTitle, sanitizeThreadTitle } from "../Utils.ts";
+import {
+  extractJsonObject,
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "../Utils.ts";
 import {
   applyCursorAcpModelSelection,
   makeCursorAcpRuntime,
@@ -24,54 +29,6 @@ import {
 import { ServerSettingsService } from "../../serverSettings.ts";
 
 const CURSOR_TIMEOUT_MS = 180_000;
-
-function extractJsonObject(raw: string): string {
-  const trimmed = raw.trim();
-  if (trimmed.length === 0) {
-    return trimmed;
-  }
-
-  const start = trimmed.indexOf("{");
-  if (start < 0) {
-    return trimmed;
-  }
-
-  let depth = 0;
-  let inString = false;
-  let escaping = false;
-  for (let index = start; index < trimmed.length; index += 1) {
-    const char = trimmed[index];
-    if (inString) {
-      if (escaping) {
-        escaping = false;
-      } else if (char === "\\") {
-        escaping = true;
-      } else if (char === '"') {
-        inString = false;
-      }
-      continue;
-    }
-
-    if (char === '"') {
-      inString = true;
-      continue;
-    }
-
-    if (char === "{") {
-      depth += 1;
-      continue;
-    }
-
-    if (char === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return trimmed.slice(start, index + 1);
-      }
-    }
-  }
-
-  return trimmed.slice(start);
-}
 
 function mapCursorAcpError(
   operation:

--- a/apps/server/src/git/Layers/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/git/Layers/OpenCodeTextGeneration.test.ts
@@ -17,7 +17,9 @@ const runtimeMock = vi.hoisted(() => {
     promptUrls: [] as string[],
     authHeaders: [] as Array<string | null>,
     closeCalls: [] as string[],
-    promptResult: undefined as { data?: { info?: { structured?: unknown } } } | undefined,
+    promptResult: undefined as
+      | { data?: { info?: { error?: unknown }; parts?: Array<{ type: string; text?: string }> } }
+      | undefined,
   };
 
   return {
@@ -63,12 +65,15 @@ vi.mock("../../provider/opencodeRuntime.ts", async () => {
             return (
               runtimeMock.state.promptResult ?? {
                 data: {
-                  info: {
-                    structured: {
-                      subject: "Improve OpenCode reuse",
-                      body: "Reuse one server for the full action.",
+                  parts: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        subject: "Improve OpenCode reuse",
+                        body: "Reuse one server for the full action.",
+                      }),
                     },
-                  },
+                  ],
                 },
               }
             );
@@ -198,7 +203,7 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGenerationLive", (it) => 
     }).pipe(Effect.provide(TestClock.layer())),
   );
 
-  it.effect("returns a typed missing-output error when OpenCode omits info.structured", () =>
+  it.effect("returns a typed empty-output error when OpenCode returns no text parts", () =>
     Effect.gen(function* () {
       runtimeMock.state.promptResult = { data: {} };
       const textGeneration = yield* TextGeneration;
@@ -213,7 +218,67 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGenerationLive", (it) => 
         })
         .pipe(Effect.flip);
 
-      expect(error.message).toContain("OpenCode returned no structured output.");
+      expect(error.message).toContain("OpenCode returned empty output.");
+    }),
+  );
+
+  it.effect("parses JSON returned as plain text output", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.promptResult = {
+        data: {
+          parts: [
+            {
+              type: "text",
+              text: 'Here is the result:\n{"subject":"Tighten OpenCode parsing","body":"Handle JSON text output locally."}',
+            },
+          ],
+        },
+      };
+      const textGeneration = yield* TextGeneration;
+
+      const result = yield* textGeneration.generateCommitMessage({
+        cwd: process.cwd(),
+        branch: "feature/opencode-reuse",
+        stagedSummary: "M README.md",
+        stagedPatch: "diff --git a/README.md b/README.md",
+        modelSelection: DEFAULT_TEST_MODEL_SELECTION,
+      });
+
+      expect(result).toEqual({
+        subject: "Tighten OpenCode parsing",
+        body: "Handle JSON text output locally.",
+      });
+    }),
+  );
+
+  it.effect("surfaces the upstream OpenCode structured-output error message", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.promptResult = {
+        data: {
+          info: {
+            error: {
+              name: "StructuredOutputError",
+              data: {
+                message: "Model did not produce structured output",
+                retries: 2,
+              },
+            },
+          },
+        },
+      };
+      const textGeneration = yield* TextGeneration;
+
+      const error = yield* textGeneration
+        .generateCommitMessage({
+          cwd: process.cwd(),
+          branch: "feature/opencode-reuse",
+          stagedSummary: "M README.md",
+          stagedPatch: "diff --git a/README.md b/README.md",
+          modelSelection: DEFAULT_TEST_MODEL_SELECTION,
+        })
+        .pipe(Effect.flip);
+
+      expect(error.message).toContain("Model did not produce structured output");
     }),
   );
 });

--- a/apps/server/src/git/Layers/OpenCodeTextGeneration.ts
+++ b/apps/server/src/git/Layers/OpenCodeTextGeneration.ts
@@ -19,10 +19,10 @@ import {
 } from "../Prompts.ts";
 import { type TextGenerationShape, TextGeneration } from "../Services/TextGeneration.ts";
 import {
+  extractJsonObject,
   sanitizeCommitSubject,
   sanitizePrTitle,
   sanitizeThreadTitle,
-  toJsonSchemaObject,
 } from "../Utils.ts";
 import {
   createOpenCodeSdkClient,
@@ -34,6 +34,49 @@ import {
 } from "../../provider/opencodeRuntime.ts";
 
 const OPENCODE_TEXT_GENERATION_IDLE_TTL_MS = 30_000;
+
+function getOpenCodePromptErrorMessage(error: unknown): string | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const message =
+    "data" in error &&
+    error.data &&
+    typeof error.data === "object" &&
+    "message" in error.data &&
+    typeof error.data.message === "string"
+      ? error.data.message.trim()
+      : "";
+  if (message.length > 0) {
+    return message;
+  }
+
+  if ("name" in error && typeof error.name === "string") {
+    const name = error.name.trim();
+    return name.length > 0 ? name : null;
+  }
+
+  return null;
+}
+
+function getOpenCodeTextResponse(parts: ReadonlyArray<unknown> | undefined): string {
+  return (parts ?? [])
+    .flatMap((part) => {
+      if (!part || typeof part !== "object") {
+        return [];
+      }
+      if (!("type" in part) || part.type !== "text") {
+        return [];
+      }
+      if (!("text" in part) || typeof part.text !== "string") {
+        return [];
+      }
+      return [part.text];
+    })
+    .join("")
+    .trim();
+}
 
 interface SharedOpenCodeTextGenerationServerState {
   server: OpenCodeServerProcess | null;
@@ -245,17 +288,18 @@ const makeOpenCodeTextGeneration = Effect.gen(function* () {
             ...(input.modelSelection.options?.variant
               ? { variant: input.modelSelection.options.variant }
               : {}),
-            format: {
-              type: "json_schema",
-              schema: toJsonSchemaObject(input.outputSchemaJson) as Record<string, unknown>,
-            },
             parts: [{ type: "text", text: input.prompt }, ...fileParts],
           });
-          const structured = result.data?.info?.structured;
-          if (structured === undefined) {
-            throw new Error("OpenCode returned no structured output.");
+          const info = result.data?.info;
+          const errorMessage = getOpenCodePromptErrorMessage(info?.error);
+          if (errorMessage) {
+            throw new Error(errorMessage);
           }
-          return structured;
+          const rawText = getOpenCodeTextResponse(result.data?.parts);
+          if (rawText.length === 0) {
+            throw new Error("OpenCode returned empty output.");
+          }
+          return rawText;
         },
         catch: (cause) =>
           new TextGenerationError({
@@ -266,7 +310,7 @@ const makeOpenCodeTextGeneration = Effect.gen(function* () {
           }),
       });
 
-    const structuredOutput =
+    const rawOutput =
       settings.serverUrl.length > 0
         ? yield* runAgainstServer({ url: settings.serverUrl })
         : yield* Effect.acquireUseRelease(
@@ -278,7 +322,9 @@ const makeOpenCodeTextGeneration = Effect.gen(function* () {
             releaseSharedServer,
           );
 
-    return yield* Schema.decodeUnknownEffect(input.outputSchemaJson)(structuredOutput).pipe(
+    return yield* Schema.decodeEffect(Schema.fromJsonString(input.outputSchemaJson))(
+      extractJsonObject(rawOutput),
+    ).pipe(
       Effect.catchTag("SchemaError", (cause) =>
         Effect.fail(
           new TextGenerationError({

--- a/apps/server/src/git/Utils.ts
+++ b/apps/server/src/git/Utils.ts
@@ -30,6 +30,54 @@ export function limitSection(value: string, maxChars: number): string {
   return `${truncated}\n\n[truncated]`;
 }
 
+export function extractJsonObject(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return trimmed;
+  }
+
+  const start = trimmed.indexOf("{");
+  if (start < 0) {
+    return trimmed;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaping = false;
+  for (let index = start; index < trimmed.length; index += 1) {
+    const char = trimmed[index];
+    if (inString) {
+      if (escaping) {
+        escaping = false;
+      } else if (char === "\\") {
+        escaping = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return trimmed.slice(start, index + 1);
+      }
+    }
+  }
+
+  return trimmed.slice(start);
+}
+
 /** Normalise a raw commit subject to imperative-mood, ≤72 chars, no trailing period. */
 export function sanitizeCommitSubject(raw: string): string {
   const singleLine = raw.trim().split(/\r?\n/g)[0]?.trim() ?? "";


### PR DESCRIPTION
## What Changed

- Updated the OpenCode git text-generation path to read JSON from text parts in the prompt response instead of requiring `info.structured`.
- Surface OpenCode's returned structured-output error message when the provider reports one, and keep failing fast on empty responses.
- Reused the existing JSON-object extraction logic from the Cursor implementation and moved it into `apps/server/src/git/Utils.ts` as shared logic so OpenCode and Cursor parse provider output the same way.
- Updated `apps/server/src/git/Layers/OpenCodeTextGeneration.test.ts` to cover the failing OpenCode response shapes: empty output, JSON returned inside plain text parts, and upstream structured-output errors.
- Tested both OpenCode and Cursor for git text generation to confirm the shared JSON extraction path still works for each provider.

## Why

OpenCode is currently returning the generated payload as plain text parts rather than populating `info.structured`, so the existing implementation treated valid responses as failures and broke commit message generation.

Parsing the returned text locally and decoding it against the existing schema keeps the validation path intact while matching the response shape OpenCode actually sends.

## UI Changes

### Before

<img width="407" height="148" alt="image" src="https://github.com/user-attachments/assets/e5174efa-ba42-4f34-97a4-d9cebe156dc2" />

### After

<img width="408" height="91" alt="image" src="https://github.com/user-attachments/assets/dfeb001a-979a-4c32-977c-9f7fef1d9694" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (not applicable)

Closes #2199

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenCode text response parsing in commit message generation
> - Removes the `json_schema` structured output format from OpenCode requests; instead reads raw text parts and extracts JSON locally using `extractJsonObject` from [Utils.ts](https://github.com/pingdotgg/t3code/pull/2202/files#diff-1ee616952fa622d2c71d75cb27872f6de2db838eec8e9f9b38b0fea34bf11b7a).
> - Adds `getOpenCodeTextResponse` to concatenate text parts into a single string, and `getOpenCodePromptErrorMessage` to surface upstream `info.error` details as thrown errors.
> - Throws a typed `'OpenCode returned empty output.'` error when no text parts are present, and maps `info.error` with `StructuredOutputError` to a readable message.
> - Moves `extractJsonObject` to [Utils.ts](https://github.com/pingdotgg/t3code/pull/2202/files#diff-1ee616952fa622d2c71d75cb27872f6de2db838eec8e9f9b38b0fea34bf11b7a) and shares it with [CursorTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/2202/files#diff-3d4564ebce0d6acfab1c1c06f09893d415f4c983f5326dfdadad90894e2a244f).
> - Behavioral Change: OpenCode prompts no longer request structured JSON output; JSON is parsed client-side from plain text responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a12331.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->