### PR TITLE
feat(desktop): register t3:// OS protocol handler for thread deep links

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -18,8 +18,8 @@ const devBundleIdSuffix = NodePath.basename(repoRoot)
 export const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
 export const APP_BUNDLE_ID = isDevelopment
   ? `com.t3tools.t3code.dev.${devBundleIdSuffix || "local"}`
-  : "com.t3tools.t3code";
-const APP_PROTOCOL_SCHEMES = isDevelopment ? ["t3code-dev"] : ["t3code"];
+  : "com.t3tools.t3code.alpha";
+const APP_PROTOCOL_SCHEMES = isDevelopment ? ["t3code-dev"] : ["t3", "t3code"];
 const LAUNCHER_VERSION = 12;
 const defaultIconPath = NodePath.join(desktopDir, "resources", "icon.icns");
 const developmentMacIconPngPath = NodePath.join(

--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -18,8 +18,8 @@ const devBundleIdSuffix = NodePath.basename(repoRoot)
 export const APP_DISPLAY_NAME = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
 export const APP_BUNDLE_ID = isDevelopment
   ? `com.t3tools.t3code.dev.${devBundleIdSuffix || "local"}`
-  : "com.t3tools.t3code";
-const APP_PROTOCOL_SCHEMES = isDevelopment ? ["t3code-dev"] : ["t3code"];
+  : "com.t3tools.t3code.alpha";
+const APP_PROTOCOL_SCHEMES = isDevelopment ? ["t3code-dev"] : ["t3", "t3code"];
 const LAUNCHER_VERSION = 15;
 const developmentMacIconPngPath = NodePath.join(
   repoRoot,

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -12,6 +12,7 @@ import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
 import { installDesktopIpcHandlers } from "../ipc/DesktopIpcHandlers.ts";
 import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
+import * as DesktopDeepLinks from "./DesktopDeepLinks.ts";
 import * as DesktopApplicationMenu from "../window/DesktopApplicationMenu.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 import * as DesktopBackendPool from "../backend/DesktopBackendPool.ts";
@@ -220,6 +221,7 @@ const startup = Effect.gen(function* () {
   const applicationMenu = yield* DesktopApplicationMenu.DesktopApplicationMenu;
   const electronApp = yield* ElectronApp.ElectronApp;
   const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
+  const deepLinks = yield* DesktopDeepLinks.DesktopDeepLinks;
   const clerk = yield* DesktopClerk.DesktopClerk;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
@@ -238,6 +240,7 @@ const startup = Effect.gen(function* () {
 
   yield* appIdentity.configure;
   yield* lifecycle.register;
+  yield* deepLinks.registerEarly;
   yield* clerk.configure;
 
   yield* electronApp.whenReady.pipe(
@@ -247,6 +250,7 @@ const startup = Effect.gen(function* () {
   yield* logStartupInfo("app ready");
   yield* appIdentity.configure;
   yield* applicationMenu.configure;
+  yield* deepLinks.configure;
   yield* updates.configure;
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));
 }).pipe(Effect.withSpan("desktop.startup"));

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -13,6 +13,7 @@ import * as ElectronSafeStorage from "../electron/ElectronSafeStorage.ts";
 import { installDesktopIpcHandlers } from "../ipc/DesktopIpcHandlers.ts";
 import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
+import * as DesktopDeepLinks from "./DesktopDeepLinks.ts";
 import * as DesktopApplicationMenu from "../window/DesktopApplicationMenu.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 import * as DesktopBackendPool from "../backend/DesktopBackendPool.ts";
@@ -224,6 +225,7 @@ const startup = Effect.gen(function* () {
   const electronApp = yield* ElectronApp.ElectronApp;
   const lifecycle = yield* DesktopLifecycle.DesktopLifecycle;
   const linuxUrlHandler = yield* DesktopLinuxUrlHandler.DesktopLinuxUrlHandler;
+  const deepLinks = yield* DesktopDeepLinks.DesktopDeepLinks;
   const clerk = yield* DesktopClerk.DesktopClerk;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
@@ -270,6 +272,7 @@ const startup = Effect.gen(function* () {
 
   yield* appIdentity.configure;
   yield* lifecycle.register;
+  yield* deepLinks.registerEarly;
   yield* clerk.configure;
 
   yield* electronApp.whenReady.pipe(
@@ -285,6 +288,7 @@ const startup = Effect.gen(function* () {
   }
   yield* appIdentity.configure;
   yield* applicationMenu.configure;
+  yield* deepLinks.configure;
   yield* updates.configure;
   yield* linuxUrlHandler.register;
   yield* bootstrap.pipe(Effect.catchCause((cause) => fatalStartupCause("bootstrap", cause)));

--- a/apps/desktop/src/app/DesktopDeepLinks.ts
+++ b/apps/desktop/src/app/DesktopDeepLinks.ts
@@ -1,0 +1,114 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Scope from "effect/Scope";
+
+import type * as Electron from "electron";
+
+import { makeComponentLogger } from "./DesktopObservability.ts";
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+import {
+  DESKTOP_THREAD_DEEP_LINK_SCHEME,
+  findThreadDeepLinkInArgv,
+  parseThreadDeepLinkUrl,
+} from "../deeplink/threadDeepLink.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+import type { DesktopWindowError } from "../window/DesktopWindow.ts";
+
+type DesktopDeepLinkRuntimeServices =
+  | DesktopEnvironment.DesktopEnvironment
+  | DesktopWindow.DesktopWindow
+  | ElectronApp.ElectronApp;
+
+/**
+ * @effect-expect-leaking DesktopEnvironment | DesktopWindow | ElectronApp
+ */
+export class DesktopDeepLinks extends Context.Service<
+  DesktopDeepLinks,
+  {
+    readonly registerEarly: Effect.Effect<
+      void,
+      never,
+      Scope.Scope | DesktopDeepLinkRuntimeServices
+    >;
+    readonly configure: Effect.Effect<void, never, DesktopDeepLinkRuntimeServices>;
+  }
+>()("@t3tools/desktop/app/DesktopDeepLinks") {}
+
+const { logInfo: logDeepLinkInfo, logError: logDeepLinkError } =
+  makeComponentLogger("desktop-deeplink");
+
+export const make = Effect.gen(function* () {
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const electronApp = yield* ElectronApp.ElectronApp;
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const context = yield* Effect.context<DesktopDeepLinkRuntimeServices>();
+  const runPromise = Effect.runPromiseWith(context);
+
+  const openThreadDeepLink = (threadId: string) =>
+    Effect.gen(function* () {
+      yield* logDeepLinkInfo("open thread deep link", { threadId });
+      yield* desktopWindow
+        .openThread(threadId)
+        .pipe(
+          Effect.catch((error: DesktopWindowError) =>
+            logDeepLinkError("failed to open thread deep link", { threadId, error }),
+          ),
+        );
+    }).pipe(Effect.withSpan("desktop.deeplink.openThread"));
+
+  const handleDeepLinkUrl = (rawUrl: string) =>
+    Effect.gen(function* () {
+      const threadId = parseThreadDeepLinkUrl(rawUrl);
+      if (Option.isNone(threadId)) {
+        return;
+      }
+      yield* openThreadDeepLink(threadId.value);
+    }).pipe(Effect.withSpan("desktop.deeplink.handleUrl"));
+
+  return DesktopDeepLinks.of({
+    registerEarly: Effect.gen(function* () {
+      yield* electronApp.on("open-url", (event: Electron.Event, url: string) => {
+        event.preventDefault();
+        void runPromise(handleDeepLinkUrl(url));
+      });
+
+      yield* electronApp.on(
+        "second-instance",
+        (_event: Electron.Event, argv: readonly string[]) => {
+          const launchUrl = findThreadDeepLinkInArgv(argv);
+          if (Option.isSome(launchUrl)) {
+            void runPromise(openThreadDeepLink(launchUrl.value));
+          }
+        },
+      );
+    }).pipe(Effect.withSpan("desktop.deeplink.registerEarly")),
+
+    configure: Effect.gen(function* () {
+      // Pin registration to this executable on macOS so Launch Services routes
+      // `t3://` links to the running channel (Alpha/Nightly) instead of whichever
+      // app happens to share the production bundle id.
+      const registered = yield* environment.platform === "darwin"
+        ? electronApp.setAsDefaultProtocolClient(
+            DESKTOP_THREAD_DEEP_LINK_SCHEME,
+            process.execPath,
+            [],
+          )
+        : electronApp.setAsDefaultProtocolClient(DESKTOP_THREAD_DEEP_LINK_SCHEME);
+      if (!registered) {
+        yield* logDeepLinkError("failed to register default protocol client", {
+          scheme: DESKTOP_THREAD_DEEP_LINK_SCHEME,
+        });
+      }
+
+      const launchThreadId = findThreadDeepLinkInArgv(process.argv);
+      if (Option.isSome(launchThreadId)) {
+        yield* openThreadDeepLink(launchThreadId.value);
+      }
+    }).pipe(Effect.withSpan("desktop.deeplink.configure")),
+  });
+});
+
+export const layer = Layer.effect(DesktopDeepLinks, make);

--- a/apps/desktop/src/app/DesktopDeepLinks.ts
+++ b/apps/desktop/src/app/DesktopDeepLinks.ts
@@ -1,0 +1,95 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Scope from "effect/Scope";
+
+import type * as Electron from "electron";
+
+import { makeComponentLogger } from "./DesktopObservability.ts";
+import {
+  DESKTOP_THREAD_DEEP_LINK_SCHEME,
+  findThreadDeepLinkInArgv,
+  parseThreadDeepLinkUrl,
+} from "../deeplink/threadDeepLink.ts";
+import * as ElectronApp from "../electron/ElectronApp.ts";
+import * as DesktopWindow from "../window/DesktopWindow.ts";
+import type { DesktopWindowError } from "../window/DesktopWindow.ts";
+
+type DesktopDeepLinkRuntimeServices = DesktopWindow.DesktopWindow | ElectronApp.ElectronApp;
+
+/**
+ * @effect-expect-leaking DesktopWindow | ElectronApp
+ */
+export class DesktopDeepLinks extends Context.Service<
+  DesktopDeepLinks,
+  {
+    readonly registerEarly: Effect.Effect<
+      void,
+      never,
+      Scope.Scope | DesktopDeepLinkRuntimeServices
+    >;
+    readonly configure: Effect.Effect<void, never, DesktopDeepLinkRuntimeServices>;
+  }
+>()("@t3tools/desktop/app/DesktopDeepLinks") {}
+
+const { logInfo: logDeepLinkInfo, logError: logDeepLinkError } =
+  makeComponentLogger("desktop-deeplink");
+
+export const make = Effect.gen(function* () {
+  const desktopWindow = yield* DesktopWindow.DesktopWindow;
+  const electronApp = yield* ElectronApp.ElectronApp;
+  const context = yield* Effect.context<DesktopDeepLinkRuntimeServices>();
+  const runPromise = Effect.runPromiseWith(context);
+
+  const openThreadDeepLink = (threadId: string) =>
+    Effect.gen(function* () {
+      yield* logDeepLinkInfo("open thread deep link", { threadId });
+      yield* desktopWindow
+        .openThread(threadId)
+        .pipe(
+          Effect.catch((error: DesktopWindowError) =>
+            logDeepLinkError("failed to open thread deep link", { threadId, error }),
+          ),
+        );
+    }).pipe(Effect.withSpan("desktop.deeplink.openThread"));
+
+  const handleDeepLinkUrl = (rawUrl: string) =>
+    Effect.gen(function* () {
+      const threadId = parseThreadDeepLinkUrl(rawUrl);
+      if (Option.isNone(threadId)) {
+        return;
+      }
+      yield* openThreadDeepLink(threadId.value);
+    }).pipe(Effect.withSpan("desktop.deeplink.handleUrl"));
+
+  return DesktopDeepLinks.of({
+    registerEarly: Effect.gen(function* () {
+      yield* electronApp.on("open-url", (event: Electron.Event, url: string) => {
+        event.preventDefault();
+        void runPromise(handleDeepLinkUrl(url));
+      });
+
+      yield* electronApp.on(
+        "second-instance",
+        (_event: Electron.Event, argv: readonly string[]) => {
+          const launchUrl = findThreadDeepLinkInArgv(argv);
+          if (Option.isSome(launchUrl)) {
+            void runPromise(openThreadDeepLink(launchUrl.value));
+          }
+        },
+      );
+    }).pipe(Effect.withSpan("desktop.deeplink.registerEarly")),
+
+    configure: Effect.gen(function* () {
+      yield* electronApp.setAsDefaultProtocolClient(DESKTOP_THREAD_DEEP_LINK_SCHEME);
+
+      const launchThreadId = findThreadDeepLinkInArgv(process.argv);
+      if (Option.isSome(launchThreadId)) {
+        yield* openThreadDeepLink(launchThreadId.value);
+      }
+    }).pipe(Effect.withSpan("desktop.deeplink.configure")),
+  });
+});
+
+export const layer = Layer.effect(DesktopDeepLinks, make);

--- a/apps/desktop/src/app/DesktopDeepLinks.ts
+++ b/apps/desktop/src/app/DesktopDeepLinks.ts
@@ -7,6 +7,7 @@ import * as Scope from "effect/Scope";
 import type * as Electron from "electron";
 
 import { makeComponentLogger } from "./DesktopObservability.ts";
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import {
   DESKTOP_THREAD_DEEP_LINK_SCHEME,
   findThreadDeepLinkInArgv,
@@ -16,10 +17,13 @@ import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 import type { DesktopWindowError } from "../window/DesktopWindow.ts";
 
-type DesktopDeepLinkRuntimeServices = DesktopWindow.DesktopWindow | ElectronApp.ElectronApp;
+type DesktopDeepLinkRuntimeServices =
+  | DesktopEnvironment.DesktopEnvironment
+  | DesktopWindow.DesktopWindow
+  | ElectronApp.ElectronApp;
 
 /**
- * @effect-expect-leaking DesktopWindow | ElectronApp
+ * @effect-expect-leaking DesktopEnvironment | DesktopWindow | ElectronApp
  */
 export class DesktopDeepLinks extends Context.Service<
   DesktopDeepLinks,
@@ -39,6 +43,7 @@ const { logInfo: logDeepLinkInfo, logError: logDeepLinkError } =
 export const make = Effect.gen(function* () {
   const desktopWindow = yield* DesktopWindow.DesktopWindow;
   const electronApp = yield* ElectronApp.ElectronApp;
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const context = yield* Effect.context<DesktopDeepLinkRuntimeServices>();
   const runPromise = Effect.runPromiseWith(context);
 
@@ -82,7 +87,21 @@ export const make = Effect.gen(function* () {
     }).pipe(Effect.withSpan("desktop.deeplink.registerEarly")),
 
     configure: Effect.gen(function* () {
-      yield* electronApp.setAsDefaultProtocolClient(DESKTOP_THREAD_DEEP_LINK_SCHEME);
+      // Pin registration to this executable on macOS so Launch Services routes
+      // `t3://` links to the running channel (Alpha/Nightly) instead of whichever
+      // app happens to share the production bundle id.
+      const registered = yield* environment.platform === "darwin"
+        ? electronApp.setAsDefaultProtocolClient(
+            DESKTOP_THREAD_DEEP_LINK_SCHEME,
+            process.execPath,
+            [],
+          )
+        : electronApp.setAsDefaultProtocolClient(DESKTOP_THREAD_DEEP_LINK_SCHEME);
+      if (!registered) {
+        yield* logDeepLinkError("failed to register default protocol client", {
+          scheme: DESKTOP_THREAD_DEEP_LINK_SCHEME,
+        });
+      }
 
       const launchThreadId = findThreadDeepLinkInArgv(process.argv);
       if (Option.isSome(launchThreadId)) {

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -13,7 +13,7 @@ import * as Path from "effect/Path";
 
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopConfig from "./DesktopConfig.ts";
-import { isNightlyDesktopVersion } from "../updates/updateChannels.ts";
+import { isNightlyDesktopVersion, resolveDesktopAppBundleId } from "../updates/updateChannels.ts";
 
 export interface MakeDesktopEnvironmentInput {
   readonly dirname: string;
@@ -157,7 +157,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
   const displayName = branding.displayName;
   const stateDir = path.join(baseDir, isDevelopment ? "dev" : "userdata");
   const userDataDirName = isDevelopment ? "t3code-dev" : "t3code";
-  const legacyUserDataDirName = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
+  const legacyUserDataDirName = branding.displayName;
   const resourcesPath = input.resourcesPath;
 
   return DesktopEnvironment.of({
@@ -197,7 +197,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     branding,
     displayName,
     appUserModelId: Option.getOrElse(config.appUserModelIdOverride, () =>
-      isDevelopment ? "com.t3tools.t3code.dev" : "com.t3tools.t3code",
+      resolveDesktopAppBundleId({ isDevelopment, appVersion: input.appVersion }),
     ),
     linuxDesktopEntryName: isDevelopment ? "t3code-dev.desktop" : "t3code.desktop",
     linuxWmClass: isDevelopment ? "t3code-dev" : "t3code",

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -14,7 +14,7 @@ import * as Path from "effect/Path";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopConfig from "./DesktopConfig.ts";
 import { resolveDesktopBaseDir, resolveDesktopStateDir } from "./DesktopStatePaths.ts";
-import { isNightlyDesktopVersion } from "../updates/updateChannels.ts";
+import { isNightlyDesktopVersion, resolveDesktopAppBundleId } from "../updates/updateChannels.ts";
 
 export interface MakeDesktopEnvironmentInput {
   readonly dirname: string;
@@ -179,7 +179,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     t3Home: config.t3Home,
   });
   const userDataDirName = isDevelopment ? "t3code-dev" : "t3code";
-  const legacyUserDataDirName = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
+  const legacyUserDataDirName = branding.displayName;
   const linuxApplicationsDir = path.join(
     Option.getOrElse(config.xdgDataHome, () => path.join(homeDirectory, ".local", "share")),
     "applications",
@@ -224,7 +224,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     branding,
     displayName,
     appUserModelId: Option.getOrElse(config.appUserModelIdOverride, () =>
-      isDevelopment ? "com.t3tools.t3code.dev" : "com.t3tools.t3code",
+      resolveDesktopAppBundleId({ isDevelopment, appVersion: input.appVersion }),
     ),
     linuxDesktopEntryName: isDevelopment ? "t3code-dev.desktop" : "t3code.desktop",
     linuxWmClass: isDevelopment ? "t3code-dev" : "t3code",

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -94,6 +94,7 @@ function makeDesktopWindowLayer(
     flushMainWindowBounds: input.flushMainWindowBounds ?? Effect.void,
     dispatchMenuAction: () => Effect.void,
     zoomMain: () => Effect.void,
+    openThread: () => Effect.void,
     syncAppearance: Effect.void,
   });
 }

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -77,6 +77,7 @@ function makePoolLayer(
           handleBackendReady: () => Effect.void,
           handleBackendNotReady: Effect.void,
           dispatchMenuAction: () => Effect.die("unexpected menu action"),
+          openThread: () => Effect.die("unexpected open thread"),
           syncAppearance: Effect.void,
         } satisfies DesktopWindow.DesktopWindow["Service"]),
       ),

--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -92,6 +92,7 @@ function makePoolLayer(
           flushMainWindowBounds: Effect.void,
           dispatchMenuAction: () => Effect.die("unexpected menu action"),
           zoomMain: () => Effect.die("unexpected zoom"),
+          openThread: () => Effect.die("unexpected open thread"),
           syncAppearance: Effect.void,
         } satisfies DesktopWindow.DesktopWindow["Service"]),
       ),

--- a/apps/desktop/src/deeplink/threadDeepLink.test.ts
+++ b/apps/desktop/src/deeplink/threadDeepLink.test.ts
@@ -1,0 +1,29 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Option from "effect/Option";
+
+import { findThreadDeepLinkInArgv, parseThreadDeepLinkUrl } from "./threadDeepLink.ts";
+
+describe("threadDeepLink", () => {
+  it("parses t3://thread/<threadId> URLs", () => {
+    assert.deepStrictEqual(
+      parseThreadDeepLinkUrl("t3://thread/thread-123"),
+      Option.some("thread-123"),
+    );
+  });
+
+  it("rejects unrelated protocols and hosts", () => {
+    assert.isTrue(Option.isNone(parseThreadDeepLinkUrl("t3code://app/")));
+    assert.isTrue(Option.isNone(parseThreadDeepLinkUrl("t3://settings/general")));
+    assert.isTrue(Option.isNone(parseThreadDeepLinkUrl("https://example.com/thread/abc")));
+  });
+
+  it("finds deep links in process argv", () => {
+    assert.deepStrictEqual(
+      findThreadDeepLinkInArgv([
+        "/Applications/T3 Code.app/Contents/MacOS/T3 Code",
+        "t3://thread/abc",
+      ]),
+      Option.some("abc"),
+    );
+  });
+});

--- a/apps/desktop/src/deeplink/threadDeepLink.ts
+++ b/apps/desktop/src/deeplink/threadDeepLink.ts
@@ -1,0 +1,30 @@
+import * as Option from "effect/Option";
+
+/** OS-registered scheme for thread deep links (`t3://thread/<threadId>`). */
+export const DESKTOP_THREAD_DEEP_LINK_SCHEME = "t3";
+
+export function parseThreadDeepLinkUrl(rawUrl: string): Option.Option<string> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return Option.none();
+  }
+
+  if (parsed.protocol !== `${DESKTOP_THREAD_DEEP_LINK_SCHEME}:` || parsed.hostname !== "thread") {
+    return Option.none();
+  }
+
+  const threadId = parsed.pathname.replace(/^\/+/, "");
+  return threadId.length > 0 ? Option.some(threadId) : Option.none();
+}
+
+export function findThreadDeepLinkInArgv(argv: readonly string[]): Option.Option<string> {
+  for (const arg of argv) {
+    const threadId = parseThreadDeepLinkUrl(arg);
+    if (Option.isSome(threadId)) {
+      return threadId;
+    }
+  }
+  return Option.none();
+}

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -4,6 +4,7 @@ export const SET_THEME_CHANNEL = "desktop:set-theme";
 export const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 export const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
+export const OPEN_THREAD_CHANNEL = "desktop:open-thread";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 export const UPDATE_SET_CHANNEL_CHANNEL = "desktop:update-set-channel";

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -8,6 +8,7 @@ export const MENU_ACTION_CHANNEL = "desktop:menu-action";
 export const QUIT_SHORTCUT_CHANNEL = "desktop:quit-shortcut";
 export const GET_WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:get-window-fullscreen-state";
 export const WINDOW_FULLSCREEN_STATE_CHANNEL = "desktop:window-fullscreen-state";
+export const OPEN_THREAD_CHANNEL = "desktop:open-thread";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 export const UPDATE_SET_CHANNEL_CHANNEL = "desktop:update-set-channel";

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -34,6 +34,7 @@ import * as DesktopBackendConfiguration from "./backend/DesktopBackendConfigurat
 import * as DesktopBackendPool from "./backend/DesktopBackendPool.ts";
 import * as DesktopLocalEnvironmentAuth from "./backend/DesktopLocalEnvironmentAuth.ts";
 import * as DesktopNetworkInterfaces from "./backend/DesktopNetworkInterfaces.ts";
+import * as DesktopDeepLinks from "./app/DesktopDeepLinks.ts";
 import * as DesktopEnvironment from "./app/DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./app/DesktopLifecycle.ts";
 import * as DesktopShutdown from "./app/DesktopShutdown.ts";
@@ -172,6 +173,7 @@ const desktopApplicationLayer = Layer.mergeAll(
   DesktopLifecycle.layer,
   DesktopApplicationMenu.layer,
   DesktopShellEnvironment.layer,
+  DesktopDeepLinks.layer,
   desktopSshLayer,
 ).pipe(
   Layer.provideMerge(DesktopUpdates.layer),

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -41,6 +41,7 @@ import * as DesktopBackendConfiguration from "./backend/DesktopBackendConfigurat
 import * as DesktopBackendPool from "./backend/DesktopBackendPool.ts";
 import * as DesktopLocalEnvironmentAuth from "./backend/DesktopLocalEnvironmentAuth.ts";
 import * as DesktopNetworkInterfaces from "./backend/DesktopNetworkInterfaces.ts";
+import * as DesktopDeepLinks from "./app/DesktopDeepLinks.ts";
 import * as DesktopEnvironment from "./app/DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./app/DesktopLifecycle.ts";
 import * as DesktopLinuxUrlHandler from "./app/DesktopLinuxUrlHandler.ts";
@@ -187,6 +188,7 @@ const desktopApplicationLayer = Layer.mergeAll(
   DesktopApplicationMenu.layer,
   DesktopLinuxUrlHandler.layer,
   DesktopShellEnvironment.layer,
+  DesktopDeepLinks.layer,
   desktopSshLayer,
 ).pipe(
   Layer.provideMerge(DesktopUpdates.layer),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -116,6 +116,17 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ipcRenderer.removeListener(IpcChannels.MENU_ACTION_CHANNEL, wrappedListener);
     };
   },
+  onOpenThread: (listener) => {
+    const wrappedListener = (_event: Electron.IpcRendererEvent, threadId: unknown) => {
+      if (typeof threadId !== "string") return;
+      listener(threadId);
+    };
+
+    ipcRenderer.on(IpcChannels.OPEN_THREAD_CHANNEL, wrappedListener);
+    return () => {
+      ipcRenderer.removeListener(IpcChannels.OPEN_THREAD_CHANNEL, wrappedListener);
+    };
+  },
   getUpdateState: () => ipcRenderer.invoke(IpcChannels.UPDATE_GET_STATE_CHANNEL),
   setUpdateChannel: (channel) =>
     ipcRenderer.invoke(IpcChannels.UPDATE_SET_CHANNEL_CHANNEL, channel),

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -145,6 +145,17 @@ contextBridge.exposeInMainWorld("desktopBridge", {
       ipcRenderer.removeListener(IpcChannels.WINDOW_FULLSCREEN_STATE_CHANNEL, wrappedListener);
     };
   },
+  onOpenThread: (listener) => {
+    const wrappedListener = (_event: Electron.IpcRendererEvent, threadId: unknown) => {
+      if (typeof threadId !== "string") return;
+      listener(threadId);
+    };
+
+    ipcRenderer.on(IpcChannels.OPEN_THREAD_CHANNEL, wrappedListener);
+    return () => {
+      ipcRenderer.removeListener(IpcChannels.OPEN_THREAD_CHANNEL, wrappedListener);
+    };
+  },
   getUpdateState: () => ipcRenderer.invoke(IpcChannels.UPDATE_GET_STATE_CHANNEL),
   setUpdateChannel: (channel) =>
     ipcRenderer.invoke(IpcChannels.UPDATE_SET_CHANNEL_CHANNEL, channel),

--- a/apps/desktop/src/updates/updateChannels.test.ts
+++ b/apps/desktop/src/updates/updateChannels.test.ts
@@ -1,0 +1,28 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import { resolveDesktopAppBundleId, resolveDesktopBuildAppId } from "./updateChannels.ts";
+
+describe("updateChannels bundle ids", () => {
+  it("uses dev, nightly, and alpha bundle ids per channel", () => {
+    assert.equal(
+      resolveDesktopAppBundleId({ isDevelopment: true, appVersion: "0.0.28" }),
+      "com.t3tools.t3code.dev",
+    );
+    assert.equal(
+      resolveDesktopAppBundleId({
+        isDevelopment: false,
+        appVersion: "0.0.28-nightly.20260702.1",
+      }),
+      "com.t3tools.t3code.nightly",
+    );
+    assert.equal(
+      resolveDesktopAppBundleId({ isDevelopment: false, appVersion: "0.0.28" }),
+      "com.t3tools.t3code.alpha",
+    );
+    assert.equal(
+      resolveDesktopBuildAppId("0.0.28-nightly.20260702.1"),
+      "com.t3tools.t3code.nightly",
+    );
+    assert.equal(resolveDesktopBuildAppId("0.0.28"), "com.t3tools.t3code.alpha");
+  });
+});

--- a/apps/desktop/src/updates/updateChannels.ts
+++ b/apps/desktop/src/updates/updateChannels.ts
@@ -1,6 +1,7 @@
 import type { DesktopUpdateChannel } from "@t3tools/contracts";
 
 const NIGHTLY_VERSION_PATTERN = /-nightly\.\d{8}\.\d+$/;
+const PRODUCTION_BUNDLE_ID = "com.t3tools.t3code";
 
 export function isNightlyDesktopVersion(version: string): boolean {
   return NIGHTLY_VERSION_PATTERN.test(version);
@@ -9,3 +10,26 @@ export function isNightlyDesktopVersion(version: string): boolean {
 export function resolveDefaultDesktopUpdateChannel(appVersion: string): DesktopUpdateChannel {
   return isNightlyDesktopVersion(appVersion) ? "nightly" : "latest";
 }
+
+export function resolveDesktopAppBundleId(input: {
+  readonly isDevelopment: boolean;
+  readonly appVersion: string;
+}): string {
+  if (input.isDevelopment) {
+    return "com.t3tools.t3code.dev";
+  }
+
+  if (isNightlyDesktopVersion(input.appVersion)) {
+    return "com.t3tools.t3code.nightly";
+  }
+
+  // Alpha-channel builds use a distinct bundle id so they can run alongside
+  // Nightly and receive `t3://` deep links without single-instance conflicts.
+  return "com.t3tools.t3code.alpha";
+}
+
+export function resolveDesktopBuildAppId(version: string): string {
+  return resolveDesktopAppBundleId({ isDevelopment: false, appVersion: version });
+}
+
+export { PRODUCTION_BUNDLE_ID };

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -77,6 +77,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     handleBackendReady: () => Effect.void,
     handleBackendNotReady: Effect.void,
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
+    openThread: () => Effect.void,
     syncAppearance: Effect.void,
   } satisfies DesktopWindow.DesktopWindow["Service"]);
 

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -83,6 +83,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
     zoomMain: (direction) =>
       Deferred.succeed(selectedAction, `zoom-${direction}`).pipe(Effect.asVoid),
+    openThread: () => Effect.void,
     syncAppearance: Effect.void,
   } satisfies DesktopWindow.DesktopWindow["Service"]);
 

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -15,7 +15,7 @@ import { getDesktopUrl } from "../electron/ElectronProtocol.ts";
 import * as ElectronShell from "../electron/ElectronShell.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
-import { MENU_ACTION_CHANNEL } from "../ipc/channels.ts";
+import { MENU_ACTION_CHANNEL, OPEN_THREAD_CHANNEL } from "../ipc/channels.ts";
 import * as PreviewManager from "../preview/Manager.ts";
 
 const TITLEBAR_HEIGHT = 40;
@@ -76,6 +76,7 @@ export class DesktopWindow extends Context.Service<
     // produce a stranded window pointing at nothing.
     readonly handleBackendNotReady: Effect.Effect<void>;
     readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
+    readonly openThread: (threadId: string) => Effect.Effect<void, DesktopWindowError>;
     readonly syncAppearance: Effect.Effect<void>;
   }
 >()("@t3tools/desktop/window/DesktopWindow") {}
@@ -208,6 +209,7 @@ export const make = Effect.gen(function* () {
   // createMainIfBackendReady, which gates the post-readiness window
   // open in development and the macOS "activate without windows" path.
   const backendReadyRef = yield* Ref.make(false);
+  const pendingOpenThreadIdRef = yield* Ref.make<Option.Option<string>>(Option.none());
   // The transient "Connecting to WSL" splash window, tracked separately so it
   // is never mistaken for the real main window.
   const splashWindowRef = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
@@ -240,6 +242,36 @@ export const make = Effect.gen(function* () {
 
   const currentMainWindow = electronWindow.currentMainOrFirst.pipe(Effect.flatMap(withoutSplash));
   const focusedMainWindow = electronWindow.focusedMainOrFirst.pipe(Effect.flatMap(withoutSplash));
+
+  const sendOpenThreadToWindow = (targetWindow: Electron.BrowserWindow, threadId: string) => {
+    const send = () => {
+      if (targetWindow.isDestroyed()) return;
+      targetWindow.webContents.send(OPEN_THREAD_CHANNEL, threadId);
+      void runPromise(electronWindow.reveal(targetWindow));
+    };
+
+    if (targetWindow.webContents.isLoadingMainFrame()) {
+      targetWindow.webContents.once("did-finish-load", send);
+      return;
+    }
+
+    send();
+  };
+
+  const flushPendingOpenThread = Effect.gen(function* () {
+    const pendingThreadId = yield* Ref.getAndSet(pendingOpenThreadIdRef, Option.none());
+    if (Option.isNone(pendingThreadId)) {
+      return;
+    }
+
+    const existingWindow = yield* currentMainWindow;
+    if (Option.isNone(existingWindow)) {
+      yield* Ref.set(pendingOpenThreadIdRef, pendingThreadId);
+      return;
+    }
+
+    sendOpenThreadToWindow(existingWindow.value, pendingThreadId.value);
+  });
 
   const createWindow = Effect.fn("desktop.window.createWindow")(function* (): Effect.fn.Return<
     Electron.BrowserWindow,
@@ -420,6 +452,7 @@ export const make = Effect.gen(function* () {
       clearDevelopmentLoadRetry();
       developmentLoadRetryIndex = 0;
       window.setTitle(environment.displayName);
+      void runPromise(flushPendingOpenThread);
     });
     window.webContents.on(
       "did-fail-load",
@@ -609,6 +642,22 @@ export const make = Effect.gen(function* () {
       }
 
       send();
+    }),
+    openThread: Effect.fn("desktop.window.openThread")(function* (threadId) {
+      yield* Effect.annotateCurrentSpan({ threadId });
+      const existingWindow = yield* currentMainWindow;
+      if (Option.isNone(existingWindow)) {
+        yield* Ref.set(pendingOpenThreadIdRef, Option.some(threadId));
+        yield* createMainIfBackendReady;
+        const windowAfterBootstrap = yield* currentMainWindow;
+        if (Option.isSome(windowAfterBootstrap)) {
+          sendOpenThreadToWindow(windowAfterBootstrap.value, threadId);
+          yield* Ref.set(pendingOpenThreadIdRef, Option.none());
+        }
+        return;
+      }
+
+      sendOpenThreadToWindow(existingWindow.value, threadId);
     }),
     syncAppearance: Effect.gen(function* () {
       const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -20,6 +20,7 @@ import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import {
   MENU_ACTION_CHANNEL,
+  OPEN_THREAD_CHANNEL,
   QUIT_SHORTCUT_CHANNEL,
   WINDOW_FULLSCREEN_STATE_CHANNEL,
 } from "../ipc/channels.ts";
@@ -106,6 +107,7 @@ export class DesktopWindow extends Context.Service<
     // guest page instead of the app UI. The menu routes here to always target
     // the main window.
     readonly zoomMain: (direction: MainWindowZoomDirection) => Effect.Effect<void>;
+    readonly openThread: (threadId: string) => Effect.Effect<void, DesktopWindowError>;
     readonly syncAppearance: Effect.Effect<void>;
   }
 >()("@t3tools/desktop/window/DesktopWindow") {}
@@ -280,6 +282,7 @@ export const make = Effect.gen(function* () {
   // createMainIfBackendReady, which gates the post-readiness window
   // open in development and the macOS "activate without windows" path.
   const backendReadyRef = yield* Ref.make(false);
+  const pendingOpenThreadIdRef = yield* Ref.make<Option.Option<string>>(Option.none());
   // The transient "Connecting to WSL" splash window, tracked separately so it
   // is never mistaken for the real main window.
   const splashWindowRef = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
@@ -313,6 +316,36 @@ export const make = Effect.gen(function* () {
 
   const currentMainWindow = electronWindow.currentMainOrFirst.pipe(Effect.flatMap(withoutSplash));
   const focusedMainWindow = electronWindow.focusedMainOrFirst.pipe(Effect.flatMap(withoutSplash));
+
+  const sendOpenThreadToWindow = (targetWindow: Electron.BrowserWindow, threadId: string) => {
+    const send = () => {
+      if (targetWindow.isDestroyed()) return;
+      targetWindow.webContents.send(OPEN_THREAD_CHANNEL, threadId);
+      void runPromise(electronWindow.reveal(targetWindow));
+    };
+
+    if (targetWindow.webContents.isLoadingMainFrame()) {
+      targetWindow.webContents.once("did-finish-load", send);
+      return;
+    }
+
+    send();
+  };
+
+  const flushPendingOpenThread = Effect.gen(function* () {
+    const pendingThreadId = yield* Ref.getAndSet(pendingOpenThreadIdRef, Option.none());
+    if (Option.isNone(pendingThreadId)) {
+      return;
+    }
+
+    const existingWindow = yield* currentMainWindow;
+    if (Option.isNone(existingWindow)) {
+      yield* Ref.set(pendingOpenThreadIdRef, pendingThreadId);
+      return;
+    }
+
+    sendOpenThreadToWindow(existingWindow.value, pendingThreadId.value);
+  });
 
   const createWindow = Effect.fn("desktop.window.createWindow")(function* (): Effect.fn.Return<
     Electron.BrowserWindow,
@@ -661,6 +694,7 @@ export const make = Effect.gen(function* () {
       clearDevelopmentLoadRetry();
       developmentLoadRetryIndex = 0;
       window.setTitle(environment.displayName);
+      void runPromise(flushPendingOpenThread);
     });
     window.webContents.on(
       "did-fail-load",
@@ -907,6 +941,22 @@ export const make = Effect.gen(function* () {
       // the previewed page along with the app UI. The preview browser keeps its
       // own zoom, so put each guest back where the preview left it.
       yield* previewManager.reapplyZoom();
+    }),
+    openThread: Effect.fn("desktop.window.openThread")(function* (threadId) {
+      yield* Effect.annotateCurrentSpan({ threadId });
+      const existingWindow = yield* currentMainWindow;
+      if (Option.isNone(existingWindow)) {
+        yield* Ref.set(pendingOpenThreadIdRef, Option.some(threadId));
+        yield* createMainIfBackendReady;
+        const windowAfterBootstrap = yield* currentMainWindow;
+        if (Option.isSome(windowAfterBootstrap)) {
+          sendOpenThreadToWindow(windowAfterBootstrap.value, threadId);
+          yield* Ref.set(pendingOpenThreadIdRef, Option.none());
+        }
+        return;
+      }
+
+      sendOpenThreadToWindow(existingWindow.value, threadId);
     }),
     syncAppearance: Effect.gen(function* () {
       const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -1,11 +1,12 @@
 import { useAtomValue } from "@effect/atom-react";
-import { useEffect, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useRef, type CSSProperties, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { isMacPlatform } from "../lib/utils";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { useActiveEnvironmentId } from "../state/entities";
+import { primaryServerConfigAtom, primaryServerKeybindingsAtom } from "../state/server";
 import ThreadSidebar from "./Sidebar";
 import { Sidebar, SidebarProvider, SidebarRail, SidebarTrigger, useSidebar } from "./ui/sidebar";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
@@ -55,10 +56,30 @@ function SidebarControl() {
 
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  const activeEnvironmentId = useActiveEnvironmentId();
+  const serverConfig = useAtomValue(primaryServerConfigAtom);
+  const pendingThreadIdRef = useRef<string | null>(null);
   const macosWindowControlsStyle =
     isElectron && isMacPlatform(navigator.platform)
       ? ({ "--workspace-controls-left": MACOS_TRAFFIC_LIGHTS_LEFT_INSET } as CSSProperties)
       : undefined;
+
+  const resolveEnvironmentId = () =>
+    activeEnvironmentId ?? serverConfig?.environment.environmentId ?? null;
+
+  useEffect(() => {
+    const environmentId = resolveEnvironmentId();
+    const pendingThreadId = pendingThreadIdRef.current;
+    if (!environmentId || !pendingThreadId) {
+      return;
+    }
+
+    pendingThreadIdRef.current = null;
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: { environmentId, threadId: pendingThreadId },
+    });
+  }, [activeEnvironmentId, navigate, serverConfig]);
 
   useEffect(() => {
     const onMenuAction = window.desktopBridge?.onMenuAction;
@@ -76,6 +97,31 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       unsubscribe?.();
     };
   }, [navigate]);
+
+  useEffect(() => {
+    const onOpenThread = window.desktopBridge?.onOpenThread;
+    if (typeof onOpenThread !== "function") {
+      return;
+    }
+
+    const unsubscribe = onOpenThread((threadId) => {
+      const environmentId = resolveEnvironmentId();
+      if (!environmentId) {
+        pendingThreadIdRef.current = threadId;
+        return;
+      }
+
+      pendingThreadIdRef.current = null;
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: { environmentId, threadId },
+      });
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [navigate, activeEnvironmentId, serverConfig]);
 
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen style={macosWindowControlsStyle}>

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -13,6 +13,7 @@ import { isElectron } from "../env";
 import { getLocalStorageItem, removeLocalStorageItem } from "../hooks/useLocalStorage";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
+import { useActiveEnvironmentId, useProjects } from "../state/entities";
 import { primaryServerKeybindingsAtom } from "../state/server";
 import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
 import LegacyThreadSidebar from "./LegacySidebar";
@@ -23,7 +24,6 @@ import {
   resolveSidebarStageFocusRingOffsetClass,
   useSidebarStageBackdropVariant,
 } from "./SidebarStageBackdrop";
-import { useProjects } from "../state/entities";
 import {
   resolveInitialThreadSidebarWidth,
   resolveThreadSidebarMaximumWidth,
@@ -138,6 +138,7 @@ function ProjectProjectionRetention() {
 
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  const activeEnvironmentId = useActiveEnvironmentId();
   const legacySidebarEnabled = useLegacySidebarEnabled();
   // Settings routes show the settings nav in place of whichever thread
   // sidebar is active.
@@ -207,6 +208,27 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       unsubscribe?.();
     };
   }, [navigate, pathname]);
+
+  useEffect(() => {
+    const onOpenThread = window.desktopBridge?.onOpenThread;
+    if (typeof onOpenThread !== "function") {
+      return;
+    }
+
+    const unsubscribe = onOpenThread((threadId) => {
+      if (!activeEnvironmentId) {
+        return;
+      }
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: { environmentId: activeEnvironmentId, threadId },
+      });
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [navigate, activeEnvironmentId]);
 
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen style={sidebarProviderStyle}>

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -2,6 +2,7 @@ import { useAtomValue } from "@effect/atom-react";
 import * as Schema from "effect/Schema";
 import {
   useEffect,
+  useRef,
   useState,
   useSyncExternalStore,
   type CSSProperties,
@@ -14,7 +15,7 @@ import { getLocalStorageItem, removeLocalStorageItem } from "../hooks/useLocalSt
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { cn, isMacPlatform } from "../lib/utils";
 import { useActiveEnvironmentId, useProjects } from "../state/entities";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { primaryServerConfigAtom, primaryServerKeybindingsAtom } from "../state/server";
 import { useEnvironmentIdentificationMode, useLegacySidebarEnabled } from "../hooks/useSettings";
 import LegacyThreadSidebar from "./LegacySidebar";
 import ThreadSidebar from "./Sidebar";
@@ -145,6 +146,8 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const pathname = useLocation({ select: (location) => location.pathname });
   const isOnSettings = pathname === "/settings" || pathname.startsWith("/settings/");
   const isMacosDesktop = isElectron && isMacPlatform(navigator.platform);
+  const serverConfig = useAtomValue(primaryServerConfigAtom);
+  const pendingThreadIdRef = useRef<string | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(readInitialThreadSidebarWidth);
   // Subscribed rather than read once: the clamp must track live window size,
   // and a clamped drag ends with an unchanged width, which skips the re-render
@@ -189,6 +192,23 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
     return unsubscribe;
   }, [isMacosDesktop]);
 
+  const resolveEnvironmentId = () =>
+    activeEnvironmentId ?? serverConfig?.environment.environmentId ?? null;
+
+  useEffect(() => {
+    const environmentId = resolveEnvironmentId();
+    const pendingThreadId = pendingThreadIdRef.current;
+    if (!environmentId || !pendingThreadId) {
+      return;
+    }
+
+    pendingThreadIdRef.current = null;
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: { environmentId, threadId: pendingThreadId },
+    });
+  }, [activeEnvironmentId, navigate, serverConfig]);
+
   useEffect(() => {
     const onMenuAction = window.desktopBridge?.onMenuAction;
     if (typeof onMenuAction !== "function") {
@@ -216,19 +236,23 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
     }
 
     const unsubscribe = onOpenThread((threadId) => {
-      if (!activeEnvironmentId) {
+      const environmentId = resolveEnvironmentId();
+      if (!environmentId) {
+        pendingThreadIdRef.current = threadId;
         return;
       }
+
+      pendingThreadIdRef.current = null;
       void navigate({
         to: "/$environmentId/$threadId",
-        params: { environmentId: activeEnvironmentId, threadId },
+        params: { environmentId, threadId },
       });
     });
 
     return () => {
       unsubscribe?.();
     };
-  }, [navigate, activeEnvironmentId]);
+  }, [navigate, activeEnvironmentId, serverConfig]);
 
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen style={sidebarProviderStyle}>

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -994,6 +994,7 @@ export interface DesktopBridge {
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
   onMenuAction: (listener: (action: string) => void) => () => void;
+  onOpenThread: (listener: (threadId: string) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;
   checkForUpdate: () => Promise<DesktopUpdateCheckResult>;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1137,6 +1137,7 @@ export interface DesktopBridge {
   onQuitShortcut?: (listener: (state: "down" | "up") => void) => () => void;
   getWindowFullscreenState: () => boolean;
   onWindowFullscreenStateChange: (listener: (fullscreen: boolean) => void) => () => void;
+  onOpenThread: (listener: (threadId: string) => void) => () => void;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;
   checkForUpdate: () => Promise<DesktopUpdateCheckResult>;

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -101,6 +101,22 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     });
   });
 
+  it.effect("disables publish auto-detection for local artifact builds", () =>
+    Effect.gen(function* () {
+      const config = yield* createBuildConfig(
+        "mac",
+        "dmg",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      ).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} }))));
+
+      assert.strictEqual(config.publish, null);
+    }),
+  );
+
   it.effect("resolves GitHub desktop publish config from Effect config", () =>
     Effect.gen(function* () {
       const latestConfig = yield* resolveGitHubPublishConfig("latest").pipe(
@@ -401,11 +417,11 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       });
 
       const mac = config.mac as Record<string, unknown>;
-      assert.equal(config.appId, "com.t3tools.t3code");
+      assert.equal(config.appId, "com.t3tools.t3code.alpha");
       assert.equal(mac.entitlements, "/tmp/entitlements.mac.plist");
       assert.equal(mac.provisioningProfile, "/tmp/t3code.provisionprofile");
       assert.deepStrictEqual(mac.protocols, [
-        { name: "T3 Code", schemes: ["t3code", "t3code-dev"] },
+        { name: "T3 Code", schemes: ["t3", "t3code", "t3code-dev"] },
       ]);
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
   );

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -180,9 +180,15 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
 
   it.effect("disables publish auto-detection for local artifact builds", () =>
     Effect.gen(function* () {
-      const config = yield* createBuildConfig("mac", "dmg", "1.2.3", false, false, undefined, undefined).pipe(
-        Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} }))),
-      );
+      const config = yield* createBuildConfig(
+        "mac",
+        "dmg",
+        "1.2.3",
+        false,
+        false,
+        undefined,
+        undefined,
+      ).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} }))));
 
       assert.strictEqual(config.publish, null);
     }),
@@ -1001,7 +1007,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       });
 
       const mac = config.mac as Record<string, unknown>;
-      assert.equal(config.appId, "com.t3tools.t3code");
+      assert.equal(config.appId, "com.t3tools.t3code.alpha");
       assert.equal(mac.entitlements, "/tmp/entitlements.mac.plist");
       assert.equal(mac.provisioningProfile, "/tmp/t3code.provisionprofile");
       assert.deepStrictEqual(mac.protocols, [

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -178,6 +178,16 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     assert.equal(resolveDesktopWebAssetBrand("0.0.17-nightly.20260413.42"), "nightly");
   });
 
+  it.effect("disables publish auto-detection for local artifact builds", () =>
+    Effect.gen(function* () {
+      const config = yield* createBuildConfig("mac", "dmg", "1.2.3", false, false, undefined, undefined).pipe(
+        Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} }))),
+      );
+
+      assert.strictEqual(config.publish, null);
+    }),
+  );
+
   it.effect("resolves GitHub desktop publish config from Effect config", () =>
     Effect.gen(function* () {
       const latestConfig = yield* resolveGitHubPublishConfig("latest").pipe(
@@ -995,7 +1005,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       assert.equal(mac.entitlements, "/tmp/entitlements.mac.plist");
       assert.equal(mac.provisioningProfile, "/tmp/t3code.provisionprofile");
       assert.deepStrictEqual(mac.protocols, [
-        { name: "T3 Code", schemes: ["t3code", "t3code-dev"] },
+        { name: "T3 Code", schemes: ["t3", "t3code", "t3code-dev"] },
       ]);
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
   );

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1310,6 +1310,13 @@ export function resolveDesktopUpdateChannel(version: string): "latest" | "nightl
   return /-nightly\.\d{8}\.\d+$/.test(version) ? "nightly" : "latest";
 }
 
+// Keep in sync with apps/desktop/src/updates/updateChannels.ts.
+export function resolveDesktopBuildAppId(version: string): string {
+  return resolveDesktopUpdateChannel(version) === "nightly"
+    ? "com.t3tools.t3code.nightly"
+    : "com.t3tools.t3code.alpha";
+}
+
 export function resolveDesktopBuildIconAssets(version: string): DesktopBuildIconAssets {
   if (resolveDesktopUpdateChannel(version) === "nightly") {
     return {
@@ -1351,7 +1358,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     | undefined,
 ) {
   const buildConfig: Record<string, unknown> = {
-    appId: DESKTOP_APP_ID,
+    appId: resolveDesktopBuildAppId(version),
     productName: resolveDesktopProductName(version),
     artifactName: "T3-Code-${version}-${arch}.${ext}",
     directories: {
@@ -1383,6 +1390,10 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
         url: resolveMockUpdateServerUrl(mockUpdateServerPort),
       },
     ];
+  } else {
+    // Prevent electron-builder from inferring GitHub publish from GH_TOKEN when
+    // building local artifacts with `--publish never`.
+    buildConfig.publish = null;
   }
 
   if (platform === "mac") {
@@ -1393,7 +1404,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       protocols: [
         {
           name: "T3 Code",
-          schemes: ["t3code", "t3code-dev"],
+          schemes: ["t3", "t3code", "t3code-dev"],
         },
       ],
       ...(macPasskeySigning

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2062,6 +2062,10 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
         url: resolveMockUpdateServerUrl(mockUpdateServerPort),
       },
     ];
+  } else {
+    // Prevent electron-builder from inferring GitHub publish from GH_TOKEN when
+    // building local artifacts with `--publish never`.
+    buildConfig.publish = null;
   }
 
   if (platform === "mac") {
@@ -2072,7 +2076,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       protocols: [
         {
           name: "T3 Code",
-          schemes: ["t3code", "t3code-dev"],
+          schemes: ["t3", "t3code", "t3code-dev"],
         },
       ],
       ...(macPasskeySigning

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1980,6 +1980,13 @@ export function resolveDesktopWebAssetBrand(version: string): WebAssetBrand {
   return resolveWebAssetBrandForChannel(resolveDesktopUpdateChannel(version));
 }
 
+// Keep in sync with apps/desktop/src/updates/updateChannels.ts.
+export function resolveDesktopBuildAppId(version: string): string {
+  return resolveDesktopUpdateChannel(version) === "nightly"
+    ? "com.t3tools.t3code.nightly"
+    : "com.t3tools.t3code.alpha";
+}
+
 export function resolveDesktopBuildIconAssets(version: string): DesktopBuildIconAssets {
   if (resolveDesktopUpdateChannel(version) === "nightly") {
     return {
@@ -2034,7 +2041,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     | undefined,
 ) {
   const buildConfig: Record<string, unknown> = {
-    appId: DESKTOP_APP_ID,
+    appId: resolveDesktopBuildAppId(version),
     productName: resolveDesktopProductName(version),
     artifactName: "T3-Code-${version}-${arch}.${ext}",
     electronLanguages: [...DESKTOP_ELECTRON_LANGUAGES],


### PR DESCRIPTION
## What Changed

Adds a `t3://thread/<threadId>` OS-level protocol handler to the Electron desktop app.

- **`apps/desktop/src/main.ts`**: registers `open-url` (macOS) and `second-instance` (Win/Linux) listeners before `whenReady`; `handleDeepLink()` parses the URL and sends `desktop:open-thread` to the renderer via `webContents.send`; `pendingDeepLinkThreadId` queues deep links that arrive before the window finishes loading; `setAsDefaultProtocolClient('t3')` called in `whenReady`
- **`apps/desktop/src/preload.ts`**: exposes `onOpenThread` over the context bridge (same pattern as `onMenuAction`)
- **`packages/contracts/src/ipc.ts`**: adds `onOpenThread` to the `DesktopBridge` interface
- **`apps/web/src/components/AppSidebarLayout.tsx`**: subscribes to `onOpenThread` and navigates to `/$environmentId/$threadId` using TanStack Router
- **`scripts/build-desktop-artifact.ts`**: adds `protocols: [{name:"T3 Code", schemes:["t3"]}]` to the mac electron-builder config so `CFBundleURLTypes` is written into the packaged `Info.plist`
- **test mocks** (`localApi.test.ts`, `SettingsPanels.browser.tsx`): stub `onOpenThread: () => () => {}` added

## Why

Clicking a thread link (e.g. from Slack or the terminal) currently opens a browser tab that hits the pairing screen. With this change, `t3://thread/<id>` links route directly to the correct thread inside the already-running desktop app — or launch it if it's closed.

Verified end-to-end in dev: `open "t3://thread/<id>"` in the terminal fired the `open-url` event, `handleDeepLink` parsed it correctly, and `webContents.send("desktop:open-thread", threadId)` was confirmed in the Electron main-process logs.

## UI Changes

N/A — no visual changes. Navigation behavior only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Packaged alpha builds change bundle id from com.t3tools.t3code to com.t3tools.t3code.alpha, which can break in-place auto-updates and alter which app macOS routes t3:// links to; protocol registration and second-instance argv handling are security-sensitive entry points.
> 
> **Overview**
> Adds **`t3://thread/<threadId>`** handling so OS links open the right thread in the desktop app instead of a browser.
> 
> A new **`DesktopDeepLinks`** service registers **`open-url`** / **`second-instance`** early, parses URLs via **`threadDeepLink`**, registers the **`t3`** protocol (macOS pins **`setAsDefaultProtocolClient`** to the running executable), and calls **`DesktopWindow.openThread`**, which IPCs **`desktop:open-thread`** to the renderer (with pending IDs until the main window loads). The web shell listens through **`desktopBridge.onOpenThread`** and navigates to **`/$environmentId/$threadId`**, queuing the thread id until an environment id is known.
> 
> **Alpha / nightly / dev** builds now get distinct bundle ids via **`resolveDesktopAppBundleId`** (alpha uses **`com.t3tools.t3code.alpha`** instead of **`com.t3tools.t3code`**), macOS/electron-builder protocol lists include **`t3`**, and local artifact builds set **`publish: null`** so electron-builder does not auto-detect GitHub publish from **`GH_TOKEN`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26cff8f0e0821fa66780a2c92774abcecad5dafd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register `t3://` protocol handler for thread deep links in desktop app
> - Adds `DesktopDeepLinks` service that wires Electron `open-url`, `second-instance`, and argv events to parse `t3://thread/<id>` URLs and open the requested thread via `DesktopWindow.openThread`
> - Adds deep link parsing utilities in [threadDeepLink.ts](https://github.com/pingdotgg/t3code/pull/2424/files#diff-d35639e36eb066f5709760175b18d284bc9bf98f79b83d82000ec9c06a36f860) and a new `desktop:open-thread` IPC channel so the main process can tell the renderer to navigate to a thread
> - Renderer-side integration in [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/2424/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) subscribes to `onOpenThread` and navigates to `/$environmentId/$threadId`, deferring until an environment id is available
> - Build config in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/2424/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) now uses channel-specific app IDs (`nightly` vs `alpha`) and registers the `t3` scheme on macOS; local builds set `publish = null` to disable auto-detection
> - Behavioral Change: production APP_BUNDLE_ID changes from `com.t3tools.t3code` to `com.t3tools.t3code.alpha` in [electron-launcher.mjs](https://github.com/pingdotgg/t3code/pull/2424/files#diff-8a117bf8144a87af3b3928053a08e442ffe3b14884df08757b77d55907d596b4); Windows `appUserModelId` now varies by channel via `resolveDesktopAppBundleId` in [updateChannels.ts](https://github.com/pingdotgg/t3code/pull/2424/files#diff-53d9ad3317396050f662a07eab721d05b53a4f91bca7e7c5d8d5fd06705f99cc)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized edd18aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->