### PR TITLE
Add model favorite ordering and visibility settings

### DIFF
--- a/apps/desktop/src/clientPersistence.test.ts
+++ b/apps/desktop/src/clientPersistence.test.ts
@@ -54,6 +54,7 @@ const clientSettings: ClientSettings = {
   confirmThreadDelete: false,
   diffWordWrap: true,
   favorites: [],
+  hiddenModels: [],
   sidebarProjectGroupingMode: "repository_path",
   sidebarProjectGroupingOverrides: {
     "environment-1:/tmp/project-a": "separate",

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -1,6 +1,6 @@
 import { type ProviderKind } from "@t3tools/contracts";
 import { memo } from "react";
-import { StarIcon } from "lucide-react";
+import { ArrowDownIcon, ArrowUpIcon, StarIcon } from "lucide-react";
 import {
   getDisplayModelName,
   getProviderLabel,
@@ -23,9 +23,16 @@ export const ModelListRow = memo(function ModelListRow(props: {
   useTriggerLabel?: boolean;
   showNewBadge?: boolean;
   jumpLabel?: string | null;
+  reorderControls?: {
+    canMoveUp: boolean;
+    canMoveDown: boolean;
+    onMoveUp: () => void;
+    onMoveDown: () => void;
+  } | null;
   onToggleFavorite: () => void;
 }) {
   const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[props.provider];
+  const reorderControls = props.isFavorite ? props.reorderControls : null;
 
   return (
     <ComboboxItem
@@ -38,31 +45,86 @@ export const ModelListRow = memo(function ModelListRow(props: {
         "data-highlighted:bg-muted data-selected:bg-accent data-selected:text-foreground",
       )}
     >
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <button
-              className="mt-0.5 shrink-0 cursor-pointer opacity-40 transition-opacity group-hover:opacity-100"
-              onClick={(event) => {
-                event.stopPropagation();
-                props.onToggleFavorite();
-              }}
-              onKeyDown={(event) => {
-                event.stopPropagation();
-              }}
-              type="button"
-              aria-label={props.isFavorite ? "Remove from favorites" : "Add to favorites"}
-            >
-              <StarIcon
-                className={cn("size-4", props.isFavorite && "fill-current text-yellow-500")}
+      <div className="mt-0.5 flex shrink-0 items-center gap-0.5">
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                className="shrink-0 cursor-pointer opacity-40 transition-opacity group-hover:opacity-100"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  props.onToggleFavorite();
+                }}
+                onKeyDown={(event) => {
+                  event.stopPropagation();
+                }}
+                type="button"
+                aria-label={props.isFavorite ? "Remove from favorites" : "Add to favorites"}
+              >
+                <StarIcon
+                  className={cn("size-4", props.isFavorite && "fill-current text-yellow-500")}
+                />
+              </button>
+            }
+          />
+          <TooltipPopup side="top" align="center">
+            {props.isFavorite ? "Remove from favorites" : "Add to favorites"}
+          </TooltipPopup>
+        </Tooltip>
+
+        {reorderControls ? (
+          <div className="flex flex-col">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    className="rounded-sm text-muted-foreground/50 transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-25"
+                    disabled={!reorderControls.canMoveUp}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      reorderControls.onMoveUp();
+                    }}
+                    onKeyDown={(event) => {
+                      event.stopPropagation();
+                    }}
+                    type="button"
+                    aria-label={`Move ${props.model.name} up in favorites`}
+                  >
+                    <ArrowUpIcon className="size-3" />
+                  </button>
+                }
               />
-            </button>
-          }
-        />
-        <TooltipPopup side="top" align="center">
-          {props.isFavorite ? "Remove from favorites" : "Add to favorites"}
-        </TooltipPopup>
-      </Tooltip>
+              <TooltipPopup side="top" align="center">
+                Move favorite up
+              </TooltipPopup>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    className="rounded-sm text-muted-foreground/50 transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-25"
+                    disabled={!reorderControls.canMoveDown}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      reorderControls.onMoveDown();
+                    }}
+                    onKeyDown={(event) => {
+                      event.stopPropagation();
+                    }}
+                    type="button"
+                    aria-label={`Move ${props.model.name} down in favorites`}
+                  >
+                    <ArrowDownIcon className="size-3" />
+                  </button>
+                }
+              />
+              <TooltipPopup side="top" align="center">
+                Move favorite down
+              </TooltipPopup>
+            </Tooltip>
+          </div>
+        ) : null}
+      </div>
 
       <div className="min-w-0 flex-1 text-left">
         <div className="flex items-center justify-between gap-2 min-w-0">

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -50,6 +50,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   const listRegionRef = useRef<HTMLDivElement>(null);
   const highlightedModelKeyRef = useRef<string | null>(null);
   const favorites = useSettings((s) => s.favorites ?? []);
