### PR TITLE
feat(keybindings): add mod+. shortcut to cycle agent trait

### DIFF
--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -69,6 +69,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
+  { key: "mod+.", command: "agent.cycle", when: "!terminalFocus" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2293,6 +2293,8 @@ export default function ChatView(props: ChatViewProps) {
       }
 
       if (command === "agent.cycle") {
+        event.preventDefault();
+        event.stopPropagation();
         const ctx = composerRef.current?.getSendContext();
         if (!ctx) return;
         const caps = getProviderModelCapabilities(
@@ -2302,8 +2304,6 @@ export default function ChatView(props: ChatViewProps) {
         );
         const agents = caps.agentOptions ?? [];
         if (agents.length < 2) return;
-        event.preventDefault();
-        event.stopPropagation();
         const store = useComposerDraftStore.getState();
         const draft = store.getComposerDraft(composerDraftTarget);
         const currentOpts =

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2292,6 +2292,39 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
 
+      if (command === "agent.cycle") {
+        const ctx = composerRef.current?.getSendContext();
+        if (!ctx) return;
+        const caps = getProviderModelCapabilities(
+          ctx.selectedProviderModels,
+          ctx.selectedModel,
+          ctx.selectedProvider,
+        );
+        const agents = caps.agentOptions ?? [];
+        if (agents.length < 2) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const store = useComposerDraftStore.getState();
+        const draft = store.getComposerDraft(composerDraftTarget);
+        const currentOpts =
+          (draft?.modelSelectionByProvider?.[ctx.selectedProvider]?.options as
+            | Record<string, unknown>
+            | undefined) ?? {};
+        const rawAgent = (currentOpts.agent as string | undefined) ?? null;
+        const effectiveAgent = rawAgent
+          ? agents.find((a) => a.value === rawAgent)
+          : (agents.find((a) => a.isDefault) ?? agents[0]);
+        const currentIndex = effectiveAgent ? agents.indexOf(effectiveAgent) : -1;
+        const nextAgent = agents[(currentIndex + 1) % agents.length]!;
+        store.setProviderModelOptions(
+          composerDraftTarget,
+          ctx.selectedProvider,
+          { ...currentOpts, agent: nextAgent.value },
+          { model: ctx.selectedModel, persistSticky: true },
+        );
+        return;
+      }
+
       const scriptId = projectScriptIdFromCommand(command);
       if (!scriptId || !activeProject) return;
       const script = activeProject.scripts.find((entry) => entry.id === scriptId);

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -32,6 +32,9 @@ import {
 } from "../ui/menu";
 import { useComposerDraftStore, DraftId } from "../../composerDraftStore";
 import { getProviderModelCapabilities } from "../../providerModels";
+import { shortcutLabelForCommand } from "../../keybindings";
+import { useServerKeybindings } from "../../rpc/serverState";
+import { Kbd } from "../ui/kbd";
 import { cn } from "~/lib/utils";
 
 type ProviderOptions = ProviderModelOptions[ProviderKind];
@@ -257,6 +260,8 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
+  const keybindings = useServerKeybindings();
+  const agentCycleLabel = shortcutLabelForCommand(keybindings, "agent.cycle");
   const updateModelOptions = useCallback(
     (nextOptions: ProviderOptions | undefined) => {
       if ("onModelOptionsChange" in persistence) {
@@ -452,7 +457,14 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
         <>
           {hasSectionsBeforeAgent ? <MenuDivider /> : null}
           <MenuGroup>
-            <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Agent</div>
+            <div className="flex items-center justify-between px-2 py-1.5 font-medium text-muted-foreground text-xs">
+              <span>Agent</span>
+              {agentCycleLabel ? (
+                <Kbd className="h-4 min-w-0 shrink-0 rounded-sm px-1.5 text-[10px]">
+                  {agentCycleLabel}
+                </Kbd>
+              ) : null}
+            </div>
             <MenuRadioGroup
               value={selectedAgent ?? ""}
               onValueChange={(value) => {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -138,6 +138,11 @@ const DEFAULT_BINDINGS = compile([
     command: "modelPicker.jump.3",
     whenAst: whenIdentifier("modelPickerOpen"),
   },
+  {
+    shortcut: modShortcut("."),
+    command: "agent.cycle",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
 ]);
 
 describe("isTerminalToggleShortcut", () => {
@@ -314,6 +319,8 @@ describe("shortcutLabelForCommand", () => {
       }),
       "⌘3",
     );
+    assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "agent.cycle", "MacIntel"), "⌘.");
+    assert.strictEqual(shortcutLabelForCommand(DEFAULT_BINDINGS, "agent.cycle", "Linux"), "Ctrl+.");
   });
 
   it("returns null for commands shadowed by a later conflicting shortcut", () => {

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -57,6 +57,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "chat.new",
   "chat.newLocal",
   "editor.openFavorite",
+  "agent.cycle",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,
 ] as const;


### PR DESCRIPTION
## What Changed

Add an `agent.cycle` keybinding command with a default `mod+.` binding (when not in terminal focus). Pressing it cycles through the available agent options (e.g. Build, Plan) for the current provider model, wrapping from last to first. No-ops when fewer than 2 agents are available.

The traits dropdown now displays the `agent.cycle` shortcut label next to the "Agent" section header, so users can discover the hotkey without memorizing it.

**Changes across 5 files (+55 lines):**
- `packages/contracts/src/keybindings.ts` — add `agent.cycle` to static keybinding commands
- `apps/server/src/keybindings.ts` — add default `mod+.` binding
- `apps/web/src/components/ChatView.tsx` — handle `agent.cycle` in the existing keydown handler
- `apps/web/src/components/chat/TraitsPicker.tsx` — show the `agent.cycle` shortcut label (e.g. `⌘.`) in the traits dropdown Agent section header
- `apps/web/src/keybindings.test.ts` — add test coverage for the new binding and its label rendering

## Why

OpenCode uses `mod+.` to cycle agents. T3 Code supports agent selection via the traits dropdown but has no keyboard shortcut for it. This adds parity for keyboard-driven workflows and makes the shortcut discoverable in the UI.

Closes #2299

## Screenshots

<img width="218" height="398" alt="hotkey-label" src="https://github.com/user-attachments/assets/3adeb447-7cea-4231-b646-45d4eb0de58d" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes (N/A)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mod+.` shortcut to cycle agent trait in the composer
> - Adds `agent.cycle` to the static keybinding commands and maps `mod+.` to it (when the terminal is not focused) in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/2300/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e).
> - In [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2300/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), handling `agent.cycle` computes the next agent from available provider/model capabilities in a cyclic order and persists the selection with `persistSticky=true`.
> - The Agent section header in [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/2300/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45) now displays the active shortcut label (e.g. `⌘.` on Mac, `Ctrl+.` on Linux) using the `Kbd` component.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea81efa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->