### PR TITLE
fix: persist project collapse state across app restarts

### DIFF
--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -284,6 +284,27 @@ describe("uiStateStore pure functions", () => {
     expect(next.projectExpandedById[project1]).toBe(false);
   });
 
+  it("syncProjects is a no-op when only cwd formatting changes", () => {
+    const projectKey = "env-local:c:\\work\\repo\\project";
+    const initialState = syncProjects(makeUiState(), [
+      {
+        key: projectKey,
+        logicalKey: projectKey,
+        cwd: "C:\\Work\\Repo\\Project\\",
+      },
+    ]);
+
+    const next = syncProjects(initialState, [
+      {
+        key: projectKey,
+        logicalKey: projectKey,
+        cwd: "c:/work/repo/project",
+      },
+    ]);
+
+    expect(next).toBe(initialState);
+  });
+
   it("syncProjects keys projectExpandedById by the logical key, not the physical key", () => {
     // In repository grouping mode, multiple physical projects (different
     // environments or different repo-relative paths) collapse into one

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -607,4 +607,30 @@ describe("uiStateStore persistence round-trip", () => {
 
     expect(rehydrated.projectExpandedById[nextLogicalKey]).toBe(false);
   });
+
+  it("rehydrates collapsed projects when Windows cwd formatting changes across restart", () => {
+    const initialProject = {
+      key: "win-kA",
+      logicalKey: "win-kA",
+      cwd: "C:\\Work\\Repo\\Project\\",
+    };
+    const restartedProject = {
+      key: "win-kA",
+      logicalKey: "win-kA",
+      cwd: "c:/work/repo/project",
+    };
+
+    let state = syncProjects(makeUiState(), [initialProject]);
+    state = setProjectExpanded(state, initialProject.logicalKey, false);
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    hydratePersistedProjectState(persisted);
+
+    const rehydrated = syncProjects(makeUiState(), [restartedProject]);
+
+    expect(rehydrated.projectExpandedById[restartedProject.logicalKey]).toBe(false);
+  });
 });

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -559,4 +559,30 @@ describe("uiStateStore persistence round-trip", () => {
 
     expect(rehydrated.projectExpandedById[nextLogicalKey]).toBe(false);
   });
+
+  it("rehydrates collapsed projects when Windows cwd formatting changes across restart", () => {
+    const initialProject = {
+      key: "win-kA",
+      logicalKey: "win-kA",
+      cwd: "C:\\Work\\Repo\\Project\\",
+    };
+    const restartedProject = {
+      key: "win-kA",
+      logicalKey: "win-kA",
+      cwd: "c:/work/repo/project",
+    };
+
+    let state = syncProjects(makeUiState(), [initialProject]);
+    state = setProjectExpanded(state, initialProject.logicalKey, false);
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    hydratePersistedProjectState(persisted);
+
+    const rehydrated = syncProjects(makeUiState(), [restartedProject]);
+
+    expect(rehydrated.projectExpandedById[restartedProject.logicalKey]).toBe(false);
+  });
 });

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -247,6 +247,27 @@ describe("uiStateStore pure functions", () => {
     expect(next.projectExpandedById[project1]).toBe(false);
   });
 
