### PR TITLE
fix(desktop): handle custom model ids with multiple colons

### DIFF
--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -33,6 +33,17 @@ type ModelPickerItem = {
 
 const EMPTY_MODEL_JUMP_LABELS = new Map<string, string>();
 
+/**
+ * Parse a composite model key of the form `provider:modelSlug` into its
+ * constituent parts.  We split on the **first** colon only so that model
+ * slugs containing colons (e.g. AWS Bedrock ARN-style IDs like
+ * `us.anthropic.claude-haiku-4-5-20251001-v1:0`) are preserved intact.
+ */
+function parseModelKey(modelKey: string): [ProviderKind, string] {
+  const colonIndex = modelKey.indexOf(":");
+  return [modelKey.slice(0, colonIndex) as ProviderKind, modelKey.slice(colonIndex + 1)];
+}
+
 export const ModelPickerContent = memo(function ModelPickerContent(props: {
   provider: ProviderKind;
   model: string;
@@ -331,7 +342,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       if (!targetModelKey) {
         return;
       }
-      const [provider, slug] = targetModelKey.split(":") as [ProviderKind, string];
+      const [provider, slug] = parseModelKey(targetModelKey);
       event.preventDefault();
       event.stopPropagation();
       handleModelSelect(slug, provider);
@@ -430,7 +441,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
             if (typeof modelKey !== "string") {
               return;
             }
-            const [provider, slug] = modelKey.split(":") as [ProviderKind, string];
+            const [provider, slug] = parseModelKey(modelKey);
             handleModelSelect(slug, provider);
           }}
         >
@@ -464,10 +475,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                     ).preventBaseUIHandler?.();
                     e.preventDefault();
                     e.stopPropagation();
-                    const [provider, slug] = highlightedModelKeyRef.current.split(":") as [
-                      ProviderKind,
-                      string,
-                    ];
+                    const [provider, slug] = parseModelKey(highlightedModelKeyRef.current);
                     handleModelSelect(slug, provider);
                     return;
                   }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Only split custom model name on first colon, not subsequent ones.

## Why

Some AWS bedrock model arns have multiple `:` characters (i.e. `us.anthropic.claude-haiku-4-5-20251001-v1:0`), which causes the split to throw away the third part which causes the model to be unselectable in the UI.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI bugfix that only changes how `provider:model` keys are parsed during model selection; behavior should be identical for normal slugs but could misbehave if a model key ever lacks a colon.
> 
> **Overview**
> Fixes model selection in the chat model picker for providers whose model IDs contain additional `:` characters (e.g. Bedrock ARN-style IDs).
> 
> Introduces `parseModelKey()` that splits the composite `provider:modelSlug` key on the *first* colon only, and uses it for keyboard jump selection, combobox value changes, and Enter-to-select on the highlighted item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e892a26d6444752bba0b92365aa7d1b5724076b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix model selection in `ModelPickerContent` to handle model IDs containing colons
> Model slugs that contain colons (e.g. custom model IDs) were being split incorrectly, causing the provider and slug to be parsed wrong. A new `parseModelKey` helper splits only on the first colon, preserving the rest of the slug intact. This fix applies to all three selection paths: jump selection, combobox selection, and enter-to-select from search.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e892a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->