### PR TITLE
fix(keybindings): let xterm handle Ctrl+Arrow natively, use CSI for Alt+Arrow

### DIFF
--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -662,11 +662,11 @@ describe("terminalNavigationShortcutData", () => {
   it("maps Option+Arrow on macOS to word movement", () => {
     assert.strictEqual(
       terminalNavigationShortcutData(event({ key: "ArrowLeft", altKey: true }), "MacIntel"),
-      "\u001bb",
+      "\u001b[1;5D",
     );
     assert.strictEqual(
       terminalNavigationShortcutData(event({ key: "ArrowRight", altKey: true }), "MacIntel"),
-      "\u001bf",
+      "\u001b[1;5C",
     );
   });
 
@@ -681,14 +681,23 @@ describe("terminalNavigationShortcutData", () => {
     );
   });
 
-  it("maps Ctrl+Arrow on non-macOS to word movement", () => {
-    assert.strictEqual(
+  it("does not intercept Ctrl+Arrow on non-macOS (let xterm handle natively)", () => {
+    assert.isNull(
       terminalNavigationShortcutData(event({ key: "ArrowLeft", ctrlKey: true }), "Win32"),
-      "\u001bb",
+    );
+    assert.isNull(
+      terminalNavigationShortcutData(event({ key: "ArrowRight", ctrlKey: true }), "Linux"),
+    );
+  });
+
+  it("remaps Alt+Arrow on non-macOS to CSI word movement", () => {
+    assert.strictEqual(
+      terminalNavigationShortcutData(event({ key: "ArrowLeft", altKey: true }), "Win32"),
+      "\u001b[1;5D",
     );
     assert.strictEqual(
-      terminalNavigationShortcutData(event({ key: "ArrowRight", ctrlKey: true }), "Linux"),
-      "\u001bf",
+      terminalNavigationShortcutData(event({ key: "ArrowRight", altKey: true }), "Linux"),
+      "\u001b[1;5C",
     );
   });
 

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -42,8 +42,8 @@ interface ResolvedShortcutLabelOptions extends ShortcutMatchOptions {
   platform?: string;
 }
 
-const TERMINAL_WORD_BACKWARD = "\u001bb";
-const TERMINAL_WORD_FORWARD = "\u001bf";
+const TERMINAL_WORD_BACKWARD = "\u001b[1;5D";
+const TERMINAL_WORD_FORWARD = "\u001b[1;5C";
 const TERMINAL_LINE_START = "\u0001";
 const TERMINAL_LINE_END = "\u0005";
 const TERMINAL_DELETE_TO_LINE_START = "\u0015";
@@ -465,24 +465,14 @@ export function terminalNavigationShortcutData(
   }
 
   const moveWord = key === "arrowleft" ? TERMINAL_WORD_BACKWARD : TERMINAL_WORD_FORWARD;
-  const moveLine = key === "arrowleft" ? TERMINAL_LINE_START : TERMINAL_LINE_END;
-
-  if (isMacPlatform(platform)) {
-    if (event.altKey && !event.metaKey && !event.ctrlKey) {
-      return moveWord;
-    }
-    if (event.metaKey && !event.altKey && !event.ctrlKey) {
-      return moveLine;
-    }
-    return null;
-  }
-
-  if (event.ctrlKey && !event.metaKey && !event.altKey) {
-    return moveWord;
-  }
 
   if (event.altKey && !event.metaKey && !event.ctrlKey) {
     return moveWord;
+  }
+
+  const moveLine = key === "arrowleft" ? TERMINAL_LINE_START : TERMINAL_LINE_END;
+  if (isMacPlatform(platform) && event.metaKey && !event.altKey && !event.ctrlKey) {
+    return moveLine;
   }
 
   return null;


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

- Let xterm handle `Ctrl+ArrowLeft/Right` natively
- Use CSI (Control Sequence Introducer) for word movement which works on bash,zsh,pwsh,powershell and cmd 

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

Previously `Ctrl+ArrowLeft/Right` and `Alt+ArrowLeft/Right` were intercepted and a move word escape sequence were sent manually. This worked fine for bash and zsh but powershell, pwsh and cmd don't handle it and resulted in just `b` or `f` added.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->
     
     

https://github.com/user-attachments/assets/0e1c11b0-890f-4863-9a85-ad6606c67a7e



## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal arrow key bindings to use CSI sequences for word movement and let xterm handle Ctrl+Arrow natively
> - Changes `TERMINAL_WORD_BACKWARD` and `TERMINAL_WORD_FORWARD` escape sequences from `ESC b`/`ESC f` to CSI sequences `ESC [1;5D`/`ESC [1;5C` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/2243/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385).
> - On all platforms, Alt+Arrow now maps to word movement using the new CSI sequences; Ctrl+Arrow is no longer intercepted and returns `null`, letting xterm handle it natively.
> - On macOS, Option+Arrow continues to trigger word movement (now with CSI sequences) and Command+Arrow continues to map to line start/end.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1e2810.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->