### PR TITLE
Fix provider cache atomic write temp path collisions

### DIFF
--- a/apps/server/src/atomicWrite.ts
+++ b/apps/server/src/atomicWrite.ts
@@ -1,4 +1,5 @@
-import { Effect, FileSystem, Path, Random } from "effect";
+import { Effect, FileSystem, Path } from "effect";
+import * as Random from "effect/Random";
 
 export const writeFileStringAtomically = (input: {
   readonly filePath: string;

--- a/apps/server/src/atomicWrite.ts
+++ b/apps/server/src/atomicWrite.ts
@@ -1,28 +1,24 @@
-import * as Crypto from "node:crypto";
-
-import { Effect, FileSystem, Path } from "effect";
-
-export const makeAtomicWriteTempPath = (filePath: string): string =>
-  `${filePath}.${process.pid}.${Crypto.randomUUID()}.tmp`;
+import { Effect, FileSystem, Path, Random } from "effect";
 
 export const writeFileStringAtomically = (input: {
   readonly filePath: string;
   readonly contents: string;
-}) => {
-  const tempPath = makeAtomicWriteTempPath(input.filePath);
-  return Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
+}) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const tempFileId = yield* Random.nextUUIDv4;
+      const targetDirectory = path.dirname(input.filePath);
 
-    yield* fs.makeDirectory(path.dirname(input.filePath), { recursive: true });
-    yield* fs.writeFileString(tempPath, input.contents);
-    yield* fs.rename(tempPath, input.filePath);
-  }).pipe(
-    Effect.ensuring(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        yield* fs.remove(tempPath, { force: true }).pipe(Effect.ignore({ log: true }));
-      }),
-    ),
+      yield* fs.makeDirectory(targetDirectory, { recursive: true });
+      const tempDirectory = yield* fs.makeTempDirectoryScoped({
+        directory: targetDirectory,
+        prefix: `${path.basename(input.filePath)}.`,
+      });
+      const tempPath = path.join(tempDirectory, `${tempFileId}.tmp`);
+
+      yield* fs.writeFileString(tempPath, input.contents);
+      yield* fs.rename(tempPath, input.filePath);
+    }),
   );
-};

--- a/apps/server/src/atomicWrite.ts
+++ b/apps/server/src/atomicWrite.ts
@@ -1,0 +1,28 @@
+import * as Crypto from "node:crypto";
+
+import { Effect, FileSystem, Path } from "effect";
+
+export const makeAtomicWriteTempPath = (filePath: string): string =>
+  `${filePath}.${process.pid}.${Crypto.randomUUID()}.tmp`;
+
+export const writeFileStringAtomically = (input: {
+  readonly filePath: string;
+  readonly contents: string;
+}) => {
+  const tempPath = makeAtomicWriteTempPath(input.filePath);
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    yield* fs.makeDirectory(path.dirname(input.filePath), { recursive: true });
+    yield* fs.writeFileString(tempPath, input.contents);
+    yield* fs.rename(tempPath, input.filePath);
+  }).pipe(
+    Effect.ensuring(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.remove(tempPath, { force: true }).pipe(Effect.ignore({ log: true }));
+      }),
+    ),
+  );
+};

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -46,6 +46,7 @@ import {
 } from "effect";
 import * as Semaphore from "effect/Semaphore";
 import { ServerConfig } from "./config.ts";
+import { writeFileStringAtomically } from "./atomicWrite.ts";
 import { fromLenientJson } from "@t3tools/shared/schemaJson";
 
 type WhenToken =
