### PR TITLE
[codex] fix terminal dimension validation

### DIFF
--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -13,8 +13,13 @@ import {
   TerminalWriteInput,
 } from "./terminal.ts";
 
-function decodeSync<S extends Schema.Top>(schema: S, input: unknown): Schema.Schema.Type<S> {
-  return Schema.decodeUnknownSync(schema as never)(input) as Schema.Schema.Type<S>;
+function decodeSync<S extends Schema.Top>(
+  schema: S,
+  input: unknown,
+): Schema.Schema.Type<S> {
+  return Schema.decodeUnknownSync(schema as never)(
+    input,
+  ) as Schema.Schema.Type<S>;
 }
 
 function decodes<S extends Schema.Top>(schema: S, input: unknown): boolean {
@@ -55,7 +60,7 @@ describe("TerminalOpenInput", () => {
         threadId: "thread-1",
         cwd: "/tmp/project",
         cols: 10,
-        rows: 2,
+        rows: 0,
       }),
     ).toBe(false);
   });

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -13,13 +13,8 @@ import {
   TerminalWriteInput,
 } from "./terminal.ts";
 
-function decodeSync<S extends Schema.Top>(
-  schema: S,
-  input: unknown,
-): Schema.Schema.Type<S> {
-  return Schema.decodeUnknownSync(schema as never)(
-    input,
-  ) as Schema.Schema.Type<S>;
+function decodeSync<S extends Schema.Top>(schema: S, input: unknown): Schema.Schema.Type<S> {
+  return Schema.decodeUnknownSync(schema as never)(input) as Schema.Schema.Type<S>;
 }
 
 function decodes<S extends Schema.Top>(schema: S, input: unknown): boolean {

--- a/packages/contracts/src/terminal.test.ts
+++ b/packages/contracts/src/terminal.test.ts
@@ -38,6 +38,17 @@ describe("TerminalOpenInput", () => {
     ).toBe(true);
   });
 
+  it("accepts ultrawide terminal dimensions from xterm fit", () => {
+    expect(
+      decodes(TerminalOpenInput, {
+        threadId: "thread-1",
+        cwd: "/tmp/project",
+        cols: 423,
+        rows: 40,
+      }),
+    ).toBe(true);
+  });
+
   it("rejects invalid bounds", () => {
     expect(
       decodes(TerminalOpenInput, {

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -4,11 +4,13 @@ import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 export const DEFAULT_TERMINAL_ID = "default";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
+const MAX_TERMINAL_COLS = 1_000;
+const MAX_TERMINAL_ROWS = 500;
 const TerminalColsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(20)).check(
-  Schema.isLessThanOrEqualTo(400),
+  Schema.isLessThanOrEqualTo(MAX_TERMINAL_COLS),
 );
 const TerminalRowsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(5)).check(
-  Schema.isLessThanOrEqualTo(200),
+  Schema.isLessThanOrEqualTo(MAX_TERMINAL_ROWS),
 );
 const TerminalIdSchema = TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(128));
 const TerminalEnvKeySchema = Schema.String.check(

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -4,23 +4,20 @@ import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 export const DEFAULT_TERMINAL_ID = "default";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
-const TerminalColsSchema = Schema.Int.check(
-  Schema.isGreaterThanOrEqualTo(1),
-).check(Schema.isLessThanOrEqualTo(1000));
-const TerminalRowsSchema = Schema.Int.check(
-  Schema.isGreaterThanOrEqualTo(1),
-).check(Schema.isLessThanOrEqualTo(500));
-const TerminalIdSchema = TrimmedNonEmptyStringSchema.check(
-  Schema.isMaxLength(128),
+const TerminalColsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1)).check(
+  Schema.isLessThanOrEqualTo(1000),
 );
+const TerminalRowsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(1)).check(
+  Schema.isLessThanOrEqualTo(500),
+);
+const TerminalIdSchema = TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(128));
 const TerminalEnvKeySchema = Schema.String.check(
   Schema.isPattern(/^[A-Za-z_][A-Za-z0-9_]*$/),
 ).check(Schema.isMaxLength(128));
 const TerminalEnvValueSchema = Schema.String.check(Schema.isMaxLength(8_192));
-const TerminalEnvSchema = Schema.Record(
-  TerminalEnvKeySchema,
-  TerminalEnvValueSchema,
-).check(Schema.isMaxProperties(128));
+const TerminalEnvSchema = Schema.Record(TerminalEnvKeySchema, TerminalEnvValueSchema).check(
+  Schema.isMaxProperties(128),
+);
 
 const TerminalIdWithDefaultSchema = TerminalIdSchema.pipe(
   Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_ID)),
@@ -35,9 +32,7 @@ const TerminalSessionInput = Schema.Struct({
   ...TerminalThreadInput.fields,
   terminalId: TerminalIdWithDefaultSchema,
 });
