### PR TITLE
fix: terminal drawer fails to load on ultrawide displays

### DIFF
--- a/apps/server/src/terminal/Layers/BunPTY.ts
+++ b/apps/server/src/terminal/Layers/BunPTY.ts
@@ -1,6 +1,11 @@
 import { Effect, Layer } from "effect";
 import { PtyAdapter } from "../Services/PTY.ts";
-import type { PtyAdapterShape, PtyExitEvent, PtyProcess } from "../Services/PTY.ts";
+import {
+  PtySpawnError,
+  type PtyAdapterShape,
+  type PtyExitEvent,
+  type PtyProcess,
+} from "../Services/PTY.ts";
 
 class BunPtyProcess implements PtyProcess {
   private readonly dataListeners = new Set<(data: string) => void>();
@@ -99,22 +104,30 @@ export const layer = Layer.effect(
     }
     return {
       spawn: (input) =>
-        Effect.sync(() => {
-          let processHandle: BunPtyProcess | null = null;
-          const command = [input.shell, ...(input.args ?? [])];
-          const subprocess = Bun.spawn(command, {
-            cwd: input.cwd,
-            env: input.env,
-            terminal: {
-              cols: input.cols,
-              rows: input.rows,
-              data: (_terminal, data) => {
-                processHandle?.emitData(data);
+        Effect.try({
+          try: () => {
+            let processHandle: BunPtyProcess | null = null;
+            const command = [input.shell, ...(input.args ?? [])];
+            const subprocess = Bun.spawn(command, {
+              cwd: input.cwd,
+              env: input.env,
+              terminal: {
+                cols: input.cols,
+                rows: input.rows,
+                data: (_terminal, data) => {
+                  processHandle?.emitData(data);
+                },
               },
-            },
-          });
-          processHandle = new BunPtyProcess(subprocess);
-          return processHandle;
+            });
+            processHandle = new BunPtyProcess(subprocess);
+            return processHandle as PtyProcess;
+          },
+          catch: (cause) =>
+            new PtySpawnError({
+              adapter: "bun-pty",
+              message: cause instanceof Error ? cause.message : "Failed to spawn PTY process",
+              cause,
+            }),
         }),
     } satisfies PtyAdapterShape;
   }),

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -46,6 +46,7 @@ import {
   type ThreadTerminalGroup,
 } from "../types";
 import { readEnvironmentApi } from "~/environmentApi";
+import { extractErrorMessage } from "~/lib/errorMessage";
 import { readLocalApi } from "~/localApi";
 import { selectTerminalEventEntries, useTerminalStateStore } from "../terminalStateStore";
 
@@ -517,10 +518,7 @@ export function TerminalViewport({
       void api.terminal
         .write({ threadId, terminalId, data })
         .catch((err) =>
-          writeSystemMessage(
-            terminal,
-            err instanceof Error ? err.message : "Terminal write failed",
-          ),
+          writeSystemMessage(terminal, extractErrorMessage(err, "Terminal write failed")),
         );
     });
 
@@ -702,10 +700,7 @@ export function TerminalViewport({
         }
       } catch (err) {
         if (disposed) return;
-        writeSystemMessage(
-          terminal,
-          err instanceof Error ? err.message : "Failed to open terminal",
-        );
+        writeSystemMessage(terminal, extractErrorMessage(err, "Failed to open terminal"));
       }
     };
 

--- a/apps/web/src/lib/errorMessage.test.ts
+++ b/apps/web/src/lib/errorMessage.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { extractErrorMessage } from "./errorMessage";
+
+describe("extractErrorMessage", () => {
+  const fallback = "fallback message";
+
+  it("returns the message of a regular Error", () => {
+    const err = new Error("boom");
+    expect(extractErrorMessage(err, fallback)).toBe("boom");
+  });
+
+  it("returns fallback when Error has empty message", () => {
+    const err = new Error("");
+    expect(extractErrorMessage(err, fallback)).toBe(fallback);
+  });
+
+  it("returns fallback when Error message is whitespace", () => {
+    const err = new Error("   ");
+    expect(extractErrorMessage(err, fallback)).toBe(fallback);
+  });
+
+  it("extracts message from a non-Error object with a message string", () => {
+    const err = { message: "RPC defect: failed to spawn" };
+    expect(extractErrorMessage(err, fallback)).toBe("RPC defect: failed to spawn");
+  });
+
+  it("formats objects carrying a _tag with the serialized payload", () => {
+    const err = { _tag: "TerminalCwdError", cwd: "/tmp/missing", reason: "notFound" };
+    expect(extractErrorMessage(err, fallback)).toContain("TerminalCwdError");
+    expect(extractErrorMessage(err, fallback)).toContain("/tmp/missing");
+  });
+
+  it("prefers object.message over _tag formatting", () => {
+    const err = { _tag: "Foo", message: "explicit message" };
+    expect(extractErrorMessage(err, fallback)).toBe("explicit message");
+  });
+
+  it("returns string rejections directly", () => {
+    expect(extractErrorMessage("a literal string defect", fallback)).toBe(
+      "a literal string defect",
+    );
+  });
+
+  it("returns fallback for null", () => {
+    expect(extractErrorMessage(null, fallback)).toBe(fallback);
+  });
+
+  it("returns fallback for undefined", () => {
+    expect(extractErrorMessage(undefined, fallback)).toBe(fallback);
+  });
+
+  it("returns fallback for numeric rejections", () => {
+    expect(extractErrorMessage(42, fallback)).toBe(fallback);
+  });
+
+  it("survives circular objects without throwing", () => {
+    const err: { _tag: string; self?: unknown } = { _tag: "Circular" };
+    err.self = err;
+    expect(extractErrorMessage(err, fallback)).toBe("Circular");
+  });
+});

--- a/apps/web/src/lib/errorMessage.ts
+++ b/apps/web/src/lib/errorMessage.ts
@@ -1,0 +1,35 @@
+export function extractErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    const message = error.message;
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message;
+    }
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const messageCandidate = (error as { message?: unknown }).message;
+    if (typeof messageCandidate === "string" && messageCandidate.trim().length > 0) {
+      return messageCandidate;
+    }
+
+    const tagCandidate = (error as { _tag?: unknown })._tag;
+    if (typeof tagCandidate === "string" && tagCandidate.length > 0) {
+      const serialized = safeStringify(error);
+      return serialized ? `${tagCandidate}: ${serialized}` : tagCandidate;
+    }
+  }
+
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+
+  return fallback;
+}
+
+function safeStringify(value: unknown): string | null {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -49,6 +49,36 @@ describe("TerminalOpenInput", () => {
     ).toBe(false);
   });
 
