### PR TITLE
fix(web): prevent mobile pinch and input-focus zoom

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#161616" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#161616" />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -51,10 +51,15 @@
   }
   html {
     background-color: var(--app-chrome-background);
+    /* iOS Safari ignores `user-scalable=no` in many contexts; touch-action
+       blocks pinch-zoom while still allowing pan/scroll. Touch-only input,
+       so desktop browsers are unaffected. */
+    touch-action: pan-x pan-y;
   }
   body {
     @apply text-foreground relative;
     background-color: var(--app-chrome-background);
+    touch-action: pan-x pan-y;
   }
 }
 


### PR DESCRIPTION
## Summary

The viewport meta omitted \`maximum-scale\` and \`user-scalable\`, so iOS Safari auto-zoomed when an input was focused and let the user pinch the chrome. Both break the remote-control workflow over Tailscale on a phone.

Two changes:

1. Tighten the existing viewport meta with \`maximum-scale=1, user-scalable=no\` (preserves \`viewport-fit=cover\`).
2. Add \`touch-action: pan-x pan-y\` to \`html\` and \`body\` in \`apps/web/src/index.css\`.

## Why both

\`user-scalable=no\` alone is unreliable on modern iOS Safari — Apple deferred to it for a long time, and even with current builds it's a hint, not a contract. \`touch-action: pan-x pan-y\` is the mechanism iOS does honor consistently: pan/scroll still works, pinch-to-zoom is blocked. It only affects touch input, so desktop browsers are unchanged.

Verified empirically that just the viewport-meta change is *not* enough on iOS — both pinch-zoom and input-focus zoom kept happening on iPhone until \`touch-action\` was added.

## Test plan

- [ ] iPhone Safari: tap composer / search input → no zoom
- [ ] iPhone Safari: pinch chat or sidebar → no zoom
- [ ] iPhone Safari: scrolling and tap targets still work
- [ ] Desktop browsers: layout unchanged

## Trade-off

System-level pinch zoom is disabled on touch. iOS still honors the OS-level "Display Zoom" / "Accessibility > Zoom" setting regardless, so a11y users keep their escape hatch. This matches the explicit user requirement for a fixed remote-control viewport.

## Screenshots / video

https://github.com/user-attachments/assets/6d7fa8b2-80f7-4732-91b7-d44c767f3f75



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent mobile pinch-zoom and input-focus zoom on web
> - Sets `maximum-scale=1` and `user-scalable=no` in the viewport meta tag in [index.html](https://github.com/pingdotgg/t3code/pull/2391/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f) to block zoom on browsers that honor these directives.
> - Adds `touch-action: pan-x pan-y` to `html` and `body` in [index.css](https://github.com/pingdotgg/t3code/pull/2391/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to disable pinch gestures on iOS Safari, which ignores the viewport meta tag restrictions.
> - Behavioral Change: users on mobile can no longer pinch-zoom or trigger input-focus zoom anywhere on the page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 277c467.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables pinch-to-zoom across the app on touch devices, which can impact accessibility and mobile usability despite being a small, localized change.
> 
> **Overview**
> Prevents iOS Safari from zooming the page (pinch-zoom and input-focus zoom) by tightening the `viewport` meta tag (`maximum-scale=1`, `user-scalable=no`).
> 
> Adds `touch-action: pan-x pan-y` on `html` and `body` to reliably block pinch-zoom while preserving scrolling/panning on touch devices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 277c467bf8fd1c60b90a0c88f689101c528d0195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile device experience by optimizing viewport behavior and touch gesture handling for better stability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->