### PR TITLE
fix(web): match model label to active provider when a stale slug is selected (#1982)

### DIFF
--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -420,4 +420,49 @@ describe("ProviderModelPicker", () => {
       await mounted.cleanup();
     }
   });
+
+  it("falls back to the active provider's first model when props.model doesn't belong to it (#1982)", async () => {
+    // Repro: user disabled codex, provider switched to claudeAgent, but the thread
+    // still has a codex slug selected. Previously the trigger rendered the Claude
+    // icon with the raw codex slug as text ("Claude icon + GPT 5.4"). The active
+    // provider's option list does NOT include the codex slug (getCustomModelOptionsByProvider
+    // only adds the selectedModel to whatever provider matches the selectedProvider).
+    const host = document.createElement("div");
+    document.body.append(host);
+    const onProviderModelChange = vi.fn();
+    // Crafted options: claudeAgent has its normal models, no dangling codex slug.
+    const modelOptionsByProvider = {
+      claudeAgent: [
+        { slug: "claude-opus-4-6", name: "Claude Opus 4.6" },
+        { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+      ],
+      codex: [{ slug: "gpt-5-codex", name: "GPT-5 Codex" }],
+      cursor: [],
+      opencode: [],
+    } as const;
+    const screen = await render(
+      <ProviderModelPicker
+        provider="claudeAgent"
+        model="gpt-5-codex"
+        lockedProvider={null}
+        providers={TEST_PROVIDERS}
+        modelOptionsByProvider={modelOptionsByProvider}
+        onProviderModelChange={onProviderModelChange}
+      />,
+      { container: host },
+    );
+
+    try {
+      const button = document.querySelector("button");
+      if (!(button instanceof HTMLButtonElement)) {
+        throw new Error("Expected picker trigger button to be rendered.");
+      }
+      const label = button.textContent ?? "";
+      expect(label).not.toContain("gpt-5-codex");
+      expect(label).toContain("Claude Opus 4.6");
+    } finally {
+      await screen.unmount();
+      host.remove();
+    }
+  });
 });

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -64,8 +64,13 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const activeProvider = props.lockedProvider ?? props.provider;
   const selectedProviderOptions = props.modelOptionsByProvider[activeProvider];
+  // When props.model doesn't belong to activeProvider (e.g. codex was just disabled
+  // and the thread still has a codex slug selected), prefer the active provider's
+  // first model over the raw slug so the icon and the label always agree.
   const selectedModelLabel =
-    selectedProviderOptions.find((option) => option.slug === props.model)?.name ?? props.model;
+    selectedProviderOptions.find((option) => option.slug === props.model)?.name ??
+    selectedProviderOptions[0]?.name ??
+    props.model;
   const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[activeProvider];
   const handleModelChange = (provider: ProviderKind, value: string) => {
     if (props.disabled) return;


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️
This is a small focused bug fix. No new features.
-->

## Summary

The model picker showed the active provider's icon next to a stale cross-provider model slug - reporter observed "Claude icon with 'GPT 5.4' text" after disabling codex and starting a new thread.

## Root cause

In `ProviderModelPicker.tsx`, `selectedModelLabel` uses `selectedProviderOptions.find(o => o.slug === props.model)?.name ?? props.model`. When a provider that the thread was using gets disabled (codex -> claudeAgent), `activeProvider` switches but `props.model` is still a codex slug. That slug isn't in claudeAgent's option list (the codex slug only gets added to the provider whose `selectedProvider` matches it in `getCustomModelOptionsByProvider`). The `find()` returns undefined and the fallback renders the raw slug alongside the Claude icon.

## Fix

Prefer the active provider's first model name before falling through to the raw slug. Icon and label agree. The `props.model` fallback stays last in case a provider legitimately has no options.

```diff
 const selectedModelLabel =
-  selectedProviderOptions.find((option) => option.slug === props.model)?.name ?? props.model;
+  selectedProviderOptions.find((option) => option.slug === props.model)?.name ??
+  selectedProviderOptions[0]?.name ??
+  props.model;
```

## Test

Added a browser test that mounts the picker with `provider="claudeAgent"`, `model="gpt-5-codex"`, and a `modelOptionsByProvider` whose claudeAgent list doesn't include the codex slug (the real-world state). Before the fix the trigger label was `gpt-5-codex`; after, it reads `Claude Opus 4.6` (the active provider's first model).

All 8 `ProviderModelPicker.browser.tsx` tests pass.

## Related open PRs

@Chrono-byte has an open redesign #2153 that touches the same two files. That PR replaces the whole picker UI; this one is a narrow stale-slug guard on the current implementation. Happy to rebase or fold into that effort if preferred.

Fixes #1982

This contribution was developed with AI assistance (Codex).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI bug fix that only changes how the trigger label is derived when the selected model slug isn’t in the active provider’s options, plus a targeted regression test.
> 
> **Overview**
> Fixes `ProviderModelPicker` trigger rendering when a thread’s `model` slug belongs to a different (now-inactive/disabled) provider by falling back to the active provider’s first available model name before displaying the raw slug.
> 
> Adds a browser regression test covering the stale cross-provider slug scenario to ensure the label no longer shows the dangling slug while the icon reflects the active provider.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d8206f1b852064a1dcb8f2676765008898153f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ProviderModelPicker` label to show active provider's first model when a stale slug is selected
> When the `model` prop holds a slug that doesn't belong to the active provider (e.g. a previously selected Codex model while the provider is switched to Claude), the trigger button now displays the active provider's first model name instead of the raw foreign slug. The fix is in [ProviderModelPicker.tsx](https://github.com/pingdotgg/t3code/pull/2203/files#diff-01e915fe10bb55b513fb511c18383cd09199ea82c807cdf1fa405ba3261b0a40), where the `selectedModelLabel` fallback chain now checks the active provider's first option before falling back to `props.model`. A browser test in [ProviderModelPicker.browser.tsx](https://github.com/pingdotgg/t3code/pull/2203/files#diff-47f34823c834c0928b07177b6f7e70bddaaa1413009424504264be6ef642261f) covers this case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d8206f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->