+  const hiddenModels = useSettings((s) => s.hiddenModels ?? []);
   const [selectedProvider, setSelectedProvider] = useState<ProviderKind | "favorites">(() => {
     if (props.lockedProvider !== null) {
       return props.lockedProvider;
@@ -99,6 +100,11 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       favorites.map((favorite, index) => [`${favorite.provider}:${favorite.model}`, index]),
     );
   }, [favorites]);
+  const hiddenModelsSet = useMemo(() => {
+    return new Set(
+      hiddenModels.map((hiddenModel) => `${hiddenModel.provider}:${hiddenModel.model}`),
+    );
+  }, [hiddenModels]);
 
   const readyProviderSet = useMemo(() => {
     if (!props.providers || props.providers.length === 0) {
@@ -117,15 +123,23 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       if (readyProviderSet && !readyProviderSet.has(providerKind as ProviderKind)) {
         return [];
       }
-      return models.map((m) => ({
-        slug: m.slug,
-        name: m.name,
-        ...(m.shortName ? { shortName: m.shortName } : {}),
-        ...(m.subProvider ? { subProvider: m.subProvider } : {}),
-        provider: providerKind as ProviderKind,
-      })) satisfies Array<ModelPickerItem>;
+      return models.flatMap((m) => {
+        const provider = providerKind as ProviderKind;
+        if (hiddenModelsSet.has(`${provider}:${m.slug}`)) {
+          return [];
+        }
+        return [
+          {
+            slug: m.slug,
+            name: m.name,
+            ...(m.shortName ? { shortName: m.shortName } : {}),
+            ...(m.subProvider ? { subProvider: m.subProvider } : {}),
+            provider,
+          },
+        ];
+      }) satisfies Array<ModelPickerItem>;
     });
-  }, [props.modelOptionsByProvider, readyProviderSet]);
+  }, [hiddenModelsSet, props.modelOptionsByProvider, readyProviderSet]);
 
   // Filter models based on search query and selected provider
   const filteredModels = useMemo(() => {
@@ -249,8 +263,30 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     [favorites, updateSettings],
   );
 
+  const moveFavorite = useCallback(
+    (provider: ProviderKind, model: string, direction: -1 | 1) => {
+      const index = favorites.findIndex(
+        (favorite) => favorite.provider === provider && favorite.model === model,
+      );
+      const nextIndex = index + direction;
+      if (index < 0 || nextIndex < 0 || nextIndex >= favorites.length) {
+        return;
+      }
+
+      const newFavorites = [...favorites];
+      const [movedFavorite] = newFavorites.splice(index, 1);
+      if (!movedFavorite) {
+        return;
+      }
+      newFavorites.splice(nextIndex, 0, movedFavorite);
+      updateSettings({ favorites: newFavorites });
+    },
+    [favorites, updateSettings],
+  );
+
   const isLocked = props.lockedProvider !== null;
   const isSearching = searchQuery.trim().length > 0;
+  const canReorderFavorites = selectedProvider === "favorites" && !isSearching;
   const showSidebar = !isLocked && !isSearching;
   const LockedProviderIcon =
     isLocked && props.lockedProvider ? PROVIDER_ICON_BY_PROVIDER[props.lockedProvider] : null;
@@ -503,6 +539,18 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                       showNewBadge={isModelPickerNewModel(model.provider, model.slug)}
                       jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
                       onToggleFavorite={() => toggleFavorite(model.provider, model.slug)}
+                      reorderControls={
+                        canReorderFavorites && favoritesSet.has(modelKey)
+                          ? {
+                              canMoveUp: (favoriteOrder.get(modelKey) ?? -1) > 0,
+                              canMoveDown:
+                                (favoriteOrder.get(modelKey) ?? favorites.length) <
+                                favorites.length - 1,
+                              onMoveUp: () => moveFavorite(model.provider, model.slug, -1),
+                              onMoveDown: () => moveFavorite(model.provider, model.slug, 1),
+                            }
+                          : null
+                      }
                     />
                   );
                 })}

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -8,6 +8,7 @@ import { render } from "vitest-browser-react";
 import { ProviderModelPicker } from "./ProviderModelPicker";
 import { getCustomModelOptionsByProvider } from "../../modelSelection";
 import { DEFAULT_CLIENT_SETTINGS, DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { __resetClientSettingsPersistenceForTests } from "../../hooks/useSettings";
 import { __resetLocalApiForTests } from "../../localApi";
 
 // Mock the environments/runtime module to provide a mock primary environment connection
@@ -294,12 +295,16 @@ function getSidebarProviderOrder() {
 describe("ProviderModelPicker", () => {
   beforeEach(async () => {
     // Reset test environment before each test
+    localStorage.clear();
     await __resetLocalApiForTests();
+    __resetClientSettingsPersistenceForTests();
   });
 
   afterEach(async () => {
     document.body.innerHTML = "";
+    localStorage.clear();
     await __resetLocalApiForTests();
+    __resetClientSettingsPersistenceForTests();
   });
 
   it("shows provider sidebar in unlocked mode", async () => {
@@ -928,6 +933,7 @@ describe("ProviderModelPicker", () => {
 
     try {
       await page.getByRole("button").click();
+      await page.getByRole("button", { name: "Favorites", exact: true }).click();
 
       await vi.waitFor(() => {
         expect(getVisibleModelNames().slice(0, 2)).toEqual(["GPT-5 Codex", "Claude Sonnet 4.6"]);
@@ -966,7 +972,9 @@ describe("ProviderModelPicker", () => {
       await page.getByRole("button", { name: "Codex", exact: true }).click();
 
       await vi.waitFor(() => {
-        expect(getVisibleModelNames()).toEqual(["GPT-5 Codex"]);
+        const visibleModelNames = getVisibleModelNames();
+        expect(visibleModelNames).toContain("GPT-5 Codex");
+        expect(visibleModelNames).not.toContain("GPT-5.3 Codex");
       });
     } finally {
       await mounted.cleanup();

--- a/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.browser.tsx
@@ -908,6 +908,72 @@ describe("ProviderModelPicker", () => {
     }
   });
 
+  it("reorders favorited models from the favorites list", async () => {
+    localStorage.setItem(
+      "t3code:client-settings:v1",
+      JSON.stringify({
+        ...DEFAULT_CLIENT_SETTINGS,
+        favorites: [
+          { provider: "codex", model: "gpt-5-codex" },
+          { provider: "claudeAgent", model: "claude-sonnet-4-6" },
+        ],
+      }),
+    );
+
+    const mounted = await mountPicker({
+      provider: "codex",
+      model: "gpt-5-codex",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+
+      await vi.waitFor(() => {
+        expect(getVisibleModelNames().slice(0, 2)).toEqual(["GPT-5 Codex", "Claude Sonnet 4.6"]);
+      });
+
+      await page
+        .getByRole("button", { name: "Move Claude Sonnet 4.6 up in favorites", exact: true })
+        .click();
+
+      await vi.waitFor(() => {
+        expect(getVisibleModelNames().slice(0, 2)).toEqual(["Claude Sonnet 4.6", "GPT-5 Codex"]);
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem("t3code:client-settings:v1");
+    }
+  });
+
+  it("does not show hidden models in the picker", async () => {
+    localStorage.setItem(
+      "t3code:client-settings:v1",
+      JSON.stringify({
+        ...DEFAULT_CLIENT_SETTINGS,
+        hiddenModels: [{ provider: "codex", model: "gpt-5.3-codex" }],
+      }),
+    );
+
+    const mounted = await mountPicker({
+      provider: "codex",
+      model: "gpt-5-codex",
+      lockedProvider: null,
+    });
+
+    try {
+      await page.getByRole("button").click();
+      await page.getByRole("button", { name: "Codex", exact: true }).click();
+
+      await vi.waitFor(() => {
+        expect(getVisibleModelNames()).toEqual(["GPT-5 Codex"]);
+      });
+    } finally {
+      await mounted.cleanup();
+      localStorage.removeItem("t3code:client-settings:v1");
+    }
+  });
+
   it("dispatches callback with correct provider and model when selected", async () => {
     const mounted = await mountPicker({
       provider: "claudeAgent",

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -3,6 +3,7 @@ import "../../index.css";
 import {
   type AuthAccessStreamEvent,
   type AuthAccessSnapshot,
+  type ClientSettings,
   AuthSessionId,
   DEFAULT_SERVER_SETTINGS,
   EnvironmentId,
@@ -23,6 +24,7 @@ import { AppAtomRegistryProvider } from "../../rpc/atomRegistry";
 import { resetServerStateForTests, setServerConfigSnapshot } from "../../rpc/serverState";
 import { ConnectionsSettings } from "./ConnectionsSettings";
 import { GeneralSettingsPanel } from "./SettingsPanels";
+import { __resetClientSettingsPersistenceForTests } from "../../hooks/useSettings";
 
 const authAccessHarness = vi.hoisted(() => {
   type Snapshot = AuthAccessSnapshot;
@@ -380,6 +382,7 @@ describe("GeneralSettingsPanel observability", () => {
   beforeEach(async () => {
     resetServerStateForTests();
     await __resetLocalApiForTests();
+    __resetClientSettingsPersistenceForTests();
     localStorage.clear();
     authAccessHarness.reset();
   });
@@ -396,6 +399,7 @@ describe("GeneralSettingsPanel observability", () => {
     document.body.innerHTML = "";
     resetServerStateForTests();
     await __resetLocalApiForTests();
+    __resetClientSettingsPersistenceForTests();
     authAccessHarness.reset();
   });
 
@@ -760,8 +764,8 @@ describe("GeneralSettingsPanel observability", () => {
   it("toggles model visibility from provider settings", async () => {
     const updateSettings = vi
       .fn<LocalApi["server"]["updateSettings"]>()
-      .mockResolvedValue(undefined);
-    const config = {
+      .mockImplementation(async () => DEFAULT_SERVER_SETTINGS);
+    const config: ServerConfig = {
       ...createBaseServerConfig(),
       providers: [
         {
@@ -788,6 +792,12 @@ describe("GeneralSettingsPanel observability", () => {
     };
     setServerConfigSnapshot(config);
     window.nativeApi = {
+      persistence: {
+        getClientSettings: async () => null,
+        setClientSettings: async (settings: ClientSettings) => {
+          localStorage.setItem("t3code:client-settings:v1", JSON.stringify(settings));
+        },
+      },
       server: {
         updateSettings,
       },

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -10,6 +10,7 @@ import {
   type DesktopUpdateChannel,
   type DesktopUpdateState,
   type LocalApi,
+  type ServerProvider,
   type ServerConfig,
 } from "@t3tools/contracts";
 import { DateTime } from "effect";
@@ -198,6 +199,43 @@ function createBaseServerConfig(): ServerConfig {
       otlpMetricsEnabled: false,
     },
     settings: DEFAULT_SERVER_SETTINGS,
+  };
+}
+
+function createProviderSettingsServerConfig(): ServerConfig {
+  const config = createBaseServerConfig();
+  const providers: ServerProvider[] = [
+    {
+      provider: "codex",
+      displayName: "Codex",
+      enabled: true,
+      installed: true,
+      version: "0.116.0",
+      status: "ready",
+      auth: { status: "authenticated" },
+      checkedAt: new Date().toISOString(),
+      slashCommands: [],
+      skills: [],
+      models: [
+        {
+          slug: "gpt-5-codex",
+          name: "GPT-5 Codex",
+          isCustom: false,
+          capabilities: null,
+        },
+        {
+          slug: "gpt-5.3-codex",
+          name: "GPT-5.3 Codex",
+          isCustom: false,
+          capabilities: null,
+        },
+      ],
+    },
+  ];
+
+  return {
+    ...config,
+    providers,
   };
 }
 
@@ -717,5 +755,56 @@ describe("GeneralSettingsPanel observability", () => {
     await expect.element(page.getByPlaceholder("http://127.0.0.1:4096")).toBeInTheDocument();
     await expect.element(page.getByText("OpenCode server password")).toBeInTheDocument();
     await expect.element(page.getByPlaceholder("Server password")).toBeInTheDocument();
+  });
+
+  it("toggles model visibility from provider settings", async () => {
+    const updateSettings = vi
+      .fn<LocalApi["server"]["updateSettings"]>()
+      .mockResolvedValue(undefined);
+    const config = {
+      ...createBaseServerConfig(),
+      providers: [
+        {
+          provider: "codex" as const,
+          displayName: "Codex",
+          enabled: true,
+          installed: true,
+          version: "0.116.0",
+          status: "ready" as const,
+          auth: { status: "authenticated" as const },
+          checkedAt: new Date().toISOString(),
+          slashCommands: [],
+          skills: [],
+          models: [
+            {
+              slug: "gpt-5-codex",
+              name: "GPT-5 Codex",
+              isCustom: false,
+              capabilities: null,
+            },
+          ],
+        },
+      ] satisfies ReadonlyArray<ServerProvider>,
+    };
+    setServerConfigSnapshot(config);
+    window.nativeApi = {
+      server: {
+        updateSettings,
+      },
+    } as unknown as LocalApi;
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <GeneralSettingsPanel />
+      </AppAtomRegistryProvider>,
+    );
+
+    await page.getByLabelText("Toggle Codex details").click();
+    await page.getByRole("button", { name: "Hide GPT-5 Codex in model picker" }).click();
+
+    await expect.element(page.getByText("hidden")).toBeInTheDocument();
+    const persisted = JSON.parse(localStorage.getItem("t3code:client-settings:v1") ?? "{}");
+    expect(persisted.hiddenModels).toEqual([{ provider: "codex", model: "gpt-5-codex" }]);
+    expect(updateSettings).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -2,6 +2,8 @@ import {
   ArchiveIcon,
   ArchiveX,
   ChevronDownIcon,
+  EyeIcon,
+  EyeOffIcon,
   InfoIcon,
   LoaderIcon,
   PlusIcon,
@@ -544,18 +546,21 @@ export function GeneralSettingsPanel() {
     codex: Boolean(
       settings.providers.codex.binaryPath !== DEFAULT_UNIFIED_SETTINGS.providers.codex.binaryPath ||
       settings.providers.codex.homePath !== DEFAULT_UNIFIED_SETTINGS.providers.codex.homePath ||
-      settings.providers.codex.customModels.length > 0,
+      settings.providers.codex.customModels.length > 0 ||
+      settings.hiddenModels.some((model) => model.provider === "codex"),
     ),
     claudeAgent: Boolean(
       settings.providers.claudeAgent.binaryPath !==
         DEFAULT_UNIFIED_SETTINGS.providers.claudeAgent.binaryPath ||
       settings.providers.claudeAgent.customModels.length > 0 ||
-      settings.providers.claudeAgent.launchArgs !== "",
+      settings.providers.claudeAgent.launchArgs !== "" ||
+      settings.hiddenModels.some((model) => model.provider === "claudeAgent"),
     ),
     cursor: Boolean(
       settings.providers.cursor.binaryPath !==
         DEFAULT_UNIFIED_SETTINGS.providers.cursor.binaryPath ||
-      settings.providers.cursor.customModels.length > 0,
+      settings.providers.cursor.customModels.length > 0 ||
+      settings.hiddenModels.some((model) => model.provider === "cursor"),
     ),
     opencode: Boolean(
       settings.providers.opencode.binaryPath !==
@@ -564,7 +569,8 @@ export function GeneralSettingsPanel() {
         DEFAULT_UNIFIED_SETTINGS.providers.opencode.serverUrl ||
       settings.providers.opencode.serverPassword !==
         DEFAULT_UNIFIED_SETTINGS.providers.opencode.serverPassword ||
-      settings.providers.opencode.customModels.length > 0,
+      settings.providers.opencode.customModels.length > 0 ||
+      settings.hiddenModels.some((model) => model.provider === "opencode"),
     ),
   });
   const [customModelInputByProvider, setCustomModelInputByProvider] = useState<
@@ -769,6 +775,22 @@ export function GeneralSettingsPanel() {
     [settings, updateSettings],
   );
 
+  const toggleHiddenModel = useCallback(
+    (provider: ProviderKind, slug: string) => {
+      const isHidden = settings.hiddenModels.some(
+        (hiddenModel) => hiddenModel.provider === provider && hiddenModel.model === slug,
+      );
+      updateSettings({
+        hiddenModels: isHidden
+          ? settings.hiddenModels.filter(
+              (hiddenModel) => hiddenModel.provider !== provider || hiddenModel.model !== slug,
+            )
+          : [...settings.hiddenModels, { provider, model: slug }],
+      });
+    },
+    [settings.hiddenModels, updateSettings],
+  );
+
   const providerCards = visibleProviderSettings.map((providerSettings) => {
     const liveProvider = serverProviders.find(
       (candidate) => candidate.provider === providerSettings.provider,
@@ -785,6 +807,11 @@ export function GeneralSettingsPanel() {
         isCustom: true,
         capabilities: null,
       }));
+    const hiddenModelSlugs = new Set(
+      settings.hiddenModels
+        .filter((hiddenModel) => hiddenModel.provider === providerSettings.provider)
+        .map((hiddenModel) => hiddenModel.model),
+    );
 
     return {
       provider: providerSettings.provider,
@@ -802,9 +829,10 @@ export function GeneralSettingsPanel() {
       binaryPathValue: providerConfig.binaryPath,
       serverUrlValue: "serverUrl" in providerConfig ? providerConfig.serverUrl : "",
       serverPasswordValue: "serverPassword" in providerConfig ? providerConfig.serverPassword : "",
-      isDirty: !Equal.equals(providerConfig, defaultProviderConfig),
+      isDirty: !Equal.equals(providerConfig, defaultProviderConfig) || hiddenModelSlugs.size > 0,
       liveProvider,
       models,
+      hiddenModelSlugs,
       providerConfig,
       statusStyle: PROVIDER_STATUS_STYLES[statusKey],
       summary,
@@ -1236,6 +1264,9 @@ export function GeneralSettingsPanel() {
                                   [providerCard.provider]:
                                     DEFAULT_UNIFIED_SETTINGS.providers[providerCard.provider],
                                 },
+                                hiddenModels: settings.hiddenModels.filter(
+                                  (hiddenModel) => hiddenModel.provider !== providerCard.provider,
+                                ),
                               });
                               setCustomModelErrorByProvider((existing) => ({
                                 ...existing,
@@ -1501,6 +1532,7 @@ export function GeneralSettingsPanel() {
                       >
                         {providerCard.models.map((model) => {
                           const caps = model.capabilities;
+                          const isHidden = providerCard.hiddenModelSlugs.has(model.slug);
                           const capLabels: string[] = [];
                           const descriptors = caps?.optionDescriptors ?? [];
                           if (descriptors.some((descriptor) => descriptor.id === "fastMode")) {
@@ -1565,8 +1597,24 @@ export function GeneralSettingsPanel() {
                                   </TooltipPopup>
                                 </Tooltip>
                               ) : null}
+                              <button
+                                type="button"
+                                className={cn(
+                                  "ml-auto inline-flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground transition-colors hover:text-foreground",
+                                  model.isCustom && "ml-0",
+                                )}
+                                aria-label={`${isHidden ? "Show" : "Hide"} ${model.name} in model picker`}
+                                onClick={() => toggleHiddenModel(providerCard.provider, model.slug)}
+                              >
+                                {isHidden ? (
+                                  <EyeOffIcon className="size-3" />
+                                ) : (
+                                  <EyeIcon className="size-3" />
+                                )}
+                                {isHidden ? "hidden" : "shown"}
+                              </button>
                               {model.isCustom ? (
-                                <div className="ml-auto flex shrink-0 items-center gap-1.5">
+                                <div className="flex shrink-0 items-center gap-1.5">
                                   <span className="text-[10px] text-muted-foreground">custom</span>
                                   <button
                                     type="button"

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -534,6 +534,7 @@ describe("wsApi", () => {
       confirmThreadDelete: false,
       diffWordWrap: true,
       favorites: [],
+      hiddenModels: [],
       sidebarProjectGroupingMode: "repository_path" as const,
       sidebarProjectGroupingOverrides: {
         "environment-local:/tmp/project": "separate" as const,
@@ -593,6 +594,7 @@ describe("wsApi", () => {
       confirmThreadDelete: false,
       diffWordWrap: true,
       favorites: [],
+      hiddenModels: [],
       sidebarProjectGroupingMode: "repository_path" as const,
       sidebarProjectGroupingOverrides: {
         "environment-local:/tmp/project": "separate" as const,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -30,17 +30,22 @@ export const SidebarProjectGroupingMode = Schema.Literals([
 export type SidebarProjectGroupingMode = typeof SidebarProjectGroupingMode.Type;
 export const DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE: SidebarProjectGroupingMode = "repository";
 
+const ClientModelPreference = Schema.Struct({
+  provider: ProviderKind,
+  model: TrimmedNonEmptyString,
+});
+
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   diffWordWrap: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  favorites: Schema.Array(
-    Schema.Struct({
-      provider: ProviderKind,
-      model: TrimmedNonEmptyString,
-    }),
-  ).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  favorites: Schema.Array(ClientModelPreference).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
+  hiddenModels: Schema.Array(ClientModelPreference).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
@@ -248,14 +253,8 @@ export const ClientSettingsPatch = Schema.Struct({
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
   diffWordWrap: Schema.optionalKey(Schema.Boolean),
-  favorites: Schema.optionalKey(
-    Schema.Array(
-      Schema.Struct({
-        provider: ProviderKind,
-        model: TrimmedNonEmptyString,
-      }),
-    ),
-  ),
+  favorites: Schema.optionalKey(Schema.Array(ClientModelPreference)),
+  hiddenModels: Schema.optionalKey(Schema.Array(ClientModelPreference)),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(
     Schema.Record(TrimmedNonEmptyString, SidebarProjectGroupingMode),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

- Added client settings support for hidden model preferences.
- Added favorite move controls in the model picker favorites view.
- Added provider settings controls to hide/show individual models in the model picker.
- Added browser coverage for favorite reordering, hidden picker filtering, and provider settings visibility persistence.

## Why

Users can now curate both the order of favorite models and which provider models appear in picker lists without removing favorites or deleting custom models.

## UI Changes

- Browser component coverage exercises the UI interactions for favorite reordering and model hiding.
- Full manual app walkthrough was attempted, but the local backend returned a 502 before the app UI loaded in this cloud environment because provider startup depends on unavailable Codex/Claude CLIs.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1da6c24e-a47f-4900-97ae-0a1e8ec8b251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1da6c24e-a47f-4900-97ae-0a1e8ec8b251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add favorite model reordering and per-model visibility toggling to the model picker
> - Adds up/down reorder controls to favorited models in the model picker (visible only on the favorites tab with no active search); new order is persisted to client settings via `favorites` in [`ModelPickerContent.tsx`](https://github.com/pingdotgg/t3code/pull/2350/files#diff-af6ec8809b715e3718ef62e155f706b7bfc2b5331a509865043ed81e0f10f50c).
> - Adds a hide/show toggle per model in the General settings panel ([`SettingsPanels.tsx`](https://github.com/pingdotgg/t3code/pull/2350/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18)); hidden models are filtered out of the picker and resetting a provider clears its hidden models.
> - Introduces a `hiddenModels` field (default `[]`) and a shared `ClientModelPreference` schema to [`settings.ts`](https://github.com/pingdotgg/t3code/pull/2350/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c); `favorites` is refactored to use the same schema.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c150fb7. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->