### PR TITLE
[codex] Fix macOS helper bundle identities

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -8,6 +8,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -19,7 +20,7 @@ import { fileURLToPath } from "node:url";
 const isDevelopment = Boolean(process.env.VITE_DEV_SERVER_URL);
 const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
 const APP_BUNDLE_ID = isDevelopment ? "com.t3tools.t3code.dev" : "com.t3tools.t3code";
-const LAUNCHER_VERSION = 2;
+const LAUNCHER_VERSION = 3;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const desktopDir = resolve(__dirname, "..");
@@ -120,6 +121,41 @@ function patchMainBundleInfoPlist(appBundlePath, iconPath) {
   copyFileSync(iconPath, join(resourcesDir, "electron.icns"));
 }
 
+function patchHelperBundleInfoPlists(appBundlePath) {
+  const frameworksDir = join(appBundlePath, "Contents", "Frameworks");
+  if (!existsSync(frameworksDir)) {
+    return;
+  }
+
+  for (const entry of readdirSync(frameworksDir, { withFileTypes: true })) {
+    if (
+      !entry.isDirectory() ||
+      !entry.name.startsWith("Electron Helper") ||
+      !entry.name.endsWith(".app")
+    ) {
+      continue;
+    }
+
+    const helperPlistPath = join(frameworksDir, entry.name, "Contents", "Info.plist");
+    if (!existsSync(helperPlistPath)) {
+      continue;
+    }
+
+    const suffix = entry.name.replace("Electron Helper", "").replace(".app", "").trim();
+    const helperName = suffix
+      ? `${APP_DISPLAY_NAME} Helper ${suffix}`
+      : `${APP_DISPLAY_NAME} Helper`;
+    const helperIdSuffix = suffix.replace(/[()]/g, "").trim().toLowerCase().replace(/\s+/g, "-");
+    const helperBundleId = helperIdSuffix
+      ? `${APP_BUNDLE_ID}.helper.${helperIdSuffix}`
+      : `${APP_BUNDLE_ID}.helper`;
+
+    setPlistString(helperPlistPath, "CFBundleDisplayName", helperName);
+    setPlistString(helperPlistPath, "CFBundleName", helperName);
+    setPlistString(helperPlistPath, "CFBundleIdentifier", helperBundleId);
+  }
+}
+
 function readJson(path) {
   try {
     return JSON.parse(readFileSync(path, "utf8"));
@@ -157,6 +193,7 @@ function buildMacLauncher(electronBinaryPath) {
   rmSync(targetAppBundlePath, { recursive: true, force: true });
   cpSync(sourceAppBundlePath, targetAppBundlePath, { recursive: true });
   patchMainBundleInfoPlist(targetAppBundlePath, iconPath);
+  patchHelperBundleInfoPlists(targetAppBundlePath);
   writeFileSync(metadataPath, `${JSON.stringify(expectedMetadata, null, 2)}\n`);
 
   return targetBinaryPath;

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -3,6 +3,8 @@ import { assert, it } from "@effect/vitest";
 import { ConfigProvider, Effect, Option } from "effect";
 
 import {
+  createBuildConfig,
+  MAC_HELPER_BUNDLE_IDS,
   resolveBuildOptions,
   resolveDesktopBuildIconAssets,
   resolveDesktopProductName,
@@ -36,6 +38,19 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       windowsIconIco: BRAND_ASSET_PATHS.nightlyWindowsIconIco,
     });
   });
