### PR TITLE
Add a shortcut to refresh providers

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -188,6 +188,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
         DEFAULT_KEYBINDINGS.map((binding) => [binding.command, binding.key] as const),
       );
 
+      assert.equal(defaultsByCommand.get("server.refreshProviders"), "mod+shift+r");
       assert.equal(defaultsByCommand.get("thread.previous"), "mod+shift+[");
       assert.equal(defaultsByCommand.get("thread.next"), "mod+shift+]");
       assert.equal(defaultsByCommand.get("thread.jump.1"), "mod+1");
@@ -286,6 +287,10 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
         );
 
         for (const defaultRule of DEFAULT_KEYBINDINGS) {
+          if (defaultRule.command === "server.refreshProviders") {
+            assert.isFalse(byCommand.has(defaultRule.command));
+            continue;
+          }
           assert.isTrue(byCommand.has(defaultRule.command), `expected ${defaultRule.command}`);
         }
         assert.isTrue(byCommand.has("script.run-tests.run"));

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -57,6 +57,7 @@ type WhenToken =
   | { type: "rparen" };
 
 export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
+  { key: "mod+shift+r", command: "server.refreshProviders" },
   { key: "mod+j", command: "terminal.toggle" },
   { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
   { key: "mod+n", command: "terminal.new", when: "terminalFocus" },

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -84,6 +84,7 @@ function compile(bindings: TestBinding[]): ResolvedKeybindingsConfig {
 }
 
 const DEFAULT_BINDINGS = compile([
+  { shortcut: modShortcut("r", { shiftKey: true }), command: "server.refreshProviders" },
   { shortcut: modShortcut("j"), command: "terminal.toggle" },
   {
     shortcut: modShortcut("d"),
@@ -161,6 +162,24 @@ describe("isTerminalToggleShortcut", () => {
         platform: "Win32",
         context: { terminalFocus: true },
       }),
+    );
+  });
+});
+
+describe("refresh providers shortcut", () => {
+  it("resolves the default refresh command on macOS", () => {
+    assert.strictEqual(
+      resolveShortcutCommand(event({ key: "r", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+      "server.refreshProviders",
+    );
+  });
+
+  it("formats the default refresh shortcut label", () => {
+    assert.strictEqual(
+      shortcutLabelForCommand(DEFAULT_BINDINGS, "server.refreshProviders", "MacIntel"),
+      "⇧⌘R",
     );
   });
 });

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -20,7 +20,9 @@ import {
 } from "../components/WebSocketConnectionSurface";
 import { Button } from "../components/ui/button";
 import { AnchoredToastProvider, ToastProvider, toastManager } from "../components/ui/toast";
+import { useCommandPaletteStore } from "../commandPaletteStore";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
+import { resolveShortcutCommand } from "../keybindings";
 import { readLocalApi } from "../localApi";
 import { useSettings } from "../hooks/useSettings";
 import {
@@ -33,6 +35,7 @@ import {
   startServerStateSync,
   useServerConfig,
   useServerConfigUpdatedSubscription,
+  useServerKeybindings,
   useServerWelcomeSubscription,
 } from "../rpc/serverState";
 import { useStore } from "../store";
@@ -94,6 +97,7 @@ function RootRouteView() {
       <AnchoredToastProvider>
         <AuthenticatedTracingBootstrap />
         <ServerStateBootstrap />
+        <AuthenticatedShellShortcuts />
         <EnvironmentConnectionManagerBootstrap />
         <EventRouter />
         <WebSocketConnectionCoordinator />
@@ -108,6 +112,40 @@ function RootRouteView() {
       </AnchoredToastProvider>
     </ToastProvider>
   );
+}
+
+function AuthenticatedShellShortcuts() {
+  const keybindings = useServerKeybindings();
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || useCommandPaletteStore.getState().open) {
+        return;
+      }
+
+      if (resolveShortcutCommand(event, keybindings) !== "server.refreshProviders") {
+        return;
+      }
+
+      const api = readLocalApi();
+      if (!api) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      void api.server.refreshProviders().catch((error: unknown) => {
+        console.warn("Failed to refresh providers", error);
+      });
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [keybindings]);
+
+  return null;
 }
 
 function RootRouteErrorView({ error, reset }: ErrorComponentProps) {

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -48,6 +48,7 @@ export const MODEL_PICKER_KEYBINDING_COMMANDS = [
 export type ModelPickerKeybindingCommand = (typeof MODEL_PICKER_KEYBINDING_COMMANDS)[number];
 
 const STATIC_KEYBINDING_COMMANDS = [
+  "server.refreshProviders",
   "terminal.toggle",
   "terminal.split",
   "terminal.new",


### PR DESCRIPTION
## What Changed

- add a `server.refreshProviders` keybinding command with `mod+shift+r` as the default binding
- trigger provider refresh from the authenticated app shell when that shortcut is pressed
- keep Electron's built-in `Cmd+R` reload behavior unchanged
- add web and server keybinding coverage, including startup conflict handling when that shortcut is already assigned to a custom command

## Why

I manually switch Codex accounts by swapping auth state on disk.

T3 Code keeps stale provider/account state until restart, so this adds a direct way to refresh provider state without restarting the app.

## Testing

- repro: switch account externally, press `Cmd+Shift+R`, verify provider/account state refreshes without app restart
- `bun run --cwd apps/web test src/keybindings.test.ts`
- `bun run --cwd apps/server test src/keybindings.test.ts`
- `bun fmt`
- `bun lint` (existing repo warnings only)
- `bun typecheck`