### PR TITLE
fix(opencode): Memory Leak - Stop OpenCode refresh from leaking serve processes

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -23,6 +23,7 @@ const runtimeMock = {
     runVersionError: null as Error | null,
     versionStdout: DEFAULT_VERSION_STDOUT,
     inventoryError: null as Error | null,
+    closeCalls: 0,
     inventory: {
       providerList: { connected: [] as string[], all: [] as unknown[], default: {} },
       agents: [] as unknown[],
@@ -32,6 +33,7 @@ const runtimeMock = {
     this.state.runVersionError = null;
     this.state.versionStdout = DEFAULT_VERSION_STDOUT;
     this.state.inventoryError = null;
+    this.state.closeCalls = 0;
     this.state.inventory = {
       providerList: { connected: [], all: [] as unknown[], default: {} },
       agents: [] as unknown[],
@@ -46,10 +48,19 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       exitCode: Effect.never,
     }),
   connectToOpenCodeServer: ({ serverUrl }) =>
-    Effect.succeed({
-      url: serverUrl ?? "http://127.0.0.1:4301",
-      exitCode: null,
-      external: Boolean(serverUrl),
+    Effect.gen(function* () {
+      if (!serverUrl) {
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            runtimeMock.state.closeCalls += 1;
+          }),
+        );
+      }
+      return {
+        url: serverUrl ?? "http://127.0.0.1:4301",
+        exitCode: null,
+        external: Boolean(serverUrl),
+      };
     }),
   runOpenCodeCommand: () =>
     runtimeMock.state.runVersionError
@@ -186,6 +197,15 @@ it.layer(makeTestLayer())("OpenCodeProviderLive", (it) => {
       );
       assert.ok(agentDescriptor && agentDescriptor.type === "select");
       assert.equal(agentDescriptor.options.find((option) => option.isDefault)?.id, "build");
+    }),
+  );
+
+  it.effect("closes the local OpenCode server scope after provider refresh", () =>
+    Effect.gen(function* () {
+      const provider = yield* OpenCodeProvider;
+      yield* provider.refresh;
+
+      assert.equal(runtimeMock.state.closeCalls, 1);
     }),
   );
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -330,6 +330,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const child = yield* spawner
         .spawn(
           ChildProcess.make(input.binaryPath, args, {
+            detached: process.platform !== "win32",
             env: {
               ...process.env,
               OPENCODE_CONFIG_CONTENT: JSON.stringify({}),
@@ -347,6 +348,25 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
               }),
           ),
         );
+
+      const killOpenCodeProcessGroup = (signal: NodeJS.Signals) =>
+        process.platform === "win32"
+          ? child.kill({ killSignal: signal, forceKillAfter: "1 second" }).pipe(Effect.asVoid)
+          : Effect.sync(() => {
+              try {
+                process.kill(-Number(child.pid), signal);
+              } catch {
+                // The direct child may already have exited after starting the
+                // server; the process group kill is best-effort cleanup for
+                // any serve process left in that group.
+              }
+            });
+      const terminateChild = killOpenCodeProcessGroup("SIGTERM").pipe(
+        Effect.andThen(Effect.sleep("1 second")),
+        Effect.andThen(killOpenCodeProcessGroup("SIGKILL")),
+        Effect.ignore,
+      );
+      yield* Scope.addFinalizer(runtimeScope, terminateChild);
 
       const stdoutRef = yield* Ref.make("");
       const stderrRef = yield* Ref.make("");


### PR DESCRIPTION
## What Changed

Fixes cleanup for scoped local OpenCode server processes used during provider refresh/model checks.

The refresh scope now terminates the spawned OpenCode process group when the scoped server is closed, preventing orphaned `opencode serve` processes from accumulating in the background.

## Why

OpenCode refresh/model checks could start a temporary local server, but the wrapper process could exit while leaving the actual long-lived serve child alive. Since refresh runs periodically, this could create a new background OpenCode process every cycle and cause memory usage to balloon.

This keeps provider refresh behavior intact and only tightens cleanup for the local refresh-owned OpenCode process. Active OpenCode thread sessions keep their existing lifecycle.

## Warning
I couldn't test on windows and the exit logic is slightly different as `process.kill(-pid, signal) is POSIX only`. It's correct in theory but should be double checked.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


**Constraint**: Keep active OpenCode thread sessions scoped to their own session lifecycle.
**Confidence**: high
**Scope-risk**: narrow
**Tested**: `bun run test src/provider/Layers/OpenCodeProvider.test.ts src/provider/Layers/OpenCodeAdapter.test.ts`
**Tested**: `bun fmt`
**Tested**: `bun lint`
**Tested**: `bun typecheck`
**Tested**: `bun run build:desktop`

## Screenshots

1. After leaving my laptop overnight
<img width="351" height="18" alt="Screenshot 2026-04-26 at 15 37 49" src="https://github.com/user-attachments/assets/c8a0345a-c42c-4dae-943b-12b7eaef4da2" />


2. Every 60s a new opencode process is launched and never exits.
<img width="1159" height="1038" alt="Screenshot 2026-04-26 at 16 41 16" src="https://github.com/user-attachments/assets/9fb2e9b3-1d7a-46a1-ad3b-bdd3b103fe41" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process-spawning/termination behavior for the local `opencode serve` used during provider refresh, including POSIX process-group killing and Windows-specific fallback; mistakes could leave servers running or kill the wrong process. Scope is narrow and covered by a new refresh cleanup test.
> 
> **Overview**
> Fixes a refresh-time memory leak by ensuring locally spawned `opencode serve` processes are reliably cleaned up when the refresh scope closes.
> 
> `startOpenCodeServerProcess` now spawns the server **detached on non-Windows** and registers a scope finalizer that **SIGTERM/SIGKILLs the entire process group** (or uses `child.kill` on Windows), preventing orphaned background servers from accumulating.
> 
> Tests update the `OpenCodeRuntime` test double to track scope finalization and add an assertion that `provider.refresh` closes the local server scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f446782d664e373a282fcb54369b6304dfc76e25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix memory leak by terminating OpenCode server processes on scope finalization
> - Spawns the OpenCode server process with `detached: true` on non-Windows so the child and its subprocesses form a separate process group.
> - Registers a scope finalizer that sends SIGTERM, waits 1 second, then SIGKILL to the process group (non-Windows) or calls `child.kill` (Windows), ensuring server processes are cleaned up when `provider.refresh` completes.
> - Adds a `closeCalls` counter to the test double and a new test asserting the local server scope is closed after refresh.
> - Behavioral Change: OpenCode server processes are now spawned detached on non-Windows and will be forcibly killed on scope close rather than left running.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f446782.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->