### PR TITLE
Stabilize logical project grouping across environments

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -117,7 +117,11 @@ import { getProviderModelCapabilities, resolveSelectableProvider } from "../prov
 import { useSettings } from "../hooks/useSettings";
 import { resolveAppModelSelection } from "../modelSelection";
 import { isTerminalFocused } from "../lib/terminalFocus";
-import { deriveLogicalProjectKeyFromSettings } from "../logicalProject";
+import {
+  buildLogicalProjectKeyMap,
+  deriveLogicalProjectKeyFromSettings,
+  derivePhysicalProjectKey,
+} from "../logicalProject";
 import {
   useSavedEnvironmentRegistryStore,
   useSavedEnvironmentRuntimeStore,
@@ -856,11 +860,19 @@ export default function ChatView(props: ChatViewProps) {
     sidebarProjectGroupingMode: settings.sidebarProjectGroupingMode,
     sidebarProjectGroupingOverrides: settings.sidebarProjectGroupingOverrides,
   }));
+  const logicalProjectKeyByPhysicalKey = useMemo(
+    () => buildLogicalProjectKeyMap(allProjects, projectGroupingSettings),
+    [allProjects, projectGroupingSettings],
+  );
   const logicalProjectEnvironments = useMemo(() => {
     if (!activeProject) return [];
-    const logicalKey = deriveLogicalProjectKeyFromSettings(activeProject, projectGroupingSettings);
+    const logicalKey =
+      logicalProjectKeyByPhysicalKey.get(derivePhysicalProjectKey(activeProject)) ??
+      deriveLogicalProjectKeyFromSettings(activeProject, projectGroupingSettings);
     const memberProjects = allProjects.filter(
-      (p) => deriveLogicalProjectKeyFromSettings(p, projectGroupingSettings) === logicalKey,
+      (p) =>
+        (logicalProjectKeyByPhysicalKey.get(derivePhysicalProjectKey(p)) ??
+          deriveLogicalProjectKeyFromSettings(p, projectGroupingSettings)) === logicalKey,
     );
     const seen = new Set<string>();
     const envs: Array<{
@@ -897,6 +909,7 @@ export default function ChatView(props: ChatViewProps) {
   }, [
     activeProject,
     allProjects,
+    logicalProjectKeyByPhysicalKey,
     projectGroupingSettings,
     primaryEnvironmentId,
     savedEnvironmentRegistry,
@@ -927,10 +940,9 @@ export default function ChatView(props: ChatViewProps) {
         throw new Error("No active project is available for this pull request.");
       }
       const activeProjectRef = scopeProjectRef(activeProject.environmentId, activeProject.id);
-      const logicalProjectKey = deriveLogicalProjectKeyFromSettings(
-        activeProject,
-        projectGroupingSettings,
-      );
+      const logicalProjectKey =
+        logicalProjectKeyByPhysicalKey.get(derivePhysicalProjectKey(activeProject)) ??
+        deriveLogicalProjectKeyFromSettings(activeProject, projectGroupingSettings);
       const storedDraftSession = getDraftSessionByLogicalProjectKey(logicalProjectKey);
       if (storedDraftSession) {
         setDraftThreadContext(storedDraftSession.draftId, input);
@@ -991,6 +1003,7 @@ export default function ChatView(props: ChatViewProps) {
       getDraftSessionByLogicalProjectKey,
       isServerThread,
       navigate,
+      logicalProjectKeyByPhysicalKey,
       projectGroupingSettings,
       routeKind,
       setDraftThreadContext,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -216,6 +216,17 @@ function formatProjectMemberActionLabel(
   return member.environmentLabel ? `${member.environmentLabel} — ${member.cwd}` : member.cwd;
 }
 
+function hasDuplicateMemberEnvironment(members: readonly SidebarProjectGroupMember[]): boolean {
+  const seen = new Set<string>();
+  for (const member of members) {
+    if (seen.has(member.environmentId)) {
+      return true;
+    }
+    seen.add(member.environmentId);
+  }
+  return false;
+}
+
 function projectGroupingModeDescription(mode: SidebarProjectGroupingMode): string {
   switch (mode) {
     case "repository":
@@ -1674,8 +1685,15 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       event.preventDefault();
       event.stopPropagation();
 
-      if (project.memberProjects.length === 1) {
-        createThreadForProjectMember(project.memberProjects[0]!);
+      if (
+        project.memberProjects.length === 1 ||
+        !hasDuplicateMemberEnvironment(project.memberProjects)
+      ) {
+        const representative =
+          project.memberProjects.find(
+            (member) => member.environmentId === project.environmentId && member.id === project.id,
+          ) ?? project.memberProjects[0]!;
+        createThreadForProjectMember(representative);
         return;
       }
 
@@ -1706,7 +1724,13 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         createThreadForProjectMember(targetMember);
       })();
     },
-    [createThreadForProjectMember, project.groupedProjectCount, project.memberProjects],
+    [
+      createThreadForProjectMember,
+      project.environmentId,
+      project.groupedProjectCount,
+      project.id,
+      project.memberProjects,
+    ],
   );
 
   const attemptArchiveThread = useCallback(
@@ -2735,9 +2759,9 @@ export default function Sidebar() {
     });
   }, [projectOrder, projects]);
 
-  // Build a mapping from physical project key → logical project key for
-  // cross-environment grouping.  Projects that share a repositoryIdentity
-  // canonicalKey are treated as one logical project in the sidebar.
+  // Build a mapping from physical project key -> logical project key. Matching
+  // projects can group across environments, but each rendered group keeps at
+  // most one member per environment so thread creation remains unambiguous.
   const physicalToLogicalKey = useMemo(() => {
     return buildPhysicalToLogicalProjectKeyMap({
       projects: orderedProjects,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2759,9 +2759,8 @@ export default function Sidebar() {
     });
   }, [projectOrder, projects]);
 
-  // Build a mapping from physical project key -> logical project key. Matching
-  // projects can group across environments, but each rendered group keeps at
-  // most one member per environment so thread creation remains unambiguous.
+  // Build a mapping from physical project key -> logical project key so the
+  // sidebar, active route, and thread buckets all use the same grouping mode.
   const physicalToLogicalKey = useMemo(() => {
     return buildPhysicalToLogicalProjectKeyMap({
       projects: orderedProjects,

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -529,7 +529,7 @@ describe("environment grouping", () => {
       );
     });
 
-    it("keeps duplicate clones in the same environment separate when repo-relative paths match", () => {
+    it("groups duplicate clones in the same environment when repo-relative paths match", () => {
       const firstClone = makeProject({
         id: sharedProjectPrimaryId,
         environmentId: primaryEnvId,
@@ -563,7 +563,7 @@ describe("environment grouping", () => {
 
       const keys = buildLogicalProjectKeyMap([firstClone, secondClone], DEFAULT_GROUPING_SETTINGS);
 
-      expect(keys.get(derivePhysicalProjectKey(firstClone))).not.toBe(
+      expect(keys.get(derivePhysicalProjectKey(firstClone))).toBe(
         keys.get(derivePhysicalProjectKey(secondClone)),
       );
     });

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -451,7 +451,7 @@ describe("environment grouping", () => {
   });
 
   describe("buildLogicalProjectKeyMap", () => {
-    it("groups matching projects across environments without merging distinct projects in one environment", () => {
+    it("groups matching projects by repository under repository grouping", () => {
       const localRoot = makeProject({
         id: sharedProjectPrimaryId,
         environmentId: primaryEnvId,
@@ -524,8 +524,50 @@ describe("environment grouping", () => {
       expect(keys.get(derivePhysicalProjectKey(localWeb))).toBe(
         keys.get(derivePhysicalProjectKey(remoteWeb)),
       );
-      expect(keys.get(derivePhysicalProjectKey(localRoot))).not.toBe(
+      expect(keys.get(derivePhysicalProjectKey(localRoot))).toBe(
         keys.get(derivePhysicalProjectKey(localWeb)),
+      );
+    });
+
+    it("splits repo root and nested projects under repository path grouping", () => {
+      const rootProject = makeProject({
+        id: sharedProjectPrimaryId,
+        environmentId: primaryEnvId,
+        name: "shared-repo",
+        cwd: "/workspace/repo",
+        repositoryIdentity: {
+          canonicalKey: SHARED_REPO_CANONICAL_KEY,
+          rootPath: "/workspace/repo",
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: "https://github.com/example/shared-repo.git",
+          },
+        },
+      });
+      const nestedProject = makeProject({
+        id: localOnlyProjectId,
+        environmentId: primaryEnvId,
+        name: "web",
+        cwd: "/workspace/repo/apps/web",
+        repositoryIdentity: {
+          canonicalKey: SHARED_REPO_CANONICAL_KEY,
+          rootPath: "/workspace/repo",
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: "https://github.com/example/shared-repo.git",
+          },
+        },
+      });
+
+      const keys = buildLogicalProjectKeyMap([rootProject, nestedProject], {
+        ...DEFAULT_GROUPING_SETTINGS,
+        sidebarProjectGroupingMode: "repository_path",
+      });
+
+      expect(keys.get(derivePhysicalProjectKey(rootProject))).not.toBe(
+        keys.get(derivePhysicalProjectKey(nestedProject)),
       );
     });
 

--- a/apps/web/src/environmentGrouping.test.ts
+++ b/apps/web/src/environmentGrouping.test.ts
@@ -11,6 +11,7 @@ import {
   type EnvironmentState,
 } from "./store";
 import {
+  buildLogicalProjectKeyMap,
   deriveLogicalProjectKey,
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKey,
@@ -446,6 +447,125 @@ describe("environment grouping", () => {
           },
         }),
       ).toBe(derivePhysicalProjectKey(project));
+    });
+  });
+
+  describe("buildLogicalProjectKeyMap", () => {
+    it("groups matching projects across environments without merging distinct projects in one environment", () => {
+      const localRoot = makeProject({
+        id: sharedProjectPrimaryId,
+        environmentId: primaryEnvId,
+        name: "shared-repo",
+        cwd: "/workspace/repo",
+        repositoryIdentity: {
+          canonicalKey: SHARED_REPO_CANONICAL_KEY,
+          rootPath: "/workspace/repo",
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: "https://github.com/example/shared-repo.git",
+          },
+        },
+      });
+      const localWeb = makeProject({
+        id: localOnlyProjectId,
+        environmentId: primaryEnvId,
+        name: "web",
+        cwd: "/workspace/repo/apps/web",
+        repositoryIdentity: {
+          canonicalKey: SHARED_REPO_CANONICAL_KEY,
+          rootPath: "/workspace/repo",
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: "https://github.com/example/shared-repo.git",
+          },
+        },
+      });
+      const remoteRoot = makeProject({
+        id: sharedProjectRemoteId,
+        environmentId: remoteEnvId,
+        name: "shared-repo",
+        cwd: "/srv/checkout",
+        repositoryIdentity: {
+          canonicalKey: SHARED_REPO_CANONICAL_KEY,
+          rootPath: "/srv/checkout",
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: "https://github.com/example/shared-repo.git",
+          },
+        },
+      });
+      const remoteWeb = makeProject({
+        id: remoteOnlyProjectId,
+        environmentId: remoteEnvId,
+        name: "web",
+        cwd: "/srv/checkout/apps/web",
+        repositoryIdentity: {
+          canonicalKey: SHARED_REPO_CANONICAL_KEY,
+          rootPath: "/srv/checkout",
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: "https://github.com/example/shared-repo.git",
+          },
+        },
+      });
+
+      const keys = buildLogicalProjectKeyMap(
+        [localRoot, localWeb, remoteRoot, remoteWeb],
+        DEFAULT_GROUPING_SETTINGS,
+      );
+
+      expect(keys.get(derivePhysicalProjectKey(localRoot))).toBe(
+        keys.get(derivePhysicalProjectKey(remoteRoot)),
+      );
+      expect(keys.get(derivePhysicalProjectKey(localWeb))).toBe(
+        keys.get(derivePhysicalProjectKey(remoteWeb)),
+      );
+      expect(keys.get(derivePhysicalProjectKey(localRoot))).not.toBe(
+        keys.get(derivePhysicalProjectKey(localWeb)),
+      );
+    });
+
+    it("keeps duplicate clones in the same environment separate when repo-relative paths match", () => {
+      const firstClone = makeProject({
+        id: sharedProjectPrimaryId,
+        environmentId: primaryEnvId,
+        name: "first",
+        cwd: "/workspace/first/repo",
+        repositoryIdentity: {
+          canonicalKey: SHARED_REPO_CANONICAL_KEY,
+          rootPath: "/workspace/first/repo",
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: "https://github.com/example/shared-repo.git",
+          },
+        },
+      });
+      const secondClone = makeProject({
+        id: localOnlyProjectId,
+        environmentId: primaryEnvId,
+        name: "second",
+        cwd: "/workspace/second/repo",
+        repositoryIdentity: {
+          canonicalKey: SHARED_REPO_CANONICAL_KEY,
+          rootPath: "/workspace/second/repo",
+          locator: {
+            source: "git-remote",
+            remoteName: "origin",
+            remoteUrl: "https://github.com/example/shared-repo.git",
+          },
+        },
+      });
+
+      const keys = buildLogicalProjectKeyMap([firstClone, secondClone], DEFAULT_GROUPING_SETTINGS);
+
+      expect(keys.get(derivePhysicalProjectKey(firstClone))).not.toBe(
+        keys.get(derivePhysicalProjectKey(secondClone)),
+      );
     });
   });
 

--- a/apps/web/src/environments/runtime/service.ts
+++ b/apps/web/src/environments/runtime/service.ts
@@ -61,10 +61,7 @@ import { useTerminalStateStore } from "~/terminalStateStore";
 import { useUiStateStore } from "~/uiStateStore";
 import { WsTransport } from "../../rpc/wsTransport";
 import { createWsRpcClient, type WsRpcClient } from "../../rpc/wsRpcClient";
-import {
-  deriveLogicalProjectKeyFromSettings,
-  derivePhysicalProjectKey,
-} from "../../logicalProject";
+import { buildLogicalProjectKeyMap, derivePhysicalProjectKey } from "../../logicalProject";
 import { getClientSettings } from "~/hooks/useSettings";
 
 type EnvironmentServiceState = {
@@ -473,10 +470,13 @@ function coalesceOrchestrationUiEvents(
 function syncProjectUiFromStore() {
   const projects = selectProjectsAcrossEnvironments(useStore.getState());
   const clientSettings = getClientSettings();
+  const logicalKeyByPhysicalKey = buildLogicalProjectKeyMap(projects, clientSettings);
   useUiStateStore.getState().syncProjects(
     projects.map((project) => ({
       key: derivePhysicalProjectKey(project),
-      logicalKey: deriveLogicalProjectKeyFromSettings(project, clientSettings),
+      logicalKey:
+        logicalKeyByPhysicalKey.get(derivePhysicalProjectKey(project)) ??
+        derivePhysicalProjectKey(project),
       cwd: project.cwd,
     })),
   );
@@ -548,10 +548,13 @@ function applyRecoveredEventBatch(
   if (needsProjectUiSync) {
     const projects = selectProjectsAcrossEnvironments(useStore.getState());
     const clientSettings = getClientSettings();
+    const logicalKeyByPhysicalKey = buildLogicalProjectKeyMap(projects, clientSettings);
     useUiStateStore.getState().syncProjects(
       projects.map((project) => ({
         key: derivePhysicalProjectKey(project),
-        logicalKey: deriveLogicalProjectKeyFromSettings(project, clientSettings),
+        logicalKey:
+          logicalKeyByPhysicalKey.get(derivePhysicalProjectKey(project)) ??
+          derivePhysicalProjectKey(project),
         cwd: project.cwd,
       })),
     );

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -10,7 +10,12 @@ import {
 } from "../composerDraftStore";
 import { newDraftId, newThreadId } from "../lib/utils";
 import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
-import { deriveLogicalProjectKeyFromSettings, getProjectOrderKey } from "../logicalProject";
+import {
+  buildLogicalProjectKeyMap,
+  deriveLogicalProjectKeyFromSettings,
+  derivePhysicalProjectKey,
+  getProjectOrderKey,
+} from "../logicalProject";
 import { selectProjectsAcrossEnvironments, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
 import { resolveThreadRouteTarget } from "../threadRoutes";
@@ -23,6 +28,10 @@ function useNewThreadState() {
     sidebarProjectGroupingMode: settings.sidebarProjectGroupingMode,
     sidebarProjectGroupingOverrides: settings.sidebarProjectGroupingOverrides,
   }));
+  const logicalKeyByPhysicalKey = useMemo(
+    () => buildLogicalProjectKeyMap(projects, projectGroupingSettings),
+    [projectGroupingSettings, projects],
+  );
   const router = useRouter();
   const getCurrentRouteTarget = useCallback(() => {
     const currentRouteParams = router.state.matches[router.state.matches.length - 1]?.params ?? {};
@@ -53,7 +62,8 @@ function useNewThreadState() {
           candidate.environmentId === projectRef.environmentId,
       );
       const logicalProjectKey = project
-        ? deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings)
+        ? (logicalKeyByPhysicalKey.get(derivePhysicalProjectKey(project)) ??
+          deriveLogicalProjectKeyFromSettings(project, projectGroupingSettings))
         : scopedProjectKey(projectRef);
       const hasBranchOption = options?.branch !== undefined;
       const hasWorktreePathOption = options?.worktreePath !== undefined;
@@ -134,7 +144,7 @@ function useNewThreadState() {
         });
       })();
     },
-    [getCurrentRouteTarget, projectGroupingSettings, router, projects],
+    [getCurrentRouteTarget, logicalKeyByPhysicalKey, projectGroupingSettings, router, projects],
   );
 }
 

--- a/apps/web/src/logicalProject.ts
+++ b/apps/web/src/logicalProject.ts
@@ -51,6 +51,21 @@ function deriveRepositoryRelativeProjectPath(
   return normalizedProjectPath.slice(rootPrefix.length).replaceAll("\\", "/");
 }
 
+function formatProjectGroupDiscriminator(value: string): string {
+  return value.length === 0 ? "." : value;
+}
+
+function hasDuplicateEnvironment(projects: ReadonlyArray<Pick<Project, "environmentId">>): boolean {
+  const seen = new Set<string>();
+  for (const project of projects) {
+    if (seen.has(project.environmentId)) {
+      return true;
+    }
+    seen.add(project.environmentId);
+  }
+  return false;
+}
+
 export function derivePhysicalProjectKeyFromPath(environmentId: string, cwd: string): string {
   return `${environmentId}:${normalizeProjectPathForComparison(cwd)}`;
 }
@@ -130,6 +145,88 @@ export function deriveLogicalProjectKeyFromSettings(
   return deriveLogicalProjectKey(project, {
     groupingMode: resolveProjectGroupingMode(project, settings),
   });
+}
+
+export function buildLogicalProjectKeyMap(
+  projects: ReadonlyArray<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>,
+  settings: ProjectGroupingSettings,
+): Map<string, string> {
+  const baseBuckets = new Map<
+    string,
+    Array<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>
+  >();
+  const physicalKeyByProject = new Map<
+    Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">,
+    string
+  >();
+
+  for (const project of projects) {
+    const physicalKey = derivePhysicalProjectKey(project);
+    physicalKeyByProject.set(project, physicalKey);
+    const baseKey = deriveLogicalProjectKeyFromSettings(project, settings);
+    const bucket = baseBuckets.get(baseKey);
+    if (bucket) {
+      bucket.push(project);
+    } else {
+      baseBuckets.set(baseKey, [project]);
+    }
+  }
+
+  const result = new Map<string, string>();
+  const assignBucket = (
+    baseKey: string,
+    bucket: ReadonlyArray<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>,
+    discriminatorIndex: number,
+  ) => {
+    if (!hasDuplicateEnvironment(bucket)) {
+      for (const project of bucket) {
+        result.set(physicalKeyByProject.get(project)!, baseKey);
+      }
+      return;
+    }
+
+    const discriminatorFns = [
+      (project: Pick<Project, "cwd" | "repositoryIdentity">) => {
+        const relativePath = deriveRepositoryRelativeProjectPath(project);
+        return relativePath === null ? null : formatProjectGroupDiscriminator(relativePath);
+      },
+      (project: Pick<Project, "cwd">) => normalizeProjectPathForComparison(project.cwd),
+      (project: Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">) =>
+        physicalKeyByProject.get(project) ?? derivePhysicalProjectKey(project),
+    ] as const;
+    const discriminator = discriminatorFns[discriminatorIndex];
+    if (!discriminator) {
+      for (const project of bucket) {
+        result.set(physicalKeyByProject.get(project)!, physicalKeyByProject.get(project)!);
+      }
+      return;
+    }
+
+    const buckets = new Map<
+      string,
+      Array<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>
+    >();
+    for (const project of bucket) {
+      const value = discriminator(project) ?? normalizeProjectPathForComparison(project.cwd);
+      const key = `${baseKey}::${value}`;
+      const existing = buckets.get(key);
+      if (existing) {
+        existing.push(project);
+      } else {
+        buckets.set(key, [project]);
+      }
+    }
+
+    for (const [key, projectsForKey] of buckets) {
+      assignBucket(key, projectsForKey, discriminatorIndex + 1);
+    }
+  };
+
+  for (const [baseKey, bucket] of baseBuckets) {
+    assignBucket(baseKey, bucket, 0);
+  }
+
+  return result;
 }
 
 export function deriveLogicalProjectKeyFromRef(

--- a/apps/web/src/logicalProject.ts
+++ b/apps/web/src/logicalProject.ts
@@ -51,21 +51,6 @@ function deriveRepositoryRelativeProjectPath(
   return normalizedProjectPath.slice(rootPrefix.length).replaceAll("\\", "/");
 }
 
-function formatProjectGroupDiscriminator(value: string): string {
-  return value.length === 0 ? "." : value;
-}
-
-function hasDuplicateEnvironment(projects: ReadonlyArray<Pick<Project, "environmentId">>): boolean {
-  const seen = new Set<string>();
-  for (const project of projects) {
-    if (seen.has(project.environmentId)) {
-      return true;
-    }
-    seen.add(project.environmentId);
-  }
-  return false;
-}
-
 export function derivePhysicalProjectKeyFromPath(environmentId: string, cwd: string): string {
   return `${environmentId}:${normalizeProjectPathForComparison(cwd)}`;
 }
@@ -151,67 +136,11 @@ export function buildLogicalProjectKeyMap(
   projects: ReadonlyArray<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>,
   settings: ProjectGroupingSettings,
 ): Map<string, string> {
-  const baseBuckets = new Map<
-    string,
-    Array<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>
-  >();
-  const physicalKeyByProject = new Map<
-    Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">,
-    string
-  >();
+  const result = new Map<string, string>();
 
   for (const project of projects) {
     const physicalKey = derivePhysicalProjectKey(project);
-    physicalKeyByProject.set(project, physicalKey);
-    const baseKey = deriveLogicalProjectKeyFromSettings(project, settings);
-    const bucket = baseBuckets.get(baseKey);
-    if (bucket) {
-      bucket.push(project);
-    } else {
-      baseBuckets.set(baseKey, [project]);
-    }
-  }
-
-  const result = new Map<string, string>();
-  const assignBucket = (
-    baseKey: string,
-    bucket: ReadonlyArray<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>,
-  ) => {
-    if (!hasDuplicateEnvironment(bucket)) {
-      for (const project of bucket) {
-        result.set(physicalKeyByProject.get(project)!, baseKey);
-      }
-      return;
-    }
-
-    const buckets = new Map<
-      string,
-      Array<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>
-    >();
-    for (const project of bucket) {
-      const relativePath = deriveRepositoryRelativeProjectPath(project);
-      const value =
-        relativePath === null
-          ? normalizeProjectPathForComparison(project.cwd)
-          : formatProjectGroupDiscriminator(relativePath);
-      const key = `${baseKey}::${value}`;
-      const existing = buckets.get(key);
-      if (existing) {
-        existing.push(project);
-      } else {
-        buckets.set(key, [project]);
-      }
-    }
-
-    for (const [key, projectsForKey] of buckets) {
-      for (const project of projectsForKey) {
-        result.set(physicalKeyByProject.get(project)!, key);
-      }
-    }
-  };
-
-  for (const [baseKey, bucket] of baseBuckets) {
-    assignBucket(baseKey, bucket);
+    result.set(physicalKey, deriveLogicalProjectKeyFromSettings(project, settings));
   }
 
   return result;

--- a/apps/web/src/logicalProject.ts
+++ b/apps/web/src/logicalProject.ts
@@ -176,28 +176,10 @@ export function buildLogicalProjectKeyMap(
   const assignBucket = (
     baseKey: string,
     bucket: ReadonlyArray<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>,
-    discriminatorIndex: number,
   ) => {
     if (!hasDuplicateEnvironment(bucket)) {
       for (const project of bucket) {
         result.set(physicalKeyByProject.get(project)!, baseKey);
-      }
-      return;
-    }
-
-    const discriminatorFns = [
-      (project: Pick<Project, "cwd" | "repositoryIdentity">) => {
-        const relativePath = deriveRepositoryRelativeProjectPath(project);
-        return relativePath === null ? null : formatProjectGroupDiscriminator(relativePath);
-      },
-      (project: Pick<Project, "cwd">) => normalizeProjectPathForComparison(project.cwd),
-      (project: Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">) =>
-        physicalKeyByProject.get(project) ?? derivePhysicalProjectKey(project),
-    ] as const;
-    const discriminator = discriminatorFns[discriminatorIndex];
-    if (!discriminator) {
-      for (const project of bucket) {
-        result.set(physicalKeyByProject.get(project)!, physicalKeyByProject.get(project)!);
       }
       return;
     }
@@ -207,7 +189,11 @@ export function buildLogicalProjectKeyMap(
       Array<Pick<Project, "environmentId" | "id" | "cwd" | "repositoryIdentity">>
     >();
     for (const project of bucket) {
-      const value = discriminator(project) ?? normalizeProjectPathForComparison(project.cwd);
+      const relativePath = deriveRepositoryRelativeProjectPath(project);
+      const value =
+        relativePath === null
+          ? normalizeProjectPathForComparison(project.cwd)
+          : formatProjectGroupDiscriminator(relativePath);
       const key = `${baseKey}::${value}`;
       const existing = buckets.get(key);
       if (existing) {
@@ -218,12 +204,14 @@ export function buildLogicalProjectKeyMap(
     }
 
     for (const [key, projectsForKey] of buckets) {
-      assignBucket(key, projectsForKey, discriminatorIndex + 1);
+      for (const project of projectsForKey) {
+        result.set(physicalKeyByProject.get(project)!, key);
+      }
     }
   };
 
   for (const [baseKey, bucket] of baseBuckets) {
-    assignBucket(baseKey, bucket, 0);
+    assignBucket(baseKey, bucket);
   }
 
   return result;

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -29,7 +29,9 @@ import { resolveAndPersistPreferredEditor } from "../editorPreferences";
 import { readLocalApi } from "../localApi";
 import { useSettings } from "../hooks/useSettings";
 import {
+  buildLogicalProjectKeyMap,
   deriveLogicalProjectKeyFromSettings,
+  derivePhysicalProjectKey,
   derivePhysicalProjectKeyFromPath,
 } from "../logicalProject";
 import {
@@ -40,7 +42,7 @@ import {
   useServerConfigUpdatedSubscription,
   useServerWelcomeSubscription,
 } from "../rpc/serverState";
-import { useStore } from "../store";
+import { selectProjectsAcrossEnvironments, useStore } from "../store";
 import { useUiStateStore } from "../uiStateStore";
 import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import {
@@ -242,9 +244,12 @@ function EventRouter() {
         useStore.getState().environmentStateById[payload.environment.environmentId];
       const bootstrapProject =
         bootstrapEnvironmentState?.projectById[payload.bootstrapProjectId] ?? null;
+      const projects = selectProjectsAcrossEnvironments(useStore.getState());
+      const logicalKeyByPhysicalKey = buildLogicalProjectKeyMap(projects, projectGroupingSettings);
       const bootstrapProjectKey =
         (bootstrapProject
-          ? deriveLogicalProjectKeyFromSettings(bootstrapProject, projectGroupingSettings)
+          ? (logicalKeyByPhysicalKey.get(derivePhysicalProjectKey(bootstrapProject)) ??
+            deriveLogicalProjectKeyFromSettings(bootstrapProject, projectGroupingSettings))
           : null) ??
         (serverConfig?.cwd
           ? derivePhysicalProjectKeyFromPath(payload.environment.environmentId, serverConfig.cwd)

--- a/apps/web/src/sidebarProjectGrouping.ts
+++ b/apps/web/src/sidebarProjectGrouping.ts
@@ -1,6 +1,7 @@
 import { scopeProjectRef } from "@t3tools/client-runtime";
 import type { EnvironmentId, ScopedProjectRef } from "@t3tools/contracts";
 import {
+  buildLogicalProjectKeyMap,
   deriveLogicalProjectKeyFromSettings,
   derivePhysicalProjectKey,
   deriveProjectGroupLabel,
@@ -29,14 +30,7 @@ export function buildPhysicalToLogicalProjectKeyMap(input: {
   projects: ReadonlyArray<Project>;
   settings: ProjectGroupingSettings;
 }): Map<string, string> {
-  const mapping = new Map<string, string>();
-  for (const project of input.projects) {
-    mapping.set(
-      derivePhysicalProjectKey(project),
-      deriveLogicalProjectKeyFromSettings(project, input.settings),
-    );
-  }
-  return mapping;
+  return buildLogicalProjectKeyMap(input.projects, input.settings);
 }
 
 export function buildSidebarProjectSnapshots(input: {
@@ -45,9 +39,12 @@ export function buildSidebarProjectSnapshots(input: {
   primaryEnvironmentId: EnvironmentId | null;
   resolveEnvironmentLabel: (environmentId: EnvironmentId) => string | null;
 }): SidebarProjectSnapshot[] {
+  const logicalKeyByPhysicalKey = buildLogicalProjectKeyMap(input.projects, input.settings);
   const groupedMembers = new Map<string, SidebarProjectGroupMember[]>();
   for (const project of input.projects) {
-    const logicalKey = deriveLogicalProjectKeyFromSettings(project, input.settings);
+    const logicalKey =
+      logicalKeyByPhysicalKey.get(derivePhysicalProjectKey(project)) ??
+      deriveLogicalProjectKeyFromSettings(project, input.settings);
     const member: SidebarProjectGroupMember = {
       ...project,
       physicalProjectKey: derivePhysicalProjectKey(project),
@@ -64,7 +61,9 @@ export function buildSidebarProjectSnapshots(input: {
   const result: SidebarProjectSnapshot[] = [];
   const seen = new Set<string>();
   for (const project of input.projects) {
-    const logicalKey = deriveLogicalProjectKeyFromSettings(project, input.settings);
+    const logicalKey =
+      logicalKeyByPhysicalKey.get(derivePhysicalProjectKey(project)) ??
+      deriveLogicalProjectKeyFromSettings(project, input.settings);
     if (seen.has(logicalKey)) {
       continue;
     }


### PR DESCRIPTION
## Summary
- Stabilize logical project key assignment so matching projects can group across environments without collapsing distinct clones in the same environment.
- Reuse the new logical key map in sidebar, chat, thread creation, and runtime UI sync paths to keep grouping and thread routing consistent.
- Add regression coverage for cross-environment grouping and same-environment duplicate clones.
- Update sidebar behavior so thread creation prefers an unambiguous representative member when a group is safe to auto-resolve.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`
- Not run: manual browser verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches project grouping keys used across sidebar, chat routing, draft-thread reuse, and UI sync, so incorrect keying could mis-group projects or reuse the wrong draft/thread. Changes are localized and backed by added regression tests, but impact core navigation behaviors.
> 
> **Overview**
> **Stabilizes logical project grouping by precomputing a shared physical→logical key map** (`buildLogicalProjectKeyMap`) and reusing it across the app so sidebar grouping, environment pickers, and thread/draft routing all agree.
> 
> Updates `ChatView`, `useHandleNewThread`, runtime UI sync, root bootstrap expansion, and `sidebarProjectGrouping` to use this map (with fallbacks) instead of deriving logical keys ad hoc per-project.
> 
> Tweaks the Sidebar “New Thread” click behavior to *auto-pick a representative member* when a group has no duplicate environment entries, only prompting the disambiguation menu when needed, and adds tests covering cross-environment grouping and repository-path edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80d4a479ce155c26bb273b4ccce847cdee4324f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize logical project key resolution across environments using a precomputed map
> - Adds `buildLogicalProjectKeyMap` in [logicalProject.ts](https://github.com/pingdotgg/t3code/pull/2375/files#diff-9fa781592e3ea36ce218eab738bf15d811679cc104ed2394cf764b2cc58bf684) to build a single `Map<physicalKey, logicalKey>` from all projects, replacing scattered per-call derivation.
> - Adopts this map in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2375/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), [useHandleNewThread.ts](https://github.com/pingdotgg/t3code/pull/2375/files#diff-4a13a04822f436fab695948f0596a6fd92885554e031426dac1954a343c98fef), [service.ts](https://github.com/pingdotgg/t3code/pull/2375/files#diff-0c6fcb6b689bfab728dafd4ef75801e020355035bffde6032ccd03d5983cc7cc), [__root.tsx](https://github.com/pingdotgg/t3code/pull/2375/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100), and [sidebarProjectGrouping.ts](https://github.com/pingdotgg/t3code/pull/2375/files#diff-56beffcb94c48f4ebb0f187f3a8be66f26b116bb7a3e13fd196af3753e10d9a9) for consistent logical key resolution with a physical-key fallback.
> - Changes the "New Thread" button in `SidebarProjectItem` to skip the context menu and immediately pick a representative member when grouped project members all come from distinct environments.
> - Behavioral Change: grouped projects with multiple members but no duplicate environments no longer prompt for environment selection before creating a thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e80d4a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->