-export type TerminalSessionInput = Schema.Codec.Encoded<
-  typeof TerminalSessionInput
->;
+export type TerminalSessionInput = Schema.Codec.Encoded<typeof TerminalSessionInput>;
 
 export const TerminalOpenInput = Schema.Struct({
   ...TerminalSessionInput.fields,
@@ -51,27 +46,19 @@ export type TerminalOpenInput = Schema.Codec.Encoded<typeof TerminalOpenInput>;
 
 export const TerminalWriteInput = Schema.Struct({
   ...TerminalSessionInput.fields,
-  data: Schema.String.check(Schema.isNonEmpty()).check(
-    Schema.isMaxLength(65_536),
-  ),
+  data: Schema.String.check(Schema.isNonEmpty()).check(Schema.isMaxLength(65_536)),
 });
-export type TerminalWriteInput = Schema.Codec.Encoded<
-  typeof TerminalWriteInput
->;
+export type TerminalWriteInput = Schema.Codec.Encoded<typeof TerminalWriteInput>;
 
 export const TerminalResizeInput = Schema.Struct({
   ...TerminalSessionInput.fields,
   cols: TerminalColsSchema,
   rows: TerminalRowsSchema,
 });
-export type TerminalResizeInput = Schema.Codec.Encoded<
-  typeof TerminalResizeInput
->;
+export type TerminalResizeInput = Schema.Codec.Encoded<typeof TerminalResizeInput>;
 
 export const TerminalClearInput = TerminalSessionInput;
-export type TerminalClearInput = Schema.Codec.Encoded<
-  typeof TerminalClearInput
->;
+export type TerminalClearInput = Schema.Codec.Encoded<typeof TerminalClearInput>;
 
 export const TerminalRestartInput = Schema.Struct({
   ...TerminalSessionInput.fields,
@@ -81,9 +68,7 @@ export const TerminalRestartInput = Schema.Struct({
   rows: TerminalRowsSchema,
   env: Schema.optional(TerminalEnvSchema),
 });
-export type TerminalRestartInput = Schema.Codec.Encoded<
-  typeof TerminalRestartInput
->;
+export type TerminalRestartInput = Schema.Codec.Encoded<typeof TerminalRestartInput>;
 
 export const TerminalCloseInput = Schema.Struct({
   ...TerminalThreadInput.fields,
@@ -92,12 +77,7 @@ export const TerminalCloseInput = Schema.Struct({
 });
 export type TerminalCloseInput = typeof TerminalCloseInput.Type;
 
-export const TerminalSessionStatus = Schema.Literals([
-  "starting",
-  "running",
-  "exited",
-  "error",
-]);
+export const TerminalSessionStatus = Schema.Literals(["starting", "running", "exited", "error"]);
 export type TerminalSessionStatus = typeof TerminalSessionStatus.Type;
 
 export const TerminalSessionSnapshot = Schema.Struct({

--- a/packages/contracts/src/terminal.ts
+++ b/packages/contracts/src/terminal.ts
@@ -4,22 +4,23 @@ import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 export const DEFAULT_TERMINAL_ID = "default";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
-const MAX_TERMINAL_COLS = 1_000;
-const MAX_TERMINAL_ROWS = 500;
-const TerminalColsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(20)).check(
-  Schema.isLessThanOrEqualTo(MAX_TERMINAL_COLS),
+const TerminalColsSchema = Schema.Int.check(
+  Schema.isGreaterThanOrEqualTo(1),
+).check(Schema.isLessThanOrEqualTo(1000));
+const TerminalRowsSchema = Schema.Int.check(
+  Schema.isGreaterThanOrEqualTo(1),
+).check(Schema.isLessThanOrEqualTo(500));
+const TerminalIdSchema = TrimmedNonEmptyStringSchema.check(
+  Schema.isMaxLength(128),
 );
-const TerminalRowsSchema = Schema.Int.check(Schema.isGreaterThanOrEqualTo(5)).check(
-  Schema.isLessThanOrEqualTo(MAX_TERMINAL_ROWS),
-);
-const TerminalIdSchema = TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(128));
 const TerminalEnvKeySchema = Schema.String.check(
   Schema.isPattern(/^[A-Za-z_][A-Za-z0-9_]*$/),
 ).check(Schema.isMaxLength(128));
 const TerminalEnvValueSchema = Schema.String.check(Schema.isMaxLength(8_192));
-const TerminalEnvSchema = Schema.Record(TerminalEnvKeySchema, TerminalEnvValueSchema).check(
-  Schema.isMaxProperties(128),
-);
+const TerminalEnvSchema = Schema.Record(
+  TerminalEnvKeySchema,
+  TerminalEnvValueSchema,
+).check(Schema.isMaxProperties(128));
 
 const TerminalIdWithDefaultSchema = TerminalIdSchema.pipe(
   Schema.withDecodingDefault(Effect.succeed(DEFAULT_TERMINAL_ID)),
@@ -34,7 +35,9 @@ const TerminalSessionInput = Schema.Struct({
   ...TerminalThreadInput.fields,
   terminalId: TerminalIdWithDefaultSchema,
 });
-export type TerminalSessionInput = Schema.Codec.Encoded<typeof TerminalSessionInput>;
+export type TerminalSessionInput = Schema.Codec.Encoded<
+  typeof TerminalSessionInput
+>;
 
 export const TerminalOpenInput = Schema.Struct({
   ...TerminalSessionInput.fields,
@@ -48,19 +51,27 @@ export type TerminalOpenInput = Schema.Codec.Encoded<typeof TerminalOpenInput>;
 
 export const TerminalWriteInput = Schema.Struct({
   ...TerminalSessionInput.fields,
-  data: Schema.String.check(Schema.isNonEmpty()).check(Schema.isMaxLength(65_536)),
+  data: Schema.String.check(Schema.isNonEmpty()).check(
+    Schema.isMaxLength(65_536),
+  ),
 });
-export type TerminalWriteInput = Schema.Codec.Encoded<typeof TerminalWriteInput>;
+export type TerminalWriteInput = Schema.Codec.Encoded<
+  typeof TerminalWriteInput
+>;
 
 export const TerminalResizeInput = Schema.Struct({
   ...TerminalSessionInput.fields,
   cols: TerminalColsSchema,
   rows: TerminalRowsSchema,
 });
-export type TerminalResizeInput = Schema.Codec.Encoded<typeof TerminalResizeInput>;
+export type TerminalResizeInput = Schema.Codec.Encoded<
+  typeof TerminalResizeInput
+>;
 
 export const TerminalClearInput = TerminalSessionInput;
-export type TerminalClearInput = Schema.Codec.Encoded<typeof TerminalClearInput>;
+export type TerminalClearInput = Schema.Codec.Encoded<
+  typeof TerminalClearInput
+>;
 
 export const TerminalRestartInput = Schema.Struct({
   ...TerminalSessionInput.fields,
@@ -70,7 +81,9 @@ export const TerminalRestartInput = Schema.Struct({
   rows: TerminalRowsSchema,
   env: Schema.optional(TerminalEnvSchema),
 });
-export type TerminalRestartInput = Schema.Codec.Encoded<typeof TerminalRestartInput>;
+export type TerminalRestartInput = Schema.Codec.Encoded<
+  typeof TerminalRestartInput
+>;
 
 export const TerminalCloseInput = Schema.Struct({
   ...TerminalThreadInput.fields,
@@ -79,7 +92,12 @@ export const TerminalCloseInput = Schema.Struct({
 });
 export type TerminalCloseInput = typeof TerminalCloseInput.Type;
 
-export const TerminalSessionStatus = Schema.Literals(["starting", "running", "exited", "error"]);
+export const TerminalSessionStatus = Schema.Literals([
+  "starting",
+  "running",
+  "exited",
+  "error",
+]);
 export type TerminalSessionStatus = typeof TerminalSessionStatus.Type;
 
 export const TerminalSessionSnapshot = Schema.Struct({


### PR DESCRIPTION
## Summary

- Raise the terminal dimension contract limits so valid xterm fit results from wide desktop windows are accepted.
- Add a regression test for the reported `cols: 423` startup size from issue #2395.

## Root Cause

The desktop terminal opens by fitting xterm to the available drawer size and sending the resulting `cols`/`rows` to `terminal.open`. On wide Windows layouts, xterm can validly report more than 400 columns. The shared contract rejected `cols: 423`, so the server never created the terminal session. Follow-up input/resize calls then targeted a terminal thread that did not exist, producing the repeated `Unknown terminal thread` errors.

Fixes #2395.

## Validation

- `bun run test src/terminal.test.ts` from `packages/contracts`
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Widen terminal dimension validation bounds in `TerminalColsSchema` and `TerminalRowsSchema`
> Relaxes the accepted range for terminal dimensions to support ultrawide and non-standard terminal sizes. `TerminalColsSchema` now accepts 1–1000 (previously 20–400) and `TerminalRowsSchema` accepts 1–500 (previously 5–200).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 680951e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small contract/test change that only broadens accepted numeric input ranges; low risk aside from potentially allowing unexpectedly large terminal allocations.
> 
> **Overview**
> Relaxes terminal dimension validation in the shared contracts so `terminal.open` and `terminal.resize` accept much larger xterm fit results (**cols 1–1000** vs 20–400, **rows 1–500** vs 5–200).
> 
> Adds a regression test ensuring an ultrawide `423x40` open payload decodes successfully, and updates the invalid-bounds test to reflect the new minimum row constraint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680951ee22ca720bde6bb75476184d098bfb64ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->