### PR TITLE
fix(server): resume OpenCode sessions from resumeCursor

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -27,6 +27,7 @@ import {
   ProviderService,
   type ProviderServiceShape,
 } from "../../provider/Services/ProviderService.ts";
+import type { ProviderResumeCursorInvalidationReason } from "../../provider/Services/ProviderAdapter.ts";
 import { GitCore, type GitCoreShape } from "../../git/Services/GitCore.ts";
 import {
   GitStatusBroadcaster,
@@ -102,6 +103,7 @@ describe("ProviderCommandReactor", () => {
     readonly baseDir?: string;
     readonly threadModelSelection?: ModelSelection;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
+    readonly resumeCursorInvalidationReasons?: ReadonlyArray<ProviderResumeCursorInvalidationReason>;
   }) {
     const now = new Date().toISOString();
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "t3code-reactor-"));
@@ -235,6 +237,9 @@ describe("ProviderCommandReactor", () => {
       getCapabilities: (_provider) =>
         Effect.succeed({
           sessionModelSwitch: input?.sessionModelSwitch ?? "in-session",
+          ...(input?.resumeCursorInvalidationReasons
+            ? { resumeCursorInvalidationReasons: input.resumeCursorInvalidationReasons }
+            : {}),
         }),
       rollbackConversation: () => unsupported(),
       get streamEvents() {
@@ -940,6 +945,69 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("drops resume cursor on workspace restarts when provider capabilities require it", async () => {
+    const harness = await createHarness({
+      threadModelSelection: { provider: "opencode", model: "anthropic/claude-sonnet-4-6" },
+      resumeCursorInvalidationReasons: ["cwd-change"],
+    });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-workspace-invalidate-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-workspace-invalidate-1"),
+          role: "user",
+          text: "first in project root",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-worktree-invalidate-change"),
+        threadId: ThreadId.make("thread-1"),
+        worktreePath: "/tmp/provider-project-worktree",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-workspace-invalidate-2"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-workspace-invalidate-2"),
+          role: "user",
+          text: "second in worktree",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      threadId: ThreadId.make("thread-1"),
+      cwd: "/tmp/provider-project-worktree",
+      runtimeMode: "approval-required",
+    });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
+  });
+
   it("restarts claude sessions when claude effort changes", async () => {
     const harness = await createHarness({
       threadModelSelection: { provider: "claudeAgent", model: "claude-sonnet-4-6" },
@@ -1071,9 +1139,9 @@ describe("ProviderCommandReactor", () => {
     expect(harness.stopSession.mock.calls.length).toBe(0);
     expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
+      resumeCursor: { opaque: "resume-1" },
       runtimeMode: "approval-required",
     });
-    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
     expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
     });
@@ -1082,6 +1150,61 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("drops resume cursor on runtime mode restarts when provider capabilities require it", async () => {
+    const harness = await createHarness({
+      resumeCursorInvalidationReasons: ["runtime-mode-change"],
+    });
+    const now = new Date().toISOString();
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.runtime-mode.set",
+        commandId: CommandId.make("cmd-runtime-mode-invalidate-set-full-access"),
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-runtime-invalidate-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-runtime-invalidate-1"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.runtime-mode.set",
+        commandId: CommandId.make("cmd-runtime-mode-invalidate-set-approval"),
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      threadId: ThreadId.make("thread-1"),
+      runtimeMode: "approval-required",
+    });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
   });
 
   it("does not inject derived model options when restarting claude on runtime mode changes", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -995,9 +995,9 @@ describe("ProviderCommandReactor", () => {
     expect(harness.stopSession.mock.calls.length).toBe(0);
     expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
-      resumeCursor: { opaque: "resume-1" },
       runtimeMode: "approval-required",
     });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
     expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
     });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -40,6 +40,7 @@ import {
   ProviderService,
   type ProviderServiceShape,
 } from "../../provider/Services/ProviderService.ts";
+import type { ProviderResumeCursorInvalidationReason } from "../../provider/Services/ProviderAdapter.ts";
 import { TextGeneration, type TextGenerationShape } from "../../textGeneration/TextGeneration.ts";
 import { RepositoryIdentityResolverLive } from "../../project/Layers/RepositoryIdentityResolver.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
