### PR TITLE
fix: run opencode server through shell on Windows

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -330,6 +330,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const child = yield* spawner
         .spawn(
           ChildProcess.make(input.binaryPath, args, {
+            shell: process.platform === "win32",
             env: {
               ...process.env,
               OPENCODE_CONFIG_CONTENT: JSON.stringify({}),


### PR DESCRIPTION
## Summary

Fix OpenCode server startup on Windows when the resolved OpenCode binary is a `.cmd` shim.

Node cannot spawn `.cmd` files directly with `shell: false`, which can make the `opencode serve` process fail with `EINVAL` on Windows. The existing OpenCode healthcheck already uses `shell: process.platform === win32` for this reason.

This PR applies the same Windows-only spawn behavior to the long-running OpenCode server process. Linux and macOS behavior is unchanged.

## Fix

- Add `shell: process.platform === win32` to the `opencode serve` spawn options in `opencodeRuntime.ts`
- Keep the change scoped to the OpenCode server startup path
- No UI changes

## Test plan

- [x] `bun fmt`
- [x] `bun lint`
- [x] `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Windows-only process spawn option change; behavior on macOS/Linux is unchanged and impact is limited to OpenCode server startup.
> 
> **Overview**
> Fixes OpenCode server startup on Windows by spawning the long-running `opencode serve` process with `shell: process.platform === "win32"`, matching the behavior already used for other command executions.
> 
> Non-Windows platforms keep the existing spawn behavior; only the server startup path in `opencodeRuntime.ts` is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b81aacc468522b8959c783a1566f4aae49df2437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenCode server process spawn on Windows by running through a shell
> On Windows, spawning a child process without a shell can fail for certain executables. The fix sets `shell: process.platform === "win32"` in the options passed to `ChildProcess.make` in [`opencodeRuntime.ts`](https://github.com/pingdotgg/t3code/pull/2400/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8). Non-Windows behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b81aacc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->