### PR TITLE
fix(release): use configured node for smoke manifest merge

### DIFF
--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -292,7 +292,7 @@ try {
           fi
 
           found_windows_manifest=true
-          node ${JSON.stringify(resolve(repoRoot, "scripts/merge-update-manifests.ts"))} --platform win \
+          ${JSON.stringify(process.execPath)} ${JSON.stringify(resolve(repoRoot, "scripts/merge-update-manifests.ts"))} --platform win \
             "$arm64_manifest" \
             "$x64_manifest" \
             "$output_manifest"


### PR DESCRIPTION
## Summary
- Run the release smoke manifest merge with the current Node executable instead of a bare `node` lookup
- Keeps the smoke script aligned with the workflow's configured Node version from `package.json`

## Verification
- `node scripts/release-smoke.ts`
- `bun fmt`
- `bun lint`
- `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps the Windows manifest-merge invocation in the release smoke script from `node` on PATH to `process.execPath`, reducing environment/version drift without changing merge logic.
> 
> **Overview**
> Updates `scripts/release-smoke.ts` so the Windows updater-manifest merge runs via the current Node executable (`process.execPath`) instead of a bare `node` lookup, keeping smoke tests aligned with the workflow’s configured Node version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 706daa4e71d73a7ee8da4fbc45d61a970d1f066b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix smoke release manifest merge to use configured Node binary
> In [release-smoke.ts](https://github.com/pingdotgg/t3code/pull/2364/files#diff-710e2c3360c77cdcd58afde8d41dac38c929463d0e49b42cb127c157ebf9a918), the Windows manifest merge step now invokes `merge-update-manifests.ts` using `process.execPath` instead of the literal `node` command, ensuring the correct Node binary is used in environments where `node` is not on PATH or resolves to a different version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 706daa4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->