### PR TITLE
Exclude subscribe RPCs from latency tracking

### DIFF
--- a/apps/web/src/rpc/requestLatencyState.ts
+++ b/apps/web/src/rpc/requestLatencyState.ts
@@ -36,7 +36,7 @@ function getSlowRpcAckRequestsValue(): ReadonlyArray<SlowRpcAckRequest> {
 }
 
 function shouldTrackRpcAck(tag: string): boolean {
-  return !tag.startsWith("subscribe");
+  return !tag.includes("subscribe");
 }
 
 export function getSlowRpcAckRequests(): ReadonlyArray<SlowRpcAckRequest> {


### PR DESCRIPTION
- Treat any RPC tag containing `subscribe` as a subscription
- Avoid flagging subscription acknowledgements as slow RPCs

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-condition change that only affects which RPCs are included in slow-ack tracking; main risk is over/under-filtering tags that contain the substring `subscribe`.
> 
> **Overview**
> Updates RPC ack latency tracking to treat *any* tag containing `subscribe` as a subscription, not just tags that start with it, preventing subscription acknowledgements from being flagged as slow in `requestLatencyState.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d504f8909af2349686afad632a10d8f4a49d93b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `shouldTrackRpcAck` to exclude subscribe RPCs with 'subscribe' anywhere in the tag
> Changes the check in [`requestLatencyState.ts`](https://github.com/pingdotgg/t3code/pull/2313/files#diff-084b89e2becd47f287bdcaaf7d1ac9de731014c0b96d196afd4d1f54814eb085) from `startsWith('subscribe')` to `includes('subscribe')`, so any RPC tag containing 'subscribe' anywhere is excluded from latency tracking, not just those prefixed with it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d504f89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->