### PR TITLE
[codex] Fix Windows GitHub PR title argument handling

### DIFF
--- a/apps/server/src/git/Layers/GitHubCli.test.ts
+++ b/apps/server/src/git/Layers/GitHubCli.test.ts
@@ -205,6 +205,50 @@ layer("GitHubCliLive", (it) => {
     }),
   );
 
+  it.effect("creates pull requests with the title passed as a single argv value", () =>
+    Effect.gen(function* () {
+      mockedRunProcess.mockResolvedValueOnce({
+        stdout: "https://github.com/pingdotgg/codething-mvp/pull/42\n",
+        stderr: "",
+        code: 0,
+        signal: null,
+        timedOut: false,
+      });
+
+      yield* Effect.gen(function* () {
+        const gh = yield* GitHubCli;
+        yield* gh.createPullRequest({
+          cwd: "/repo",
+          baseBranch: "main",
+          headSelector: "dev",
+          title: "Stabilize map selection, pricing badges, and camera handling",
+          bodyFile:
+            "C:\\Users\\leo20\\AppData\\Local\\Temp\\t3code-pr-body-38228-73481782-d57c-4b4d-ab5e-9906dc728b2b.md",
+        });
+      });
+
+      expect(mockedRunProcess).toHaveBeenCalledWith(
+        "gh",
+        [
+          "pr",
+          "create",
+          "--base",
+          "main",
+          "--head",
+          "dev",
+          "--title",
+          "Stabilize map selection, pricing badges, and camera handling",
+          "--body-file",
+          "C:\\Users\\leo20\\AppData\\Local\\Temp\\t3code-pr-body-38228-73481782-d57c-4b4d-ab5e-9906dc728b2b.md",
+        ],
+        expect.objectContaining({
+          cwd: "/repo",
+          shell: false,
+        }),
+      );
+    }),
+  );
+
   it.effect("surfaces a friendly error when the pull request is not found", () =>
     Effect.gen(function* () {
       mockedRunProcess.mockRejectedValueOnce(

--- a/apps/server/src/git/Layers/GitHubCli.ts
+++ b/apps/server/src/git/Layers/GitHubCli.ts
@@ -107,6 +107,7 @@ const makeGitHubCli = Effect.sync(() => {
       try: () =>
         runProcess("gh", input.args, {
           cwd: input.cwd,
+          shell: false,
           timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         }),
       catch: (error) => normalizeGitHubCliError("execute", error),

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -5,6 +5,7 @@ export interface ProcessRunOptions {
   timeoutMs?: number | undefined;
   env?: NodeJS.ProcessEnv | undefined;
   stdin?: string | undefined;
+  shell?: boolean | string | undefined;
   allowNonZeroExit?: boolean | undefined;
   maxBufferBytes?: number | undefined;
   outputMode?: "error" | "truncate" | undefined;
@@ -152,7 +153,7 @@ export async function runProcess(
       cwd: options.cwd,
       env: options.env,
       stdio: "pipe",
-      shell: process.platform === "win32",
+      shell: options.shell ?? process.platform === "win32",
     });
 
     let stdout = "";


### PR DESCRIPTION
## Summary

Fixes #1672.

This changes the GitHub CLI layer to invoke `gh` without shell re-parsing so PR titles containing spaces remain a single argv value on Windows. It also adds an explicit `runProcess` shell override for callers that need to bypass the default Windows shell behavior.

## Root Cause

`runProcess` defaults to `shell: true` on Windows. When `gh pr create` was executed through `cmd.exe`, a multi-word `--title` value could be split into separate arguments before reaching GitHub CLI.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test -- --filter=t3`
- `bun run test -- src/git/Layers/GitHubCli.test.ts src/processRunner.test.ts` from `apps/server`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows GitHub PR title argument handling by disabling shell for `gh` CLI invocations
> - Adds an optional `shell` property to `ProcessRunOptions` in [processRunner.ts](https://github.com/pingdotgg/t3code/pull/2410/files#diff-5a47a42313dddcd1d898b2fd498aab076e20a9447c1fc581a0eaa174b917068c), defaulting to `true` on Windows and `false` elsewhere when not specified.
> - Updates `makeGitHubCli` in [GitHubCli.ts](https://github.com/pingdotgg/t3code/pull/2410/files#diff-97968eab7fdc99fda8af3ce3b46949beac5e717c360efb086a5a94d9c1829b85) to explicitly pass `shell: false`, so PR titles with special characters are not mangled by the shell on Windows.
> - Behavioral Change: `gh` commands now always run without a shell regardless of platform, overriding the previous Windows default.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 387a577.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->