### PR TITLE
improve and prevent silent thread branch drift and PR fetching

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2512,7 +2512,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       };
 
       expect(
-        matchesBranchHeadContext(
+        GitManager.matchesBranchHeadContext(
           {
             number: 2284,
             title: "Improve branch mismatch warnings",

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2413,6 +2413,72 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     12_000,
   );
 
+  it.effect(
+    "does not reuse a cross-repo PR when GitHub omits head identity metadata",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("t3code-git-manager-");
+        yield* initRepo(repoDir);
+        yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
+        const forkDir = yield* createBareRemote();
+        yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
+        yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
+        yield* runGit(repoDir, [
+          "config",
+          "remote.fork-seed.url",
+          "git@github.com:octocat/codething-mvp.git",
+        ]);
+
+        const { manager, ghCalls } = yield* makeManager({
+          ghScenario: {
+            prListSequenceByHeadSelector: {
+              "octocat:statemachine": [
+                JSON.stringify([
+                  {
+                    number: 41,
+                    title: "Ambiguous fork PR",
+                    url: "https://github.com/pingdotgg/codething-mvp/pull/41",
+                    baseRefName: "main",
+                    headRefName: "statemachine",
+                    state: "OPEN",
+                  },
+                ]),
+                JSON.stringify([
+                  {
+                    number: 142,
+                    title: "Add stacked git actions",
+                    url: "https://github.com/pingdotgg/codething-mvp/pull/142",
+                    baseRefName: "main",
+                    headRefName: "statemachine",
+                    state: "OPEN",
+                    isCrossRepository: true,
+                    headRepository: {
+                      nameWithOwner: "octocat/codething-mvp",
+                    },
+                    headRepositoryOwner: {
+                      login: "octocat",
+                    },
+                  },
+                ]),
+              ],
+              "fork-seed:statemachine": [JSON.stringify([])],
+              statemachine: [JSON.stringify([])],
+            },
+          },
+        });
+
+        const result = yield* runStackedAction(manager, {
+          cwd: repoDir,
+          action: "commit_push_pr",
+        });
+
+        expect(result.pr.status).toBe("created");
+        expect(result.pr.number).toBe(142);
+        expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(true);
+      }),
+    12_000,
+  );
+
   it.effect("creates PR when one does not already exist", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2526,6 +2526,35 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("accepts fork PR metadata when origin is the fork checkout remote", () =>
+    Effect.sync(() => {
+      const headContext = {
+        headBranch: "t3code/git-audit-stability",
+        headRepositoryNameWithOwner: "justsomelegs/t3code",
+        headRepositoryOwnerLogin: "justsomelegs",
+        isCrossRepository: false,
+      };
+
+      expect(
+        matchesBranchHeadContext(
+          {
+            number: 2284,
+            title: "Improve branch mismatch warnings",
+            url: "https://github.com/pingdotgg/t3code/pull/2284",
+            baseRefName: "main",
+            headRefName: "t3code/git-audit-stability",
+            state: "open",
+            updatedAt: null,
+            isCrossRepository: true,
+            headRepositoryNameWithOwner: "justsomelegs/t3code",
+            headRepositoryOwnerLogin: "justsomelegs",
+          },
+          headContext,
+        ),
+      ).toBe(true);
+    }),
+  );
+
   it.effect("creates PR when one does not already exist", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2479,6 +2479,53 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     12_000,
   );
 
+  it.effect("rejects same-repo PR metadata when matching a cross-repo head context", () =>
+    Effect.sync(() => {
+      const headContext = {
+        headBranch: "statemachine",
+        headRepositoryNameWithOwner: "pingdotgg/codething-mvp",
+        headRepositoryOwnerLogin: "pingdotgg",
+        isCrossRepository: true,
+      };
+
+      expect(
+        GitManager.matchesBranchHeadContext(
+          {
+            number: 41,
+            title: "Same-repo PR",
+            url: "https://github.com/pingdotgg/codething-mvp/pull/41",
+            baseRefName: "main",
+            headRefName: "statemachine",
+            state: "open",
+            updatedAt: null,
+            isCrossRepository: false,
+            headRepositoryNameWithOwner: "pingdotgg/codething-mvp",
+            headRepositoryOwnerLogin: "pingdotgg",
+          },
+          headContext,
+        ),
+      ).toBe(false);
+
+      expect(
+        GitManager.matchesBranchHeadContext(
+          {
+            number: 142,
+            title: "Fork PR",
+            url: "https://github.com/pingdotgg/codething-mvp/pull/142",
+            baseRefName: "main",
+            headRefName: "statemachine",
+            state: "open",
+            updatedAt: null,
+            isCrossRepository: true,
+            headRepositoryNameWithOwner: "pingdotgg/codething-mvp",
+            headRepositoryOwnerLogin: "pingdotgg",
+          },
+          headContext,
+        ),
+      ).toBe(true);
+    }),
+  );
+
   it.effect("creates PR when one does not already exist", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -8,6 +8,7 @@ import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Scope from "effect/Scope";
 import { ChildProcessSpawner } from "effect/unstable/process";
@@ -2497,7 +2498,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
             baseRefName: "main",
             headRefName: "statemachine",
             state: "open",
-            updatedAt: null,
+            updatedAt: Option.none(),
             isCrossRepository: false,
             headRepositoryNameWithOwner: "pingdotgg/codething-mvp",
             headRepositoryOwnerLogin: "pingdotgg",
@@ -2515,7 +2516,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
             baseRefName: "main",
             headRefName: "statemachine",
             state: "open",
-            updatedAt: null,
+            updatedAt: Option.none(),
             isCrossRepository: true,
             headRepositoryNameWithOwner: "pingdotgg/codething-mvp",
             headRepositoryOwnerLogin: "pingdotgg",
@@ -2544,7 +2545,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
             baseRefName: "main",
             headRefName: "t3code/git-audit-stability",
             state: "open",
-            updatedAt: null,
+            updatedAt: Option.none(),
             isCrossRepository: true,
             headRepositoryNameWithOwner: "justsomelegs/t3code",
             headRepositoryOwnerLogin: "justsomelegs",

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2452,7 +2452,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         expect(result.pr.number).toBe(142);
         expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(true);
       }),
-    12_000,
+    20_000,
   );
 
   it.effect("rejects same-repo PR metadata when matching a cross-repo head context", () =>

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2434,36 +2434,11 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           ghScenario: {
             prListSequenceByHeadSelector: {
               "octocat:statemachine": [
-                JSON.stringify([
-                  {
-                    number: 41,
-                    title: "Ambiguous fork PR",
-                    url: "https://github.com/pingdotgg/codething-mvp/pull/41",
-                    baseRefName: "main",
-                    headRefName: "statemachine",
-                    state: "OPEN",
-                  },
-                ]),
-                JSON.stringify([
-                  {
-                    number: 142,
-                    title: "Add stacked git actions",
-                    url: "https://github.com/pingdotgg/codething-mvp/pull/142",
-                    baseRefName: "main",
-                    headRefName: "statemachine",
-                    state: "OPEN",
-                    isCrossRepository: true,
-                    headRepository: {
-                      nameWithOwner: "octocat/codething-mvp",
-                    },
-                    headRepositoryOwner: {
-                      login: "octocat",
-                    },
-                  },
-                ]),
+                `[{"number":41,"title":"Ambiguous fork PR","url":"https://github.com/pingdotgg/codething-mvp/pull/41","baseRefName":"main","headRefName":"statemachine","state":"OPEN"}]`,
+                `[{"number":142,"title":"Add stacked git actions","url":"https://github.com/pingdotgg/codething-mvp/pull/142","baseRefName":"main","headRefName":"statemachine","state":"OPEN","isCrossRepository":true,"headRepository":{"nameWithOwner":"octocat/codething-mvp"},"headRepositoryOwner":{"login":"octocat"}}]`,
               ],
-              "fork-seed:statemachine": [JSON.stringify([])],
-              statemachine: [JSON.stringify([])],
+              "fork-seed:statemachine": ["[]"],
+              statemachine: ["[]"],
             },
           },
         });

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -331,7 +331,12 @@ export function matchesBranchHeadContext(
   }
 
   if (pr.isCrossRepository === true) {
-    return false;
+    if (
+      (!expectedHead.repositoryNameWithOwner && !expectedHead.ownerLogin) ||
+      (!pullRequestHead.repositoryNameWithOwner && !pullRequestHead.ownerLogin)
+    ) {
+      return false;
+    }
   }
 
   return true;

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -283,7 +283,7 @@ function resolvePullRequestHeadIdentity(pr: PullRequestInfo): PullRequestHeadIde
   };
 }
 
