### PR TITLE
Ignore stale WebSocket lifecycle events after reconnect

### DIFF
--- a/apps/web/src/rpc/protocol.ts
+++ b/apps/web/src/rpc/protocol.ts
@@ -18,6 +18,7 @@ import {
 } from "./wsConnectionState";
 
 export interface WsProtocolLifecycleHandlers {
+  readonly isActive?: () => boolean;
   readonly onAttempt?: (socketUrl: string) => void;
   readonly onOpen?: () => void;
   readonly onError?: (message: string) => void;
@@ -49,6 +50,7 @@ function resolveWsRpcSocketUrl(rawUrl: string): string {
 
 function defaultLifecycleHandlers(): Required<WsProtocolLifecycleHandlers> {
   return {
+    isActive: () => true,
     onAttempt: recordWsConnectionAttempt,
     onOpen: recordWsConnectionOpened,
     onError: (message) => {
@@ -66,21 +68,35 @@ function composeLifecycleHandlers(
   handlers?: WsProtocolLifecycleHandlers,
 ): Required<WsProtocolLifecycleHandlers> {
   const defaults = defaultLifecycleHandlers();
+  const isActive = handlers?.isActive ?? (() => true);
 
   return {
+    isActive,
     onAttempt: (socketUrl) => {
+      if (!isActive()) {
+        return;
+      }
       defaults.onAttempt(socketUrl);
       handlers?.onAttempt?.(socketUrl);
     },
     onOpen: () => {
+      if (!isActive()) {
+        return;
+      }
       defaults.onOpen();
       handlers?.onOpen?.();
     },
     onError: (message) => {
+      if (!isActive()) {
+        return;
+      }
       defaults.onError(message);
       handlers?.onError?.(message);
     },
     onClose: (details) => {
+      if (!isActive()) {
+        return;
+      }
       defaults.onClose(details);
       handlers?.onClose?.(details);
     },

--- a/apps/web/src/rpc/wsTransport.test.ts
+++ b/apps/web/src/rpc/wsTransport.test.ts
@@ -324,6 +324,11 @@ describe("WsTransport", () => {
     const secondSocket = getSocket();
     expect(secondSocket).not.toBe(firstSocket);
     expect(firstSocket.readyState).toBe(MockWebSocket.CLOSED);
+    expect(getWsConnectionStatus()).toMatchObject({
+      closeCode: null,
+      closeReason: null,
+      phase: "connecting",
+    });
 
     const requestPromise = transport.request((client) =>
       client[WS_METHODS.serverUpsertKeybinding]({
@@ -356,6 +361,58 @@ describe("WsTransport", () => {
     await expect(requestPromise).resolves.toEqual({
       keybindings: [],
       issues: [],
+    });
+
+    await transport.dispose();
+  });
+
+  it("ignores stale socket lifecycle events after a reconnect starts a new session", async () => {
+    const onClose = vi.fn();
+    const transport = createTransport("ws://localhost:3020", { onClose });
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    const firstSocket = getSocket();
+    firstSocket.open();
+
+    await waitFor(() => {
+      expect(getWsConnectionStatus()).toMatchObject({
+        hasConnected: true,
+        phase: "connected",
+      });
+    });
+
+    await transport.reconnect();
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(2);
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(getWsConnectionStatus()).toMatchObject({
+      closeCode: null,
+      closeReason: null,
+      phase: "connecting",
+    });
+
+    const secondSocket = getSocket();
+    secondSocket.open();
+
+    await waitFor(() => {
+      expect(getWsConnectionStatus()).toMatchObject({
+        phase: "connected",
+      });
+    });
+
+    firstSocket.close(1006, "stale close");
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(getWsConnectionStatus()).toMatchObject({
+      closeCode: null,
+      closeReason: null,
+      phase: "connected",
     });
 
     await transport.dispose();

--- a/apps/web/src/rpc/wsTransport.ts
+++ b/apps/web/src/rpc/wsTransport.ts
@@ -53,6 +53,8 @@ export class WsTransport {
   private disposed = false;
   private hasReportedTransportDisconnect = false;
   private reconnectChain: Promise<void> = Promise.resolve();
+  private nextSessionId = 0;
+  private activeSessionId = 0;
   private session: TransportSession;
 
   constructor(
@@ -215,8 +217,17 @@ export class WsTransport {
   }
 
   private createSession(): TransportSession {
+    const sessionId = this.nextSessionId + 1;
+    this.nextSessionId = sessionId;
+    this.activeSessionId = sessionId;
     const runtime = ManagedRuntime.make(
-      Layer.mergeAll(createWsRpcProtocolLayer(this.url, this.lifecycleHandlers), ClientTracingLive),
+      Layer.mergeAll(
+        createWsRpcProtocolLayer(this.url, {
+          ...this.lifecycleHandlers,
+          isActive: () => !this.disposed && this.activeSessionId === sessionId,
+        }),
+        ClientTracingLive,
+      ),
     );
     const clientScope = runtime.runSync(Scope.make());
     return {


### PR DESCRIPTION
- Gate protocol lifecycle callbacks on the active session
- Prevent old sockets from mutating connection state after reconnect
- Add regression coverage for stale close handling

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebSocket transport/protocol lifecycle handling and reconnect behavior; a mistake could suppress legitimate connection state updates or mask errors.
> 
> **Overview**
> Prevents old WebSocket sessions from updating connection/error state after a `WsTransport.reconnect()` by introducing an `isActive` guard on protocol lifecycle callbacks.
> 
> `WsTransport` now assigns a per-session id and passes an `isActive` predicate into `createWsRpcProtocolLayer`, while tests add regression coverage ensuring a stale socket `close` does not trigger `onClose` or overwrite the current connection status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f6bcd85c0c674b0b703c761e5de968e832db4da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore stale WebSocket lifecycle events after reconnect in `WsTransport`
> - Introduces per-session tracking (`nextSessionId`/`activeSessionId`) in [`WsTransport`](https://github.com/pingdotgg/t3code/pull/2372/files#diff-fcf0fef38d38807751d2b8042c13809e6ac1cec6acf3dcf78139a7c28e666440) so each connection attempt gets a unique session ID.
> - Adds an `isActive(): boolean` hook to the `WsProtocolLifecycleHandlers` interface in [`protocol.ts`](https://github.com/pingdotgg/t3code/pull/2372/files#diff-250cbb4e2b2844f783c3a5bb6459ce28b1faeb587d4babdd2a4bc024fb8fce4c); `onAttempt`, `onOpen`, `onError`, and `onClose` are skipped when `isActive()` returns false.
> - When a reconnect starts, the previous session's `isActive` returns false, so any late-arriving lifecycle events (e.g. a `close` from the old socket) are silently ignored instead of mutating connection state.
> - Behavioral Change: lifecycle callbacks from stale sessions no longer fire, which prevents spurious `onClose` calls from updating connection status after a reconnect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f6bcd8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->