### PR TITLE
Implement provider usage sidebar

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -29,6 +29,7 @@ import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import { buildServerProvider } from "../providerSnapshot.ts";
 import { CodexProvider } from "../Services/CodexProvider.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { codexAccountAuthMetadata } from "../codexAccount.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 
 const PROVIDER = "codex" as const;
@@ -49,37 +50,6 @@ const REASONING_EFFORT_LABELS: Record<CodexSchema.V2ModelListResponse__Reasoning
   high: "High",
   xhigh: "Extra High",
 };
-
-function codexAccountAuthLabel(account: CodexSchema.V2GetAccountResponse["account"]) {
-  if (!account) return undefined;
-  if (account.type === "apiKey") return "OpenAI API Key";
-
-  switch (account.planType) {
-    case "free":
-      return "ChatGPT Free Subscription";
-    case "go":
-      return "ChatGPT Go Subscription";
-    case "plus":
-      return "ChatGPT Plus Subscription";
-    case "pro":
-      return "ChatGPT Pro Subscription";
-    case "team":
-      return "ChatGPT Team Subscription";
-    case "self_serve_business_usage_based":
-    case "business":
-      return "ChatGPT Business Subscription";
-    case "enterprise_cbp_usage_based":
-    case "enterprise":
-      return "ChatGPT Enterprise Subscription";
-    case "edu":
-      return "ChatGPT Edu Subscription";
-    case "unknown":
-      return "ChatGPT Subscription";
-    default:
-      account.planType satisfies never;
-      return undefined;
-  }
-}
 
 function mapCodexModelCapabilities(
   model: CodexSchema.V2ModelListResponse__Model,
@@ -324,11 +294,15 @@ function accountProbeStatus(account: CodexAppServerProviderSnapshot["account"]):
   readonly auth: ServerProvider["auth"];
   readonly message?: string;
 } {
-  const authLabel = codexAccountAuthLabel(account.account);
+  const planType = account.account?.type === "chatgpt" ? account.account.planType : undefined;
+  const authMetadata = codexAccountAuthMetadata({
+    accountType: account.account?.type,
+    planType,
+  });
   const auth = {
     status: account.account ? ("authenticated" as const) : ("unknown" as const),
-    ...(account.account?.type ? { type: account.account?.type } : {}),
-    ...(authLabel ? { label: authLabel } : {}),
+    ...(authMetadata?.type ? { type: authMetadata.type } : {}),
+    ...(authMetadata?.label ? { label: authMetadata.label } : {}),
   } satisfies ServerProvider["auth"];
 
   if (account.account) {

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -403,6 +403,107 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest()))(
         ]);
       });
 
