### PR TITLE
fix(server): key AskUserQuestion answers by question text

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3228,6 +3228,34 @@ describe("ClaudeAdapterLive", () => {
       assert.deepEqual(updatedInput.answers, { "Which framework?": "React" });
       // Original questions should be passed through.
       assert.deepEqual(updatedInput.questions, askInput.questions);
+
+      // Compatibility check for #2388: the answers shape we hand to the SDK
+      // must produce a non-empty rendered tool_result on BOTH SDK iteration
+      // patterns we have seen, so we don't regress the issue and we don't
+      // break users still on the older Claude CLI.
+      const sdkAnswers = updatedInput.answers as Record<string, unknown>;
+      const sdkQuestions = updatedInput.questions as ReadonlyArray<{
+        readonly question: string;
+      }>;
+
+      // Claude CLI 2.1.119 — key-agnostic Object.entries iteration. Any key
+      // works here, but it must at least round-trip into a non-empty string.
+      const v119Rendered = Object.entries(sdkAnswers)
+        .map(([key, value]) => `"${key}"="${String(value)}"`)
+        .join(", ");
+      assert.equal(v119Rendered, '"Which framework?"="React"');
+
+      // Claude CLI 2.1.121 — lookup by full question text. This is the path
+      // that regressed in #2388 when the answers were keyed by `header`.
+      const v121Rendered = sdkQuestions
+        .map(({ question }) => {
+          const answer = sdkAnswers[question];
+          return answer === undefined ? null : `"${question}"="${String(answer)}"`;
+        })
+        .filter((entry): entry is string => entry !== null)
+        .join(", ");
+      assert.notEqual(v121Rendered, "", "Expected non-empty SDK 2.1.121 tool_result (#2388)");
+      assert.equal(v121Rendered, '"Which framework?"="React"');
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -3191,6 +3191,9 @@ describe("ClaudeAdapterLive", () => {
       assert.equal(typeof requestId, "string");
       assert.equal(requestedEvent.value.payload.questions.length, 1);
       assert.equal(requestedEvent.value.payload.questions[0]?.question, "Which framework?");
+      // Regression for #2388: `id` must equal the full question text so the
+      // UI's draft-answer key matches what the SDK looks up downstream.
+      assert.equal(requestedEvent.value.payload.questions[0]?.id, "Which framework?");
       assert.deepEqual(requestedEvent.value.providerRefs, {
         providerItemId: ProviderItemId.make("tool-ask-1"),
       });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2549,10 +2549,14 @@ const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         const requestId = ApprovalRequestId.make(yield* Random.nextUUIDv4);
 
         // Parse questions from the SDK's AskUserQuestion input.
+        // `id` MUST equal the full question text — Claude SDK >= 2.1.121 looks
+        // up answers by question text in `mapToolResultToToolResultBlockParam`,
+        // so the key the UI uses to keep its draft answer must match the SDK's
+        // expected lookup key. See https://github.com/pingdotgg/t3code/issues/2388
         const rawQuestions = Array.isArray(toolInput.questions) ? toolInput.questions : [];
         const questions: Array<UserInputQuestion> = rawQuestions.map(
           (q: Record<string, unknown>, idx: number) => ({
-            id: typeof q.header === "string" ? q.header : `q-${idx}`,
+            id: typeof q.question === "string" && q.question.length > 0 ? q.question : `q-${idx}`,
             header: typeof q.header === "string" ? q.header : `Question ${idx + 1}`,
             question: typeof q.question === "string" ? q.question : "",
             options: Array.isArray(q.options)


### PR DESCRIPTION
## What Changed

`UserInputQuestion.id` (parsed in `ClaudeAdapter.handleAskUserQuestion`) is now derived from the full `question` text instead of `header`. The web UI keys its draft answers by `question.id`, so the answers record returned to the SDK in `updatedInput.answers` is now keyed by question text, exactly what Claude SDK ≥ 2.1.121 looks up. `header` stays UI-display only.

A regression assertion in the existing `"handles AskUserQuestion via user-input.requested/resolved lifecycle"` test renders the adapter's `updatedInput.answers` through both SDK iteration patterns (2.1.119's key-agnostic `Object.entries` and 2.1.121's `answers[question]` lookup) and asserts both produce a non-empty `tool_result`, locking the keying contract on either side of the regression.

## Why

Fixes #2388.

Between Claude CLI **2.1.119** and **2.1.121** the SDK's `mapToolResultToToolResultBlockParam` for `AskUserQuestion` switched from a key-agnostic `Object.entries(answers)` map to a lookup by full question text:

```js
// 2.1.121
questions.map(({ question }) => {
  const a = answers[question];
  if (!a && !annotations?.[question]?.notes) return null;
  return `"${question}"="${a}"`;
}).filter(x => x !== null).join(", ")
```

T3 was submitting `answers` keyed by `header` (e.g. `"Approach"`), not by the full `question` text (e.g. `"Which approach do you prefer?"`). Under 2.1.121 every lookup missed, every entry was filtered out, and the model received an empty interpolation:

```
User has answered your questions: . You can now continue with the user's answers in mind.
```

Keying by question text is also what the documented `outputSchema` shape calls for, so this aligns T3 with the spec rather than relying on the older SDK's lax behavior. The change is backwards compatible with 2.1.119, its `Object.entries` iteration accepts any key, so older CLI users keep working (and now see semantically richer rendered answers, e.g. `"Which approach?"="Option A"` instead of `"Approach"="Option A"`).

`id` in `UserInputQuestion` is `TrimmedNonEmptyStringSchema` with no length cap and is only used as a `Record<string, …>` key in `pendingUserInput.ts` and `session-logic.ts`, never as a URL/route key, so widening it to the full question text is safe.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes <!-- N/A: server-only -->
- [x] I included a video for animation/interaction changes <!-- N/A: server-only -->


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Key `AskUserQuestion` answers by full question text instead of header
> - In [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/2404/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), the `id` field of each `UserInputQuestion` is now set to the full question text (falling back to `q-<idx>` if empty) rather than `q.header`.
> - This aligns answer key lookup with how the Claude SDK iterates answers, fixing a mismatch when resolving responses back to their questions (see issue #2388).
> - Behavioral Change: The `id` values in emitted `user-input.requested` payloads will differ from previous behavior, so any consumers keying answers by the old header-derived id will need to update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d6d905.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->