### PR TITLE
fix(server): restore fast mode for nightly GPT-5 models

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.test.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type * as CodexSchema from "effect-codex-app-server/schema";
+
+import { parseCodexModelListResponse } from "./CodexProvider.ts";
+
+function makeModel(
+  overrides: Partial<CodexSchema.V2ModelListResponse__Model> = {},
+): CodexSchema.V2ModelListResponse__Model {
+  return {
+    id: "gpt-5.4",
+    model: "gpt-5.4",
+    upgrade: null,
+    upgradeInfo: null,
+    availabilityNux: null,
+    displayName: "gpt-5.4",
+    description: "Latest frontier agentic coding model.",
+    hidden: false,
+    supportedReasoningEfforts: [
+      {
+        reasoningEffort: "medium",
+        description: "Balances speed and reasoning depth for everyday tasks",
+      },
+    ],
+    defaultReasoningEffort: "medium",
+    inputModalities: ["text", "image"],
+    supportsPersonality: true,
+    isDefault: true,
+    ...overrides,
+  };
+}
+
+describe("parseCodexModelListResponse", () => {
+  it("preserves fast mode for GPT-5 models when app-server omits additionalSpeedTiers", () => {
+    const [model] = parseCodexModelListResponse({
+      data: [makeModel()],
+      nextCursor: null,
+    });
+
+    expect(model).toBeDefined();
+    expect(model?.capabilities).toMatchObject({
+      supportsFastMode: true,
+    });
+  });
+
+  it("honors an explicit empty additionalSpeedTiers list", () => {
+    const [model] = parseCodexModelListResponse({
+      data: [
+        makeModel({
+          additionalSpeedTiers: [],
+        }),
+      ],
+      nextCursor: null,
+    });
+
+    expect(model).toBeDefined();
+    expect(model?.capabilities).toMatchObject({
+      supportsFastMode: false,
+    });
+  });
+});

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -84,13 +84,17 @@ function codexAccountAuthLabel(account: CodexSchema.V2GetAccountResponse["accoun
 function mapCodexModelCapabilities(
   model: CodexSchema.V2ModelListResponse__Model,
 ): ModelCapabilities {
+  const supportsFastMode = globalThis.Array.isArray(model.additionalSpeedTiers)
+    ? model.additionalSpeedTiers.includes("fast")
+    : /^gpt-5(?:[.-]|$)/.test(model.model);
+
   return {
     reasoningEffortLevels: model.supportedReasoningEfforts.map(({ reasoningEffort }) => ({
       value: reasoningEffort,
       label: REASONING_EFFORT_LABELS[reasoningEffort],
       ...(reasoningEffort === model.defaultReasoningEffort ? { isDefault: true } : {}),
     })),
-    supportsFastMode: (model.additionalSpeedTiers ?? []).includes("fast"),
+    supportsFastMode,
     supportsThinkingToggle: false,
     contextWindowOptions: [],
     promptInjectedEffortLevels: [],
@@ -104,7 +108,7 @@ const toDisplayName = (model: CodexSchema.V2ModelListResponse__Model): string =>
     .replace(/-([a-z])/g, (_, c) => "-" + c.toUpperCase());
 };
 
-function parseCodexModelListResponse(
+export function parseCodexModelListResponse(
   response: CodexSchema.V2ModelListResponse,
 ): ReadonlyArray<ServerProviderModel> {
   return response.data.map((model) => ({


### PR DESCRIPTION
## What Changed

Restores `supportsFastMode` for GPT-5 models when the Codex app-server model list response omits `additionalSpeedTiers`.

- In `mapCodexModelCapabilities`, default `supportsFastMode` to `true` for models matching `/^gpt-5(?:[.-]|$)/` when `additionalSpeedTiers` is not provided.
- When `additionalSpeedTiers` is explicitly provided (including an empty array), honor it as before: `supportsFastMode` is `true` only if the array includes `'fast'`.
- Export `parseCodexModelListResponse` so the capability mapping can be unit tested directly.

## Why

Nightly builds stopped surfacing the Fast mode control for GPT-5 models because the app-server metadata no longer included `additionalSpeedTiers`. The previous mapping collapsed the missing-field and empty-array cases into the same disabled state, even though the runtime still accepts the `fast` service tier for GPT-5.

This change distinguishes the two shapes so fast mode stays enabled on nightly while still letting the server explicitly opt out by sending an empty tiers list.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

Not applicable: this is a provider capability-mapping change with no UI surface area.

## Validation

- `bun run --cwd apps/server test src/provider/Layers/CodexProvider.test.ts`
- `bun fmt`
- `bun lint`
- `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small capability-mapping tweak plus targeted unit tests. Main risk is misclassifying `supportsFastMode` for non-GPT-5 models if the regex fallback is too broad or narrow.
> 
> **Overview**
> Restores `supportsFastMode` for GPT-5 models when the app-server model metadata omits `additionalSpeedTiers`, by falling back to a `gpt-5` name check while still honoring an explicitly provided (including empty) tiers list.
> 
> Exports `parseCodexModelListResponse` and adds a regression test covering both the missing-field case (fast stays enabled) and the explicit-empty case (fast disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d59b876405d9ddfc91b9fa2c488b9c03d0293752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore fast mode for GPT-5 models when `additionalSpeedTiers` is absent
> - In [`CodexProvider.ts`](https://github.com/pingdotgg/t3code/pull/2257/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53), `mapCodexModelCapabilities` now defaults `supportsFastMode` to `true` for models matching `/^gpt-5(?:[.-]|$)/` when `additionalSpeedTiers` is not provided by the API.
> - When `additionalSpeedTiers` is explicitly provided, the existing behavior applies: `supportsFastMode` is `true` only if the array includes `'fast'`.
> - Exports `parseCodexModelListResponse` so it can be unit tested directly.
> - Behavioral Change: nightly GPT-5 models that omit `additionalSpeedTiers` will now have `supportsFastMode: true` instead of `false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d59b876.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->