### PR TITLE
fix(desktop): preserve colons in model slugs when resolving picker selection

### DIFF
--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -33,6 +33,18 @@ type ModelPickerItem = {
 
 const EMPTY_MODEL_JUMP_LABELS = new Map<string, string>();
 
+// Keys are `${provider}:${slug}`; slugs can contain colons, so split on the first one only.
+function parseModelKey(modelKey: string): { provider: ProviderKind; slug: string } | null {
+  const separatorIndex = modelKey.indexOf(":");
+  if (separatorIndex <= 0 || separatorIndex === modelKey.length - 1) {
+    return null;
+  }
+  return {
+    provider: modelKey.slice(0, separatorIndex) as ProviderKind,
+    slug: modelKey.slice(separatorIndex + 1),
+  };
+}
+
 export const ModelPickerContent = memo(function ModelPickerContent(props: {
   provider: ProviderKind;
   model: string;
@@ -331,10 +343,13 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       if (!targetModelKey) {
         return;
       }
-      const [provider, slug] = targetModelKey.split(":") as [ProviderKind, string];
+      const parsed = parseModelKey(targetModelKey);
+      if (!parsed) {
+        return;
+      }
       event.preventDefault();
       event.stopPropagation();
-      handleModelSelect(slug, provider);
+      handleModelSelect(parsed.slug, parsed.provider);
     };
 
     window.addEventListener("keydown", onWindowKeyDown, true);
@@ -430,8 +445,11 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
             if (typeof modelKey !== "string") {
               return;
             }
-            const [provider, slug] = modelKey.split(":") as [ProviderKind, string];
-            handleModelSelect(slug, provider);
+            const parsed = parseModelKey(modelKey);
+            if (!parsed) {
+              return;
+            }
+            handleModelSelect(parsed.slug, parsed.provider);
           }}
         >
           <div
@@ -464,11 +482,11 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                     ).preventBaseUIHandler?.();
                     e.preventDefault();
                     e.stopPropagation();
-                    const [provider, slug] = highlightedModelKeyRef.current.split(":") as [
-                      ProviderKind,
-                      string,
-                    ];
-                    handleModelSelect(slug, provider);
+                    const parsed = parseModelKey(highlightedModelKeyRef.current);
+                    if (!parsed) {
+                      return;
+                    }
+                    handleModelSelect(parsed.slug, parsed.provider);
                     return;
                   }
                   e.stopPropagation();

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -937,6 +937,53 @@ describe("ProviderModelPicker", () => {
     }
   });
 
+  // Regression: slugs with colons (e.g. Ollama-style `gpt-oss:120b`) must survive
+  // the `${provider}:${slug}` combobox key round-trip.
+  it("dispatches callback when the selected model slug contains a colon", async () => {
+    const providers: ReadonlyArray<ServerProvider> = [
+      buildOpenCodeProvider([
+        {
+          slug: "litellm_provider/baseline",
+          name: "Baseline",
+          subProvider: "LiteLLM",
+          isCustom: false,
+          capabilities: createModelCapabilities({ optionDescriptors: [] }),
+        },
+        {
+          slug: "litellm_provider/gpt-oss:120b",
+          name: "openai/gpt-oss-120b",
+          subProvider: "LiteLLM",
+          isCustom: false,
+          capabilities: createModelCapabilities({ optionDescriptors: [] }),
+        },
+      ]),
+    ];
+    const mounted = await mountPicker({
+      provider: "opencode",
+      model: "litellm_provider/baseline",
+      lockedProvider: "opencode",
+      providers,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(getModelPickerListText()).toContain("openai/gpt-oss-120b");
+      });
+
+      const modelRow = page.getByText("openai/gpt-oss-120b").first();
+      await modelRow.click();
+
+      expect(mounted.onProviderModelChange).toHaveBeenCalledWith(
+        "opencode",
+        "litellm_provider/gpt-oss:120b",
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("only shows codex spark when the server reports it", async () => {
     const providersWithoutSpark: ReadonlyArray<ServerProvider> = [
       buildCodexProvider([


### PR DESCRIPTION
## What Changed

`ModelPickerContent` keys each combobox item as `` `${provider}:${slug}` ``. Three handlers (mouse click via `onValueChange`, Enter in the search input, jump-shortcut via `onWindowKeyDown`) decoded that key with `modelKey.split(":")`, which splits on **every** colon.

Introduced a small `parseModelKey` helper that splits on the first colon only and reuses it at all three call sites. Added a regression browser test that mounts an OpenCode provider with a `litellm_provider/gpt-oss:120b` slug, clicks the row, and asserts `onProviderModelChange` fires with the full, unsharded slug.

## Why

Models whose slug itself contains a colon — common for OpenAI-compatible custom providers surfaced through OpenCode (Ollama-style tags like `gpt-oss:120b`, or LiteLLM-proxied deployments like `minimax-m2.7:229b`) — were unselectable: the slug got truncated on the second colon, `resolveSelectableModel` returned `null`, the `if (resolvedModel)` guard blocked `onProviderModelChange`, and the click looked like a silent no-op. The model showed up in the list but couldn't be picked.

First-colon split is the minimal fix that keeps the existing encoding and doesn't touch any other code paths. `flattenOpenCodeModels` already produces `${providerID}/${modelID}` slugs, and provider kinds never contain a colon, so the first `:` is always the provider/slug boundary.

Local verification:
- `bun run typecheck --filter=@t3tools/web` — 4 tasks successful
- `bun x vitest run --config vitest.browser.config.ts src/components/chat/ProviderModelPicker.browser.tsx` — 22/22 passed (incl. new regression)
- `bun run fmt:check` on the two touched files — clean
- `bun run lint` — no new warnings in touched files

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable)
- [x] I included a video for animation/interaction changes (not applicable)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI bugfix limited to model-key parsing and a new regression test; main risk is unintended parsing behavior if malformed keys are produced elsewhere.
> 
> **Overview**
> Fixes a model picker bug where combobox item keys of the form `${provider}:${slug}` were decoded with `split(":")`, truncating slugs that themselves contain colons and making those models unselectable.
> 
> Adds a `parseModelKey` helper in `ModelPickerContent` that splits on the *first* colon only and uses it for click selection, Enter-to-select, and jump-shortcut selection. Includes a new browser regression test ensuring an OpenCode/LiteLLM model slug like `litellm_provider/gpt-oss:120b` round-trips and triggers `onProviderModelChange` with the full slug.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 563e86cc46cd55db9ba682649d956fdf1ff6c645. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model slug parsing in `ModelPickerContent` to preserve colons
> Naive `split(":")` parsing broke model slugs containing colons (e.g. `litellm_provider/gpt-oss:120b`) by truncating everything after the first colon. A `parseModelKey` helper is added that splits only on the first colon, returning the provider and full slug. All three selection paths (keyboard jump, combobox `onValueChange`, and Enter on highlighted item) now use this helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 563e86c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->