-function matchesBranchHeadContext(
+export function matchesBranchHeadContext(
   pr: PullRequestInfo,
   headContext: Pick<
     BranchHeadContext,
@@ -299,18 +299,21 @@ function matchesBranchHeadContext(
 
   if (expectedHead.repositoryNameWithOwner) {
     if (pullRequestHead.repositoryNameWithOwner) {
-      return expectedHead.repositoryNameWithOwner === pullRequestHead.repositoryNameWithOwner;
+      if (expectedHead.repositoryNameWithOwner !== pullRequestHead.repositoryNameWithOwner) {
+        return false;
+      }
     }
     if (expectedHead.ownerLogin && pullRequestHead.ownerLogin) {
-      return expectedHead.ownerLogin === pullRequestHead.ownerLogin;
-    }
-    if (pr.isCrossRepository === true) {
-      return false;
+      if (expectedHead.ownerLogin !== pullRequestHead.ownerLogin) {
+        return false;
+      }
     }
   }
 
   if (expectedHead.ownerLogin && pullRequestHead.ownerLogin) {
-    return expectedHead.ownerLogin === pullRequestHead.ownerLogin;
+    if (expectedHead.ownerLogin !== pullRequestHead.ownerLogin) {
+      return false;
+    }
   }
 
   if (headContext.isCrossRepository) {

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -252,6 +252,37 @@ function resolvePullRequestHeadRepositoryNameWithOwner(
   return `${ownerLogin}/${repositoryName}`;
 }
 
+interface PullRequestHeadIdentity {
+  readonly repositoryNameWithOwner: string | null;
+  readonly ownerLogin: string | null;
+}
+
+function resolveExpectedHeadIdentity(
+  headContext: Pick<BranchHeadContext, "headRepositoryNameWithOwner" | "headRepositoryOwnerLogin">,
+): PullRequestHeadIdentity {
+  const repositoryNameWithOwner = normalizeOptionalRepositoryNameWithOwner(
+    headContext.headRepositoryNameWithOwner,
+  );
+  return {
+    repositoryNameWithOwner,
+    ownerLogin:
+      normalizeOptionalOwnerLogin(headContext.headRepositoryOwnerLogin) ??
+      parseRepositoryOwnerLogin(repositoryNameWithOwner),
+  };
+}
+
+function resolvePullRequestHeadIdentity(pr: PullRequestInfo): PullRequestHeadIdentity {
+  const repositoryNameWithOwner = normalizeOptionalRepositoryNameWithOwner(
+    resolvePullRequestHeadRepositoryNameWithOwner(pr),
+  );
+  return {
+    repositoryNameWithOwner,
+    ownerLogin:
+      normalizeOptionalOwnerLogin(pr.headRepositoryOwnerLogin) ??
+      parseRepositoryOwnerLogin(repositoryNameWithOwner),
+  };
+}
+
 function matchesBranchHeadContext(
   pr: PullRequestInfo,
   headContext: Pick<
@@ -263,44 +294,33 @@ function matchesBranchHeadContext(
     return false;
   }
 
-  const expectedHeadRepository = normalizeOptionalRepositoryNameWithOwner(
-    headContext.headRepositoryNameWithOwner,
-  );
-  const expectedHeadOwner =
-    normalizeOptionalOwnerLogin(headContext.headRepositoryOwnerLogin) ??
-    parseRepositoryOwnerLogin(expectedHeadRepository);
-  const prHeadRepository = normalizeOptionalRepositoryNameWithOwner(
-    resolvePullRequestHeadRepositoryNameWithOwner(pr),
-  );
-  const prHeadOwner =
-    normalizeOptionalOwnerLogin(pr.headRepositoryOwnerLogin) ??
-    parseRepositoryOwnerLogin(prHeadRepository);
+  const expectedHead = resolveExpectedHeadIdentity(headContext);
+  const pullRequestHead = resolvePullRequestHeadIdentity(pr);
+
+  if (expectedHead.repositoryNameWithOwner) {
+    if (pullRequestHead.repositoryNameWithOwner) {
+      return expectedHead.repositoryNameWithOwner === pullRequestHead.repositoryNameWithOwner;
+    }
+    if (expectedHead.ownerLogin && pullRequestHead.ownerLogin) {
+      return expectedHead.ownerLogin === pullRequestHead.ownerLogin;
+    }
+    if (pr.isCrossRepository === true) {
+      return false;
+    }
+  }
+
+  if (expectedHead.ownerLogin && pullRequestHead.ownerLogin) {
+    return expectedHead.ownerLogin === pullRequestHead.ownerLogin;
+  }
 
   if (headContext.isCrossRepository) {
-    if (pr.isCrossRepository === false) {
-      return false;
-    }
-    if ((expectedHeadRepository || expectedHeadOwner) && !prHeadRepository && !prHeadOwner) {
-      return false;
-    }
-    if (expectedHeadRepository && prHeadRepository && expectedHeadRepository !== prHeadRepository) {
-      return false;
-    }
-    if (expectedHeadOwner && prHeadOwner && expectedHeadOwner !== prHeadOwner) {
-      return false;
-    }
-    return true;
+    return pr.isCrossRepository !== false;
   }
 
   if (pr.isCrossRepository === true) {
     return false;
   }
-  if (expectedHeadRepository && prHeadRepository && expectedHeadRepository !== prHeadRepository) {
-    return false;
-  }
-  if (expectedHeadOwner && prHeadOwner && expectedHeadOwner !== prHeadOwner) {
-    return false;
-  }
+
   return true;
 }
 

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -314,7 +314,17 @@ function matchesBranchHeadContext(
   }
 
   if (headContext.isCrossRepository) {
-    return pr.isCrossRepository !== false;
+    if (pr.isCrossRepository === false) {
+      return false;
+    }
+    if (
+      (expectedHead.repositoryNameWithOwner || expectedHead.ownerLogin) &&
+      !pullRequestHead.repositoryNameWithOwner &&
+      !pullRequestHead.ownerLogin
+    ) {
+      return false;
+    }
+    return true;
   }
 
   if (pr.isCrossRepository === true) {

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -11,6 +11,7 @@ import {
   resolveEnvModeLabel,
   resolveBranchToolbarValue,
   resolveLockedWorkspaceLabel,
+  resolveLocalCheckoutBranchMismatch,
   shouldIncludeBranchPickerItem,
   shouldShowEnvironmentIndicator,
 } from "./BranchToolbar.logic";
@@ -82,6 +83,55 @@ describe("resolveBranchToolbarValue", () => {
         currentGitBranch: "main",
       }),
     ).toBe("main");
+  });
+});
+
+describe("resolveLocalCheckoutBranchMismatch", () => {
+  it("detects when a local thread is associated with a different branch than the checkout", () => {
+    expect(
+      resolveLocalCheckoutBranchMismatch({
+        effectiveEnvMode: "local",
+        activeWorktreePath: null,
+        activeThreadBranch: "feature/thread",
+        currentGitBranch: "feature/current",
+      }),
+    ).toEqual({
+      threadBranch: "feature/thread",
+      currentBranch: "feature/current",
+    });
+  });
+
+  it("ignores matching local checkout state", () => {
+    expect(
+      resolveLocalCheckoutBranchMismatch({
+        effectiveEnvMode: "local",
+        activeWorktreePath: null,
+        activeThreadBranch: "feature/thread",
+        currentGitBranch: "feature/thread",
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores dedicated worktrees because their checkout is already thread-scoped", () => {
+    expect(
+      resolveLocalCheckoutBranchMismatch({
+        effectiveEnvMode: "worktree",
+        activeWorktreePath: "/repo/.t3/worktrees/feature-thread",
+        activeThreadBranch: "feature/thread",
+        currentGitBranch: "feature/current",
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores new-worktree base selection before a worktree exists", () => {
+    expect(
+      resolveLocalCheckoutBranchMismatch({
+        effectiveEnvMode: "worktree",
+        activeWorktreePath: null,
+        activeThreadBranch: "feature/base",
+        currentGitBranch: "main",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -108,6 +108,22 @@ export function resolveBranchToolbarValue(input: {
   return currentGitBranch ?? activeThreadBranch;
 }
 
+export function resolveLocalCheckoutBranchMismatch(input: {
+  effectiveEnvMode: EnvMode;
+  activeWorktreePath: string | null;
+  activeThreadBranch: string | null;
+  currentGitBranch: string | null;
+}): { threadBranch: string; currentBranch: string } | null {
+  const { effectiveEnvMode, activeWorktreePath, activeThreadBranch, currentGitBranch } = input;
+  if (effectiveEnvMode !== "local" || activeWorktreePath !== null) {
+    return null;
+  }
+  if (!activeThreadBranch || !currentGitBranch || activeThreadBranch === currentGitBranch) {
+    return null;
+  }
+  return { threadBranch: activeThreadBranch, currentBranch: currentGitBranch };
+}
+
 export function resolveBranchSelectionTarget(input: {
   activeProjectCwd: string;
   activeWorktreePath: string | null;

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -5,13 +5,7 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 import type { ContextMenuItem, EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
-import {
-  ChevronDownIcon,
-  GitBranchIcon,
-  RefreshCwIcon,
-  SearchIcon,
-  TriangleAlertIcon,
-} from "lucide-react";
+import { ChevronDownIcon, GitBranchIcon, RefreshCwIcon, SearchIcon } from "lucide-react";
 import {
   useCallback,
   useDeferredValue,
@@ -45,7 +39,6 @@ import {
   resolveBranchToolbarValue,
   resolveDraftEnvModeAfterBranchChange,
   resolveEffectiveEnvMode,
-  resolveLocalCheckoutBranchMismatch,
   shouldIncludeBranchPickerItem,
 } from "./BranchToolbar.logic";
 import {
@@ -265,12 +258,6 @@ export function BranchToolbarBranchSelector({
     activeThreadBranch,
     currentGitBranch,
   });
-  const localCheckoutBranchMismatch = resolveLocalCheckoutBranchMismatch({
-    effectiveEnvMode,
-    activeWorktreePath,
-    activeThreadBranch,
-    currentGitBranch,
-  });
   const branchNames = useMemo(() => refs.map((refName) => refName.name), [refs]);
   const branchByName = useMemo(
     () => new Map(refs.map((refName) => [refName.name, refName] as const)),
@@ -486,53 +473,6 @@ export function BranchToolbarBranchSelector({
   const worktreeBaseBranchCandidate = isInitialBranchesLoadPending
     ? null
     : (defaultBranchName ?? currentGitBranch);
-
-  const switchCheckoutToThreadBranch = () => {
-    if (!activeProjectCwd || !localCheckoutBranchMismatch || isBranchActionPending) {
-      return;
-    }
-
-    runBranchAction(async () => {
-      const previousBranch = resolvedActiveBranch;
-      setOptimisticBranch(localCheckoutBranchMismatch.threadBranch);
-      const checkoutResult = await switchRef({
-        environmentId,
-        input: {
-          cwd: activeProjectCwd,
-          refName: localCheckoutBranchMismatch.threadBranch,
-        },
-      });
-      if (checkoutResult._tag === "Success") {
-        const nextBranchName =
-          checkoutResult.value.refName ?? localCheckoutBranchMismatch.threadBranch;
-        setOptimisticBranch(nextBranchName);
-        setThreadBranch(nextBranchName, null);
-        setIsBranchMenuOpen(false);
-        onComposerFocusRequest?.();
-        return;
-      }
-      setOptimisticBranch(previousBranch);
-      if (!isAtomCommandInterrupted(checkoutResult)) {
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Failed to switch checkout.",
-            description: toBranchActionErrorMessage(squashAtomCommandFailure(checkoutResult)),
-          }),
-        );
-      }
-    });
-  };
-
-  const updateThreadToCurrentCheckout = () => {
-    if (!localCheckoutBranchMismatch || isBranchActionPending) {
-      return;
-    }
-
-    setThreadBranch(localCheckoutBranchMismatch.currentBranch, null);
-    setIsBranchMenuOpen(false);
-    onComposerFocusRequest?.();
-  };
 
   useEffect(() => {
     if (
@@ -791,11 +731,7 @@ export function BranchToolbarBranchSelector({
         >
           <ComboboxTrigger
             render={<Button variant="ghost" size="xs" />}
-            className={cn(
-              "min-w-0 text-muted-foreground/70 hover:text-foreground/80",
-              localCheckoutBranchMismatch &&
-                "border-warning/35 bg-warning/10 text-warning hover:bg-warning/15 hover:text-warning",
-            )}
+            className="min-w-0 text-muted-foreground/70 hover:text-foreground/80"
             disabled={isInitialBranchesLoadPending || isBranchActionPending}
           >
             <GitBranchIcon className="size-3 shrink-0 opacity-70" />
@@ -805,66 +741,6 @@ export function BranchToolbarBranchSelector({
         </span>
       </div>
       <ComboboxPopup align="end" side="top" className="flex w-80 flex-col">
-        {localCheckoutBranchMismatch ? (
-          <div className="space-y-1.5 border-b bg-warning/5 px-3 py-2 text-xs">
-            <div className="flex items-center gap-1.5">
-              <TriangleAlertIcon aria-hidden="true" className="size-3.5 shrink-0 text-warning" />
-              <span className="font-medium text-foreground">Branches diverged</span>
-            </div>
-            <div className="space-y-0.5 text-[11px]">
-              <div className="flex items-center gap-2">
-                <span className="w-14 shrink-0 text-muted-foreground">thread</span>
-                <code className="min-w-0 flex-1 truncate text-foreground">
-                  {localCheckoutBranchMismatch.threadBranch}
-                </code>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="w-14 shrink-0 text-warning/80">checkout</span>
-                <code className="min-w-0 flex-1 truncate text-warning">
-                  {localCheckoutBranchMismatch.currentBranch}
-                </code>
-              </div>
-            </div>
-            <div className="flex gap-1.5">
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      className="h-7 flex-1 justify-center text-[11px]"
-                      disabled={isBranchActionPending}
-                      onClick={updateThreadToCurrentCheckout}
-                    >
-                      Update thread
-                    </Button>
-                  }
-                />
-                <TooltipPopup side="top" align="center">
-                  Associate this thread with {localCheckoutBranchMismatch.currentBranch}
-                </TooltipPopup>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Button
-                      variant="ghost"
-                      size="xs"
-                      className="h-7 flex-1 justify-center text-[11px] text-muted-foreground hover:text-foreground"
-                      disabled={isBranchActionPending}
-                      onClick={switchCheckoutToThreadBranch}
-                    >
-                      Switch checkout
-                    </Button>
-                  }
-                />
-                <TooltipPopup side="top" align="center">
-                  Checkout {localCheckoutBranchMismatch.threadBranch}
-                </TooltipPopup>
-              </Tooltip>
-            </div>
-          </div>
-        ) : null}
         <div className="shrink-0 px-3 pt-2.5">
           <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
             <SearchIcon

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -498,9 +498,10 @@ export function BranchToolbarBranchSelector({
         },
       });
       if (checkoutResult._tag === "Success") {
-        setOptimisticBranch(
-          checkoutResult.value.refName ?? localCheckoutBranchMismatch.threadBranch,
-        );
+        const nextBranchName =
+          checkoutResult.value.refName ?? localCheckoutBranchMismatch.threadBranch;
+        setOptimisticBranch(nextBranchName);
+        setThreadBranch(nextBranchName, null);
         setIsMismatchPopoverOpen(false);
         onComposerFocusRequest?.();
         return;

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -39,6 +39,7 @@ import {
   resolveBranchToolbarValue,
   resolveDraftEnvModeAfterBranchChange,
   resolveEffectiveEnvMode,
+  resolveLocalCheckoutBranchMismatch,
   shouldIncludeBranchPickerItem,
 } from "./BranchToolbar.logic";
 import {
@@ -218,6 +219,7 @@ export function BranchToolbarBranchSelector({
   // Git ref queries
   // ---------------------------------------------------------------------------
   const [isBranchMenuOpen, setIsBranchMenuOpen] = useState(false);
+  const [isMismatchPopoverOpen, setIsMismatchPopoverOpen] = useState(false);
   const [branchQuery, setBranchQuery] = useState("");
   const deferredBranchQuery = useDeferredValue(branchQuery);
 
@@ -254,6 +256,12 @@ export function BranchToolbarBranchSelector({
   const SourceControlIcon = sourceControlPresentation.Icon;
   const canonicalActiveBranch = resolveBranchToolbarValue({
     envMode: effectiveEnvMode,
+    activeWorktreePath,
+    activeThreadBranch,
+    currentGitBranch,
+  });
+  const localCheckoutBranchMismatch = resolveLocalCheckoutBranchMismatch({
+    effectiveEnvMode,
     activeWorktreePath,
     activeThreadBranch,
     currentGitBranch,
@@ -473,6 +481,53 @@ export function BranchToolbarBranchSelector({
   const worktreeBaseBranchCandidate = isInitialBranchesLoadPending
     ? null
     : (defaultBranchName ?? currentGitBranch);
+
+  const switchCheckoutToThreadBranch = () => {
+    if (!activeProjectCwd || !localCheckoutBranchMismatch || isBranchActionPending) {
+      return;
+    }
+
+    runBranchAction(async () => {
+      const previousBranch = resolvedActiveBranch;
+      setOptimisticBranch(localCheckoutBranchMismatch.threadBranch);
+      const checkoutResult = await switchRef({
+        environmentId,
+        input: {
+          cwd: activeProjectCwd,
+          refName: localCheckoutBranchMismatch.threadBranch,
+        },
+      });
+      if (checkoutResult._tag === "Success") {
+        setOptimisticBranch(
+          checkoutResult.value.refName ?? localCheckoutBranchMismatch.threadBranch,
+        );
+        setIsMismatchPopoverOpen(false);
+        onComposerFocusRequest?.();
+        return;
+      }
+      setOptimisticBranch(previousBranch);
+      if (!isAtomCommandInterrupted(checkoutResult)) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to switch checkout.",
+            description: toBranchActionErrorMessage(squashAtomCommandFailure(checkoutResult)),
+          }),
+        );
+      }
+    });
+  };
+
+  const useCurrentCheckoutForThread = () => {
+    if (!localCheckoutBranchMismatch || isBranchActionPending) {
+      return;
+    }
+
+    setThreadBranch(localCheckoutBranchMismatch.currentBranch, null);
+    setIsMismatchPopoverOpen(false);
+    onComposerFocusRequest?.();
+  };
+
   useEffect(() => {
     if (
       effectiveEnvMode !== "worktree" ||

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -589,7 +589,11 @@ export function BranchToolbarBranchSelector({
   });
 
   // PR pill shown next to the branch selector when the active branch has one.
-  const branchPr = resolveThreadPr(resolvedActiveBranch, branchStatusQuery.data ?? null);
+  const branchPr = resolveThreadPr({
+    threadBranch: resolvedActiveBranch,
+    gitStatus: branchStatusQuery.data ?? null,
+    hasDedicatedWorktree: activeWorktreePath !== null,
+  });
   const branchPrStatus = prStatusIndicator(branchPr, branchStatusQuery.data?.sourceControlProvider);
   // Action-oriented tooltip (the pill opens the PR), distinct from the sidebar's
   // state-description tooltip.

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -5,7 +5,13 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 import type { ContextMenuItem, EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
-import { ChevronDownIcon, GitBranchIcon, RefreshCwIcon, SearchIcon } from "lucide-react";
+import {
+  ChevronDownIcon,
+  GitBranchIcon,
+  RefreshCwIcon,
+  SearchIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
 import {
   useCallback,
   useDeferredValue,
@@ -219,7 +225,6 @@ export function BranchToolbarBranchSelector({
   // Git ref queries
   // ---------------------------------------------------------------------------
   const [isBranchMenuOpen, setIsBranchMenuOpen] = useState(false);
-  const [isMismatchPopoverOpen, setIsMismatchPopoverOpen] = useState(false);
   const [branchQuery, setBranchQuery] = useState("");
   const deferredBranchQuery = useDeferredValue(branchQuery);
 
@@ -502,7 +507,7 @@ export function BranchToolbarBranchSelector({
           checkoutResult.value.refName ?? localCheckoutBranchMismatch.threadBranch;
         setOptimisticBranch(nextBranchName);
         setThreadBranch(nextBranchName, null);
-        setIsMismatchPopoverOpen(false);
+        setIsBranchMenuOpen(false);
         onComposerFocusRequest?.();
         return;
       }
@@ -519,13 +524,13 @@ export function BranchToolbarBranchSelector({
     });
   };
 
-  const useCurrentCheckoutForThread = () => {
+  const updateThreadToCurrentCheckout = () => {
     if (!localCheckoutBranchMismatch || isBranchActionPending) {
       return;
     }
 
     setThreadBranch(localCheckoutBranchMismatch.currentBranch, null);
-    setIsMismatchPopoverOpen(false);
+    setIsBranchMenuOpen(false);
     onComposerFocusRequest?.();
   };
 
@@ -786,7 +791,11 @@ export function BranchToolbarBranchSelector({
         >
           <ComboboxTrigger
             render={<Button variant="ghost" size="xs" />}
-            className="min-w-0 text-muted-foreground/70 hover:text-foreground/80"
+            className={cn(
+              "min-w-0 text-muted-foreground/70 hover:text-foreground/80",
+              localCheckoutBranchMismatch &&
+                "border-warning/35 bg-warning/10 text-warning hover:bg-warning/15 hover:text-warning",
+            )}
             disabled={isInitialBranchesLoadPending || isBranchActionPending}
           >
             <GitBranchIcon className="size-3 shrink-0 opacity-70" />
@@ -796,6 +805,66 @@ export function BranchToolbarBranchSelector({
         </span>
       </div>
       <ComboboxPopup align="end" side="top" className="flex w-80 flex-col">
+        {localCheckoutBranchMismatch ? (
+          <div className="space-y-1.5 border-b bg-warning/5 px-3 py-2 text-xs">
+            <div className="flex items-center gap-1.5">
+              <TriangleAlertIcon aria-hidden="true" className="size-3.5 shrink-0 text-warning" />
+              <span className="font-medium text-foreground">Branches diverged</span>
+            </div>
+            <div className="space-y-0.5 text-[11px]">
+              <div className="flex items-center gap-2">
+                <span className="w-14 shrink-0 text-muted-foreground">thread</span>
+                <code className="min-w-0 flex-1 truncate text-foreground">
+                  {localCheckoutBranchMismatch.threadBranch}
+                </code>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-14 shrink-0 text-warning/80">checkout</span>
+                <code className="min-w-0 flex-1 truncate text-warning">
+                  {localCheckoutBranchMismatch.currentBranch}
+                </code>
+              </div>
+            </div>
+            <div className="flex gap-1.5">
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      className="h-7 flex-1 justify-center text-[11px]"
+                      disabled={isBranchActionPending}
+                      onClick={updateThreadToCurrentCheckout}
+                    >
+                      Update thread
+                    </Button>
+                  }
+                />
+                <TooltipPopup side="top" align="center">
+                  Associate this thread with {localCheckoutBranchMismatch.currentBranch}
+                </TooltipPopup>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      className="h-7 flex-1 justify-center text-[11px] text-muted-foreground hover:text-foreground"
+                      disabled={isBranchActionPending}
+                      onClick={switchCheckoutToThreadBranch}
+                    >
+                      Switch checkout
+                    </Button>
+                  }
+                />
+                <TooltipPopup side="top" align="center">
+                  Checkout {localCheckoutBranchMismatch.threadBranch}
+                </TooltipPopup>
+              </Tooltip>
+            </div>
+          </div>
+        ) : null}
         <div className="shrink-0 px-3 pt-2.5">
           <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">
             <SearchIcon

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -20,6 +20,7 @@ import {
   hasServerAcknowledgedLocalDispatch,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
+  resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
@@ -78,6 +79,34 @@ const readySession = {
   lastError: null,
   updatedAt: "2026-03-29T00:00:10.000Z",
 };
+
+describe("resolveThreadMetadataUpdateForNextTurn", () => {
+  const modelSelection = {
+    instanceId: ProviderInstanceId.make("codex"),
+    model: "gpt-5.4",
+  };
+
+  it("updates a stale local thread branch to the active checkout", () => {
+    expect(
+      resolveThreadMetadataUpdateForNextTurn({
+        currentModelSelection: modelSelection,
+        currentBranch: "feature/thread",
+        nextBranch: "feature/checkout",
+      }),
+    ).toEqual({ branch: "feature/checkout", worktreePath: null });
+  });
+
+  it("does not write metadata when the model and branch are unchanged", () => {
+    expect(
+      resolveThreadMetadataUpdateForNextTurn({
+        currentModelSelection: modelSelection,
+        nextModelSelection: modelSelection,
+        currentBranch: "feature/current",
+        nextBranch: "feature/current",
+      }),
+    ).toBeNull();
+  });
+});
 
 describe("buildThreadTurnInterruptInput", () => {
   it("targets the session's active running turn", () => {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -27,6 +27,33 @@ export const MAX_HIDDEN_MOUNTED_PREVIEW_THREADS = 3;
 
 export const LastInvokedScriptByProjectSchema = Schema.Record(ProjectId, Schema.String);
 
+export function resolveThreadMetadataUpdateForNextTurn(input: {
+  currentModelSelection: ModelSelection;
+  nextModelSelection?: ModelSelection;
+  currentBranch: string | null;
+  nextBranch?: string;
+}): {
+  modelSelection?: ModelSelection;
+  branch?: string;
+  worktreePath?: null;
+} | null {
+  const nextModelSelection = input.nextModelSelection;
+  const modelSelectionChanged =
+    nextModelSelection !== undefined &&
+    (nextModelSelection.model !== input.currentModelSelection.model ||
+      nextModelSelection.instanceId !== input.currentModelSelection.instanceId ||
+      JSON.stringify(nextModelSelection.options ?? null) !==
+        JSON.stringify(input.currentModelSelection.options ?? null));
+  const branchChanged = input.nextBranch !== undefined && input.nextBranch !== input.currentBranch;
+  if (!modelSelectionChanged && !branchChanged) {
+    return null;
+  }
+  return {
+    ...(modelSelectionChanged ? { modelSelection: nextModelSelection } : {}),
+    ...(branchChanged ? { branch: input.nextBranch, worktreePath: null } : {}),
+  };
+}
+
 export function buildLocalDraftThread(
   threadId: ThreadId,
   draftThread: DraftThreadState,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -212,7 +212,7 @@ import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
-import { resolveEffectiveEnvMode } from "./BranchToolbar.logic";
+import { resolveEffectiveEnvMode, resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import { ProviderStatusBanner } from "./chat/ProviderStatusBanner";
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
@@ -242,6 +242,7 @@ import {
   deriveLockedProvider,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
+  resolveThreadMetadataUpdateForNextTurn,
   resolveSendEnvMode,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
@@ -1080,6 +1081,10 @@ type LocalThreadErrorEntry = {
   readonly at: number;
 };
 
+function chatActionErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "An error occurred.";
+}
+
 function ChatViewContent(props: ChatViewProps) {
   const {
     environmentId,
@@ -1107,6 +1112,7 @@ function ChatViewContent(props: ChatViewProps) {
   const updateThreadMetadata = useAtomCommand(threadEnvironment.updateMetadata, {
     reportFailure: false,
   });
+  const switchGitRef = useAtomCommand(vcsEnvironment.switchRef, { reportFailure: false });
   const setThreadRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
     reportFailure: false,
   });
@@ -1790,7 +1796,7 @@ function ChatViewContent(props: ChatViewProps) {
   const versionMismatchEnvironmentId =
     versionMismatch && activeThread ? activeThread.environmentId : null;
   const versionMismatchSelfUpdate = resolveServerSelfUpdateCapability(serverConfig);
-  const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
+  const systemComposerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
     const items: ComposerBannerStackItem[] = [];
     if (activeEnvironmentUnavailableState) {
       const connection = activeEnvironmentUnavailableState.connection;
@@ -3250,6 +3256,7 @@ function ChatViewContent(props: ChatViewProps) {
       threadId: ThreadId;
       createdAt: string;
       modelSelection?: ModelSelection;
+      branch?: string;
       runtimeMode: RuntimeMode;
       interactionMode: ProviderInteractionMode;
     }): Promise<AtomCommandResult<void, unknown>> => {
@@ -3258,19 +3265,19 @@ function ChatViewContent(props: ChatViewProps) {
       }
 
       let result: AtomCommandResult<void, unknown> = AsyncResult.success(undefined);
-      if (
-        input.modelSelection !== undefined &&
-        (input.modelSelection.model !== serverThread.modelSelection.model ||
-          input.modelSelection.instanceId !== serverThread.modelSelection.instanceId ||
-          JSON.stringify(input.modelSelection.options ?? null) !==
-            JSON.stringify(serverThread.modelSelection.options ?? null))
-      ) {
+      const metadataUpdate = resolveThreadMetadataUpdateForNextTurn({
+        currentModelSelection: serverThread.modelSelection,
+        ...(input.modelSelection ? { nextModelSelection: input.modelSelection } : {}),
+        currentBranch: serverThread.branch,
+        ...(input.branch ? { nextBranch: input.branch } : {}),
+      });
+      if (metadataUpdate) {
         result = mapAtomCommandResult(
           await updateThreadMetadata({
             environmentId,
             input: {
               threadId: input.threadId,
-              modelSelection: input.modelSelection,
+              ...metadataUpdate,
             },
           }),
           () => undefined,
@@ -3764,6 +3771,180 @@ function ChatViewContent(props: ChatViewProps) {
     requestedEnvMode: envMode,
     isGitRepo,
   });
+  const localCheckoutBranchMismatch = useMemo(
+    () =>
+      isServerThread
+        ? resolveLocalCheckoutBranchMismatch({
+            effectiveEnvMode: envMode,
+            activeWorktreePath,
+            activeThreadBranch,
+            currentGitBranch: gitStatusQuery.data?.refName ?? null,
+          })
+        : null,
+    [activeThreadBranch, activeWorktreePath, envMode, gitStatusQuery.data?.refName, isServerThread],
+  );
+  const [branchRepairAction, setBranchRepairAction] = useState<
+    "update-thread" | "switch-checkout" | null
+  >(null);
+  const handleUpdateThreadToCheckout = useCallback(async () => {
+    if (!activeThread || !localCheckoutBranchMismatch || branchRepairAction !== null) {
+      return;
+    }
+    setBranchRepairAction("update-thread");
+    const updateResult = await updateThreadMetadata({
+      environmentId,
+      input: {
+        threadId: activeThread.id,
+        branch: localCheckoutBranchMismatch.currentBranch,
+        worktreePath: null,
+      },
+    });
+    setBranchRepairAction(null);
+    if (updateResult._tag === "Failure" && !isAtomCommandInterrupted(updateResult)) {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Failed to update thread branch",
+          description: chatActionErrorMessage(squashAtomCommandFailure(updateResult)),
+        }),
+      );
+      return;
+    }
+    scheduleComposerFocus();
+  }, [
+    activeThread,
+    branchRepairAction,
+    environmentId,
+    localCheckoutBranchMismatch,
+    scheduleComposerFocus,
+    updateThreadMetadata,
+  ]);
+  const handleSwitchCheckoutToThread = useCallback(async () => {
+    if (
+      !activeProjectCwd ||
+      !activeThread ||
+      !localCheckoutBranchMismatch ||
+      branchRepairAction !== null
+    ) {
+      return;
+    }
+    setBranchRepairAction("switch-checkout");
+    const checkoutResult = await switchGitRef({
+      environmentId,
+      input: {
+        cwd: activeProjectCwd,
+        refName: localCheckoutBranchMismatch.threadBranch,
+      },
+    });
+    if (checkoutResult._tag === "Failure") {
+      setBranchRepairAction(null);
+      if (!isAtomCommandInterrupted(checkoutResult)) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to switch checkout",
+            description: chatActionErrorMessage(squashAtomCommandFailure(checkoutResult)),
+          }),
+        );
+      }
+      return;
+    }
+
+    const nextBranch = checkoutResult.value.refName ?? localCheckoutBranchMismatch.threadBranch;
+    if (nextBranch !== activeThread.branch) {
+      const updateResult = await updateThreadMetadata({
+        environmentId,
+        input: { threadId: activeThread.id, branch: nextBranch, worktreePath: null },
+      });
+      if (updateResult._tag === "Failure") {
+        setBranchRepairAction(null);
+        if (!isAtomCommandInterrupted(updateResult)) {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Checkout switched, but the thread could not be updated",
+              description: chatActionErrorMessage(squashAtomCommandFailure(updateResult)),
+            }),
+          );
+        }
+        gitStatusQuery.refresh();
+        return;
+      }
+    }
+    gitStatusQuery.refresh();
+    setBranchRepairAction(null);
+    scheduleComposerFocus();
+  }, [
+    activeProjectCwd,
+    activeThread,
+    branchRepairAction,
+    environmentId,
+    gitStatusQuery,
+    localCheckoutBranchMismatch,
+    scheduleComposerFocus,
+    switchGitRef,
+    updateThreadMetadata,
+  ]);
+  const composerBannerItems = useMemo<ComposerBannerStackItem[]>(() => {
+    if (!localCheckoutBranchMismatch) {
+      return systemComposerBannerItems;
+    }
+    const isRepairingBranch = branchRepairAction !== null;
+    return [
+      ...systemComposerBannerItems,
+      {
+        id: `branch-mismatch:${activeThread?.id ?? "unknown"}:${localCheckoutBranchMismatch.threadBranch}:${localCheckoutBranchMismatch.currentBranch}`,
+        variant: "warning",
+        icon: <TriangleAlertIcon />,
+        title: "Branches diverged",
+        className:
+          "text-base sm:text-sm [&>div]:items-start max-sm:[&>div]:flex-wrap max-sm:[&>div>div:last-child]:w-full max-sm:[&>div>div:last-child]:self-start dark:shadow-none",
+        actionClassName:
+          "max-sm:w-full max-sm:border-t max-sm:border-border/60 max-sm:pt-2 max-sm:pl-6 sm:border-l sm:border-border/60 sm:pl-3",
+        description: (
+          <p className="text-pretty">
+            Thread{" "}
+            <code className="font-medium text-foreground">
+              {localCheckoutBranchMismatch.threadBranch}
+            </code>
+            <span aria-hidden="true"> · </span>
+            Checkout{" "}
+            <code className="font-medium text-foreground">
+              {localCheckoutBranchMismatch.currentBranch}
+            </code>
+            . Sending a message will update the thread branch.
+          </p>
+        ),
+        actions: (
+          <>
+            <Button
+              size="xs"
+              variant="outline"
+              disabled={isRepairingBranch}
+              onClick={() => void handleUpdateThreadToCheckout()}
+            >
+              {branchRepairAction === "update-thread" ? "Updating..." : "Update thread"}
+            </Button>
+            <Button
+              size="xs"
+              variant="ghost"
+              disabled={isRepairingBranch}
+              onClick={() => void handleSwitchCheckoutToThread()}
+            >
+              {branchRepairAction === "switch-checkout" ? "Switching..." : "Switch checkout"}
+            </Button>
+          </>
+        ),
+      },
+    ];
+  }, [
+    activeThread?.id,
+    branchRepairAction,
+    handleSwitchCheckoutToThread,
+    handleUpdateThreadToCheckout,
+    localCheckoutBranchMismatch,
+    systemComposerBannerItems,
+  ]);
 
   useEffect(() => {
     setPendingServerThreadEnvMode(null);
@@ -4313,6 +4494,9 @@ function ChatViewContent(props: ChatViewProps) {
         threadId: threadIdForSend,
         createdAt: messageCreatedAt,
         ...(ctxSelectedModel ? { modelSelection: ctxSelectedModelSelection } : {}),
+        ...(localCheckoutBranchMismatch
+          ? { branch: localCheckoutBranchMismatch.currentBranch }
+          : {}),
         runtimeMode,
         interactionMode,
       });
@@ -4694,6 +4878,9 @@ function ChatViewContent(props: ChatViewProps) {
         threadId: threadIdForSend,
         createdAt: messageCreatedAt,
         modelSelection: ctxSelectedModelSelection,
+        ...(localCheckoutBranchMismatch
+          ? { branch: localCheckoutBranchMismatch.currentBranch }
+          : {}),
         runtimeMode,
         interactionMode: nextInteractionMode,
       });
@@ -4770,6 +4957,7 @@ function ChatViewContent(props: ChatViewProps) {
       isConnecting,
       isSendBusy,
       isServerThread,
+      localCheckoutBranchMismatch,
       persistThreadSettingsForNextTurn,
       resetLocalDispatch,
       runtimeMode,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3896,23 +3896,22 @@ function ChatViewContent(props: ChatViewProps) {
         id: `branch-mismatch:${activeThread?.id ?? "unknown"}:${localCheckoutBranchMismatch.threadBranch}:${localCheckoutBranchMismatch.currentBranch}`,
         variant: "warning",
         icon: <TriangleAlertIcon />,
-        title: "Branches diverged",
+        title: "You're on a different branch",
         className:
           "text-base sm:text-sm [&>div]:items-start max-sm:[&>div]:flex-wrap max-sm:[&>div>div:last-child]:w-full max-sm:[&>div>div:last-child]:self-start dark:shadow-none",
         actionClassName:
           "max-sm:w-full max-sm:border-t max-sm:border-border/60 max-sm:pt-2 max-sm:pl-6 sm:border-l sm:border-border/60 sm:pl-3",
         description: (
           <p className="text-pretty">
-            Thread{" "}
+            This thread is on{" "}
             <code className="font-medium text-foreground">
               {localCheckoutBranchMismatch.threadBranch}
             </code>
-            <span aria-hidden="true"> · </span>
-            Checkout{" "}
+            , but you're currently checked out at{" "}
             <code className="font-medium text-foreground">
               {localCheckoutBranchMismatch.currentBranch}
             </code>
-            . Sending a message will update the thread branch.
+            . Sending a message will update the thread.
           </p>
         ),
         actions: (
@@ -3923,7 +3922,7 @@ function ChatViewContent(props: ChatViewProps) {
               disabled={isRepairingBranch}
               onClick={() => void handleUpdateThreadToCheckout()}
             >
-              {branchRepairAction === "update-thread" ? "Updating..." : "Update thread"}
+              {branchRepairAction === "update-thread" ? "Moving..." : "Move thread here"}
             </Button>
             <Button
               size="xs"
@@ -3931,7 +3930,7 @@ function ChatViewContent(props: ChatViewProps) {
               disabled={isRepairingBranch}
               onClick={() => void handleSwitchCheckoutToThread()}
             >
-              {branchRepairAction === "switch-checkout" ? "Switching..." : "Switch checkout"}
+              {branchRepairAction === "switch-checkout" ? "Switching..." : "Checkout thread branch"}
             </Button>
           </>
         ),

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1117,12 +1117,12 @@ export default function GitActionsControl({
     activeDraftThread.worktreePath === null;
 
   useEffect(() => {
-    if (isGitActionRunning || isSelectingWorktreeBase) {
+    if (isGitActionRunning || isSelectingWorktreeBase || activeServerThread) {
       return;
     }
 
     const branchUpdate = resolveLiveThreadBranchUpdate({
-      threadBranch: activeServerThread?.branch ?? activeDraftThread?.branch ?? null,
+      threadBranch: activeDraftThread?.branch ?? null,
       gitStatus: gitStatusForActions,
     });
     if (!branchUpdate) {
@@ -1131,7 +1131,7 @@ export default function GitActionsControl({
 
     persistThreadBranchSync(branchUpdate.branch);
   }, [
-    activeServerThread?.branch,
+    activeServerThread,
     activeDraftThread?.branch,
     gitStatusForActions,
     isGitActionRunning,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
 import {
   ChangeRequestStatusIcon,
   prStatusIndicator,
+  PrStatusTooltipContent,
   resolveThreadPr,
   terminalStatusFromRunningIds,
   ThreadStatusLabel,
@@ -460,7 +461,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
       lastVisitedAt,
     },
   });
-  const pr = resolveThreadPr(thread.branch, gitStatus.data);
+  const pr = resolveThreadPr({
+    threadBranch: thread.branch,
+    gitStatus: gitStatus.data,
+    hasDedicatedWorktree: thread.worktreePath !== null,
+  });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
   const terminalStatus = terminalStatusFromRunningIds(runningTerminalIds);
   const isConfirmingArchive = confirmingArchiveThreadKey === threadKey && !isThreadRunning;
@@ -700,7 +705,9 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
                   </button>
                 }
               />
-              <TooltipPopup side="top">{prStatus.tooltip}</TooltipPopup>
+              <TooltipPopup side="top">
+                <PrStatusTooltipContent status={prStatus} />
+              </TooltipPopup>
             </Tooltip>
           )}
           {threadStatus && <ThreadStatusLabel status={threadStatus} />}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -210,8 +210,7 @@ function SidebarV2ThreadTooltip({
             <div className="flex min-w-0 items-start gap-2 text-warning">
               <CircleAlertIcon aria-hidden className="mt-0.5 size-4 shrink-0 stroke-current" />
               <div className="min-w-0 flex-1 wrap-break-word leading-5">
-                Thread branch differs from active checkout {branchMismatch.currentBranch}; sending a
-                message will update the thread branch
+                You're currently checked out on another branch.
               </div>
             </div>
           ) : null}

--- a/apps/web/src/components/SidebarV2.tsx
+++ b/apps/web/src/components/SidebarV2.tsx
@@ -83,6 +83,7 @@ import {
   resolveSidebarV2Status,
   sortThreadsForSidebarV2,
 } from "./Sidebar.logic";
+import { resolveLocalCheckoutBranchMismatch } from "./BranchToolbar.logic";
 import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ProviderInstanceIcon } from "./chat/ProviderInstanceIcon";
@@ -127,6 +128,7 @@ function SidebarV2ThreadTooltip({
   modelInstanceId,
   modelLabel,
   status,
+  branchMismatch,
 }: {
   thread: SidebarThreadSummary;
   projectTitle: string | null;
@@ -139,6 +141,10 @@ function SidebarV2ThreadTooltip({
     label: string;
     className: string;
     icon: "working" | "done" | null;
+  } | null;
+  branchMismatch: {
+    threadBranch: string;
+    currentBranch: string;
   } | null;
 }) {
   return (
@@ -197,6 +203,15 @@ function SidebarV2ThreadTooltip({
               <GitBranchIcon className="size-4 shrink-0 stroke-muted-foreground" />
               <div className="min-w-0 flex-1 wrap-break-word text-foreground/90">
                 {thread.branch}
+              </div>
+            </div>
+          ) : null}
+          {branchMismatch ? (
+            <div className="flex min-w-0 items-start gap-2 text-warning">
+              <CircleAlertIcon aria-hidden className="mt-0.5 size-4 shrink-0 stroke-current" />
+              <div className="min-w-0 flex-1 wrap-break-word leading-5">
+                Thread branch differs from active checkout {branchMismatch.currentBranch}; sending a
+                message will update the thread branch
               </div>
             </div>
           ) : null}
@@ -321,14 +336,24 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
 
   const gitCwd = thread.worktreePath ?? props.projectCwd;
   const gitStatus = useEnvironmentQuery(
-    thread.branch != null && gitCwd !== null
+    (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },
         })
       : null,
   );
-  const pr = resolveThreadPr(thread.branch, gitStatus.data);
+  const branchMismatch = resolveLocalCheckoutBranchMismatch({
+    effectiveEnvMode: thread.worktreePath === null ? "local" : "worktree",
+    activeWorktreePath: thread.worktreePath,
+    activeThreadBranch: thread.branch,
+    currentGitBranch: gitStatus.data?.refName ?? null,
+  });
+  const pr = resolveThreadPr({
+    threadBranch: thread.branch,
+    gitStatus: gitStatus.data,
+    hasDedicatedWorktree: thread.worktreePath !== null,
+  });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
   // Report the PR state up: the parent partitions rows with effectiveSettled,
   // and a merged/closed PR auto-settles a thread — data only rows have.
@@ -360,6 +385,7 @@ const SidebarV2Row = memo(function SidebarV2Row(props: {
       modelInstanceId={modelInstanceId}
       modelLabel={modelLabel}
       status={topStatus}
+      branchMismatch={branchMismatch}
     />
   );
 

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -18,8 +18,8 @@ function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
       number: 42,
       title: "PR branch",
       url: "https://github.com/pingdotgg/t3code/pull/42",
-      baseBranch: "main",
-      headBranch: "feature/current",
+      baseRef: "main",
+      headRef: "feature/current",
       state: "open",
     },
     ...overrides,
@@ -64,7 +64,7 @@ describe("resolveThreadPr", () => {
 
 describe("prStatusIndicator", () => {
   it("formats PR tooltips with number, uppercase status, and title", () => {
-    expect(prStatusIndicator(status().pr)).toMatchObject({
+    expect(prStatusIndicator(status().pr, undefined)).toMatchObject({
       tooltip: "PR #42 - Open: PR branch",
       tooltipLead: "PR #42 - Open",
       tooltipTitle: "PR branch",

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -1,5 +1,5 @@
 import type { VcsStatusResult } from "@t3tools/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "vite-plus/test";
 
 import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
 

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -1,0 +1,63 @@
+import type { VcsStatusResult } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import { resolveThreadPr } from "./ThreadStatusIndicators";
+
+function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
+  return {
+    isRepo: true,
+    hasPrimaryRemote: true,
+    isDefaultRef: false,
+    refName: "feature/current",
+    hasWorkingTreeChanges: false,
+    workingTree: { files: [], insertions: 0, deletions: 0 },
+    hasUpstream: true,
+    aheadCount: 0,
+    behindCount: 0,
+    pr: {
+      number: 42,
+      title: "PR branch",
+      url: "https://github.com/pingdotgg/t3code/pull/42",
+      baseBranch: "main",
+      headBranch: "feature/current",
+      state: "open",
+    },
+    ...overrides,
+  };
+}
+
+describe("resolveThreadPr", () => {
+  it("keeps local-checkout PR indicators scoped to the stored thread branch", () => {
+    expect(
+      resolveThreadPr({
+        threadBranch: "feature/other",
+        gitStatus: status(),
+        hasDedicatedWorktree: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("shows PR indicators for dedicated worktree threads even when branch metadata is stale", () => {
+    const gitStatus = status();
+
+    expect(
+      resolveThreadPr({
+        threadBranch: "feature/old-name",
+        gitStatus,
+        hasDedicatedWorktree: true,
+      }),
+    ).toBe(gitStatus.pr);
+  });
+
+  it("shows PR indicators for dedicated worktree threads even when branch metadata is missing", () => {
+    const gitStatus = status();
+
+    expect(
+      resolveThreadPr({
+        threadBranch: null,
+        gitStatus,
+        hasDedicatedWorktree: true,
+      }),
+    ).toBe(gitStatus.pr);
+  });
+});

--- a/apps/web/src/components/ThreadStatusIndicators.test.ts
+++ b/apps/web/src/components/ThreadStatusIndicators.test.ts
@@ -1,7 +1,7 @@
 import type { VcsStatusResult } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { resolveThreadPr } from "./ThreadStatusIndicators";
+import { prStatusIndicator, resolveThreadPr } from "./ThreadStatusIndicators";
 
 function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
   return {
@@ -59,5 +59,15 @@ describe("resolveThreadPr", () => {
         hasDedicatedWorktree: true,
       }),
     ).toBe(gitStatus.pr);
+  });
+});
+
+describe("prStatusIndicator", () => {
+  it("formats PR tooltips with number, uppercase status, and title", () => {
+    expect(prStatusIndicator(status().pr)).toMatchObject({
+      tooltip: "PR #42 - Open: PR branch",
+      tooltipLead: "PR #42 - Open",
+      tooltipTitle: "PR branch",
+    });
   });
 });

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -39,16 +39,13 @@ export function prStatusIndicator(
   pr: ThreadPr,
   provider: VcsStatusResult["sourceControlProvider"] | null | undefined,
 ): PrStatusIndicator | null {
-function formatPrState(state: NonNullable<ThreadPr>["state"]): string {
-  return state.charAt(0).toUpperCase() + state.slice(1);
-}
+  function formatPrState(state: NonNullable<ThreadPr>["state"]): string {
+    return state.charAt(0).toUpperCase() + state.slice(1);
+  }
 
-function formatPrStatusLead(
-  pr: NonNullable<ThreadPr>,
-  changeRequestShortName: string,
-): string {
-  return `${changeRequestShortName} #${pr.number} - ${formatPrState(pr.state)}`;
-}
+  function formatPrStatusLead(pr: NonNullable<ThreadPr>, changeRequestShortName: string): string {
+    return `${changeRequestShortName} #${pr.number} - ${formatPrState(pr.state)}`;
+  }
   if (!pr) return null;
   const presentation = resolveChangeRequestPresentation(provider);
 

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -237,7 +237,7 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
   const threadProjectCwd = threadProject?.workspaceRoot ?? null;
   const gitCwd = thread.worktreePath ?? threadProjectCwd;
   const gitStatus = useEnvironmentQuery(
-    thread.branch != null && gitCwd !== null
+    (thread.branch != null || thread.worktreePath !== null) && gitCwd !== null
       ? vcsEnvironment.status({
           environmentId: thread.environmentId,
           input: { cwd: gitCwd },

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -22,6 +22,8 @@ export interface PrStatusIndicator {
   label: string;
   colorClass: string;
   tooltip: string;
+  tooltipLead: string;
+  tooltipTitle: string;
   url: string;
 }
 
@@ -37,14 +39,29 @@ export function prStatusIndicator(
   pr: ThreadPr,
   provider: VcsStatusResult["sourceControlProvider"] | null | undefined,
 ): PrStatusIndicator | null {
+function formatPrState(state: NonNullable<ThreadPr>["state"]): string {
+  return state.charAt(0).toUpperCase() + state.slice(1);
+}
+
+function formatPrStatusLead(
+  pr: NonNullable<ThreadPr>,
+  changeRequestShortName: string,
+): string {
+  return `${changeRequestShortName} #${pr.number} - ${formatPrState(pr.state)}`;
+}
   if (!pr) return null;
   const presentation = resolveChangeRequestPresentation(provider);
+
+  const tooltipLead = formatPrStatusLead(pr, presentation.shortName);
+  const tooltip = `${tooltipLead}: ${pr.title}`;
 
   if (pr.state === "open") {
     return {
       label: `${presentation.shortName} open`,
       colorClass: "text-emerald-600 dark:text-emerald-300/90",
-      tooltip: `#${pr.number} ${presentation.shortName} open: ${pr.title}`,
+      tooltip,
+      tooltipLead,
+      tooltipTitle: pr.title,
       url: pr.url,
     };
   }
@@ -52,7 +69,9 @@ export function prStatusIndicator(
     return {
       label: `${presentation.shortName} closed`,
       colorClass: "text-zinc-500 dark:text-zinc-400/80",
-      tooltip: `#${pr.number} ${presentation.shortName} closed: ${pr.title}`,
+      tooltip,
+      tooltipLead,
+      tooltipTitle: pr.title,
       url: pr.url,
     };
   }
@@ -60,7 +79,9 @@ export function prStatusIndicator(
     return {
       label: `${presentation.shortName} merged`,
       colorClass: "text-violet-600 dark:text-violet-300/90",
-      tooltip: `#${pr.number} ${presentation.shortName} merged: ${pr.title}`,
+      tooltip,
+      tooltipLead,
+      tooltipTitle: pr.title,
       url: pr.url,
     };
   }
@@ -71,11 +92,31 @@ export function ChangeRequestStatusIcon({ className }: { className?: string }) {
   return <GitPullRequestIcon className={className} />;
 }
 
-export function resolveThreadPr(
-  threadBranch: string | null,
-  gitStatus: VcsStatusResult | null,
-): ThreadPr | null {
-  if (threadBranch === null || gitStatus === null || gitStatus.refName !== threadBranch) {
+export function PrStatusTooltipContent({ status }: { status: PrStatusIndicator }) {
+  return (
+    <span className="flex max-w-[min(34rem,calc(100vw-2rem))] items-stretch overflow-hidden whitespace-nowrap">
+      <span className="shrink-0 pr-2 font-medium">{status.tooltipLead}</span>
+      <span className="min-h-4 shrink-0 border-border/70 border-l" aria-hidden="true" />
+      <span className="min-w-0 truncate pl-2">{status.tooltipTitle}</span>
+    </span>
+  );
+}
+
+export function resolveThreadPr(input: {
+  threadBranch: string | null;
+  gitStatus: VcsStatusResult | null;
+  hasDedicatedWorktree: boolean;
+}): ThreadPr | null {
+  const { threadBranch, gitStatus, hasDedicatedWorktree } = input;
+  if (gitStatus === null) {
+    return null;
+  }
+
+  if (hasDedicatedWorktree) {
+    return gitStatus.pr ?? null;
+  }
+
+  if (threadBranch === null || gitStatus.refName !== threadBranch) {
     return null;
   }
 
@@ -206,7 +247,11 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
         })
       : null,
   );
-  const pr = resolveThreadPr(thread.branch, gitStatus.data);
+  const pr = resolveThreadPr({
+    threadBranch: thread.branch,
+    gitStatus: gitStatus.data,
+    hasDedicatedWorktree: thread.worktreePath !== null,
+  });
   const prStatus = prStatusIndicator(pr, gitStatus.data?.sourceControlProvider);
   const threadStatus = resolveThreadStatusPill({
     thread: {
@@ -233,7 +278,9 @@ export function ThreadRowLeadingStatus({ thread }: { thread: SidebarThreadSummar
           >
             <ChangeRequestStatusIcon className="size-3" />
           </TooltipTrigger>
-          <TooltipPopup side="top">{prStatus.tooltip}</TooltipPopup>
+          <TooltipPopup side="top">
+            <PrStatusTooltipContent status={prStatus} />
+          </TooltipPopup>
         </Tooltip>
       ) : null}
       {threadStatus ? <ThreadStatusLabel status={threadStatus} /> : null}

--- a/apps/web/src/components/chat/ComposerBannerStack.test.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.test.tsx
@@ -34,4 +34,22 @@ describe("ComposerBannerStack", () => {
 
     expect(markup).not.toContain("data-composer-banner-stack-expanded-items");
   });
+
+  it("applies item-specific surface and action layout classes", () => {
+    const markup = renderToStaticMarkup(
+      <ComposerBannerStack
+        items={[
+          {
+            ...banner("branch"),
+            className: "branch-surface",
+            actionClassName: "branch-actions",
+            actions: <button type="button">Repair</button>,
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("branch-surface");
+    expect(markup).toContain("branch-actions");
+  });
 });

--- a/apps/web/src/components/chat/ComposerBannerStack.tsx
+++ b/apps/web/src/components/chat/ComposerBannerStack.tsx
@@ -30,6 +30,8 @@ export interface ComposerBannerStackItem {
   readonly title: ReactNode;
   readonly description?: ReactNode;
   readonly actions?: ReactNode;
+  readonly className?: string;
+  readonly actionClassName?: string;
   readonly dismissLabel?: string;
   readonly onDismiss?: () => void;
 }
@@ -171,17 +173,18 @@ function ComposerBannerStackAlert({
   const dismissOnly = item.onDismiss && !item.actions;
 
   return (
-    <Alert variant={item.variant}>
+    <Alert variant={item.variant} className={item.className}>
       {item.icon}
       <AlertTitle>{item.title}</AlertTitle>
       {item.description ? <AlertDescription>{item.description}</AlertDescription> : null}
       {item.actions || item.onDismiss ? (
         <AlertAction
-          className={
+          className={cn(
+            item.actionClassName,
             dismissOnly
               ? "max-sm:col-start-3 max-sm:row-start-1 max-sm:mt-0 max-sm:self-start"
-              : undefined
-          }
+              : undefined,
+          )}
         >
           {item.actions}
           {item.onDismiss ? (


### PR DESCRIPTION
## What Changed

Improves the local branch mismatch warning in the branch picker.

- Highlights the branch picker with a warning color when the thread branch and current checkout differ.
- Adds an inline warning icon to the picker.
- Shows a popover above the picker explaining the mismatch.
- Adds actions to either switch the checkout back to the thread branch or update the thread to use the current checkout.
- Keeps server thread branch metadata from being overwritten when the shared local checkout changes.
- Tightens PR/status indicator behavior so local checkout PR state is scoped to the relevant thread branch.
- Improves PR fetching so that forked repos with PR on upstream not origin allow showing PR status in application

## Why

When using local checkout mode, the active Git branch can drift away from the branch a thread was last associated with. Previously this was easy to miss and could lead to continuing work on the wrong branch.

This makes the mismatch visible in-place and gives users clear recovery actions without changing branches automatically.

The thread’s associated branch should only change when the user intentionally chooses a branch for the thread, creates/checks out a branch through the picker, or clicks `Use current` in the warning popover. It should not change just because the shared local checkout moved while viewing an existing server thread.


## UI Changes

<img width="875" height="202" alt="image" src="https://github.com/user-attachments/assets/c63777da-ec58-48d3-a50d-fad77caa08b0" />

<img width="535" height="262" alt="image" src="https://github.com/user-attachments/assets/62f9adc7-b7e2-4b82-be9f-23d460295415" />



Screenshots/video to attach:
- Before screenshot of the old picker state.
- After screenshot of the warning picker and popover.
- Short video showing hover/click on the warning icon and the `Use current` / `Switch` actions.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread branch drift and PR matching for local checkouts and worktrees
> - Fixes `resolveThreadPr` to return the correct PR for dedicated worktrees (ignoring stale branch metadata) and to require `gitStatus.refName` to match `threadBranch` for local checkouts.
> - Reworks `matchesBranchHeadContext` in [GitManager.ts](https://github.com/pingdotgg/t3code/pull/2284/files#diff-cd0cda31b0a40baa44db979a23ee89f041c9bae39aa597513a8628cccebd0337) to use normalized head identities, correctly rejecting cross-repo PRs in same-repo contexts and vice versa, and tolerating missing GitHub head identity metadata.
> - Adds `resolveLocalCheckoutBranchMismatch` to detect when the active git checkout differs from the thread's stored branch, and surfaces a warning banner in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2284/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) with actions to repair the mismatch or update the thread branch on send.
> - Adds `resolveThreadMetadataUpdateForNextTurn` to compute minimal thread metadata updates (model and/or branch) before sending a message.
> - Stops auto-syncing branch metadata from checkout in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/2284/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) when a server thread is active.
> - Risk: branch metadata persistence behavior changes on send when a local checkout mismatch is detected — the thread branch will be silently updated to the current checkout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3910e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/2284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes git PR reuse/matching and when thread branch metadata updates from the UI; mistakes could show wrong PRs or leave thread branch out of sync, though behavior is covered by new tests.
> 
> **Overview**
> **Prevents silent drift** between a thread’s stored branch and the shared local checkout, and **tightens when PRs and status indicators apply** to a thread.
> 
> In **local checkout** mode, the branch picker now detects when the thread branch and current Git checkout differ (`resolveLocalCheckoutBranchMismatch`), highlights the trigger, and shows a **“Branches diverged”** panel with **Update thread** (reassign to checkout) or **Switch checkout** (checkout the thread branch). **`GitActionsControl`** no longer auto-syncs thread branch from live git status while a **server-backed thread** is active—only draft threads still reconcile from status.
> 
> **PR indicators** (`resolveThreadPr`) now require the stored thread branch to match git status for local checkouts, but still show PR state for **dedicated worktree** threads even when thread branch metadata is stale or missing. PR tooltips use a richer **`PrStatusTooltipContent`** layout.
> 
> On the server, **`matchesBranchHeadContext`** is exported and reworked to compare expected vs PR head identity more carefully: reject same-repo PRs for cross-repo head contexts, refuse ambiguous PRs when GitHub omits head repo/owner on cross-repo lookups, and accept cross-repo PR metadata when the checkout remote is the fork. New **`GitManager`** tests cover these matching paths and fork PR reuse behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f762024b80f81708be8ce77561d17a2dc422c533. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->