@@ -670,14 +671,17 @@ const makeKeybindings = Effect.gen(function* () {
   });
 
   const writeConfigAtomically = (rules: readonly KeybindingRule[]) => {
-    const tempPath = `${keybindingsConfigPath}.${process.pid}.${Date.now()}.tmp`;
-
     return Schema.encodeEffect(KeybindingsConfigPrettyJson)(rules).pipe(
       Effect.map((encoded) => `${encoded}\n`),
-      Effect.tap(() => fs.makeDirectory(path.dirname(keybindingsConfigPath), { recursive: true })),
-      Effect.tap((encoded) => fs.writeFileString(tempPath, encoded)),
-      Effect.flatMap(() => fs.rename(tempPath, keybindingsConfigPath)),
-      Effect.ensuring(fs.remove(tempPath, { force: true }).pipe(Effect.ignore({ log: true }))),
+      Effect.flatMap((encoded) =>
+        writeFileStringAtomically({
+          filePath: keybindingsConfigPath,
+          contents: encoded,
+        }).pipe(
+          Effect.provideService(FileSystem.FileSystem, fs),
+          Effect.provideService(Path.Path, path),
+        ),
+      ),
       Effect.mapError(
         (cause) =>
           new KeybindingsConfigError({

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -110,8 +110,8 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
 
       const persistedProvider = yield* readProviderStatusCache(filePath);
       assert.deepStrictEqual(
-        [initialProvider, updatedProvider].some((provider) =>
-          JSON.stringify(provider) === JSON.stringify(persistedProvider),
+        [initialProvider, updatedProvider].some(
+          (provider) => JSON.stringify(provider) === JSON.stringify(persistedProvider),
         ),
         true,
       );

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -2,6 +2,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { ServerProvider } from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import { Effect, FileSystem } from "effect";
+import { afterEach, vi } from "vitest";
 
 import {
   hydrateCachedProvider,
@@ -25,6 +26,10 @@ const makeProvider = (
   slashCommands: [],
   skills: [],
   ...overrides,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 it.layer(NodeServices.layer)("providerStatusCache", (it) => {
@@ -70,6 +75,46 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
       assert.deepStrictEqual(yield* readProviderStatusCache(codexPath), codexProvider);
       assert.deepStrictEqual(yield* readProviderStatusCache(claudePath), claudeProvider);
       assert.deepStrictEqual(yield* readProviderStatusCache(openCodePath), openCodeProvider);
+    }),
+  );
+
+  it.effect("supports overlapping writes for the same provider cache file", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-provider-cache-overlap-" });
+      const filePath = resolveProviderStatusCachePath({
+        cacheDir: tempDir,
+        provider: "opencode",
+      });
+      const stableNow = 1_776_841_093_506;
+      vi.spyOn(Date, "now").mockReturnValue(stableNow);
+
+      const initialProvider = makeProvider("opencode", {
+        auth: { status: "unknown", type: "opencode" },
+      });
+      const updatedProvider = makeProvider("opencode", {
+        version: "1.0.1",
+        auth: { status: "unknown", type: "opencode" },
+      });
+
+      const results = yield* Effect.all(
+        [
+          Effect.exit(writeProviderStatusCache({ filePath, provider: initialProvider })),
+          Effect.exit(writeProviderStatusCache({ filePath, provider: updatedProvider })),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      assert.strictEqual(results[0]._tag, "Success");
+      assert.strictEqual(results[1]._tag, "Success");
+
+      const persistedProvider = yield* readProviderStatusCache(filePath);
+      assert.deepStrictEqual(
+        [initialProvider, updatedProvider].some((provider) =>
+          JSON.stringify(provider) === JSON.stringify(persistedProvider),
+        ),
+        true,
+      );
     }),
   );
 

--- a/apps/server/src/provider/providerStatusCache.test.ts
+++ b/apps/server/src/provider/providerStatusCache.test.ts
@@ -2,7 +2,6 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { ServerProvider } from "@t3tools/contracts";
 import { assert, it } from "@effect/vitest";
 import { Effect, FileSystem } from "effect";
-import { afterEach, vi } from "vitest";
 
 import {
   hydrateCachedProvider,
@@ -26,10 +25,6 @@ const makeProvider = (
   slashCommands: [],
   skills: [],
   ...overrides,
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
 });
 
 it.layer(NodeServices.layer)("providerStatusCache", (it) => {
@@ -75,46 +70,6 @@ it.layer(NodeServices.layer)("providerStatusCache", (it) => {
       assert.deepStrictEqual(yield* readProviderStatusCache(codexPath), codexProvider);
       assert.deepStrictEqual(yield* readProviderStatusCache(claudePath), claudeProvider);
       assert.deepStrictEqual(yield* readProviderStatusCache(openCodePath), openCodeProvider);
-    }),
-  );
-
-  it.effect("supports overlapping writes for the same provider cache file", () =>
-    Effect.gen(function* () {
-      const fs = yield* FileSystem.FileSystem;
-      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-provider-cache-overlap-" });
-      const filePath = resolveProviderStatusCachePath({
-        cacheDir: tempDir,
-        provider: "opencode",
-      });
-      const stableNow = 1_776_841_093_506;
-      vi.spyOn(Date, "now").mockReturnValue(stableNow);
-
-      const initialProvider = makeProvider("opencode", {
-        auth: { status: "unknown", type: "opencode" },
-      });
-      const updatedProvider = makeProvider("opencode", {
-        version: "1.0.1",
-        auth: { status: "unknown", type: "opencode" },
-      });
-
-      const results = yield* Effect.all(
-        [
-          Effect.exit(writeProviderStatusCache({ filePath, provider: initialProvider })),
-          Effect.exit(writeProviderStatusCache({ filePath, provider: updatedProvider })),
-        ],
-        { concurrency: "unbounded" },
-      );
-
-      assert.strictEqual(results[0]._tag, "Success");
-      assert.strictEqual(results[1]._tag, "Success");
-
-      const persistedProvider = yield* readProviderStatusCache(filePath);
-      assert.deepStrictEqual(
-        [initialProvider, updatedProvider].some(
-          (provider) => JSON.stringify(provider) === JSON.stringify(persistedProvider),
-        ),
-        true,
-      );
     }),
   );
 

--- a/apps/server/src/provider/providerStatusCache.ts
+++ b/apps/server/src/provider/providerStatusCache.ts
@@ -1,6 +1,8 @@
 import * as nodePath from "node:path";
 import { type ServerProvider, ServerProvider as ServerProviderSchema } from "@t3tools/contracts";
-import { Cause, Effect, FileSystem, Path, Schema } from "effect";
+import { Cause, Effect, FileSystem, Schema } from "effect";
+
+import { writeFileStringAtomically } from "../atomicWrite.ts";
 
 export const PROVIDER_CACHE_IDS = [
   "codex",
@@ -96,22 +98,8 @@ export const readProviderStatusCache = (filePath: string) =>
 export const writeProviderStatusCache = (input: {
   readonly filePath: string;
   readonly provider: ServerProvider;
-}) => {
-  const tempPath = `${input.filePath}.${process.pid}.${Date.now()}.tmp`;
-  return Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const encoded = `${JSON.stringify(input.provider, null, 2)}\n`;
-
-    yield* fs.makeDirectory(path.dirname(input.filePath), { recursive: true });
-    yield* fs.writeFileString(tempPath, encoded);
-    yield* fs.rename(tempPath, input.filePath);
-  }).pipe(
-    Effect.ensuring(
-      Effect.gen(function* () {
-        const fs = yield* FileSystem.FileSystem;
-        yield* fs.remove(tempPath, { force: true }).pipe(Effect.ignore({ log: true }));
-      }),
-    ),
-  );
-};
+}) =>
+  writeFileStringAtomically({
+    filePath: input.filePath,
+    contents: `${JSON.stringify(input.provider, null, 2)}\n`,
+  });

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -1,5 +1,6 @@
-import { Effect, FileSystem, Option, Path, Schema } from "effect";
+import { Effect, FileSystem, Option, Schema } from "effect";
 
+import { writeFileStringAtomically } from "./atomicWrite.ts";
 import { type ServerConfigShape } from "./config.ts";
 import { formatHostForUrl, isWildcardHost } from "./startupAccess.ts";
 
@@ -42,15 +43,9 @@ export const persistServerRuntimeState = (input: {
   readonly path: string;
   readonly state: PersistedServerRuntimeState;
 }) =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const pathService = yield* Path.Path;
-    const tempPath = `${input.path}.${process.pid}.${Date.now()}.tmp`;
-    return yield* fs.makeDirectory(pathService.dirname(input.path), { recursive: true }).pipe(
-      Effect.flatMap(() => fs.writeFileString(tempPath, `${JSON.stringify(input.state)}\n`)),
-      Effect.flatMap(() => fs.rename(tempPath, input.path)),
-      Effect.ensuring(fs.remove(tempPath, { force: true }).pipe(Effect.ignore({ log: true }))),
-    );
+  writeFileStringAtomically({
+    filePath: input.path,
+    contents: `${JSON.stringify(input.state)}\n`,
   });
 
 export const clearPersistedServerRuntimeState = (path: string) =>

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -240,6 +240,8 @@ const makeServerSettings = Effect.gen(function* () {
       filePath: settingsPath,
       contents: `${JSON.stringify(sparseSettings, null, 2)}\n`,
     }).pipe(
+      Effect.provideService(FileSystem.FileSystem, fs),
+      Effect.provideService(Path.Path, pathService),
       Effect.mapError(
         (cause) =>
           new ServerSettingsError({

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -39,6 +39,7 @@ import {
   Cause,
 } from "effect";
 import * as Semaphore from "effect/Semaphore";
+import { writeFileStringAtomically } from "./atomicWrite.ts";
 import { ServerConfig } from "./config.ts";
 import { type DeepPartial, deepMerge } from "@t3tools/shared/Struct";
 import { fromLenientJson } from "@t3tools/shared/schemaJson";
@@ -233,14 +234,12 @@ const makeServerSettings = Effect.gen(function* () {
   const getSettingsFromCache = Cache.get(settingsCache, cacheKey);
 
   const writeSettingsAtomically = (settings: ServerSettings) => {
-    const tempPath = `${settingsPath}.${process.pid}.${Date.now()}.tmp`;
     const sparseSettings = stripDefaultServerSettings(settings, DEFAULT_SERVER_SETTINGS) ?? {};
 
-    return Effect.succeed(`${JSON.stringify(sparseSettings, null, 2)}\n`).pipe(
-      Effect.tap(() => fs.makeDirectory(pathService.dirname(settingsPath), { recursive: true })),
-      Effect.tap((encoded) => fs.writeFileString(tempPath, encoded)),
-      Effect.flatMap(() => fs.rename(tempPath, settingsPath)),
-      Effect.ensuring(fs.remove(tempPath, { force: true }).pipe(Effect.ignore({ log: true }))),
+    return writeFileStringAtomically({
+      filePath: settingsPath,
+      contents: `${JSON.stringify(sparseSettings, null, 2)}\n`,
+    }).pipe(
       Effect.mapError(
         (cause) =>
           new ServerSettingsError({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

- introduced a shared atomic file write helper that now uses Effect-native UUID generation and scoped temp directories
- switched provider cache persistence to use the shared helper
- added a regression test covering overlapping writes to the same provider cache file
- migrated the other duplicated server-side atomic JSON writers to the same helper for consistency

## Why

Provider cache writes used temp filenames derived from `process.pid` and `Date.now()`. Two writes to the same cache file in the same process and same millisecond could pick the same temp path, causing one `rename()` to move the file and the other to fail with `ENOENT`. The helper now creates a scoped temp directory beside the target file and writes a UUID-named temp file before the final atomic rename, removing that collision class while keeping the implementation inside Effect APIs.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6610da53-e1b9-424c-b285-0dfd3ceb6462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6610da53-e1b9-424c-b285-0dfd3ceb6462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix temp path collisions in provider cache atomic writes by extracting `writeFileStringAtomically`
> - Introduces [atomicWrite.ts](https://github.com/pingdotgg/t3code/pull/2291/files#diff-2157eb2625b9817718e6132f30d21339c4919e5855d274070ef84597f4a18baf) with a `writeFileStringAtomically` utility that writes to a UUID-named temp file in a scoped temp directory co-located with the target, then renames it to the final path.
> - Replaces duplicated inline atomic-write logic (mkdir, write temp, rename, ensure cleanup) across [providerStatusCache.ts](https://github.com/pingdotgg/t3code/pull/2291/files#diff-6de08e2cd95df6ffd1cc93a059448e8a80f0392091e10e0d7aabd9b6b01dbb07), [serverRuntimeState.ts](https://github.com/pingdotgg/t3code/pull/2291/files#diff-b7e137a54141b0eed3e4f1279655a7ebb0e17e88a6ea34e1b4e65b942939dde8), [serverSettings.ts](https://github.com/pingdotgg/t3code/pull/2291/files#diff-ec910be99e19e00c0e09b15484059b34164d71de8d0026f4ba98471bbbb3680e), and [keybindings.ts](https://github.com/pingdotgg/t3code/pull/2291/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e) with calls to the new utility.
> - The original implementations shared a fixed temp filename suffix, causing collisions under concurrent writes; the UUID-based naming in the new utility prevents this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ad9e56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->