### PR TITLE
fix(settings): disable auto-open of task sidebar by default

### DIFF
--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -40,7 +40,7 @@ export type SidebarThreadPreviewCount = typeof SidebarThreadPreviewCount.Type;
 export const DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT: SidebarThreadPreviewCount = 6;
 
 export const ClientSettingsSchema = Schema.Struct({
-  autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   dismissedProviderUpdateNotificationKeys: Schema.Array(TrimmedNonEmptyString).pipe(


### PR DESCRIPTION
## Summary
- The task/plan sidebar was automatically opening every time a chat with task steps was opened, which is distracting.
- Flip the default of \`autoOpenPlanSidebar\` from \`true\` to \`false\` so the sidebar stays closed until the user clicks to open it.
- Users who prefer the previous behavior can re-enable auto-open in settings.

## Test plan
- [ ] On a fresh client (or after clearing this setting), opening a chat that has plan/task steps does NOT auto-open the plan sidebar.
- [ ] Manually toggling the plan sidebar (button / shortcut) still works.
- [ ] Setting \`autoOpenPlanSidebar\` to \`true\` in settings restores the auto-open behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/2421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default-value change in client settings decoding; no logic or persistence format changes, and users who already saved `true` are unaffected.
> 
> **Overview**
> Changes the **default** for client setting `autoOpenPlanSidebar` in `ClientSettingsSchema` from `true` to `false` via `withDecodingDefault`.
> 
> When the preference is missing (new installs or unset field), the plan/task sidebar **no longer auto-opens** when a chat has plan steps; users can still open it manually or turn auto-open back on in settings. Existing stored values are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22bccbaa21bb369f556f1a51f3e1365fbc9d4772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable auto-open of task sidebar by default in `ClientSettingsSchema`
> Changes the default value of `autoOpenPlanSidebar` in [settings.ts](https://github.com/pingdotgg/t3code/pull/2421/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) from `true` to `false`. Behavioral Change: users who have not explicitly set this preference will no longer see the task sidebar open automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22bccba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default client setting for the plan sidebar to remain closed when first loading the app, instead of opening automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->