+  it("accepts maximum cols and rows", () => {
+    expect(
+      decodes(TerminalOpenInput, {
+        threadId: "thread-1",
+        cwd: "/tmp/project",
+        cols: 1000,
+        rows: 500,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects cols and rows above maximum", () => {
+    expect(
+      decodes(TerminalOpenInput, {
+        threadId: "thread-1",
+        cwd: "/tmp/project",
+        cols: 1001,
+        rows: 24,
+      }),
+    ).toBe(false);
+    expect(
+      decodes(TerminalOpenInput, {
+        threadId: "thread-1",
+        cwd: "/tmp/project",
+        cols: 80,
+        rows: 501,
+      }),
+    ).toBe(false);
+  });
+
   it("defaults terminalId when missing", () => {
     const parsed = decodeSync(TerminalOpenInput, {
       threadId: "thread-1",

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -5,10 +5,10 @@ export const DEFAULT_TERMINAL_ID = "default";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const TerminalColsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(20)).check(
-  Schema.isLessThanOrEqualTo(400),
+  Schema.isLessThanOrEqualTo(1000),
 );
 const TerminalRowsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(5)).check(
-  Schema.isLessThanOrEqualTo(200),
+  Schema.isLessThanOrEqualTo(500),
 );
 const TerminalIdSchema = TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(128));
 const TerminalEnvKeySchema = Schema.String.check(


### PR DESCRIPTION
## Summary

- **Schema bounds.** `cols`/`rows` were capped at 400/200, but xterm's `FitAddon` produces ~411 cols on a 3440x1440 ultrawide. The decode rejected the `terminal.open`/`terminal.resize` call client-side and the drawer showed `Expected a value less than or equal to 400, got 411 at ["cols"]`. Raised to 1000/500 — covers ultrawide / 4K / 8K at small font sizes while staying bounded.
- **Bun PTY defects.** With the schema fix in place, the next failure surfaced as the generic `Failed to open terminal` fallback because `BunPTY` used `Effect.sync`, turning any synchronous `Bun.spawn` throw into an untyped defect. Effect's `runPromise` rejects with raw `Cause.die` payloads (verified in isolation), so on the client `err instanceof Error` returns `false` and the underlying message is lost. Switched to `Effect.try` to mirror `NodePTY`, mapping spawn failures to typed `PtySpawnError`.
- **Error-message helper.** Added `extractErrorMessage(error, fallback)` that handles `Error`, objects with a `message` string, `_tag`-discriminated RPC payloads, and string rejections, falling back only when nothing meaningful is present. Used in the terminal drawer's open/write catch handlers; the previous `err instanceof Error ? err.message : fallback` pattern silently swallowed non-`Error` rejections.

## Test plan

- [ ] On a 3440x1440 ultrawide, open the terminal drawer — the terminal loads (no `Expected a value less than or equal to 400` error).
- [ ] On a regular display (e.g. 1920x1080), the terminal still loads normally.
- [ ] Force a PTY spawn failure (e.g. point shell resolver at a non-existent binary) — the drawer shows a meaningful error message instead of `Failed to open terminal`.
- [ ] `bun run test` passes (added 2 schema-bound tests in `terminal.test.ts`, 11 helper tests in `errorMessage.test.ts`).
- [ ] `bun fmt`, `bun lint`, `bun typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal size validation limits and alters Bun PTY spawn error handling, which can affect terminal session creation and resizing across clients. Risk is moderate because failures will now propagate as typed errors and larger dimensions may impact performance/memory in extreme cases.
> 
> **Overview**
> Fixes terminal drawer failures on large/ultrawide displays by increasing contract validation bounds for terminal `cols`/`rows` (to `1000`/`500`) and adding tests for the new maxima.
> 
> Improves terminal error surfacing: Bun’s PTY adapter now wraps `Bun.spawn` in `Effect.try` and maps failures to `PtySpawnError` (instead of dying via `Effect.sync`), and the web terminal drawer uses a new `extractErrorMessage` helper to display meaningful messages for non-`Error` rejections (including `_tag`-shaped RPC errors) when `open`/`write` fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab83fa028506a202d314f916479cf187ca54466d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal drawer failing to load on ultrawide displays by raising max terminal dimensions
> - Increases the accepted terminal size limits in [`terminal.ts`](https://github.com/pingdotgg/t3code/pull/2342/files#diff-68613534653e19cf33dc0ddf6c6bf01ac3c4848b8fbfdd29363100dd6a7c2a89): `cols` from 400→1000 and `rows` from 200→500, fixing validation rejection on ultrawide displays.
> - Adds [`extractErrorMessage`](https://github.com/pingdotgg/t3code/pull/2342/files#diff-3b2d5c696151095054c9d7ff488cee685416ea4b5690d419398623e8fc85ba69) utility that normalizes unknown errors to a human-readable string, with fallback support and safe handling of circular references.
> - Uses `extractErrorMessage` in [`ThreadTerminalDrawer`](https://github.com/pingdotgg/t3code/pull/2342/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) for both the write and open failure paths.
> - Wraps `Bun.spawn` in `Effect.try` in [`BunPTY.ts`](https://github.com/pingdotgg/t3code/pull/2342/files#diff-2f794d80b0d8c3934deef78660a54354c840cada33e62267ce6a13aef77b3ad3) so spawn failures surface as typed `PtySpawnError` instead of a generic thrown error.
> - Behavioral Change: terminals with cols 401–1000 or rows 201–500 are now accepted rather than rejected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ab83fa0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->