### PR TITLE
fix(web): allow closing diff panel in non-git projects

### DIFF
--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -149,14 +149,14 @@ export const ChatHeader = memo(function ChatHeader({
                 aria-label="Toggle diff panel"
                 variant="outline"
                 size="xs"
-                disabled={!isGitRepo}
+                disabled={!isGitRepo && !diffOpen}
               >
                 <DiffIcon className="size-3" />
               </Toggle>
             }
           />
           <TooltipPopup side="bottom">
-            {!isGitRepo
+            {!isGitRepo && !diffOpen
               ? "Diff panel is unavailable because this project is not a git repository."
               : diffToggleShortcutLabel
                 ? `Toggle diff panel (${diffToggleShortcutLabel})`


### PR DESCRIPTION
## What Changed

- keep the diff toggle enabled when the diff panel is already open, even if the active project is not a git repository
- keep the existing disabled state for non-git projects when the diff panel is closed
- keep the tooltip in the normal toggle state while the panel is open so the user can still close it

## Why

If you open the diff panel in a git-backed project and then switch to an already existing thread whose project does not have git, the panel stays open but the header toggle becomes disabled. That traps the panel in an open state.

Opening a new thread already closes the diff panel properly. The broken case is specifically switching to another existing thread where the diff panel remains open across navigation.

This fix stays small and local to the header control: if the panel is currently enabled, it must also be possible to disable it.

Related to #937, but this is a different close-path regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized UI-state change to toggle/tooltip gating; no backend, data, or security impact.
> 
> **Overview**
> Fixes a UI trap where the diff panel could remain open after switching to a non-git project by keeping the diff toggle enabled while `diffOpen` is true.
> 
> Updates the tooltip logic to only show the “not a git repository” message when the panel is closed, allowing users to close the diff panel even when `isGitRepo` is false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e3d5bdfd54228c3d7046f058e734e26d3f467d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix diff panel toggle to allow closing in non-git projects
> In [ChatHeader.tsx](https://github.com/pingdotgg/t3code/pull/2413/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c), the diff toggle button was always disabled for non-git repos, trapping users with an open diff panel they couldn't close. The disabled condition and tooltip now check both `!isGitRepo` and `!diffOpen`, so the toggle stays enabled when the panel is open regardless of git status.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e3d5bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->