### PR TITLE
fix(keybindings): macos keybindings with option modifier

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -11,6 +11,7 @@ import {
   type ProjectId,
   type ServerConfig,
   type ServerLifecycleWelcomePayload,
+  type TerminalOpenInput,
   type ThreadId,
   type TurnId,
   WS_METHODS,
@@ -1479,24 +1480,18 @@ async function dispatchInputKey(
   await waitForLayout();
 }
 
-interface TerminalOpenRequestLike {
-  _tag: string;
-  threadId?: string;
-  cwd?: string;
-  worktreePath?: string | null;
-  env?: Record<string, string>;
-}
-
 async function waitForTerminalOpenRequest(
-  expected: Partial<TerminalOpenRequestLike>,
-): Promise<TerminalOpenRequestLike> {
-  let openRequest: TerminalOpenRequestLike | undefined;
+  expected: Partial<TerminalOpenInput>,
+): Promise<TerminalOpenInput> {
+  let openRequest: TerminalOpenInput | undefined;
   await vi.waitFor(
     () => {
-      openRequest = wsRequests.find((request) => request._tag === WS_METHODS.terminalOpen) as
-        | TerminalOpenRequestLike
-        | undefined;
-      expect(openRequest).toMatchObject({
+      const request = wsRequests.find(
+        (entry): entry is NormalizedWsRpcRequestBody & TerminalOpenInput =>
+          entry._tag === WS_METHODS.terminalOpen,
+      );
+      openRequest = request;
+      expect(request).toMatchObject({
         _tag: WS_METHODS.terminalOpen,
         ...expected,
       });

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1479,6 +1479,38 @@ async function dispatchInputKey(
   await waitForLayout();
 }
 
+interface TerminalOpenRequestLike {
+  _tag: string;
+  threadId?: string;
+  cwd?: string;
+  worktreePath?: string | null;
+  env?: Record<string, string>;
+}
+
+async function waitForTerminalOpenRequest(
+  expected: Partial<TerminalOpenRequestLike>,
+): Promise<TerminalOpenRequestLike> {
+  let openRequest: TerminalOpenRequestLike | undefined;
+  await vi.waitFor(
+    () => {
+      openRequest = wsRequests.find((request) => request._tag === WS_METHODS.terminalOpen) as
+        | TerminalOpenRequestLike
+        | undefined;
+      expect(openRequest).toMatchObject({
+        _tag: WS_METHODS.terminalOpen,
+        ...expected,
+      });
+    },
+    { timeout: 8_000, interval: 16 },
+  );
+
+  if (!openRequest) {
+    throw new Error("Expected a terminalOpen request.");
+  }
+
+  return openRequest;
+}
+
 async function mountChatView(options: {
   viewport: ViewportSpec;
   snapshot: OrchestrationReadModel;
@@ -1784,30 +1816,14 @@ describe("ChatView timeline estimator parity (full app)", () => {
     });
 
     try {
-      await vi.waitFor(
-        () => {
-          const openRequest = wsRequests.find(
-            (request) => request._tag === WS_METHODS.terminalOpen,
-          ) as
-            | {
-                _tag: string;
-                cwd?: string;
-                worktreePath?: string | null;
-                env?: Record<string, string>;
-              }
-            | undefined;
-          expect(openRequest).toMatchObject({
-            _tag: WS_METHODS.terminalOpen,
-            cwd: "/repo/project",
-            worktreePath: null,
-            env: {
-              T3CODE_PROJECT_ROOT: "/repo/project",
-            },
-          });
-          expect(openRequest?.env?.T3CODE_WORKTREE_PATH).toBeUndefined();
+      const openRequest = await waitForTerminalOpenRequest({
+        cwd: "/repo/project",
+        worktreePath: null,
+        env: {
+          T3CODE_PROJECT_ROOT: "/repo/project",
         },
-        { timeout: 8_000, interval: 16 },
-      );
+      });
+      expect(openRequest.env?.T3CODE_WORKTREE_PATH).toBeUndefined();
     } finally {
       await mounted.cleanup();
     }
@@ -2108,22 +2124,13 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
       runButton.click();
 
-      await vi.waitFor(
-        () => {
-          const openRequest = wsRequests.find(
-            (request) => request._tag === WS_METHODS.terminalOpen,
-          );
-          expect(openRequest).toMatchObject({
-            _tag: WS_METHODS.terminalOpen,
-            threadId: THREAD_ID,
-            cwd: "/repo/project",
-            env: {
-              T3CODE_PROJECT_ROOT: "/repo/project",
-            },
-          });
+      await waitForTerminalOpenRequest({
+        threadId: THREAD_ID,
+        cwd: "/repo/project",
+        env: {
+          T3CODE_PROJECT_ROOT: "/repo/project",
         },
-        { timeout: 8_000, interval: 16 },
-      );
+      });
 
       await vi.waitFor(
         () => {
@@ -2187,23 +2194,14 @@ describe("ChatView timeline estimator parity (full app)", () => {
       );
       runButton.click();
 
-      await vi.waitFor(
-        () => {
-          const openRequest = wsRequests.find(
-            (request) => request._tag === WS_METHODS.terminalOpen,
-          );
-          expect(openRequest).toMatchObject({
-            _tag: WS_METHODS.terminalOpen,
-            threadId: THREAD_ID,
-            cwd: "/repo/worktrees/feature-draft",
-            env: {
-              T3CODE_PROJECT_ROOT: "/repo/project",
-              T3CODE_WORKTREE_PATH: "/repo/worktrees/feature-draft",
-            },
-          });
+      await waitForTerminalOpenRequest({
+        threadId: THREAD_ID,
+        cwd: "/repo/worktrees/feature-draft",
+        env: {
+          T3CODE_PROJECT_ROOT: "/repo/project",
+          T3CODE_WORKTREE_PATH: "/repo/worktrees/feature-draft",
         },
-        { timeout: 8_000, interval: 16 },
-      );
+      });
     } finally {
       await mounted.cleanup();
     }
@@ -4105,22 +4103,13 @@ describe("ChatView timeline estimator parity (full app)", () => {
         }),
       );
 
-      await vi.waitFor(
-        () => {
-          const openRequest = wsRequests.find(
-            (request) => request._tag === WS_METHODS.terminalOpen,
-          );
-          expect(openRequest).toMatchObject({
-            _tag: WS_METHODS.terminalOpen,
-            threadId: THREAD_ID,
-            cwd: "/repo/project",
-            env: {
-              T3CODE_PROJECT_ROOT: "/repo/project",
-            },
-          });
+      await waitForTerminalOpenRequest({
+        threadId: THREAD_ID,
+        cwd: "/repo/project",
+        env: {
+          T3CODE_PROJECT_ROOT: "/repo/project",
         },
-        { timeout: 8_000, interval: 16 },
-      );
+      });
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -4062,6 +4062,70 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("opens the terminal from an option-modified explicit shortcut using the physical letter key", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-terminal-option-shortcut-test" as MessageId,
+        targetText: "terminal option shortcut test",
+      }),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          keybindings: [
+            {
+              command: "terminal.toggle",
+              shortcut: {
+                key: "s",
+                metaKey: true,
+                ctrlKey: true,
+                shiftKey: true,
+                altKey: true,
+                modKey: false,
+              },
+            },
+          ],
+        };
+      },
+    });
+
+    try {
+      await waitForServerConfigToApply();
+
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Í",
+          code: "KeyS",
+          metaKey: true,
+          ctrlKey: true,
+          shiftKey: true,
+          altKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+
+      await vi.waitFor(
+        () => {
+          const openRequest = wsRequests.find(
+            (request) => request._tag === WS_METHODS.terminalOpen,
+          );
+          expect(openRequest).toMatchObject({
+            _tag: WS_METHODS.terminalOpen,
+            threadId: THREAD_ID,
+            cwd: "/repo/project",
+            env: {
+              T3CODE_PROJECT_ROOT: "/repo/project",
+            },
+          });
+        },
+        { timeout: 8_000, interval: 16 },
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("does not consume chat.new when there is no project context", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -590,6 +590,40 @@ describe("resolveShortcutCommand", () => {
       "thread.next",
     );
   });
+
+  it("matches option-modified letter shortcuts using the physical key code", () => {
+    const keybindings = compile([
+      {
+        shortcut: {
+          key: "s",
+          metaKey: true,
+          ctrlKey: true,
+          shiftKey: true,
+          altKey: true,
+          modKey: false,
+        },
+        command: "terminal.toggle",
+      },
+    ]);
+
+    assert.strictEqual(
+      resolveShortcutCommand(
+        event({
+          key: "Í",
+          code: "KeyS",
+          metaKey: true,
+          ctrlKey: true,
+          shiftKey: true,
+          altKey: true,
+        }),
+        keybindings,
+        {
+          platform: "MacIntel",
+        },
+      ),
+      "terminal.toggle",
+    );
+  });
 });
 
 describe("formatShortcutLabel", () => {

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -78,8 +78,8 @@ function resolveEventKeys(event: ShortcutEventLike): Set<string> {
     }
   }
 
-  // Option-modified letter shortcuts can surface a symbol or dead key in `event.key`
-  // even though the physical letter key is still the user's intended shortcut.
+  // On macOS, Option+letter can change `event.key` to a symbol or dead key.
+  // Fall back to the physical letter key from `event.code`.
   const letterCodeMatch =
     event.altKey && event.code ? LETTER_EVENT_CODE_PATTERN.exec(event.code) : null;
   if (letterCodeMatch?.[1]) {

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -47,6 +47,7 @@ const TERMINAL_WORD_FORWARD = "\u001bf";
 const TERMINAL_LINE_START = "\u0001";
 const TERMINAL_LINE_END = "\u0005";
 const TERMINAL_DELETE_TO_LINE_START = "\u0015";
+const LETTER_EVENT_CODE_PATTERN = /^Key([A-Z])$/;
 const EVENT_CODE_KEY_ALIASES: Readonly<Record<string, readonly string[]>> = {
   BracketLeft: ["["],
   BracketRight: ["]"],
@@ -71,10 +72,18 @@ function normalizeEventKey(key: string): string {
 function resolveEventKeys(event: ShortcutEventLike): Set<string> {
   const keys = new Set([normalizeEventKey(event.key)]);
   const aliases = event.code ? EVENT_CODE_KEY_ALIASES[event.code] : undefined;
-  if (!aliases) return keys;
+  if (aliases) {
+    for (const alias of aliases) {
+      keys.add(alias);
+    }
+  }
 
-  for (const alias of aliases) {
-    keys.add(alias);
+  // Option-modified letter shortcuts can surface a symbol or dead key in `event.key`
+  // even though the physical letter key is still the user's intended shortcut.
+  const letterCodeMatch =
+    event.altKey && event.code ? LETTER_EVENT_CODE_PATTERN.exec(event.code) : null;
+  if (letterCodeMatch?.[1]) {
+    keys.add(letterCodeMatch[1].toLowerCase());
   }
   return keys;
 }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

  - Fixes shortcut matching for macOS `Option`-modified explicit letter keybindings by falling back to the physical letter from `KeyboardEvent.code` when `event.key` becomes a symbol or dead key.
  - Adds a focused unit test in `apps/web/src/keybindings.test.ts` for `ctrl+shift+option+cmd+s`.
  - Adds a browser test in `apps/web/src/components/ChatView.browser.tsx` covering the `terminal.toggle` flow for the same shortcut.


## Why

Configured shortcuts like `ctrl+shift+option+cmd+s` are a practical macOS use case for people using Hyperkey, which maps a key such as Caps Lock to all four modifiers combined (`ctrl+option+cmd+shift`).

In t3code, that shortcut is accepted by the config layer but can fail at runtime because `Option+letter` may change `event.key` away from the configured letter. Falling back to `event.code` for Option-modified letter keys keeps matching aligned with the physical key the user configured without changing unrelated shortcuts.

  Closes #2261.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to keybinding matching plus added tests; risk is limited to unintended shortcut matches for Option+letter combos on macOS.
> 
> **Overview**
> Fixes shortcut matching on macOS for *Option-modified explicit letter keybindings* (e.g. hyperkey combos) by extending `resolveEventKeys` to include the physical letter derived from `KeyboardEvent.code` (`Key[A-Z]`) when `altKey` is pressed.
> 
> Adds regression coverage: a new unit test in `keybindings.test.ts` for `ctrl+shift+alt+cmd+s` mapping when `event.key` is transformed, and a `ChatView.browser.tsx` flow test asserting `terminal.toggle` triggers `terminalOpen` under the same conditions. Also refactors browser tests with a typed `waitForTerminalOpenRequest` helper to reduce duplicated polling/assertion logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d84958ea109dbbc4f9aacb8b0c6696c19475e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix macOS Option+letter keybindings by matching on physical key code
> On macOS, pressing Option+letter changes `event.key` to a symbol (e.g. `Í` instead of `s`), breaking shortcut matching. `resolveEventKeys` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/2269/files#diff-0c56a39781768a3ed42f3d306e35b87e9d2426ccb4a81010bc2c4fe735001385) now detects when `altKey` is pressed and `event.code` matches a letter pattern (`Key[A-Z]`), and includes the lowercase physical letter in the resolved key set so shortcuts match regardless of the transformed key value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d84958.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->