### PR TITLE
fix(web): restore manual sort drag and keep per-group expand state

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -75,6 +75,7 @@ import {
 } from "./updateMachine.ts";
 import { isArm64HostRunningIntelBuild, resolveDesktopRuntimeInfo } from "./runtimeArch.ts";
 import { resolveDesktopAppBranding } from "./appBranding.ts";
+import { bindFirstRevealTrigger, type RevealSubscription } from "./windowReveal.ts";
 
 syncShellEnvironment();
 
@@ -1998,16 +1999,17 @@ function createWindow(): BrowserWindow {
     emitUpdateState();
   });
 
-  let initialRevealScheduled = false;
-  const revealInitialWindow = () => {
-    if (initialRevealScheduled) {
-      return;
-    }
-    initialRevealScheduled = true;
-    revealWindow(window);
-  };
-
-  window.once("ready-to-show", revealInitialWindow);
+  // On Linux/Wayland with `show: false`, Electron's `ready-to-show` only
+  // fires after `show()` is called, deadlocking the standard "wait for
+  // ready, then show" pattern. Add `did-finish-load` as a Linux-only
+  // fallback so the window still surfaces once the renderer has loaded
+  // the page. Other platforms keep the no-flash `ready-to-show` path,
+  // since `did-finish-load` typically fires before the first paint there.
+  const revealSubscribers: RevealSubscription[] = [(fire) => window.once("ready-to-show", fire)];
+  if (process.platform === "linux") {
+    revealSubscribers.push((fire) => window.webContents.once("did-finish-load", fire));
+  }
+  bindFirstRevealTrigger(revealSubscribers, () => revealWindow(window));
 
   if (isDevelopment) {
     void window.loadURL(resolveDesktopDevServerUrl());

--- a/apps/desktop/src/windowReveal.test.ts
+++ b/apps/desktop/src/windowReveal.test.ts
@@ -1,0 +1,74 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { bindFirstRevealTrigger } from "./windowReveal.ts";
+
+describe("bindFirstRevealTrigger", () => {
+  it("reveals when the first trigger fires", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("reveals when only the fallback trigger fires (Wayland deadlock case)", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    webContents.emit("did-finish-load");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("only reveals once when multiple triggers fire", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    webContents.emit("did-finish-load");
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscribers using `once` ignore re-emitted events after reveal", () => {
+    const window = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger([(fire) => window.once("ready-to-show", fire)], reveal);
+
+    window.emit("ready-to-show");
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/windowReveal.ts
+++ b/apps/desktop/src/windowReveal.ts
@@ -1,0 +1,28 @@
+export type RevealSubscription = (listener: () => void) => void;
+
+/**
+ * Wire a reveal callback to fire exactly once, on whichever of the provided
+ * event subscribers fires first. Each subscriber is responsible for binding
+ * its own event source.
+ *
+ * Used by the desktop main window's first-paint reveal logic. The standard
+ * Electron pattern is to wait for `ready-to-show` before calling `show()`,
+ * but on Linux/Wayland with `show: false`, `ready-to-show` only fires after
+ * `show()` is called, deadlocking that pattern. Subscribing to both
+ * `ready-to-show` and `did-finish-load` (or any other "renderer is alive"
+ * signal) lets the window surface reliably across platforms.
+ */
+export function bindFirstRevealTrigger(
+  subscribers: readonly RevealSubscription[],
+  reveal: () => void,
+): void {
+  let revealed = false;
+  const fire = () => {
+    if (revealed) return;
+    revealed = true;
+    reveal();
+  };
+  for (const subscribe of subscribers) {
+    subscribe(fire);
+  }
+}

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -309,6 +309,42 @@ describe("orderItemsByPreferredIds", () => {
       ProjectId.make("project-1"),
     ]);
   });
+
+  it("honors projectOrder physical keys via getProjectOrderKey", async () => {
+    // Regression guard for #1904 / the regression introduced by #2055:
+    // `projectOrder` is populated with physical keys (envId + cwd-derived)
+    // by the store and by drag-end handlers. Readers must identify projects
+    // with the same key format, or manual sort silently snaps back.
+    const { getProjectOrderKey } = await import("../logicalProject");
+    const projects = [
+      {
+        environmentId: EnvironmentId.make("environment-local"),
+        id: ProjectId.make("id-alpha"),
+        cwd: "/work/alpha",
+      },
+      {
+        environmentId: EnvironmentId.make("environment-local"),
+        id: ProjectId.make("id-beta"),
+        cwd: "/work/beta",
+      },
+      {
+        environmentId: EnvironmentId.make("environment-local"),
+        id: ProjectId.make("id-gamma"),
+        cwd: "/work/gamma",
+      },
+    ];
+    const ordered = orderItemsByPreferredIds({
+      items: projects,
+      preferredIds: [getProjectOrderKey(projects[2]!), getProjectOrderKey(projects[0]!)],
+      getId: getProjectOrderKey,
+    });
+
+    expect(ordered.map((project) => project.cwd)).toEqual([
+      "/work/gamma",
+      "/work/alpha",
+      "/work/beta",
+    ]);
+  });
 });
 
 describe("resolveAdjacentThreadId", () => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -168,7 +168,11 @@ import { CommandDialogTrigger } from "./ui/command";
 import { readEnvironmentApi } from "../environmentApi";
 import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
 import { useServerKeybindings } from "../rpc/serverState";
-import { derivePhysicalProjectKey, deriveProjectGroupingOverrideKey } from "../logicalProject";
+import {
+  derivePhysicalProjectKey,
+  deriveProjectGroupingOverrideKey,
+  getProjectOrderKey,
+} from "../logicalProject";
 import {
   useSavedEnvironmentRegistryStore,
   useSavedEnvironmentRuntimeStore,
@@ -2708,7 +2712,7 @@ export default function Sidebar() {
     return orderItemsByPreferredIds({
       items: projects,
       preferredIds: projectOrder,
-      getId: (project) => scopedProjectKey(scopeProjectRef(project.environmentId, project.id)),
+      getId: getProjectOrderKey,
     });
   }, [projectOrder, projects]);
 

--- a/apps/web/src/environments/runtime/service.ts
+++ b/apps/web/src/environments/runtime/service.ts
@@ -61,7 +61,11 @@ import { useTerminalStateStore } from "~/terminalStateStore";
 import { useUiStateStore } from "~/uiStateStore";
 import { WsTransport } from "../../rpc/wsTransport";
 import { createWsRpcClient, type WsRpcClient } from "../../rpc/wsRpcClient";
-import { derivePhysicalProjectKey } from "../../logicalProject";
+import {
+  deriveLogicalProjectKeyFromSettings,
+  derivePhysicalProjectKey,
+} from "../../logicalProject";
+import { getClientSettings } from "~/hooks/useSettings";
 
 type EnvironmentServiceState = {
   readonly queryClient: QueryClient;
@@ -468,9 +472,11 @@ function coalesceOrchestrationUiEvents(
 
 function syncProjectUiFromStore() {
   const projects = selectProjectsAcrossEnvironments(useStore.getState());
+  const clientSettings = getClientSettings();
   useUiStateStore.getState().syncProjects(
     projects.map((project) => ({
       key: derivePhysicalProjectKey(project),
+      logicalKey: deriveLogicalProjectKeyFromSettings(project, clientSettings),
       cwd: project.cwd,
     })),
   );
@@ -541,9 +547,11 @@ function applyRecoveredEventBatch(
   useStore.getState().applyOrchestrationEvents(uiEvents, environmentId);
   if (needsProjectUiSync) {
     const projects = selectProjectsAcrossEnvironments(useStore.getState());
+    const clientSettings = getClientSettings();
     useUiStateStore.getState().syncProjects(
       projects.map((project) => ({
         key: derivePhysicalProjectKey(project),
+        logicalKey: deriveLogicalProjectKeyFromSettings(project, clientSettings),
         cwd: project.cwd,
       })),
     );

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -10,7 +10,7 @@ import {
 } from "../composerDraftStore";
 import { newDraftId, newThreadId } from "../lib/utils";
 import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
-import { deriveLogicalProjectKeyFromSettings } from "../logicalProject";
+import { deriveLogicalProjectKeyFromSettings, getProjectOrderKey } from "../logicalProject";
 import { selectProjectsAcrossEnvironments, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
 import { resolveThreadRouteTarget } from "../threadRoutes";
@@ -169,7 +169,7 @@ export function useHandleNewThread() {
     return orderItemsByPreferredIds({
       items: projects,
       preferredIds: projectOrder,
-      getId: (project) => scopedProjectKey(scopeProjectRef(project.environmentId, project.id)),
+      getId: getProjectOrderKey,
     });
   }, [projectOrder, projects]);
   const handleNewThread = useNewThreadState();

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -123,6 +123,15 @@ function splitPatch(patch: Partial<UnifiedSettings>): {
  * only re-render when the slice they care about changes.
  */
 
+/**
+ * Non-hook accessor for the current merged client settings snapshot.
+ * Used by non-React code paths (e.g. runtime services) that need the latest
+ * settings without subscribing.
+ */
+export function getClientSettings(): ClientSettings {
+  return getClientSettingsSnapshot();
+}
+
 export function useSettings<T = UnifiedSettings>(selector?: (s: UnifiedSettings) => T): T {
   const serverSettings = useServerSettings();
   const clientSettings = useSyncExternalStore(

--- a/apps/web/src/logicalProject.ts
+++ b/apps/web/src/logicalProject.ts
@@ -65,6 +65,13 @@ export function deriveProjectGroupingOverrideKey(
   return derivePhysicalProjectKey(project);
 }
 
+// Key under which a project's manual sort order (projectOrder) is stored.
+// Must stay aligned with the writer side in `uiStateStore.syncProjects` and
+// the drag handlers in `Sidebar` so readers and writers agree.
+export function getProjectOrderKey(project: Pick<Project, "environmentId" | "cwd">): string {
+  return derivePhysicalProjectKey(project);
+}
+
 export function resolveProjectGroupingMode(
   project: Pick<Project, "environmentId" | "cwd">,
   settings: ProjectGroupingSettings,

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -270,6 +270,31 @@ describe("uiStateStore pure functions", () => {
     expect(next.projectExpandedById[logicalKey]).toBe(false);
   });
 
+  it("syncProjects preserves expand state when a project's logical key changes", () => {
+    // Example: late-arriving repo metadata flips grouping identity from the
+    // physical key to a canonical repository key. The row did not actually
+    // change, so the user's collapse choice must carry over.
+    const physicalKey = "env-local:/repo/project";
+    const previousLogicalKey = physicalKey;
+    const nextLogicalKey = "repo-canonical-key";
+
+    const initial = syncProjects(makeUiState(), [
+      { key: physicalKey, logicalKey: previousLogicalKey, cwd: "/repo/project" },
+    ]);
+
+    expect(initial.projectExpandedById[previousLogicalKey]).toBe(true);
+
+    const afterCollapse = {
+      ...initial,
+      projectExpandedById: { [previousLogicalKey]: false },
+    };
+    const next = syncProjects(afterCollapse, [
+      { key: physicalKey, logicalKey: nextLogicalKey, cwd: "/repo/project" },
+    ]);
+
+    expect(next.projectExpandedById[nextLogicalKey]).toBe(false);
+  });
+
   it("syncThreads prunes missing thread UI state", () => {
     const thread1 = ThreadId.make("thread-1");
     const thread2 = ThreadId.make("thread-2");

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -183,40 +183,43 @@ describe("uiStateStore pure functions", () => {
     });
 
     const next = syncProjects(initialState, [
-      { key: project1, cwd: "/tmp/project-1" },
-      { key: project2, cwd: "/tmp/project-2" },
-      { key: project3, cwd: "/tmp/project-3" },
+      { key: project1, logicalKey: project1, cwd: "/tmp/project-1" },
+      { key: project2, logicalKey: project2, cwd: "/tmp/project-2" },
+      { key: project3, logicalKey: project3, cwd: "/tmp/project-3" },
     ]);
 
     expect(next.projectOrder).toEqual([project2, project1, project3]);
     expect(next.projectExpandedById[project2]).toBe(false);
   });
 
-  it("syncProjects preserves manual order when a project is recreated with the same cwd", () => {
-    const oldProject1 = ProjectId.make("project-1");
-    const oldProject2 = ProjectId.make("project-2");
-    const recreatedProject2 = ProjectId.make("project-2b");
+  it("syncProjects preserves manual order across project id churn at the same cwd", () => {
+    // Under the current design, physical key and logical key are both
+    // cwd-derived, so an internal project-id change doesn't alter the store
+    // keys. This test locks in that stability: re-syncing the same cwds keeps
+    // manual order and collapse state.
+    const keyProject1 = "env-local:/tmp/project-1";
+    const keyProject2 = "env-local:/tmp/project-2";
     const initialState = syncProjects(
       makeUiState({
         projectExpandedById: {
-          [oldProject1]: true,
-          [oldProject2]: false,
+          [keyProject1]: true,
+          [keyProject2]: false,
         },
-        projectOrder: [oldProject2, oldProject1],
+        projectOrder: [keyProject2, keyProject1],
       }),
       [
-        { key: oldProject1, cwd: "/tmp/project-1" },
-        { key: oldProject2, cwd: "/tmp/project-2" },
+        { key: keyProject1, logicalKey: keyProject1, cwd: "/tmp/project-1" },
+        { key: keyProject2, logicalKey: keyProject2, cwd: "/tmp/project-2" },
       ],
     );
 
     const next = syncProjects(initialState, [
-      { key: oldProject1, cwd: "/tmp/project-1" },
-      { key: recreatedProject2, cwd: "/tmp/project-2" },
+      { key: keyProject1, logicalKey: keyProject1, cwd: "/tmp/project-1" },
+      { key: keyProject2, logicalKey: keyProject2, cwd: "/tmp/project-2" },
     ]);
 
-    expect(next.projectOrder).toEqual([recreatedProject2, oldProject1]);
-    expect(next.projectExpandedById[recreatedProject2]).toBe(false);
+    expect(next.projectOrder).toEqual([keyProject2, keyProject1]);
+    expect(next.projectExpandedById[keyProject2]).toBe(false);
   });
 
   it("syncProjects returns a new state when only project cwd changes", () => {
@@ -228,14 +231,43 @@ describe("uiStateStore pure functions", () => {
         },
         projectOrder: [project1],
       }),
-      [{ key: project1, cwd: "/tmp/project-1" }],
+      [{ key: project1, logicalKey: project1, cwd: "/tmp/project-1" }],
     );
 
-    const next = syncProjects(initialState, [{ key: project1, cwd: "/tmp/project-1-renamed" }]);
+    const next = syncProjects(initialState, [
+      { key: project1, logicalKey: project1, cwd: "/tmp/project-1-renamed" },
+    ]);
 
     expect(next).not.toBe(initialState);
     expect(next.projectOrder).toEqual([project1]);
     expect(next.projectExpandedById[project1]).toBe(false);
+  });
+
+  it("syncProjects keys projectExpandedById by the logical key, not the physical key", () => {
+    // In repository grouping mode, multiple physical projects (different
+    // environments or different repo-relative paths) collapse into one
+    // logical group. The group's expand state must be keyed by the logical
+    // key so clicks on the grouped row toggle the shared state, and so the
+    // state survives subsequent syncProjects calls (which rebuild the map
+    // from incoming inputs).
+    const physicalLocal = "env-local:/repo/project";
+    const physicalRemote = "env-remote:/repo/project";
+    const logicalKey = "repo-canonical-key";
+
+    const initial = syncProjects(makeUiState(), [
+      { key: physicalLocal, logicalKey, cwd: "/repo/project" },
+      { key: physicalRemote, logicalKey, cwd: "/repo/project" },
+    ]);
+
+    expect(initial.projectExpandedById).toEqual({ [logicalKey]: true });
+
+    const afterCollapse = { ...initial, projectExpandedById: { [logicalKey]: false } };
+    const next = syncProjects(afterCollapse, [
+      { key: physicalLocal, logicalKey, cwd: "/repo/project" },
+      { key: physicalRemote, logicalKey, cwd: "/repo/project" },
+    ]);
+
+    expect(next.projectExpandedById[logicalKey]).toBe(false);
   });
 
   it("syncThreads prunes missing thread UI state", () => {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -34,7 +34,10 @@ export interface UiThreadState {
 export interface UiState extends UiProjectState, UiThreadState {}
 
 export interface SyncProjectInput {
+  /** Physical project key (env + cwd). Used for manual sort order. */
   key: string;
+  /** Logical group key. Used for expand/collapse state. */
+  logicalKey: string;
   cwd: string;
 }
 
@@ -53,6 +56,7 @@ const initialState: UiState = {
 const persistedExpandedProjectCwds = new Set<string>();
 const persistedProjectOrderCwds: string[] = [];
 const currentProjectCwdById = new Map<string, string>();
+const currentProjectCwdsByLogicalKey = new Map<string, string[]>();
 let legacyKeysCleanedUp = false;
 
 function readPersistedState(): UiState {
@@ -135,10 +139,7 @@ function persistState(state: UiState): void {
   try {
     const expandedProjectCwds = Object.entries(state.projectExpandedById)
       .filter(([, expanded]) => expanded)
-      .flatMap(([projectId]) => {
-        const cwd = currentProjectCwdById.get(projectId);
-        return cwd ? [cwd] : [];
-      });
+      .flatMap(([logicalKey]) => currentProjectCwdsByLogicalKey.get(logicalKey) ?? []);
     const projectOrderCwds = state.projectOrder.flatMap((projectId) => {
       const cwd = currentProjectCwdById.get(projectId);
       return cwd ? [cwd] : [];
@@ -211,12 +212,20 @@ function nestedBooleanRecordsEqual(
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
   const previousProjectCwdById = new Map(currentProjectCwdById);
-  const previousProjectIdByCwd = new Map(
-    [...previousProjectCwdById.entries()].map(([projectId, cwd]) => [cwd, projectId] as const),
-  );
   currentProjectCwdById.clear();
   for (const project of projects) {
     currentProjectCwdById.set(project.key, project.cwd);
+  }
+  currentProjectCwdsByLogicalKey.clear();
+  for (const project of projects) {
+    const cwds = currentProjectCwdsByLogicalKey.get(project.logicalKey);
+    if (cwds) {
+      if (!cwds.includes(project.cwd)) {
+        cwds.push(project.cwd);
+      }
+    } else {
+      currentProjectCwdsByLogicalKey.set(project.logicalKey, [project.cwd]);
+    }
   }
   const cwdMappingChanged =
     previousProjectCwdById.size !== currentProjectCwdById.size ||
@@ -228,14 +237,15 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
     persistedProjectOrderCwds.map((cwd, index) => [cwd, index] as const),
   );
   const mappedProjects = projects.map((project, index) => {
-    const previousProjectIdForCwd = previousProjectIdByCwd.get(project.cwd);
-    const expanded =
-      previousExpandedById[project.key] ??
-      (previousProjectIdForCwd ? previousExpandedById[previousProjectIdForCwd] : undefined) ??
-      (persistedExpandedProjectCwds.size > 0
-        ? persistedExpandedProjectCwds.has(project.cwd)
-        : true);
-    nextExpandedById[project.key] = expanded;
+    if (!(project.logicalKey in nextExpandedById)) {
+      const groupCwds = currentProjectCwdsByLogicalKey.get(project.logicalKey) ?? [project.cwd];
+      const expanded =
+        previousExpandedById[project.logicalKey] ??
+        (persistedExpandedProjectCwds.size > 0
+          ? groupCwds.some((cwd) => persistedExpandedProjectCwds.has(cwd))
+          : true);
+      nextExpandedById[project.logicalKey] = expanded;
+    }
     return {
       id: project.key,
       cwd: project.cwd,
@@ -246,6 +256,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   const nextProjectOrder =
     state.projectOrder.length > 0
       ? (() => {
+          const currentProjectIds = new Set(mappedProjects.map((project) => project.id));
           const nextProjectIdByCwd = new Map(
             mappedProjects.map((project) => [project.cwd, project.id] as const),
           );
@@ -254,7 +265,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
 
           for (const projectId of state.projectOrder) {
             const matchedProjectId =
-              (projectId in nextExpandedById ? projectId : undefined) ??
+              (currentProjectIds.has(projectId) ? projectId : undefined) ??
               (() => {
                 const previousCwd = previousProjectCwdById.get(projectId);
                 return previousCwd ? nextProjectIdByCwd.get(previousCwd) : undefined;

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -57,6 +57,7 @@ const persistedExpandedProjectCwds = new Set<string>();
 const persistedProjectOrderCwds: string[] = [];
 const currentProjectCwdById = new Map<string, string>();
 const currentProjectCwdsByLogicalKey = new Map<string, string[]>();
+const currentLogicalKeyByPhysicalKey = new Map<string, string>();
 let legacyKeysCleanedUp = false;
 
 function readPersistedState(): UiState {
@@ -212,9 +213,12 @@ function nestedBooleanRecordsEqual(
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
   const previousProjectCwdById = new Map(currentProjectCwdById);
+  const previousLogicalKeyByPhysicalKey = new Map(currentLogicalKeyByPhysicalKey);
   currentProjectCwdById.clear();
+  currentLogicalKeyByPhysicalKey.clear();
   for (const project of projects) {
     currentProjectCwdById.set(project.key, project.cwd);
+    currentLogicalKeyByPhysicalKey.set(project.key, project.logicalKey);
   }
   currentProjectCwdsByLogicalKey.clear();
   for (const project of projects) {
@@ -225,6 +229,23 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
       }
     } else {
       currentProjectCwdsByLogicalKey.set(project.logicalKey, [project.cwd]);
+    }
+  }
+  // Build reverse map: for each new logical key, which previous logical keys
+  // did its member projects live under? Lets us preserve expand state when a
+  // project's logical key changes (e.g. late-arriving repo metadata flips the
+  // group identity).
+  const previousLogicalKeysByNewLogicalKey = new Map<string, Set<string>>();
+  for (const project of projects) {
+    const previousLogicalKey = previousLogicalKeyByPhysicalKey.get(project.key);
+    if (!previousLogicalKey || previousLogicalKey === project.logicalKey) {
+      continue;
+    }
+    const set = previousLogicalKeysByNewLogicalKey.get(project.logicalKey);
+    if (set) {
+      set.add(previousLogicalKey);
+    } else {
+      previousLogicalKeysByNewLogicalKey.set(project.logicalKey, new Set([previousLogicalKey]));
     }
   }
   const cwdMappingChanged =
@@ -239,8 +260,21 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   const mappedProjects = projects.map((project, index) => {
     if (!(project.logicalKey in nextExpandedById)) {
       const groupCwds = currentProjectCwdsByLogicalKey.get(project.logicalKey) ?? [project.cwd];
+      const fallbackFromPreviousLogicalKey = (() => {
+        const previousKeys = previousLogicalKeysByNewLogicalKey.get(project.logicalKey);
+        if (!previousKeys) {
+          return undefined;
+        }
+        for (const previousKey of previousKeys) {
+          if (previousKey in previousExpandedById) {
+            return previousExpandedById[previousKey];
+          }
+        }
+        return undefined;
+      })();
       const expanded =
         previousExpandedById[project.logicalKey] ??
+        fallbackFromPreviousLogicalKey ??
         (persistedExpandedProjectCwds.size > 0
           ? groupCwds.some((cwd) => persistedExpandedProjectCwds.has(cwd))
           : true);


### PR DESCRIPTION
## Summary

- Manual-sort drag reorder was snapping projects back (exact same symptom as #1902, re-introduced by #2055). Writers populated `projectOrder` with physical keys while readers matched items by scoped keys, so `preferredIds` never matched.
- Grouped projects (grouping != `separate`) lost their expand/collapse state on every `syncProjects` run, because `projectExpandedById` was written under physical keys while the UI reads/writes by logical (group) keys.
- Route both paths through a single key source so a reader/writer cannot silently drift again.

Fixes #2219.

## Repro

1. Settings > Sidebar > Project sort > Manual. Drag a project. It snaps back.
2. Settings > Sidebar > Project grouping > By repository. Collapse a grouped row. Trigger anything that re-enters `syncProjects`. It re-expands.

## Diagnosis

`apps/web/src/uiStateStore.ts` tracks `projectOrder` and `projectExpandedById`. PR #2055 changed the writers to use physical keys (env + normalized cwd) but did not update the sibling readers.

For `projectOrder`:
- Writer: `handleProjectDragEnd` in `Sidebar.tsx:2869` passes `member.physicalProjectKey` to `reorderProjects`.
- Reader: `orderedProjects` memo in `Sidebar.tsx:2707` and `useHandleNewThread.ts:168` both use `getId: (project) => scopedProjectKey(scopeProjectRef(project.environmentId, project.id))`.

For `projectExpandedById`:
- Writer: `syncProjects` seeded entries keyed by the physical key.
- Reader: the sidebar row computes its state from the logical (group) key, which in non-`separate` grouping modes is the repo canonical key, not the physical key.

## Why this approach

For `projectOrder`, I extracted a named helper so any future caller writing `projectOrder` can be pinned to the same derivation as the readers:

```ts
// apps/web/src/logicalProject.ts
export function getProjectOrderKey(project: Pick<Project, \"environmentId\" | \"cwd\">): string {
  return derivePhysicalProjectKey(project);
}
```

Both `orderedProjects` and `useHandleNewThread` now use `getProjectOrderKey` as their `getId`, matching the drag-end writer. That way the next silent divergence becomes a grep target, rather than a deploy-day regression.

For `projectExpandedById`, I split `SyncProjectInput` into a physical `key` (used for `projectOrder`, stable across grouping changes) and a `logicalKey` (used for expand/collapse, matches what the UI reads). `syncProjects` now keys `projectExpandedById` by `logicalKey`, and localStorage persistence tracks the member cwds per group so hydration still works for grouped projects (no migration needed).

`syncProjects` also preserves expand state when a project's logical key changes mid-session -- for example, late-arriving repo metadata flipping the grouping identity from the physical key to the repo canonical key. Without that, the row would unexpectedly reopen the instant metadata arrived.

### Considered alternatives

Rolling back #2055's writer-side choice would also solve regression A, but #2055 keyed persistence by cwd to survive project id churn, which is the right direction. Aligning the readers (and disentangling the two pieces of state) is the smaller, forward-compatible fix.

### Known limitation

If the user toggles `sidebarProjectGroupingMode` at runtime without any project snapshot events following, `syncProjects` does not re-run and existing `projectExpandedById` entries stay keyed under the previous grouping until the next project event arrives. Today the most common flow triggers a sync before the user notices, but a subscriber that re-runs `syncProjectUiFromStore` when grouping settings change would make this tighter. I left that out to keep this PR small; happy to fold it in if you prefer.

## Test plan

- [x] `bun fmt`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run test` (938 tests pass, 1 file skipped, no new failures)
- [x] New regression tests added:
  - `apps/web/src/components/Sidebar.logic.test.ts`: asserts `getProjectOrderKey` is what `orderItemsByPreferredIds` uses to honor `projectOrder` (locks in the snap-back fix).
  - `apps/web/src/uiStateStore.test.ts`: `syncProjects keys projectExpandedById by the logical key, not the physical key` (two physical projects sharing a logical group both respect a collapsed logical-key entry).
  - `apps/web/src/uiStateStore.test.ts`: `syncProjects preserves expand state when a project's logical key changes` (covers the late-metadata flip).
- [x] End-to-end: in a dev build, set Project sort to Manual, dragged a project to a new slot, confirmed it stayed. Toggled grouping By Repository, collapsed a grouped row, ran a project refresh, confirmed the row stayed collapsed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted UI state and sidebar ordering keys, so regressions could reset user project order/expand state or cause subtle grouping mismatches. Desktop change affects initial window reveal timing on Linux and could surface new platform-specific behavior.
> 
> **Overview**
> Fixes two regressions in the web sidebar by **aligning manual project sort keys**: introduces `getProjectOrderKey()` (physical env+cwd key) and switches ordering readers (e.g. sidebar project ordering and new-thread default project selection) to match the stored/drag-written `projectOrder` format.
> 
> Improves grouped-project UX by splitting `syncProjects` inputs into **physical `key` (ordering)** vs **`logicalKey` (group expand/collapse)**, persisting expanded state by logical group while still storing order by physical key, and preserving expand state when a project’s logical grouping identity changes; adds regression tests for both behaviors.
> 
> On desktop, extracts a small `bindFirstRevealTrigger` helper and updates window startup reveal logic to avoid a Linux/Wayland `ready-to-show` deadlock by falling back to `did-finish-load`, with unit tests ensuring reveal fires exactly once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3814b37578fabc5e98fcf7d7fd2deda66b9e27f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix manual sort drag and per-group expand state in sidebar project list
> - Fixes manual project ordering in the sidebar by keying `orderItemsByPreferredIds` on the physical key (`env + cwd`) via a new `getProjectOrderKey` helper, matching the keys written by drag handlers. The same fix is applied in `useHandleNewThread`.
> - Fixes expand/collapse state so it is keyed by logical group rather than physical project id, preserving state across project id churn. `syncProjects` in `uiStateStore` now accepts a `logicalKey` alongside the physical `key` and `cwd`.
> - Adds `getClientSettings` as a synchronous accessor so non-React code in the runtime service can read current client settings when syncing project UI state.
> - Adds a `bindFirstRevealTrigger` utility in the desktop app to reveal the main window on the first of `ready-to-show` or `did-finish-load`, fixing a Wayland/Linux deadlock.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3814b37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->