### PR TITLE
feat(web): scrollable and copayable error alerts

### DIFF
--- a/apps/web/src/components/chat/ProviderStatusBanner.tsx
+++ b/apps/web/src/components/chat/ProviderStatusBanner.tsx
@@ -1,8 +1,7 @@
 import { type ServerProvider } from "@t3tools/contracts";
 import { memo } from "react";
-import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
-import { CircleAlertIcon } from "lucide-react";
 import { formatProviderKindLabel } from "../../providerModels";
+import { ErrorAlert } from "~/components/ui/error-alert";
 
 export const ProviderStatusBanner = memo(function ProviderStatusBanner({
   status,
@@ -18,17 +17,14 @@ export const ProviderStatusBanner = memo(function ProviderStatusBanner({
     status.status === "error"
       ? `${providerLabel} provider is unavailable.`
       : `${providerLabel} provider has limited availability.`;
-  const title = `${providerLabel} provider status`;
 
   return (
     <div className="pt-3 mx-auto max-w-3xl">
-      <Alert variant={status.status === "error" ? "error" : "warning"}>
-        <CircleAlertIcon />
-        <AlertTitle>{title}</AlertTitle>
-        <AlertDescription className="line-clamp-3" title={status.message ?? defaultMessage}>
-          {status.message ?? defaultMessage}
-        </AlertDescription>
-      </Alert>
+      <ErrorAlert
+        variant={status.status === "error" ? "error" : "warning"}
+        title={`${providerLabel} provider status`}
+        message={status.message ?? defaultMessage}
+      />
     </div>
   );
 });

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -1,6 +1,5 @@
 import { memo } from "react";
-import { Alert, AlertAction, AlertDescription } from "../ui/alert";
-import { CircleAlertIcon, XIcon } from "lucide-react";
+import { ErrorAlert } from "~/components/ui/error-alert";
 
 export const ThreadErrorBanner = memo(function ThreadErrorBanner({
   error,
@@ -10,26 +9,10 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
   onDismiss?: () => void;
 }) {
   if (!error) return null;
+
   return (
     <div className="pt-3 mx-auto max-w-3xl">
-      <Alert variant="error">
-        <CircleAlertIcon />
-        <AlertDescription className="line-clamp-3" title={error}>
-          {error}
-        </AlertDescription>
-        {onDismiss && (
-          <AlertAction>
-            <button
-              type="button"
-              aria-label="Dismiss error"
-              className="inline-flex size-6 items-center justify-center rounded-md text-destructive/60 transition-colors hover:text-destructive"
-              onClick={onDismiss}
-            >
-              <XIcon className="size-3.5" />
-            </button>
-          </AlertAction>
-        )}
-      </Alert>
+      <ErrorAlert message={error} {...(onDismiss ? { onDismiss } : {})} />
     </div>
   );
 });

--- a/apps/web/src/components/ui/error-alert.tsx
+++ b/apps/web/src/components/ui/error-alert.tsx
@@ -1,0 +1,104 @@
+import { CheckIcon, CircleAlertIcon, CopyIcon, XIcon } from "lucide-react";
+import { memo } from "react";
+import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { cn } from "~/lib/utils";
+import { Alert } from "./alert";
+import { ScrollArea } from "./scroll-area";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./tooltip";
+
+export const ErrorAlert = memo(function ErrorAlert({
+  message,
+  title,
+  variant = "error",
+  onDismiss,
+}: {
+  message: string;
+  title?: string;
+  variant?: "error" | "warning";
+  onDismiss?: () => void;
+}) {
+  const { copyToClipboard, isCopied } = useCopyToClipboard();
+
+  const accentClass =
+    variant === "error"
+      ? "text-destructive/60 hover:text-destructive"
+      : "text-warning/60 hover:text-warning";
+
+  const buttonClass = cn(
+    "inline-flex size-6 cursor-pointer items-center justify-center rounded-md outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+    accentClass,
+  );
+
+  return (
+    // Alert uses CSS grid layout; flex! overrides it intentionally to support a
+    // scrollable description alongside top-aligned action buttons.
+    <Alert variant={variant} className="flex! gap-2">
+      <CircleAlertIcon className="mt-0.5 size-4 shrink-0" />
+      <div className="min-w-0 flex-1">
+        {title && <div className="font-medium">{title}</div>}
+        <ScrollArea
+          scrollFade
+          className={cn(
+            "h-auto rounded-none *:data-[slot=scroll-area-viewport]:max-h-28 *:data-[slot=scroll-area-viewport]:rounded-none",
+            title && "mt-0.5",
+          )}
+        >
+          <div className="wrap-break-word pr-3 text-muted-foreground">
+            {message}
+          </div>
+        </ScrollArea>
+      </div>
+      <div className="flex shrink-0 flex-row gap-1">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                aria-label={isCopied ? "Copied" : "Copy message"}
+                className={buttonClass}
+                onClick={() => copyToClipboard(message)}
+              />
+            }
+          >
+            <span className="relative size-3.5">
+              <CopyIcon
+                className={cn(
+                  "absolute inset-0 size-3.5 transition-all duration-150",
+                  isCopied ? "scale-75 opacity-0" : "scale-100 opacity-100",
+                )}
+              />
+              <CheckIcon
+                className={cn(
+                  "absolute inset-0 size-3.5 transition-all duration-150",
+                  isCopied ? "scale-100 opacity-100" : "scale-75 opacity-0",
+                )}
+              />
+            </span>
+          </TooltipTrigger>
+          <TooltipPopup>
+            <p>{isCopied ? "Copied!" : "Copy message"}</p>
+          </TooltipPopup>
+        </Tooltip>
+        {onDismiss && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  aria-label="Dismiss"
+                  className={buttonClass}
+                  onClick={onDismiss}
+                />
+              }
+            >
+              <XIcon className="size-3.5" />
+            </TooltipTrigger>
+            <TooltipPopup>
+              <p>Dismiss</p>
+            </TooltipPopup>
+          </Tooltip>
+        )}
+      </div>
+    </Alert>
+  );
+});


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Created `ErrorAlert` component to standardise the behaviour of error alerts 
- Added the ability to copy error messages
- Added `ScrollArea` to handle overflow

## Why

Currently the error alert does not allow you to view the whole error message if it is long. Making it harder to debug. 

Also copying error messages has to be done manually, which creates friction when debugging. 

## UI Changes

Before:
<img width="818" height="245" alt="image" src="https://github.com/user-attachments/assets/2dd578d4-1b01-47ad-bf00-a753d91607c3" />

After:
<img width="841" height="310" alt="image" src="https://github.com/user-attachments/assets/ea556dc7-c1fe-40e8-9020-ed7a1d2f372a" />

https://github.com/user-attachments/assets/b476a465-79b2-4f66-9062-0d35e702a42d


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that centralizes alert rendering; main risk is minor layout/interaction regressions in error/warning banners and new clipboard behavior.
> 
> **Overview**
> Introduces a reusable `ErrorAlert` component that standardizes error/warning banner UI, makes long messages scrollable, and adds one-click copy (with tooltip feedback) plus optional dismiss.
> 
> Updates chat banners (`ProviderStatusBanner`, `ThreadErrorBanner`) to use `ErrorAlert`, removing duplicated `Alert`/icon/action markup while preserving existing conditional rendering and error vs warning variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6baaa70ff3a01f81a4938fa75029f664ac715e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add scrollable and copyable error alerts to chat banners
> - Introduces a reusable [`ErrorAlert`](https://github.com/pingdotgg/t3code/pull/2263/files#diff-32ec31c5f0546efc933ea3c56afc55478cdc263bf1e9fd871aec20cfb3de19b1) component that composes `Alert`, `ScrollArea`, and `Tooltip` to display scrollable error/warning messages with a copy-to-clipboard button (with animated icon feedback) and an optional dismiss button.
> - Updates [`ProviderStatusBanner`](https://github.com/pingdotgg/t3code/pull/2263/files#diff-d53076993b72ce28ed4241d2451251fe23b3d13a1fbc6effc6cc4a65c525e981) and [`ThreadErrorBanner`](https://github.com/pingdotgg/t3code/pull/2263/files#diff-3fa9e223d4ae557ff232900844d971974d42e09f07a6d6e005538eab923867f0) to use `ErrorAlert`, replacing static clamped text with the scrollable, copyable layout.
> - Behavioral Change: the previous line-clamped description with a title attribute is replaced by a scrollable message area; copy and tooltipped dismiss controls are now always present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd48cad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->