### PR TITLE
fix(web): ignore stale runtime projection snapshots

### DIFF
--- a/apps/web/src/environments/runtime/service.test.ts
+++ b/apps/web/src/environments/runtime/service.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldApplyTerminalEvent } from "./service";
+import {
+  shouldApplyProjectionEvent,
+  shouldApplyProjectionSnapshot,
+  shouldApplyTerminalEvent,
+} from "./service";
 
 describe("shouldApplyTerminalEvent", () => {
   it("applies terminal events for draft-only threads", () => {
@@ -35,6 +39,109 @@ describe("shouldApplyTerminalEvent", () => {
       shouldApplyTerminalEvent({
         serverThreadArchivedAt: null,
         hasDraftThread: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldApplyProjectionSnapshot", () => {
+  it("accepts the first snapshot for an environment", () => {
+    expect(
+      shouldApplyProjectionSnapshot({
+        current: null,
+        next: {
+          snapshotSequence: 1,
+          updatedAt: "2026-04-22T10:00:00.000Z",
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("drops snapshots with an older sequence", () => {
+    expect(
+      shouldApplyProjectionSnapshot({
+        current: {
+          sequence: 5,
+          updatedAt: "2026-04-22T10:05:00.000Z",
+        },
+        next: {
+          snapshotSequence: 4,
+          updatedAt: "2026-04-22T10:06:00.000Z",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("drops snapshots with the same sequence and older timestamp", () => {
+    expect(
+      shouldApplyProjectionSnapshot({
+        current: {
+          sequence: 5,
+          updatedAt: "2026-04-22T10:05:00.000Z",
+        },
+        next: {
+          snapshotSequence: 5,
+          updatedAt: "2026-04-22T10:04:59.000Z",
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts snapshots with the same sequence and a newer timestamp", () => {
+    expect(
+      shouldApplyProjectionSnapshot({
+        current: {
+          sequence: 5,
+          updatedAt: "2026-04-22T10:05:00.000Z",
+        },
+        next: {
+          snapshotSequence: 5,
+          updatedAt: "2026-04-22T10:05:01.000Z",
+        },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldApplyProjectionEvent", () => {
+  it("accepts the first event for an environment", () => {
+    expect(
+      shouldApplyProjectionEvent({
+        current: null,
+        sequence: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("drops stale or duplicate events", () => {
+    expect(
+      shouldApplyProjectionEvent({
+        current: {
+          sequence: 5,
+          updatedAt: "2026-04-22T10:05:00.000Z",
+        },
+        sequence: 5,
+      }),
+    ).toBe(false);
+    expect(
+      shouldApplyProjectionEvent({
+        current: {
+          sequence: 5,
+          updatedAt: "2026-04-22T10:05:00.000Z",
+        },
+        sequence: 4,
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts newer events", () => {
+    expect(
+      shouldApplyProjectionEvent({
+        current: {
+          sequence: 5,
+          updatedAt: "2026-04-22T10:05:00.000Z",
+        },
+        sequence: 6,
       }),
     ).toBe(true);
   });

--- a/apps/web/src/environments/runtime/service.ts
+++ b/apps/web/src/environments/runtime/service.ts
@@ -87,6 +87,13 @@ type ThreadDetailSubscriptionEntry = {
 const environmentConnections = new Map<EnvironmentId, EnvironmentConnection>();
 const environmentConnectionListeners = new Set<() => void>();
 const threadDetailSubscriptions = new Map<string, ThreadDetailSubscriptionEntry>();
+const lastAppliedProjectionVersionByEnvironment = new Map<
+  EnvironmentId,
+  {
+    readonly sequence: number;
+    readonly updatedAt: string | null;
+  }
+>();
 
 let activeService: EnvironmentServiceState | null = null;
 let needsProviderInvalidation = false;
@@ -101,6 +108,98 @@ let needsProviderInvalidation = false;
 const THREAD_DETAIL_SUBSCRIPTION_IDLE_EVICTION_MS = 15 * 60 * 1000;
 const MAX_CACHED_THREAD_DETAIL_SUBSCRIPTIONS = 32;
 const NOOP = () => undefined;
+
+function compareAppliedProjectionVersion(
+  left: { readonly sequence: number; readonly updatedAt: string | null },
+  right: { readonly sequence: number; readonly updatedAt: string | null },
+): number {
+  if (left.sequence !== right.sequence) {
+    return left.sequence - right.sequence;
+  }
+
+  const leftUpdatedAt = left.updatedAt ?? "";
+  const rightUpdatedAt = right.updatedAt ?? "";
+  if (leftUpdatedAt === rightUpdatedAt) {
+    return 0;
+  }
+
+  return leftUpdatedAt < rightUpdatedAt ? -1 : 1;
+}
+
+function toAppliedProjectionVersion(
+  snapshot: Pick<OrchestrationShellSnapshot, "snapshotSequence" | "updatedAt">,
+): {
+  readonly sequence: number;
+  readonly updatedAt: string;
+} {
+  return {
+    sequence: snapshot.snapshotSequence,
+    updatedAt: snapshot.updatedAt,
+  };
+}
+
+export function shouldApplyProjectionSnapshot(input: {
+  readonly current: {
+    readonly sequence: number;
+    readonly updatedAt: string | null;
+  } | null;
+  readonly next: Pick<OrchestrationShellSnapshot, "snapshotSequence" | "updatedAt">;
+}): boolean {
+  if (input.current === null) {
+    return true;
+  }
+
+  return compareAppliedProjectionVersion(input.current, toAppliedProjectionVersion(input.next)) < 0;
+}
+
+export function shouldApplyProjectionEvent(input: {
+  readonly current: {
+    readonly sequence: number;
+    readonly updatedAt: string | null;
+  } | null;
+  readonly sequence: number;
+}): boolean {
+  if (input.current === null) {
+    return true;
+  }
+
+  return input.sequence > input.current.sequence;
+}
+
+function readLastAppliedProjectionVersion(environmentId: EnvironmentId): {
+  readonly sequence: number;
+  readonly updatedAt: string | null;
+} | null {
+  return lastAppliedProjectionVersionByEnvironment.get(environmentId) ?? null;
+}
+
+function markAppliedProjectionSnapshot(
+  environmentId: EnvironmentId,
+  snapshot: Pick<OrchestrationShellSnapshot, "snapshotSequence" | "updatedAt">,
+): void {
+  const nextVersion = toAppliedProjectionVersion(snapshot);
+  const currentVersion = readLastAppliedProjectionVersion(environmentId);
+  if (
+    currentVersion !== null &&
+    compareAppliedProjectionVersion(currentVersion, nextVersion) >= 0
+  ) {
+    return;
+  }
+
+  lastAppliedProjectionVersionByEnvironment.set(environmentId, nextVersion);
+}
+
+function markAppliedProjectionEvent(environmentId: EnvironmentId, sequence: number): void {
+  const currentVersion = readLastAppliedProjectionVersion(environmentId);
+  if (currentVersion !== null && sequence <= currentVersion.sequence) {
+    return;
+  }
+
+  lastAppliedProjectionVersionByEnvironment.set(environmentId, {
+    sequence,
+    updatedAt: currentVersion?.updatedAt ?? null,
+  });
+}
 
 function getThreadDetailSubscriptionKey(environmentId: EnvironmentId, threadId: ThreadId): string {
   return scopedThreadKey(scopeThreadRef(environmentId, threadId));
@@ -600,6 +699,15 @@ export function applyEnvironmentThreadDetailEvent(
 }
 
 function applyShellEvent(event: OrchestrationShellStreamEvent, environmentId: EnvironmentId) {
+  if (
+    !shouldApplyProjectionEvent({
+      current: readLastAppliedProjectionVersion(environmentId),
+      sequence: event.sequence,
+    })
+  ) {
+    return;
+  }
+
   const threadId =
     event.kind === "thread-upserted"
       ? event.thread.id
@@ -610,6 +718,7 @@ function applyShellEvent(event: OrchestrationShellStreamEvent, environmentId: En
   const previousThread = threadRef ? selectThreadByRef(useStore.getState(), threadRef) : undefined;
 
   useStore.getState().applyShellEvent(event, environmentId);
+  markAppliedProjectionEvent(environmentId, event.sequence);
 
   switch (event.kind) {
     case "project-upserted":
@@ -643,7 +752,17 @@ function createEnvironmentConnectionHandlers() {
   return {
     applyShellEvent,
     syncShellSnapshot: (snapshot: OrchestrationShellSnapshot, environmentId: EnvironmentId) => {
+      if (
+        !shouldApplyProjectionSnapshot({
+          current: readLastAppliedProjectionVersion(environmentId),
+          next: snapshot,
+        })
+      ) {
+        return;
+      }
+
       useStore.getState().syncServerShellSnapshot(snapshot, environmentId);
+      markAppliedProjectionSnapshot(environmentId, snapshot);
       reconcileThreadDetailSubscriptionsForEnvironment(
         environmentId,
         snapshot.threads.map((thread) => thread.id),
@@ -758,6 +877,7 @@ async function removeConnection(environmentId: EnvironmentId): Promise<boolean> 
   }
 
   disposeThreadDetailSubscriptionsForEnvironment(environmentId);
+  lastAppliedProjectionVersionByEnvironment.delete(environmentId);
   environmentConnections.delete(environmentId);
   emitEnvironmentConnectionRegistryChange();
   await connection.dispose();
@@ -1086,6 +1206,7 @@ export function startEnvironmentConnectionService(queryClient: QueryClient): () 
 
 export async function resetEnvironmentServiceForTests(): Promise<void> {
   stopActiveService();
+  lastAppliedProjectionVersionByEnvironment.clear();
   for (const key of Array.from(threadDetailSubscriptions.keys())) {
     disposeThreadDetailSubscriptionByKey(key);
   }


### PR DESCRIPTION
## What Changed

- track the last applied shell projection version per environment in the runtime service
- drop stale shell snapshots and duplicate or out-of-order shell stream events instead of applying them
- add targeted tests for older-sequence, older-timestamp, duplicate-event, and newer-event cases

## Why

The shell stream and shell snapshot recovery path can arrive out of order. When an older snapshot lands after a newer shell event or snapshot, the client can briefly replace the current project and thread state with stale data. That shows up as threads or projects disappearing and then reappearing on the next update.

This change makes shell projection application monotonic by sequence and timestamp so older state is ignored instead of overwriting newer state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime environment projection sync to drop out-of-order snapshots and stream events; a bug in the version comparison/tracking could cause clients to ignore legitimate updates and appear stuck.
> 
> **Overview**
> Makes shell projection application monotonic per environment by tracking the last applied `{sequence, updatedAt}` and **ignoring stale shell snapshots** (older sequence or same sequence with older `updatedAt`).
> 
> Also **drops duplicate/out-of-order shell stream events** by sequence, updates the tracked version after applying accepted events/snapshots, and clears this per-environment state on disconnect/test resets. Adds focused unit tests for snapshot/event acceptance and rejection edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781f242ad3a9078f602145263812bbf6b0025886. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore stale runtime projection snapshots and events in environment service
> - Adds `shouldApplyProjectionSnapshot` and `shouldApplyProjectionEvent` guards in [service.ts](https://github.com/pingdotgg/t3code/pull/2301/files#diff-0c6fcb6b689bfab728dafd4ef75801e020355035bffde6032ccd03d5983cc7cc) to skip applying outdated data. Snapshots are compared by sequence first, then `updatedAt` as a tiebreaker; events require a strictly increasing sequence.
> - Tracks the last applied projection version per environment in a new `lastAppliedProjectionVersionByEnvironment` map, cleared when a connection is removed.
> - Behavioral Change: `applyShellEvent` and `syncShellSnapshot` handlers now silently drop duplicate or out-of-order updates instead of applying them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 781f242.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->