### PR TITLE
feat(web): add archive action to thread context menu

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -3567,6 +3567,91 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("offers archive in the thread context menu and dispatches archive when selected", async () => {
+    const showContextMenu = vi.fn().mockResolvedValue("archive");
+
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-thread-context-archive-test" as MessageId,
+        targetText: "thread context archive target",
+      }),
+    });
+
+    try {
+      window.desktopBridge = {
+        showContextMenu,
+        setTheme: vi.fn().mockResolvedValue(undefined),
+      } as unknown as NonNullable<typeof window.desktopBridge>;
+
+      const threadRow = await waitForElement(
+        () => document.querySelector<HTMLElement>(`[data-testid="thread-row-${THREAD_ID}"]`),
+        "Unable to find thread row.",
+      );
+
+      threadRow.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: 120,
+          clientY: 180,
+        }),
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(showContextMenu).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+
+      const [items, menuPosition] = showContextMenu.mock.calls[0]! as [
+        Array<{
+          id: string;
+          label: string;
+          destructive?: boolean;
+          disabled?: boolean;
+        }>,
+        { x: number; y: number },
+      ];
+      expect(menuPosition).toEqual({ x: 120, y: 180 });
+      expect(items.map((item) => item.id)).toEqual([
+        "rename",
+        "mark-unread",
+        "copy-path",
+        "copy-thread-id",
+        "archive",
+        "delete",
+      ]);
+      expect(items[4]).toMatchObject({
+        id: "archive",
+        label: "Archive",
+        destructive: true,
+        disabled: false,
+      });
+      expect(items[5]).toMatchObject({
+        id: "delete",
+        label: "Delete",
+        destructive: true,
+      });
+
+      await vi.waitFor(
+        () => {
+          const archiveRequest = wsRequests.find(
+            (request) =>
+              request._tag === ORCHESTRATION_WS_METHODS.dispatchCommand &&
+              request.type === "thread.archive" &&
+              request.threadId === THREAD_ID,
+          );
+          expect(archiveRequest).toBeDefined();
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("canonicalizes promoted draft threads to the server thread route", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1873,12 +1873,15 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
       );
       const threadWorkspacePath = thread.worktreePath ?? threadProject?.cwd ?? project.cwd ?? null;
+      const isThreadRunning =
+        thread.session?.status === "running" && thread.session.activeTurnId != null;
       const clicked = await api.contextMenu.show(
         [
           { id: "rename", label: "Rename thread" },
           { id: "mark-unread", label: "Mark unread" },
           { id: "copy-path", label: "Copy Path" },
           { id: "copy-thread-id", label: "Copy Thread ID" },
+          { id: "archive", label: "Archive", destructive: true, disabled: isThreadRunning },
           { id: "delete", label: "Delete", destructive: true },
         ],
         position,
@@ -1893,6 +1896,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
       if (clicked === "mark-unread") {
         markThreadUnread(threadKey, thread.latestTurn?.completedAt);
+        return;
+      }
+      if (clicked === "archive") {
+        await attemptArchiveThread(threadRef);
         return;
       }
       if (clicked === "copy-path") {
@@ -1933,6 +1940,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       markThreadUnread,
       memberProjectByScopedKey,
       project.cwd,
+      attemptArchiveThread,
     ],
   );
 


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Added "Archive" option in context menu of threads in the sidebar.
<!-- Describe the change clearly and keep scope tight. -->

## Why

because (I believe) its better ux to have it there too, not only as an icon you have to click in the sidebar.
<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

| before | after |
|--------|-----|
| <img width="130" height="155" alt="image" src="https://github.com/user-attachments/assets/e9c7761d-bbfe-4622-990c-bafdde87c7c0" /> | <img width="167" height="178" alt="image" src="https://github.com/user-attachments/assets/8212d1da-5489-46d6-9ed0-7a14d2f58d6e" /> |

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that adds a new sidebar context-menu action and a regression test; behavior is gated/disabled while a thread is actively running.
> 
> **Overview**
> Adds an **Archive** action to the sidebar thread right-click context menu, wiring it to the existing `attemptArchiveThread` flow and disabling it when the thread has an active running turn.
> 
> Extends the browser test suite (`ChatView.browser.tsx`) with coverage that the context menu includes `archive` and that selecting it triggers the `thread.archive` dispatch over the websocket harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af4be2319d8e02c636d8743e0f9f7979267d30ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add archive action to thread context menu in sidebar
> - Adds an 'Archive' item to the right-click context menu for threads in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2213/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), invoking `attemptArchiveThread` when selected.
> - The archive option is disabled when the thread is currently running (status is `running` or an active turn is present).
> - Adds a browser test in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/2213/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) verifying the context menu contains the archive item and dispatches a `thread.archive` command on selection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af4be23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->