### PR TITLE
fix: enforce opencode >= 1.14.19 and reveal window on Wayland

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -75,6 +75,7 @@ import {
 } from "./updateMachine.ts";
 import { isArm64HostRunningIntelBuild, resolveDesktopRuntimeInfo } from "./runtimeArch.ts";
 import { resolveDesktopAppBranding } from "./appBranding.ts";
+import { bindFirstRevealTrigger, type RevealSubscription } from "./windowReveal.ts";
 
 syncShellEnvironment();
 
@@ -1998,16 +1999,17 @@ function createWindow(): BrowserWindow {
     emitUpdateState();
   });
 
-  let initialRevealScheduled = false;
-  const revealInitialWindow = () => {
-    if (initialRevealScheduled) {
-      return;
-    }
-    initialRevealScheduled = true;
-    revealWindow(window);
-  };
-
-  window.once("ready-to-show", revealInitialWindow);
+  // On Linux/Wayland with `show: false`, Electron's `ready-to-show` only
+  // fires after `show()` is called, deadlocking the standard "wait for
+  // ready, then show" pattern. Add `did-finish-load` as a Linux-only
+  // fallback so the window still surfaces once the renderer has loaded
+  // the page. Other platforms keep the no-flash `ready-to-show` path,
+  // since `did-finish-load` typically fires before the first paint there.
+  const revealSubscribers: RevealSubscription[] = [(fire) => window.once("ready-to-show", fire)];
+  if (process.platform === "linux") {
+    revealSubscribers.push((fire) => window.webContents.once("did-finish-load", fire));
+  }
+  bindFirstRevealTrigger(revealSubscribers, () => revealWindow(window));
 
   if (isDevelopment) {
     void window.loadURL(resolveDesktopDevServerUrl());

--- a/apps/desktop/src/windowReveal.test.ts
+++ b/apps/desktop/src/windowReveal.test.ts
@@ -1,0 +1,74 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { bindFirstRevealTrigger } from "./windowReveal.ts";
+
+describe("bindFirstRevealTrigger", () => {
+  it("reveals when the first trigger fires", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("reveals when only the fallback trigger fires (Wayland deadlock case)", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    webContents.emit("did-finish-load");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("only reveals once when multiple triggers fire", () => {
+    const window = new EventEmitter();
+    const webContents = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger(
+      [
+        (fire) => window.once("ready-to-show", fire),
+        (fire) => webContents.once("did-finish-load", fire),
+      ],
+      reveal,
+    );
+
+    webContents.emit("did-finish-load");
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscribers using `once` ignore re-emitted events after reveal", () => {
+    const window = new EventEmitter();
+    const reveal = vi.fn();
+
+    bindFirstRevealTrigger([(fire) => window.once("ready-to-show", fire)], reveal);
+
+    window.emit("ready-to-show");
+    window.emit("ready-to-show");
+
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/windowReveal.ts
+++ b/apps/desktop/src/windowReveal.ts
@@ -1,0 +1,28 @@
+export type RevealSubscription = (listener: () => void) => void;
+
+/**
+ * Wire a reveal callback to fire exactly once, on whichever of the provided
+ * event subscribers fires first. Each subscriber is responsible for binding
+ * its own event source.
+ *
+ * Used by the desktop main window's first-paint reveal logic. The standard
+ * Electron pattern is to wait for `ready-to-show` before calling `show()`,
+ * but on Linux/Wayland with `show: false`, `ready-to-show` only fires after
+ * `show()` is called, deadlocking that pattern. Subscribing to both
+ * `ready-to-show` and `did-finish-load` (or any other "renderer is alive"
+ * signal) lets the window surface reliably across platforms.
+ */
+export function bindFirstRevealTrigger(
+  subscribers: readonly RevealSubscription[],
+  reveal: () => void,
+): void {
+  let revealed = false;
+  const fire = () => {
+    if (revealed) return;
+    revealed = true;
+    reveal();
+  };
+  for (const subscribe of subscribers) {
+    subscribe(fire);
+  }
+}

--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -16,9 +16,12 @@ import {
 import { OpenCodeProviderLive } from "./OpenCodeProvider.ts";
 import type { OpenCodeInventory } from "../opencodeRuntime.ts";
 
+const DEFAULT_VERSION_STDOUT = "opencode 1.14.19\n";
+
 const runtimeMock = {
   state: {
     runVersionError: null as Error | null,
+    versionStdout: DEFAULT_VERSION_STDOUT,
     inventoryError: null as Error | null,
     inventory: {
       providerList: { connected: [] as string[], all: [] as unknown[], default: {} },
@@ -27,6 +30,7 @@ const runtimeMock = {
   },
   reset() {
     this.state.runVersionError = null;
+    this.state.versionStdout = DEFAULT_VERSION_STDOUT;
     this.state.inventoryError = null;
     this.state.inventory = {
       providerList: { connected: [], all: [] as unknown[], default: {} },
@@ -56,7 +60,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             cause: runtimeMock.state.runVersionError,
           }),
         )
-      : Effect.succeed({ stdout: "opencode 1.0.0\n", stderr: "", code: 0 }),
+      : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
   createOpenCodeSdkClient: () =>
     ({}) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -105,6 +109,33 @@ it.layer(makeTestLayer())("OpenCodeProviderLive", (it) => {
       assert.equal(snapshot.status, "error");
       assert.equal(snapshot.installed, true);
       assert.equal(snapshot.message, "Failed to execute OpenCode CLI health check.");
+    }),
+  );
+
+  it.effect("refuses to probe when opencode is older than the required minimum", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.versionStdout = "opencode 1.4.7\n";
+      const provider = yield* OpenCodeProvider;
+      const snapshot = yield* provider.refresh;
+
+      assert.equal(snapshot.status, "error");
+      assert.equal(snapshot.installed, true);
+      assert.equal(snapshot.version, "1.4.7");
+      assert.ok(snapshot.message?.includes("1.14.19"));
+      assert.ok(snapshot.message?.toLowerCase().includes("upgrade"));
+    }),
+  );
+
+  it.effect("refuses to probe when opencode --version output is unparseable", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.versionStdout = "garbled binary output\n";
+      const provider = yield* OpenCodeProvider;
+      const snapshot = yield* provider.refresh;
+
+      assert.equal(snapshot.status, "error");
+      assert.equal(snapshot.installed, true);
+      assert.equal(snapshot.version, null);
+      assert.ok(snapshot.message?.includes("1.14.19"));
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -15,6 +15,7 @@ import {
   parseGenericCliVersion,
   providerModelsFromSettings,
 } from "../providerSnapshot.ts";
+import { compareCliVersions } from "../cliVersion.ts";
 import { OpenCodeProvider } from "../Services/OpenCodeProvider.ts";
 import {
   OpenCodeRuntime,
@@ -24,6 +25,7 @@ import {
 import type { Agent, ProviderListResponse } from "@opencode-ai/sdk/v2";
 
 const PROVIDER = "opencode" as const;
+const MINIMUM_OPENCODE_VERSION = "1.14.19";
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
   readonly cause: unknown;
@@ -354,6 +356,35 @@ export const OpenCodeProviderLive = Layer.effect(
           return fallback(Cause.squash(versionExit.cause));
         }
         version = parseGenericCliVersion(versionExit.value.stdout) ?? null;
+
+        if (!version) {
+          return fallback(
+            new Error(
+              `Unable to determine OpenCode version from \`opencode --version\` output. T3 Code requires OpenCode v${MINIMUM_OPENCODE_VERSION} or newer.`,
+            ),
+            null,
+          );
+        }
+        if (compareCliVersions(version, MINIMUM_OPENCODE_VERSION) < 0) {
+          return buildServerProvider({
+            provider: PROVIDER,
+            enabled: input.settings.enabled,
+            checkedAt,
+            models: providerModelsFromSettings(
+              [],
+              PROVIDER,
+              customModels,
+              DEFAULT_OPENCODE_MODEL_CAPABILITIES,
+            ),
+            probe: {
+              installed: true,
+              version,
+              status: "error",
+              auth: { status: "unknown" },
+              message: `OpenCode v${version} is too old. Upgrade to v${MINIMUM_OPENCODE_VERSION} or newer.`,
+            },
+          });
+        }
       }
 
       const inventoryExit = yield* Effect.exit(


### PR DESCRIPTION
## Summary

Two Linux-critical fixes that need to land together for t3code to be
usable on Wayland against a freshly-installed opencode.

1. `fix(server)`: gate the opencode provider probe behind a minimum
   version of 1.14.19. Older opencode versions corrupt
   `~/.config/opencode/package-lock.json` on every probe via a buggy
   `Npm.install` health check, blocking cold start for 45-75s per probe
   once the lockfile balloons. Fixes #2248.
2. `fix(desktop)`: on Linux, reveal the window on `did-finish-load` as a
   fallback so the app actually shows up under Electron 40 + Wayland,
   where `ready-to-show` can never fire when `BrowserWindow` is created
   with `show: false`. Fixes #2216.

This supersedes #2217 (Wayland-only) since I hit both problems on the
same regression-test AppImage and they're cheapest to review together.

## Fix 1 - opencode min-version (#2248)

Older opencode versions (< 1.14.19) have a bug in their `Npm.install`
health check: the `declared` set includes raw `name@version` strings
from the caller's `add` input alongside bare keys from package.json,
while the `locked` set only ever contains bare names. The sets never
match, so `arborist.reify()` runs on every probe. When
`~/.config/opencode` is a symlink into a dotfiles directory, arborist
records paths relative to the resolved target and prepends another
`../` segment on each pass, corrupting the lockfile.

T3 Code's opencode provider currently spawns a local opencode server
during every health check (via `connectToOpenCodeServer` ->
`loadOpenCodeInventory`), which triggers that forkDetach'd
`Npm.install` and further pollutes the lockfile. This change
short-circuits the probe before the server spawn when the detected
version is below 1.14.19, returning a provider snapshot with
`status: \"error\"` and a message directing the user to upgrade.

- Add `MINIMUM_OPENCODE_VERSION = \"1.14.19\"` gate in OpenCodeProvider.
- Treat unparseable `--version` output as failing the gate.
- Leave the external-server code path unchanged (no local spawn, no
  bug).
- Bump the test double's default version string to a gate-passing
  value and add two tests covering the version-gate and
  unparseable-version paths.

### Live regression test

- opencode v1.4.7 installed system-wide, `~/.config/opencode`
  symlinked into a dotfiles dir with a pre-polluted 31 MB
  package-lock.json.
- Built fresh AppImage with both fixes (this branch's HEAD).
- Launched AppImage; window appeared within ~1s; Settings -> Providers
  showed \"OpenCode v1.4.7 is too old. Upgrade to v1.14.19 or newer.\"
- `sha256sum ~/.config/opencode/package-lock.json` unchanged before
  vs. after launch; no further lockfile corruption.

## Fix 2 - Wayland deadlock (#2216)

Verbatim from #2217 (same commit cherry-picked here). On
Linux/Wayland with Electron 40, a `BrowserWindow` created with
`show: false` never receives `ready-to-show`, because the wl_surface
has no role assigned until `show()` is called and the compositor never
reports the surface as ready. Add `did-finish-load` as a Linux-only
fallback reveal trigger so the first event from either source surfaces
the window. Other platforms keep the no-flash `ready-to-show` path.
Logic extracted into `bindFirstRevealTrigger`
(`apps/desktop/src/windowReveal.ts`) with focused unit tests.

## Test plan

- [x] `bun fmt`
- [x] `bun lint` (0 errors)
- [x] `bun typecheck` (10/10 tasks pass)
- [x] `bun run test` for `apps/server/src/provider/Layers/OpenCodeProvider.test.ts` (7/7)
- [x] `bun run test` for `apps/desktop/src/windowReveal.test.ts` (4/4)
- [x] End-to-end regression on Linux/Wayland (niri) using a v1.4.7 +
      polluted-lockfile setup; see \"Live regression test\" above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes desktop window surfacing behavior on Linux and alters OpenCode provider health-check flow to short-circuit based on CLI version parsing/comparison, which could affect provider availability detection.
> 
> **Overview**
> Fixes two Linux-facing issues.
> 
> On desktop, window reveal is refactored to fire on the *first* of `ready-to-show` or (Linux-only) `did-finish-load`, avoiding an Electron/Wayland deadlock when windows are created with `show: false`; this logic is extracted into `bindFirstRevealTrigger` with unit tests.
> 
> On server, the OpenCode provider probe now enforces `MINIMUM_OPENCODE_VERSION = 1.14.19`: if `opencode --version` is unparseable or older than the minimum, the provider returns an `error` snapshot with an upgrade message instead of spawning/probing the server; tests were updated and extended to cover these paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cff00bf2cb9c9be9a66e5dfa16c13ff2440afb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce opencode >= 1.14.19 and fix window reveal on Linux/Wayland
> - Adds a `MINIMUM_OPENCODE_VERSION` check (`1.14.19`) in `OpenCodeProviderLive`: returns an error status immediately if the CLI version is unparseable or below the minimum, instead of proceeding to probe inventory.
> - Fixes window reveal on Linux/Wayland by introducing `bindFirstRevealTrigger` in [windowReveal.ts](https://github.com/pingdotgg/t3code/pull/2262/files#diff-701c7d0214598620179c82a706ead2a876c769ade0207057466048eef417abe8), which fires a reveal callback once on whichever of `ready-to-show` or (Linux-only) `did-finish-load` arrives first — guarding against `ready-to-show` never firing with `show: false` on Wayland.
> - Behavioral Change: provider checks that previously silently continued on an old or unrecognized CLI version now return an error status to the UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cff00b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->