### PR TITLE
fix: increase Claude auth probe timeout to 10s

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -19,6 +19,7 @@ import {
 
 import {
   buildServerProvider,
+  AUTH_PROBE_TIMEOUT_MS,
   DEFAULT_TIMEOUT_MS,
   detailFromResult,
   extractAuthBoolean,
@@ -674,7 +675,7 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   // ── Auth check + subscription detection ────────────────────────────
 
   const authProbe = yield* runClaudeCommand(["auth", "status"]).pipe(
-    Effect.timeoutOption(DEFAULT_TIMEOUT_MS),
+    Effect.timeoutOption(AUTH_PROBE_TIMEOUT_MS),
     Effect.result,
   );
 

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -13,6 +13,8 @@ import { normalizeModelSlug } from "@t3tools/shared/model";
 import { isWindowsCommandNotFound } from "../processRunner.ts";
 
 export const DEFAULT_TIMEOUT_MS = 4_000;
+// Auth status checks involve disk/network lookups and can be slow on first run (especially Windows)
+export const AUTH_PROBE_TIMEOUT_MS = 10_000;
 
 export interface CommandResult {
   readonly stdout: string;


### PR DESCRIPTION
## Summary

- Adds `AUTH_PROBE_TIMEOUT_MS = 10_000` to `providerSnapshot.ts`
- Uses it for the `claude auth status` probe in `ClaudeProvider.ts` instead of `DEFAULT_TIMEOUT_MS` (4s)

## Why

`claude auth status` involves disk/account lookups and can exceed 4s on Windows due to Node.js cold-start overhead. This causes a spurious **"Could not verify Claude authentication status. Timed out while running command."** warning in the provider panel — even when the CLI is correctly installed and authenticated.

The `--version` probe is fast and keeps its 4s timeout unchanged. Only the auth check gets the higher limit.

## Before / After

**Before:** Provider shows yellow "Needs attention – Could not verify Claude authentication status. Timed out while running command." on Windows on first load.

**After:** Auth check has 10s to complete, resolving the false positive on Windows.

## Test plan

- [ ] Launch T3 Code on Windows with `claude` on PATH and authenticated
- [ ] Confirm provider status shows green "Ready" instead of the timeout warning
- [ ] Confirm `--version` probe speed is unaffected (still uses 4s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the timeout used for the `claude auth status` probe to reduce false timeout warnings, without changing auth parsing or other probes.
> 
> **Overview**
> Increases the timeout for the Claude provider’s `claude auth status` check by introducing `AUTH_PROBE_TIMEOUT_MS` (10s) and using it instead of `DEFAULT_TIMEOUT_MS`.
> 
> This makes the auth probe more tolerant of slow first-run startup (notably on Windows) while leaving other CLI probes (e.g. `--version`) on the existing 4s timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8179582c7d7c7b9bd96eebc6df843836d2fbe103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase Claude auth probe timeout to 10s
> Auth checks against Claude can be slow, causing false failures with the previous 4s timeout. Introduces a new `AUTH_PROBE_TIMEOUT_MS` constant (10,000ms) in [`providerSnapshot.ts`](https://github.com/pingdotgg/t3code/pull/2272/files#diff-62373f674410fb63637739f0efeb07b9ef79b579393ae2adf51567de0b812b26) and applies it in [`ClaudeProvider.ts`](https://github.com/pingdotgg/t3code/pull/2272/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) instead of the general `DEFAULT_TIMEOUT_MS`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8179582.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->