### PR TITLE
Add sidebar project colors setting

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -24,6 +24,10 @@ const clientSettings: ClientSettings = {
   sidebarProjectGroupingOverrides: {
     "environment-1:/tmp/project-a": "separate",
   },
+  sidebarProjectColorizing: false,
+  sidebarProjectColorOverrides: {
+    "environment-1:/tmp/project-a": "indigo",
+  },
   sidebarProjectSortOrder: "manual",
   sidebarThreadSortOrder: "created_at",
   sidebarThreadPreviewCount: 6,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2196,7 +2196,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         )}
         {colorIdentity ? (
           <ProjectColorDot
-            className="absolute top-1 right-7"
+            className={cn(
+              "absolute top-1 right-7",
+              // On narrow viewports the cloud badge for remote-only projects
+              // moves from right-1.5 to right-7 (where it stays visible even on
+              // hover), so shift the color dot one slot further left to avoid
+              // overlapping it.
+              project.environmentPresence === "remote-only" && "max-sm:right-12",
+            )}
             identity={colorIdentity}
             projectName={project.displayName}
             onSelect={handleColorSelect}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -56,6 +56,7 @@ import { Link, useLocation, useNavigate, useParams, useRouter } from "@tanstack/
 import {
   MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
   MIN_SIDEBAR_THREAD_PREVIEW_COUNT,
+  type SidebarProjectColor,
   type SidebarProjectSortOrder,
   type SidebarThreadPreviewCount,
   type SidebarThreadSortOrder,
@@ -64,7 +65,7 @@ import { usePrimaryEnvironmentId } from "../environments/primary";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
 import { isTerminalFocused } from "../lib/terminalFocus";
-import { isMacPlatform, newCommandId } from "../lib/utils";
+import { cn, isMacPlatform, newCommandId } from "../lib/utils";
 import {
   selectProjectByRef,
   selectProjectsAcrossEnvironments,
@@ -126,6 +127,7 @@ import { Input } from "./ui/input";
 import {
   Menu,
   MenuGroup,
+  MenuItem,
   MenuPopup,
   MenuRadioGroup,
   MenuRadioItem,
@@ -198,6 +200,12 @@ import {
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
 import { SidebarProviderUpdatePill } from "./sidebar/SidebarProviderUpdatePill";
+import {
+  buildSidebarProjectColorMap,
+  EMPTY_SIDEBAR_PROJECT_COLOR_MAP,
+  SIDEBAR_PROJECT_COLOR_PALETTE,
+  type SidebarProjectColorIdentity,
+} from "../sidebarProjectColors";
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
@@ -246,6 +254,109 @@ function projectGroupingModeDescription(mode: SidebarProjectGroupingMode): strin
       return "Every project path gets its own sidebar row.";
   }
 }
+
+interface ProjectColorDotProps {
+  identity: SidebarProjectColorIdentity;
+  projectName: string;
+  onSelect: (color: SidebarProjectColor | null) => void;
+  /**
+   * Extra classes for the trigger itself — typically the absolute positioning
+   * applied by the parent. Putting positioning on the trigger directly (rather
+   * than a wrapping div) keeps this dot's box dimensions identical to the
+   * sibling new-thread button so they line up vertically.
+   */
+  className?: string;
+}
+
+/**
+ * Always-visible color dot rendered to the left of the per-project new-thread
+ * button when "Sidebar project colors" is enabled. Clicking opens a palette
+ * menu; selecting a swatch persists the override; selecting "Auto" clears it.
+ */
+const ProjectColorDot = memo(function ProjectColorDot({
+  identity,
+  projectName,
+  onSelect,
+  className,
+}: ProjectColorDotProps) {
+  return (
+    <Menu>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <MenuTrigger
+              type="button"
+              aria-label={`Project color for ${projectName}`}
+              className={cn(
+                "inline-flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md outline-hidden focus-visible:ring-1 focus-visible:ring-ring",
+                className,
+              )}
+              onPointerDown={(event) => {
+                // The wrapping project header treats unhandled pointerdown as
+                // the start of a row drag. Stop the event so opening the
+                // picker doesn't also begin a sortable drag.
+                event.stopPropagation();
+              }}
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+            />
+          }
+        >
+          <span
+            aria-hidden="true"
+            className={cn("block size-2.5 rounded-full", identity.palette.dotClass)}
+          />
+        </TooltipTrigger>
+        <TooltipPopup side="top">
+          {identity.override
+            ? `Color: ${identity.palette.label}`
+            : `Color: ${identity.palette.label} (auto)`}
+        </TooltipPopup>
+      </Tooltip>
+      <MenuPopup align="end" side="bottom" className="min-w-44">
+        <MenuGroup>
+          <div className="px-2 py-1 sm:text-xs font-medium text-muted-foreground">
+            Project color
+          </div>
+          <MenuItem
+            onClick={() => onSelect(null)}
+            className={cn(
+              "min-h-7 py-1 sm:text-xs",
+              identity.override === undefined && "font-medium",
+            )}
+          >
+            <span
+              aria-hidden="true"
+              className="inline-flex size-3 items-center justify-center rounded-full border border-dashed border-muted-foreground/40"
+            />
+            <span className="flex-1">Auto</span>
+            {identity.override === undefined ? (
+              <span className="text-muted-foreground/60">{identity.palette.label}</span>
+            ) : null}
+          </MenuItem>
+          <MenuSeparator />
+          {SIDEBAR_PROJECT_COLOR_PALETTE.map((entry) => {
+            const isSelected = identity.override === entry.key;
+            return (
+              <MenuItem
+                key={entry.key}
+                onClick={() => onSelect(entry.key)}
+                className={cn("min-h-7 py-1 sm:text-xs", isSelected && "font-medium")}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn("inline-block size-3 rounded-full", entry.dotClass)}
+                />
+                <span className="flex-1">{entry.label}</span>
+              </MenuItem>
+            );
+          })}
+        </MenuGroup>
+      </MenuPopup>
+    </Menu>
+  );
+});
 
 function buildThreadJumpLabelMap(input: {
   keybindings: ReturnType<typeof useServerKeybindings>;
@@ -764,6 +875,12 @@ interface SidebarProjectThreadListProps {
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
+  /**
+   * When true, hides the vertical guide line on the left of the thread list.
+   * Used to declutter the sidebar when project tints provide their own
+   * grouping cue.
+   */
+  hideThreadListBorder: boolean;
 }
 
 const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
@@ -803,6 +920,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     openPrLink,
     expandThreadListForProject,
     collapseThreadListForProject,
+    hideThreadListBorder,
   } = props;
   const showMoreButtonRender = useMemo(() => <button type="button" />, []);
   const showLessButtonRender = useMemo(() => <button type="button" />, []);
@@ -810,7 +928,10 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
   return (
     <SidebarMenuSub
       ref={attachThreadListAutoAnimateRef}
-      className="mx-0.5 my-0 w-full translate-x-0 gap-0.5 overflow-hidden px-1 py-0 sm:mx-1 sm:px-1.5"
+      className={cn(
+        "mx-0.5 my-0 w-full translate-x-0 gap-0.5 overflow-hidden px-1 py-0 sm:mx-1 sm:px-1.5",
+        hideThreadListBorder && "border-l-0",
+      )}
     >
       {shouldShowThreadPanel && showEmptyThreadState ? (
         <SidebarMenuSubItem className="w-full" data-thread-selection-safe>
@@ -909,6 +1030,13 @@ interface SidebarProjectItemProps {
   suppressProjectClickForContextMenuRef: React.RefObject<boolean>;
   isManualProjectSorting: boolean;
   dragHandleProps: SortableProjectHandleProps | null;
+  /** Resolved color for this group, or null when colorizing is disabled. */
+  colorIdentity: SidebarProjectColorIdentity | null;
+  /**
+   * Called when the user picks a color from this project's swatch menu.
+   * `color` is `null` for "Auto" (clears the override).
+   */
+  onColorSelect: (overrideKey: string, color: SidebarProjectColor | null) => void;
 }
 
 const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjectItemProps) {
@@ -929,6 +1057,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     suppressProjectClickForContextMenuRef,
     isManualProjectSorting,
     dragHandleProps,
+    colorIdentity,
+    onColorSelect,
   } = props;
   const threadSortOrder = useSettings<SidebarThreadSortOrder>(
     (settings) => settings.sidebarThreadSortOrder,
@@ -1901,6 +2031,19 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     updateSettings,
   ]);
 
+  // Per-row wrapper around the parent's stable `onColorSelect`. Depending on
+  // `overrideKey` (a string) instead of `colorIdentity` (an object reference
+  // that changes every parent render) keeps this callback stable across
+  // unrelated re-renders, so the memoized ProjectColorDot doesn't churn.
+  const colorOverrideKey = colorIdentity?.overrideKey;
+  const handleColorSelect = useCallback(
+    (color: SidebarProjectColor | null) => {
+      if (!colorOverrideKey) return;
+      onColorSelect(colorOverrideKey, color);
+    },
+    [colorOverrideKey, onColorSelect],
+  );
+
   const handleThreadContextMenu = useCallback(
     async (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
       const api = readLocalApi();
@@ -2051,6 +2194,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
             </TooltipPopup>
           </Tooltip>
         )}
+        {colorIdentity ? (
+          <ProjectColorDot
+            className="absolute top-1 right-7"
+            identity={colorIdentity}
+            projectName={project.displayName}
+            onSelect={handleColorSelect}
+          />
+        ) : null}
         <Tooltip>
           <TooltipTrigger
             render={
@@ -2107,6 +2258,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         openPrLink={openPrLink}
         expandThreadListForProject={expandThreadListForProject}
         collapseThreadListForProject={collapseThreadListForProject}
+        hideThreadListBorder={colorIdentity !== null}
       />
 
       <Dialog
@@ -2231,8 +2383,12 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 });
 
 const SidebarProjectListRow = memo(function SidebarProjectListRow(props: SidebarProjectItemProps) {
+  // The `p-1` is intentionally only applied alongside the tint: it gives the
+  // colored block uniform breathing room around the project header. Without a
+  // tint there's nothing to "pad", so the layout stays compact.
+  const tintClass = props.colorIdentity?.palette.tintClass;
   return (
-    <SidebarMenuItem className="rounded-md">
+    <SidebarMenuItem className={cn("rounded-md", tintClass, tintClass && "p-1")}>
       <SidebarProjectItem {...props} />
     </SidebarMenuItem>
   );
@@ -2411,10 +2567,12 @@ function ProjectSortMenu({
 function SortableProjectItem({
   projectId,
   disabled = false,
+  colorIdentity,
   children,
 }: {
   projectId: string;
   disabled?: boolean;
+  colorIdentity: SidebarProjectColorIdentity | null;
   children: (handleProps: SortableProjectHandleProps) => React.ReactNode;
 }) {
   const {
@@ -2427,6 +2585,7 @@ function SortableProjectItem({
     isDragging,
     isOver,
   } = useSortable({ id: projectId, disabled });
+  const tintClass = colorIdentity?.palette.tintClass;
   return (
     <li
       ref={setNodeRef}
@@ -2434,9 +2593,13 @@ function SortableProjectItem({
         transform: CSS.Translate.toString(transform),
         transition,
       }}
-      className={`group/menu-item relative rounded-md ${
-        isDragging ? "z-20 opacity-80" : ""
-      } ${isOver && !isDragging ? "ring-1 ring-primary/40" : ""}`}
+      className={cn(
+        "group/menu-item relative rounded-md",
+        tintClass,
+        tintClass && "p-1",
+        isDragging && "z-20 opacity-80",
+        isOver && !isDragging && "ring-1 ring-primary/40",
+      )}
       data-sidebar="menu-item"
       data-slot="sidebar-menu-item"
     >
@@ -2553,6 +2716,18 @@ interface SidebarProjectsContentProps {
   suppressProjectClickForContextMenuRef: React.RefObject<boolean>;
   attachProjectListAutoAnimateRef: (node: HTMLElement | null) => void;
   projectsLength: number;
+  /**
+   * Per-project color identity, indexed by the snapshot's `projectKey`. The
+   * map is empty when the colorizing setting is off, in which case neither
+   * the tint nor the color dot are rendered.
+   */
+  projectColorByKey: ReadonlyMap<string, SidebarProjectColorIdentity>;
+  /**
+   * Persists (or clears) a per-project color override. Stable callback —
+   * defined once at the Sidebar root so individual rows don't have to
+   * subscribe to the override map themselves.
+   */
+  onProjectColorSelect: (overrideKey: string, color: SidebarProjectColor | null) => void;
 }
 
 const SidebarProjectsContent = memo(function SidebarProjectsContent(
@@ -2594,6 +2769,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     suppressProjectClickForContextMenuRef,
     attachProjectListAutoAnimateRef,
     projectsLength,
+    projectColorByKey,
+    onProjectColorSelect,
   } = props;
 
   const handleProjectSortOrderChange = useCallback(
@@ -2718,34 +2895,45 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 items={sortedProjects.map((project) => project.projectKey)}
                 strategy={verticalListSortingStrategy}
               >
-                {sortedProjects.map((project) => (
-                  <SortableProjectItem key={project.projectKey} projectId={project.projectKey}>
-                    {(dragHandleProps) => (
-                      <SidebarProjectItem
-                        project={project}
-                        isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
-                        activeRouteThreadKey={
-                          activeRouteProjectKey === project.projectKey ? routeThreadKey : null
-                        }
-                        newThreadShortcutLabel={newThreadShortcutLabel}
-                        handleNewThread={handleNewThread}
-                        archiveThread={archiveThread}
-                        deleteThread={deleteThread}
-                        threadJumpLabelByKey={threadJumpLabelByKey}
-                        attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
-                        expandThreadListForProject={expandThreadListForProject}
-                        collapseThreadListForProject={collapseThreadListForProject}
-                        dragInProgressRef={dragInProgressRef}
-                        suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
-                        suppressProjectClickForContextMenuRef={
-                          suppressProjectClickForContextMenuRef
-                        }
-                        isManualProjectSorting={isManualProjectSorting}
-                        dragHandleProps={dragHandleProps}
-                      />
-                    )}
-                  </SortableProjectItem>
-                ))}
+                {sortedProjects.map((project) => {
+                  const colorIdentity = projectColorByKey.get(project.projectKey) ?? null;
+                  return (
+                    <SortableProjectItem
+                      key={project.projectKey}
+                      projectId={project.projectKey}
+                      colorIdentity={colorIdentity}
+                    >
+                      {(dragHandleProps) => (
+                        <SidebarProjectItem
+                          project={project}
+                          isThreadListExpanded={expandedThreadListsByProject.has(
+                            project.projectKey,
+                          )}
+                          activeRouteThreadKey={
+                            activeRouteProjectKey === project.projectKey ? routeThreadKey : null
+                          }
+                          newThreadShortcutLabel={newThreadShortcutLabel}
+                          handleNewThread={handleNewThread}
+                          archiveThread={archiveThread}
+                          deleteThread={deleteThread}
+                          threadJumpLabelByKey={threadJumpLabelByKey}
+                          attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
+                          expandThreadListForProject={expandThreadListForProject}
+                          collapseThreadListForProject={collapseThreadListForProject}
+                          dragInProgressRef={dragInProgressRef}
+                          suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
+                          suppressProjectClickForContextMenuRef={
+                            suppressProjectClickForContextMenuRef
+                          }
+                          isManualProjectSorting={isManualProjectSorting}
+                          dragHandleProps={dragHandleProps}
+                          colorIdentity={colorIdentity}
+                          onColorSelect={onProjectColorSelect}
+                        />
+                      )}
+                    </SortableProjectItem>
+                  );
+                })}
               </SortableContext>
             </SidebarMenu>
           </DndContext>
@@ -2772,6 +2960,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
                 isManualProjectSorting={isManualProjectSorting}
                 dragHandleProps={null}
+                colorIdentity={projectColorByKey.get(project.projectKey) ?? null}
+                onColorSelect={onProjectColorSelect}
               />
             ))}
           </SidebarMenu>
@@ -2801,6 +2991,8 @@ export default function Sidebar() {
   const sidebarProjectGroupingMode = useSettings((s) => s.sidebarProjectGroupingMode);
   const projectGroupingSettings = useSettings(selectProjectGroupingSettings);
   const sidebarThreadPreviewCount = useSettings((s) => s.sidebarThreadPreviewCount);
+  const sidebarProjectColorizing = useSettings((s) => s.sidebarProjectColorizing);
+  const sidebarProjectColorOverrides = useSettings((s) => s.sidebarProjectColorOverrides);
   const { updateSettings } = useUpdateSettings();
   const { handleNewThread } = useNewThreadHandler();
   const { archiveThread, deleteThread } = useThreadActions();
@@ -3071,6 +3263,42 @@ export default function Sidebar() {
     visibleThreads,
   ]);
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
+  // Resolve each visible project group's color identity once per render. Stays
+  // empty when colorizing is disabled so consumers can use map size as the
+  // toggle and avoid touching identity logic at all. The builder spreads auto
+  // colors across the palette so adjacent projects don't end up sharing a hue
+  // until the palette is exhausted.
+  const projectColorByKey = useMemo<ReadonlyMap<string, SidebarProjectColorIdentity>>(() => {
+    if (!sidebarProjectColorizing) {
+      // Reuse the module-level empty map so the prop reference stays stable
+      // across renders for users who never enable colorizing.
+      return EMPTY_SIDEBAR_PROJECT_COLOR_MAP;
+    }
+    return buildSidebarProjectColorMap({
+      projects: sortedProjects.map((project) => ({
+        projectKey: project.projectKey,
+        overrideKey: deriveProjectGroupingOverrideKey(project),
+      })),
+      overrides: sidebarProjectColorOverrides,
+    });
+  }, [sidebarProjectColorizing, sidebarProjectColorOverrides, sortedProjects]);
+  // Stable color-select handler shared across all rows. Reading the latest
+  // override map through a ref keeps the callback identity fixed, so flipping
+  // one project's color doesn't re-render every other row's color picker.
+  const sidebarProjectColorOverridesRef = useRef(sidebarProjectColorOverrides);
+  sidebarProjectColorOverridesRef.current = sidebarProjectColorOverrides;
+  const handleProjectColorSelect = useCallback(
+    (overrideKey: string, color: SidebarProjectColor | null) => {
+      const next = { ...sidebarProjectColorOverridesRef.current };
+      if (color === null) {
+        delete next[overrideKey];
+      } else {
+        next[overrideKey] = color;
+      }
+      updateSettings({ sidebarProjectColorOverrides: next });
+    },
+    [updateSettings],
+  );
   const visibleSidebarThreadKeys = useMemo(
     () =>
       sortedProjects.flatMap((project) => {
@@ -3457,6 +3685,8 @@ export default function Sidebar() {
             suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
             attachProjectListAutoAnimateRef={attachProjectListAutoAnimateRef}
             projectsLength={projects.length}
+            projectColorByKey={projectColorByKey}
+            onProjectColorSelect={handleProjectColorSelect}
           />
 
           <SidebarSeparator />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -470,6 +470,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       diffWordWrap: DEFAULT_UNIFIED_SETTINGS.diffWordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+      sidebarProjectColorizing: DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorizing,
+      sidebarProjectColorOverrides: DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorOverrides,
       autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
       enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -658,12 +658,15 @@ export function GeneralSettingsPanel() {
           description="Tint each project with its own muted color and show a color dot you can click to change it."
           resetAction={
             settings.sidebarProjectColorizing !==
-            DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorizing ? (
+              DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorizing ||
+            Object.keys(settings.sidebarProjectColorOverrides).length > 0 ? (
               <SettingResetButton
                 label="sidebar project colors"
                 onClick={() =>
                   updateSettings({
                     sidebarProjectColorizing: DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorizing,
+                    sidebarProjectColorOverrides:
+                      DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorOverrides,
                   })
                 }
               />

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -404,6 +404,13 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.diffIgnoreWhitespace !== DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace
         ? ["Diff whitespace changes"]
         : []),
+      // Either the toggle is non-default, or the user has picked custom colors
+      // for one or more projects — both flow through Restore defaults so the
+      // single label covers both pieces of state.
+      ...(settings.sidebarProjectColorizing !== DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorizing ||
+      Object.keys(settings.sidebarProjectColorOverrides).length > 0
+        ? ["Sidebar project colors"]
+        : []),
       ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
         ? ["Auto-open task panel"]
         : []),
@@ -440,6 +447,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.automaticGitFetchInterval,
       settings.enableAssistantStreaming,
       settings.sidebarThreadPreviewCount,
+      settings.sidebarProjectColorizing,
+      settings.sidebarProjectColorOverrides,
       settings.timestampFormat,
       theme,
     ],
@@ -640,6 +649,33 @@ export function GeneralSettingsPanel() {
                 updateSettings({ diffIgnoreWhitespace: Boolean(checked) })
               }
               aria-label="Hide whitespace changes by default"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Sidebar project colors"
+          description="Tint each project with its own muted color and show a color dot you can click to change it."
+          resetAction={
+            settings.sidebarProjectColorizing !==
+            DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorizing ? (
+              <SettingResetButton
+                label="sidebar project colors"
+                onClick={() =>
+                  updateSettings({
+                    sidebarProjectColorizing: DEFAULT_UNIFIED_SETTINGS.sidebarProjectColorizing,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.sidebarProjectColorizing}
+              onCheckedChange={(checked) =>
+                updateSettings({ sidebarProjectColorizing: Boolean(checked) })
+              }
+              aria-label="Color each sidebar project group"
             />
           }
         />

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -641,6 +641,10 @@ describe("wsApi", () => {
       sidebarProjectGroupingOverrides: {
         "environment-local:/tmp/project": "separate" as const,
       },
+      sidebarProjectColorizing: false,
+      sidebarProjectColorOverrides: {
+        "environment-local:/tmp/project": "indigo" as const,
+      },
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
       sidebarThreadPreviewCount: 6,
@@ -703,6 +707,10 @@ describe("wsApi", () => {
       sidebarProjectGroupingMode: "repository_path" as const,
       sidebarProjectGroupingOverrides: {
         "environment-local:/tmp/project": "separate" as const,
+      },
+      sidebarProjectColorizing: false,
+      sidebarProjectColorOverrides: {
+        "environment-local:/tmp/project": "indigo" as const,
       },
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,

--- a/apps/web/src/sidebarProjectColors.test.ts
+++ b/apps/web/src/sidebarProjectColors.test.ts
@@ -1,45 +1,19 @@
 import { describe, expect, it } from "vitest";
 import type { SidebarProjectColor } from "@t3tools/contracts/settings";
-import {
-  autoSidebarProjectColor,
-  buildSidebarProjectColorMap,
-  resolveSidebarProjectColor,
-  SIDEBAR_PROJECT_COLOR_PALETTE,
-} from "./sidebarProjectColors";
+import { buildSidebarProjectColorMap, SIDEBAR_PROJECT_COLOR_PALETTE } from "./sidebarProjectColors";
 
-describe("sidebarProjectColors", () => {
-  it("returns a palette entry for any seed", () => {
-    const result = autoSidebarProjectColor("environment-local:/tmp/example");
-    expect(SIDEBAR_PROJECT_COLOR_PALETTE).toContain(result);
+/**
+ * Helper: returns the auto color the builder would pick for `seed` if it were
+ * the only project in the visible set. Lets tests construct collision
+ * scenarios without depending on the builder's internal hash directly.
+ */
+function autoColorForSeed(seed: string): SidebarProjectColor {
+  const map = buildSidebarProjectColorMap({
+    projects: [{ projectKey: seed, overrideKey: seed }],
+    overrides: {},
   });
-
-  it("is deterministic for the same seed", () => {
-    const seed = "environment-local:/tmp/example";
-    expect(autoSidebarProjectColor(seed).key).toBe(autoSidebarProjectColor(seed).key);
-  });
-
-  it("spreads similar seeds across multiple palette entries", () => {
-    const seeds = Array.from({ length: 24 }, (_, index) => `env:/tmp/project-${index}`);
-    const usedKeys = new Set(seeds.map((seed) => autoSidebarProjectColor(seed).key));
-    // Not strictly guaranteed by the palette length, but the FNV-1a spread
-    // should easily hit at least half the palette across 24 distinct seeds.
-    expect(usedKeys.size).toBeGreaterThanOrEqual(SIDEBAR_PROJECT_COLOR_PALETTE.length / 2);
-  });
-
-  it("prefers the explicit override over the auto color", () => {
-    const seed = "environment-local:/tmp/example";
-    const auto = autoSidebarProjectColor(seed);
-    // Pick an override that doesn't match the auto choice for the seed.
-    const override =
-      SIDEBAR_PROJECT_COLOR_PALETTE.find((entry) => entry.key !== auto.key)?.key ?? "rose";
-    expect(resolveSidebarProjectColor(seed, override).key).toBe(override);
-  });
-
-  it("falls back to the auto color when override is undefined", () => {
-    const seed = "environment-local:/tmp/example";
-    expect(resolveSidebarProjectColor(seed, undefined).key).toBe(autoSidebarProjectColor(seed).key);
-  });
-});
+  return map.get(seed)!.palette.key;
+}
 
 describe("buildSidebarProjectColorMap", () => {
   it("returns an empty map when no projects are passed", () => {
@@ -56,14 +30,26 @@ describe("buildSidebarProjectColorMap", () => {
     expect(new Set(keys).size).toBe(SIDEBAR_PROJECT_COLOR_PALETTE.length);
   });
 
+  it("spreads similar seeds across multiple palette entries", () => {
+    const projects = Array.from({ length: 24 }, (_, index) => ({
+      projectKey: `key-${index}`,
+      overrideKey: `env:/tmp/project-${index}`,
+    }));
+    const map = buildSidebarProjectColorMap({ projects, overrides: {} });
+    const usedKeys = new Set(Array.from(map.values()).map((identity) => identity.palette.key));
+    // Beyond the first 10 projects the palette is full, but every slot should
+    // be in use — that's the strongest spread guarantee the builder makes.
+    expect(usedKeys.size).toBe(SIDEBAR_PROJECT_COLOR_PALETTE.length);
+  });
+
   it("walks past colors already claimed by overrides", () => {
-    // Find an override-key whose hash lands on the same palette entry as the
-    // override below — that's the case where naive resolution would collide.
+    // Find an override-key whose auto color collides with the override below —
+    // that's the case where naive resolution would assign the same hue twice.
     const targetColor: SidebarProjectColor = "rose";
     const collidingSeed = (() => {
       for (let i = 0; i < 1000; i++) {
         const seed = `seed-${i}`;
-        if (autoSidebarProjectColor(seed).key === targetColor) {
+        if (autoColorForSeed(seed) === targetColor) {
           return seed;
         }
       }

--- a/apps/web/src/sidebarProjectColors.test.ts
+++ b/apps/web/src/sidebarProjectColors.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import type { SidebarProjectColor } from "@t3tools/contracts/settings";
+import {
+  autoSidebarProjectColor,
+  buildSidebarProjectColorMap,
+  resolveSidebarProjectColor,
+  SIDEBAR_PROJECT_COLOR_PALETTE,
+} from "./sidebarProjectColors";
+
+describe("sidebarProjectColors", () => {
+  it("returns a palette entry for any seed", () => {
+    const result = autoSidebarProjectColor("environment-local:/tmp/example");
+    expect(SIDEBAR_PROJECT_COLOR_PALETTE).toContain(result);
+  });
+
+  it("is deterministic for the same seed", () => {
+    const seed = "environment-local:/tmp/example";
+    expect(autoSidebarProjectColor(seed).key).toBe(autoSidebarProjectColor(seed).key);
+  });
+
+  it("spreads similar seeds across multiple palette entries", () => {
+    const seeds = Array.from({ length: 24 }, (_, index) => `env:/tmp/project-${index}`);
+    const usedKeys = new Set(seeds.map((seed) => autoSidebarProjectColor(seed).key));
+    // Not strictly guaranteed by the palette length, but the FNV-1a spread
+    // should easily hit at least half the palette across 24 distinct seeds.
+    expect(usedKeys.size).toBeGreaterThanOrEqual(SIDEBAR_PROJECT_COLOR_PALETTE.length / 2);
+  });
+
+  it("prefers the explicit override over the auto color", () => {
+    const seed = "environment-local:/tmp/example";
+    const auto = autoSidebarProjectColor(seed);
+    // Pick an override that doesn't match the auto choice for the seed.
+    const override =
+      SIDEBAR_PROJECT_COLOR_PALETTE.find((entry) => entry.key !== auto.key)?.key ?? "rose";
+    expect(resolveSidebarProjectColor(seed, override).key).toBe(override);
+  });
+
+  it("falls back to the auto color when override is undefined", () => {
+    const seed = "environment-local:/tmp/example";
+    expect(resolveSidebarProjectColor(seed, undefined).key).toBe(autoSidebarProjectColor(seed).key);
+  });
+});
+
+describe("buildSidebarProjectColorMap", () => {
+  it("returns an empty map when no projects are passed", () => {
+    expect(buildSidebarProjectColorMap({ projects: [], overrides: {} }).size).toBe(0);
+  });
+
+  it("gives each project a distinct auto color when the palette has room", () => {
+    const projects = SIDEBAR_PROJECT_COLOR_PALETTE.map((_, index) => ({
+      projectKey: `key-${index}`,
+      overrideKey: `override-${index}`,
+    }));
+    const map = buildSidebarProjectColorMap({ projects, overrides: {} });
+    const keys = Array.from(map.values()).map((identity) => identity.palette.key);
+    expect(new Set(keys).size).toBe(SIDEBAR_PROJECT_COLOR_PALETTE.length);
+  });
+
+  it("walks past colors already claimed by overrides", () => {
+    // Find an override-key whose hash lands on the same palette entry as the
+    // override below — that's the case where naive resolution would collide.
+    const targetColor: SidebarProjectColor = "rose";
+    const collidingSeed = (() => {
+      for (let i = 0; i < 1000; i++) {
+        const seed = `seed-${i}`;
+        if (autoSidebarProjectColor(seed).key === targetColor) {
+          return seed;
+        }
+      }
+      throw new Error("Failed to find a colliding seed for the test fixture");
+    })();
+
+    const map = buildSidebarProjectColorMap({
+      projects: [
+        { projectKey: "with-override", overrideKey: "override-key" },
+        { projectKey: "auto", overrideKey: collidingSeed },
+      ],
+      overrides: {
+        "override-key": targetColor,
+      },
+    });
+
+    expect(map.get("with-override")?.palette.key).toBe(targetColor);
+    expect(map.get("auto")?.palette.key).not.toBe(targetColor);
+  });
+
+  it("gives 11 projects 10 distinct colors plus one unavoidable repeat", () => {
+    const projects = Array.from({ length: SIDEBAR_PROJECT_COLOR_PALETTE.length + 1 }, (_, i) => ({
+      projectKey: `key-${i}`,
+      overrideKey: `override-${i}`,
+    }));
+    const map = buildSidebarProjectColorMap({ projects, overrides: {} });
+    const keys = Array.from(map.values()).map((identity) => identity.palette.key);
+    expect(keys).toHaveLength(SIDEBAR_PROJECT_COLOR_PALETTE.length + 1);
+    expect(new Set(keys).size).toBe(SIDEBAR_PROJECT_COLOR_PALETTE.length);
+  });
+
+  it("preserves an existing project's color when a later-sorted project is added", () => {
+    const before = buildSidebarProjectColorMap({
+      projects: [{ projectKey: "alpha", overrideKey: "aaa" }],
+      overrides: {},
+    });
+    const after = buildSidebarProjectColorMap({
+      projects: [
+        { projectKey: "alpha", overrideKey: "aaa" },
+        { projectKey: "beta", overrideKey: "zzz" },
+      ],
+      overrides: {},
+    });
+    // The earlier-sorted overrideKey ("aaa") gets first pick in both runs, so
+    // its color must not change when "zzz" is added.
+    expect(after.get("alpha")?.palette.key).toBe(before.get("alpha")?.palette.key);
+  });
+
+  it("processes auto-colors in overrideKey order regardless of input order", () => {
+    const aRun = buildSidebarProjectColorMap({
+      projects: [
+        { projectKey: "a", overrideKey: "aaa" },
+        { projectKey: "b", overrideKey: "zzz" },
+      ],
+      overrides: {},
+    });
+    const bRun = buildSidebarProjectColorMap({
+      projects: [
+        { projectKey: "b", overrideKey: "zzz" },
+        { projectKey: "a", overrideKey: "aaa" },
+      ],
+      overrides: {},
+    });
+    expect(aRun.get("a")?.palette.key).toBe(bRun.get("a")?.palette.key);
+    expect(aRun.get("b")?.palette.key).toBe(bRun.get("b")?.palette.key);
+  });
+
+  it("records the explicit override on the identity entry", () => {
+    const map = buildSidebarProjectColorMap({
+      projects: [{ projectKey: "p", overrideKey: "k" }],
+      overrides: { k: "indigo" },
+    });
+    const identity = map.get("p");
+    expect(identity?.override).toBe("indigo");
+    expect(identity?.palette.key).toBe("indigo");
+  });
+
+  it("leaves auto entries with undefined override", () => {
+    const map = buildSidebarProjectColorMap({
+      projects: [{ projectKey: "p", overrideKey: "k" }],
+      overrides: {},
+    });
+    expect(map.get("p")?.override).toBeUndefined();
+  });
+});

--- a/apps/web/src/sidebarProjectColors.ts
+++ b/apps/web/src/sidebarProjectColors.ts
@@ -1,0 +1,231 @@
+import { type SidebarProjectColor } from "@t3tools/contracts/settings";
+
+/**
+ * Tailwind classes used to render a sidebar project's color identity. The
+ * palette keys are persisted as `SidebarProjectColor` literals in client
+ * settings; this module is the single mapping point from those keys to
+ * concrete classes used by the sidebar UI.
+ *
+ * - `tintClass`: Applied to the group's `<li>` wrapper. Uses very low alpha
+ *   so the color reads as a faint wash, not a card surface.
+ * - `dotClass`: Applied to the always-visible color dot next to the new-thread
+ *   button (and the swatches in the picker). Renders as a transparent
+ *   interior with a saturated hue-matched ring, so the dot's interior shows
+ *   whatever sits behind it (the tinted row, the popover surface, etc.) and
+ *   only the ring carries the color identity.
+ *
+ * The class strings are written as literals so Tailwind's JIT can extract them.
+ */
+export interface SidebarProjectColorClasses {
+  readonly key: SidebarProjectColor;
+  readonly label: string;
+  readonly tintClass: string;
+  readonly dotClass: string;
+}
+
+export const SIDEBAR_PROJECT_COLOR_PALETTE: readonly SidebarProjectColorClasses[] = [
+  {
+    key: "slate",
+    label: "Slate",
+    tintClass: "bg-slate-500/8 dark:bg-slate-400/10",
+    dotClass: "ring-2 ring-inset ring-slate-500/70 dark:ring-slate-400/70",
+  },
+  {
+    key: "rose",
+    label: "Rose",
+    tintClass: "bg-rose-500/8 dark:bg-rose-400/10",
+    dotClass: "ring-2 ring-inset ring-rose-500/70 dark:ring-rose-400/70",
+  },
+  {
+    key: "orange",
+    label: "Orange",
+    tintClass: "bg-orange-500/8 dark:bg-orange-400/10",
+    dotClass: "ring-2 ring-inset ring-orange-500/70 dark:ring-orange-400/70",
+  },
+  {
+    key: "amber",
+    label: "Amber",
+    tintClass: "bg-amber-500/8 dark:bg-amber-400/10",
+    dotClass: "ring-2 ring-inset ring-amber-500/70 dark:ring-amber-400/70",
+  },
+  {
+    key: "emerald",
+    label: "Emerald",
+    tintClass: "bg-emerald-500/8 dark:bg-emerald-400/10",
+    dotClass: "ring-2 ring-inset ring-emerald-500/70 dark:ring-emerald-400/70",
+  },
+  {
+    key: "teal",
+    label: "Teal",
+    tintClass: "bg-teal-500/8 dark:bg-teal-400/10",
+    dotClass: "ring-2 ring-inset ring-teal-500/70 dark:ring-teal-400/70",
+  },
+  {
+    key: "sky",
+    label: "Sky",
+    tintClass: "bg-sky-500/8 dark:bg-sky-400/10",
+    dotClass: "ring-2 ring-inset ring-sky-500/70 dark:ring-sky-400/70",
+  },
+  {
+    key: "indigo",
+    label: "Indigo",
+    tintClass: "bg-indigo-500/8 dark:bg-indigo-400/10",
+    dotClass: "ring-2 ring-inset ring-indigo-500/70 dark:ring-indigo-400/70",
+  },
+  {
+    key: "violet",
+    label: "Violet",
+    tintClass: "bg-violet-500/8 dark:bg-violet-400/10",
+    dotClass: "ring-2 ring-inset ring-violet-500/70 dark:ring-violet-400/70",
+  },
+  {
+    key: "pink",
+    label: "Pink",
+    tintClass: "bg-pink-500/8 dark:bg-pink-400/10",
+    dotClass: "ring-2 ring-inset ring-pink-500/70 dark:ring-pink-400/70",
+  },
+];
+
+const PALETTE_BY_KEY = new Map<SidebarProjectColor, SidebarProjectColorClasses>(
+  SIDEBAR_PROJECT_COLOR_PALETTE.map((entry) => [entry.key, entry] as const),
+);
+
+/**
+ * 32-bit FNV-1a hash. Cheap, deterministic, and good enough for spreading
+ * project keys across the palette without obvious clustering.
+ */
+function hashStringToUint32(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    // 32-bit FNV prime multiply (Math.imul keeps the result inside int32).
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Picks the deterministic auto-color for a project that has no override. The
+ * same input always yields the same palette entry, so projects keep their
+ * color across reloads even before the user customizes anything.
+ */
+export function autoSidebarProjectColor(seed: string): SidebarProjectColorClasses {
+  const palette = SIDEBAR_PROJECT_COLOR_PALETTE;
+  const index = hashStringToUint32(seed) % palette.length;
+  return palette[index]!;
+}
+
+/**
+ * Resolves the effective color for a project: the user's override if set,
+ * otherwise the deterministic default derived from `seed` (typically the
+ * project's physical override key).
+ */
+export function resolveSidebarProjectColor(
+  seed: string,
+  override: SidebarProjectColor | undefined,
+): SidebarProjectColorClasses {
+  if (override) {
+    const palette = PALETTE_BY_KEY.get(override);
+    if (palette) {
+      return palette;
+    }
+  }
+  return autoSidebarProjectColor(seed);
+}
+
+/**
+ * Per-project color identity passed through the sidebar render tree. Carries
+ * everything the row needs to paint the tint + dot and update overrides.
+ */
+export interface SidebarProjectColorIdentity {
+  /** Stable key (physical project key) under which the override is stored. */
+  readonly overrideKey: string;
+  /** Resolved palette entry — auto if no override, else the user's pick. */
+  readonly palette: SidebarProjectColorClasses;
+  /** The user's explicit override key, or undefined when on auto. */
+  readonly override: SidebarProjectColor | undefined;
+}
+
+/**
+ * Shared empty map returned by callers when colorizing is disabled. Hoisted so
+ * consumers can pass a stable reference to memoized children (e.g.
+ * SidebarProjectsContent) without rebuilding an empty Map every render.
+ */
+export const EMPTY_SIDEBAR_PROJECT_COLOR_MAP: ReadonlyMap<string, SidebarProjectColorIdentity> =
+  new Map();
+
+export interface SidebarProjectColorInput {
+  /** UI-scoped key the sidebar uses to look the entry back up. */
+  readonly projectKey: string;
+  /** Stable identity used both for the override map and the auto-color hash. */
+  readonly overrideKey: string;
+}
+
+/**
+ * Builds a color identity for every visible project group, with collision
+ * avoidance across the auto-colored set.
+ *
+ * Algorithm:
+ *  1. Pass 1 — claim every override's color before assigning auto colors so
+ *     auto-projects never reuse a slot the user explicitly picked.
+ *  2. Pass 2 — sort auto-projects by `overrideKey` (a stable, UI-independent
+ *     order) and, for each, start at the FNV-1a hash position and walk
+ *     forward through the palette until an unused slot is found. Sorting by
+ *     `overrideKey` rather than by sidebar order means changing UI sort or
+ *     grouping doesn't reshuffle established colors.
+ *
+ * If more than `palette.length` projects need auto colors, the overflow falls
+ * back to the bare hash position (collisions are unavoidable past 10).
+ */
+export function buildSidebarProjectColorMap(input: {
+  projects: ReadonlyArray<SidebarProjectColorInput>;
+  overrides: Readonly<Record<string, SidebarProjectColor>>;
+}): Map<string, SidebarProjectColorIdentity> {
+  const palette = SIDEBAR_PROJECT_COLOR_PALETTE;
+  const result = new Map<string, SidebarProjectColorIdentity>();
+  const usedKeys = new Set<SidebarProjectColor>();
+
+  // Pass 1: explicit overrides claim their slot first.
+  const autoCandidates: SidebarProjectColorInput[] = [];
+  for (const project of input.projects) {
+    const override = input.overrides[project.overrideKey];
+    const entry = override ? PALETTE_BY_KEY.get(override) : undefined;
+    if (entry && override) {
+      result.set(project.projectKey, {
+        overrideKey: project.overrideKey,
+        palette: entry,
+        override,
+      });
+      usedKeys.add(override);
+    } else {
+      autoCandidates.push(project);
+    }
+  }
+
+  // Pass 2: auto-color the rest in stable identity order so adding/removing
+  // projects only perturbs colors that genuinely need to move.
+  const sortedAuto = autoCandidates.toSorted((left, right) =>
+    left.overrideKey.localeCompare(right.overrideKey),
+  );
+  for (const project of sortedAuto) {
+    const startIndex = hashStringToUint32(project.overrideKey) % palette.length;
+    let chosen = palette[startIndex]!;
+    if (usedKeys.size < palette.length) {
+      for (let step = 0; step < palette.length; step++) {
+        const candidate = palette[(startIndex + step) % palette.length]!;
+        if (!usedKeys.has(candidate.key)) {
+          chosen = candidate;
+          break;
+        }
+      }
+    }
+    result.set(project.projectKey, {
+      overrideKey: project.overrideKey,
+      palette: chosen,
+      override: undefined,
+    });
+    usedKeys.add(chosen.key);
+  }
+
+  return result;
+}

--- a/apps/web/src/sidebarProjectColors.ts
+++ b/apps/web/src/sidebarProjectColors.ts
@@ -105,35 +105,6 @@ function hashStringToUint32(value: string): number {
 }
 
 /**
- * Picks the deterministic auto-color for a project that has no override. The
- * same input always yields the same palette entry, so projects keep their
- * color across reloads even before the user customizes anything.
- */
-export function autoSidebarProjectColor(seed: string): SidebarProjectColorClasses {
-  const palette = SIDEBAR_PROJECT_COLOR_PALETTE;
-  const index = hashStringToUint32(seed) % palette.length;
-  return palette[index]!;
-}
-
-/**
- * Resolves the effective color for a project: the user's override if set,
- * otherwise the deterministic default derived from `seed` (typically the
- * project's physical override key).
- */
-export function resolveSidebarProjectColor(
-  seed: string,
-  override: SidebarProjectColor | undefined,
-): SidebarProjectColorClasses {
-  if (override) {
-    const palette = PALETTE_BY_KEY.get(override);
-    if (palette) {
-      return palette;
-    }
-  }
-  return autoSidebarProjectColor(seed);
-}
-
-/**
  * Per-project color identity passed through the sidebar render tree. Carries
  * everything the row needs to paint the tint + dot and update overrides.
  */

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -39,6 +39,24 @@ export const SidebarThreadPreviewCount = Schema.Int.check(
 export type SidebarThreadPreviewCount = typeof SidebarThreadPreviewCount.Type;
 export const DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT: SidebarThreadPreviewCount = 6;
 
+// Curated palette of muted hues used to tint sidebar project groups when
+// "Sidebar project colors" is enabled. The web app maps these literal keys to
+// concrete Tailwind classes; keeping the literal set in `contracts` keeps the
+// persisted override values strongly typed across the client/server boundary.
+export const SidebarProjectColor = Schema.Literals([
+  "slate",
+  "rose",
+  "orange",
+  "amber",
+  "emerald",
+  "teal",
+  "sky",
+  "indigo",
+  "violet",
+  "pink",
+]);
+export type SidebarProjectColor = typeof SidebarProjectColor.Type;
+
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -73,6 +91,10 @@ export const ClientSettingsSchema = Schema.Struct({
       modelOrder: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
     }),
   ).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  sidebarProjectColorizing: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  sidebarProjectColorOverrides: Schema.Record(TrimmedNonEmptyString, SidebarProjectColor).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
@@ -500,6 +522,10 @@ export const ClientSettingsPatch = Schema.Struct({
         ),
       }),
     ),
+  ),
+  sidebarProjectColorizing: Schema.optionalKey(Schema.Boolean),
+  sidebarProjectColorOverrides: Schema.optionalKey(
+    Schema.Record(TrimmedNonEmptyString, SidebarProjectColor),
   ),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(


### PR DESCRIPTION
## Summary
- Adds an opt-in **Sidebar project colors** client setting (Settings → General). When enabled, each visible project group is tinted with a muted hue and gets a clickable color dot in the header.
- Auto-colors are picked from a 10-entry palette via FNV-1a hash with collision avoidance: in a typical sidebar, no two adjacent projects share a hue until the palette is exhausted. Explicit overrides claim their slot first; auto-projects are processed in stable identity order so adding/removing a project doesn't reshuffle existing colors.
- Per-project picks are persisted in `sidebarProjectColorOverrides` (record keyed by physical project key, same identity used for grouping overrides). Clicking the color dot opens a swatch popover; "Auto" clears the override.

## Why
With the default thin-line guide, adjacent project groups visually blend together. Tinting each group with its own muted hue gives a clearer grouping cue, and lets users tag projects they switch between often with distinguishing colors.

## Screenshots

#### Settings toggle (off by default)
<img width="1208" height="502" alt="Screenshot 2026-05-01 at 11 09 24" src="https://github.com/user-attachments/assets/16ebc838-2f85-4d9d-a41c-30c0600395eb" />

#### Auto assign unique(if available) colors
<img width="633" height="472" alt="Screenshot 2026-05-01 at 11 09 34" src="https://github.com/user-attachments/assets/f056e97f-ead2-4496-b9dc-ad741abf0f2a" />

#### Manually change the colors from a pre-defined list
<img width="943" height="700" alt="Screenshot 2026-05-01 at 11 09 49" src="https://github.com/user-attachments/assets/64617bd0-e5d9-42d1-869e-d3b10ee4cfa6" />


## UX details
- Tints use very low alpha (`bg-{color}-500/8` light / `bg-{color}-400/10` dark) — same hue as the dot, just heavily muted.
- Dot is rendered as a transparent interior with a saturated colored ring, so its interior shows the row's color and only the border carries the identity.
- The vertical thread-list guide line is hidden while colorizing is on (the tint already groups the rows).
- Colored block has uniform `p-1` padding so it doesn't sit flush against neighbours.
- Restore Defaults clears both the toggle and any saved per-project picks.

## Files
- `packages/contracts/src/settings.ts` — `SidebarProjectColor` literal + two new `ClientSettings` fields (and patch entries).
- `apps/web/src/sidebarProjectColors.ts` (new) — palette, hash, `buildSidebarProjectColorMap` with collision avoidance.
- `apps/web/src/sidebarProjectColors.test.ts` (new) — 13 unit tests.
- `apps/web/src/components/Sidebar.tsx` — `ProjectColorDot` component, color identity plumbing, parent-level stable color-select handler.
- `apps/web/src/components/settings/SettingsPanels.tsx` — new SettingsRow + restore-defaults wiring.
- `apps/desktop/src/clientPersistence.test.ts`, `apps/web/src/localApi.test.ts` — fixture updates for the two new fields.

## Test plan
- [x] Toggle "Sidebar project colors" on/off — persists across reloads
- [x] With colorizing on: each visible project gets a distinct color (verified up to 10; 11+ wraps)
- [x] Adding a new project doesn't shift existing projects' colors when they sort earlier
- [x] Click color dot → swatch menu appears → pick swatch → row tint + dot update; choice persists
- [x] "Auto" entry clears the override and reverts to the hash-derived default
- [x] Light + dark theme parity for tint and ring opacity
- [x] Manual sort: dragging a colored row preserves its color identity
- [x] Restore Defaults wipes both the toggle and per-project picks
- [x] `bun fmt` / `bun lint` / `bun typecheck` pass
- [x] `bun run test` for `sidebarProjectColors`, `Sidebar.logic`, `localApi`, `clientPersistence`

> **Note**: Before/after screenshots and a short interaction video to come — happy to add inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar and client settings changes with no auth, security, or data-handling impact; behavior is off by default.
> 
> **Overview**
> Adds an opt-in **Sidebar project colors** feature: new client settings (`sidebarProjectColorizing`, `sidebarProjectColorOverrides`) and a typed `SidebarProjectColor` palette in contracts.
> 
> When enabled, the sidebar tints each project group, shows a **ProjectColorDot** menu to pick or clear per-project colors (same override keys as grouping), and hides the thread-list left border. Auto colors come from `buildSidebarProjectColorMap` (FNV-1a + collision avoidance, stable `overrideKey` order). Settings General gets a toggle and restore-defaults wiring; tests cover the color map and fixture updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa93a3e2acf45b014c750ed333a59221c15a242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sidebar project colors setting with per-project color overrides
> - Adds a `sidebarProjectColorizing` toggle to the General settings page; when enabled, each project row in the sidebar gets a background tint and a color dot button.
> - Introduces [`sidebarProjectColors.ts`](https://github.com/pingdotgg/t3code/pull/2381/files#diff-f1414a04718526829a75b964b0a242638a6390a3113d27f1f995ca26c562f2bf) with a curated Tailwind palette and a two-pass `buildSidebarProjectColorMap` algorithm that auto-assigns non-conflicting colors via FNV-1a hashing and respects user overrides.
> - Per-project color overrides are persisted in the new `sidebarProjectColorOverrides` setting (a string-keyed record); overrides and the toggle can be reset to defaults from settings.
> - Extends [`packages/contracts/src/settings.ts`](https://github.com/pingdotgg/t3code/pull/2381/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) with `SidebarProjectColor` union type, `sidebarProjectColorizing`, and `sidebarProjectColorOverrides` schema fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fa93a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/2381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
