### PR TITLE
fix(git): pass --no-ext-diff to patch-emitting git diff calls

### DIFF
--- a/apps/server/src/checkpointing/Layers/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/Layers/CheckpointStore.ts
@@ -246,7 +246,15 @@ const makeCheckpointStore = Effect.gen(function* () {
       const result = yield* git.execute({
         operation,
         cwd: input.cwd,
-        args: ["diff", "--patch", "--minimal", "--no-color", fromCommitOid, toCommitOid],
+        args: [
+          "diff",
+          "--no-ext-diff",
+          "--patch",
+          "--minimal",
+          "--no-color",
+          fromCommitOid,
+          toCommitOid,
+        ],
         maxOutputBytes: CHECKPOINT_DIFF_MAX_OUTPUT_BYTES,
       });
 

--- a/apps/server/src/git/Layers/GitCore.ts
+++ b/apps/server/src/git/Layers/GitCore.ts
@@ -1392,7 +1392,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
     const stagedPatch = yield* runGitStdoutWithOptions(
       "GitCore.prepareCommitContext.stagedPatch",
       cwd,
-      ["diff", "--cached", "--patch", "--minimal"],
+      ["diff", "--no-ext-diff", "--cached", "--patch", "--minimal"],
       {
         maxOutputBytes: PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES,
         truncateOutputAtMaxBytes: true,
@@ -1610,7 +1610,7 @@ export const makeGitCore = Effect.fn("makeGitCore")(function* (options?: {
           runGitStdoutWithOptions(
             "GitCore.readRangeContext.diffPatch",
             cwd,
-            ["diff", "--patch", "--minimal", range],
+            ["diff", "--no-ext-diff", "--patch", "--minimal", range],
             {
               maxOutputBytes: RANGE_DIFF_PATCH_MAX_OUTPUT_BYTES,
               truncateOutputAtMaxBytes: true,


### PR DESCRIPTION
Without `--no-ext-diff`, patches passed to `parsePatchFiles` (`@pierre/diffs`) honor the user's `diff.external` config — anyone with difftastic / delta set globally got "Unsupported diff format. Showing raw patch." in the diff panel.

Adds `--no-ext-diff` to the three call sites whose stdout is parsed:
- `CheckpointStore.diffCheckpoints`
- `GitCore.prepareCommitContext.stagedPatch`
- `GitCore.readRangeContext.diffPatch`

## Repro

```
git config --global diff.external difft
```

Make an edit → diff panel falls back to raw patch.