### PR TITLE
Fix Claude context window fallback accounting

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1611,12 +1611,12 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("clamps oversized Claude usage to the reported context window", () => {
+  it.effect("does not infer current context from accumulated-only Claude result totals", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
 
-      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 6).pipe(
         Stream.runCollect,
         Effect.forkChild,
       );
@@ -1657,14 +1657,113 @@ describe("ClaudeAdapterLive", () => {
 
       const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
       const usageEvent = runtimeEvents.find((event) => event.type === "thread.token-usage.updated");
-      assert.equal(usageEvent?.type, "thread.token-usage.updated");
-      if (usageEvent?.type === "thread.token-usage.updated") {
-        assert.deepEqual(usageEvent.payload, {
+      assert.equal(usageEvent, undefined);
+
+      const completionEvent = runtimeEvents.find((event) => event.type === "turn.completed");
+      assert.equal(completionEvent?.type, "turn.completed");
+      if (completionEvent?.type === "turn.completed") {
+        assert.deepEqual(completionEvent.payload.usage, {
+          total_tokens: 535000,
+        });
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("prefers Claude stream usage snapshots over accumulated result totals", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 8).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: "claudeAgent",
+        runtimeMode: "full-access",
+      });
+
+      yield* adapter.sendTurn({
+        threadId: THREAD_ID,
+        input: "hello",
+        attachments: [],
+      });
+
+      harness.query.emit({
+        type: "stream_event",
+        session_id: "sdk-session-result-usage-accumulated",
+        uuid: "stream-usage-1",
+        parent_tool_use_id: null,
+        event: {
+          type: "message_delta",
+          delta: {
+            stop_reason: "end_turn",
+            stop_sequence: null,
+            stop_details: null,
+          },
           usage: {
-            usedTokens: 200000,
-            lastUsedTokens: 200000,
-            totalProcessedTokens: 535000,
-            maxTokens: 200000,
+            input_tokens: 1,
+            cache_creation_input_tokens: 627,
+            cache_read_input_tokens: 222320,
+            output_tokens: 847,
+          },
+        },
+      } as unknown as SDKMessage);
+
+      harness.query.emit({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 1234,
+        duration_api_ms: 1200,
+        num_turns: 52,
+        result: "done",
+        stop_reason: "end_turn",
+        session_id: "sdk-session-result-usage-accumulated",
+        usage: {
+          input_tokens: 54,
+          cache_creation_input_tokens: 37312,
+          cache_read_input_tokens: 10215493,
+          output_tokens: 23808,
+          iterations: [
+            {
+              input_tokens: 1,
+              cache_creation_input_tokens: 627,
+              cache_read_input_tokens: 222320,
+              output_tokens: 847,
+              type: "message",
+            },
+          ],
+        },
+        modelUsage: {
+          "claude-opus-4-7[1m]": {
+            contextWindow: 1000000,
+            maxOutputTokens: 64000,
+          },
+        },
+      } as unknown as SDKMessage);
+      harness.query.finish();
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const usageEvents = runtimeEvents.filter(
+        (event) => event.type === "thread.token-usage.updated",
+      );
+      const finalUsageEvent = usageEvents.at(-1);
+      assert.equal(finalUsageEvent?.type, "thread.token-usage.updated");
+      if (finalUsageEvent?.type === "thread.token-usage.updated") {
+        assert.deepEqual(finalUsageEvent.payload, {
+          usage: {
+            usedTokens: 223795,
+            lastUsedTokens: 223795,
+            totalProcessedTokens: 10276667,
+            inputTokens: 222948,
+            outputTokens: 847,
+            maxTokens: 1000000,
           },
         });
       }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -290,10 +290,14 @@ function maxClaudeContextWindowFromModelUsage(
   return maxContextWindow;
 }
 
-function normalizeClaudeTokenUsage(
-  value: unknown,
-  contextWindow?: number,
-): ThreadTokenUsageSnapshot | undefined {
+function readClaudeUsageStats(value: unknown):
+  | {
+      readonly usage: Record<string, unknown>;
+      readonly inputTokens: number;
+      readonly outputTokens: number;
+      readonly totalProcessedTokens: number;
+    }
+  | undefined {
   if (!value || typeof value !== "object") {
     return undefined;
   }
@@ -324,6 +328,24 @@ function normalizeClaudeTokenUsage(
     return undefined;
   }
 
+  return {
+    usage,
+    inputTokens,
+    outputTokens,
+    totalProcessedTokens,
+  };
+}
+
+function normalizeClaudeTokenUsage(
+  value: unknown,
+  contextWindow?: number,
+): ThreadTokenUsageSnapshot | undefined {
+  const stats = readClaudeUsageStats(value);
+  if (!stats) {
+    return undefined;
+  }
+
+  const { usage, inputTokens, outputTokens, totalProcessedTokens } = stats;
   const maxTokens =
     typeof contextWindow === "number" && Number.isFinite(contextWindow) && contextWindow > 0
       ? contextWindow
@@ -345,6 +367,69 @@ function normalizeClaudeTokenUsage(
       ? { durationMs: usage.duration_ms }
       : {}),
   };
+}
+
+function extractClaudeTotalProcessedTokens(value: unknown): number | undefined {
+  return readClaudeUsageStats(value)?.totalProcessedTokens;
+}
+
+function hasClaudeDetailedUsageBreakdown(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const usage = value as Record<string, unknown>;
+  return (
+    (typeof usage.input_tokens === "number" && Number.isFinite(usage.input_tokens)) ||
+    (typeof usage.cache_creation_input_tokens === "number" &&
+      Number.isFinite(usage.cache_creation_input_tokens)) ||
+    (typeof usage.cache_read_input_tokens === "number" &&
+      Number.isFinite(usage.cache_read_input_tokens)) ||
+    (typeof usage.output_tokens === "number" && Number.isFinite(usage.output_tokens))
+  );
+}
+
+function extractClaudeResultIterationUsage(value: unknown): unknown {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+
+  const usage = value as { iterations?: unknown };
+  if (!Array.isArray(usage.iterations)) {
+    return undefined;
+  }
+
+  for (let index = usage.iterations.length - 1; index >= 0; index -= 1) {
+    const iteration = usage.iterations[index];
+    if (iteration && typeof iteration === "object") {
+      return iteration;
+    }
+  }
+
+  return undefined;
+}
+
+function extractClaudeStreamUsage(event: unknown): unknown {
+  if (!event || typeof event !== "object") {
+    return undefined;
+  }
+
+  const streamEvent = event as {
+    type?: unknown;
+    usage?: unknown;
+    message?: {
+      usage?: unknown;
+    };
+  };
+
+  switch (streamEvent.type) {
+    case "message_start":
+      return streamEvent.message?.usage;
+    case "message_delta":
+      return streamEvent.usage;
+    default:
+      return undefined;
+  }
 }
 
 function asCanonicalTurnId(value: TurnId): TurnId {
@@ -1065,6 +1150,33 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     };
   });
 
+  const recordClaudeUsageSnapshot = Effect.fn("recordClaudeUsageSnapshot")(function* (
+    context: ClaudeSessionContext,
+    value: unknown,
+  ) {
+    const normalizedUsage = normalizeClaudeTokenUsage(value, context.lastKnownContextWindow);
+    if (!normalizedUsage) {
+      return undefined;
+    }
+
+    context.lastKnownTokenUsage = normalizedUsage;
+    const usageStamp = yield* makeEventStamp();
+    yield* offerRuntimeEvent({
+      type: "thread.token-usage.updated",
+      eventId: usageStamp.eventId,
+      provider: PROVIDER,
+      createdAt: usageStamp.createdAt,
+      threadId: context.session.threadId,
+      ...(context.turnState ? { turnId: asCanonicalTurnId(context.turnState.turnId) } : {}),
+      payload: {
+        usage: normalizedUsage,
+      },
+      providerRefs: nativeProviderRefs(context),
+    });
+
+    return normalizedUsage;
+  });
+
   const ensureAssistantTextBlock = Effect.fn("ensureAssistantTextBlock")(function* (
     context: ClaudeSessionContext,
     blockIndex: number,
@@ -1388,31 +1500,33 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     // The SDK result.usage contains *accumulated* totals across all API calls
     // (input_tokens, cache_read_input_tokens, etc. summed over every request).
     // This does NOT represent the current context window size.
-    // Instead, use the last known context-window-accurate usage from task_progress
-    // events and treat the accumulated total as totalProcessedTokens.
-    const accumulatedSnapshot = normalizeClaudeTokenUsage(
-      result?.usage,
-      resultContextWindow ?? context.lastKnownContextWindow,
-    );
-    const accumulatedTotalProcessedTokens =
-      accumulatedSnapshot?.totalProcessedTokens ?? accumulatedSnapshot?.usedTokens;
+    // Instead, prefer the last known context-window-accurate usage from live
+    // events and treat the accumulated total as totalProcessedTokens only.
+    const accumulatedTotalProcessedTokens = extractClaudeTotalProcessedTokens(result?.usage);
     const lastGoodUsage = context.lastKnownTokenUsage;
     const maxTokens = resultContextWindow ?? context.lastKnownContextWindow;
-    const usageSnapshot: ThreadTokenUsageSnapshot | undefined = lastGoodUsage
+    const resultIterationUsage = extractClaudeResultIterationUsage(result?.usage);
+    const resultUsageFallback =
+      normalizeClaudeTokenUsage(resultIterationUsage, maxTokens) ??
+      (hasClaudeDetailedUsageBreakdown(result?.usage)
+        ? normalizeClaudeTokenUsage(result?.usage, maxTokens)
+        : undefined);
+    const baseUsageSnapshot = lastGoodUsage ?? resultUsageFallback;
+    const usageSnapshot: ThreadTokenUsageSnapshot | undefined = baseUsageSnapshot
       ? {
-          ...lastGoodUsage,
+          ...baseUsageSnapshot,
           ...(typeof maxTokens === "number" && Number.isFinite(maxTokens) && maxTokens > 0
             ? { maxTokens }
             : {}),
           ...(typeof accumulatedTotalProcessedTokens === "number" &&
           Number.isFinite(accumulatedTotalProcessedTokens) &&
-          accumulatedTotalProcessedTokens > lastGoodUsage.usedTokens
+          accumulatedTotalProcessedTokens > baseUsageSnapshot.usedTokens
             ? {
                 totalProcessedTokens: accumulatedTotalProcessedTokens,
               }
             : {}),
         }
-      : accumulatedSnapshot;
+      : undefined;
 
     const turnState = context.turnState;
     if (!turnState) {
@@ -1558,6 +1672,10 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     const { event } = message;
+    const streamUsage = extractClaudeStreamUsage(event);
+    if (streamUsage) {
+      yield* recordClaudeUsageSnapshot(context, streamUsage);
+    }
 
     if (event.type === "content_block_delta") {
       if (
@@ -2119,23 +2237,7 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         return;
       case "task_progress":
         if (message.usage) {
-          const normalizedUsage = normalizeClaudeTokenUsage(
-            message.usage,
-            context.lastKnownContextWindow,
-          );
-          if (normalizedUsage) {
-            context.lastKnownTokenUsage = normalizedUsage;
-            const usageStamp = yield* makeEventStamp();
-            yield* offerRuntimeEvent({
-              ...base,
-              eventId: usageStamp.eventId,
-              createdAt: usageStamp.createdAt,
-              type: "thread.token-usage.updated",
-              payload: {
-                usage: normalizedUsage,
-              },
-            });
-          }
+          yield* recordClaudeUsageSnapshot(context, message.usage);
         }
         yield* offerRuntimeEvent({
           ...base,
@@ -2151,23 +2253,7 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         return;
       case "task_notification":
         if (message.usage) {
-          const normalizedUsage = normalizeClaudeTokenUsage(
-            message.usage,
-            context.lastKnownContextWindow,
-          );
-          if (normalizedUsage) {
-            context.lastKnownTokenUsage = normalizedUsage;
-            const usageStamp = yield* makeEventStamp();
-            yield* offerRuntimeEvent({
-              ...base,
-              eventId: usageStamp.eventId,
-              createdAt: usageStamp.createdAt,
-              type: "thread.token-usage.updated",
-              payload: {
-                usage: normalizedUsage,
-              },
-            });
-          }
+          yield* recordClaudeUsageSnapshot(context, message.usage);
         }
         yield* offerRuntimeEvent({
           ...base,


### PR DESCRIPTION
## Summary
- stop treating accumulated Claude `result.usage` totals as current context occupancy
- record live usage snapshots from Claude stream events and reuse them for the meter
- add regression coverage for accumulated-only results and stream-usage preservation

## Verification
- bun run test src/provider/Layers/ClaudeAdapter.test.ts
- bun fmt
- bun lint
- bun typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts token-usage metering for Claude turns, which affects user-visible usage reporting and any logic that depends on `thread.token-usage.updated` events. Risk is moderate due to multiple new fallback paths (stream snapshots, iteration usage) and changed behavior when only accumulated totals are available.
> 
> **Overview**
> **Fixes Claude context-window usage accounting.** The adapter no longer treats accumulated `result.usage.total_tokens` as the current context occupancy; if only accumulated totals are present, it skips emitting `thread.token-usage.updated` and only preserves the totals in `turn.completed`.
> 
> **Prefers live usage snapshots and adds safer fallbacks.** Usage snapshots are now recorded from Claude stream events (`message_start`/`message_delta`) and reused at turn completion, while accumulated totals are optionally kept as `totalProcessedTokens`. When stream snapshots are missing, completion can fall back to the last `usage.iterations` entry (or detailed result usage when available).
> 
> **Tests updated/added** to cover the accumulated-only case and to ensure stream usage snapshots win over accumulated result totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb1018409a091790e6245df9d60b932c4dceeec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude context window fallback accounting to prefer stream usage snapshots over accumulated totals
> - Accumulated-only result totals (lacking detailed per-token breakdown fields) no longer produce `thread.token-usage.updated` events; they now only appear on `turn.completed`.
> - Adds `extractClaudeStreamUsage` to capture usage from `message_start` and `message_delta` stream events, and a centralized `recordClaudeUsageSnapshot` effect to normalize and emit usage updates.
> - Result processing now prefers the last known stream snapshot or per-iteration result usage as the base, using accumulated totals only to override `totalProcessedTokens` when larger.
> - Behavioral Change: `thread.token-usage.updated` may now fire earlier (on stream events) and will not fire at all when only accumulated totals are available without a detailed breakdown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb10184.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->