### PR TITLE
fix(web): close mobile sidebar on navigation

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,12 +1,25 @@
 import { useEffect, type ReactNode } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
 
 import ThreadSidebar from "./Sidebar";
-import { Sidebar, SidebarProvider, SidebarRail } from "./ui/sidebar";
+import { Sidebar, SidebarProvider, SidebarRail, useSidebar } from "./ui/sidebar";
 import {
   clearShortcutModifierState,
   syncShortcutModifierStateFromKeyboardEvent,
 } from "../shortcutModifierState";
+
+function CloseMobileSidebarOnNavigate() {
+  const { isMobile, openMobile, setOpenMobile } = useSidebar();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  useEffect(() => {
+    if (isMobile && openMobile) {
+      setOpenMobile(false);
+    }
+    // Only close on pathname changes — isMobile/openMobile flips alone shouldn't dismiss.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+  return null;
+}
 
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
 const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
@@ -55,6 +68,7 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
 
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen>
+      <CloseMobileSidebarOnNavigate />
       <Sidebar
         side="left"
         collapsible="offcanvas"


### PR DESCRIPTION
## Summary

The offcanvas mobile sidebar drawer stays open after creating a thread or selecting one from the list, forcing a manual second tap to dismiss it before reaching the chat. Subscribe to the TanStack Router pathname at the layout level and close the mobile drawer on every route change.

## Why this approach

`Sidebar.tsx`, `useHandleNewThread`, command palette navigation, and keybindings all call `router.navigate(...)` separately. A single layout-level subscription catches every entry point without touching each handler, and any future navigation paths inherit the fix automatically. Desktop is unaffected because of the `isMobile` guard.

## Test plan

- [ ] iPhone via Tailscale: open sidebar → tap an existing thread → drawer auto-dismisses
- [ ] iPhone: open sidebar → "New thread" → drawer dismisses after the route lands on \`/draft/...\`
- [ ] iPhone: open sidebar → command palette navigation → drawer dismisses
- [ ] Desktop: sidebar open/close behavior unchanged

## Screenshots / video

https://github.com/user-attachments/assets/32a6d7e0-a425-4a87-84b3-024c8ffa3236



---

Reproduction: I run \`t3 serve --host "\$(tailscale ip -4)"\` on a Macbook and use the web UI from an iPhone over Tailscale. This is the first of four small mobile-usability fixes I plan to open separately per the small-and-focused guidance in CONTRIBUTING.md.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close mobile sidebar on navigation in `AppSidebarLayout`
> Adds a `CloseMobileSidebarOnNavigate` component in [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/2390/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) that watches the current pathname via `useRouterState()`. When the pathname changes and the sidebar is open on mobile, it calls `setOpenMobile(false)` to dismiss it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1dd833.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small layout-only UX change gated on mobile sidebar state; no auth, data, or API impact.
> 
> **Overview**
> **`AppSidebarLayout`** now mounts a **`CloseMobileSidebarOnNavigate`** helper inside **`SidebarProvider`** so the offcanvas thread sidebar dismisses automatically after route changes on mobile.
> 
> The helper reads **`openMobile`** / **`isMobile`** from **`useSidebar()`** and subscribes to **`useRouterState`** for **`pathname`**. When the path changes, it calls **`setOpenMobile(false)`** only if the drawer is open on mobile; the effect depends on **`pathname`** alone so viewport or open-state toggles without navigation do not force a close.
> 
> Desktop layout behavior is unchanged because of the **`isMobile`** guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1dd8339e8dd9de5808bd1f22797b088f8616479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile sidebar now automatically closes when navigating between pages, improving the mobile browsing experience and reducing manual interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->