### PR TITLE
fix(web): keep oversized diff lines from locking the UI

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -33,6 +33,7 @@ import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch"
 import { useTheme } from "../hooks/useTheme";
 import {
   buildFileDiffRenderKey,
+  canRenderFileDiff,
   getDiffCollapseIconClassName,
   getRenderablePatch,
   resolveDiffThemeName,
@@ -325,12 +326,22 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
     if (!renderablePatch || renderablePatch.kind !== "files") {
       return [];
     }
-    return renderablePatch.files.toSorted((left, right) =>
-      resolveFileDiffPath(left).localeCompare(resolveFileDiffPath(right), undefined, {
-        numeric: true,
-        sensitivity: "base",
-      }),
-    );
+    return renderablePatch.files
+      .map((fileDiff) => ({
+        canRender: canRenderFileDiff(fileDiff),
+        fileDiff,
+        filePath: resolveFileDiffPath(fileDiff),
+      }))
+      .toSorted((left, right) => {
+        const renderOrder = Number(!left.canRender) - Number(!right.canRender);
+        return (
+          renderOrder ||
+          left.filePath.localeCompare(right.filePath, undefined, {
+            numeric: true,
+            sensitivity: "base",
+          })
+        );
+      });
   }, [renderablePatch]);
 
   useEffect(() => {
@@ -679,11 +690,10 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
                   intersectionObserverMargin: 1200,
                 }}
               >
-                {renderableFiles.map((fileDiff) => {
-                  const filePath = resolveFileDiffPath(fileDiff);
+                {renderableFiles.map(({ canRender, fileDiff, filePath }) => {
                   const fileKey = buildFileDiffRenderKey(fileDiff);
                   const themedFileKey = `${fileKey}:${resolvedTheme}`;
-                  const collapsed = collapsedDiffFileKeys.has(fileKey);
+                  const collapsed = !canRender || collapsedDiffFileKeys.has(fileKey);
                   return (
                     <div
                       key={themedFileKey}
@@ -720,8 +730,10 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
                                     collapsed ? `Expand ${filePath}` : `Collapse ${filePath}`
                                   }
                                   aria-expanded={!collapsed}
+                                  disabled={!canRender}
                                   onClick={(event) => {
                                     event.stopPropagation();
+                                    if (!canRender) return;
                                     toggleDiffFileCollapsed(fileKey);
                                   }}
                                 />
@@ -748,6 +760,11 @@ export default function DiffPanel({ mode = "inline", composerDraftTarget }: Diff
                           unsafeCSS: DIFF_PANEL_UNSAFE_CSS,
                         }}
                       />
+                      {!canRender && (
+                        <div className="px-3 py-3 text-[11px] leading-relaxed text-muted-foreground">
+                          This file is too large to display. Open the file to inspect the change.
+                        </div>
+                      )}
                     </div>
                   );
                 })}

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -27,8 +27,7 @@ import { readLocalApi } from "../localApi";
 import { resolvePathLinkTarget } from "../terminal-links";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
 import { useTheme } from "../hooks/useTheme";
-import { buildPatchCacheKey } from "../lib/diffRendering";
-import { resolveDiffThemeName } from "../lib/diffRendering";
+import { buildPatchCacheKey, canRenderFileDiff, resolveDiffThemeName } from "../lib/diffRendering";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { selectProjectByRef, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
@@ -306,12 +305,22 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     if (!renderablePatch || renderablePatch.kind !== "files") {
       return [];
     }
-    return renderablePatch.files.toSorted((left, right) =>
-      resolveFileDiffPath(left).localeCompare(resolveFileDiffPath(right), undefined, {
-        numeric: true,
-        sensitivity: "base",
-      }),
-    );
+    return renderablePatch.files
+      .map((fileDiff) => ({
+        canRender: canRenderFileDiff(fileDiff),
+        fileDiff,
+        filePath: resolveFileDiffPath(fileDiff),
+      }))
+      .toSorted((left, right) => {
+        const renderOrder = Number(!left.canRender) - Number(!right.canRender);
+        if (renderOrder !== 0) {
+          return renderOrder;
+        }
+        return left.filePath.localeCompare(right.filePath, undefined, {
+          numeric: true,
+          sensitivity: "base",
+        });
+      });
   }, [renderablePatch]);
 
   useEffect(() => {
@@ -600,8 +609,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                   intersectionObserverMargin: 1200,
                 }}
               >
