### PR TITLE
[codex] Fix visited timestamp under clock skew

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1021,7 +1021,10 @@ export default function ChatView(props: ChatViewProps) {
     const lastVisitedAt = activeThreadLastVisitedAt ? Date.parse(activeThreadLastVisitedAt) : NaN;
     if (!Number.isNaN(lastVisitedAt) && lastVisitedAt >= turnCompletedAt) return;
 
-    markThreadVisited(scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)));
+    markThreadVisited(
+      scopedThreadKey(scopeThreadRef(serverThread.environmentId, serverThread.id)),
+      activeLatestTurn.completedAt,
+    );
   }, [
     activeLatestTurn?.completedAt,
     activeThreadLastVisitedAt,

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearThreadUi,
   hydratePersistedProjectState,
+  markThreadVisited,
   markThreadUnread,
   PERSISTED_STATE_KEY,
   type PersistedUiState,
@@ -27,6 +28,28 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
 }
 
 describe("uiStateStore pure functions", () => {
+  it("markThreadVisited stores the provided server timestamp", () => {
+    const threadId = ThreadId.make("thread-1");
+    const initialState = makeUiState();
+
+    const next = markThreadVisited(initialState, threadId, "2026-02-25T12:30:00.700Z");
+
+    expect(next.threadLastVisitedAtById[threadId]).toBe("2026-02-25T12:30:00.700Z");
+  });
+
+  it("markThreadVisited does not move visit state backwards under clock skew", () => {
+    const threadId = ThreadId.make("thread-1");
+    const initialState = makeUiState({
+      threadLastVisitedAtById: {
+        [threadId]: "2026-02-25T12:30:00.700Z",
+      },
+    });
+
+    const next = markThreadVisited(initialState, threadId, "2026-02-25T12:30:00.000Z");
+
+    expect(next).toBe(initialState);
+  });
+
   it("markThreadUnread moves lastVisitedAt before completion for a completed thread", () => {
     const threadId = ThreadId.make("thread-1");
     const latestTurnCompletedAt = "2026-02-25T12:30:00.000Z";


### PR DESCRIPTION
## Summary

Fixes #2087.

This updates the settled-turn visited marker to use the server-provided turn completion timestamp instead of falling back to the client wall clock. That prevents the active thread from repeatedly trying to mark itself visited when the client clock is slightly behind the server completion time.

A focused regression test now covers preserving provided visited timestamps and refusing to move visit state backwards under skew.

## Validation

- `bun run --filter @t3tools/web test -- uiStateStore.test.ts`
- `bun fmt`
- `bun lint` (passes with existing warnings)
- `bun typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix visited timestamp in `markThreadVisited` under clock skew
> - Updates [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2408/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to pass `activeLatestTurn.completedAt` as a second argument to `markThreadVisited`, so the stored timestamp reflects the server's completion time rather than the local clock.
> - Updates `markThreadVisited` in the UI state store to avoid overwriting a stored timestamp with an earlier one, preventing regressions under clock skew.
> - Adds two unit tests in [uiStateStore.test.ts](https://github.com/pingdotgg/t3code/pull/2408/files#diff-f045a4bbc0c8a95f991978fe10ac7a4b4c0fcd8109f1f4c180f9ce253f3faf1d) covering the new timestamp storage and the clock skew guard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccafe71.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the read/unread visit timestamp logic, which could affect badge/visited state across threads if timestamps are malformed or comparisons are incorrect, but the scope is small and covered by new tests.
> 
> **Overview**
> Fixes thread visit tracking so the UI records the *server-provided* `latestTurn.completedAt` timestamp when a settled turn completes, instead of implicitly using the client wall clock.
> 
> Updates `markThreadVisited` to accept an explicit `visitedAt` and to no-op when the incoming timestamp is older than the stored one (guarding against clock skew), with new unit tests covering both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccafe71b7efa83f1ed3da3403558c63be29c6db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->