### PR TITLE
fix(desktop): standard Linux AppImage icons for AppImageLauncher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,17 +232,32 @@ jobs:
         shell: pwsh
         run: |
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-             $installPath = & $vswhere -products * -latest -property installationPath
-             $setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
-             $proc = Start-Process -FilePath $setupExe `
-              -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `
-              "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre", "--quiet", "--norestart" `
-              -Wait -PassThru -NoNewWindow
-             if ($null -eq $proc -or $proc.ExitCode -ne 0) {
-               $code = if ($null -ne $proc) { $proc.ExitCode } else { 1 }
-               Write-Error "Visual Studio Installer failed with exit code $code"
-               exit $code
-             }
+          $installPath = & $vswhere -products * -latest -property installationPath
+          $setupExe = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+          $proc = Start-Process -FilePath $setupExe `
+            -ArgumentList "modify", "--installPath", "`"$installPath`"", "--add", `
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64.Spectre", "--quiet", "--norestart" `
+            -Wait -PassThru -NoNewWindow
+          if ($null -eq $proc -or $proc.ExitCode -ne 0) {
+            $code = if ($null -ne $proc) { $proc.ExitCode } else { 1 }
+            Write-Error "Visual Studio Installer failed with exit code $code"
+            exit $code
+          }
+
+      - name: Install ImageMagick
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: |
+          if ! command -v magick >/dev/null 2>&1 && ! command -v convert >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y imagemagick
+          fi
+
+          if command -v magick >/dev/null 2>&1; then
+              magick -version
+          else
+              convert -version
+          fi
 
       - name: Build desktop artifact
         shell: bash

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -25,6 +25,8 @@ import {
 import { Command, Flag } from "effect/unstable/cli";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
+const LINUX_ICON_SIZES = [16, 22, 24, 32, 48, 64, 128, 256, 512] as const;
+
 const BuildPlatform = Schema.Literals(["mac", "linux", "win"]);
 const BuildArch = Schema.Literals(["arm64", "x64", "universal"]);
 
@@ -419,7 +421,7 @@ function stageMacIcons(stageResourcesDir: string, sourcePng: string, verbose: bo
   });
 }
 
-function stageLinuxIcons(stageResourcesDir: string, sourcePng: string) {
+function stageLinuxIcons(stageResourcesDir: string, sourcePng: string, verbose: boolean) {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -431,7 +433,46 @@ function stageLinuxIcons(stageResourcesDir: string, sourcePng: string) {
 
     const iconPath = path.join(stageResourcesDir, "icon.png");
     yield* fs.copyFile(sourcePng, iconPath);
+
+    const iconsDir = path.join(stageResourcesDir, "icons");
+    yield* fs.makeDirectory(iconsDir, { recursive: true });
+    for (const iconSize of LINUX_ICON_SIZES) {
+      yield* stageLinuxIconSize(
+        sourcePng,
+        path.join(iconsDir, `${iconSize}x${iconSize}.png`),
+        iconSize,
+        verbose,
+      );
+    }
   });
+}
+
+function stageLinuxIconSize(
+  sourcePng: string,
+  targetPng: string,
+  iconSize: number,
+  verbose: boolean,
+) {
+  const resize = (command: string) =>
+    runCommand(
+      ChildProcess.make(command, [sourcePng, "-resize", `${iconSize}x${iconSize}`, targetPng], {
+        ...commandOutputOptions(verbose),
+      }),
+    );
+
+  return resize("magick").pipe(
+    Effect.catch(() =>
+      resize("convert").pipe(
+        Effect.mapError(
+          () =>
+            new BuildScriptError({
+              message:
+                "ImageMagick is required to generate Linux desktop icon sizes. Install ImageMagick so either `magick` or `convert` is available.",
+            }),
+        ),
+      ),
+    ),
+  );
 }
 
 function stageWindowsIcons(stageResourcesDir: string, sourceIco: string) {
@@ -599,7 +640,7 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     buildConfig.linux = {
       target: [target],
       executableName: "t3code",
-      icon: "icon.png",
+      icon: "icons",
       category: "Development",
       desktop: {
         entry: {
@@ -638,7 +679,7 @@ const assertPlatformBuildResources = Effect.fn("assertPlatformBuildResources")(f
   }
 
   if (platform === "linux") {
-    yield* stageLinuxIcons(stageResourcesDir, iconAssets.linuxIconPng);
+    yield* stageLinuxIcons(stageResourcesDir, iconAssets.linuxIconPng, verbose);
     return;
   }
 


### PR DESCRIPTION
## What Changed

- Generate standard Linux hicolor icon sizes for AppImage builds from the selected desktop icon source.
- Point the Linux electron-builder config at the generated icon directory instead of a single source PNG.
- Install ImageMagick in the Linux release workflow when it is not already available.

## Why

Closes #2331.

AppImageLauncher and Linux desktop shells can fail to show an integrated AppImage icon when the package only contains the large source icon. Shipping the usual hicolor app icon sizes gives desktop icon lookup a standard path such as `usr/share/icons/hicolor/512x512/apps/t3code.png`.

This keeps the source assets small and generates the resized Linux icons at package time instead of committing generated PNGs.

Related prior art: #838 looked at runtime AppImage icon lookup. This PR fixes the packaged AppImage icon-theme entries instead.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes: N/A, packaging-only change
- [x] I included a video for animation/interaction changes: N/A

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`
- Built a local AppImage and verified AppImageLauncher integration shows the icon in Niri/Noctalia.
- Verified CI Linux AppImage artifacts for both channels:
  - Nightly: https://github.com/mwolson/t3code/actions/runs/24896075119
  - Release: https://github.com/mwolson/t3code/actions/runs/24897399770
- Extracted both AppImages and confirmed they include hicolor icon entries for `16`, `22`, `24`, `32`, `48`, `64`, `128`, `256`, and `512`.
- Confirmed the nightly artifact uses the nightly icon art and the release artifact uses the release icon art.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Linux packaging to generate and ship a multi-size icon theme and adds an ImageMagick build dependency, which could cause Linux release builds to fail or produce incorrect icons if tooling/config is off.
> 
> **Overview**
> Linux AppImage packaging now generates a standard set of hicolor-sized app icons (16–512) during `build-desktop-artifact`, using ImageMagick (`magick` with `convert` fallback) and failing with a clear error if neither is available.
> 
> Electron-builder’s Linux config is switched from a single `icon.png` to the staged `icons/` directory so the produced AppImage includes the multi-size icon set, and the release workflow installs ImageMagick on Linux runners when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5fce535d30664c0e3b34066f9a26cbd0ac74569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Generate standard multi-size icons for Linux AppImage builds
> - Adds `stageLinuxIconSize` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/2332/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to resize the source PNG to standard Linux icon sizes (16–512px) using ImageMagick (`magick` or `convert`), with a clear error if neither is available.
> - Updates the Electron builder `icon` config for Linux from `icon.png` to the generated `icons` directory so the packaged AppImage includes all sizes.
> - Updates the [release.yml](https://github.com/pingdotgg/t3code/pull/2332/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) CI workflow to install ImageMagick on Linux runners when neither `magick` nor `convert` is present.
> - Risk: introduces a hard build-time dependency on ImageMagick; builds will fail with an explicit error if it is missing and cannot be auto-installed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5fce53.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->