+  it("syncProjects is a no-op when only cwd formatting changes", () => {
+    const projectKey = "env-local:c:\\work\\repo\\project";
+    const initialState = syncProjects(makeUiState(), [
+      {
+        key: projectKey,
+        logicalKey: projectKey,
+        cwd: "C:\\Work\\Repo\\Project\\",
+      },
+    ]);
+
+    const next = syncProjects(initialState, [
+      {
+        key: projectKey,
+        logicalKey: projectKey,
+        cwd: "c:/work/repo/project",
+      },
+    ]);
+
+    expect(next).toBe(initialState);
+  });
+
   it("syncProjects keys projectExpandedById by the logical key, not the physical key", () => {
     // In repository grouping mode, multiple physical projects (different
     // environments or different repo-relative paths) collapse into one

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -253,18 +253,21 @@ function nestedBooleanRecordsEqual(
 }
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
+  const normalizedProjects = projects.map((project) => ({
+    ...project,
+    cwd: normalizeProjectPathForComparison(project.cwd),
+  }));
   const previousProjectCwdById = new Map(currentProjectCwdById);
   const previousLogicalKeyByPhysicalKey = new Map(currentLogicalKeyByPhysicalKey);
   currentProjectCwdById.clear();
   currentLogicalKeyByPhysicalKey.clear();
-  for (const project of projects) {
-    currentProjectCwdById.set(project.key, normalizeProjectPathForComparison(project.cwd));
+  for (const project of normalizedProjects) {
+    currentProjectCwdById.set(project.key, project.cwd);
     currentLogicalKeyByPhysicalKey.set(project.key, project.logicalKey);
   }
   currentProjectCwdsByLogicalKey.clear();
   const currentProjectCwdSetsByLogicalKey = new Map<string, Set<string>>();
-  for (const project of projects) {
-    const normalizedCwd = normalizeProjectPathForComparison(project.cwd);
+  for (const project of normalizedProjects) {
     const cwds = currentProjectCwdsByLogicalKey.get(project.logicalKey);
     if (cwds) {
       let cwdSet = currentProjectCwdSetsByLogicalKey.get(project.logicalKey);
@@ -272,13 +275,13 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
         cwdSet = new Set(cwds);
         currentProjectCwdSetsByLogicalKey.set(project.logicalKey, cwdSet);
       }
-      if (!cwdSet.has(normalizedCwd)) {
-        cwdSet.add(normalizedCwd);
-        cwds.push(normalizedCwd);
+      if (!cwdSet.has(project.cwd)) {
+        cwdSet.add(project.cwd);
+        cwds.push(project.cwd);
       }
     } else {
-      currentProjectCwdsByLogicalKey.set(project.logicalKey, [normalizedCwd]);
-      currentProjectCwdSetsByLogicalKey.set(project.logicalKey, new Set([normalizedCwd]));
+      currentProjectCwdsByLogicalKey.set(project.logicalKey, [project.cwd]);
+      currentProjectCwdSetsByLogicalKey.set(project.logicalKey, new Set([project.cwd]));
     }
   }
   // Build reverse map: for each new logical key, which previous logical keys
@@ -286,7 +289,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   // project's logical key changes (e.g. late-arriving repo metadata flips the
   // group identity).
   const previousLogicalKeysByNewLogicalKey = new Map<string, Set<string>>();
-  for (const project of projects) {
+  for (const project of normalizedProjects) {
     const previousLogicalKey = previousLogicalKeyByPhysicalKey.get(project.key);
     if (!previousLogicalKey || previousLogicalKey === project.logicalKey) {
       continue;
@@ -300,14 +303,14 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   }
   const cwdMappingChanged =
     previousProjectCwdById.size !== currentProjectCwdById.size ||
-    projects.some((project) => previousProjectCwdById.get(project.key) !== project.cwd);
+    normalizedProjects.some((project) => previousProjectCwdById.get(project.key) !== project.cwd);
 
   const nextExpandedById: Record<string, boolean> = {};
   const previousExpandedById = state.projectExpandedById;
   const persistedOrderByCwd = new Map(
     persistedProjectOrderCwds.map((cwd, index) => [cwd, index] as const),
   );
-  const mappedProjects = projects.map((project, index) => {
+  const mappedProjects = normalizedProjects.map((project, index) => {
     if (!(project.logicalKey in nextExpandedById)) {
       const groupCwds = currentProjectCwdsByLogicalKey.get(project.logicalKey) ?? [project.cwd];
       const fallbackFromPreviousLogicalKey = (() => {
@@ -342,7 +345,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
     }
     return {
       id: project.key,
-      cwd: normalizeProjectPathForComparison(project.cwd),
+      cwd: project.cwd,
       incomingIndex: index,
     };
   });

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -1,5 +1,6 @@
 import { Debouncer } from "@tanstack/react-pacer";
 import { create } from "zustand";
+import { normalizeProjectPathForComparison } from "./lib/projectPaths";
 
 export const PERSISTED_STATE_KEY = "t3code:ui-state:v1";
 const LEGACY_PERSISTED_STATE_KEYS = [
@@ -145,18 +146,22 @@ export function hydratePersistedProjectState(parsed: PersistedUiState): void {
   persistedProjectStateUsesLegacyShape = !Array.isArray(parsed.collapsedProjectCwds);
   for (const cwd of parsed.collapsedProjectCwds ?? []) {
     if (typeof cwd === "string" && cwd.length > 0) {
-      persistedCollapsedProjectCwds.add(cwd);
+      persistedCollapsedProjectCwds.add(normalizeProjectPathForComparison(cwd));
     }
   }
   for (const cwd of parsed.expandedProjectCwds ?? []) {
     if (typeof cwd === "string" && cwd.length > 0) {
-      persistedExpandedProjectCwds.add(cwd);
+      persistedExpandedProjectCwds.add(normalizeProjectPathForComparison(cwd));
     }
   }
   for (const cwd of parsed.projectOrderCwds ?? []) {
-    if (typeof cwd === "string" && cwd.length > 0 && !persistedProjectOrderCwdSet.has(cwd)) {
-      persistedProjectOrderCwdSet.add(cwd);
-      persistedProjectOrderCwds.push(cwd);
+    if (typeof cwd !== "string" || cwd.length === 0) {
+      continue;
+    }
+    const normalizedCwd = normalizeProjectPathForComparison(cwd);
+    if (!persistedProjectOrderCwdSet.has(normalizedCwd)) {
+      persistedProjectOrderCwdSet.add(normalizedCwd);
+      persistedProjectOrderCwds.push(normalizedCwd);
     }
   }
 }
@@ -253,12 +258,13 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   currentProjectCwdById.clear();
   currentLogicalKeyByPhysicalKey.clear();
   for (const project of projects) {
-    currentProjectCwdById.set(project.key, project.cwd);
+    currentProjectCwdById.set(project.key, normalizeProjectPathForComparison(project.cwd));
     currentLogicalKeyByPhysicalKey.set(project.key, project.logicalKey);
   }
   currentProjectCwdsByLogicalKey.clear();
   const currentProjectCwdSetsByLogicalKey = new Map<string, Set<string>>();
   for (const project of projects) {
+    const normalizedCwd = normalizeProjectPathForComparison(project.cwd);
     const cwds = currentProjectCwdsByLogicalKey.get(project.logicalKey);
     if (cwds) {
       let cwdSet = currentProjectCwdSetsByLogicalKey.get(project.logicalKey);
@@ -266,13 +272,13 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
         cwdSet = new Set(cwds);
         currentProjectCwdSetsByLogicalKey.set(project.logicalKey, cwdSet);
       }
-      if (!cwdSet.has(project.cwd)) {
-        cwdSet.add(project.cwd);
-        cwds.push(project.cwd);
+      if (!cwdSet.has(normalizedCwd)) {
+        cwdSet.add(normalizedCwd);
+        cwds.push(normalizedCwd);
       }
     } else {
-      currentProjectCwdsByLogicalKey.set(project.logicalKey, [project.cwd]);
-      currentProjectCwdSetsByLogicalKey.set(project.logicalKey, new Set([project.cwd]));
+      currentProjectCwdsByLogicalKey.set(project.logicalKey, [normalizedCwd]);
+      currentProjectCwdSetsByLogicalKey.set(project.logicalKey, new Set([normalizedCwd]));
     }
   }
   // Build reverse map: for each new logical key, which previous logical keys
@@ -336,7 +342,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
     }
     return {
       id: project.key,
-      cwd: project.cwd,
+      cwd: normalizeProjectPathForComparison(project.cwd),
       incomingIndex: index,
     };
   });

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -1,5 +1,6 @@
 import { Debouncer } from "@tanstack/react-pacer";
 import { create } from "zustand";
+import { normalizeProjectPathForComparison } from "./lib/projectPaths";
 
 export const PERSISTED_STATE_KEY = "t3code:ui-state:v1";
 const LEGACY_PERSISTED_STATE_KEYS = [
@@ -132,17 +133,21 @@ export function hydratePersistedProjectState(parsed: PersistedUiState): void {
   persistedProjectStateUsesLegacyShape = !Array.isArray(parsed.collapsedProjectCwds);
   for (const cwd of parsed.collapsedProjectCwds ?? []) {
     if (typeof cwd === "string" && cwd.length > 0) {
-      persistedCollapsedProjectCwds.add(cwd);
+      persistedCollapsedProjectCwds.add(normalizeProjectPathForComparison(cwd));
     }
   }
   for (const cwd of parsed.expandedProjectCwds ?? []) {
     if (typeof cwd === "string" && cwd.length > 0) {
-      persistedExpandedProjectCwds.add(cwd);
+      persistedExpandedProjectCwds.add(normalizeProjectPathForComparison(cwd));
     }
   }
   for (const cwd of parsed.projectOrderCwds ?? []) {
-    if (typeof cwd === "string" && cwd.length > 0 && !persistedProjectOrderCwds.includes(cwd)) {
-      persistedProjectOrderCwds.push(cwd);
+    if (typeof cwd !== "string" || cwd.length === 0) {
+      continue;
+    }
+    const normalizedCwd = normalizeProjectPathForComparison(cwd);
+    if (!persistedProjectOrderCwds.includes(normalizedCwd)) {
+      persistedProjectOrderCwds.push(normalizedCwd);
     }
   }
 }
@@ -238,18 +243,19 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   currentProjectCwdById.clear();
   currentLogicalKeyByPhysicalKey.clear();
   for (const project of projects) {
-    currentProjectCwdById.set(project.key, project.cwd);
+    currentProjectCwdById.set(project.key, normalizeProjectPathForComparison(project.cwd));
     currentLogicalKeyByPhysicalKey.set(project.key, project.logicalKey);
   }
   currentProjectCwdsByLogicalKey.clear();
   for (const project of projects) {
+    const normalizedCwd = normalizeProjectPathForComparison(project.cwd);
     const cwds = currentProjectCwdsByLogicalKey.get(project.logicalKey);
     if (cwds) {
-      if (!cwds.includes(project.cwd)) {
-        cwds.push(project.cwd);
+      if (!cwds.includes(normalizedCwd)) {
+        cwds.push(normalizedCwd);
       }
     } else {
-      currentProjectCwdsByLogicalKey.set(project.logicalKey, [project.cwd]);
+      currentProjectCwdsByLogicalKey.set(project.logicalKey, [normalizedCwd]);
     }
   }
   // Build reverse map: for each new logical key, which previous logical keys
@@ -313,7 +319,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
     }
     return {
       id: project.key,
-      cwd: project.cwd,
+      cwd: normalizeProjectPathForComparison(project.cwd),
       incomingIndex: index,
     };
   });

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -238,24 +238,27 @@ function nestedBooleanRecordsEqual(
 }
 
 export function syncProjects(state: UiState, projects: readonly SyncProjectInput[]): UiState {
+  const normalizedProjects = projects.map((project) => ({
+    ...project,
+    cwd: normalizeProjectPathForComparison(project.cwd),
+  }));
   const previousProjectCwdById = new Map(currentProjectCwdById);
   const previousLogicalKeyByPhysicalKey = new Map(currentLogicalKeyByPhysicalKey);
   currentProjectCwdById.clear();
   currentLogicalKeyByPhysicalKey.clear();
-  for (const project of projects) {
-    currentProjectCwdById.set(project.key, normalizeProjectPathForComparison(project.cwd));
+  for (const project of normalizedProjects) {
+    currentProjectCwdById.set(project.key, project.cwd);
     currentLogicalKeyByPhysicalKey.set(project.key, project.logicalKey);
   }
   currentProjectCwdsByLogicalKey.clear();
-  for (const project of projects) {
-    const normalizedCwd = normalizeProjectPathForComparison(project.cwd);
+  for (const project of normalizedProjects) {
     const cwds = currentProjectCwdsByLogicalKey.get(project.logicalKey);
     if (cwds) {
-      if (!cwds.includes(normalizedCwd)) {
-        cwds.push(normalizedCwd);
+      if (!cwds.includes(project.cwd)) {
+        cwds.push(project.cwd);
       }
     } else {
-      currentProjectCwdsByLogicalKey.set(project.logicalKey, [normalizedCwd]);
+      currentProjectCwdsByLogicalKey.set(project.logicalKey, [project.cwd]);
     }
   }
   // Build reverse map: for each new logical key, which previous logical keys
@@ -263,7 +266,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   // project's logical key changes (e.g. late-arriving repo metadata flips the
   // group identity).
   const previousLogicalKeysByNewLogicalKey = new Map<string, Set<string>>();
-  for (const project of projects) {
+  for (const project of normalizedProjects) {
     const previousLogicalKey = previousLogicalKeyByPhysicalKey.get(project.key);
     if (!previousLogicalKey || previousLogicalKey === project.logicalKey) {
       continue;
@@ -277,14 +280,14 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
   }
   const cwdMappingChanged =
     previousProjectCwdById.size !== currentProjectCwdById.size ||
-    projects.some((project) => previousProjectCwdById.get(project.key) !== project.cwd);
+    normalizedProjects.some((project) => previousProjectCwdById.get(project.key) !== project.cwd);
 
   const nextExpandedById: Record<string, boolean> = {};
   const previousExpandedById = state.projectExpandedById;
   const persistedOrderByCwd = new Map(
     persistedProjectOrderCwds.map((cwd, index) => [cwd, index] as const),
   );
-  const mappedProjects = projects.map((project, index) => {
+  const mappedProjects = normalizedProjects.map((project, index) => {
     if (!(project.logicalKey in nextExpandedById)) {
       const groupCwds = currentProjectCwdsByLogicalKey.get(project.logicalKey) ?? [project.cwd];
       const fallbackFromPreviousLogicalKey = (() => {
@@ -319,7 +322,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
     }
     return {
       id: project.key,
-      cwd: normalizeProjectPathForComparison(project.cwd),
+      cwd: project.cwd,
       incomingIndex: index,
     };
   });


### PR DESCRIPTION
## Summary
This fixes a sidebar state persistence bug where collapsed projects could reopen after restarting the app.

## Problem
Project collapse and expand state was persisted using raw project cwd strings. On restart, the same project path could be represented differently, especially on Windows, causing the persisted state lookup to miss and the sidebar to fall back to the default expanded state.

## What changed
Project paths used for persisted sidebar state are now normalized before they are stored and before they are matched during rehydration. A regression test was also added to cover Windows path formatting differences across restarts.

## Why
The sidebar should treat semantically identical project paths as the same project across application restarts. Normalizing persisted paths makes collapse state restoration deterministic and prevents projects from appearing randomly expanded.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI persistence logic with existing path normalizer; no auth, network, or data-model changes.
> 
> **Overview**
> Fixes collapsed projects reopening after restart when the same folder path is reported with different formatting (especially on Windows).
> 
> **`uiStateStore`** now runs project `cwd` values through `normalizeProjectPathForComparison` when loading persisted collapse/expand/order lists and when **`syncProjects`** builds in-memory cwd maps and matches against persisted state. Semantically identical paths no longer count as cwd changes, so **`syncProjects`** can stay a no-op when only separators or casing differ. Hydration also deduplicates **`projectOrderCwds`** after normalization.
> 
> Regression tests cover formatting-only sync and a Windows restart round-trip for collapsed state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aca85094340cc8e265030225f0ab973c9bf2a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix project collapse state persistence across app restarts when cwd formatting changes
> - Normalizes project `cwd` values using `normalizeProjectPathForComparison` in both `hydratePersistedProjectState` and `syncProjects` in [uiStateStore.ts](https://github.com/pingdotgg/t3code/pull/2253/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8), so path variants differing only in case or slash style are treated as the same project.
> - Rehydration now correctly restores collapsed/expanded state and project order even when the stored cwd format differs from the current one (e.g., after a Windows path case or separator change).
> - `syncProjects` no longer triggers state updates when only cwd formatting differs between calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5aca850.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->