### PR TITLE
feat(web): configurable composer send key

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -1748,9 +1748,14 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         return true;
       }
     }
-    if (key === "Enter" && !event.shiftKey) {
-      submitComposer();
-      return true;
+    if (key === "Enter") {
+      const sendKey = settings.composerSendKey;
+      const wantsSend =
+        sendKey === "enter" ? !event.shiftKey : sendKey === "shift-enter" ? event.shiftKey : false;
+      if (wantsSend) {
+        submitComposer();
+        return true;
+      }
     }
     return false;
   };

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -417,6 +417,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
         : []),
+      ...(settings.composerSendKey !== DEFAULT_UNIFIED_SETTINGS.composerSendKey
+        ? ["Composer send key"]
+        : []),
       ...(settings.addProjectBaseDirectory !== DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory
         ? ["Add project base directory"]
         : []),
@@ -434,6 +437,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
+      settings.composerSendKey,
       settings.defaultThreadEnvMode,
       settings.diffIgnoreWhitespace,
       settings.diffWordWrap,
@@ -732,6 +736,54 @@ export function GeneralSettingsPanel() {
                 </SelectItem>
                 <SelectItem hideIndicator value="worktree">
                   New worktree
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Composer send key"
+          description="Choose which keystroke submits the composer. Use 'Send button only' on touch devices to avoid accidental sends from the soft keyboard's Enter."
+          resetAction={
+            settings.composerSendKey !== DEFAULT_UNIFIED_SETTINGS.composerSendKey ? (
+              <SettingResetButton
+                label="composer send key"
+                onClick={() =>
+                  updateSettings({
+                    composerSendKey: DEFAULT_UNIFIED_SETTINGS.composerSendKey,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.composerSendKey}
+              onValueChange={(value) => {
+                if (value === "enter" || value === "shift-enter" || value === "button-only") {
+                  updateSettings({ composerSendKey: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-44" aria-label="Composer send key">
+                <SelectValue>
+                  {settings.composerSendKey === "shift-enter"
+                    ? "Shift + Enter"
+                    : settings.composerSendKey === "button-only"
+                      ? "Send button only"
+                      : "Enter"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="enter">
+                  Enter
+                </SelectItem>
+                <SelectItem hideIndicator value="shift-enter">
+                  Shift + Enter
+                </SelectItem>
+                <SelectItem hideIndicator value="button-only">
+                  Send button only
                 </SelectItem>
               </SelectPopup>
             </Select>

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -102,6 +102,10 @@ export const DEFAULT_CLIENT_SETTINGS: ClientSettings = Schema.decodeSync(ClientS
 export const ThreadEnvMode = Schema.Literals(["local", "worktree"]);
 export type ThreadEnvMode = typeof ThreadEnvMode.Type;
 
+export const ComposerSendKey = Schema.Literals(["enter", "shift-enter", "button-only"]);
+export type ComposerSendKey = typeof ComposerSendKey.Type;
+export const DEFAULT_COMPOSER_SEND_KEY: ComposerSendKey = "enter";
+
 const makeBinaryPathSetting = (fallback: string) =>
   TrimmedString.pipe(
     Schema.decodeTo(
@@ -373,6 +377,9 @@ export const ServerSettings = Schema.Struct({
   defaultThreadEnvMode: ThreadEnvMode.pipe(
     Schema.withDecodingDefault(Effect.succeed("local" as const satisfies ThreadEnvMode)),
   ),
+  composerSendKey: ComposerSendKey.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_COMPOSER_SEND_KEY)),
+  ),
   addProjectBaseDirectory: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   textGenerationModelSelection: ModelSelection.pipe(
     Schema.withDecodingDefault(
@@ -481,6 +488,7 @@ export const ServerSettingsPatch = Schema.Struct({
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
   automaticGitFetchInterval: Schema.optionalKey(Schema.DurationFromMillis),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
+  composerSendKey: Schema.optionalKey(ComposerSendKey),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
   observability: Schema.optionalKey(


### PR DESCRIPTION
## Summary

Add a \"Composer send key\" setting (server-synced via \`UnifiedSettings\`) with three options:

- **Enter** (default, current behavior): Enter sends, Shift+Enter newlines
- **Shift + Enter**: Shift+Enter sends, Enter newlines
- **Send button only**: neither key sends, only the dedicated send button

## Why

On a phone the soft keyboard's Enter key sends partial messages on every tap, which is wrong for a touch UX. \"Send button only\" fixes that without forcing one heuristic on everyone — vim/editor users may prefer \"Shift + Enter\" on desktop, etc.

The default preserves existing desktop behavior, so this is an additive change with no migration concerns. The slash-command / mention menu's Enter-to-confirm path is unchanged — the menu branch fires before the send branch in \`onComposerCommandKey\`.

## Files

- \`packages/contracts/src/settings.ts\`: new \`ComposerSendKey\` literal, field on \`ServerSettings\` + \`ServerSettingsPatch\`. Decoding default keeps existing settings files compatible.
- \`apps/web/src/components/settings/SettingsPanels.tsx\`: new \`SettingsRow\` between \"New threads\" and \"Add project starts in\", using the same Select pattern as \`defaultThreadEnvMode\`.
- \`apps/web/src/components/chat/ChatComposer.tsx\`: replace the unconditional \`Enter && !shiftKey\` send branch with a settings-driven check.

## Test plan

- [ ] Settings → General shows the new \"Composer send key\" row with three options and a reset button when non-default
- [ ] \"Enter\" mode: Enter sends, Shift+Enter inserts newline (= current default behavior)
- [ ] \"Shift + Enter\" mode: Shift+Enter sends, Enter inserts newline
- [ ] \"Send button only\" mode: neither Enter nor Shift+Enter sends; the send button still does
- [ ] Slash-command menu: open, hit Enter — still selects the highlighted command in all three modes
- [ ] Setting persists across reload (server-synced)
- [ ] Existing settings files without the field decode cleanly (defaults to \"Enter\")

## Screenshots / video

<img width="1179" height="2556" alt="925A1689-F0ED-4D91-90A8-1F833B85A350_1_102_o" src="https://github.com/user-attachments/assets/be239227-bffa-48b3-93a4-7c42495950c4" />


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add configurable composer send key setting with Enter, Shift+Enter, and button-only options
> - Introduces a `composerSendKey` setting (values: `enter`, `shift-enter`, `button-only`) in [settings.ts](https://github.com/pingdotgg/t3code/pull/2393/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), defaulting to `enter`.
> - Updates [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/2393/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a) to compute a `wantsSend` flag on keydown based on the setting, replacing the previous hardcoded Shift+Enter behavior.
> - Adds a 'Composer send key' row to the General settings panel in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/2393/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) with a Select control and a reset-to-default action.
> - Behavioral Change: existing users retain the default `enter` behavior, but the send key is now user-configurable and persisted in server settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e55fe9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UX setting with default preserving current Enter-to-send behavior; no auth, data, or server logic changes beyond settings schema.
> 
> **Overview**
> Adds a server-synced **`composerSendKey`** preference so users can choose how the chat composer submits: **Enter** (default, same as today), **Shift + Enter**, or **send button only** (no Enter/Shift+Enter submit).
> 
> **Contracts** define `ComposerSendKey` on `ServerSettings` / `ServerSettingsPatch` with decode default `"enter"` so older settings files stay compatible.
> 
> **General settings** get a new row (with per-field reset and inclusion in the “changed settings” list). **ChatComposer** replaces the fixed `Enter && !shiftKey` send path with logic driven by `settings.composerSendKey`; slash/@ menu **Enter** still confirms the highlighted item because that branch runs before send.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55fe9e9115997fad0b55b8d30a72910a93980ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced customizable composer send key setting. Users can now configure their preferred keyboard shortcut for sending messages through General preferences: Enter, Shift+Enter, or Send button only. Settings persist across all sessions and synchronize across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->