### PR TITLE
fix(desktop): filter out stale custom models in settings panel

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -778,7 +778,11 @@ export function GeneralSettingsPanel() {
     const statusKey = liveProvider?.status ?? (providerConfig.enabled ? "warning" : "disabled");
     const summary = getProviderSummary(liveProvider);
     const models: ReadonlyArray<ServerProviderModel> =
-      liveProvider?.models ??
+      liveProvider?.models.filter(
+        // remove any custom models not in providerConfig.customModels, this is because on remove, liveProvider can
+        // become stale (but providerConfig.customModels) is always up to date.
+        (m) => !m.isCustom || providerConfig.customModels.includes(m.slug)
+      ) ??
       providerConfig.customModels.map((slug) => ({
         slug,
         name: slug,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

When rendering the SettingsPanel, filter out custom models in the `liveProvider` that have been deleted from `providerConfig`.

## Why

When a custom model is deleted from a live provider, the list is stale (not 100% sure why, it might have to do with the delete not being part of an optimistic update). In any case, `providerConfig` is always up to date so using it as the source of truth for custom model list state fixes the issue.

### Before

[before](https://github.com/user-attachments/assets/ebe86c95-5d32-4003-b51b-18ed6196130e)

### After

[after](https://github.com/user-attachments/assets/531d4094-c5a3-49c3-afc0-cf550329b35a)

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that filters provider model lists to avoid displaying stale custom entries; no persistence, auth, or backend behavior is modified.
> 
> **Overview**
> Prevents deleted custom models from lingering in the Providers settings UI by filtering `liveProvider.models` to only include custom entries still present in `providerConfig.customModels`.
> 
> If no live models are available, the panel still falls back to building the model list from `providerConfig.customModels` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55b8617651b703107f1d252631723c3947eeaf67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter stale custom models from provider cards in `GeneralSettingsPanel`
> When building `providerCards`, custom models from `liveProvider.models` are now filtered to only include models whose slug exists in `providerConfig.customModels`, preventing stale entries from appearing in the settings panel. The fallback that builds models directly from `providerConfig.customModels` is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 55b8617.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->