### PR TITLE
fix(server): restore CODEX_HOME tilde expansion for Codex launches

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -28,6 +28,7 @@ import { ServerSettingsError } from "@t3tools/contracts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import { buildServerProvider } from "../providerSnapshot.ts";
 import { CodexProvider } from "../Services/CodexProvider.ts";
+import { expandHomePath } from "../../pathExpansion.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 
@@ -220,7 +221,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
       command: input.binaryPath,
       args: ["app-server"],
       cwd: input.cwd,
-      ...(input.homePath ? { env: { CODEX_HOME: input.homePath } } : {}),
+      ...(input.homePath ? { env: { CODEX_HOME: expandHomePath(input.homePath) } } : {}),
     }),
   );
   const client = yield* Effect.service(CodexClient.CodexAppServerClient).pipe(

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -30,6 +30,7 @@ import {
   CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
   CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
 } from "../CodexDeveloperInstructions.ts";
+import { expandHomePath } from "../../pathExpansion.ts";
 
 const PROVIDER = "codex" as const;
 
@@ -680,7 +681,9 @@ export const makeCodexSessionRuntime = (
       .spawn(
         ChildProcess.make(options.binaryPath, ["app-server"], {
           cwd: options.cwd,
-          ...(options.homePath ? { env: { ...process.env, CODEX_HOME: options.homePath } } : {}),
+          ...(options.homePath
+            ? { env: { ...process.env, CODEX_HOME: expandHomePath(options.homePath) } }
+            : {}),
           shell: process.platform === "win32",
         }),
       )


### PR DESCRIPTION
## What Changed

This restores `~` expansion for `providers.codex.homePath` before T3 Code exports it as `CODEX_HOME` for Codex app-server launches.

The current provider probe and live session runtime paths passed `homePath` through verbatim, so a setting like `~/.codex` was forwarded literally instead of being resolved to the user home directory.

## Why

Codex does not expand `~` in `CODEX_HOME` itself. With a literal `CODEX_HOME="~/.codex"`, `codex app-server` exits with:

`CODEX_HOME points to "~/.codex", but that path does not exist`

That prevents Codex from loading its config from the intended home directory, including MCP configuration.

The repo already has a shared `expandHomePath(...)` helper, and the git text-generation launch path already uses it. This applies the same normalization to the remaining Codex app-server launch sites so provider probing and live sessions behave consistently.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Not applicable: this change only updates backend launch configuration.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `CODEX_HOME` tilde expansion for Codex app-server launches
> Both [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/2255/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) and [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/2255/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) were passing the raw `homePath` value as `CODEX_HOME` when spawning the app-server process. Both files now call `expandHomePath()` on the value before setting the environment variable, restoring correct tilde expansion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f756ab1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change limited to normalizing `providers.codex.homePath` before spawning the Codex `app-server`. Main risk is only potential behavior change for users who intentionally relied on a literal leading `~` in the path.
> 
> **Overview**
> Restores `~` home-directory expansion when setting `CODEX_HOME` for Codex `app-server` processes.
> 
> Both the provider probe path (`CodexProvider`) and the live session runtime spawn path (`CodexSessionRuntime`) now pass `providers.codex.homePath` through `expandHomePath()` before exporting it, ensuring Codex receives a real filesystem path instead of a literal `~` string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f756ab152d95e92209d9760e95fe52da4e53de66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->