### PR TITLE
fix(web): make changed-files collapse persistence configurable

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -16,6 +16,7 @@ const clientSettings: ClientSettings = {
   autoOpenPlanSidebar: false,
   confirmThreadArchive: true,
   confirmThreadDelete: false,
+  defaultOpenChangedFiles: false,
   dismissedProviderUpdateNotificationKeys: [],
   diffIgnoreWhitespace: true,
   favorites: [],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5273,6 +5273,7 @@ function ChatViewContent(props: ChatViewProps) {
                 markdownCwd={gitCwd ?? undefined}
                 resolvedTheme={resolvedTheme}
                 timestampFormat={timestampFormat}
+                defaultOpenChangedFiles={settings.defaultOpenChangedFiles}
                 workspaceRoot={activeWorkspaceRoot}
                 skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
                 anchorMessageId={timelineAnchorMessageId}

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -185,6 +185,7 @@ function buildProps() {
     markdownCwd: undefined,
     resolvedTheme: "light" as const,
     timestampFormat: "locale" as const,
+    defaultOpenChangedFiles: true,
     workspaceRoot: undefined,
     anchorMessageId: null,
     onAnchorReady: () => {},
@@ -269,6 +270,50 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Collapse all"');
     expect(markup).toContain('aria-label="View diff"');
     expect(markup).toContain("1 changed file");
+  });
+
+  it("uses the collapsed setting default when no turn override exists", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const assistantMessageId = MessageId.make("message-assistant-setting-default");
+    const turnId = TurnId.make("turn-setting-default");
+    const props = {
+      ...buildProps(),
+      defaultOpenChangedFiles: false,
+      timelineEntries: [
+        {
+          id: "entry-assistant-setting-default",
+          kind: "message" as const,
+          createdAt: MESSAGE_CREATED_AT,
+          message: {
+            id: assistantMessageId,
+            role: "assistant" as const,
+            text: "Updated the fixture.",
+            turnId,
+            createdAt: MESSAGE_CREATED_AT,
+            updatedAt: MESSAGE_CREATED_AT,
+            streaming: false,
+          },
+        },
+      ],
+      turnDiffSummaryByAssistantMessageId: new Map([
+        [
+          assistantMessageId,
+          {
+            turnId,
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("checkpoint-setting-default"),
+            status: "ready" as const,
+            files: [{ path: "README.md", kind: "modified" as const, additions: 2, deletions: 1 }],
+            assistantMessageId,
+            completedAt: MESSAGE_CREATED_AT,
+          },
+        ],
+      ]),
+    };
+
+    expect(renderToStaticMarkup(<MessagesTimeline {...props} />)).toContain(
+      'aria-label="Expand all"',
+    );
   });
 
   it("uses LegendList isNearEnd when deciding whether the live edge is visible", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -100,7 +100,7 @@ import {
   type ParsedPreviewAnnotation,
 } from "~/lib/previewAnnotation";
 import { cn } from "~/lib/utils";
-import { useUiStateStore } from "~/uiStateStore";
+import { getThreadChangedFilesExpanded, useUiStateStore } from "~/uiStateStore";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
 import { formatChatTimestampTooltip, formatShortTimestamp } from "../../timestampFormat";
 
@@ -128,6 +128,7 @@ import {
 interface TimelineRowSharedState {
   timestampFormat: TimestampFormat;
   routeThreadKey: string;
+  defaultOpenChangedFiles: boolean;
   threadRef: ScopedThreadRef | null;
   markdownCwd: string | undefined;
   resolvedTheme: "light" | "dark";
@@ -176,6 +177,7 @@ interface MessagesTimelineProps {
   markdownCwd: string | undefined;
   resolvedTheme: "light" | "dark";
   timestampFormat: TimestampFormat;
+  defaultOpenChangedFiles: boolean;
   workspaceRoot: string | undefined;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   anchorMessageId: MessageId | null;
@@ -210,6 +212,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   markdownCwd,
   resolvedTheme,
   timestampFormat,
+  defaultOpenChangedFiles,
   workspaceRoot,
   skills = EMPTY_TIMELINE_SKILLS,
   anchorMessageId,
@@ -419,6 +422,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     () => ({
       timestampFormat,
       routeThreadKey,
+      defaultOpenChangedFiles,
       threadRef: parseScopedThreadKey(routeThreadKey),
       markdownCwd,
       resolvedTheme,
@@ -434,6 +438,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     [
       timestampFormat,
       routeThreadKey,
+      defaultOpenChangedFiles,
       markdownCwd,
       resolvedTheme,
       workspaceRoot,
@@ -1028,6 +1033,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
         <AssistantChangedFilesSection
           turnSummary={row.assistantTurnDiffSummary}
           routeThreadKey={ctx.routeThreadKey}
+          defaultOpenChangedFiles={ctx.defaultOpenChangedFiles}
           resolvedTheme={ctx.resolvedTheme}
           onOpenTurnDiff={ctx.onOpenTurnDiff}
         />
@@ -1234,11 +1240,13 @@ function WorkGroupToggleTimelineRow({
 const AssistantChangedFilesSection = memo(function AssistantChangedFilesSection({
   turnSummary,
   routeThreadKey,
+  defaultOpenChangedFiles,
   resolvedTheme,
   onOpenTurnDiff,
 }: {
   turnSummary: TurnDiffSummary | undefined;
   routeThreadKey: string;
+  defaultOpenChangedFiles: boolean;
   resolvedTheme: "light" | "dark";
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
 }) {
@@ -1251,6 +1259,7 @@ const AssistantChangedFilesSection = memo(function AssistantChangedFilesSection(
       turnSummary={turnSummary}
       checkpointFiles={checkpointFiles}
       routeThreadKey={routeThreadKey}
+      defaultOpenChangedFiles={defaultOpenChangedFiles}
       resolvedTheme={resolvedTheme}
       onOpenTurnDiff={onOpenTurnDiff}
     />
@@ -1263,17 +1272,24 @@ function AssistantChangedFilesSectionInner({
   turnSummary,
   checkpointFiles,
   routeThreadKey,
+  defaultOpenChangedFiles,
   resolvedTheme,
   onOpenTurnDiff,
 }: {
   turnSummary: TurnDiffSummary;
   checkpointFiles: TurnDiffSummary["files"];
   routeThreadKey: string;
+  defaultOpenChangedFiles: boolean;
   resolvedTheme: "light" | "dark";
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
 }) {
-  const allDirectoriesExpanded = useUiStateStore(
-    (store) => store.threadChangedFilesExpandedById[routeThreadKey]?.[turnSummary.turnId] ?? true,
+  const allDirectoriesExpanded = useUiStateStore((store) =>
+    getThreadChangedFilesExpanded(
+      store,
+      routeThreadKey,
+      turnSummary.turnId,
+      defaultOpenChangedFiles,
+    ),
   );
   const setExpanded = useUiStateStore((store) => store.setThreadChangedFilesExpanded);
   const summaryStat = summarizeTurnDiffStats(checkpointFiles);
@@ -1306,7 +1322,12 @@ function AssistantChangedFilesSectionInner({
                   aria-label={allDirectoriesExpanded ? "Collapse all" : "Expand all"}
                   data-scroll-anchor-ignore
                   onClick={() =>
-                    setExpanded(routeThreadKey, turnSummary.turnId, !allDirectoriesExpanded)
+                    setExpanded(
+                      routeThreadKey,
+                      turnSummary.turnId,
+                      !allDirectoriesExpanded,
+                      defaultOpenChangedFiles,
+                    )
                   }
                 />
               }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -66,6 +66,7 @@ import { Switch } from "../ui/switch";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
+import { buildGeneralSettingsRestorePatch } from "./settingsRestore";
 import {
   canOneClickUpdateProviderCandidate,
   collectProviderUpdateCandidates,
@@ -392,6 +393,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
+      ...(settings.defaultOpenChangedFiles !== DEFAULT_UNIFIED_SETTINGS.defaultOpenChangedFiles
+        ? ["Changed-files default state"]
+        : []),
       ...(settings.sidebarThreadPreviewCount !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
         ? ["Visible threads"]
         : []),
@@ -437,6 +441,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
+      settings.defaultOpenChangedFiles,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -461,22 +466,7 @@ export function useSettingsRestore(onRestored?: () => void) {
     if (!confirmed) return;
 
     setTheme("system");
-    updateSettings({
-      timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
-      wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
-      diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
-      sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
-      autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
-      enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
-      enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
-      automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
-      defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
-      newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
-      addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
-      confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
-      confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
-      textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
-    });
+    updateSettings(buildGeneralSettingsRestorePatch());
     onRestored?.();
   }, [changedSettingLabels, onRestored, setTheme, updateSettings]);
 
@@ -598,6 +588,33 @@ export function GeneralSettingsPanel() {
                 </SelectItem>
               </SelectPopup>
             </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Changed-files default state"
+          description="Choose whether changed-files blocks start expanded before you manually toggle a turn."
+          resetAction={
+            settings.defaultOpenChangedFiles !==
+            DEFAULT_UNIFIED_SETTINGS.defaultOpenChangedFiles ? (
+              <SettingResetButton
+                label="changed-files default state"
+                onClick={() =>
+                  updateSettings({
+                    defaultOpenChangedFiles: DEFAULT_UNIFIED_SETTINGS.defaultOpenChangedFiles,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.defaultOpenChangedFiles}
+              onCheckedChange={(checked) =>
+                updateSettings({ defaultOpenChangedFiles: Boolean(checked) })
+              }
+              aria-label="Open changed files by default"
+            />
           }
         />
 

--- a/apps/web/src/components/settings/settingsRestore.test.ts
+++ b/apps/web/src/components/settings/settingsRestore.test.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildGeneralSettingsRestorePatch } from "./settingsRestore";
+
+describe("buildGeneralSettingsRestorePatch", () => {
+  it("restores the changed-files expansion default", () => {
+    expect(buildGeneralSettingsRestorePatch().defaultOpenChangedFiles).toBe(
+      DEFAULT_UNIFIED_SETTINGS.defaultOpenChangedFiles,
+    );
+  });
+});

--- a/apps/web/src/components/settings/settingsRestore.ts
+++ b/apps/web/src/components/settings/settingsRestore.ts
@@ -1,0 +1,21 @@
+import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+
+export function buildGeneralSettingsRestorePatch() {
+  return {
+    timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
+    defaultOpenChangedFiles: DEFAULT_UNIFIED_SETTINGS.defaultOpenChangedFiles,
+    wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
+    diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+    sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+    autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
+    enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
+    enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+    automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
+    defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
+    newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
+    addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
+    confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
+    confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+    textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
+  };
+}

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -2,6 +2,7 @@ import { ProjectId, ThreadId } from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
+  getThreadChangedFilesExpanded,
   legacyProjectCwdPreferenceKey,
   markThreadUnread,
   markThreadVisited,
@@ -15,6 +16,7 @@ import {
   setProjectExpanded,
   setThreadChangedFilesExpanded,
   type UiState,
+  useUiStateStore,
 } from "./uiStateStore";
 
 function makeUiState(overrides: Partial<UiState> = {}): UiState {
@@ -116,9 +118,17 @@ describe("uiStateStore pure functions", () => {
     );
   });
 
-  it("stores only collapsed changed-file turns", () => {
+  it("uses the setting default until a turn is manually overridden", () => {
     const threadId = ThreadId.make("thread-1");
-    const collapsed = setThreadChangedFilesExpanded(makeUiState(), threadId, "turn-1", false);
+    const initialState = makeUiState();
+
+    expect(getThreadChangedFilesExpanded(initialState, threadId, "turn-1", true)).toBe(true);
+    expect(getThreadChangedFilesExpanded(initialState, threadId, "turn-1", false)).toBe(false);
+  });
+
+  it("stores per-turn overrides relative to either setting default", () => {
+    const threadId = ThreadId.make("thread-1");
+    const collapsed = setThreadChangedFilesExpanded(makeUiState(), threadId, "turn-1", false, true);
 
     expect(collapsed.threadChangedFilesExpandedById).toEqual({
       [threadId]: {
@@ -126,9 +136,32 @@ describe("uiStateStore pure functions", () => {
       },
     });
     expect(
-      setThreadChangedFilesExpanded(collapsed, threadId, "turn-1", true)
+      setThreadChangedFilesExpanded(collapsed, threadId, "turn-1", true, true)
         .threadChangedFilesExpandedById,
     ).toEqual({});
+
+    const expanded = setThreadChangedFilesExpanded(makeUiState(), threadId, "turn-1", true, false);
+    expect(expanded.threadChangedFilesExpandedById).toEqual({
+      [threadId]: {
+        "turn-1": true,
+      },
+    });
+    expect(getThreadChangedFilesExpanded(expanded, threadId, "turn-1", false)).toBe(true);
+    expect(getThreadChangedFilesExpanded(expanded, threadId, "turn-2", false)).toBe(false);
+  });
+
+  it("keeps an explicit turn override when the setting default changes", () => {
+    const threadId = ThreadId.make("thread-1");
+    const overridden = setThreadChangedFilesExpanded(
+      makeUiState(),
+      threadId,
+      "turn-1",
+      false,
+      true,
+    );
+
+    expect(getThreadChangedFilesExpanded(overridden, threadId, "turn-1", false)).toBe(false);
+    expect(getThreadChangedFilesExpanded(overridden, threadId, "turn-1", true)).toBe(false);
   });
 
   it("stores the endpoint preference by stable key", () => {
@@ -175,6 +208,7 @@ describe("parsePersistedState", () => {
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
           "turn-1": false,
+          "turn-2": true,
         },
       },
     });
@@ -210,6 +244,24 @@ describe("parsePersistedState", () => {
         legacyProjectCwdPreferenceKey("/repo/b"),
       ]),
     ).toBe(false);
+  });
+
+  it("ignores obsolete thread-wide and malformed changed-files preferences", () => {
+    const parsed = parsePersistedState({
+      threadChangedFilesExpandedById: {
+        "legacy-thread": false as unknown as Record<string, boolean>,
+        "valid-thread": {
+          "valid-turn": true,
+          "invalid-turn": "yes" as unknown as boolean,
+        },
+      },
+    });
+
+    expect(parsed.threadChangedFilesExpandedById).toEqual({
+      "valid-thread": {
+        "valid-turn": true,
+      },
+    });
   });
 });
 
@@ -281,17 +333,11 @@ describe("uiStateStore persistence", () => {
       threadChangedFilesExpandedById: {
         "environment:thread-1": {
           "turn-1": false,
+          "turn-2": true,
         },
       },
     });
-    expect(parsePersistedState(persisted)).toEqual({
-      ...state,
-      threadChangedFilesExpandedById: {
-        "environment:thread-1": {
-          "turn-1": false,
-        },
-      },
-    });
+    expect(parsePersistedState(persisted)).toEqual(state);
   });
 
   it("drops the temporary expanded-only migration fallback when rewriting state", () => {
@@ -305,5 +351,26 @@ describe("uiStateStore persistence", () => {
       localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
     ) as PersistedUiState;
     expect(resolveProjectExpanded(persisted.projectExpandedById ?? {}, ["unknown"])).toBe(true);
+  });
+
+  it("persists both changed-files override values immediately", () => {
+    useUiStateStore.setState(makeUiState());
+
+    useUiStateStore
+      .getState()
+      .setThreadChangedFilesExpanded("environment:thread-1", "turn-collapsed", false, true);
+    useUiStateStore
+      .getState()
+      .setThreadChangedFilesExpanded("environment:thread-1", "turn-expanded", true, false);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    expect(persisted.threadChangedFilesExpandedById).toEqual({
+      "environment:thread-1": {
+        "turn-collapsed": false,
+        "turn-expanded": true,
+      },
+    });
   });
 });

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -172,8 +172,8 @@ function sanitizePersistedThreadChangedFilesExpanded(
 
     const nextTurns: Record<string, boolean> = {};
     for (const [turnId, expanded] of Object.entries(turns)) {
-      if (turnId && typeof expanded === "boolean" && expanded === false) {
-        nextTurns[turnId] = false;
+      if (turnId && typeof expanded === "boolean") {
+        nextTurns[turnId] = expanded;
       }
     }
 
@@ -195,14 +195,7 @@ export function persistState(state: UiState): void {
         ([key]) => key !== LEGACY_PROJECT_EXPANSION_DEFAULT_KEY,
       ),
     );
-    const threadChangedFilesExpandedById = Object.fromEntries(
-      Object.entries(state.threadChangedFilesExpandedById).flatMap(([threadId, turns]) => {
-        const nextTurns = Object.fromEntries(
-          Object.entries(turns).filter(([, expanded]) => expanded === false),
-        );
-        return Object.keys(nextTurns).length > 0 ? [[threadId, nextTurns]] : [];
-      }),
-    );
+    const threadChangedFilesExpandedById = { ...state.threadChangedFilesExpandedById };
     window.localStorage.setItem(
       PERSISTED_STATE_KEY,
       JSON.stringify({
@@ -279,14 +272,15 @@ export function setThreadChangedFilesExpanded(
   threadId: string,
   turnId: string,
   expanded: boolean,
+  defaultExpanded: boolean,
 ): UiState {
   const currentThreadState = state.threadChangedFilesExpandedById[threadId] ?? {};
-  const currentExpanded = currentThreadState[turnId] ?? true;
+  const currentExpanded = getThreadChangedFilesExpanded(state, threadId, turnId, defaultExpanded);
   if (currentExpanded === expanded) {
     return state;
   }
 
-  if (expanded) {
+  if (expanded === defaultExpanded) {
     if (!(turnId in currentThreadState)) {
       return state;
     }
@@ -317,10 +311,19 @@ export function setThreadChangedFilesExpanded(
       ...state.threadChangedFilesExpandedById,
       [threadId]: {
         ...currentThreadState,
-        [turnId]: false,
+        [turnId]: expanded,
       },
     },
   };
+}
+
+export function getThreadChangedFilesExpanded(
+  state: UiState,
+  threadId: string,
+  turnId: string,
+  defaultExpanded: boolean,
+): boolean {
+  return state.threadChangedFilesExpandedById[threadId]?.[turnId] ?? defaultExpanded;
 }
 
 export function setDefaultAdvertisedEndpointKey(state: UiState, key: string | null): UiState {
@@ -414,7 +417,12 @@ export function reorderProjects(
 interface UiStateStore extends UiState {
   markThreadVisited: (threadId: string, visitedAt: string) => void;
   markThreadUnread: (threadId: string, latestTurnCompletedAt: string | null | undefined) => void;
-  setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
+  setThreadChangedFilesExpanded: (
+    threadId: string,
+    turnId: string,
+    expanded: boolean,
+    defaultExpanded: boolean,
+  ) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   setProjectExpanded: (projectIds: string | readonly string[], expanded: boolean) => void;
   reorderProjects: (
@@ -424,14 +432,27 @@ interface UiStateStore extends UiState {
   ) => void;
 }
 
-export const useUiStateStore = create<UiStateStore>((set) => ({
+export const useUiStateStore = create<UiStateStore>((set, get) => ({
   ...readPersistedState(),
   markThreadVisited: (threadId, visitedAt) =>
     set((state) => markThreadVisited(state, threadId, visitedAt)),
   markThreadUnread: (threadId, latestTurnCompletedAt) =>
     set((state) => markThreadUnread(state, threadId, latestTurnCompletedAt)),
-  setThreadChangedFilesExpanded: (threadId, turnId, expanded) =>
-    set((state) => setThreadChangedFilesExpanded(state, threadId, turnId, expanded)),
+  setThreadChangedFilesExpanded: (threadId, turnId, expanded, defaultExpanded) => {
+    const previousState = get();
+    const nextState = setThreadChangedFilesExpanded(
+      previousState,
+      threadId,
+      turnId,
+      expanded,
+      defaultExpanded,
+    );
+    if (nextState === previousState) {
+      return;
+    }
+    set(nextState);
+    persistState(nextState);
+  },
   setDefaultAdvertisedEndpointKey: (key) =>
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
   setProjectExpanded: (projectIds, expanded) =>

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -3,6 +3,7 @@ import * as Schema from "effect/Schema";
 
 import { ProviderInstanceId } from "./providerInstance.ts";
 import {
+  ClientSettingsPatch,
   ClientSettingsSchema,
   DEFAULT_SERVER_SETTINGS,
   ServerSettings,
@@ -10,6 +11,7 @@ import {
 } from "./settings.ts";
 
 const decodeClientSettings = Schema.decodeUnknownSync(ClientSettingsSchema);
+const decodeClientSettingsPatch = Schema.decodeUnknownSync(ClientSettingsPatch);
 const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
@@ -28,6 +30,21 @@ describe("ClientSettings word wrap", () => {
     expect(decoded.wordWrap).toBe(true);
     expect(decoded).not.toHaveProperty("chatWordWrap");
     expect(decoded).not.toHaveProperty("diffWordWrap");
+  });
+});
+
+describe("ClientSettings changed-files default", () => {
+  it("defaults changed-files blocks to expanded for existing users", () => {
+    expect(decodeClientSettings({}).defaultOpenChangedFiles).toBe(true);
+  });
+
+  it("accepts persisted defaults and partial updates", () => {
+    expect(decodeClientSettings({ defaultOpenChangedFiles: false }).defaultOpenChangedFiles).toBe(
+      false,
+    );
+    expect(decodeClientSettingsPatch({ defaultOpenChangedFiles: false })).toEqual({
+      defaultOpenChangedFiles: false,
+    });
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -43,6 +43,7 @@ export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  defaultOpenChangedFiles: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   dismissedProviderUpdateNotificationKeys: Schema.Array(TrimmedNonEmptyString).pipe(
     Schema.withDecodingDefault(Effect.succeed([])),
   ),
@@ -545,6 +546,7 @@ export const ClientSettingsPatch = Schema.Struct({
   autoOpenPlanSidebar: Schema.optionalKey(Schema.Boolean),
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
+  defaultOpenChangedFiles: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
   favorites: Schema.optionalKey(
     Schema.Array(


### PR DESCRIPTION
## Summary

This keeps changed-files collapse scoped per turn by default, and adds a settings toggle for people who want collapse state to persist across future turns in the same thread and survive relaunch.

## What Changed

- added a client setting for changed-files collapse persistence in General settings
- restored per-turn changed-files collapse as the default behavior
- kept thread-wide collapse persistence available when the new setting is enabled
- preserved immediate persistence so collapse changes still survive relaunch
- normalized persisted changed-files state so both legacy per-turn data and the thread-wide shape continue to hydrate correctly
- added regression coverage for:
  - default per-turn collapse behavior
  - opt-in cross-turn collapse persistence
  - settings hydration
  - browser and desktop client-settings persistence fixtures

## Review Feedback Addressed

- kept the original per-turn UX as the default, per review feedback
- made cross-turn persistence configurable instead of always-on
- retained the persistence fix that avoids losing the latest collapse state on relaunch

## User Impact

Users who prefer the old per-turn behavior keep it by default. Users who want changed-files blocks to stay collapsed across future prompts can enable the new toggle in Settings.

## Validation

- `bun run --cwd apps/web test -- src/uiStateStore.test.ts src/components/chat/MessagesTimeline.test.tsx src/localApi.test.ts`
- `bun run --cwd apps/web test:browser -- src/components/chat/MessagesTimeline.browser.tsx`
- `bun run --cwd apps/web test:browser -- src/components/settings/SettingsPanels.browser.tsx`
- `bun run --cwd apps/desktop test -- src/clientPersistence.test.ts`
- `bun fmt`
- `bun lint`
- `bun typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable default expanded/collapsed state for changed-files sections
> - Adds a `defaultOpenChangedFiles` boolean to `ClientSettings` (defaults to `true`) and exposes a toggle in the General Settings panel so users can choose whether changed-files blocks start expanded or collapsed.
> - Propagates the setting from `ChatView` through `MessagesTimeline` down to `AssistantChangedFilesSectionInner`, where it determines the initial expansion state.
> - Reworks per-turn overrides in `uiStateStore` so they are stored relative to the user's default: overrides matching the default are removed, and both `true` and `false` overrides are persisted to local storage.
> - Extracts `buildGeneralSettingsRestorePatch` in [settingsRestore.ts](https://github.com/pingdotgg/t3code/pull/2260/files#diff-85f3cc914a7d21019cf63da49dc2fde3219f8579b299aec22fe7027592142800) to centralize general settings reset, including the new field.
> - Behavioral Change: previously only collapsed (`false`) per-turn overrides were persisted; now both expanded and collapsed overrides are saved and restored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3003d0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to client settings, chat UI expansion defaults, and localStorage UI state with added migration tests; no auth, server, or data-path changes.
> 
> **Overview**
> Adds a **client setting** `defaultOpenChangedFiles` (defaults to **expanded**) and a General settings switch so users can choose whether assistant **changed-files** blocks start open before they touch a turn.
> 
> The chat timeline passes that setting into `AssistantChangedFilesSection`, which now resolves expansion via `getThreadChangedFilesExpanded` instead of assuming turns are always expanded. **Per-turn toggles** are stored as overrides only when they differ from the setting; matching the default clears the override to keep local state small.
> 
> **UI state persistence** now keeps both `true` and `false` per-turn overrides, writes changed-files state to localStorage immediately on toggle, and **sanitizes** legacy/malformed `threadChangedFilesExpandedById` shapes on load. General **restore defaults** is centralized in `buildGeneralSettingsRestorePatch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3003d0ef5b7b400f4d28d2111385f6997a940376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #2158