-                {renderableFiles.map((fileDiff) => {
-                  const filePath = resolveFileDiffPath(fileDiff);
+                {renderableFiles.map(({ canRender, fileDiff, filePath }) => {
                   const fileKey = buildFileDiffRenderKey(fileDiff);
                   const themedFileKey = `${fileKey}:${resolvedTheme}`;
                   return (
@@ -629,8 +637,17 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
                           theme: resolveDiffThemeName(resolvedTheme),
                           themeType: resolvedTheme as DiffThemeType,
                           unsafeCSS: DIFF_PANEL_UNSAFE_CSS,
+                          collapsed: !canRender,
                         }}
                       />
+
+                      {!canRender && (
+                        <div className="px-3 py-3 text-[11px] leading-relaxed text-muted-foreground">
+                          <p>
+                            This file is too large to display. Open the file to inspect the change.
+                          </p>
+                        </div>
+                      )}
                     </div>
                   );
                 })}

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
-import { buildPatchCacheKey } from "./diffRendering";
+import {
+  buildPatchCacheKey,
+  canRenderFileDiff,
+  MAX_RENDERABLE_DIFF_LINE_LENGTH,
+} from "./diffRendering";
 
 describe("buildPatchCacheKey", () => {
   it("returns a stable cache key for identical content", () => {
@@ -27,5 +31,25 @@ describe("buildPatchCacheKey", () => {
     expect(buildPatchCacheKey(patch, "diff-panel:light")).not.toBe(
       buildPatchCacheKey(patch, "diff-panel:dark"),
     );
+  });
+});
+
+describe("diff render line limits", () => {
+  it("rejects file diffs with pathological line lengths", () => {
+    expect(
+      canRenderFileDiff({
+        additionLines: ["small"],
+        deletionLines: ["x".repeat(MAX_RENDERABLE_DIFF_LINE_LENGTH + 1)],
+      }),
+    ).toBe(false);
+  });
+
+  it("allows file diffs within the line length limit", () => {
+    expect(
+      canRenderFileDiff({
+        additionLines: ["x".repeat(MAX_RENDERABLE_DIFF_LINE_LENGTH)],
+        deletionLines: ["small"],
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/lib/diffRendering.test.ts
+++ b/apps/web/src/lib/diffRendering.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildPatchCacheKey } from "./diffRendering";
+import {
+  buildPatchCacheKey,
+  canRenderFileDiff,
+  MAX_RENDERABLE_DIFF_LINE_LENGTH,
+} from "./diffRendering";
 
 describe("buildPatchCacheKey", () => {
   it("returns a stable cache key for identical content", () => {
@@ -27,5 +31,25 @@ describe("buildPatchCacheKey", () => {
     expect(buildPatchCacheKey(patch, "diff-panel:light")).not.toBe(
       buildPatchCacheKey(patch, "diff-panel:dark"),
     );
+  });
+});
+
+describe("diff render line limits", () => {
+  it("rejects file diffs with pathological line lengths", () => {
+    expect(
+      canRenderFileDiff({
+        additionLines: ["small"],
+        deletionLines: ["x".repeat(MAX_RENDERABLE_DIFF_LINE_LENGTH + 1)],
+      }),
+    ).toBe(false);
+  });
+
+  it("allows file diffs within the line length limit", () => {
+    expect(
+      canRenderFileDiff({
+        additionLines: ["x".repeat(MAX_RENDERABLE_DIFF_LINE_LENGTH)],
+        deletionLines: ["small"],
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -8,6 +8,8 @@ export const DIFF_THEME_NAMES = {
 
 export type DiffThemeName = (typeof DIFF_THEME_NAMES)[keyof typeof DIFF_THEME_NAMES];
 
+export const MAX_RENDERABLE_DIFF_LINE_LENGTH = 500_000;
+
 export function resolveDiffThemeName(theme: "light" | "dark"): DiffThemeName {
   return theme === "dark" ? DIFF_THEME_NAMES.dark : DIFF_THEME_NAMES.light;
 }
@@ -109,4 +111,13 @@ export function getDiffCollapseIconClassName(fileDiff: FileDiffMetadata): string
     default:
       return "text-muted-foreground/80";
   }
+}
+
+export function canRenderFileDiff(
+  fileDiff: Pick<FileDiffMetadata, "additionLines" | "deletionLines">,
+): boolean {
+  return (
+    fileDiff.additionLines.every((line) => line.length <= MAX_RENDERABLE_DIFF_LINE_LENGTH) &&
+    fileDiff.deletionLines.every((line) => line.length <= MAX_RENDERABLE_DIFF_LINE_LENGTH)
+  );
 }

--- a/apps/web/src/lib/diffRendering.ts
+++ b/apps/web/src/lib/diffRendering.ts
@@ -1,9 +1,13 @@
+import type { FileDiffMetadata } from "@pierre/diffs";
+
 export const DIFF_THEME_NAMES = {
   light: "pierre-light",
   dark: "pierre-dark",
 } as const;
 
 export type DiffThemeName = (typeof DIFF_THEME_NAMES)[keyof typeof DIFF_THEME_NAMES];
+
+export const MAX_RENDERABLE_DIFF_LINE_LENGTH = 500_000;
 
 export function resolveDiffThemeName(theme: "light" | "dark"): DiffThemeName {
   return theme === "dark" ? DIFF_THEME_NAMES.dark : DIFF_THEME_NAMES.light;
@@ -36,4 +40,13 @@ export function buildPatchCacheKey(patch: string, scope = "diff-panel"): string 
     SECONDARY_HASH_MULTIPLIER,
   ).toString(36);
   return `${scope}:${normalizedPatch.length}:${primary}:${secondary}`;
+}
+
+export function canRenderFileDiff(
+  fileDiff: Pick<FileDiffMetadata, "additionLines" | "deletionLines">,
+): boolean {
+  return (
+    fileDiff.additionLines.every((line) => line.length <= MAX_RENDERABLE_DIFF_LINE_LENGTH) &&
+    fileDiff.deletionLines.every((line) => line.length <= MAX_RENDERABLE_DIFF_LINE_LENGTH)
+  );
 }


### PR DESCRIPTION
## What Changed

Adds a render-safety guard to the web diff panel so files with pathologically long diff lines are skipped instead of being passed into the browser diff renderer.

This includes:

- a shared `canRenderFileDiff` helper in `diffRendering`
- a `MAX_RENDERABLE_DIFF_LINE_LENGTH` limit for oversized added/deleted lines
- updated `DiffPanel` sorting and rendering behavior
- user-facing fallback copy for files that are too large to render safely
- unit coverage for both accepted and rejected line lengths

Renderable diffs continue to display normally. Files that exceed the line-length threshold still appear in the diff list, but their diff body is collapsed and replaced with guidance to open the file directly.

## Why

A single extremely long added or deleted line can make browser-side diff rendering expensive enough to freeze or severely degrade the UI, even when the rest of the patch is small.

This keeps the diff panel reliable under pathological inputs without rejecting or hiding the entire patch. Safe files remain visible, oversized files remain represented, and users can still inspect the full change in their editor when needed.

The implementation is intentionally localized: shared diff-rendering logic owns the renderability decision, and `DiffPanel` uses that result only to avoid the unsafe render path.

## UI Changes

For files that are too large to render safely, the diff panel now shows:

- the file header in a collapsed state
- fallback text: `This file is too large to display. Open the file to inspect the change.`

There are no layout or interaction changes for normal-sized diffs.

<img width="772" height="814" alt="Screenshot 2026-04-24 at 2 09 00 PM" src="https://github.com/user-attachments/assets/0ab9bab3-be51-4748-a646-f2eeff154fac" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI guard with a clear fallback; normal diffs are unchanged aside from sort order prioritizing renderable files.
> 
> **Overview**
> Adds a **500k character per-line** guard in shared diff rendering via `canRenderFileDiff` and `MAX_RENDERABLE_DIFF_LINE_LENGTH`, so pathologically long added/deleted lines are not treated as safe to render in the browser.
> 
> **`DiffPanel`** now annotates each file with that result: renderable files sort first, oversized entries stay in the list but are **forced collapsed**, their expand/collapse control is **disabled**, and a short message tells users to open the file in the editor instead of viewing the inline diff.
> 
> Unit tests cover acceptance at the limit and rejection when a line exceeds it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c66665a71617af74fb6eda85a6519236310c97b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent oversized diff lines from locking the UI in DiffPanel
> - Adds `canRenderFileDiff` in [`diffRendering.ts`](https://github.com/pingdotgg/t3code/pull/2338/files#diff-cc9236c452007592d65fe06c8cee08b0cf4e86d1d36030ac2dcfb3d43e470c2c) that returns false if any line in a file diff exceeds 500,000 characters.
> - Non-renderable files are sorted after renderable ones, shown collapsed by default, and have the collapse toggle disabled.
> - A message is shown below the diff view indicating the file is too large to display.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5c66665.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/2338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