+
+  it.effect("pins macOS Electron helper bundle IDs to the T3 Code app identity", () =>
+    Effect.gen(function* () {
+      const buildConfig = yield* createBuildConfig("mac", "dmg", "0.0.21", false, false, undefined);
+
+      assert.deepStrictEqual(buildConfig.mac, {
+        target: ["dmg", "zip"],
+        icon: "icon.icns",
+        category: "public.app-category.developer-tools",
+        ...MAC_HELPER_BUNDLE_IDS,
+      });
+    }),
+  );
 
   it("falls back to the default mock update port when the configured port is blank", () => {
     assert.equal(resolveMockUpdateServerUrl(undefined), "http://localhost:3000");

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -63,6 +63,17 @@ const PLATFORM_CONFIG: Record<typeof BuildPlatform.Type, PlatformConfig> = {
   },
 };
 
+const MAC_APP_BUNDLE_ID = "com.t3tools.t3code";
+
+export const MAC_HELPER_BUNDLE_IDS = {
+  helperBundleId: `${MAC_APP_BUNDLE_ID}.helper`,
+  helperEHBundleId: `${MAC_APP_BUNDLE_ID}.helper.eh`,
+  helperGPUBundleId: `${MAC_APP_BUNDLE_ID}.helper.gpu`,
+  helperNPBundleId: `${MAC_APP_BUNDLE_ID}.helper.np`,
+  helperPluginBundleId: `${MAC_APP_BUNDLE_ID}.helper.plugin`,
+  helperRendererBundleId: `${MAC_APP_BUNDLE_ID}.helper.renderer`,
+} as const;
+
 interface BuildCliInput {
   readonly platform: Option.Option<typeof BuildPlatform.Type>;
   readonly target: Option.Option<string>;
@@ -558,7 +569,7 @@ export function resolveDesktopProductName(version: string): string {
     : (desktopPackageJson.productName ?? "T3 Code");
 }
 
-const createBuildConfig = Effect.fn("createBuildConfig")(function* (
+export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   platform: typeof BuildPlatform.Type,
   target: string,
   version: string,
@@ -567,7 +578,7 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   mockUpdateServerPort: number | undefined,
 ) {
   const buildConfig: Record<string, unknown> = {
-    appId: "com.t3tools.t3code",
+    appId: MAC_APP_BUNDLE_ID,
     productName: resolveDesktopProductName(version),
     artifactName: "T3-Code-${version}-${arch}.${ext}",
     directories: {
@@ -592,6 +603,7 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       target: target === "dmg" ? [target, "zip"] : [target],
       icon: "icon.icns",
       category: "public.app-category.developer-tools",
+      ...MAC_HELPER_BUNDLE_IDS,
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #2405.

Restores T3 Code-specific macOS Electron helper identity so enterprise EDR tools can associate helper processes, especially the GPU helper, with the parent app instead of the default Electron identity.

## Changes

- Explicitly configure electron-builder mac helper bundle IDs under `com.t3tools.t3code.helper.*`, including `com.t3tools.t3code.helper.gpu`.
- Restore production launcher helper `Info.plist` patching for launcher-created macOS bundles while keeping dev launches on the stock Electron path.
- Add a scripts regression test that verifies the mac build config pins helper bundle IDs.

## Validation

- `bun fmt`
- `bun lint` (passes with existing warnings outside this change)
- `bun typecheck`
- `bun run --filter @t3tools/scripts test -- build-desktop-artifact.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix macOS Electron helper bundle identities in the desktop app build
> - Adds `MAC_HELPER_BUNDLE_IDS` constant in [`build-desktop-artifact.ts`](https://github.com/pingdotgg/t3code/pull/2407/files#diff-5d48b7d871d48227341de6f5e0816f3a5282c42c4cca44734829988ee7607a00) defining explicit bundle IDs for all six Electron helper processes, rooted at `com.t3tools.t3code`.
> - Spreads these IDs into the `mac` config in `createBuildConfig` so electron-builder sets them at package time.
> - Adds `patchHelperBundleInfoPlists` in [`electron-launcher.mjs`](https://github.com/pingdotgg/t3code/pull/2407/files#diff-8a117bf8144a87af3b3928053a08e442ffe3b14884df08757b77d55907d596b4) to scan `Contents/Frameworks` for `Electron Helper*.app` bundles and rewrite their `CFBundleDisplayName`, `CFBundleName`, and `CFBundleIdentifier` to match the app's display name and bundle ID.
> - Bumps `LAUNCHER_VERSION` from 2 to 3 to trigger re-patching on existing installs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f760713.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS packaging/launcher plist patching and bundle IDs, which can affect helper process launching and code signing/notarization behavior on macOS.
> 
> **Overview**
> Ensures macOS Electron helper apps (including GPU/renderer/plugin helpers) use T3 Code-specific bundle identifiers instead of the default Electron identity.
> 
> This updates the production macOS launcher to also rewrite each `Electron Helper*.app` `Info.plist` (name + `CFBundleIdentifier`) and bumps `LAUNCHER_VERSION` to force regeneration. Separately, the desktop build script now hard-codes and applies `MAC_HELPER_BUNDLE_IDS` in the mac electron-builder config and adds a regression test asserting these IDs are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7607138c54e6051f88be2f7d9060956e43d4f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->