### PR TITLE
Devcontainer / IDE updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,15 +2,22 @@
   "name": "T3 Code Dev",
   "image": "debian:bookworm",
   "features": {
-    "ghcr.io/devcontainers-extra/features/bun:1": {},
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers-extra/features/bun:1": {
+      "version": "1.3.11"
+    },
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "24",
-      "nodeGypDependencies": true
+      "version": "24.13.1"
     },
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.12"
+      "version": "3.10",
+      "installTools": false
     }
   },
+  "overrideFeatureInstallOrder": [
+    "ghcr.io/devcontainers/features/git",
+    "ghcr.io/devcontainers-extra/features/bun"
+  ],
   "postCreateCommand": {
     "bun-install": "bun install --backend=copyfile --frozen-lockfile"
   },

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -13,5 +13,13 @@
     "apps/web/src/lib/vendor/qrcodegen.ts",
     "*.icon/**"
   ],
-  "sortPackageJson": {}
+  "sortPackageJson": {},
+  "overrides": [
+    {
+      "files": [".devcontainer/devcontainer.json"],
+      "options": {
+        "trailingComma": "none"
+      }
+    }
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "source.fixAll.oxc": "always"
   },
   "oxc.unusedDisableDirectives": "warn",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->
* Use the oldest supported version of tools that are supported by t3, maximizing reproducibility and avoiding using features not supported by the latest version.
* Trailing commas are not part of devcontainer.json schema, do not add them when running oxfmt
* typescript.tsdk is a deprecated setting for VSCode

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local dev tooling/config (devcontainer, formatter, VS Code) and do not affect runtime application logic.
> 
> **Overview**
> Updates the devcontainer setup by adding the `git` feature, pinning `bun` to `1.3.11`, tightening the `node` version to `24.13.1`, and switching `python` to `3.10` with `installTools: false`, plus an explicit feature install order.
> 
> Adjusts `oxfmt` to avoid trailing commas specifically in `.devcontainer/devcontainer.json`, and updates VS Code settings to use the non-deprecated `js/ts.tsdk.path` key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6810f79c356ed099e1b6b27258d51d1f2c05871c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update devcontainer tool versions and VS Code TypeScript SDK config key
> - Pins bun to 1.3.11, updates Node.js to 24.13.1 (drops `nodeGypDependencies`), and downgrades Python from 3.12 to 3.10 (disables `installTools`) in [devcontainer.json](https://github.com/pingdotgg/t3code/pull/2208/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686)
> - Adds the git feature with an explicit install order (git before bun) via `overrideFeatureInstallOrder`
> - Replaces `typescript.tsdk` with `js/ts.tsdk.path` in [settings.json](https://github.com/pingdotgg/t3code/pull/2208/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357) to align with the current VS Code TypeScript SDK config key
> - Adds a formatter override in [.oxfmtrc.json](https://github.com/pingdotgg/t3code/pull/2208/files#diff-ba6bdb5315b18041509bd0925c6394aa9250917b715ab46ca0a36231c566c8e5) to suppress trailing commas in `devcontainer.json`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6810f79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->