### PR TITLE
Enables image attachments in plan follow-up messages

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2433,12 +2433,14 @@ export default function ChatView(props: ChatViewProps) {
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
       });
+      const planFollowUpImages = [...composerImages];
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);
       composerRef.current?.resetCursorState();
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
+        images: planFollowUpImages,
       });
       return;
     }
@@ -2870,9 +2872,11 @@ export default function ChatView(props: ChatViewProps) {
     async ({
       text,
       interactionMode: nextInteractionMode,
+      images = [],
     }: {
       text: string;
       interactionMode: "default" | "plan";
+      images?: ReadonlyArray<ComposerImageAttachment>;
     }) => {
       const api = readEnvironmentApi(environmentId);
       if (
@@ -2914,6 +2918,27 @@ export default function ChatView(props: ChatViewProps) {
         text: trimmed,
       });
 
+      const turnAttachmentsPromise =
+        images.length > 0
+          ? Promise.all(
+              images.map(async (image) => ({
+                type: "image" as const,
+                name: image.name,
+                mimeType: image.mimeType,
+                sizeBytes: image.sizeBytes,
+                dataUrl: await readFileAsDataUrl(image.file),
+              })),
+            )
+          : Promise.resolve([]);
+      const optimisticAttachments = images.map((image) => ({
+        type: "image" as const,
+        id: image.id,
+        name: image.name,
+        mimeType: image.mimeType,
+        sizeBytes: image.sizeBytes,
+        previewUrl: image.previewUrl,
+      }));
+
       sendInFlightRef.current = true;
       beginLocalDispatch({ preparingWorktree: false });
       setThreadError(threadIdForSend, null);
@@ -2930,12 +2955,15 @@ export default function ChatView(props: ChatViewProps) {
           id: messageIdForSend,
           role: "user",
           text: outgoingMessageText,
+          ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
           createdAt: messageCreatedAt,
           streaming: false,
         },
       ]);
 
       try {
+        const turnAttachments = await turnAttachmentsPromise;
+
         await persistThreadSettingsForNextTurn({
           threadId: threadIdForSend,
           createdAt: messageCreatedAt,
@@ -2959,7 +2987,7 @@ export default function ChatView(props: ChatViewProps) {
             messageId: messageIdForSend,
             role: "user",
             text: outgoingMessageText,
-            attachments: [],
+            attachments: turnAttachments,
           },
           modelSelection: ctxSelectedModelSelection,
           titleSeed: activeThread.title,


### PR DESCRIPTION
## What Changed

The `ChatView` component now supports sending image attachments within "plan follow-up" messages. This involved:
- Updating the `onSubmitPlanFollowUp` function to accept an array of image attachments.
- Implementing logic to process these images for optimistic display in the user interface.
- Preparing image data (converting to data URLs) for inclusion in the actual API request payload.

## Why

This enhancement allows users to provide richer context and detailed information when responding to a proposed plan. By enabling the inclusion of relevant images, it improves the clarity and effectiveness of communication within the chat, making follow-up interactions more comprehensive.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/2417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new attachment-handling paths to the plan follow-up send flow, including file-to-dataURL conversion and payload changes, which could affect message dispatch reliability and UI optimism/handoff.
> 
> **Overview**
> Plan follow-up submissions now support image attachments: `onSend` snapshots current composer images when sending a plan follow-up, and `onSubmitPlanFollowUp` accepts an optional `images` array.
> 
> When images are provided, the follow-up message is rendered optimistically with image previews and the subsequent `thread.turn.start` request includes the images as `attachments` by reading files to data URLs before dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad814b5afad7b6c500d7eba92144cf6315207890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add image attachment support to plan follow-up messages in ChatView
> - Extends `onSubmitPlanFollowUp` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2417/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to accept an optional `images` array from the composer.
> - Builds optimistic attachments immediately for UI feedback using image metadata and preview URLs, while asynchronously reading file data URLs for the actual API payload.
> - The `thread.turn.start` command now sends resolved image attachments instead of an empty array for plan follow-up submissions.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized ad814b5. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->