### PR TITLE
feat: add support for gpt 5.5

### DIFF
--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -145,6 +145,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER: Record<ProviderKind,
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Record<ProviderKind, Record<string, string>> = {
   codex: {
     "gpt-5-codex": "gpt-5.4",
+    "5.5": "gpt-5.5",
     "5.4": "gpt-5.4",
     "5.3": "gpt-5.3-codex",
     "gpt-5.3": "gpt-5.3-codex",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -68,6 +68,7 @@ const claudeCaps: ModelCapabilities = createModelCapabilities({
 describe("normalizeModelSlug", () => {
   it("maps known aliases to canonical slugs", () => {
     expect(normalizeModelSlug("gpt-5-codex")).toBe("gpt-5.4");
+    expect(normalizeModelSlug("5.5")).toBe("gpt-5.5");
     expect(normalizeModelSlug("5.3")).toBe("gpt-5.3-codex");
     expect(normalizeModelSlug("sonnet", "claudeAgent")).toBe("claude-sonnet-4-6");
   });
@@ -98,9 +99,11 @@ describe("resolveModelSlugForProvider", () => {
 describe("resolveSelectableModel", () => {
   it("resolves exact slugs, labels, and aliases", () => {
     const options = [
+      { slug: "gpt-5.5", name: "GPT-5.5" },
       { slug: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
       { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
     ];
+    expect(resolveSelectableModel("codex", "5.5", options)).toBe("gpt-5.5");
     expect(resolveSelectableModel("codex", "gpt-5.3-codex", options)).toBe("gpt-5.3-codex");
     expect(resolveSelectableModel("codex", "gpt-5.3 codex", options)).toBe("gpt-5.3-codex");
     expect(resolveSelectableModel("claudeAgent", "sonnet", options)).toBe("claude-sonnet-4-6");


### PR DESCRIPTION
## Summary
- add a Codex model alias so the `5.5` shorthand resolves to the documented `gpt-5.5` slug
- cover the new alias in shared model normalization and selectable-model resolution tests
- leave the default Codex model unchanged because OpenAI documents `gpt-5.5` as a rollout-only ChatGPT-auth model for now

## Verification
- `bun fmt`
- `bun lint` (passes with existing repo warnings unrelated to this change)
- `bun typecheck`
- `bun run test --filter=@t3tools/shared`

## Notes
- OpenAI's Codex models docs currently document the model name as `gpt-5.5`
- the API models docs mention GPT-5.5, but do not publish an API model ID yet and say API availability is coming soon

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to model-slug alias mapping plus test updates; only affects how the `codex` provider interprets the `5.5` shorthand.
> 
> **Overview**
> Adds a new `codex` model-slug alias so the shorthand `5.5` normalizes to the canonical `gpt-5.5` slug.
> 
> Updates shared model tests to cover normalization and `resolveSelectableModel` resolution for the new alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8a2e16d19022dbac984e5eb988aa8dcfbf6dd7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize GPT-5.5 shorthand alias in `MODEL_SLUG_ALIASES_BY_PROVIDER` for codex provider
> Adds `"5.5"` as an alias mapping to `"gpt-5.5"` in the codex provider entry of `MODEL_SLUG_ALIASES_BY_PROVIDER` in [model.ts](https://github.com/pingdotgg/t3code/pull/2320/files#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959). Tests in [model.test.ts](https://github.com/pingdotgg/t3code/pull/2320/files#diff-698991b568d5a708e88e5354a2d43bf1cd0afbf0bfcabbc07378d2f6847537f0) verify that `normalizeModelSlug("5.5")` and `resolveSelectableModel("codex", "5.5", ...)` both return `"gpt-5.5"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a8a2e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->