### PR TITLE
[codex] fix diff sidebar close behavior and macos desktop start

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -162,17 +162,28 @@ function buildMacLauncher(electronBinaryPath) {
   return targetBinaryPath;
 }
 
+export function resolveElectronLaunchStrategy({ platform, isDevelopment, useMacWrapper }) {
+  if (platform !== "darwin") {
+    return "original";
+  }
+
+  if (isDevelopment) {
+    return "original";
+  }
+
+  return useMacWrapper ? "wrapped" : "original";
+}
+
 export function resolveElectronPath() {
   const require = createRequire(import.meta.url);
   const electronBinaryPath = require("electron");
+  const launchStrategy = resolveElectronLaunchStrategy({
+    platform: process.platform,
+    isDevelopment,
+    useMacWrapper: process.env.T3CODE_DESKTOP_USE_MAC_WRAPPER === "1",
+  });
 
-  if (process.platform !== "darwin") {
-    return electronBinaryPath;
-  }
-
-  // Dev launches do not need a renamed app bundle badly enough to risk breaking
-  // Electron helper resource lookup on macOS.
-  if (isDevelopment) {
+  if (launchStrategy === "original") {
     return electronBinaryPath;
   }
 

--- a/apps/desktop/scripts/electron-launcher.test.ts
+++ b/apps/desktop/scripts/electron-launcher.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveElectronLaunchStrategy } from "./electron-launcher.mjs";
+
+describe("resolveElectronLaunchStrategy", () => {
+  it("uses the original Electron bundle on macOS local starts by default", () => {
+    expect(
+      resolveElectronLaunchStrategy({
+        platform: "darwin",
+        isDevelopment: false,
+        useMacWrapper: false,
+      }),
+    ).toBe("original");
+  });
+
+  it("allows opting into the wrapped macOS bundle", () => {
+    expect(
+      resolveElectronLaunchStrategy({
+        platform: "darwin",
+        isDevelopment: false,
+        useMacWrapper: true,
+      }),
+    ).toBe("wrapped");
+  });
+
+  it("keeps development launches on the original Electron bundle", () => {
+    expect(
+      resolveElectronLaunchStrategy({
+        platform: "darwin",
+        isDevelopment: true,
+        useMacWrapper: true,
+      }),
+    ).toBe("original");
+  });
+
+  it("keeps non-macOS launches on the original Electron bundle", () => {
+    expect(
+      resolveElectronLaunchStrategy({
+        platform: "linux",
+        isDevelopment: false,
+        useMacWrapper: true,
+      }),
+    ).toBe("original");
+  });
+});

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -10,6 +10,7 @@ import {
   Columns2Icon,
   Rows3Icon,
   TextWrapIcon,
+  XIcon,
 } from "lucide-react";
 import {
   type WheelEvent as ReactWheelEvent,
@@ -25,7 +26,11 @@ import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
 import { cn } from "~/lib/utils";
 import { readLocalApi } from "../localApi";
 import { resolvePathLinkTarget } from "../terminal-links";
-import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import {
+  clearDiffSearchParams,
+  parseDiffRouteSearch,
+  stripDiffSearchParams,
+} from "../diffRouteSearch";
 import { useTheme } from "../hooks/useTheme";
 import { buildPatchCacheKey } from "../lib/diffRendering";
 import { resolveDiffThemeName } from "../lib/diffRendering";
@@ -365,6 +370,14 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       },
     });
   };
+  const closeDiffPanel = useCallback(() => {
+    if (!activeThread) return;
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
+      search: (previous) => clearDiffSearchParams(previous),
+    });
+  }, [activeThread, navigate]);
   const updateTurnStripScrollState = useCallback(() => {
     const element = turnStripRef.current;
     if (!element) {
@@ -519,7 +532,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
           ))}
         </div>
       </div>
-      <div className="flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
+      <div className="relative z-30 flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]">
         <ToggleGroup
           className="shrink-0"
           variant="outline"
@@ -551,6 +564,15 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         >
           <TextWrapIcon className="size-3" />
         </Toggle>
+        <button
+          type="button"
+          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md border border-border/70 bg-background/70 text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+          onClick={closeDiffPanel}
+          aria-label="Close diff panel"
+          title="Close diff panel"
+        >
+          <XIcon className="size-3.5" />
+        </button>
       </div>
     </>
   );

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -11,7 +11,7 @@ import {
   ChevronRightIcon,
   EllipsisIcon,
   LoaderIcon,
-  PanelRightCloseIcon,
+  XIcon,
 } from "lucide-react";
 import { cn } from "~/lib/utils";
 import type { ActivePlanState } from "../session-logic";
@@ -186,7 +186,7 @@ const PlanSidebar = memo(function PlanSidebar({
             aria-label={`Close ${label.toLowerCase()} sidebar`}
             className="text-muted-foreground/50 hover:text-foreground/70"
           >
-            <PanelRightCloseIcon className="size-3.5" />
+            <XIcon className="size-3.5" />
           </Button>
         </div>
       </div>

--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseDiffRouteSearch } from "./diffRouteSearch";
+import { clearDiffSearchParams, parseDiffRouteSearch } from "./diffRouteSearch";
 
 describe("parseDiffRouteSearch", () => {
   it("parses valid diff search values", () => {
@@ -69,6 +69,22 @@ describe("parseDiffRouteSearch", () => {
 
     expect(parsed).toEqual({
       diff: "1",
+    });
+  });
+});
+
+describe("clearDiffSearchParams", () => {
+  it("clears turn and file params while explicitly closing diff state", () => {
+    expect(
+      clearDiffSearchParams({
+        tab: "changes",
+        diff: "1",
+        diffTurnId: "turn-1",
+        diffFilePath: "src/app.ts",
+      }),
+    ).toEqual({
+      tab: "changes",
+      diff: undefined,
     });
   });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -25,6 +25,16 @@ export function stripDiffSearchParams<T extends Record<string, unknown>>(
   return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
 }
 
+export function clearDiffSearchParams<T extends Record<string, unknown>>(
+  params: T,
+): Omit<T, "diffTurnId" | "diffFilePath"> & { diff?: undefined } {
+  const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, ...rest } = params;
+  return {
+    ...rest,
+    diff: undefined,
+  } as Omit<T, "diffTurnId" | "diffFilePath"> & { diff?: undefined };
+}
+
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
   const diff = isDiffOpenValue(search.diff) ? "1" : undefined;
   const diffTurnIdRaw = diff ? normalizeSearchString(search.diffTurnId) : undefined;

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -12,6 +12,7 @@ import {
 } from "../components/DiffPanelShell";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
 import {
+  clearDiffSearchParams,
   type DiffRouteSearch,
   parseDiffRouteSearch,
   stripDiffSearchParams,
@@ -194,7 +195,7 @@ function ChatThreadRouteView() {
     void navigate({
       to: "/$environmentId/$threadId",
       params: buildThreadRouteParams(threadRef),
-      search: { diff: undefined },
+      search: (previous) => clearDiffSearchParams(previous),
     });
   }, [navigate, threadRef]);
   const openDiff = useCallback(() => {


### PR DESCRIPTION
## Before

To close the diff panel, you had to click the diff panel button again.

img

## After

A cross button is now added in the diff panel header, so closing the diff panel becomes easier without moving the mouse cursor away from the panel.

img

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
<!-- Macroscope's pull request summary ends here -->