### PR TITLE
fix: lower toast z-index so dropdowns render above toasts

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -556,3 +556,23 @@ label:has(> select#reasoning-effort) select {
 .dark .model-picker-list::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.15);
 }
+
+/* When an interactive overlay (menu, select, popover, combobox, autocomplete) is open
+   but no dialog is covering it, lower toast z-index so the overlay renders above toasts. */
+body:has(
+    [data-slot="menu-positioner"],
+    [data-slot="select-positioner"],
+    [data-slot="popover-positioner"],
+    [data-slot="combobox-positioner"],
+    [data-slot="autocomplete-positioner"]
+  ):not(
+    :has(
+      [data-slot="dialog-backdrop"],
+      [data-slot="command-dialog-backdrop"],
+      [data-slot="sheet-backdrop"],
+      [data-slot="alert-dialog-backdrop"]
+    )
+  )
+  [data-slot="toast-viewport"] {
+  z-index: 40;
+}


### PR DESCRIPTION
Closes #2287

## What Changed

Lowered the toast viewport z-index from `z-100` to `z-40` in `apps/web/src/components/ui/toast.tsx`.

## Why

Menus and popovers use `z-50`, so when a toast is visible and a user opens a dropdown (e.g. "Open" or "Commit & push" in the toolbar), the dropdown renders behind the toast. Interactive overlays should take priority over passive notifications.

## UI Changes


https://github.com/user-attachments/assets/e9cff7a0-deaf-4818-b3e5-d526a24a14eb



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only stacking change; main risk is `:has()` selector support/behavior differences potentially affecting toast layering in some browsers.
> 
> **Overview**
> Adjusts toast stacking so interactive overlays (menus/selects/popovers/comboboxes/autocomplete) render above notifications.
> 
> Adds a `body:has(...)` CSS rule in `index.css` that lowers `[data-slot="toast-viewport"]` to `z-index: 40` when an overlay is open, while keeping existing layering when a dialog/sheet/alert backdrop is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14dc47c3341aa0a8a781c76c396f6939ee815434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lower toast z-index when dropdowns are open so they render above toasts
> Adds a CSS rule in [index.css](https://github.com/pingdotgg/t3code/pull/2288/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) that sets `[data-slot="toast-viewport"]` to `z-index: 40` when any menu, select, popover, combobox, or autocomplete positioner is open and no dialog backdrop is present. This prevents toasts from overlapping dropdowns outside of dialog contexts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 14dc47c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->