@@ -142,6 +143,7 @@ describe("ProviderCommandReactor", () => {
     readonly baseDir?: string;
     readonly threadModelSelection?: ModelSelection;
     readonly sessionModelSwitch?: "unsupported" | "in-session";
+    readonly resumeCursorInvalidationReasons?: ReadonlyArray<ProviderResumeCursorInvalidationReason>;
   }) {
     const now = "2026-01-01T00:00:00.000Z";
     const baseDir = input?.baseDir ?? fs.mkdtempSync(path.join(os.tmpdir(), "t3code-reactor-"));
@@ -293,6 +295,9 @@ describe("ProviderCommandReactor", () => {
       getCapabilities: (_provider) =>
         Effect.succeed({
           sessionModelSwitch: input?.sessionModelSwitch ?? "in-session",
+          ...(input?.resumeCursorInvalidationReasons
+            ? { resumeCursorInvalidationReasons: input.resumeCursorInvalidationReasons }
+            : {}),
         }),
       getInstanceInfo: (instanceId) => {
         const raw = String(instanceId);
@@ -879,6 +884,59 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("drops resume cursor on unsupported model changes even when provider declares custom invalidation reasons", async () => {
+    const harness = await createHarness({
+      sessionModelSwitch: "unsupported",
+      resumeCursorInvalidationReasons: ["cwd-change"],
+    });
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-unsupported-model-custom-invalidation-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-unsupported-model-custom-invalidation-1"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-unsupported-model-custom-invalidation-2"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-unsupported-model-custom-invalidation-2"),
+          role: "user",
+          text: "second",
+          attachments: [],
+        },
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5.3-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
+  });
+
   it("starts a first turn on the requested provider instance even when it differs from the thread model", async () => {
     const harness = await createHarness({
       threadModelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5-codex" },
@@ -1108,6 +1166,72 @@ describe("ProviderCommandReactor", () => {
     });
   });
 
+  it("drops resume cursor on workspace restarts when provider capabilities require it", async () => {
+    const harness = await createHarness({
+      threadModelSelection: {
+        instanceId: ProviderInstanceId.make("opencode"),
+        model: "anthropic/claude-sonnet-4-6",
+      },
+      resumeCursorInvalidationReasons: ["cwd-change"],
+    });
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-workspace-invalidate-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-workspace-invalidate-1"),
+          role: "user",
+          text: "first in project root",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-thread-worktree-invalidate-change"),
+        threadId: ThreadId.make("thread-1"),
+        worktreePath: "/tmp/provider-project-worktree",
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-workspace-invalidate-2"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-workspace-invalidate-2"),
+          role: "user",
+          text: "second in worktree",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      threadId: ThreadId.make("thread-1"),
+      cwd: "/tmp/provider-project-worktree",
+      runtimeMode: "approval-required",
+    });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
+  });
+
   it("restarts claude sessions when claude effort changes", async () => {
     const harness = await createHarness({
       threadModelSelection: {
@@ -1248,9 +1372,9 @@ describe("ProviderCommandReactor", () => {
     expect(harness.stopSession.mock.calls.length).toBe(0);
     expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
+      resumeCursor: { opaque: "resume-1" },
       runtimeMode: "approval-required",
     });
-    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
     expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
     });
@@ -1259,6 +1383,61 @@ describe("ProviderCommandReactor", () => {
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("drops resume cursor on runtime mode restarts when provider capabilities require it", async () => {
+    const harness = await createHarness({
+      resumeCursorInvalidationReasons: ["runtime-mode-change"],
+    });
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.runtime-mode.set",
+        commandId: CommandId.make("cmd-runtime-mode-invalidate-set-full-access"),
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-runtime-invalidate-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-runtime-invalidate-1"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "full-access",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.runtime-mode.set",
+        commandId: CommandId.make("cmd-runtime-mode-invalidate-set-approval"),
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      threadId: ThreadId.make("thread-1"),
+      runtimeMode: "approval-required",
+    });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
   });
 
   it("does not inject derived model options when restarting claude on runtime mode changes", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1248,9 +1248,9 @@ describe("ProviderCommandReactor", () => {
     expect(harness.stopSession.mock.calls.length).toBe(0);
     expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
-      resumeCursor: { opaque: "resume-1" },
       runtimeMode: "approval-required",
     });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
     expect(harness.sendTurn.mock.calls[1]?.[0]).toMatchObject({
       threadId: ThreadId.make("thread-1"),
     });

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -335,10 +335,11 @@ const make = Effect.gen(function* () {
     if (existingSessionThreadId) {
       const runtimeModeChanged = thread.runtimeMode !== thread.session?.runtimeMode;
       const cwdChanged = effectiveCwd !== activeSession?.cwd;
-      const sessionModelSwitch =
+      const capabilities =
         currentProvider === undefined
-          ? "in-session"
-          : (yield* providerService.getCapabilities(currentProvider)).sessionModelSwitch;
+          ? { sessionModelSwitch: "in-session" as const }
+          : yield* providerService.getCapabilities(currentProvider);
+      const sessionModelSwitch = capabilities.sessionModelSwitch;
       const modelChanged =
         requestedModelSelection !== undefined &&
         requestedModelSelection.model !== activeSession?.model;
@@ -358,10 +359,17 @@ const make = Effect.gen(function* () {
         return existingSessionThreadId;
       }
 
-      const resumeCursor =
-        runtimeModeChanged || shouldRestartForModelChange
-          ? undefined
-          : (activeSession?.resumeCursor ?? undefined);
+      const resumeCursorInvalidationReasons = new Set(
+        capabilities.resumeCursorInvalidationReasons ?? ["unsupported-model-change"],
+      );
+      const shouldClearResumeCursor =
+        (runtimeModeChanged && resumeCursorInvalidationReasons.has("runtime-mode-change")) ||
+        (cwdChanged && resumeCursorInvalidationReasons.has("cwd-change")) ||
+        (shouldRestartForModelChange &&
+          resumeCursorInvalidationReasons.has("unsupported-model-change"));
+      const resumeCursor = shouldClearResumeCursor
+        ? undefined
+        : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
         existingSessionThreadId,
@@ -376,6 +384,7 @@ const make = Effect.gen(function* () {
         modelChanged,
         shouldRestartForModelChange,
         shouldRestartForModelSelectionChange,
+        shouldClearResumeCursor,
         hasResumeCursor: resumeCursor !== undefined,
       });
       const restartedSession = yield* startProviderSession(

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -356,9 +356,10 @@ const make = Effect.gen(function* () {
         return existingSessionThreadId;
       }
 
-      const resumeCursor = shouldRestartForModelChange
-        ? undefined
-        : (activeSession?.resumeCursor ?? undefined);
+      const resumeCursor =
+        runtimeModeChanged || shouldRestartForModelChange
+          ? undefined
+          : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
         existingSessionThreadId,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -470,9 +470,10 @@ const make = Effect.gen(function* () {
         return existingSessionThreadId;
       }
 
-      const resumeCursor = shouldRestartForModelChange
-        ? undefined
-        : (activeSession?.resumeCursor ?? undefined);
+      const resumeCursor =
+        runtimeModeChanged || shouldRestartForModelChange
+          ? undefined
+          : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
         existingSessionThreadId,

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -445,8 +445,8 @@ const make = Effect.gen(function* () {
     if (existingSessionThreadId) {
       const runtimeModeChanged = thread.runtimeMode !== thread.session?.runtimeMode;
       const cwdChanged = effectiveCwd !== activeSession?.cwd;
-      const sessionModelSwitch = (yield* providerService.getCapabilities(desiredInstanceId))
-        .sessionModelSwitch;
+      const capabilities = yield* providerService.getCapabilities(currentInstanceId);
+      const sessionModelSwitch = capabilities.sessionModelSwitch;
       const modelChanged =
         requestedModelSelection !== undefined &&
         requestedModelSelection.model !== activeSession?.model;
@@ -470,10 +470,16 @@ const make = Effect.gen(function* () {
         return existingSessionThreadId;
       }
 
-      const resumeCursor =
-        runtimeModeChanged || shouldRestartForModelChange
-          ? undefined
-          : (activeSession?.resumeCursor ?? undefined);
+      const resumeCursorInvalidationReasons = new Set(
+        capabilities.resumeCursorInvalidationReasons ?? [],
+      );
+      const shouldClearResumeCursor =
+        shouldRestartForModelChange ||
+        (runtimeModeChanged && resumeCursorInvalidationReasons.has("runtime-mode-change")) ||
+        (cwdChanged && resumeCursorInvalidationReasons.has("cwd-change"));
+      const resumeCursor = shouldClearResumeCursor
+        ? undefined
+        : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
         existingSessionThreadId,
@@ -491,6 +497,7 @@ const make = Effect.gen(function* () {
         instanceChanged,
         shouldRestartForModelChange,
         shouldRestartForModelSelectionChange,
+        shouldClearResumeCursor,
         hasResumeCursor: resumeCursor !== undefined,
       });
       const restartedSession = yield* startProviderSession(

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -35,6 +35,7 @@ const runtimeMock = {
   state: {
     startCalls: [] as string[],
     sessionCreateUrls: [] as string[],
+    sessionGetCalls: [] as string[],
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
     closeCalls: [] as string[],
@@ -47,6 +48,7 @@ const runtimeMock = {
   reset() {
     this.state.startCalls.length = 0;
     this.state.sessionCreateUrls.length = 0;
+    this.state.sessionGetCalls.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
     this.state.closeCalls.length = 0;
@@ -107,6 +109,15 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             serverPassword ? `Basic ${btoa(`opencode:${serverPassword}`)}` : null,
           );
           return { data: { id: `${baseUrl}/session` } };
+        },
+        get: async ({ sessionID }: { sessionID: string }) => {
+          runtimeMock.state.sessionGetCalls.push(sessionID);
+          return {
+            data: {
+              id: sessionID,
+              directory: "/tmp/opencode-resumed",
+            },
+          };
         },
         abort: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.abortCalls.push(sessionID);
@@ -230,9 +241,38 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("resumes an existing OpenCode session when a resume cursor is provided", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+
+      const session = yield* adapter.startSession({
+        provider: "opencode",
+        threadId: asThreadId("thread-opencode-resume"),
+        runtimeMode: "full-access",
+        resumeCursor: {
+          sessionID: "ses-existing",
+          directory: "/tmp/ignored-by-session-get",
+        },
+      });
+
+      assert.equal(session.provider, "opencode");
+      assert.equal(session.threadId, "thread-opencode-resume");
+      assert.equal(session.cwd, "/tmp/opencode-resumed");
+      assert.deepEqual(runtimeMock.state.sessionCreateUrls, []);
+      assert.deepEqual(runtimeMock.state.sessionGetCalls, ["ses-existing"]);
+      assert.deepEqual(session.resumeCursor, {
+        sessionID: "ses-existing",
+        directory: "/tmp/opencode-resumed",
+      });
+    }),
+  );
+
   it.effect("clears session state even when cleanup finalizers throw", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
+      yield* Effect.exit(adapter.stopAll());
+      runtimeMock.state.closeCalls.length = 0;
+
       yield* adapter.startSession({
         provider: "opencode",
         threadId: asThreadId("thread-stop-all-a"),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -54,6 +54,7 @@ const runtimeMock = {
   state: {
     startCalls: [] as string[],
     sessionCreateUrls: [] as string[],
+    sessionGetCalls: [] as string[],
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
     closeCalls: [] as string[],
@@ -67,6 +68,7 @@ const runtimeMock = {
   reset() {
     this.state.startCalls.length = 0;
     this.state.sessionCreateUrls.length = 0;
+    this.state.sessionGetCalls.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
     this.state.closeCalls.length = 0;
@@ -128,6 +130,15 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
             serverPassword ? `Basic ${btoa(`opencode:${serverPassword}`)}` : null,
           );
           return { data: { id: `${baseUrl}/session` } };
+        },
+        get: async ({ sessionID }: { sessionID: string }) => {
+          runtimeMock.state.sessionGetCalls.push(sessionID);
+          return {
+            data: {
+              id: sessionID,
+              directory: "/tmp/opencode-resumed",
+            },
+          };
         },
         abort: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.abortCalls.push(sessionID);
@@ -293,9 +304,38 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
+  it.effect("resumes an existing OpenCode session when a resume cursor is provided", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+
+      const session = yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId: asThreadId("thread-opencode-resume"),
+        runtimeMode: "full-access",
+        resumeCursor: {
+          sessionID: "ses-existing",
+          directory: "/tmp/ignored-by-session-get",
+        },
+      });
+
+      assert.equal(session.provider, "opencode");
+      assert.equal(session.threadId, "thread-opencode-resume");
+      assert.equal(session.cwd, "/tmp/opencode-resumed");
+      assert.deepEqual(runtimeMock.state.sessionCreateUrls, []);
+      assert.deepEqual(runtimeMock.state.sessionGetCalls, ["ses-existing"]);
+      assert.deepEqual(session.resumeCursor, {
+        sessionID: "ses-existing",
+        directory: "/tmp/opencode-resumed",
+      });
+    }),
+  );
+
   it.effect("clears session state even when cleanup finalizers throw", () =>
     Effect.gen(function* () {
       const adapter = yield* OpenCodeAdapter;
+      yield* Effect.exit(adapter.stopAll());
+      runtimeMock.state.closeCalls.length = 0;
+
       yield* adapter.startSession({
         provider: ProviderDriverKind.make("opencode"),
         threadId: asThreadId("thread-stop-all-a"),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -61,6 +61,7 @@ const runtimeMock = {
     revertCalls: [] as Array<{ sessionID: string; messageID?: string }>,
     promptCalls: [] as Array<unknown>,
     promptAsyncError: null as Error | null,
+    sessionGetError: null as unknown,
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as unknown[],
@@ -75,6 +76,7 @@ const runtimeMock = {
     this.state.revertCalls.length = 0;
     this.state.promptCalls.length = 0;
     this.state.promptAsyncError = null;
+    this.state.sessionGetError = null;
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
@@ -133,6 +135,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         },
         get: async ({ sessionID }: { sessionID: string }) => {
           runtimeMock.state.sessionGetCalls.push(sessionID);
+          if (runtimeMock.state.sessionGetError) {
+            throw runtimeMock.state.sessionGetError;
+          }
           return {
             data: {
               id: sessionID,
@@ -328,6 +333,69 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         directory: "/tmp/opencode-resumed",
       });
     }),
+  );
+
+  it.effect("creates a fresh OpenCode session when resume cursor points to a missing session", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      runtimeMock.state.sessionGetError = {
+        response: { status: 404 },
+        error: { message: "session not found" },
+      };
+
+      const session = yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId: asThreadId("thread-opencode-stale-resume"),
+        runtimeMode: "approval-required",
+        resumeCursor: {
+          sessionID: "ses-missing",
+          directory: "/tmp/opencode-stale-resume",
+        },
+      });
+
+      assert.equal(session.provider, "opencode");
+      assert.equal(session.threadId, "thread-opencode-stale-resume");
+      assert.equal(session.cwd, "/tmp/opencode-stale-resume");
+      assert.deepEqual(runtimeMock.state.sessionGetCalls, ["ses-missing"]);
+      assert.deepEqual(runtimeMock.state.sessionCreateUrls, ["http://127.0.0.1:9999"]);
+      assert.deepEqual(session.resumeCursor, {
+        sessionID: "http://127.0.0.1:9999/session",
+        directory: "/tmp/opencode-stale-resume",
+      });
+    }),
+  );
+
+  it.effect(
+    "does not fall back to session creation when resume fails for a non-missing session",
+    () =>
+      Effect.gen(function* () {
+        const adapter = yield* OpenCodeAdapter;
+        runtimeMock.state.sessionGetError = {
+          response: { status: 401 },
+          error: { message: "unauthorized" },
+        };
+
+        const exit = yield* Effect.exit(
+          adapter.startSession({
+            provider: ProviderDriverKind.make("opencode"),
+            threadId: asThreadId("thread-opencode-resume-auth-failure"),
+            runtimeMode: "full-access",
+            resumeCursor: {
+              sessionID: "ses-existing",
+              directory: "/tmp/opencode-resume-auth-failure",
+            },
+          }),
+        );
+        const sessions = yield* adapter.listSessions();
+
+        assert.equal(Exit.isFailure(exit), true);
+        assert.deepEqual(runtimeMock.state.sessionGetCalls, ["ses-existing"]);
+        assert.deepEqual(runtimeMock.state.sessionCreateUrls, []);
+        assert.equal(
+          sessions.some((session) => session.threadId === "thread-opencode-resume-auth-failure"),
+          false,
+        );
+      }),
   );
 
   it.effect("clears session state even when cleanup finalizers throw", () =>

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1418,6 +1418,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
         provider: PROVIDER,
         capabilities: {
           sessionModelSwitch: "in-session",
+          resumeCursorInvalidationReasons: ["runtime-mode-change", "cwd-change"],
         },
         startSession,
         sendTurn,

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -88,6 +88,11 @@ interface OpenCodeSessionContext {
   readonly sessionScope: Scope.Closeable;
 }
 
+interface OpenCodeResumeState {
+  readonly sessionID: string;
+  readonly directory?: string;
+}
+
 export interface OpenCodeAdapterLiveOptions {
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
@@ -95,6 +100,33 @@ export interface OpenCodeAdapterLiveOptions {
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+function readOpenCodeResumeState(resumeCursor: unknown): OpenCodeResumeState | undefined {
+  if (!resumeCursor || typeof resumeCursor !== "object") {
+    return undefined;
+  }
+
+  const cursor = resumeCursor as {
+    sessionID?: unknown;
+    directory?: unknown;
+  };
+  const sessionID =
+    typeof cursor.sessionID === "string" && cursor.sessionID.trim().length > 0
+      ? cursor.sessionID.trim()
+      : undefined;
+  if (!sessionID) {
+    return undefined;
+  }
+
+  const directory =
+    typeof cursor.directory === "string" && cursor.directory.trim().length > 0
+      ? cursor.directory.trim()
+      : undefined;
+  return {
+    sessionID,
+    ...(directory ? { directory } : {}),
+  };
 }
 
 /**
@@ -1003,7 +1035,8 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           const binaryPath = settings.providers.opencode.binaryPath;
           const serverUrl = settings.providers.opencode.serverUrl;
           const serverPassword = settings.providers.opencode.serverPassword;
-          const directory = input.cwd ?? serverConfig.cwd;
+          const resumeState = readOpenCodeResumeState(input.resumeCursor);
+          const directory = resumeState?.directory ?? input.cwd ?? serverConfig.cwd;
           const existing = sessions.get(input.threadId);
           if (existing) {
             yield* stopOpenCodeContext(existing);
@@ -1026,19 +1059,31 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
                   directory,
                   ...(server.external && serverPassword ? { serverPassword } : {}),
                 });
-                const openCodeSession = yield* runOpenCodeSdk("session.create", () =>
-                  client.session.create({
-                    title: `T3 Code ${input.threadId}`,
-                    permission: buildOpenCodePermissionRules(input.runtimeMode),
-                  }),
-                );
+                const openCodeSession = yield* resumeState
+                  ? runOpenCodeSdk("session.get", () =>
+                      client.session.get({ sessionID: resumeState.sessionID }),
+                    )
+                  : runOpenCodeSdk("session.create", () =>
+                      client.session.create({
+                        title: `T3 Code ${input.threadId}`,
+                        permission: buildOpenCodePermissionRules(input.runtimeMode),
+                      }),
+                    );
                 if (!openCodeSession.data) {
                   return yield* new OpenCodeRuntimeError({
-                    operation: "session.create",
-                    detail: "OpenCode session.create returned no session payload.",
+                    operation: resumeState ? "session.get" : "session.create",
+                    detail: resumeState
+                      ? "OpenCode session.get returned no session payload."
+                      : "OpenCode session.create returned no session payload.",
                   });
                 }
-                return { sessionScope, server, client, openCodeSession: openCodeSession.data };
+                return {
+                  sessionScope,
+                  server,
+                  client,
+                  openCodeSession: openCodeSession.data,
+                  resumed: resumeState !== undefined,
+                };
               }).pipe(Effect.provideService(Scope.Scope, sessionScope)),
             );
             if (Exit.isFailure(startedExit)) {
@@ -1054,21 +1099,28 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
           if (raceWinner) {
             // Another call won the race – clean up the session we just created
             // (including the remote SDK session) and return the existing one.
-            yield* runOpenCodeSdk("session.abort", () =>
-              started.client.session.abort({ sessionID: started.openCodeSession.id }),
-            ).pipe(Effect.ignore);
+            if (!started.resumed) {
+              yield* runOpenCodeSdk("session.abort", () =>
+                started.client.session.abort({ sessionID: started.openCodeSession.id }),
+              ).pipe(Effect.ignore);
+            }
             yield* Scope.close(started.sessionScope, Exit.void).pipe(Effect.ignore);
             return raceWinner.session;
           }
 
           const createdAt = nowIso();
+          const sessionDirectory = started.openCodeSession.directory || directory;
           const session: ProviderSession = {
             provider: PROVIDER,
             status: "ready",
             runtimeMode: input.runtimeMode,
-            cwd: directory,
+            cwd: sessionDirectory,
             ...(input.modelSelection ? { model: input.modelSelection.model } : {}),
             threadId: input.threadId,
+            resumeCursor: {
+              sessionID: started.openCodeSession.id,
+              directory: sessionDirectory,
+            },
             createdAt,
             updatedAt: createdAt,
           };
@@ -1077,7 +1129,7 @@ export function makeOpenCodeAdapterLive(options?: OpenCodeAdapterLiveOptions) {
             session,
             client: started.client,
             server: started.server,
-            directory,
+            directory: sessionDirectory,
             openCodeSessionId: started.openCodeSession.id,
             pendingPermissions: new Map(),
             pendingQuestions: new Map(),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -97,6 +97,11 @@ interface OpenCodeSessionContext {
   readonly sessionScope: Scope.Closeable;
 }
 
+interface OpenCodeResumeState {
+  readonly sessionID: string;
+  readonly directory?: string;
+}
+
 export interface OpenCodeAdapterLiveOptions {
   readonly instanceId?: ProviderInstanceId;
   readonly environment?: NodeJS.ProcessEnv;
@@ -105,6 +110,33 @@ export interface OpenCodeAdapterLiveOptions {
 }
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+
+function readOpenCodeResumeState(resumeCursor: unknown): OpenCodeResumeState | undefined {
+  if (!resumeCursor || typeof resumeCursor !== "object") {
+    return undefined;
+  }
+
+  const cursor = resumeCursor as {
+    sessionID?: unknown;
+    directory?: unknown;
+  };
+  const sessionID =
+    typeof cursor.sessionID === "string" && cursor.sessionID.trim().length > 0
+      ? cursor.sessionID.trim()
+      : undefined;
+  if (!sessionID) {
+    return undefined;
+  }
+
+  const directory =
+    typeof cursor.directory === "string" && cursor.directory.trim().length > 0
+      ? cursor.directory.trim()
+      : undefined;
+  return {
+    sessionID,
+    ...(directory ? { directory } : {}),
+  };
+}
 
 /**
  * Map a tagged OpenCodeRuntimeError produced by {@link runOpenCodeSdk} into
@@ -1020,7 +1052,8 @@ export function makeOpenCodeAdapter(
         const binaryPath = openCodeSettings.binaryPath;
         const serverUrl = openCodeSettings.serverUrl;
         const serverPassword = openCodeSettings.serverPassword;
-        const directory = input.cwd ?? serverConfig.cwd;
+        const resumeState = readOpenCodeResumeState(input.resumeCursor);
+        const directory = resumeState?.directory ?? input.cwd ?? serverConfig.cwd;
         const existing = sessions.get(input.threadId);
         if (existing) {
           yield* stopOpenCodeContext(existing);
@@ -1044,16 +1077,22 @@ export function makeOpenCodeAdapter(
                 directory,
                 ...(server.external && serverPassword ? { serverPassword } : {}),
               });
-              const openCodeSession = yield* runOpenCodeSdk("session.create", () =>
-                client.session.create({
-                  title: `T3 Code ${input.threadId}`,
-                  permission: buildOpenCodePermissionRules(input.runtimeMode),
-                }),
-              );
+              const openCodeSession = yield* resumeState
+                ? runOpenCodeSdk("session.get", () =>
+                    client.session.get({ sessionID: resumeState.sessionID }),
+                  )
+                : runOpenCodeSdk("session.create", () =>
+                    client.session.create({
+                      title: `T3 Code ${input.threadId}`,
+                      permission: buildOpenCodePermissionRules(input.runtimeMode),
+                    }),
+                  );
               if (!openCodeSession.data) {
                 return yield* new OpenCodeRuntimeError({
-                  operation: "session.create",
-                  detail: "OpenCode session.create returned no session payload.",
+                  operation: resumeState ? "session.get" : "session.create",
+                  detail: resumeState
+                    ? "OpenCode session.get returned no session payload."
+                    : "OpenCode session.create returned no session payload.",
                 });
               }
               return {
@@ -1061,6 +1100,7 @@ export function makeOpenCodeAdapter(
                 server,
                 client,
                 openCodeSession: openCodeSession.data,
+                resumed: resumeState !== undefined,
               };
             }).pipe(Effect.provideService(Scope.Scope, sessionScope)),
           );
@@ -1077,24 +1117,31 @@ export function makeOpenCodeAdapter(
         if (raceWinner) {
           // Another call won the race – clean up the session we just created
           // (including the remote SDK session) and return the existing one.
-          yield* runOpenCodeSdk("session.abort", () =>
-            started.client.session.abort({
-              sessionID: started.openCodeSession.id,
-            }),
-          ).pipe(Effect.ignore);
+          if (!started.resumed) {
+            yield* runOpenCodeSdk("session.abort", () =>
+              started.client.session.abort({
+                sessionID: started.openCodeSession.id,
+              }),
+            ).pipe(Effect.ignore);
+          }
           yield* Scope.close(started.sessionScope, Exit.void).pipe(Effect.ignore);
           return raceWinner.session;
         }
 
         const createdAt = yield* nowIso;
+        const sessionDirectory = started.openCodeSession.directory || directory;
         const session: ProviderSession = {
           provider: PROVIDER,
           providerInstanceId: boundInstanceId,
           status: "ready",
           runtimeMode: input.runtimeMode,
-          cwd: directory,
+          cwd: sessionDirectory,
           ...(input.modelSelection ? { model: input.modelSelection.model } : {}),
           threadId: input.threadId,
+          resumeCursor: {
+            sessionID: started.openCodeSession.id,
+            directory: sessionDirectory,
+          },
           createdAt,
           updatedAt: createdAt,
         };
@@ -1103,7 +1150,7 @@ export function makeOpenCodeAdapter(
           session,
           client: started.client,
           server: started.server,
-          directory,
+          directory: sessionDirectory,
           openCodeSessionId: started.openCodeSession.id,
           pendingPermissions: new Map(),
           pendingQuestions: new Map(),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -138,6 +138,27 @@ function readOpenCodeResumeState(resumeCursor: unknown): OpenCodeResumeState | u
   };
 }
 
+function getOpenCodeErrorStatus(cause: unknown): number | undefined {
+  if (!cause || typeof cause !== "object") {
+    return undefined;
+  }
+
+  const error = cause as {
+    readonly status?: unknown;
+    readonly response?: {
+      readonly status?: unknown;
+    };
+  };
+  if (typeof error.response?.status === "number") {
+    return error.response.status;
+  }
+  return typeof error.status === "number" ? error.status : undefined;
+}
+
+function isMissingOpenCodeResumeSession(cause: OpenCodeRuntimeError): boolean {
+  return cause.operation === "session.get" && getOpenCodeErrorStatus(cause.cause) === 404;
+}
+
 /**
  * Map a tagged OpenCodeRuntimeError produced by {@link runOpenCodeSdk} into
  * the adapter-boundary `ProviderAdapterRequestError`. SDK-method-level call
@@ -1077,20 +1098,25 @@ export function makeOpenCodeAdapter(
                 directory,
                 ...(server.external && serverPassword ? { serverPassword } : {}),
               });
-              const openCodeSession = yield* resumeState
+              const createOpenCodeSession = runOpenCodeSdk("session.create", () =>
+                client.session.create({
+                  title: `T3 Code ${input.threadId}`,
+                  permission: buildOpenCodePermissionRules(input.runtimeMode),
+                }),
+              ).pipe(Effect.map((response) => ({ response, resumed: false as const })));
+              const openCodeSessionStart = yield* resumeState
                 ? runOpenCodeSdk("session.get", () =>
                     client.session.get({ sessionID: resumeState.sessionID }),
+                  ).pipe(
+                    Effect.map((response) => ({ response, resumed: true as const })),
+                    Effect.catchIf(isMissingOpenCodeResumeSession, () => createOpenCodeSession),
                   )
-                : runOpenCodeSdk("session.create", () =>
-                    client.session.create({
-                      title: `T3 Code ${input.threadId}`,
-                      permission: buildOpenCodePermissionRules(input.runtimeMode),
-                    }),
-                  );
-              if (!openCodeSession.data) {
+                : createOpenCodeSession;
+              if (!openCodeSessionStart.response.data) {
+                const operation = openCodeSessionStart.resumed ? "session.get" : "session.create";
                 return yield* new OpenCodeRuntimeError({
-                  operation: resumeState ? "session.get" : "session.create",
-                  detail: resumeState
+                  operation,
+                  detail: openCodeSessionStart.resumed
                     ? "OpenCode session.get returned no session payload."
                     : "OpenCode session.create returned no session payload.",
                 });
@@ -1099,8 +1125,8 @@ export function makeOpenCodeAdapter(
                 sessionScope,
                 server,
                 client,
-                openCodeSession: openCodeSession.data,
-                resumed: resumeState !== undefined,
+                openCodeSession: openCodeSessionStart.response.data,
+                resumed: openCodeSessionStart.resumed,
               };
             }).pipe(Effect.provideService(Scope.Scope, sessionScope)),
           );
@@ -1462,6 +1488,7 @@ export function makeOpenCodeAdapter(
       provider: PROVIDER,
       capabilities: {
         sessionModelSwitch: "in-session",
+        resumeCursorInvalidationReasons: ["runtime-mode-change", "cwd-change"],
       },
       startSession,
       sendTurn,

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -24,12 +24,17 @@ import type { Effect } from "effect";
 import type { Stream } from "effect";
 
 export type ProviderSessionModelSwitchMode = "in-session" | "unsupported";
+export type ProviderResumeCursorInvalidationReason =
+  | "runtime-mode-change"
+  | "cwd-change"
+  | "unsupported-model-change";
 
 export interface ProviderAdapterCapabilities {
   /**
    * Declares whether changing the model on an existing session is supported.
    */
   readonly sessionModelSwitch: ProviderSessionModelSwitchMode;
+  readonly resumeCursorInvalidationReasons?: ReadonlyArray<ProviderResumeCursorInvalidationReason>;
 }
 
 export interface ProviderThreadTurnSnapshot {

--- a/apps/server/src/provider/Services/ProviderAdapter.ts
+++ b/apps/server/src/provider/Services/ProviderAdapter.ts
@@ -24,12 +24,14 @@ import type * as Effect from "effect/Effect";
 import type * as Stream from "effect/Stream";
 
 export type ProviderSessionModelSwitchMode = "in-session" | "unsupported";
+export type ProviderResumeCursorInvalidationReason = "runtime-mode-change" | "cwd-change";
 
 export interface ProviderAdapterCapabilities {
   /**
    * Declares whether changing the model on an existing session is supported.
    */
   readonly sessionModelSwitch: ProviderSessionModelSwitchMode;
+  readonly resumeCursorInvalidationReasons?: ReadonlyArray<ProviderResumeCursorInvalidationReason>;
 }
 
 export interface ProviderThreadTurnSnapshot {


### PR DESCRIPTION
## What Changed

- teach `OpenCodeAdapter.startSession` to resume an existing OpenCode session from a persisted `resumeCursor` instead of always creating a new native session
- fall back to creating a fresh OpenCode session when a persisted resume cursor points to a missing native session
- persist the resumed or newly-created OpenCode session ID and resolved directory back into T3 provider session state
- add provider-declared `resumeCursorInvalidationReasons` so restart cursor handling is capability-driven rather than hard-coded in the orchestration layer
- configure OpenCode to clear stale resume cursors when runtime mode or workspace cwd changes, while preserving existing behavior for other providers by default
- add regression tests for OpenCode resume, stale-cursor fallback, non-404 resume failures, and provider-scoped cursor invalidation on runtime-mode and cwd restarts

## Why

T3 already persists provider resume state, but the OpenCode adapter ignored that state and always started a fresh OpenCode session. That broke continuity when T3 knew the OpenCode `sessionID` and needed to reconnect to it.

The first fix made OpenCode reuse `resumeCursor`, but review correctly pointed out that some restarts make an OpenCode cursor unsafe: resuming after a permission-mode change can keep the old permission behavior, and resuming after a cwd change can keep the old workspace.

OpenCode native sessions can also disappear independently of T3, so resume needs to be opportunistic rather than brittle. If `session.get` reports that the native session is missing, the adapter now creates a fresh session and replaces the stale cursor. Other resume failures still surface normally.

This update keeps the fix provider-compatible by moving restart invalidation decisions into provider capabilities. OpenCode opts into clearing cursors for runtime-mode and cwd changes. Other providers keep the previous restart behavior unless they explicitly declare additional invalidation reasons.

## UI Changes

None.

## Verification

- [x] `bun fmt`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run test src/orchestration/Layers/ProviderCommandReactor.test.ts src/provider/Layers/OpenCodeAdapter.test.ts`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable)
- [x] I included a video for animation/interaction changes (not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider session restart/resume behavior and makes resume-cursor clearing capability-driven, which could affect session continuity or restart semantics across providers if misconfigured.
> 
> **Overview**
> **OpenCode sessions can now be resumed instead of always recreated.** `OpenCodeAdapter.startSession` parses/validates `resumeCursor`, attempts `session.get` to reconnect, persists the resolved session directory back into the returned session `resumeCursor`, and only falls back to `session.create` when the resume target is missing (404).
> 
> **Resume-cursor invalidation is now provider-driven.** A new `resumeCursorInvalidationReasons` capability (typed via `ProviderResumeCursorInvalidationReason`) lets `ProviderCommandReactor` decide when to drop `resumeCursor` on restarts (model switch unsupported, and optionally runtime-mode/cwd changes). OpenCode opts into invalidating on `runtime-mode-change` and `cwd-change`, with new regression tests covering resume and cursor-dropping scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0588c99b8c8da4d41397be815598995f944dae40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resume OpenCode sessions from a resumeCursor in the provider adapter
> - `OpenCodeAdapter.startSession` now attempts `session.get` to resume an existing session using a `resumeCursor`, falling back to `session.create` only on a 404 response. The resumed session's server-reported directory is used as `cwd`.
> - `startSession` returns a populated `resumeCursor` (sessionID + directory) and skips aborting the session on a start race when the winner was a resumed session.
> - `ProviderCommandReactor` clears the `resumeCursor` on restart when the provider's capabilities declare `runtime-mode-change` or `cwd-change` as invalidation reasons, in addition to the existing model-change check.
> - The reactor now queries provider capabilities using `currentInstanceId` instead of `desiredInstanceId`.
> - `OpenCodeAdapter` exposes `resumeCursorInvalidationReasons: ['runtime-mode-change', 'cwd-change']` in its capabilities.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0588c99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
