### PR TITLE
fix(desktop): on Linux, reveal window on did-finish-load to avoid Wayland deadlock

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -75,6 +75,7 @@ import {
 } from "./updateMachine.ts";
 import { isArm64HostRunningIntelBuild, resolveDesktopRuntimeInfo } from "./runtimeArch.ts";
 import { resolveDesktopAppBranding } from "./appBranding.ts";
+import { bindFirstRevealTrigger, type RevealSubscription } from "./windowReveal.ts";
 
 syncShellEnvironment();
 
@@ -1998,16 +1999,17 @@ function createWindow(): BrowserWindow {
     emitUpdateState();
   });
 
-  let initialRevealScheduled = false;
-  const revealInitialWindow = () => {
-    if (initialRevealScheduled) {
-      return;
-    }
-    initialRevealScheduled = true;
-    revealWindow(window);
-  };
-
-  window.once("ready-to-show", revealInitialWindow);
+  // On Linux/Wayland with `show: false`, Electron's `ready-to-show` only
+  // fires after `show()` is called, deadlocking the standard "wait for
+  // ready, then show" pattern. Add `did-finish-load` as a Linux-only
+  // fallback so the window still surfaces once the renderer has loaded
+  // the page. Other platforms keep the no-flash `ready-to-show` path,
+  // since `did-finish-load` typically fires before the first paint there.
+  const revealSubscribers: RevealSubscription[] = [(fire) => window.once("ready-to-show", fire)];
+  if (process.platform === "linux") {
+    revealSubscribers.push((fire) => window.webContents.once("did-finish-load", fire));
+  }
+  bindFirstRevealTrigger(revealSubscribers, () => revealWindow(window));
 
   if (isDevelopment) {
     void window.loadURL(resolveDesktopDevServerUrl());

--- a/apps/desktop/src/windowReveal.test.ts
+++ b/apps/desktop/src/windowReveal.test.ts
@@ -1,0 +1,74 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { bindFirstRevealTrigger } from "./windowReveal.ts";
+
+describe("bindFirstRevealTrigger", () => {
+  it("reveals when the first trigger fires", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("reveals when only the fallback trigger fires (Wayland deadlock case)", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    webContents.emit("did-finish-load");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("only reveals once when multiple triggers fire", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    webContents.emit("did-finish-load");
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscribers using `once` ignore re-emitted events after reveal", () => {
+    const window = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger([(fire) => window.once("ready-to-show", fire)], reveal);
+
+    window.emit("ready-to-show");
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/windowReveal.ts
+++ b/apps/desktop/src/windowReveal.ts
@@ -1,0 +1,28 @@
+export type RevealSubscription = (listener: () => void) => void;
+
+/**
+ * Wire a reveal callback to fire exactly once, on whichever of the provided
+ * event subscribers fires first. Each subscriber is responsible for binding
+ * its own event source.
+ *
+ * Used by the desktop main window's first-paint reveal logic. The standard
+ * Electron pattern is to wait for `ready-to-show` before calling `show()`,
+ * but on Linux/Wayland with `show: false`, `ready-to-show` only fires after
+ * `show()` is called, deadlocking that pattern. Subscribing to both
+ * `ready-to-show` and `did-finish-load` (or any other "renderer is alive"
+ * signal) lets the window surface reliably across platforms.
+ */
+export function bindFirstRevealTrigger(
+  subscribers: readonly RevealSubscription[],
+  reveal: () => void,
+): void {
+  let revealed = false;
+  const fire = () => {
+    if (revealed) return;
+    revealed = true;
+    reveal();
+  };
+  for (const subscribe of subscribers) {
+    subscribe(fire);
+  }
+}


### PR DESCRIPTION
## Summary

- On Linux/Wayland with Electron 40, a `BrowserWindow` created with `show: false` never receives `ready-to-show`, because the wl_surface has no role assigned until `show()` is called and the compositor never reports the surface as ready. Net effect: the renderer loads but the window never appears.
- Add `did-finish-load` as a **Linux-only** fallback reveal trigger so the first event from either source surfaces the window. Other platforms keep the no-flash `ready-to-show` path, since `did-finish-load` typically fires before the first paint there.
- Extract the bind-once logic into `bindFirstRevealTrigger` (`apps/desktop/src/windowReveal.ts`) with focused unit tests.

Fixes #2216.

## Repro

1. Linux + Wayland session (reproduced on niri; root cause is in Electron, not the compositor).
2. Run a recent nightly AppImage (e.g. `T3-Code-0.0.20-x86_64.AppImage`).
3. Process starts, renderer loads (network requests fire, React app mounts), no window appears.

## Diagnosis

Confirmed via the Electron main-process Node inspector against the running process:

- `webContents.isLoading()` transitioned to `false` and `did-finish-load` fired.
- `ready-to-show` did NOT fire during an 8 s observation window.
- After forcing `window.show()` from the inspector, `ready-to-show` then fired and the window appeared.

This matches Electron's documented behavior: `ready-to-show` is gated behind the renderer being marked "visible," which on Wayland requires the wl_surface to have a role assigned, which only happens once `show()` is called.

## Why Linux-only (and not Wayland-only)

Per Electron's docs, `ready-to-show` is "usually emitted after the `did-finish-load` event." So on macOS / Windows / X11, a dual-listener that fires on whichever comes first would reveal the window before first paint, regressing the no-flash startup behavior the original `ready-to-show` pattern was buying us.

Gating the fallback to `process.platform === "linux"` keeps the no-flash path intact on macOS / Windows / X11. X11 strictly doesn't need the fallback either, so this leaves a small avoidable regression for X11 users, a brief flash of the theme-matched `backgroundColor` (`#0a0a0a` or `#ffffff`) on first paint. I went with the broader Linux gate for simplicity.

If you'd prefer to narrow this to actual Wayland sessions, the standard heuristic is:

```ts
const isWayland =
  process.platform === "linux" &&
  process.env.XDG_SESSION_TYPE === "wayland" &&
  !!process.env.WAYLAND_DISPLAY;
```

Since Electron 38 (Sept 2025), the default `--ozone-platform-hint=auto` makes "Wayland session" effectively equal to "Wayland Ozone backend" unless the user forces `--ozone-platform=x11`. The two-env-var conjunction matches what Chromium itself uses for auto-detection and what VS Code / Signal use. Footguns: it can be missing in nested/non-systemd/sudo launches (rare for an AppImage launched from a desktop entry), and it cannot detect an explicit `--ozone-platform=x11` override. Happy to switch if maintainers prefer.

## Test plan

- [x] `bun run test --filter=@t3tools/desktop` (4 new tests, 91 total pass)
- [x] `bun typecheck`
- [x] `bun lint` (0 errors)
- [x] `bun fmt`
- [x] AppImage rebuilt and launched on Linux/Wayland (niri) - window now appears

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to window reveal timing in the desktop main process; Linux-only fallback reduces risk of cross-platform behavior regressions.
> 
> **Overview**
> Fixes a Linux/Wayland startup deadlock where a `BrowserWindow` created with `show: false` may never emit `ready-to-show`, leaving the app invisible.
> 
> `main.ts` now reveals the first window on whichever happens first: `ready-to-show` (all platforms) or *Linux-only* `did-finish-load` as a fallback, using a new `bindFirstRevealTrigger` helper with unit tests to ensure the reveal callback fires exactly once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c6bc3412c326939886b56e2531a2eabfc1c042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Wayland deadlock by revealing window on `did-finish-load` as a fallback on Linux
> - Adds a new `bindFirstRevealTrigger` utility in [`windowReveal.ts`](https://github.com/pingdotgg/t3code/pull/2217/files#diff-701c7d0214598620179c82a706ead2a876c769ade0207057466048eef417abe8) that accepts multiple event subscribers and fires a reveal callback exactly once on the first event to trigger.
> - On Linux, `ready-to-show` can never fire when `show: false` is set under Wayland; a `did-finish-load` subscriber is added as a fallback so the window still reveals.
> - On other platforms, behavior is unchanged — the window reveals on `ready-to-show` as before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32c6bc3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->