### PR TITLE
feat(settings): add submit key configuration for message sending

### DIFF
--- a/apps/desktop/src/clientPersistence.test.ts
+++ b/apps/desktop/src/clientPersistence.test.ts
@@ -60,6 +60,7 @@ const clientSettings: ClientSettings = {
   },
   sidebarProjectSortOrder: "manual",
   sidebarThreadSortOrder: "created_at",
+  submitKey: "enter",
   timestampFormat: "24-hour",
 };
 

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1469,10 +1469,17 @@ export const ChatComposer = memo(
           return true;
         }
       }
-      if (key === "Enter" && !event.shiftKey) {
+      const shouldSend =
+        settings.submitKey === "shift-enter"
+          ? key === "Enter" && event.shiftKey
+          : key === "Enter" && !event.shiftKey;
+      if (shouldSend) {
         void onSend();
         return true;
       }
+      // When submitKey is "shift-enter", let plain Enter fall through to
+      // Lexical so it inserts a newline. When submitKey is "enter",
+      // Shift+Enter already falls through (default Lexical behaviour).
       return false;
     };
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -100,6 +100,11 @@ const TIMESTAMP_FORMAT_LABELS = {
   "24-hour": "24-hour",
 } as const;
 
+const SUBMIT_KEY_LABELS = {
+  enter: "Enter",
+  "shift-enter": "Shift + Enter",
+} as const;
+
 type InstallProviderSettings = {
   provider: ProviderKind;
   title: string;
@@ -490,6 +495,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
+      ...(settings.submitKey !== DEFAULT_UNIFIED_SETTINGS.submitKey ? ["Submit key"] : []),
       ...(isGitWritingModelDirty ? ["Git writing model"] : []),
       ...(areProviderSettingsDirty ? ["Providers"] : []),
     ],
@@ -503,6 +509,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.defaultThreadEnvMode,
       settings.diffWordWrap,
       settings.enableAssistantStreaming,
+      settings.submitKey,
       settings.timestampFormat,
       theme,
     ],
@@ -892,6 +899,45 @@ export function GeneralSettingsPanel() {
                 </SelectItem>
                 <SelectItem hideIndicator value="24-hour">
                   {TIMESTAMP_FORMAT_LABELS["24-hour"]}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Submit key"
+          description="Choose which key sends a message. The other key inserts a new line."
+          resetAction={
+            settings.submitKey !== DEFAULT_UNIFIED_SETTINGS.submitKey ? (
+              <SettingResetButton
+                label="submit key"
+                onClick={() =>
+                  updateSettings({
+                    submitKey: DEFAULT_UNIFIED_SETTINGS.submitKey,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.submitKey}
+              onValueChange={(value) => {
+                if (value === "enter" || value === "shift-enter") {
+                  updateSettings({ submitKey: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Submit key">
+                <SelectValue>{SUBMIT_KEY_LABELS[settings.submitKey]}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="enter">
+                  {SUBMIT_KEY_LABELS.enter}
+                </SelectItem>
+                <SelectItem hideIndicator value="shift-enter">
+                  {SUBMIT_KEY_LABELS["shift-enter"]}
                 </SelectItem>
               </SelectPopup>
             </Select>

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -540,6 +540,7 @@ describe("wsApi", () => {
       },
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
+      submitKey: "enter" as const,
       timestampFormat: "24-hour" as const,
     };
     const getClientSettings = vi.fn().mockResolvedValue({
@@ -599,6 +600,7 @@ describe("wsApi", () => {
       },
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
+      submitKey: "enter" as const,
       timestampFormat: "24-hour" as const,
     };
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -22,6 +22,10 @@ export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 
+export const SubmitKey = Schema.Literals(["enter", "shift-enter"]);
+export type SubmitKey = typeof SubmitKey.Type;
+export const DEFAULT_SUBMIT_KEY: SubmitKey = "enter";
+
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
   "repository_path",
@@ -35,6 +39,7 @@ export const ClientSettingsSchema = Schema.Struct({
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  submitKey: SubmitKey.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_SUBMIT_KEY))),
   favorites: Schema.Array(
     Schema.Struct({
       provider: ProviderKind,
@@ -248,6 +253,7 @@ export const ClientSettingsPatch = Schema.Struct({
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffWordWrap: Schema.optionalKey(Schema.Boolean),
+  submitKey: Schema.optionalKey(SubmitKey),
   favorites: Schema.optionalKey(
     Schema.Array(
       Schema.Struct({


### PR DESCRIPTION
## What Changed

Added a new **Submit key** setting under General settings that lets users choose between **Enter** and **Shift + Enter** as the key that sends a message in the chat composer. The other key inserts a new line.

- New `submitKey` client setting with two options: `"enter"` (default) and `"shift-enter"`
- Select dropdown in General settings between "Time format" and "Diff line wrapping"
- Chat composer key handler reads the setting and inverts Enter/Shift+Enter behavior accordingly
- Setting is tracked by "Restore defaults" and has its own reset button

## Why

Some users prefer Shift+Enter to send messages, while others prefer the default Enter-to-send behavior. This is a personal ergonomics preference, users who write multi-line prompts frequently find Enter-for-newline more natural since it avoids needing a modifier key for the most common action (line breaks in longer prompts).

## UI Changes

**General settings — new "Submit key" row:**

<img width="1032" height="550" alt="image" src="https://github.com/user-attachments/assets/a0473895-165e-43ea-aa91-0aebc2fae6e3" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new client-side setting and UI control, and only tweaks key handling in the chat composer without touching server/auth or data migrations.
> 
> **Overview**
> Adds a new **client setting** `submitKey` (default `enter`) to control whether `Enter` or `Shift+Enter` submits messages.
> 
> Updates the chat composer key handler to send only when the configured key combo is pressed, letting the other combo fall through to insert a newline.
> 
> Exposes the setting in General settings via a new “Submit key” dropdown with per-setting reset support, and updates desktop/web persistence tests to include the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c4dd124da4f5eda9d8cacb2b05041d9712d96a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable submit key setting for sending chat messages
> - Adds a `submitKey` field (`'enter'` or `'shift-enter'`) to `ClientSettingsSchema` in [settings.ts](https://github.com/pingdotgg/t3code/pull/2335/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), defaulting to `'enter'`.
> - Adds a "Submit key" selector to the General settings panel in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/2335/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18), with reset-to-default support.
> - Updates [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/2335/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to gate message sending on `settings.submitKey`: when set to `'shift-enter'`, Shift+Enter sends and Enter inserts a newline; otherwise Enter sends and Shift+Enter inserts a newline.
> - Behavioral Change: users who previously relied on Enter to send will see no change (default is `'enter'`), but the behavior is now user-configurable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 81c4dd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->