### PR TITLE
fix(server): trim OpenCode provider model names

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -11,6 +11,7 @@ import { ServerSettingsService } from "../../serverSettings.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import {
   buildServerProvider,
+  nonEmptyTrimmed,
   parseGenericCliVersion,
   providerModelsFromSettings,
 } from "../providerSnapshot.ts";
@@ -204,10 +205,16 @@ function flattenOpenCodeModels(input: OpenCodeInventory): ReadonlyArray<ServerPr
     }
 
     for (const model of Object.values(provider.models)) {
+      const name = nonEmptyTrimmed(model.name);
+      if (!name) {
+        continue;
+      }
+
+      const subProvider = nonEmptyTrimmed(provider.name);
       models.push({
         slug: `${provider.id}/${model.id}`,
-        name: model.name,
-        subProvider: provider.name,
+        name,
+        ...(subProvider ? { subProvider } : {}),
         isCustom: false,
         capabilities: openCodeCapabilitiesForModel({
           providerID: provider.id,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Trim OpenCode-derived display strings before constructing `ServerProviderModel` entries.

Specifically:
- trim `model.name`
- trim `provider.name` before using it as `subProvider`
- skip models whose trimmed display name is empty

## Why

This fixes the nightly bug reported in #2251 where the app gets stuck on `waiting for provider status...` if OpenCode returns model names with trailing whitespace.

The shared contract requires trimmed non-empty strings for `ServerProviderModel.name` and `subProvider`, but `OpenCodeProvider` was forwarding upstream values verbatim. A single malformed model name causes the initial config snapshot to fail frontend decoding, which prevents provider state from initializing.

Trimming at the OpenCode boundary is the smallest fix and keeps the bad upstream data from poisoning the snapshot payload.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trim and validate model names in `flattenOpenCodeModels`
> Models with empty or whitespace-only names are now skipped, and valid names are trimmed before use. The `subProvider` field is only included when the provider name is non-empty after trimming. Changes are in [OpenCodeProvider.ts](https://github.com/pingdotgg/t3code/pull/2252/files#diff-4477b51690b8bf5db4f32c13ac9bb4ed2be7798d366111f84b38be236cc034bd).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfbb323.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small validation/sanitization change limited to OpenCode model metadata; main behavior change is skipping models with empty/whitespace-only names, which could hide bad upstream entries.
> 
> **Overview**
> Trims and validates OpenCode-derived display strings when building `ServerProviderModel` entries.
> 
> `flattenOpenCodeModels` now uses `nonEmptyTrimmed` for `model.name` and `provider.name`, skips models whose trimmed name is empty, and only includes `subProvider` when the provider name is non-empty after trimming to prevent malformed upstream data from breaking snapshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfbb323f10ede16c717b484739479f641155b37e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->