### PR TITLE
Clamp Claude token usage to selected context window

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1710,6 +1710,133 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("uses the selected 200k Claude context window for progress snapshots", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+
+      const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 6).pipe(
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-4-6",
+          [{ id: "contextWindow", value: "200k" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      harness.query.emit({
+        type: "system",
+        subtype: "task_progress",
+        task_id: "task-usage-selected-window",
+        description: "Thinking through the patch",
+        usage: {
+          total_tokens: 535000,
+        },
+        session_id: "sdk-session-task-usage-selected-window",
+        uuid: "task-usage-selected-window",
+      } as unknown as SDKMessage);
+
+      const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+      const usageEvent = runtimeEvents.find((event) => event.type === "thread.token-usage.updated");
+      assert.equal(usageEvent?.type, "thread.token-usage.updated");
+      if (usageEvent?.type === "thread.token-usage.updated") {
+        assert.deepEqual(usageEvent.payload, {
+          usage: {
+            usedTokens: 200000,
+            lastUsedTokens: 200000,
+            totalProcessedTokens: 535000,
+            maxTokens: 200000,
+          },
+        });
+      }
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect(
+    "keeps the selected 200k Claude context window when result model usage is larger",
+    () => {
+      const harness = makeHarness();
+      return Effect.gen(function* () {
+        const adapter = yield* ClaudeAdapter;
+
+        const runtimeEventsFiber = yield* Stream.take(adapter.streamEvents, 7).pipe(
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        const modelSelection = createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-4-6",
+          [{ id: "contextWindow", value: "200k" }],
+        );
+
+        yield* adapter.startSession({
+          threadId: THREAD_ID,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          modelSelection,
+          runtimeMode: "full-access",
+        });
+
+        yield* adapter.sendTurn({
+          threadId: THREAD_ID,
+          input: "hello",
+          attachments: [],
+          modelSelection,
+        });
+
+        harness.query.emit({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          duration_ms: 1234,
+          duration_api_ms: 1200,
+          num_turns: 1,
+          result: "done",
+          stop_reason: "end_turn",
+          session_id: "sdk-session-result-usage-selected-window",
+          usage: {
+            total_tokens: 535000,
+          },
+          modelUsage: {
+            "claude-opus-4-6[1m]": {
+              contextWindow: 1000000,
+              maxOutputTokens: 64000,
+            },
+          },
+        } as unknown as SDKMessage);
+        harness.query.finish();
+
+        const runtimeEvents = Array.from(yield* Fiber.join(runtimeEventsFiber));
+        const usageEvent = runtimeEvents.find(
+          (event) => event.type === "thread.token-usage.updated",
+        );
+        assert.equal(usageEvent?.type, "thread.token-usage.updated");
+        if (usageEvent?.type === "thread.token-usage.updated") {
+          assert.deepEqual(usageEvent.payload, {
+            usage: {
+              usedTokens: 200000,
+              lastUsedTokens: 200000,
+              totalProcessedTokens: 535000,
+              maxTokens: 200000,
+            },
+          });
+        }
+      }).pipe(
+        Effect.provideService(Random.Random, makeDeterministicRandomService()),
+        Effect.provide(harness.layer),
+      );
+    },
+  );
+
   it.effect(
     "preserves oversized Claude result totals after task progress snapshots are recorded",
     () => {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -34,6 +34,7 @@ import {
   type ProviderRuntimeTurnStatus,
   type ProviderSendTurnInput,
   type ProviderSession,
+  type ModelSelection,
   type ThreadTokenUsageSnapshot,
   type ProviderUserInputAnswers,
   type RuntimeContentStreamKind,
@@ -305,6 +306,34 @@ function maxClaudeContextWindowFromModelUsage(
   }
 
   return maxContextWindow;
+}
+
+function parseClaudeContextWindowOption(value: string | undefined): number | undefined {
+  switch (value) {
+    case "200k":
+      return 200_000;
+    case "1m":
+      return 1_000_000;
+    default:
+      return undefined;
+  }
+}
+
+function resolveClaudeSelectedContextWindow(
+  modelSelection: ModelSelection | undefined,
+): number | undefined {
+  if (!modelSelection?.model) {
+    return undefined;
+  }
+  const caps = getClaudeModelCapabilities(modelSelection.model);
+  const contextWindowDescriptor = getProviderOptionDescriptors({
+    caps,
+    selections: modelSelection.options,
+  }).find((descriptor) => descriptor.id === "contextWindow" && descriptor.type === "select");
+
+  return parseClaudeContextWindowOption(
+    contextWindowDescriptor?.type === "select" ? contextWindowDescriptor.currentValue : undefined,
+  );
 }
 
 function normalizeClaudeTokenUsage(
@@ -1408,23 +1437,20 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     result?: SDKResultMessage,
   ) {
     const resultContextWindow = maxClaudeContextWindowFromModelUsage(result?.modelUsage);
-    if (resultContextWindow !== undefined) {
+    if (resultContextWindow !== undefined && context.lastKnownContextWindow === undefined) {
       context.lastKnownContextWindow = resultContextWindow;
     }
+    const maxTokens = context.lastKnownContextWindow ?? resultContextWindow;
 
     // The SDK result.usage contains *accumulated* totals across all API calls
     // (input_tokens, cache_read_input_tokens, etc. summed over every request).
     // This does NOT represent the current context window size.
     // Instead, use the last known context-window-accurate usage from task_progress
     // events and treat the accumulated total as totalProcessedTokens.
-    const accumulatedSnapshot = normalizeClaudeTokenUsage(
-      result?.usage,
-      resultContextWindow ?? context.lastKnownContextWindow,
-    );
+    const accumulatedSnapshot = normalizeClaudeTokenUsage(result?.usage, maxTokens);
     const accumulatedTotalProcessedTokens =
       accumulatedSnapshot?.totalProcessedTokens ?? accumulatedSnapshot?.usedTokens;
     const lastGoodUsage = context.lastKnownTokenUsage;
-    const maxTokens = resultContextWindow ?? context.lastKnownContextWindow;
     const usageSnapshot: ThreadTokenUsageSnapshot | undefined = lastGoodUsage
       ? {
           ...lastGoodUsage,
@@ -2838,6 +2864,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const extraArgs = parseCliArgs(claudeSettings.launchArgs).flags;
       const modelSelection =
         input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+      const selectedContextWindow = resolveClaudeSelectedContextWindow(modelSelection);
       const caps = getClaudeModelCapabilities(modelSelection?.model);
       const descriptors = getProviderOptionDescriptors({ caps });
       const apiModelId = modelSelection ? resolveClaudeApiModelId(modelSelection) : undefined;
@@ -2964,7 +2991,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         turns: [],
         inFlightTools,
         turnState: undefined,
-        lastKnownContextWindow: undefined,
+        lastKnownContextWindow: selectedContextWindow,
         lastKnownTokenUsage: undefined,
         lastAssistantUuid: resumeState?.resumeSessionAt,
         lastThreadStartedId: undefined,
@@ -3049,6 +3076,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       input.modelSelection !== undefined && input.modelSelection.instanceId === boundInstanceId
         ? input.modelSelection
         : undefined;
+    const selectedContextWindow = resolveClaudeSelectedContextWindow(modelSelection);
 
     if (context.turnState) {
       // Auto-close a stale synthetic turn (from background agent responses
@@ -3069,6 +3097,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...context.session,
         model: modelSelection.model,
       };
+      context.lastKnownContextWindow = selectedContextWindow;
     }
 
     // Apply interaction mode by switching the SDK's permission mode.


### PR DESCRIPTION
## Summary
- seed Claude sessions with the selected context window option
- keep the selected 200k window authoritative for progress and completion usage snapshots instead of adopting larger SDK model usage
- add regression coverage for task progress and final result usage events

Fixes #2394

## Validation
- `bun fmt`
- `bun lint` (passes with existing warnings)
- `bun typecheck`
- `cd apps/server && bun run test src/provider/Layers/ClaudeAdapter.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how token usage/maxTokens are derived and emitted for Claude sessions, which can affect UI and any downstream usage/billing telemetry consumers.
> 
> **Overview**
> Makes the Claude adapter treat the **user-selected `contextWindow` option** (e.g. `200k` vs `1m`) as the authoritative max token limit for `thread.token-usage.updated` snapshots.
> 
> The adapter now parses the selected context window from `modelSelection`, seeds `lastKnownContextWindow` at `startSession`, refreshes it on `sendTurn`, and avoids overriding it with larger `result.modelUsage` values when completing a turn; new tests cover task progress and result cases where totals exceed the selected window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f96a63a47976e2b0a93555b159cbcc272f7b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clamp Claude token usage to the user-selected context window
> - Adds `resolveClaudeSelectedContextWindow` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/2412/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) to parse a `ModelSelection`'s `contextWindow` option (`200k` → 200000, `1m` → 1000000) into a numeric value.
> - Initializes `lastKnownContextWindow` from the selected window at session start and on `sendTurn`, so user-chosen limits are set before any result arrives.
> - On turn completion, prefers an existing `lastKnownContextWindow` over the result-reported context window, preventing a larger model-reported window from overriding the user's selection.
> - Behavioral Change: `thread.token-usage.updated` events now report `maxTokens` and clamp `usedTokens` to the selected window rather than the model-reported window when the two differ.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e7f96a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->