### PR TITLE
fix(web): restore manual sort drag and keep per-group expand state

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -309,6 +309,42 @@ describe("orderItemsByPreferredIds", () => {
       ProjectId.make("project-1"),
     ]);
   });
+
+  it("honors projectOrder physical keys via getProjectOrderKey", async () => {
+    // Regression guard for #1904 / the regression introduced by #2055:
+    // `projectOrder` is populated with physical keys (envId + cwd-derived)
+    // by the store and by drag-end handlers. Readers must identify projects
+    // with the same key format, or manual sort silently snaps back.
+    const { getProjectOrderKey } = await import("../logicalProject");
+    const projects = [
+      {
+        environmentId: EnvironmentId.make("environment-local"),
+        id: ProjectId.make("id-alpha"),
+        cwd: "/work/alpha",
+      },
+      {
+        environmentId: EnvironmentId.make("environment-local"),
+        id: ProjectId.make("id-beta"),
+        cwd: "/work/beta",
+      },
+      {
+        environmentId: EnvironmentId.make("environment-local"),
+        id: ProjectId.make("id-gamma"),
+        cwd: "/work/gamma",
+      },
+    ];
+    const ordered = orderItemsByPreferredIds({
+      items: projects,
+      preferredIds: [getProjectOrderKey(projects[2]!), getProjectOrderKey(projects[0]!)],
+      getId: getProjectOrderKey,
+    });
+
+    expect(ordered.map((project) => project.cwd)).toEqual([
+      "/work/gamma",
+      "/work/alpha",
+      "/work/beta",
+    ]);
+  });
 });
 
 describe("resolveAdjacentThreadId", () => {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -168,7 +168,11 @@ import { CommandDialogTrigger } from "./ui/command";
 import { readEnvironmentApi } from "../environmentApi";
 import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
 import { useServerKeybindings } from "../rpc/serverState";
-import { derivePhysicalProjectKey, deriveProjectGroupingOverrideKey } from "../logicalProject";
+import {
+  derivePhysicalProjectKey,
+  deriveProjectGroupingOverrideKey,
+  getProjectOrderKey,
+} from "../logicalProject";
 import {
   useSavedEnvironmentRegistryStore,
   useSavedEnvironmentRuntimeStore,
@@ -2708,7 +2712,7 @@ export default function Sidebar() {
     return orderItemsByPreferredIds({
       items: projects,
       preferredIds: projectOrder,
-      getId: (project) => scopedProjectKey(scopeProjectRef(project.environmentId, project.id)),
+      getId: getProjectOrderKey,
     });
   }, [projectOrder, projects]);
 

--- a/apps/web/src/environments/runtime/service.ts
+++ b/apps/web/src/environments/runtime/service.ts
@@ -61,7 +61,11 @@ import { useTerminalStateStore } from "~/terminalStateStore";
 import { useUiStateStore } from "~/uiStateStore";
 import { WsTransport } from "../../rpc/wsTransport";
 import { createWsRpcClient, type WsRpcClient } from "../../rpc/wsRpcClient";
-import { derivePhysicalProjectKey } from "../../logicalProject";
+import {
+  deriveLogicalProjectKeyFromSettings,
+  derivePhysicalProjectKey,
+} from "../../logicalProject";
+import { getClientSettings } from "~/hooks/useSettings";
 
 type EnvironmentServiceState = {
   readonly queryClient: QueryClient;
@@ -468,9 +472,11 @@ function coalesceOrchestrationUiEvents(
 
 function syncProjectUiFromStore() {
   const projects = selectProjectsAcrossEnvironments(useStore.getState());
+  const clientSettings = getClientSettings();
   useUiStateStore.getState().syncProjects(
     projects.map((project) => ({
       key: derivePhysicalProjectKey(project),
+      logicalKey: deriveLogicalProjectKeyFromSettings(project, clientSettings),
       cwd: project.cwd,
     })),
   );
@@ -541,9 +547,11 @@ function applyRecoveredEventBatch(
   useStore.getState().applyOrchestrationEvents(uiEvents, environmentId);
   if (needsProjectUiSync) {
     const projects = selectProjectsAcrossEnvironments(useStore.getState());
+    const clientSettings = getClientSettings();
     useUiStateStore.getState().syncProjects(
       projects.map((project) => ({
         key: derivePhysicalProjectKey(project),
+        logicalKey: deriveLogicalProjectKeyFromSettings(project, clientSettings),
         cwd: project.cwd,
       })),
     );

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -10,7 +10,7 @@ import {
 } from "../composerDraftStore";
 import { newDraftId, newThreadId } from "../lib/utils";
 import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
-import { deriveLogicalProjectKeyFromSettings } from "../logicalProject";
+import { deriveLogicalProjectKeyFromSettings, getProjectOrderKey } from "../logicalProject";
 import { selectProjectsAcrossEnvironments, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
 import { resolveThreadRouteTarget } from "../threadRoutes";
@@ -169,7 +169,7 @@ export function useHandleNewThread() {
     return orderItemsByPreferredIds({
       items: projects,
       preferredIds: projectOrder,
-      getId: (project) => scopedProjectKey(scopeProjectRef(project.environmentId, project.id)),
+      getId: getProjectOrderKey,
     });
   }, [projectOrder, projects]);
   const handleNewThread = useNewThreadState();

--- a/apps/web/src/hooks/useSettings.ts
+++ b/apps/web/src/hooks/useSettings.ts
@@ -123,6 +123,15 @@ function splitPatch(patch: Partial<UnifiedSettings>): {
  * only re-render when the slice they care about changes.
  */
 
+/**
+ * Non-hook accessor for the current merged client settings snapshot.
+ * Used by non-React code paths (e.g. runtime services) that need the latest
+ * settings without subscribing.
+ */
+export function getClientSettings(): ClientSettings {
+  return getClientSettingsSnapshot();
+}
+
 export function useSettings<T = UnifiedSettings>(selector?: (s: UnifiedSettings) => T): T {
   const serverSettings = useServerSettings();
   const clientSettings = useSyncExternalStore(

--- a/apps/web/src/logicalProject.ts
+++ b/apps/web/src/logicalProject.ts
@@ -65,6 +65,13 @@ export function deriveProjectGroupingOverrideKey(
   return derivePhysicalProjectKey(project);
 }
 
+// Key under which a project's manual sort order (projectOrder) is stored.
+// Must stay aligned with the writer side in `uiStateStore.syncProjects` and
+// the drag handlers in `Sidebar` so readers and writers agree.
+export function getProjectOrderKey(project: Pick<Project, "environmentId" | "cwd">): string {
+  return derivePhysicalProjectKey(project);
+}
+
 export function resolveProjectGroupingMode(
   project: Pick<Project, "environmentId" | "cwd">,
   settings: ProjectGroupingSettings,

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -270,6 +270,31 @@ describe("uiStateStore pure functions", () => {
     expect(next.projectExpandedById[logicalKey]).toBe(false);
   });
 
+  it("syncProjects preserves expand state when a project's logical key changes", () => {
+    // Example: late-arriving repo metadata flips grouping identity from the
+    // physical key to a canonical repository key. The row did not actually
+    // change, so the user's collapse choice must carry over.
+    const physicalKey = "env-local:/repo/project";
+    const previousLogicalKey = physicalKey;
+    const nextLogicalKey = "repo-canonical-key";
+
+    const initial = syncProjects(makeUiState(), [
+      { key: physicalKey, logicalKey: previousLogicalKey, cwd: "/repo/project" },
+    ]);
+
+    expect(initial.projectExpandedById[previousLogicalKey]).toBe(true);
+
+    const afterCollapse = {
+      ...initial,
+      projectExpandedById: { [previousLogicalKey]: false },
+    };
+    const next = syncProjects(afterCollapse, [
+      { key: physicalKey, logicalKey: nextLogicalKey, cwd: "/repo/project" },
+    ]);
+
+    expect(next.projectExpandedById[nextLogicalKey]).toBe(false);
+  });
+
   it("syncThreads prunes missing thread UI state", () => {
     const thread1 = ThreadId.make("thread-1");
     const thread2 = ThreadId.make("thread-2");

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -183,40 +183,43 @@ describe("uiStateStore pure functions", () => {
     });
 
     const next = syncProjects(initialState, [
-      { key: project1, cwd: "/tmp/project-1" },
-      { key: project2, cwd: "/tmp/project-2" },
-      { key: project3, cwd: "/tmp/project-3" },
+      { key: project1, logicalKey: project1, cwd: "/tmp/project-1" },
+      { key: project2, logicalKey: project2, cwd: "/tmp/project-2" },
+      { key: project3, logicalKey: project3, cwd: "/tmp/project-3" },
     ]);
 
     expect(next.projectOrder).toEqual([project2, project1, project3]);
     expect(next.projectExpandedById[project2]).toBe(false);
   });
 
-  it("syncProjects preserves manual order when a project is recreated with the same cwd", () => {
-    const oldProject1 = ProjectId.make("project-1");
-    const oldProject2 = ProjectId.make("project-2");
-    const recreatedProject2 = ProjectId.make("project-2b");
+  it("syncProjects preserves manual order across project id churn at the same cwd", () => {
+    // Under the current design, physical key and logical key are both
+    // cwd-derived, so an internal project-id change doesn't alter the store
+    // keys. This test locks in that stability: re-syncing the same cwds keeps
+    // manual order and collapse state.
+    const keyProject1 = "env-local:/tmp/project-1";
+    const keyProject2 = "env-local:/tmp/project-2";
     const initialState = syncProjects(
       makeUiState({
         projectExpandedById: {
-          [oldProject1]: true,
-          [oldProject2]: false,
+          [keyProject1]: true,
+          [keyProject2]: false,
         },
-        projectOrder: [oldProject2, oldProject1],
+        projectOrder: [keyProject2, keyProject1],
       }),
       [
-        { key: oldProject1, cwd: "/tmp/project-1" },
-        { key: oldProject2, cwd: "/tmp/project-2" },
+        { key: keyProject1, logicalKey: keyProject1, cwd: "/tmp/project-1" },
+        { key: keyProject2, logicalKey: keyProject2, cwd: "/tmp/project-2" },
       ],
     );
 
     const next = syncProjects(initialState, [
-      { key: oldProject1, cwd: "/tmp/project-1" },
-      { key: recreatedProject2, cwd: "/tmp/project-2" },
+      { key: keyProject1, logicalKey: keyProject1, cwd: "/tmp/project-1" },
+      { key: keyProject2, logicalKey: keyProject2, cwd: "/tmp/project-2" },
     ]);
 
-    expect(next.projectOrder).toEqual([recreatedProject2, oldProject1]);
-    expect(next.projectExpandedById[recreatedProject2]).toBe(false);
+    expect(next.projectOrder).toEqual([keyProject2, keyProject1]);
+    expect(next.projectExpandedById[keyProject2]).toBe(false);
   });
 
   it("syncProjects returns a new state when only project cwd changes", () => {
@@ -228,14 +231,43 @@ describe("uiStateStore pure functions", () => {
         },
         projectOrder: [project1],
       }),
-      [{ key: project1, cwd: "/tmp/project-1" }],
+      [{ key: project1, logicalKey: project1, cwd: "/tmp/project-1" }],
     );
 
-    const next = syncProjects(initialState, [{ key: project1, cwd: "/tmp/project-1-renamed" }]);
+    const next = syncProjects(initialState, [
+      { key: project1, logicalKey: project1, cwd: "/tmp/project-1-renamed" },
+    ]);
 
     expect(next).not.toBe(initialState);
     expect(next.projectOrder).toEqual([project1]);
     expect(next.projectExpandedById[project1]).toBe(false);
+  });
+
+  it("syncProjects keys projectExpandedById by the logical key, not the physical key", () => {
+    // In repository grouping mode, multiple physical projects (different
+    // environments or different repo-relative paths) collapse into one
+    // logical group. The group's expand state must be keyed by the logical
+    // key so clicks on the grouped row toggle the shared state, and so the
+    // state survives subsequent syncProjects calls (which rebuild the map
+    // from incoming inputs).
+    const physicalLocal = "env-local:/repo/project";
+    const physicalRemote = "env-remote:/repo/project";
+    const logicalKey = "repo-canonical-key";
+
+    const initial = syncProjects(makeUiState(), [
+      { key: physicalLocal, logicalKey, cwd: "/repo/project" },
+      { key: physicalRemote, logicalKey, cwd: "/repo/project" },
+    ]);
+
+    expect(initial.projectExpandedById).toEqual({ [logicalKey]: true });
+
+    const afterCollapse = { ...initial, projectExpandedById: { [logicalKey]: false } };
+    const next = syncProjects(afterCollapse, [
+      { key: physicalLocal, logicalKey, cwd: "/repo/project" },
+      { key: physicalRemote, logicalKey, cwd: "/repo/project" },
+    ]);
+
+    expect(next.projectExpandedById[logicalKey]).toBe(false);
   });
 
   it("syncThreads prunes missing thread UI state", () => {

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -507,4 +507,56 @@ describe("uiStateStore persistence round-trip", () => {
       kB: false,
     });
   });
+
+  it("preserves manual project order across restart", () => {
+    const projectA = { key: "kOrderA", logicalKey: "kOrderA", cwd: "/order-projA" };
+    const projectB = { key: "kOrderB", logicalKey: "kOrderB", cwd: "/order-projB" };
+    const projectC = { key: "kOrderC", logicalKey: "kOrderC", cwd: "/order-projC" };
+
+    let state = syncProjects(makeUiState(), [projectA, projectB, projectC]);
+    state = reorderProjects(state, [projectC.key], [projectA.key]);
+    expect(state.projectOrder).toEqual([projectC.key, projectA.key, projectB.key]);
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    expect(persisted.projectOrderCwds).toEqual([projectC.cwd, projectA.cwd, projectB.cwd]);
+
+    hydratePersistedProjectState(persisted);
+    // Fresh state (empty projectOrder) so syncProjects derives order from
+    // persistedProjectOrderCwds rather than the in-memory projectOrder branch.
+    const rehydrated = syncProjects(makeUiState(), [projectA, projectB, projectC]);
+
+    expect(rehydrated.projectOrder).toEqual([projectC.key, projectA.key, projectB.key]);
+  });
+
+  it("preserves expand state across restart when project's logical key changes", () => {
+    // After restart, in-memory previousExpandedById is empty, so the
+    // previousLogicalKey-to-state bridge in syncProjects cannot help. The
+    // persisted-cwd fallback is the only mechanism that can carry collapse
+    // state across a restart that also flips a project into a new logical
+    // group (e.g. late-arriving repo metadata). This locks in that path.
+    const physicalKey = "env-local:/lk-restart-proj";
+    const previousLogicalKey = physicalKey;
+    const cwd = "/lk-restart-proj";
+
+    let state = syncProjects(makeUiState(), [
+      { key: physicalKey, logicalKey: previousLogicalKey, cwd },
+    ]);
+    state = setProjectExpanded(state, previousLogicalKey, false);
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    hydratePersistedProjectState(persisted);
+
+    const nextLogicalKey = "lk-restart-canonical";
+    const rehydrated = syncProjects(makeUiState(), [
+      { key: physicalKey, logicalKey: nextLogicalKey, cwd },
+    ]);
+
+    expect(rehydrated.projectExpandedById[nextLogicalKey]).toBe(false);
+  });
 });

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -1,9 +1,13 @@
 import { ProjectId, ThreadId } from "@t3tools/contracts";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   clearThreadUi,
+  hydratePersistedProjectState,
   markThreadUnread,
+  PERSISTED_STATE_KEY,
+  type PersistedUiState,
+  persistState,
   reorderProjects,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
@@ -401,5 +405,106 @@ describe("uiStateStore pure functions", () => {
     const next = setThreadChangedFilesExpanded(initialState, thread1, "turn-1", true);
 
     expect(next.threadChangedFilesExpandedById).toEqual({});
+  });
+});
+
+describe("uiStateStore persistence round-trip", () => {
+  function createLocalStorageStub(): Storage {
+    const store = new Map<string, string>();
+    return {
+      clear: () => {
+        store.clear();
+      },
+      getItem: (key) => store.get(key) ?? null,
+      key: (index) => [...store.keys()][index] ?? null,
+      get length() {
+        return store.size;
+      },
+      removeItem: (key) => {
+        store.delete(key);
+      },
+      setItem: (key, value) => {
+        store.set(key, value);
+      },
+    };
+  }
+
+  let localStorageStub: Storage;
+
+  beforeEach(() => {
+    localStorageStub = createLocalStorageStub();
+    vi.stubGlobal("window", { localStorage: localStorageStub });
+    vi.stubGlobal("localStorage", localStorageStub);
+    // Reset module-level persistence state so tests don't bleed into each other.
+    hydratePersistedProjectState({ collapsedProjectCwds: [], expandedProjectCwds: [] });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves all-collapsed project state across restart", () => {
+    // Regression: pre-fix, persistState only wrote `expandedProjectCwds`, so
+    // an empty array on rehydrate was indistinguishable from a fresh install
+    // and the syncProjects fallback re-expanded every row.
+    const projectA = { key: "kA", logicalKey: "kA", cwd: "/projA" };
+    const projectB = { key: "kB", logicalKey: "kB", cwd: "/projB" };
+
+    let state = syncProjects(makeUiState(), [projectA, projectB]);
+    state = setProjectExpanded(state, projectA.key, false);
+    state = setProjectExpanded(state, projectB.key, false);
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    hydratePersistedProjectState(persisted);
+    const rehydrated = syncProjects(makeUiState(), [projectA, projectB]);
+
+    expect(rehydrated.projectExpandedById).toEqual({
+      [projectA.key]: false,
+      [projectB.key]: false,
+    });
+  });
+
+  it("respects mixed expand state on rehydrate and defaults new projects to expanded", () => {
+    const projectA = { key: "kA", logicalKey: "kA", cwd: "/projA" };
+    const projectB = { key: "kB", logicalKey: "kB", cwd: "/projB" };
+    const projectC = { key: "kC", logicalKey: "kC", cwd: "/projC" };
+
+    let state = syncProjects(makeUiState(), [projectA, projectB]);
+    state = setProjectExpanded(state, projectB.key, false);
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    hydratePersistedProjectState(persisted);
+    const rehydrated = syncProjects(makeUiState(), [projectA, projectB, projectC]);
+
+    expect(rehydrated.projectExpandedById).toEqual({
+      [projectA.key]: true,
+      [projectB.key]: false,
+      [projectC.key]: true,
+    });
+  });
+
+  it("preserves legacy not-in-expanded-list = collapsed for one upgrade session", () => {
+    // Pre-fix shape only stored expandedProjectCwds. Absence of
+    // collapsedProjectCwds opts the session into the legacy fallback so
+    // upgrade users do not see previously collapsed rows pop open.
+    hydratePersistedProjectState({
+      expandedProjectCwds: ["/projA"],
+    });
+
+    const rehydrated = syncProjects(makeUiState(), [
+      { key: "kA", logicalKey: "kA", cwd: "/projA" },
+      { key: "kB", logicalKey: "kB", cwd: "/projB" },
+    ]);
+
+    expect(rehydrated.projectExpandedById).toEqual({
+      kA: true,
+      kB: false,
+    });
   });
 });

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -34,7 +34,10 @@ export interface UiThreadState {
 export interface UiState extends UiProjectState, UiThreadState {}
 
 export interface SyncProjectInput {
+  /** Physical project key (env + cwd). Used for manual sort order. */
   key: string;
+  /** Logical group key. Used for expand/collapse state. */
+  logicalKey: string;
   cwd: string;
 }
 
@@ -53,6 +56,7 @@ const initialState: UiState = {
 const persistedExpandedProjectCwds = new Set<string>();
 const persistedProjectOrderCwds: string[] = [];
 const currentProjectCwdById = new Map<string, string>();
+const currentProjectCwdsByLogicalKey = new Map<string, string[]>();
 let legacyKeysCleanedUp = false;
 
 function readPersistedState(): UiState {
@@ -135,10 +139,7 @@ function persistState(state: UiState): void {
   try {
     const expandedProjectCwds = Object.entries(state.projectExpandedById)
       .filter(([, expanded]) => expanded)
-      .flatMap(([projectId]) => {
-        const cwd = currentProjectCwdById.get(projectId);
-        return cwd ? [cwd] : [];
-      });
+      .flatMap(([logicalKey]) => currentProjectCwdsByLogicalKey.get(logicalKey) ?? []);
     const projectOrderCwds = state.projectOrder.flatMap((projectId) => {
       const cwd = currentProjectCwdById.get(projectId);
       return cwd ? [cwd] : [];
@@ -211,12 +212,20 @@ function nestedBooleanRecordsEqual(
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
   const previousProjectCwdById = new Map(currentProjectCwdById);
-  const previousProjectIdByCwd = new Map(
-    [...previousProjectCwdById.entries()].map(([projectId, cwd]) => [cwd, projectId] as const),
-  );
   currentProjectCwdById.clear();
   for (const project of projects) {
     currentProjectCwdById.set(project.key, project.cwd);
+  }
+  currentProjectCwdsByLogicalKey.clear();
+  for (const project of projects) {
+    const cwds = currentProjectCwdsByLogicalKey.get(project.logicalKey);
+    if (cwds) {
+      if (!cwds.includes(project.cwd)) {
+        cwds.push(project.cwd);
+      }
+    } else {
+      currentProjectCwdsByLogicalKey.set(project.logicalKey, [project.cwd]);
+    }
   }
   const cwdMappingChanged =
     previousProjectCwdById.size !== currentProjectCwdById.size ||
@@ -228,14 +237,15 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
     persistedProjectOrderCwds.map((cwd, index) => [cwd, index] as const),
   );
   const mappedProjects = projects.map((project, index) => {
-    const previousProjectIdForCwd = previousProjectIdByCwd.get(project.cwd);
-    const expanded =
-      previousExpandedById[project.key] ??
-      (previousProjectIdForCwd ? previousExpandedById[previousProjectIdForCwd] : undefined) ??
-      (persistedExpandedProjectCwds.size > 0
-        ? persistedExpandedProjectCwds.has(project.cwd)
-        : true);
-    nextExpandedById[project.key] = expanded;
+    if (!(project.logicalKey in nextExpandedById)) {
+      const groupCwds = currentProjectCwdsByLogicalKey.get(project.logicalKey) ?? [project.cwd];
+      const expanded =
+        previousExpandedById[project.logicalKey] ??
+        (persistedExpandedProjectCwds.size > 0
+          ? groupCwds.some((cwd) => persistedExpandedProjectCwds.has(cwd))
+          : true);
+      nextExpandedById[project.logicalKey] = expanded;
+    }
     return {
       id: project.key,
       cwd: project.cwd,
@@ -246,6 +256,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   const nextProjectOrder =
     state.projectOrder.length > 0
       ? (() => {
+          const currentProjectIds = new Set(mappedProjects.map((project) => project.id));
           const nextProjectIdByCwd = new Map(
             mappedProjects.map((project) => [project.cwd, project.id] as const),
           );
@@ -254,7 +265,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
 
           for (const projectId of state.projectOrder) {
             const matchedProjectId =
-              (projectId in nextExpandedById ? projectId : undefined) ??
+              (currentProjectIds.has(projectId) ? projectId : undefined) ??
               (() => {
                 const previousCwd = previousProjectCwdById.get(projectId);
                 return previousCwd ? nextProjectIdByCwd.get(previousCwd) : undefined;

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -57,6 +57,7 @@ const persistedExpandedProjectCwds = new Set<string>();
 const persistedProjectOrderCwds: string[] = [];
 const currentProjectCwdById = new Map<string, string>();
 const currentProjectCwdsByLogicalKey = new Map<string, string[]>();
+const currentLogicalKeyByPhysicalKey = new Map<string, string>();
 let legacyKeysCleanedUp = false;
 
 function readPersistedState(): UiState {
@@ -212,9 +213,12 @@ function nestedBooleanRecordsEqual(
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
   const previousProjectCwdById = new Map(currentProjectCwdById);
+  const previousLogicalKeyByPhysicalKey = new Map(currentLogicalKeyByPhysicalKey);
   currentProjectCwdById.clear();
+  currentLogicalKeyByPhysicalKey.clear();
   for (const project of projects) {
     currentProjectCwdById.set(project.key, project.cwd);
+    currentLogicalKeyByPhysicalKey.set(project.key, project.logicalKey);
   }
   currentProjectCwdsByLogicalKey.clear();
   for (const project of projects) {
@@ -225,6 +229,23 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
       }
     } else {
       currentProjectCwdsByLogicalKey.set(project.logicalKey, [project.cwd]);
+    }
+  }
+  // Build reverse map: for each new logical key, which previous logical keys
+  // did its member projects live under? Lets us preserve expand state when a
+  // project's logical key changes (e.g. late-arriving repo metadata flips the
+  // group identity).
+  const previousLogicalKeysByNewLogicalKey = new Map<string, Set<string>>();
+  for (const project of projects) {
+    const previousLogicalKey = previousLogicalKeyByPhysicalKey.get(project.key);
+    if (!previousLogicalKey || previousLogicalKey === project.logicalKey) {
+      continue;
+    }
+    const set = previousLogicalKeysByNewLogicalKey.get(project.logicalKey);
+    if (set) {
+      set.add(previousLogicalKey);
+    } else {
+      previousLogicalKeysByNewLogicalKey.set(project.logicalKey, new Set([previousLogicalKey]));
     }
   }
   const cwdMappingChanged =
@@ -239,8 +260,21 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   const mappedProjects = projects.map((project, index) => {
     if (!(project.logicalKey in nextExpandedById)) {
       const groupCwds = currentProjectCwdsByLogicalKey.get(project.logicalKey) ?? [project.cwd];
+      const fallbackFromPreviousLogicalKey = (() => {
+        const previousKeys = previousLogicalKeysByNewLogicalKey.get(project.logicalKey);
+        if (!previousKeys) {
+          return undefined;
+        }
+        for (const previousKey of previousKeys) {
+          if (previousKey in previousExpandedById) {
+            return previousExpandedById[previousKey];
+          }
+        }
+        return undefined;
+      })();
       const expanded =
         previousExpandedById[project.logicalKey] ??
+        fallbackFromPreviousLogicalKey ??
         (persistedExpandedProjectCwds.size > 0
           ? groupCwds.some((cwd) => persistedExpandedProjectCwds.has(cwd))
           : true);

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -16,6 +16,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 ] as const;
 
 interface PersistedUiState {
+  collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
@@ -53,8 +54,14 @@ const initialState: UiState = {
   threadChangedFilesExpandedById: {},
 };
 
+const persistedCollapsedProjectCwds = new Set<string>();
 const persistedExpandedProjectCwds = new Set<string>();
 const persistedProjectOrderCwds: string[] = [];
+// Pre-fix persisted shape only listed expanded cwds, so anything not listed
+// was treated as collapsed. Track whether the loaded blob carried the new
+// `collapsedProjectCwds` field so we can preserve that legacy semantic for
+// one session after upgrade, until persistState rewrites in the new shape.
+let persistedProjectStateUsesLegacyShape = false;
 const currentProjectCwdById = new Map<string, string>();
 const currentProjectCwdsByLogicalKey = new Map<string, string[]>();
 const currentLogicalKeyByPhysicalKey = new Map<string, string>();
@@ -119,8 +126,15 @@ function sanitizePersistedThreadChangedFilesExpanded(
 }
 
 function hydratePersistedProjectState(parsed: PersistedUiState): void {
+  persistedCollapsedProjectCwds.clear();
   persistedExpandedProjectCwds.clear();
   persistedProjectOrderCwds.length = 0;
+  persistedProjectStateUsesLegacyShape = !Array.isArray(parsed.collapsedProjectCwds);
+  for (const cwd of parsed.collapsedProjectCwds ?? []) {
+    if (typeof cwd === "string" && cwd.length > 0) {
+      persistedCollapsedProjectCwds.add(cwd);
+    }
+  }
   for (const cwd of parsed.expandedProjectCwds ?? []) {
     if (typeof cwd === "string" && cwd.length > 0) {
       persistedExpandedProjectCwds.add(cwd);
@@ -138,6 +152,12 @@ function persistState(state: UiState): void {
     return;
   }
   try {
+    // Persist collapsed cwds explicitly so an empty/missing field unambiguously
+    // means "first install" rather than "user collapsed everything"; without
+    // this, the syncProjects fallback would re-expand all rows on next launch.
+    const collapsedProjectCwds = Object.entries(state.projectExpandedById)
+      .filter(([, expanded]) => !expanded)
+      .flatMap(([logicalKey]) => currentProjectCwdsByLogicalKey.get(logicalKey) ?? []);
     const expandedProjectCwds = Object.entries(state.projectExpandedById)
       .filter(([, expanded]) => expanded)
       .flatMap(([logicalKey]) => currentProjectCwdsByLogicalKey.get(logicalKey) ?? []);
@@ -156,6 +176,7 @@ function persistState(state: UiState): void {
     window.localStorage.setItem(
       PERSISTED_STATE_KEY,
       JSON.stringify({
+        collapsedProjectCwds,
         expandedProjectCwds,
         projectOrderCwds,
         threadChangedFilesExpandedById,
@@ -272,12 +293,22 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
         }
         return undefined;
       })();
+      const fallbackFromPersistedShape = (() => {
+        if (groupCwds.some((cwd) => persistedExpandedProjectCwds.has(cwd))) {
+          return true;
+        }
+        if (groupCwds.some((cwd) => persistedCollapsedProjectCwds.has(cwd))) {
+          return false;
+        }
+        if (persistedProjectStateUsesLegacyShape && persistedExpandedProjectCwds.size > 0) {
+          return false;
+        }
+        return true;
+      })();
       const expanded =
         previousExpandedById[project.logicalKey] ??
         fallbackFromPreviousLogicalKey ??
-        (persistedExpandedProjectCwds.size > 0
-          ? groupCwds.some((cwd) => persistedExpandedProjectCwds.has(cwd))
-          : true);
+        fallbackFromPersistedShape;
       nextExpandedById[project.logicalKey] = expanded;
     }
     return {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -1,7 +1,7 @@
 import { Debouncer } from "@tanstack/react-pacer";
 import { create } from "zustand";
 
-const PERSISTED_STATE_KEY = "t3code:ui-state:v1";
+export const PERSISTED_STATE_KEY = "t3code:ui-state:v1";
 const LEGACY_PERSISTED_STATE_KEYS = [
   "t3code:renderer-state:v8",
   "t3code:renderer-state:v7",
@@ -15,7 +15,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
   "codething:renderer-state:v1",
 ] as const;
 
-interface PersistedUiState {
+export interface PersistedUiState {
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
   projectOrderCwds?: string[];
@@ -125,7 +125,7 @@ function sanitizePersistedThreadChangedFilesExpanded(
   return nextState;
 }
 
-function hydratePersistedProjectState(parsed: PersistedUiState): void {
+export function hydratePersistedProjectState(parsed: PersistedUiState): void {
   persistedCollapsedProjectCwds.clear();
   persistedExpandedProjectCwds.clear();
   persistedProjectOrderCwds.length = 0;
@@ -147,7 +147,7 @@ function hydratePersistedProjectState(parsed: PersistedUiState): void {
   }
 }
 
-function persistState(state: UiState): void {
+export function persistState(state: UiState): void {
   if (typeof window === "undefined") {
     return;
   }


### PR DESCRIPTION
## Summary

- Manual-sort drag reorder was snapping projects back; writers populated `projectOrder` with physical keys while readers matched items by scoped keys, so `preferredIds` never matched. Same reader/writer mismatch as #1902, re-introduced in #2055.
- Grouped projects (grouping != `separate`) lost their expand/collapse state on every `syncProjects` run, because `projectExpandedById` was written under physical keys while the UI reads/writes by logical (group) keys.
- Route both paths through a single key source so a reader/writer cannot silently drift again.

Fixes #2219.

## Repro

1. In the sidebar, click the "Sort projects" icon (arrows-up-down, next to the sidebar header) and set Sort projects to `Manual`. Drag a project. It snaps back.
2. In the same menu, set Group projects to `Group by repository`. Collapse a grouped row. Trigger anything that re-enters `syncProjects` (e.g. a project refresh). It re-expands.

## Diagnosis

`apps/web/src/uiStateStore.ts` tracks `projectOrder` and `projectExpandedById`. PR #2055 changed the writers to use physical keys (env + normalized cwd) but did not update the sibling readers.

For `projectOrder`:
- Writer: `handleProjectDragEnd` in `Sidebar.tsx:2857` passes `member.physicalProjectKey` to `reorderProjects` (see lines 2870-2873).
- Reader: `orderedProjects` memo in `Sidebar.tsx:2707` and `useHandleNewThread.ts:168` both use `getId: (project) => scopedProjectKey(scopeProjectRef(project.environmentId, project.id))`.

For `projectExpandedById`:
- Writer: `syncProjects` seeded entries keyed by the physical key.
- Reader: the sidebar row computes its state from the logical (group) key, which in non-`separate` grouping modes is the repo canonical key, not the physical key.

## Why this approach

For `projectOrder`, I extracted a named helper so any future caller writing `projectOrder` can be pinned to the same derivation as the readers:

```ts
// apps/web/src/logicalProject.ts
export function getProjectOrderKey(project: Pick<Project, "environmentId" | "cwd">): string {
  return derivePhysicalProjectKey(project);
}
```

Both `orderedProjects` and `useHandleNewThread` now use `getProjectOrderKey` as their `getId`, matching the drag-end writer. That way the next silent divergence becomes a grep target, rather than a deploy-day regression.

For `projectExpandedById`, I split `SyncProjectInput` into a physical `key` (used for `projectOrder`, stable across grouping changes) and a `logicalKey` (used for expand/collapse, matches what the UI reads). `syncProjects` now keys `projectExpandedById` by `logicalKey`, and localStorage persistence tracks the member cwds per group so hydration still works for grouped projects (no migration needed).

`syncProjects` also preserves expand state when a project's logical key changes mid-session -- for example, late-arriving repo metadata flipping the grouping identity from the physical key to the repo canonical key. Without that, the row would unexpectedly reopen the instant metadata arrived.

### Considered alternatives

Rolling back #2055's writer-side choice would also solve regression A, but #2055 keyed persistence by cwd to survive project id churn, which is the right direction. Aligning the readers (and disentangling the two pieces of state) is the smaller, forward-compatible fix.

### Known limitation

If the user toggles `sidebarProjectGroupingMode` at runtime without any project snapshot events following, `syncProjects` does not re-run and existing `projectExpandedById` entries stay keyed under the previous grouping until the next project event arrives. Today the most common flow triggers a sync before the user notices, but a subscriber that re-runs `syncProjectUiFromStore` when grouping settings change would make this tighter. I left that out to keep this PR small; happy to fold it in if you prefer.

## Test plan

- [x] `bun fmt`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run test` (938 tests pass, 1 file skipped, no new failures)
- [x] New regression tests added:
  - `apps/web/src/components/Sidebar.logic.test.ts`: asserts `getProjectOrderKey` is what `orderItemsByPreferredIds` uses to honor `projectOrder` (locks in the snap-back fix).
  - `apps/web/src/uiStateStore.test.ts`: `syncProjects keys projectExpandedById by the logical key, not the physical key` (two physical projects sharing a logical group both respect a collapsed logical-key entry).
  - `apps/web/src/uiStateStore.test.ts`: `syncProjects preserves expand state when a project's logical key changes` (covers the late-metadata flip).
- [x] End-to-end in the Linux AppImage build:
  - Set Sort projects to `Manual` and dragged several projects into new positions (rows that used to snap back). They stayed put.
  - With Group projects set to `Group by repository`, collapsed several grouped rows.
  - Restarted t3code and confirmed both the manual order and the collapsed states persisted across the restart.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sidebar ordering and `uiStateStore` persistence/keying logic; regressions could affect project ordering/expand state across sessions, but scope is contained to client UI state.
> 
> **Overview**
> Restores manual project drag ordering by making sidebar readers (`Sidebar`, `useHandleNewThread`) identify projects using the same **physical key** (`environmentId` + normalized `cwd`) that drag handlers/store write, via new `getProjectOrderKey`.
> 
> Refactors project UI state syncing/persistence to support **grouped projects**: `syncProjects` now distinguishes physical `key` (ordering) from `logicalKey` (expand/collapse), preserves expand state when logical keys change, and persists both `collapsedProjectCwds` and ordering cwds to avoid “everything re-expands” and order loss on restart. Adds a non-hook `getClientSettings()` accessor so runtime services can compute `logicalKey` during project sync.
> 
> Adds regression tests covering physical-key ordering, logical-key expand state, logical-key churn, and persistence round-trips for collapse/order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb544d9d8e0353bb1bfc028cab1b448df139aa50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix manual sort drag and per-group expand/collapse state persistence in sidebar
> - Introduces `getProjectOrderKey` in [logicalProject.ts](https://github.com/pingdotgg/t3code/pull/2221/files#diff-9fa781592e3ea36ce218eab738bf15d811679cc104ed2394cf764b2cc58bf684) as the canonical key for project sort order, then updates [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2221/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and [useHandleNewThread.ts](https://github.com/pingdotgg/t3code/pull/2221/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef) to use it, preventing manual drag order from snapping back.
> - Reworks `syncProjects` in [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/2221/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8) to key expand/collapse state by logical group rather than physical project id, preserving collapsed rows across project id churn and restarts.
> - Adds `collapsedProjectCwds` to the persisted state shape and updates `persistState`/`hydratePersistedProjectState` so an all-collapsed sidebar remains collapsed after a page reload.
> - Passes `logicalKey` (derived via `deriveLogicalProjectKeyFromSettings`) into `syncProjects` from [service.ts](https://github.com/pingdotgg/t3code/pull/2221/files#diff-0c6fcb6b689bfab728dafd4ef75801e020355035bffde6032ccd03d5983cc7cc) to support grouping-aware expand state.
> - Behavioral Change: legacy persisted state (without `collapsedProjectCwds`) defaults all projects to collapsed for one session to avoid ambiguity, then writes the new format on next persist.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb544d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->