+      it("preserves provider usage when a refresh does not include a new usage snapshot", () => {
+        const previousProvider = {
+          provider: "codex",
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: {
+            status: "authenticated",
+            type: "chatgpt",
+            label: "ChatGPT Pro Subscription",
+          },
+          checkedAt: "2026-04-20T00:00:00.000Z",
+          version: "1.0.0",
+          usage: {
+            state: "available",
+            checkedAt: "2026-04-20T00:00:00.000Z",
+            windows: [
+              {
+                id: "5h",
+                label: "5h",
+                percentUsed: 72,
+                resetsAt: "2026-04-20T05:00:00.000Z",
+                level: "warning",
+                exhausted: false,
+              },
+            ],
+          },
+          models: [],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...previousProvider,
+          checkedAt: "2026-04-20T00:01:00.000Z",
+          usage: undefined,
+        } satisfies ServerProvider;
+
+        assert.deepStrictEqual(mergeProviderSnapshot(previousProvider, refreshedProvider).usage, {
+          state: "available",
+          checkedAt: "2026-04-20T00:00:00.000Z",
+          windows: [
+            {
+              id: "5h",
+              label: "5h",
+              percentUsed: 72,
+              resetsAt: "2026-04-20T05:00:00.000Z",
+              level: "warning",
+              exhausted: false,
+            },
+          ],
+        });
+      });
+
+      it("clears codex usage when a refreshed provider snapshot is using an api key", () => {
+        const previousProvider = {
+          provider: "codex",
+          status: "ready",
+          enabled: true,
+          installed: true,
+          auth: {
+            status: "authenticated",
+            type: "chatgpt",
+            label: "ChatGPT Pro Subscription",
+          },
+          checkedAt: "2026-04-20T00:00:00.000Z",
+          version: "1.0.0",
+          usage: {
+            state: "available",
+            checkedAt: "2026-04-20T00:00:00.000Z",
+            windows: [
+              {
+                id: "5h",
+                label: "5h",
+                percentUsed: 72,
+                resetsAt: "2026-04-20T05:00:00.000Z",
+                level: "warning",
+                exhausted: false,
+              },
+            ],
+          },
+          models: [],
+          slashCommands: [],
+          skills: [],
+        } as const satisfies ServerProvider;
+        const refreshedProvider = {
+          ...previousProvider,
+          checkedAt: "2026-04-20T00:01:00.000Z",
+          auth: {
+            status: "authenticated",
+            type: "apiKey",
+            label: "OpenAI API Key",
+          },
+          usage: undefined,
+        } satisfies ServerProvider;
+
+        assert.strictEqual(
+          mergeProviderSnapshot(previousProvider, refreshedProvider).usage,
+          undefined,
+        );
+      });
+
       it.effect("probes enabled providers in the background during registry startup", () =>
         Effect.gen(function* () {
           let spawnCount = 0;

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -4,7 +4,7 @@
  * @module ProviderRegistryLive
  */
 import type { ProviderKind, ServerProvider } from "@t3tools/contracts";
-import { Effect, Equal, FileSystem, Layer, Path, PubSub, Ref, Stream } from "effect";
+import { Effect, Equal, FileSystem, Layer, Option, Path, PubSub, Ref, Stream } from "effect";
 
 import { ServerConfig } from "../../config.ts";
 import { ClaudeProviderLive } from "./ClaudeProvider.ts";
@@ -25,6 +25,8 @@ import {
   resolveProviderStatusCachePath,
   writeProviderStatusCache,
 } from "../providerStatusCache.ts";
+import { ProviderService } from "../Services/ProviderService.ts";
+import { mergeProviderRuntimeEventIntoSnapshot } from "../providerUsage.ts";
 
 type ProviderSnapshotSource = {
   readonly provider: ProviderKind;
@@ -70,16 +72,30 @@ const mergeProviderModels = (
   return [...mergedModels, ...previousModels.filter((model) => !nextSlugs.has(model.slug))];
 };
 
+const shouldClearProviderUsage = (provider: ServerProvider): boolean =>
+  !provider.enabled || (provider.provider === "codex" && provider.auth.type === "apiKey");
+
 export const mergeProviderSnapshot = (
   previousProvider: ServerProvider | undefined,
   nextProvider: ServerProvider,
 ): ServerProvider =>
   !previousProvider
     ? nextProvider
-    : {
-        ...nextProvider,
-        models: mergeProviderModels(previousProvider.models, nextProvider.models),
-      };
+    : (() => {
+        const mergedProvider: ServerProvider = {
+          ...nextProvider,
+          models: mergeProviderModels(previousProvider.models, nextProvider.models),
+        };
+        if (shouldClearProviderUsage(mergedProvider)) {
+          return mergedProvider;
+        }
+        return nextProvider.usage === undefined && previousProvider.usage !== undefined
+          ? {
+              ...mergedProvider,
+              usage: previousProvider.usage,
+            }
+          : mergedProvider;
+      })();
 
 export const haveProvidersChanged = (
   previousProviders: ReadonlyArray<ServerProvider>,
@@ -97,6 +113,7 @@ const ProviderRegistryLiveBase = Layer.effect(
     const path = yield* Path.Path;
 
     const cursorProvider = yield* CursorProvider;
+    const providerServiceOption = yield* Effect.serviceOption(ProviderService);
 
     const providerSources = [
       {
@@ -263,6 +280,24 @@ const ProviderRegistryLiveBase = Layer.effect(
         discard: true,
       },
     );
+    if (Option.isSome(providerServiceOption)) {
+      yield* Stream.runForEach(providerServiceOption.value.streamEvents, (event) => {
+        if (event.type !== "account.updated" && event.type !== "account.rate-limits.updated") {
+          return Effect.void;
+        }
+
+        return Ref.get(providersRef).pipe(
+          Effect.map((providers) =>
+            providers.find((provider) => provider.provider === event.provider),
+          ),
+          Effect.flatMap((provider) =>
+            provider
+              ? syncProvider(mergeProviderRuntimeEventIntoSnapshot(provider, event))
+              : Effect.void,
+          ),
+        );
+      }).pipe(Effect.forkScoped);
+    }
     yield* loadProviders(providerSources).pipe(
       Effect.flatMap((providers) => upsertProviders(providers, { publish: false })),
     );

--- a/apps/server/src/provider/codexAccount.ts
+++ b/apps/server/src/provider/codexAccount.ts
@@ -1,0 +1,72 @@
+export function normalizeCodexAuthType(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  switch (normalized) {
+    case "apikey":
+    case "api_key":
+      return "apiKey";
+    case "chatgpt":
+    case "chatgptauthtokens":
+    case "chatgpt_auth_tokens":
+      return "chatgpt";
+    default:
+      return undefined;
+  }
+}
+
+function codexSubscriptionLabel(planType: unknown): string | undefined {
+  if (typeof planType !== "string") {
+    return undefined;
+  }
+
+  switch (planType) {
+    case "free":
+      return "ChatGPT Free Subscription";
+    case "go":
+      return "ChatGPT Go Subscription";
+    case "plus":
+      return "ChatGPT Plus Subscription";
+    case "pro":
+      return "ChatGPT Pro Subscription";
+    case "team":
+      return "ChatGPT Team Subscription";
+    case "self_serve_business_usage_based":
+    case "business":
+      return "ChatGPT Business Subscription";
+    case "enterprise_cbp_usage_based":
+    case "enterprise":
+      return "ChatGPT Enterprise Subscription";
+    case "edu":
+      return "ChatGPT Edu Subscription";
+    case "unknown":
+      return "ChatGPT Subscription";
+    default:
+      return undefined;
+  }
+}
+
+export function codexAccountAuthMetadata(input: {
+  readonly accountType?: unknown;
+  readonly authMode?: unknown;
+  readonly planType?: unknown;
+}): { readonly type?: string; readonly label?: string } | undefined {
+  const type = normalizeCodexAuthType(input.accountType) ?? normalizeCodexAuthType(input.authMode);
+  if (!type) {
+    return undefined;
+  }
+
+  if (type === "apiKey") {
+    return {
+      type,
+      label: "OpenAI API Key",
+    };
+  }
+
+  return {
+    type,
+    label: codexSubscriptionLabel(input.planType) ?? "ChatGPT Subscription",
+  };
+}

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -53,6 +53,7 @@ export const hydrateCachedProvider = (input: {
     status: input.cachedProvider.status,
     auth: input.cachedProvider.auth,
     checkedAt: input.cachedProvider.checkedAt,
+    ...(input.cachedProvider.usage ? { usage: input.cachedProvider.usage } : {}),
     slashCommands: input.cachedProvider.slashCommands,
     skills: input.cachedProvider.skills,
   };

--- a/apps/server/src/provider/providerUsage.test.ts
+++ b/apps/server/src/provider/providerUsage.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderRuntimeEvent, ServerProvider } from "@t3tools/contracts";
+
+import {
+  mergeProviderRuntimeEventIntoSnapshot,
+  normalizeProviderUsageSnapshot,
+} from "./providerUsage.ts";
+
+const CHECKED_AT = "2026-04-20T00:00:00.000Z";
+
+function makeProvider(overrides: Partial<ServerProvider> = {}): ServerProvider {
+  return {
+    provider: "codex",
+    enabled: true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: {
+      status: "authenticated",
+      type: "chatgpt",
+      label: "ChatGPT Pro Subscription",
+    },
+    checkedAt: CHECKED_AT,
+    models: [],
+    slashCommands: [],
+    skills: [],
+    ...overrides,
+  };
+}
+
+describe("normalizeProviderUsageSnapshot", () => {
+  it("normalizes codex rate-limit snapshots into canonical usage windows", () => {
+    const snapshot = normalizeProviderUsageSnapshot(
+      {
+        limitName: "ChatGPT",
+        primary: {
+          usedPercent: 72,
+          resetsAt: 1_776_628_800,
+          windowDurationMins: 300,
+        },
+        secondary: {
+          usedPercent: 91,
+          resetsAt: 1_777_233_600,
+          windowDurationMins: 10_080,
+        },
+      },
+      CHECKED_AT,
+    );
+
+    expect(snapshot.state).toBe("available");
+    expect(snapshot.checkedAt).toBe(CHECKED_AT);
+    expect(snapshot.windows).toEqual([
+      {
+        id: "5h",
+        label: "5h",
+        percentUsed: 72,
+        resetsAt: "2026-04-19T20:00:00.000Z",
+        level: "warning",
+        exhausted: false,
+      },
+      {
+        id: "7d",
+        label: "7d",
+        percentUsed: 91,
+        resetsAt: "2026-04-26T20:00:00.000Z",
+        level: "critical",
+        exhausted: false,
+      },
+    ]);
+  });
+
+  it("normalizes claude subscription payloads and converts utilization ratios into percentages", () => {
+    const snapshot = normalizeProviderUsageSnapshot(
+      {
+        rate_limit_info: {
+          status: "allowed_warning",
+          rateLimitType: "seven_day_opus",
+          resetsAt: 1_777_233_600,
+          utilization: 0.92,
+        },
+      },
+      CHECKED_AT,
+    );
+
+    expect(snapshot.state).toBe("available");
+    expect(snapshot.windows).toEqual([
+      {
+        id: "7d-opus",
+        label: "7d Opus",
+        percentUsed: 92,
+        resetsAt: "2026-04-26T20:00:00.000Z",
+        level: "critical",
+        exhausted: false,
+      },
+    ]);
+  });
+
+  it("returns syncing snapshots when providers report an in-flight state without windows", () => {
+    const snapshot = normalizeProviderUsageSnapshot(
+      {
+        status: "syncing",
+        message: "Waiting for provider usage data.",
+      },
+      CHECKED_AT,
+    );
+
+    expect(snapshot).toEqual({
+      state: "syncing",
+      checkedAt: CHECKED_AT,
+      windows: [],
+      message: "Waiting for provider usage data.",
+    });
+  });
+});
+
+describe("mergeProviderRuntimeEventIntoSnapshot", () => {
+  it("merges account.rate-limits.updated events into provider usage snapshots", () => {
+    const provider = makeProvider();
+    const event = {
+      eventId: "event-1" as never,
+      provider: "codex",
+      threadId: "thread-1" as never,
+      createdAt: CHECKED_AT,
+      type: "account.rate-limits.updated",
+      payload: {
+        rateLimits: {
+          primary: {
+            usedPercent: 72,
+            resetsAt: 1_776_628_800,
+            windowDurationMins: 300,
+          },
+        },
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const merged = mergeProviderRuntimeEventIntoSnapshot(provider, event);
+
+    expect(merged.usage).toEqual({
+      state: "available",
+      checkedAt: CHECKED_AT,
+      windows: [
+        {
+          id: "5h",
+          label: "5h",
+          percentUsed: 72,
+          resetsAt: "2026-04-19T20:00:00.000Z",
+          level: "warning",
+          exhausted: false,
+        },
+      ],
+    });
+  });
+
+  it("clears stale codex usage when account.updated switches to api key auth", () => {
+    const provider = makeProvider({
+      usage: {
+        state: "available",
+        checkedAt: CHECKED_AT,
+        windows: [
+          {
+            id: "5h",
+            label: "5h",
+            percentUsed: 84,
+            resetsAt: "2026-04-20T00:00:00.000Z",
+            level: "warning",
+            exhausted: false,
+          },
+        ],
+      },
+    });
+    const event = {
+      eventId: "event-2" as never,
+      provider: "codex",
+      threadId: "thread-1" as never,
+      createdAt: CHECKED_AT,
+      type: "account.updated",
+      payload: {
+        account: {
+          authMode: "apikey",
+          planType: "pro",
+        },
+      },
+    } satisfies ProviderRuntimeEvent;
+
+    const merged = mergeProviderRuntimeEventIntoSnapshot(provider, event);
+
+    expect(merged.usage).toBeUndefined();
+    expect(merged.auth.type).toBe("apiKey");
+    expect(merged.auth.label).toBe("OpenAI API Key");
+  });
+});

--- a/apps/server/src/provider/providerUsage.ts
+++ b/apps/server/src/provider/providerUsage.ts
@@ -1,0 +1,555 @@
+import type {
+  ProviderRuntimeEvent,
+  ServerProvider,
+  ServerProviderUsage,
+  ServerProviderUsageLevel,
+} from "@t3tools/contracts";
+
+import { codexAccountAuthMetadata } from "./codexAccount.ts";
+
+type WindowCandidate = {
+  readonly hint?: string | undefined;
+  readonly value: unknown;
+};
+
+const WINDOW_CONTAINER_KEYS = new Set(["windows", "limits", "rateLimits", "rate_limits"]);
+const PERCENT_KEYS = new Set([
+  "percentused",
+  "usedpercent",
+  "percentage",
+  "pct",
+  "usagepercent",
+  "usedpct",
+]);
+const RATIO_KEYS = new Set(["utilization", "ratio", "usageratio"]);
+const WINDOW_DURATION_KEYS = new Set([
+  "windowdurationmins",
+  "windowdurationminutes",
+  "durationmins",
+  "durationminutes",
+]);
+const RESET_KEYS = new Set(["resetsat", "resetat", "retryat", "overageresetsat"]);
+const STATUS_KEYS = new Set(["state", "status", "message", "detail", "error", "reason"]);
+const MESSAGE_KEYS = new Set(["message", "detail", "error", "reason"]);
+const EXHAUSTED_KEYS = new Set(["exhausted", "isexhausted"]);
+
+const NUMBER_WORDS: Record<string, string> = {
+  one: "1",
+  two: "2",
+  three: "3",
+  four: "4",
+  five: "5",
+  six: "6",
+  seven: "7",
+  eight: "8",
+  nine: "9",
+  ten: "10",
+  eleven: "11",
+  twelve: "12",
+};
+
+const UNIT_SUFFIXES: Record<string, string> = {
+  minute: "m",
+  minutes: "m",
+  min: "m",
+  mins: "m",
+  m: "m",
+  hour: "h",
+  hours: "h",
+  hr: "h",
+  hrs: "h",
+  h: "h",
+  day: "d",
+  days: "d",
+  d: "d",
+  week: "w",
+  weeks: "w",
+  w: "w",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeLookupKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function trimString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function firstMatchingValue(
+  record: Record<string, unknown>,
+  keys: ReadonlySet<string>,
+): unknown | undefined {
+  for (const [key, value] of Object.entries(record)) {
+    if (keys.has(normalizeLookupKey(key))) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function firstMatchingString(
+  record: Record<string, unknown>,
+  keys: ReadonlySet<string>,
+): string | undefined {
+  return trimString(firstMatchingValue(record, keys));
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function firstMatchingNumber(
+  record: Record<string, unknown>,
+  keys: ReadonlySet<string>,
+): number | undefined {
+  return toFiniteNumber(firstMatchingValue(record, keys));
+}
+
+function firstMatchingBoolean(
+  record: Record<string, unknown>,
+  keys: ReadonlySet<string>,
+): boolean | undefined {
+  const value = firstMatchingValue(record, keys);
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}
+
+function formatWindowDurationLabel(windowDurationMins: number | undefined): string | undefined {
+  if (windowDurationMins === undefined || !Number.isFinite(windowDurationMins)) {
+    return undefined;
+  }
+
+  const roundedMinutes = Math.round(windowDurationMins);
+  if (roundedMinutes <= 0) {
+    return undefined;
+  }
+  if (roundedMinutes % (24 * 60) === 0) {
+    return `${roundedMinutes / (24 * 60)}d`;
+  }
+  if (roundedMinutes % 60 === 0) {
+    return `${roundedMinutes / 60}h`;
+  }
+  return `${roundedMinutes}m`;
+}
+
+function titleCaseWord(value: string): string {
+  if (value.length === 0) {
+    return value;
+  }
+
+  return value[0]!.toUpperCase() + value.slice(1).toLowerCase();
+}
+
+function toTitleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter((part) => part.length > 0)
+    .map(titleCaseWord)
+    .join(" ");
+}
+
+function normalizeWindowLabel(
+  rawLabel: string | undefined,
+  windowDurationMins: number | undefined,
+): string {
+  const durationLabel = formatWindowDurationLabel(windowDurationMins);
+  const trimmedLabel = trimString(rawLabel);
+  if (!trimmedLabel) {
+    return durationLabel ?? "Usage";
+  }
+
+  const normalized = trimmedLabel.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim().toLowerCase();
+  if (normalized === "primary" || normalized === "secondary" || normalized === "ratelimitinfo") {
+    return durationLabel ?? "Usage";
+  }
+  if (normalized === "overage") {
+    return "Overage";
+  }
+
+  const tokens = normalized.split(" ");
+  let base = "";
+  let suffixStartIndex = 0;
+  if (tokens.length >= 2 && NUMBER_WORDS[tokens[0]!] && UNIT_SUFFIXES[tokens[1]!]) {
+    base = `${NUMBER_WORDS[tokens[0]!]}${UNIT_SUFFIXES[tokens[1]!]}`;
+    suffixStartIndex = 2;
+  } else if (tokens.length >= 2 && /^\d+$/.test(tokens[0]!) && UNIT_SUFFIXES[tokens[1]!]) {
+    base = `${tokens[0]}${UNIT_SUFFIXES[tokens[1]!]}`;
+    suffixStartIndex = 2;
+  } else if (/^\d+[mhdw]$/.test(tokens[0]!)) {
+    base = tokens[0]!;
+    suffixStartIndex = 1;
+  }
+
+  if (base) {
+    const suffix = tokens
+      .slice(suffixStartIndex)
+      .filter((token) => token !== "limit" && token !== "window")
+      .map(titleCaseWord)
+      .join(" ");
+    return suffix.length > 0 ? `${base} ${suffix}` : base;
+  }
+
+  return durationLabel ?? toTitleCase(normalized);
+}
+
+function normalizeWindowId(label: string): string {
+  const normalized = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return normalized.length > 0 ? normalized : "usage";
+}
+
+function toIsoDateTime(value: unknown): string | null {
+  const numeric = toFiniteNumber(value);
+  if (numeric !== undefined) {
+    const millis =
+      numeric > 1_000_000_000_000 ? numeric : numeric > 1_000_000_000 ? numeric * 1_000 : numeric;
+    const date = new Date(millis);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+
+  const trimmed = trimString(value);
+  if (!trimmed) {
+    return null;
+  }
+
+  const timestamp = Date.parse(trimmed);
+  return Number.isNaN(timestamp) ? null : new Date(timestamp).toISOString();
+}
+
+function isSyncingStateText(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = normalizeLookupKey(value);
+  return (
+    normalized.includes("syncing") ||
+    normalized.includes("loading") ||
+    normalized.includes("pending") ||
+    normalized.includes("refreshing") ||
+    normalized.includes("checking") ||
+    normalized.includes("fetching")
+  );
+}
+
+function isUnavailableStateText(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = normalizeLookupKey(value);
+  return (
+    normalized.includes("unavailable") ||
+    normalized.includes("unsupported") ||
+    normalized.includes("disabled") ||
+    normalized.includes("failed") ||
+    normalized.includes("missing") ||
+    normalized.includes("notavailable") ||
+    normalized === "error"
+  );
+}
+
+function isExhaustedStatus(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+
+  const normalized = normalizeLookupKey(value);
+  return (
+    normalized === "rejected" ||
+    normalized === "exhausted" ||
+    normalized === "outofcredits" ||
+    normalized === "limitreached"
+  );
+}
+
+function resolveUsageLevel(
+  percentUsed: number | null,
+  exhausted: boolean,
+): ServerProviderUsageLevel {
+  if (exhausted || (percentUsed !== null && percentUsed >= 100)) {
+    return "exhausted";
+  }
+  if (percentUsed !== null && percentUsed >= 85) {
+    return "critical";
+  }
+  if (percentUsed !== null && percentUsed >= 70) {
+    return "warning";
+  }
+  return "normal";
+}
+
+function looksLikeWindowRecord(record: Record<string, unknown>): boolean {
+  return (
+    firstMatchingNumber(record, PERCENT_KEYS) !== undefined ||
+    firstMatchingNumber(record, RATIO_KEYS) !== undefined ||
+    firstMatchingNumber(record, WINDOW_DURATION_KEYS) !== undefined ||
+    firstMatchingValue(record, RESET_KEYS) !== undefined ||
+    firstMatchingBoolean(record, EXHAUSTED_KEYS) !== undefined ||
+    trimString(record.rateLimitType) !== undefined ||
+    trimString(record.rate_limit_type) !== undefined ||
+    trimString(record.overageStatus) !== undefined ||
+    trimString(record.overage_status) !== undefined
+  );
+}
+
+function collectWindowCandidates(
+  value: unknown,
+  hint?: string,
+  seen = new WeakSet<Record<string, unknown>>(),
+): ReadonlyArray<WindowCandidate> {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectWindowCandidates(entry, hint, seen));
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const candidates: WindowCandidate[] = [];
+  if (looksLikeWindowRecord(value)) {
+    candidates.push({ hint, value });
+    const overageStatus = trimString(value.overageStatus) ?? trimString(value.overage_status);
+    if (
+      overageStatus ||
+      value.overageResetsAt !== undefined ||
+      value.overage_resets_at !== undefined
+    ) {
+      candidates.push({
+        hint: "overage",
+        value: {
+          label: "overage",
+          status: overageStatus,
+          resetsAt: value.overageResetsAt ?? value.overage_resets_at,
+          exhausted: isExhaustedStatus(overageStatus),
+        },
+      });
+    }
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry === undefined || entry === null) {
+      continue;
+    }
+
+    if (Array.isArray(entry) || isRecord(entry) || WINDOW_CONTAINER_KEYS.has(key)) {
+      candidates.push(...collectWindowCandidates(entry, key, seen));
+    }
+  }
+
+  return candidates;
+}
+
+function normalizeWindow(
+  candidate: WindowCandidate,
+): ServerProviderUsage["windows"][number] | undefined {
+  if (!isRecord(candidate.value)) {
+    return undefined;
+  }
+
+  const percentValue = firstMatchingNumber(candidate.value, PERCENT_KEYS);
+  const ratioValue = firstMatchingNumber(candidate.value, RATIO_KEYS);
+  const derivedPercent =
+    percentValue ??
+    (ratioValue !== undefined ? (ratioValue <= 1 ? ratioValue * 100 : ratioValue) : undefined);
+  const percentUsed = derivedPercent === undefined ? null : clampPercent(derivedPercent);
+
+  const windowDurationMins = firstMatchingNumber(candidate.value, WINDOW_DURATION_KEYS);
+  const label = normalizeWindowLabel(
+    trimString(candidate.value.rateLimitType) ??
+      trimString(candidate.value.rate_limit_type) ??
+      trimString(candidate.value.label) ??
+      trimString(candidate.value.limitName) ??
+      trimString(candidate.value.limit_name) ??
+      trimString(candidate.value.name) ??
+      trimString(candidate.value.windowLabel) ??
+      trimString(candidate.value.window_label) ??
+      trimString(candidate.value.window) ??
+      trimString(candidate.value.kind) ??
+      trimString(candidate.value.id) ??
+      trimString(candidate.value.limitId) ??
+      trimString(candidate.value.limit_id) ??
+      candidate.hint,
+    windowDurationMins,
+  );
+  const id = normalizeWindowId(label);
+  const resetsAt = toIsoDateTime(firstMatchingValue(candidate.value, RESET_KEYS));
+  const statusText = firstMatchingString(candidate.value, STATUS_KEYS);
+  const exhausted =
+    firstMatchingBoolean(candidate.value, EXHAUSTED_KEYS) === true ||
+    isExhaustedStatus(statusText) ||
+    (percentUsed !== null && percentUsed >= 100);
+
+  if (percentUsed === null && resetsAt === null && !exhausted && label === "Usage") {
+    return undefined;
+  }
+
+  return {
+    id,
+    label,
+    percentUsed,
+    resetsAt,
+    level: resolveUsageLevel(percentUsed, exhausted),
+    exhausted,
+  };
+}
+
+function windowCompletenessScore(window: ServerProviderUsage["windows"][number]): number {
+  return (
+    (window.percentUsed !== null ? 4 : 0) +
+    (window.resetsAt !== null ? 2 : 0) +
+    (window.exhausted ? 1 : 0)
+  );
+}
+
+function readUsageState(value: unknown): ServerProviderUsage["state"] | undefined {
+  if (typeof value === "string") {
+    if (isSyncingStateText(value)) {
+      return "syncing";
+    }
+    if (isUnavailableStateText(value)) {
+      return "unavailable";
+    }
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const directState = firstMatchingString(value, new Set(["state", "status"]));
+  if (isSyncingStateText(directState)) {
+    return "syncing";
+  }
+  if (isUnavailableStateText(directState)) {
+    return "unavailable";
+  }
+  return undefined;
+}
+
+function readUsageMessage(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return isSyncingStateText(value) || isUnavailableStateText(value)
+      ? undefined
+      : trimString(value);
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return firstMatchingString(value, MESSAGE_KEYS) ?? firstMatchingString(value, STATUS_KEYS);
+}
+
+export function normalizeProviderUsageSnapshot(
+  value: unknown,
+  checkedAt: string,
+): ServerProviderUsage {
+  const windowsById = new Map<string, ServerProviderUsage["windows"][number]>();
+  for (const candidate of collectWindowCandidates(value)) {
+    const normalizedWindow = normalizeWindow(candidate);
+    if (!normalizedWindow) {
+      continue;
+    }
+
+    const existing = windowsById.get(normalizedWindow.id);
+    if (
+      !existing ||
+      windowCompletenessScore(normalizedWindow) > windowCompletenessScore(existing)
+    ) {
+      windowsById.set(normalizedWindow.id, normalizedWindow);
+    }
+  }
+
+  const windows = [...windowsById.values()];
+  const explicitState = readUsageState(value);
+  const message = readUsageMessage(value);
+  const state =
+    explicitState ?? (windows.length > 0 ? ("available" as const) : ("unavailable" as const));
+
+  return {
+    state,
+    checkedAt,
+    windows,
+    ...(message ? { message } : {}),
+  };
+}
+
+export function mergeProviderRuntimeEventIntoSnapshot(
+  provider: ServerProvider,
+  event: ProviderRuntimeEvent,
+): ServerProvider {
+  if (provider.provider !== event.provider) {
+    return provider;
+  }
+
+  if (event.type === "account.rate-limits.updated") {
+    return {
+      ...provider,
+      usage: normalizeProviderUsageSnapshot(event.payload.rateLimits, event.createdAt),
+    };
+  }
+
+  if (
+    event.type !== "account.updated" ||
+    provider.provider !== "codex" ||
+    !isRecord(event.payload.account)
+  ) {
+    return provider;
+  }
+
+  const authMetadata = codexAccountAuthMetadata({
+    authMode: event.payload.account.authMode,
+    planType: event.payload.account.planType,
+  });
+  const authChanged =
+    authMetadata !== undefined &&
+    (provider.auth.type !== authMetadata.type || provider.auth.label !== authMetadata.label);
+  const shouldClearUsage = authMetadata?.type === "apiKey" && provider.usage !== undefined;
+  if (!authChanged && !shouldClearUsage) {
+    return provider;
+  }
+
+  const nextAuth = authMetadata ? { ...provider.auth, ...authMetadata } : provider.auth;
+  const nextProviderBase = authChanged ? { ...provider, auth: nextAuth } : provider;
+  if (!shouldClearUsage) {
+    return nextProviderBase;
+  }
+
+  const { usage: _usage, ...providerWithoutUsage } = nextProviderBase;
+  return providerWithoutUsage;
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -163,6 +163,7 @@ import {
 } from "./Sidebar.logic";
 import { sortThreads } from "../lib/threadSort";
 import { SidebarUpdatePill } from "./sidebar/SidebarUpdatePill";
+import { SidebarProviderUsageCard } from "./sidebar/SidebarProviderUsageCard";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { CommandDialogTrigger } from "./ui/command";
 import { readEnvironmentApi } from "../environmentApi";
@@ -2389,6 +2390,7 @@ const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   return (
     <SidebarFooter className="p-2">
       <SidebarUpdatePill />
+      <SidebarProviderUsageCard />
       <SidebarMenu>
         <SidebarMenuItem>
           <SidebarMenuButton

--- a/apps/web/src/components/sidebar/SidebarProviderUsageCard.browser.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUsageCard.browser.tsx
@@ -1,0 +1,278 @@
+import "../../index.css";
+
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import type { LocalApi, ServerProvider } from "@t3tools/contracts";
+
+const { ensureLocalApiMock, useServerProvidersMock } = vi.hoisted(() => ({
+  ensureLocalApiMock: vi.fn(),
+  useServerProvidersMock: vi.fn(),
+}));
+
+vi.mock("../../localApi", () => ({
+  ensureLocalApi: ensureLocalApiMock,
+}));
+
+vi.mock("../../rpc/serverState", () => ({
+  useServerProviders: useServerProvidersMock,
+}));
+
+import { SidebarProviderUsageCard } from "./SidebarProviderUsageCard";
+
+function mockLocalApi(refreshProviders: LocalApi["server"]["refreshProviders"]) {
+  ensureLocalApiMock.mockReturnValue({
+    server: {
+      refreshProviders,
+    },
+  } as Pick<LocalApi, "server"> as LocalApi);
+}
+
+function createProviders(): ReadonlyArray<ServerProvider> {
+  return [
+    {
+      provider: "codex",
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: {
+        status: "authenticated",
+        label: "ChatGPT Pro Subscription",
+      },
+      checkedAt: "2026-04-20T00:00:00.000Z",
+      usage: {
+        state: "available",
+        checkedAt: "2026-04-20T00:00:00.000Z",
+        windows: [
+          {
+            id: "7d",
+            label: "7d",
+            percentUsed: 82,
+            resetsAt: "2026-04-27T00:00:00.000Z",
+            level: "warning",
+            exhausted: false,
+          },
+          {
+            id: "5h",
+            label: "5h",
+            percentUsed: 42,
+            resetsAt: "2026-04-20T05:00:00.000Z",
+            level: "normal",
+            exhausted: false,
+          },
+        ],
+      },
+      models: [],
+      slashCommands: [],
+      skills: [],
+    },
+    {
+      provider: "claudeAgent",
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: {
+        status: "authenticated",
+        label: "Claude Max Subscription",
+      },
+      checkedAt: "2026-04-20T00:00:00.000Z",
+      usage: {
+        state: "available",
+        checkedAt: "2026-04-20T00:00:00.000Z",
+        windows: [
+          {
+            id: "7d-opus",
+            label: "7d Opus",
+            percentUsed: 88,
+            resetsAt: "2026-04-27T00:00:00.000Z",
+            level: "critical",
+            exhausted: false,
+          },
+        ],
+      },
+      models: [],
+      slashCommands: [],
+      skills: [],
+    },
+  ];
+}
+
+async function mountCard() {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const screen = await render(<SidebarProviderUsageCard />, { container: host });
+
+  return {
+    cleanup: async () => {
+      await screen.unmount();
+      host.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.innerHTML = "";
+});
+
+describe("SidebarProviderUsageCard", () => {
+  it("renders both providers and orders windows as 5h then 7d", async () => {
+    useServerProvidersMock.mockReturnValue(createProviders());
+    mockLocalApi(vi.fn().mockResolvedValue({ providers: createProviders() }));
+
+    const mounted = await mountCard();
+
+    try {
+      await vi.waitFor(() => {
+        expect(document.body.textContent).toContain("Usage limits");
+        expect(document.body.textContent).toContain("Codex");
+        expect(document.body.textContent).toContain("Claude");
+      });
+
+      const codexSection = document.querySelector<HTMLElement>(
+        '[data-provider-usage-provider="codex"]',
+      );
+      expect(codexSection).not.toBeNull();
+      const orderedIds = Array.from(
+        codexSection!.querySelectorAll<HTMLElement>("[data-provider-usage-window]"),
+      ).map((element) => element.dataset.providerUsageWindow);
+      expect(orderedIds).toEqual(["5h", "7d"]);
+      expect(document.body.textContent).toContain("Pro");
+      expect(document.body.textContent).toContain("Max");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("calls server.refreshProviders from the refresh button", async () => {
+    const refreshProviders = vi.fn().mockResolvedValue({ providers: createProviders() });
+    useServerProvidersMock.mockReturnValue(createProviders());
+    mockLocalApi(refreshProviders);
+
+    const mounted = await mountCard();
+
+    try {
+      await page.getByRole("button", { name: "Refresh provider usage" }).click();
+      expect(refreshProviders).toHaveBeenCalledTimes(1);
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("disables the refresh button while a refresh is in flight", async () => {
+    let resolveRefresh!: (value: { providers: ReadonlyArray<ServerProvider> }) => void;
+    const refreshProviders = vi.fn(
+      () =>
+        new Promise<{ providers: ReadonlyArray<ServerProvider> }>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    useServerProvidersMock.mockReturnValue(createProviders());
+    mockLocalApi(refreshProviders);
+
+    const mounted = await mountCard();
+
+    try {
+      const button = page.getByRole("button", { name: "Refresh provider usage" });
+      await button.click();
+
+      await vi.waitFor(() => {
+        const element = document.querySelector<HTMLButtonElement>(
+          'button[aria-label="Refresh provider usage"]',
+        );
+        expect(element?.disabled).toBe(true);
+      });
+
+      resolveRefresh({ providers: createProviders() });
+
+      await vi.waitFor(() => {
+        const element = document.querySelector<HTMLButtonElement>(
+          'button[aria-label="Refresh provider usage"]',
+        );
+        expect(element?.disabled).toBe(false);
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("renders syncing fallback copy when a provider is still refreshing usage", async () => {
+    const providers = createProviders();
+    useServerProvidersMock.mockReturnValue([
+      {
+        ...providers[0]!,
+        usage: {
+          state: "syncing",
+          checkedAt: "2026-04-20T00:00:00.000Z",
+          windows: [],
+          message: "Syncing usage limits from Codex...",
+        },
+      },
+    ]);
+    mockLocalApi(vi.fn().mockResolvedValue({ providers }));
+
+    const mounted = await mountCard();
+
+    try {
+      await vi.waitFor(() => {
+        expect(document.body.textContent).toContain("Syncing usage limits from Codex...");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("renders fallback copy for missing and unavailable usage", async () => {
+    useServerProvidersMock.mockReturnValue([
+      {
+        provider: "codex",
+        enabled: true,
+        installed: true,
+        version: "1.0.0",
+        status: "ready",
+        auth: {
+          status: "authenticated",
+        },
+        checkedAt: "2026-04-20T00:00:00.000Z",
+        message: "Usage data has not been reported yet.",
+        models: [],
+        slashCommands: [],
+        skills: [],
+      },
+      {
+        provider: "claudeAgent",
+        enabled: true,
+        installed: true,
+        version: "1.0.0",
+        status: "ready",
+        auth: {
+          status: "authenticated",
+        },
+        checkedAt: "2026-04-20T00:00:00.000Z",
+        usage: {
+          state: "unavailable",
+          checkedAt: "2026-04-20T00:00:00.000Z",
+          windows: [],
+          message: "Usage is unavailable for this account.",
+        },
+        models: [],
+        slashCommands: [],
+        skills: [],
+      },
+    ]);
+    mockLocalApi(vi.fn().mockResolvedValue({ providers: [] }));
+
+    const mounted = await mountCard();
+
+    try {
+      await vi.waitFor(() => {
+        expect(document.body.textContent).toContain("Usage data has not been reported yet.");
+        expect(document.body.textContent).toContain("Usage is unavailable for this account.");
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+});

--- a/apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx
+++ b/apps/web/src/components/sidebar/SidebarProviderUsageCard.tsx
@@ -1,0 +1,206 @@
+import { RefreshCwIcon } from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+import type { ServerProvider, ServerProviderUsageWindow } from "@t3tools/contracts";
+
+import { ensureLocalApi } from "../../localApi";
+import {
+  formatProviderUsagePercent,
+  formatProviderUsageResetAt,
+  orderProviderUsageWindows,
+  shortProviderPlanLabel,
+} from "../../lib/providerUsage";
+import { useServerProviders } from "../../rpc/serverState";
+import { Spinner } from "../ui/spinner";
+
+const PROVIDER_ORDER = ["codex", "claudeAgent"] as const;
+const PROVIDER_LABELS: Record<(typeof PROVIDER_ORDER)[number], string> = {
+  codex: "Codex",
+  claudeAgent: "Claude",
+};
+type ProviderUsageState = NonNullable<ServerProvider["usage"]>["state"] | "unavailable";
+
+function providerDisplayLabel(providerKind: ServerProvider["provider"]): string {
+  switch (providerKind) {
+    case "codex":
+      return PROVIDER_LABELS.codex;
+    case "claudeAgent":
+      return PROVIDER_LABELS.claudeAgent;
+    default:
+      return providerKind;
+  }
+}
+
+function providerStatusMessage(provider: ServerProvider): string {
+  if (!provider.usage) {
+    if (!provider.enabled) {
+      return "Disabled in settings.";
+    }
+    return provider.message ?? "Usage data has not been reported yet.";
+  }
+
+  if (provider.usage.state === "syncing") {
+    return provider.usage.message ?? "Syncing usage limits...";
+  }
+
+  if (provider.usage.state === "unavailable") {
+    return provider.usage.message ?? provider.message ?? "Usage data is unavailable.";
+  }
+
+  if (provider.usage.windows.length === 0) {
+    return provider.usage.message ?? "No usage windows were reported.";
+  }
+
+  return provider.usage.message ?? "";
+}
+
+function usageBarClass(state: ProviderUsageState, window: ServerProviderUsageWindow): string {
+  if (state === "syncing") {
+    return "bg-sky-500";
+  }
+  if (window.level === "warning") {
+    return "bg-amber-500";
+  }
+  if (window.level === "critical" || window.level === "exhausted") {
+    return "bg-red-500";
+  }
+  return "bg-emerald-500";
+}
+
+function usageBarWidth(state: ProviderUsageState, percentUsed: number | null): number {
+  if (typeof percentUsed === "number" && Number.isFinite(percentUsed)) {
+    return Math.max(4, Math.min(100, percentUsed));
+  }
+  if (state === "syncing") {
+    return 35;
+  }
+  return 0;
+}
+
+export function SidebarProviderUsageCard() {
+  const providers = useServerProviders();
+  const [refreshing, setRefreshing] = useState(false);
+  const refreshingRef = useRef(false);
+  const knownProviders = PROVIDER_ORDER.flatMap((providerKind) => {
+    const provider = providers.find((candidate) => candidate.provider === providerKind);
+    return provider && (provider.enabled || provider.usage !== undefined) ? [provider] : [];
+  });
+
+  const handleRefresh = useCallback(() => {
+    if (refreshingRef.current) {
+      return;
+    }
+
+    refreshingRef.current = true;
+    setRefreshing(true);
+    void ensureLocalApi()
+      .server.refreshProviders()
+      .catch(() => undefined)
+      .finally(() => {
+        refreshingRef.current = false;
+        setRefreshing(false);
+      });
+  }, []);
+
+  if (knownProviders.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className="rounded-2xl border border-border/70 bg-card/70 px-2.5 py-2 text-xs shadow-xs/5"
+      data-testid="sidebar-provider-usage-card"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/80">
+          Usage limits
+        </div>
+        <button
+          type="button"
+          aria-label="Refresh provider usage"
+          className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={refreshing}
+          onClick={handleRefresh}
+        >
+          {refreshing ? <Spinner className="size-3.5" /> : <RefreshCwIcon className="size-3.5" />}
+        </button>
+      </div>
+
+      <div className="space-y-2.5">
+        {knownProviders.map((provider) => {
+          const orderedWindows = orderProviderUsageWindows(provider.usage?.windows ?? []);
+          const planLabel = shortProviderPlanLabel(provider.auth.label);
+          const statusMessage = providerStatusMessage(provider);
+          const showFallbackMessage =
+            !provider.usage ||
+            provider.usage.windows.length === 0 ||
+            provider.usage.state !== "available";
+
+          return (
+            <div
+              key={provider.provider}
+              className="space-y-1.5"
+              data-provider-usage-provider={provider.provider}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="font-medium text-foreground">
+                  {providerDisplayLabel(provider.provider)}
+                </div>
+                {planLabel ? (
+                  <div className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                    {planLabel}
+                  </div>
+                ) : null}
+              </div>
+
+              {showFallbackMessage && statusMessage ? (
+                <div className="text-[11px] leading-4 text-muted-foreground">{statusMessage}</div>
+              ) : null}
+
+              {orderedWindows.length > 0 ? (
+                <div className="space-y-1.5">
+                  {orderedWindows.map((window) => {
+                    const resetLabel = formatProviderUsageResetAt(window.resetsAt);
+                    const state = provider.usage?.state ?? "unavailable";
+
+                    return (
+                      <div
+                        key={window.id}
+                        className="space-y-1"
+                        data-provider-usage-window={window.id}
+                      >
+                        <div className="flex items-baseline justify-between gap-2">
+                          <div className="min-w-0">
+                            <div className="font-medium text-foreground/90">{window.label}</div>
+                            {resetLabel ? (
+                              <div className="text-[11px] text-muted-foreground">
+                                Resets in {resetLabel}
+                              </div>
+                            ) : null}
+                          </div>
+                          <div className="shrink-0 tabular-nums text-muted-foreground">
+                            {formatProviderUsagePercent(window.percentUsed)}
+                          </div>
+                        </div>
+                        <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                          <div
+                            className={`h-full rounded-full transition-[width] duration-200 ${usageBarClass(
+                              state,
+                              window,
+                            )}`}
+                            style={{
+                              width: `${usageBarWidth(state, window.percentUsed)}%`,
+                            }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/providerUsage.test.ts
+++ b/apps/web/src/lib/providerUsage.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatProviderUsagePercent,
+  formatProviderUsageResetAt,
+  orderProviderUsageWindows,
+  primaryProviderUsageWindow,
+  shortProviderPlanLabel,
+} from "./providerUsage";
+
+describe("primaryProviderUsageWindow", () => {
+  it("prefers the short-term usage window before longer windows", () => {
+    const primary = primaryProviderUsageWindow([
+      {
+        id: "7d",
+        label: "7d",
+        percentUsed: 60,
+        resetsAt: null,
+        level: "normal",
+        exhausted: false,
+      },
+      {
+        id: "5h",
+        label: "5h",
+        percentUsed: 20,
+        resetsAt: null,
+        level: "normal",
+        exhausted: false,
+      },
+    ]);
+
+    expect(primary?.id).toBe("5h");
+  });
+});
+
+describe("shortProviderPlanLabel", () => {
+  it("compacts long subscription labels for sidebar display", () => {
+    expect(shortProviderPlanLabel("ChatGPT Pro Subscription")).toBe("Pro");
+    expect(shortProviderPlanLabel("Claude Max Subscription")).toBe("Max");
+    expect(shortProviderPlanLabel("OpenAI API Key")).toBeNull();
+  });
+});
+
+describe("formatProviderUsagePercent", () => {
+  it("keeps one decimal place below ten percent and rounds larger values", () => {
+    expect(formatProviderUsagePercent(9.4)).toBe("9.4%");
+    expect(formatProviderUsagePercent(42)).toBe("42%");
+    expect(formatProviderUsagePercent(null)).toBe("--");
+  });
+});
+
+describe("formatProviderUsageResetAt", () => {
+  it("formats short, hourly, and multi-day reset times relative to now", () => {
+    const now = new Date("2026-04-20T00:00:00.000Z");
+
+    expect(formatProviderUsageResetAt("2026-04-20T00:45:00.000Z", now)).toBe("45m");
+    expect(formatProviderUsageResetAt("2026-04-20T01:30:00.000Z", now)).toBe("1h 30m");
+    expect(formatProviderUsageResetAt("2026-04-22T04:00:00.000Z", now)).toBe("2d 4h");
+    expect(formatProviderUsageResetAt("invalid", now)).toBeNull();
+    expect(formatProviderUsageResetAt("2026-04-19T23:59:00.000Z", now)).toBeNull();
+  });
+});
+
+describe("orderProviderUsageWindows", () => {
+  it("orders sidebar windows as 5h, then 7d, then preserves the rest", () => {
+    expect(
+      orderProviderUsageWindows([
+        {
+          id: "overage",
+          label: "Overage",
+          percentUsed: null,
+          resetsAt: null,
+          level: "normal",
+          exhausted: false,
+        },
+        {
+          id: "7d",
+          label: "7d",
+          percentUsed: 60,
+          resetsAt: null,
+          level: "normal",
+          exhausted: false,
+        },
+        {
+          id: "5h",
+          label: "5h",
+          percentUsed: 20,
+          resetsAt: null,
+          level: "normal",
+          exhausted: false,
+        },
+        {
+          id: "7d-opus",
+          label: "7d Opus",
+          percentUsed: 80,
+          resetsAt: null,
+          level: "warning",
+          exhausted: false,
+        },
+      ]).map((window) => window.id),
+    ).toEqual(["5h", "7d", "overage", "7d-opus"]);
+  });
+});

--- a/apps/web/src/lib/providerUsage.ts
+++ b/apps/web/src/lib/providerUsage.ts
@@ -1,0 +1,123 @@
+import type { ServerProvider, ServerProviderUsageWindow } from "@t3tools/contracts";
+
+const PREFERRED_WINDOW_ORDER = ["5h", "7d"] as const;
+
+function normalizeWindowOrderKey(window: ServerProviderUsageWindow): string {
+  return window.id.trim().toLowerCase();
+}
+
+export function orderProviderUsageWindows(
+  windows: ReadonlyArray<ServerProviderUsageWindow>,
+): ReadonlyArray<ServerProviderUsageWindow> {
+  return windows
+    .map((window, index) => ({ window, index }))
+    .toSorted((left, right) => {
+      const leftRank = PREFERRED_WINDOW_ORDER.indexOf(
+        normalizeWindowOrderKey(left.window) as (typeof PREFERRED_WINDOW_ORDER)[number],
+      );
+      const rightRank = PREFERRED_WINDOW_ORDER.indexOf(
+        normalizeWindowOrderKey(right.window) as (typeof PREFERRED_WINDOW_ORDER)[number],
+      );
+
+      if (leftRank !== rightRank) {
+        const resolvedLeftRank = leftRank === -1 ? Number.MAX_SAFE_INTEGER : leftRank;
+        const resolvedRightRank = rightRank === -1 ? Number.MAX_SAFE_INTEGER : rightRank;
+        return resolvedLeftRank - resolvedRightRank;
+      }
+
+      return left.index - right.index;
+    })
+    .map(({ window }) => window);
+}
+
+export function primaryProviderUsageWindow(
+  windows: ReadonlyArray<ServerProviderUsageWindow>,
+): ServerProviderUsageWindow | undefined {
+  return orderProviderUsageWindows(windows)[0];
+}
+
+export function shortProviderPlanLabel(
+  authLabel: ServerProvider["auth"]["label"] | null | undefined,
+): string | null {
+  if (!authLabel) {
+    return null;
+  }
+
+  const normalized = authLabel.trim().toLowerCase();
+  if (normalized.includes("api key")) {
+    return null;
+  }
+  if (normalized.includes(" max ")) {
+    return "Max";
+  }
+  if (normalized.includes(" pro ")) {
+    return "Pro";
+  }
+  if (normalized.includes(" plus ")) {
+    return "Plus";
+  }
+  if (normalized.includes(" team ")) {
+    return "Team";
+  }
+  if (normalized.includes(" business ")) {
+    return "Business";
+  }
+  if (normalized.includes(" enterprise ")) {
+    return "Enterprise";
+  }
+  if (normalized.includes(" edu ")) {
+    return "Edu";
+  }
+  if (normalized.includes(" free ")) {
+    return "Free";
+  }
+  if (normalized.includes(" go ")) {
+    return "Go";
+  }
+
+  return null;
+}
+
+export function formatProviderUsagePercent(percentUsed: number | null): string {
+  if (percentUsed === null || !Number.isFinite(percentUsed)) {
+    return "--";
+  }
+
+  return percentUsed < 10
+    ? `${Number(percentUsed.toFixed(1)).toString()}%`
+    : `${Math.round(percentUsed)}%`;
+}
+
+export function formatProviderUsageResetAt(
+  resetsAt: string | null,
+  now: number | Date = Date.now(),
+): string | null {
+  if (!resetsAt) {
+    return null;
+  }
+
+  const targetTime = Date.parse(resetsAt);
+  if (Number.isNaN(targetTime)) {
+    return null;
+  }
+
+  const currentTime = now instanceof Date ? now.getTime() : now;
+  const totalMinutes = Math.ceil((targetTime - currentTime) / 60_000);
+  if (totalMinutes <= 0) {
+    return null;
+  }
+
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`;
+  }
+
+  if (totalMinutes < 24 * 60) {
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes - days * 24 * 60) / 60);
+  return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+}

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -23,4 +23,49 @@ describe("ServerProvider", () => {
     expect(parsed.slashCommands).toEqual([]);
     expect(parsed.skills).toEqual([]);
   });
+
+  it("decodes normalized provider usage snapshots", () => {
+    const parsed = decodeServerProvider({
+      provider: "codex",
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: {
+        status: "authenticated",
+        label: "ChatGPT Pro Subscription",
+      },
+      checkedAt: "2026-04-10T00:00:00.000Z",
+      usage: {
+        state: "available",
+        checkedAt: "2026-04-10T00:00:00.000Z",
+        windows: [
+          {
+            id: "5h",
+            label: "5h",
+            percentUsed: 72,
+            resetsAt: "2026-04-10T05:00:00.000Z",
+            level: "warning",
+            exhausted: false,
+          },
+        ],
+      },
+      models: [],
+    });
+
+    expect(parsed.usage).toEqual({
+      state: "available",
+      checkedAt: "2026-04-10T00:00:00.000Z",
+      windows: [
+        {
+          id: "5h",
+          label: "5h",
+          percentUsed: 72,
+          resetsAt: "2026-04-10T05:00:00.000Z",
+          level: "warning",
+          exhausted: false,
+        },
+      ],
+    });
+  });
 });

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -50,6 +50,37 @@ export const ServerProviderAuth = Schema.Struct({
 });
 export type ServerProviderAuth = typeof ServerProviderAuth.Type;
 
+export const ServerProviderUsageState = Schema.Literals(["available", "syncing", "unavailable"]);
+export type ServerProviderUsageState = typeof ServerProviderUsageState.Type;
+
+export const ServerProviderUsageLevel = Schema.Literals([
+  "normal",
+  "warning",
+  "critical",
+  "exhausted",
+]);
+export type ServerProviderUsageLevel = typeof ServerProviderUsageLevel.Type;
+
+export const ServerProviderUsageWindow = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  label: TrimmedNonEmptyString,
+  percentUsed: Schema.NullOr(Schema.Number),
+  resetsAt: Schema.NullOr(IsoDateTime),
+  level: ServerProviderUsageLevel,
+  exhausted: Schema.Boolean,
+});
+export type ServerProviderUsageWindow = typeof ServerProviderUsageWindow.Type;
+
+export const ServerProviderUsage = Schema.Struct({
+  state: ServerProviderUsageState,
+  checkedAt: IsoDateTime,
+  windows: Schema.Array(ServerProviderUsageWindow).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
+  message: Schema.optional(TrimmedNonEmptyString),
+});
+export type ServerProviderUsage = typeof ServerProviderUsage.Type;
+
 export const ServerProviderModel = Schema.Struct({
   slug: TrimmedNonEmptyString,
   name: TrimmedNonEmptyString,
@@ -92,6 +123,7 @@ export const ServerProvider = Schema.Struct({
   auth: ServerProviderAuth,
   checkedAt: IsoDateTime,
   message: Schema.optional(TrimmedNonEmptyString),
+  usage: Schema.optional(ServerProviderUsage),
   models: Schema.Array(ServerProviderModel),
   slashCommands: Schema.Array(ServerProviderSlashCommand).pipe(
     Schema.withDecodingDefault(Effect.succeed([])),


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared provider contracts and snapshot merge/caching logic, so regressions could affect provider state rendering and persistence across refreshes; changes are additive with tests but span server+web.
> 
> **Overview**
> Adds first-class `ServerProvider.usage` support end-to-end: contracts now define a normalized usage snapshot schema (state + windows), the server can derive it from runtime `account.*` events, and provider snapshots/cached snapshots now retain usage across refreshes (while clearing it when disabled or Codex switches to API key auth).
> 
> Introduces shared Codex auth metadata normalization (`codexAccountAuthMetadata`) and uses it in both Codex provider probing and runtime event handling.
> 
> Updates the web sidebar to render a new `SidebarProviderUsageCard` with refresh control, window ordering, percent/reset formatting, and plan-label compaction; adds unit/browser tests for the normalization, merge, and UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dc812131672f7b0ea6c07a967399464163dd642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider usage sidebar card showing rate limit windows and refresh control
> - Adds a `SidebarProviderUsageCard` component to the sidebar footer that displays per-provider usage windows (percent used, reset time, level) for Codex and Claude, with a manual refresh button.
> - Introduces `ServerProviderUsage`, `ServerProviderUsageWindow`, `ServerProviderUsageState`, and `ServerProviderUsageLevel` schemas in the contracts layer so usage data is validated end-to-end.
> - Adds `normalizeProviderUsageSnapshot` on the server to convert heterogeneous provider payloads into a canonical usage shape, and `mergeProviderRuntimeEventIntoSnapshot` to update snapshots in real-time from `ProviderService` events without a full refresh.
> - `mergeProviderSnapshot` in `ProviderRegistry` now preserves previous usage when a refreshed snapshot carries none, and clears Codex usage when auth switches to API key.
> - Adds formatting utilities (`formatProviderUsagePercent`, `formatProviderUsageResetAt`, `shortProviderPlanLabel`, `orderProviderUsageWindows`) for consistent sidebar display.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9dc8121. 10 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->