### PR TITLE
feat: adds floating terminal layout

### DIFF
--- a/apps/desktop/src/clientPersistence.test.ts
+++ b/apps/desktop/src/clientPersistence.test.ts
@@ -61,6 +61,7 @@ const clientSettings: ClientSettings = {
   sidebarProjectSortOrder: "manual",
   sidebarThreadSortOrder: "created_at",
   timestampFormat: "24-hour",
+  terminalLayout: "floating",
 };
 
 const savedRegistryRecord: PersistedSavedEnvironmentRecord = {

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1911,6 +1911,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
         [THREAD_KEY]: {
           terminalOpen: true,
           terminalHeight: 280,
+          terminalWidth: 900,
           terminalIds: ["default"],
           runningTerminalIds: [],
           activeTerminalId: "default",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -12,6 +12,7 @@ import {
   type ServerProvider,
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
+  type TerminalLayout,
   type ThreadId,
   type TurnId,
   type KeybindingCommand,
@@ -35,7 +36,7 @@ import {
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
 import { Debouncer } from "@tanstack/react-pacer";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
 import { useGitStatus } from "~/lib/gitStatusState";
@@ -104,7 +105,7 @@ import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import PlanSidebar from "./PlanSidebar";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
-import { ChevronDownIcon, TriangleAlertIcon, WifiOffIcon } from "lucide-react";
+import { ChevronDownIcon, TriangleAlertIcon, WifiOffIcon, XIcon } from "lucide-react";
 import { cn, randomUUID } from "~/lib/utils";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
@@ -438,6 +439,7 @@ interface PersistentThreadTerminalDrawerProps {
   newShortcutLabel: string | undefined;
   closeShortcutLabel: string | undefined;
   keybindings: ResolvedKeybindingsConfig;
+  terminalLayout: TerminalLayout;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
 }
 
@@ -451,6 +453,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   newShortcutLabel,
   closeShortcutLabel,
   keybindings,
+  terminalLayout,
   onAddTerminalContext,
 }: PersistentThreadTerminalDrawerProps) {
   const serverThread = useStore(useMemo(() => createThreadSelectorByRef(threadRef), [threadRef]));
@@ -469,7 +472,9 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const storeNewTerminal = useTerminalStateStore((state) => state.newTerminal);
   const storeSetActiveTerminal = useTerminalStateStore((state) => state.setActiveTerminal);
   const storeCloseTerminal = useTerminalStateStore((state) => state.closeTerminal);
+  const storeSetTerminalOpen = useTerminalStateStore((state) => state.setTerminalOpen);
   const [localFocusRequestId, setLocalFocusRequestId] = useState(0);
+  const floatingTerminalTitleId = useId();
   const worktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const effectiveWorktreePath = useMemo(() => {
     if (launchContext !== null) {
@@ -569,39 +574,81 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     },
     [onAddTerminalContext, visible],
   );
+  const closeTerminalWindow = useCallback(() => {
+    storeSetTerminalOpen(threadRef, false);
+  }, [storeSetTerminalOpen, threadRef]);
 
   if (!project || !terminalState.terminalOpen || !cwd) {
     return null;
   }
 
-  return (
-    <div className={visible ? undefined : "hidden"}>
-      <ThreadTerminalDrawer
-        threadRef={threadRef}
-        threadId={threadId}
-        cwd={cwd}
-        worktreePath={effectiveWorktreePath}
-        runtimeEnv={runtimeEnv}
-        visible={visible}
-        height={terminalState.terminalHeight}
-        terminalIds={terminalState.terminalIds}
-        activeTerminalId={terminalState.activeTerminalId}
-        terminalGroups={terminalState.terminalGroups}
-        activeTerminalGroupId={terminalState.activeTerminalGroupId}
-        focusRequestId={focusRequestId + localFocusRequestId + (visible ? 1 : 0)}
-        onSplitTerminal={splitTerminal}
-        onNewTerminal={createNewTerminal}
-        splitShortcutLabel={visible ? splitShortcutLabel : undefined}
-        newShortcutLabel={visible ? newShortcutLabel : undefined}
-        closeShortcutLabel={visible ? closeShortcutLabel : undefined}
-        keybindings={keybindings}
-        onActiveTerminalChange={activateTerminal}
-        onCloseTerminal={closeTerminal}
-        onHeightChange={setTerminalHeight}
-        onAddTerminalContext={handleAddTerminalContext}
-      />
-    </div>
+  const drawer = (
+    <ThreadTerminalDrawer
+      threadRef={threadRef}
+      threadId={threadId}
+      cwd={cwd}
+      worktreePath={effectiveWorktreePath}
+      runtimeEnv={runtimeEnv}
+      visible={visible}
+      height={terminalState.terminalHeight}
+      terminalIds={terminalState.terminalIds}
+      activeTerminalId={terminalState.activeTerminalId}
+      terminalGroups={terminalState.terminalGroups}
+      activeTerminalGroupId={terminalState.activeTerminalGroupId}
+      focusRequestId={focusRequestId + localFocusRequestId + (visible ? 1 : 0)}
+      onSplitTerminal={splitTerminal}
+      onNewTerminal={createNewTerminal}
+      splitShortcutLabel={visible ? splitShortcutLabel : undefined}
+      newShortcutLabel={visible ? newShortcutLabel : undefined}
+      closeShortcutLabel={visible ? closeShortcutLabel : undefined}
+      keybindings={keybindings}
+      onActiveTerminalChange={activateTerminal}
+      onCloseTerminal={closeTerminal}
+      onHeightChange={setTerminalHeight}
+      onAddTerminalContext={handleAddTerminalContext}
+      layout={terminalLayout}
+    />
   );
+
+  if (terminalLayout === "floating") {
+    return (
+      <div
+        className={cn(
+          "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm",
+          visible ? "grid grid-rows-[1fr_auto_3fr] justify-items-center p-4" : "hidden",
+        )}
+        onMouseDown={(event) => {
+          if (event.target === event.currentTarget) {
+            closeTerminalWindow();
+          }
+        }}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={floatingTerminalTitleId}
+          className="row-start-2 w-[min(96vw,72rem)] max-w-[min(96vw,72rem)] overflow-hidden rounded-lg border bg-background p-0 shadow-xl"
+        >
+          <div className="flex h-8 shrink-0 items-center justify-between border-b border-border/80 px-2">
+            <h2 id={floatingTerminalTitleId} className="text-xs font-medium leading-none">
+              Terminal
+            </h2>
+            <button
+              type="button"
+              className="inline-flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              onClick={closeTerminalWindow}
+              aria-label="Close terminal window"
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          </div>
+          {drawer}
+        </div>
+      </div>
+    );
+  }
+
+  return <div className={visible ? undefined : "hidden"}>{drawer}</div>;
 });
 
 export default function ChatView(props: ChatViewProps) {
@@ -3527,6 +3574,7 @@ export default function ChatView(props: ChatViewProps) {
           availableEditors={availableEditors}
           terminalAvailable={activeProject !== undefined}
           terminalOpen={terminalState.terminalOpen}
+          terminalLayout={settings.terminalLayout}
           terminalToggleShortcutLabel={terminalToggleShortcutLabel}
           diffToggleShortcutLabel={diffPanelShortcutLabel}
           gitCwd={gitCwd}
@@ -3753,6 +3801,7 @@ export default function ChatView(props: ChatViewProps) {
           newShortcutLabel={newTerminalShortcutLabel ?? undefined}
           closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
           keybindings={keybindings}
+          terminalLayout={settings.terminalLayout}
           onAddTerminalContext={addTerminalContextToDraft}
         />
       ))}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -89,6 +89,7 @@ import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
   DEFAULT_THREAD_TERMINAL_ID,
+  DEFAULT_THREAD_TERMINAL_WIDTH,
   MAX_TERMINALS_PER_GROUP,
   type ChatMessage,
   type SessionPhase,
@@ -429,6 +430,17 @@ function useLocalDispatchState(input: {
   };
 }
 
+const MIN_FLOATING_TERMINAL_WIDTH = 400;
+const MAX_FLOATING_TERMINAL_WIDTH_RATIO = 0.97;
+
+function clampFloatingTerminalWidth(w: number): number {
+  if (typeof window === "undefined") return DEFAULT_THREAD_TERMINAL_WIDTH;
+  return Math.min(
+    Math.max(Math.round(w), MIN_FLOATING_TERMINAL_WIDTH),
+    Math.floor(window.innerWidth * MAX_FLOATING_TERMINAL_WIDTH_RATIO),
+  );
+}
+
 interface PersistentThreadTerminalDrawerProps {
   threadRef: { environmentId: EnvironmentId; threadId: ThreadId };
   threadId: ThreadId;
@@ -468,6 +480,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     selectThreadTerminalState(state.terminalStateByThreadKey, threadRef),
   );
   const storeSetTerminalHeight = useTerminalStateStore((state) => state.setTerminalHeight);
+  const storeSetTerminalWidth = useTerminalStateStore((state) => state.setTerminalWidth);
   const storeSplitTerminal = useTerminalStateStore((state) => state.splitTerminal);
   const storeNewTerminal = useTerminalStateStore((state) => state.newTerminal);
   const storeSetActiveTerminal = useTerminalStateStore((state) => state.setActiveTerminal);
@@ -475,6 +488,19 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const storeSetTerminalOpen = useTerminalStateStore((state) => state.setTerminalOpen);
   const [localFocusRequestId, setLocalFocusRequestId] = useState(0);
   const floatingTerminalTitleId = useId();
+
+  const [floatingWidth, setFloatingWidth] = useState(() =>
+    clampFloatingTerminalWidth(terminalState.terminalWidth),
+  );
+  const floatingWidthRef = useRef(floatingWidth);
+  const widthResizeStateRef = useRef<{
+    pointerId: number;
+    side: "left" | "right";
+    startX: number;
+    startWidth: number;
+  } | null>(null);
+  const didWidthResizeDuringDragRef = useRef(false);
+
   const worktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const effectiveWorktreePath = useMemo(() => {
     if (launchContext !== null) {
@@ -516,6 +542,87 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
       storeSetTerminalHeight(threadRef, height);
     },
     [storeSetTerminalHeight, threadRef],
+  );
+
+  const setTerminalWidth = useCallback(
+    (width: number) => {
+      storeSetTerminalWidth(threadRef, width);
+    },
+    [storeSetTerminalWidth, threadRef],
+  );
+
+  useEffect(() => {
+    floatingWidthRef.current = floatingWidth;
+  }, [floatingWidth]);
+
+  useEffect(() => {
+    if (widthResizeStateRef.current) return;
+    const clamped = clampFloatingTerminalWidth(terminalState.terminalWidth);
+    floatingWidthRef.current = clamped;
+    setFloatingWidth(clamped);
+  }, [terminalState.terminalWidth, threadId]);
+
+  const handleWidthResizePointerDownLeft = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      didWidthResizeDuringDragRef.current = false;
+      widthResizeStateRef.current = {
+        pointerId: event.pointerId,
+        side: "left",
+        startX: event.clientX,
+        startWidth: floatingWidthRef.current,
+      };
+    },
+    [],
+  );
+
+  const handleWidthResizePointerDownRight = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      didWidthResizeDuringDragRef.current = false;
+      widthResizeStateRef.current = {
+        pointerId: event.pointerId,
+        side: "right",
+        startX: event.clientX,
+        startWidth: floatingWidthRef.current,
+      };
+    },
+    [],
+  );
+
+  const handleWidthResizePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const state = widthResizeStateRef.current;
+      if (!state || state.pointerId !== event.pointerId) return;
+      event.preventDefault();
+      const delta = event.clientX - state.startX;
+      const rawWidth =
+        state.side === "right" ? state.startWidth + delta : state.startWidth - delta;
+      const clamped = clampFloatingTerminalWidth(rawWidth);
+      if (clamped === floatingWidthRef.current) return;
+      didWidthResizeDuringDragRef.current = true;
+      floatingWidthRef.current = clamped;
+      setFloatingWidth(clamped);
+    },
+    [],
+  );
+
+  const handleWidthResizePointerEnd = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const state = widthResizeStateRef.current;
+      if (!state || state.pointerId !== event.pointerId) return;
+      widthResizeStateRef.current = null;
+      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }
+      if (!didWidthResizeDuringDragRef.current) return;
+      setTerminalWidth(floatingWidthRef.current);
+    },
+    [setTerminalWidth],
   );
 
   const splitTerminal = useCallback(() => {
@@ -615,7 +722,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
       <div
         className={cn(
           "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm",
-          visible ? "grid grid-rows-[1fr_auto_3fr] justify-items-center p-4" : "hidden",
+          visible ? "flex items-center justify-center p-3" : "hidden",
         )}
         onMouseDown={(event) => {
           if (event.target === event.currentTarget) {
@@ -627,8 +734,25 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
           role="dialog"
           aria-modal="true"
           aria-labelledby={floatingTerminalTitleId}
-          className="row-start-2 w-[min(96vw,72rem)] max-w-[min(96vw,72rem)] overflow-hidden rounded-lg border bg-background p-0 shadow-xl"
+          className="relative overflow-hidden rounded-lg border bg-background p-0 shadow-xl"
+          style={{ width: `${floatingWidth}px` }}
         >
+          {/* Left resize handle */}
+          <div
+            className="absolute inset-y-0 left-0 z-20 w-1.5 cursor-col-resize"
+            onPointerDown={handleWidthResizePointerDownLeft}
+            onPointerMove={handleWidthResizePointerMove}
+            onPointerUp={handleWidthResizePointerEnd}
+            onPointerCancel={handleWidthResizePointerEnd}
+          />
+          {/* Right resize handle */}
+          <div
+            className="absolute inset-y-0 right-0 z-20 w-1.5 cursor-col-resize"
+            onPointerDown={handleWidthResizePointerDownRight}
+            onPointerMove={handleWidthResizePointerMove}
+            onPointerUp={handleWidthResizePointerEnd}
+            onPointerCancel={handleWidthResizePointerEnd}
+          />
           <div className="flex h-8 shrink-0 items-center justify-between border-b border-border/80 px-2">
             <h2 id={floatingTerminalTitleId} className="text-xs font-medium leading-none">
               Terminal

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -11,6 +11,7 @@ import {
   type ServerProvider,
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
+  type TerminalLayout,
   type ThreadId,
   type TurnId,
   type KeybindingCommand,
@@ -33,7 +34,7 @@ import {
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { truncate } from "@t3tools/shared/String";
 import { Debouncer } from "@tanstack/react-pacer";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
 import { useGitStatus } from "~/lib/gitStatusState";
@@ -102,7 +103,7 @@ import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import PlanSidebar from "./PlanSidebar";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
-import { ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon, XIcon } from "lucide-react";
 import { cn, randomUUID } from "~/lib/utils";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { decodeProjectScriptKeybindingRule } from "~/lib/projectScriptKeybindings";
@@ -418,6 +419,7 @@ interface PersistentThreadTerminalDrawerProps {
   newShortcutLabel: string | undefined;
   closeShortcutLabel: string | undefined;
   keybindings: ResolvedKeybindingsConfig;
+  terminalLayout: TerminalLayout;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
 }
 
@@ -431,6 +433,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   newShortcutLabel,
   closeShortcutLabel,
   keybindings,
+  terminalLayout,
   onAddTerminalContext,
 }: PersistentThreadTerminalDrawerProps) {
   const serverThread = useStore(useMemo(() => createThreadSelectorByRef(threadRef), [threadRef]));
@@ -449,7 +452,9 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const storeNewTerminal = useTerminalStateStore((state) => state.newTerminal);
   const storeSetActiveTerminal = useTerminalStateStore((state) => state.setActiveTerminal);
   const storeCloseTerminal = useTerminalStateStore((state) => state.closeTerminal);
+  const storeSetTerminalOpen = useTerminalStateStore((state) => state.setTerminalOpen);
   const [localFocusRequestId, setLocalFocusRequestId] = useState(0);
+  const floatingTerminalTitleId = useId();
   const worktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const effectiveWorktreePath = useMemo(() => {
     if (launchContext !== null) {
@@ -549,39 +554,81 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     },
     [onAddTerminalContext, visible],
   );
+  const closeTerminalWindow = useCallback(() => {
+    storeSetTerminalOpen(threadRef, false);
+  }, [storeSetTerminalOpen, threadRef]);
 
   if (!project || !terminalState.terminalOpen || !cwd) {
     return null;
   }
 
-  return (
-    <div className={visible ? undefined : "hidden"}>
-      <ThreadTerminalDrawer
-        threadRef={threadRef}
-        threadId={threadId}
-        cwd={cwd}
-        worktreePath={effectiveWorktreePath}
-        runtimeEnv={runtimeEnv}
-        visible={visible}
-        height={terminalState.terminalHeight}
-        terminalIds={terminalState.terminalIds}
-        activeTerminalId={terminalState.activeTerminalId}
-        terminalGroups={terminalState.terminalGroups}
-        activeTerminalGroupId={terminalState.activeTerminalGroupId}
-        focusRequestId={focusRequestId + localFocusRequestId + (visible ? 1 : 0)}
-        onSplitTerminal={splitTerminal}
-        onNewTerminal={createNewTerminal}
-        splitShortcutLabel={visible ? splitShortcutLabel : undefined}
-        newShortcutLabel={visible ? newShortcutLabel : undefined}
-        closeShortcutLabel={visible ? closeShortcutLabel : undefined}
-        keybindings={keybindings}
-        onActiveTerminalChange={activateTerminal}
-        onCloseTerminal={closeTerminal}
-        onHeightChange={setTerminalHeight}
-        onAddTerminalContext={handleAddTerminalContext}
-      />
-    </div>
+  const drawer = (
+    <ThreadTerminalDrawer
+      threadRef={threadRef}
+      threadId={threadId}
+      cwd={cwd}
+      worktreePath={effectiveWorktreePath}
+      runtimeEnv={runtimeEnv}
+      visible={visible}
+      height={terminalState.terminalHeight}
+      terminalIds={terminalState.terminalIds}
+      activeTerminalId={terminalState.activeTerminalId}
+      terminalGroups={terminalState.terminalGroups}
+      activeTerminalGroupId={terminalState.activeTerminalGroupId}
+      focusRequestId={focusRequestId + localFocusRequestId + (visible ? 1 : 0)}
+      onSplitTerminal={splitTerminal}
+      onNewTerminal={createNewTerminal}
+      splitShortcutLabel={visible ? splitShortcutLabel : undefined}
+      newShortcutLabel={visible ? newShortcutLabel : undefined}
+      closeShortcutLabel={visible ? closeShortcutLabel : undefined}
+      keybindings={keybindings}
+      onActiveTerminalChange={activateTerminal}
+      onCloseTerminal={closeTerminal}
+      onHeightChange={setTerminalHeight}
+      onAddTerminalContext={handleAddTerminalContext}
+      layout={terminalLayout}
+    />
   );
+
+  if (terminalLayout === "floating") {
+    return (
+      <div
+        className={cn(
+          "fixed inset-0 z-50 bg-black/32 backdrop-blur-sm",
+          visible ? "grid grid-rows-[1fr_auto_3fr] justify-items-center p-4" : "hidden",
+        )}
+        onMouseDown={(event) => {
+          if (event.target === event.currentTarget) {
+            closeTerminalWindow();
+          }
+        }}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={floatingTerminalTitleId}
+          className="row-start-2 w-[min(96vw,72rem)] max-w-[min(96vw,72rem)] overflow-hidden rounded-lg border bg-background p-0 shadow-xl"
+        >
+          <div className="flex h-8 shrink-0 items-center justify-between border-b border-border/80 px-2">
+            <h2 id={floatingTerminalTitleId} className="text-xs font-medium leading-none">
+              Terminal
+            </h2>
+            <button
+              type="button"
+              className="inline-flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              onClick={closeTerminalWindow}
+              aria-label="Close terminal window"
+            >
+              <XIcon className="size-3.5" />
+            </button>
+          </div>
+          {drawer}
+        </div>
+      </div>
+    );
+  }
+
+  return <div className={visible ? undefined : "hidden"}>{drawer}</div>;
 });
 
 export default function ChatView(props: ChatViewProps) {
@@ -3263,6 +3310,7 @@ export default function ChatView(props: ChatViewProps) {
           availableEditors={availableEditors}
           terminalAvailable={activeProject !== undefined}
           terminalOpen={terminalState.terminalOpen}
+          terminalLayout={settings.terminalLayout}
           terminalToggleShortcutLabel={terminalToggleShortcutLabel}
           diffToggleShortcutLabel={diffPanelShortcutLabel}
           gitCwd={gitCwd}
@@ -3477,6 +3525,7 @@ export default function ChatView(props: ChatViewProps) {
           newShortcutLabel={newTerminalShortcutLabel ?? undefined}
           closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
           keybindings={keybindings}
+          terminalLayout={settings.terminalLayout}
           onAddTerminalContext={addTerminalContextToDraft}
         />
       ))}

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -52,17 +52,18 @@ import { readLocalApi } from "~/localApi";
 import { selectTerminalEventEntries, useTerminalStateStore } from "../terminalStateStore";
 
 const MIN_DRAWER_HEIGHT = 180;
-const MAX_DRAWER_HEIGHT_RATIO = 0.75;
+const DEFAULT_MAX_DRAWER_HEIGHT_RATIO = 0.75;
+const FLOATING_MAX_DRAWER_HEIGHT_RATIO = 0.92;
 const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
 
-function maxDrawerHeight(): number {
+function maxDrawerHeight(ratio = DEFAULT_MAX_DRAWER_HEIGHT_RATIO): number {
   if (typeof window === "undefined") return DEFAULT_THREAD_TERMINAL_HEIGHT;
-  return Math.max(MIN_DRAWER_HEIGHT, Math.floor(window.innerHeight * MAX_DRAWER_HEIGHT_RATIO));
+  return Math.max(MIN_DRAWER_HEIGHT, Math.floor(window.innerHeight * ratio));
 }
 
-function clampDrawerHeight(height: number): number {
+function clampDrawerHeight(height: number, ratio = DEFAULT_MAX_DRAWER_HEIGHT_RATIO): number {
   const safeHeight = Number.isFinite(height) ? height : DEFAULT_THREAD_TERMINAL_HEIGHT;
-  const maxHeight = maxDrawerHeight();
+  const maxHeight = maxDrawerHeight(ratio);
   return Math.min(Math.max(Math.round(safeHeight), MIN_DRAWER_HEIGHT), maxHeight);
 }
 
@@ -880,10 +881,14 @@ export default function ThreadTerminalDrawer({
   keybindings,
   layout = "docked",
 }: ThreadTerminalDrawerProps) {
-  const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height));
+  const maxHeightRatio =
+    layout === "floating" ? FLOATING_MAX_DRAWER_HEIGHT_RATIO : DEFAULT_MAX_DRAWER_HEIGHT_RATIO;
+  const maxHeightRatioRef = useRef(maxHeightRatio);
+  maxHeightRatioRef.current = maxHeightRatio;
+  const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height, maxHeightRatio));
   const [resizeEpoch, setResizeEpoch] = useState(0);
   const drawerHeightRef = useRef(drawerHeight);
-  const lastSyncedHeightRef = useRef(clampDrawerHeight(height));
+  const lastSyncedHeightRef = useRef(clampDrawerHeight(height, maxHeightRatio));
   const onHeightChangeRef = useRef(onHeightChange);
   const resizeStateRef = useRef<{
     pointerId: number;
@@ -1020,14 +1025,14 @@ export default function ThreadTerminalDrawer({
   }, [drawerHeight]);
 
   const syncHeight = useCallback((nextHeight: number) => {
-    const clampedHeight = clampDrawerHeight(nextHeight);
+    const clampedHeight = clampDrawerHeight(nextHeight, maxHeightRatioRef.current);
     if (lastSyncedHeightRef.current === clampedHeight) return;
     lastSyncedHeightRef.current = clampedHeight;
     onHeightChangeRef.current(clampedHeight);
   }, []);
 
   useEffect(() => {
-    const clampedHeight = clampDrawerHeight(height);
+    const clampedHeight = clampDrawerHeight(height, maxHeightRatioRef.current);
     setDrawerHeight(clampedHeight);
     drawerHeightRef.current = clampedHeight;
     lastSyncedHeightRef.current = clampedHeight;
@@ -1051,6 +1056,7 @@ export default function ThreadTerminalDrawer({
     event.preventDefault();
     const clampedHeight = clampDrawerHeight(
       resizeState.startHeight + (resizeState.startY - event.clientY),
+      maxHeightRatioRef.current,
     );
     if (clampedHeight === drawerHeightRef.current) {
       return;
@@ -1083,7 +1089,7 @@ export default function ThreadTerminalDrawer({
     }
 
     const onWindowResize = () => {
-      const clampedHeight = clampDrawerHeight(drawerHeightRef.current);
+      const clampedHeight = clampDrawerHeight(drawerHeightRef.current, maxHeightRatioRef.current);
       const changed = clampedHeight !== drawerHeightRef.current;
       if (changed) {
         setDrawerHeight(clampedHeight);

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -3,6 +3,7 @@ import { Plus, SquareSplitHorizontal, TerminalSquare, Trash2, XIcon } from "luci
 import {
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
+  type TerminalLayout,
   type TerminalEvent,
   type TerminalSessionSnapshot,
   type ThreadId,
@@ -20,6 +21,7 @@ import {
 } from "react";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { type TerminalContextSelection } from "~/lib/terminalContext";
+import { cn } from "~/lib/utils";
 import { openInPreferredEditor } from "../editorPreferences";
 import {
   collectWrappedTerminalLinkLine,
@@ -821,6 +823,7 @@ interface ThreadTerminalDrawerProps {
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   keybindings: ResolvedKeybindingsConfig;
+  layout?: TerminalLayout;
 }
 
 interface TerminalActionButtonProps {
@@ -875,6 +878,7 @@ export default function ThreadTerminalDrawer({
   onHeightChange,
   onAddTerminalContext,
   keybindings,
+  layout = "docked",
 }: ThreadTerminalDrawerProps) {
   const [drawerHeight, setDrawerHeight] = useState(() => clampDrawerHeight(height));
   const [resizeEpoch, setResizeEpoch] = useState(0);
@@ -1111,7 +1115,10 @@ export default function ThreadTerminalDrawer({
 
   return (
     <aside
-      className="thread-terminal-drawer relative flex min-w-0 shrink-0 flex-col overflow-hidden border-t border-border/80 bg-background"
+      className={cn(
+        "thread-terminal-drawer relative flex min-w-0 shrink-0 flex-col overflow-hidden bg-background",
+        layout === "docked" ? "border-t border-border/80" : "border-0",
+      )}
       style={{ height: `${drawerHeight}px` }}
     >
       <div

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -3,6 +3,7 @@ import {
   type EditorId,
   type ProjectScript,
   type ResolvedKeybindingsConfig,
+  type TerminalLayout,
   type ThreadId,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime";
@@ -32,6 +33,7 @@ interface ChatHeaderProps {
   availableEditors: ReadonlyArray<EditorId>;
   terminalAvailable: boolean;
   terminalOpen: boolean;
+  terminalLayout: TerminalLayout;
   terminalToggleShortcutLabel: string | null;
   diffToggleShortcutLabel: string | null;
   gitCwd: string | null;
@@ -70,6 +72,7 @@ export const ChatHeader = memo(function ChatHeader({
   availableEditors,
   terminalAvailable,
   terminalOpen,
+  terminalLayout,
   terminalToggleShortcutLabel,
   diffToggleShortcutLabel,
   gitCwd,
@@ -87,6 +90,8 @@ export const ChatHeader = memo(function ChatHeader({
     activeThreadEnvironmentId,
     primaryEnvironmentId,
   });
+  const terminalSurfaceLabel =
+    terminalLayout === "floating" ? "terminal window" : "terminal drawer";
 
   return (
     <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2">
@@ -142,7 +147,7 @@ export const ChatHeader = memo(function ChatHeader({
                 className="shrink-0"
                 pressed={terminalOpen}
                 onPressedChange={onToggleTerminal}
-                aria-label="Toggle terminal drawer"
+                aria-label={`Toggle ${terminalSurfaceLabel}`}
                 variant="outline"
                 size="xs"
                 disabled={!terminalAvailable}
@@ -155,8 +160,8 @@ export const ChatHeader = memo(function ChatHeader({
             {!terminalAvailable
               ? "Terminal is unavailable until this thread has an active project."
               : terminalToggleShortcutLabel
-                ? `Toggle terminal drawer (${terminalToggleShortcutLabel})`
-                : "Toggle terminal drawer"}
+                ? `Toggle ${terminalSurfaceLabel} (${terminalToggleShortcutLabel})`
+                : `Toggle ${terminalSurfaceLabel}`}
           </TooltipPopup>
         </Tooltip>
         <Tooltip>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -3,6 +3,7 @@ import {
   type EditorId,
   type ProjectScript,
   type ResolvedKeybindingsConfig,
+  type TerminalLayout,
   type ThreadId,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime";
@@ -31,6 +32,7 @@ interface ChatHeaderProps {
   availableEditors: ReadonlyArray<EditorId>;
   terminalAvailable: boolean;
   terminalOpen: boolean;
+  terminalLayout: TerminalLayout;
   terminalToggleShortcutLabel: string | null;
   diffToggleShortcutLabel: string | null;
   gitCwd: string | null;
@@ -57,6 +59,7 @@ export const ChatHeader = memo(function ChatHeader({
   availableEditors,
   terminalAvailable,
   terminalOpen,
+  terminalLayout,
   terminalToggleShortcutLabel,
   diffToggleShortcutLabel,
   gitCwd,
@@ -68,6 +71,9 @@ export const ChatHeader = memo(function ChatHeader({
   onToggleTerminal,
   onToggleDiff,
 }: ChatHeaderProps) {
+  const terminalSurfaceLabel =
+    terminalLayout === "floating" ? "terminal window" : "terminal drawer";
+
   return (
     <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
@@ -122,7 +128,7 @@ export const ChatHeader = memo(function ChatHeader({
                 className="shrink-0"
                 pressed={terminalOpen}
                 onPressedChange={onToggleTerminal}
-                aria-label="Toggle terminal drawer"
+                aria-label={`Toggle ${terminalSurfaceLabel}`}
                 variant="outline"
                 size="xs"
                 disabled={!terminalAvailable}
@@ -135,8 +141,8 @@ export const ChatHeader = memo(function ChatHeader({
             {!terminalAvailable
               ? "Terminal is unavailable until this thread has an active project."
               : terminalToggleShortcutLabel
-                ? `Toggle terminal drawer (${terminalToggleShortcutLabel})`
-                : "Toggle terminal drawer"}
+                ? `Toggle ${terminalSurfaceLabel} (${terminalToggleShortcutLabel})`
+                : `Toggle ${terminalSurfaceLabel}`}
           </TooltipPopup>
         </Tooltip>
         <Tooltip>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -106,20 +106,6 @@ const TERMINAL_LAYOUT_LABELS = {
   floating: "Floating",
 } as const;
 
-type InstallProviderSettings = {
-  provider: ProviderKind;
-  title: string;
-  badgeLabel?: string;
-  binaryPlaceholder: string;
-  binaryDescription: ReactNode;
-  serverUrlPlaceholder?: string;
-  serverUrlDescription?: ReactNode;
-  serverPasswordPlaceholder?: string;
-  serverPasswordDescription?: ReactNode;
-  homePathKey?: "codexHomePath";
-  homePlaceholder?: string;
-  homeDescription?: ReactNode;
-};
 
 function withoutProviderInstanceKey<V>(
   record: Readonly<Record<ProviderInstanceId, V>> | undefined,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -101,6 +101,26 @@ const TIMESTAMP_FORMAT_LABELS = {
 
 const DEFAULT_DRIVER_KIND = ProviderDriverKind.make("codex");
 
+const TERMINAL_LAYOUT_LABELS = {
+  docked: "Docked",
+  floating: "Floating",
+} as const;
+
+type InstallProviderSettings = {
+  provider: ProviderKind;
+  title: string;
+  badgeLabel?: string;
+  binaryPlaceholder: string;
+  binaryDescription: ReactNode;
+  serverUrlPlaceholder?: string;
+  serverUrlDescription?: ReactNode;
+  serverPasswordPlaceholder?: string;
+  serverPasswordDescription?: ReactNode;
+  homePathKey?: "codexHomePath";
+  homePlaceholder?: string;
+  homeDescription?: ReactNode;
+};
+
 function withoutProviderInstanceKey<V>(
   record: Readonly<Record<ProviderInstanceId, V>> | undefined,
   key: ProviderInstanceId,
@@ -405,6 +425,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
         ? ["Auto-open task panel"]
         : []),
+      ...(settings.terminalLayout !== DEFAULT_UNIFIED_SETTINGS.terminalLayout
+        ? ["Terminal layout"]
+        : []),
       ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
@@ -438,6 +461,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.automaticGitFetchInterval,
       settings.enableAssistantStreaming,
       settings.sidebarThreadPreviewCount,
+      settings.terminalLayout,
       settings.timestampFormat,
       theme,
     ],
@@ -692,6 +716,45 @@ export function GeneralSettingsPanel() {
               }
               aria-label="Open the task panel automatically"
             />
+          }
+        />
+
+        <SettingsRow
+          title="Terminal layout"
+          description="Choose whether the terminal opens docked under chat or in a floating window."
+          resetAction={
+            settings.terminalLayout !== DEFAULT_UNIFIED_SETTINGS.terminalLayout ? (
+              <SettingResetButton
+                label="terminal layout"
+                onClick={() =>
+                  updateSettings({
+                    terminalLayout: DEFAULT_UNIFIED_SETTINGS.terminalLayout,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.terminalLayout}
+              onValueChange={(value) => {
+                if (value === "docked" || value === "floating") {
+                  updateSettings({ terminalLayout: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Terminal layout">
+                <SelectValue>{TERMINAL_LAYOUT_LABELS[settings.terminalLayout]}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="docked">
+                  {TERMINAL_LAYOUT_LABELS.docked}
+                </SelectItem>
+                <SelectItem hideIndicator value="floating">
+                  {TERMINAL_LAYOUT_LABELS.floating}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
           }
         />
 

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -100,6 +100,11 @@ const TIMESTAMP_FORMAT_LABELS = {
   "24-hour": "24-hour",
 } as const;
 
+const TERMINAL_LAYOUT_LABELS = {
+  docked: "Docked",
+  floating: "Floating",
+} as const;
+
 type InstallProviderSettings = {
   provider: ProviderKind;
   title: string;
@@ -475,6 +480,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
         ? ["Task sidebar"]
         : []),
+      ...(settings.terminalLayout !== DEFAULT_UNIFIED_SETTINGS.terminalLayout
+        ? ["Terminal layout"]
+        : []),
       ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
@@ -503,6 +511,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.defaultThreadEnvMode,
       settings.diffWordWrap,
       settings.enableAssistantStreaming,
+      settings.terminalLayout,
       settings.timestampFormat,
       theme,
     ],
@@ -972,6 +981,45 @@ export function GeneralSettingsPanel() {
               }
               aria-label="Open the task sidebar automatically"
             />
+          }
+        />
+
+        <SettingsRow
+          title="Terminal layout"
+          description="Choose whether the terminal opens docked under chat or in a floating window."
+          resetAction={
+            settings.terminalLayout !== DEFAULT_UNIFIED_SETTINGS.terminalLayout ? (
+              <SettingResetButton
+                label="terminal layout"
+                onClick={() =>
+                  updateSettings({
+                    terminalLayout: DEFAULT_UNIFIED_SETTINGS.terminalLayout,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.terminalLayout}
+              onValueChange={(value) => {
+                if (value === "docked" || value === "floating") {
+                  updateSettings({ terminalLayout: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Terminal layout">
+                <SelectValue>{TERMINAL_LAYOUT_LABELS[settings.terminalLayout]}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="docked">
+                  {TERMINAL_LAYOUT_LABELS.docked}
+                </SelectItem>
+                <SelectItem hideIndicator value="floating">
+                  {TERMINAL_LAYOUT_LABELS.floating}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
           }
         />
 

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -615,6 +615,7 @@ describe("wsApi", () => {
       sidebarThreadSortOrder: "created_at" as const,
       sidebarThreadPreviewCount: 6,
       timestampFormat: "24-hour" as const,
+      terminalLayout: "floating" as const,
     };
     const getClientSettings = vi.fn().mockResolvedValue({
       ...clientSettings,
@@ -678,6 +679,7 @@ describe("wsApi", () => {
       sidebarThreadSortOrder: "created_at" as const,
       sidebarThreadPreviewCount: 6,
       timestampFormat: "24-hour" as const,
+      terminalLayout: "floating" as const,
     };
 
     await api.persistence.setClientSettings(clientSettings);

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -541,6 +541,7 @@ describe("wsApi", () => {
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
       timestampFormat: "24-hour" as const,
+      terminalLayout: "floating" as const,
     };
     const getClientSettings = vi.fn().mockResolvedValue({
       ...clientSettings,
@@ -600,6 +601,7 @@ describe("wsApi", () => {
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
       timestampFormat: "24-hour" as const,
+      terminalLayout: "floating" as const,
     };
 
     await api.persistence.setClientSettings(clientSettings);

--- a/apps/web/src/terminalStateStore.ts
+++ b/apps/web/src/terminalStateStore.ts
@@ -13,6 +13,7 @@ import { resolveStorage } from "./lib/storage";
 import { terminalRunningSubprocessFromEvent } from "./terminalActivity";
 import {
   DEFAULT_THREAD_TERMINAL_HEIGHT,
+  DEFAULT_THREAD_TERMINAL_WIDTH,
   DEFAULT_THREAD_TERMINAL_ID,
   MAX_TERMINALS_PER_GROUP,
   type ThreadTerminalGroup,
@@ -21,6 +22,7 @@ import {
 interface ThreadTerminalState {
   terminalOpen: boolean;
   terminalHeight: number;
+  terminalWidth: number;
   terminalIds: string[];
   runningTerminalIds: string[];
   activeTerminalId: string;
@@ -181,6 +183,7 @@ function threadTerminalStateEqual(left: ThreadTerminalState, right: ThreadTermin
   return (
     left.terminalOpen === right.terminalOpen &&
     left.terminalHeight === right.terminalHeight &&
+    left.terminalWidth === right.terminalWidth &&
     left.activeTerminalId === right.activeTerminalId &&
     left.activeTerminalGroupId === right.activeTerminalGroupId &&
     arraysEqual(left.terminalIds, right.terminalIds) &&
@@ -192,6 +195,7 @@ function threadTerminalStateEqual(left: ThreadTerminalState, right: ThreadTermin
 const DEFAULT_THREAD_TERMINAL_STATE: ThreadTerminalState = Object.freeze({
   terminalOpen: false,
   terminalHeight: DEFAULT_THREAD_TERMINAL_HEIGHT,
+  terminalWidth: DEFAULT_THREAD_TERMINAL_WIDTH,
   terminalIds: [DEFAULT_THREAD_TERMINAL_ID],
   runningTerminalIds: [],
   activeTerminalId: DEFAULT_THREAD_TERMINAL_ID,
@@ -239,6 +243,10 @@ function normalizeThreadTerminalState(state: ThreadTerminalState): ThreadTermina
       Number.isFinite(state.terminalHeight) && state.terminalHeight > 0
         ? state.terminalHeight
         : DEFAULT_THREAD_TERMINAL_HEIGHT,
+    terminalWidth:
+      Number.isFinite(state.terminalWidth) && state.terminalWidth > 0
+        ? state.terminalWidth
+        : DEFAULT_THREAD_TERMINAL_WIDTH,
     terminalIds: nextTerminalIds,
     runningTerminalIds,
     activeTerminalId,
@@ -413,6 +421,14 @@ function setThreadTerminalHeight(state: ThreadTerminalState, height: number): Th
   return { ...normalized, terminalHeight: height };
 }
 
+function setThreadTerminalWidth(state: ThreadTerminalState, width: number): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (!Number.isFinite(width) || width <= 0 || normalized.terminalWidth === width) {
+    return normalized;
+  }
+  return { ...normalized, terminalWidth: width };
+}
+
 function splitThreadTerminal(state: ThreadTerminalState, terminalId: string): ThreadTerminalState {
   return upsertTerminalIntoGroups(state, terminalId, "split");
 }
@@ -479,6 +495,7 @@ function closeThreadTerminal(state: ThreadTerminalState, terminalId: string): Th
   return normalizeThreadTerminalState({
     terminalOpen: normalized.terminalOpen,
     terminalHeight: normalized.terminalHeight,
+    terminalWidth: normalized.terminalWidth,
     terminalIds: remainingTerminalIds,
     runningTerminalIds: normalized.runningTerminalIds.filter((id) => id !== terminalId),
     activeTerminalId: nextActiveTerminalId,
@@ -570,6 +587,7 @@ interface TerminalStateStoreState {
   nextTerminalEventId: number;
   setTerminalOpen: (threadRef: ScopedThreadRef, open: boolean) => void;
   setTerminalHeight: (threadRef: ScopedThreadRef, height: number) => void;
+  setTerminalWidth: (threadRef: ScopedThreadRef, width: number) => void;
   splitTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   newTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   ensureTerminal: (
@@ -627,6 +645,8 @@ export const useTerminalStateStore = create<TerminalStateStoreState>()(
           updateTerminal(threadRef, (state) => setThreadTerminalOpen(state, open)),
         setTerminalHeight: (threadRef, height) =>
           updateTerminal(threadRef, (state) => setThreadTerminalHeight(state, height)),
+        setTerminalWidth: (threadRef, width) =>
+          updateTerminal(threadRef, (state) => setThreadTerminalWidth(state, width)),
         splitTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => splitThreadTerminal(state, terminalId)),
         newTerminal: (threadRef, terminalId) =>

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -23,6 +23,7 @@ export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
 
 export const DEFAULT_INTERACTION_MODE: ProviderInteractionMode = "default";
 export const DEFAULT_THREAD_TERMINAL_HEIGHT = 280;
+export const DEFAULT_THREAD_TERMINAL_WIDTH = 900;
 export const DEFAULT_THREAD_TERMINAL_ID = "default";
 export const MAX_TERMINALS_PER_GROUP = 4;
 export type ProjectScript = ContractProjectScript;

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -39,6 +39,10 @@ export const SidebarThreadPreviewCount = Schema.Int.check(
 export type SidebarThreadPreviewCount = typeof SidebarThreadPreviewCount.Type;
 export const DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT: SidebarThreadPreviewCount = 6;
 
+export const TerminalLayout = Schema.Literals(["docked", "floating"]);
+export type TerminalLayout = typeof TerminalLayout.Type;
+export const DEFAULT_TERMINAL_LAYOUT: TerminalLayout = "docked";
+
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -91,6 +95,9 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
+  ),
+  terminalLayout: TerminalLayout.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_LAYOUT)),
   ),
 });
 export type ClientSettings = typeof ClientSettingsSchema.Type;
@@ -509,5 +516,6 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   timestampFormat: Schema.optionalKey(TimestampFormat),
+  terminalLayout: Schema.optionalKey(TerminalLayout),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -30,6 +30,10 @@ export const SidebarProjectGroupingMode = Schema.Literals([
 export type SidebarProjectGroupingMode = typeof SidebarProjectGroupingMode.Type;
 export const DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE: SidebarProjectGroupingMode = "repository";
 
+export const TerminalLayout = Schema.Literals(["docked", "floating"]);
+export type TerminalLayout = typeof TerminalLayout.Type;
+export const DEFAULT_TERMINAL_LAYOUT: TerminalLayout = "docked";
+
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -56,6 +60,9 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
+  ),
+  terminalLayout: TerminalLayout.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_LAYOUT)),
   ),
 });
 export type ClientSettings = typeof ClientSettingsSchema.Type;
@@ -263,5 +270,6 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   timestampFormat: Schema.optionalKey(TimestampFormat),
+  terminalLayout: Schema.optionalKey(TerminalLayout),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;


### PR DESCRIPTION
## Summary
Adds an option to have the terminal in a floating window
- add a client setting for docked vs floating terminal layout
- render the existing terminal drawer in a floating window when selected


### Settings page
<img width="911" height="339" alt="Screenshot 2026-04-25 at 14 35 59" src="https://github.com/user-attachments/assets/15c6af97-05e4-46e5-957b-a2ee19b02fdb" />

### floating terminal
<img width="1416" height="854" alt="Screenshot 2026-04-25 at 14 36 46" src="https://github.com/user-attachments/assets/f4825802-8a2e-4df9-a767-ce92791fd27f" />






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and persisted client preferences only; terminal session behavior is unchanged aside from presentation and width/height limits.
> 
> **Overview**
> Introduces a **docked vs floating** terminal layout as a client setting (`TerminalLayout`), defaulting to docked.
> 
> When **floating** is selected, the same `ThreadTerminalDrawer` is shown inside a centered modal (backdrop dismiss, header close control, `role="dialog"`) with **horizontal resize** on both edges; width is stored per thread in `terminalStateStore` (default 900px, clamped 400px–97% viewport) and synced on drag end. The drawer gains a `layout` prop: floating mode uses a taller max height ratio (92% vs 75%) and drops the docked top border styling.
> 
> **Settings** adds a Terminal layout select (included in “changed settings” / restore defaults). **Chat header** copy and aria labels reflect “terminal window” vs “terminal drawer”. Contracts and persistence tests pick up the new setting field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9090da8ee6ba2ea9fdc1cde527a02792f2d8b8e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add floating terminal layout option as an alternative to the docked drawer
> - Adds a `TerminalLayout` type (`'docked'` | `'floating'`) to client settings in [settings.ts](https://github.com/pingdotgg/t3code/pull/2344/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), defaulting to `'docked'`.
> - When set to `'floating'`, the terminal renders as a centered modal dialog with a backdrop, close button, and left/right resize handles instead of the bottom drawer.
> - Terminal width is now tracked per-thread in [terminalStateStore.ts](https://github.com/pingdotgg/t3code/pull/2344/files#diff-9e98e54d562825d3d06313f14e0c37ba761ec3457248dd98e1e388a6948fcd34), persisted after pointer drag ends, and clamped between 400px and 97% of viewport width.
> - Floating layout allows up to 92% viewport height vs. 75% for docked; the top border is removed in floating mode.
> - A new "Terminal layout" select control in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/2344/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) lets users switch layouts and reset to default.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9090da8. 8 files reviewed, 3 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->