### PR TITLE
Add Discord release announcements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -511,10 +511,11 @@ jobs:
       - name: Announce prerelease on Discord
         if: needs.preflight.outputs.is_prerelease == 'true'
         env:
+          DISCORD_RELEASE_NIGHTLY_ROLE_ID: ${{ vars.DISCORD_RELEASE_NIGHTLY_ROLE_ID }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
         run: |
           node scripts/notify-discord-release.ts prerelease \
-            --mention "@t3-code-nightly-announcements" \
+            --role-id "$DISCORD_RELEASE_NIGHTLY_ROLE_ID" \
             --release-name "${{ needs.preflight.outputs.release_name }}" \
             --version "${{ needs.preflight.outputs.version }}" \
             --tag "${{ needs.preflight.outputs.tag }}" \
@@ -523,10 +524,11 @@ jobs:
       - name: Announce latest release on Discord
         if: needs.preflight.outputs.make_latest == 'true'
         env:
+          DISCORD_RELEASE_LATEST_ROLE_ID: ${{ vars.DISCORD_RELEASE_LATEST_ROLE_ID }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
         run: |
           node scripts/notify-discord-release.ts latest \
-            --mention "@t3-code-announcements" \
+            --role-id "$DISCORD_RELEASE_LATEST_ROLE_ID" \
             --release-name "${{ needs.preflight.outputs.release_name }}" \
             --version "${{ needs.preflight.outputs.version }}" \
             --tag "${{ needs.preflight.outputs.tag }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,32 +508,6 @@ jobs:
           fail_on_unmatched_files: true
           token: ${{ steps.app_token.outputs.token }}
 
-      - name: Announce prerelease on Discord
-        if: needs.preflight.outputs.is_prerelease == 'true'
-        env:
-          DISCORD_RELEASE_NIGHTLY_ROLE_ID: ${{ vars.DISCORD_RELEASE_NIGHTLY_ROLE_ID }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
-        run: |
-          node scripts/notify-discord-release.ts prerelease \
-            --role-id "$DISCORD_RELEASE_NIGHTLY_ROLE_ID" \
-            --release-name "${{ needs.preflight.outputs.release_name }}" \
-            --version "${{ needs.preflight.outputs.version }}" \
-            --tag "${{ needs.preflight.outputs.tag }}" \
-            --release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.preflight.outputs.tag }}"
-
-      - name: Announce latest release on Discord
-        if: needs.preflight.outputs.make_latest == 'true'
-        env:
-          DISCORD_RELEASE_LATEST_ROLE_ID: ${{ vars.DISCORD_RELEASE_LATEST_ROLE_ID }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
-        run: |
-          node scripts/notify-discord-release.ts latest \
-            --role-id "$DISCORD_RELEASE_LATEST_ROLE_ID" \
-            --release-name "${{ needs.preflight.outputs.release_name }}" \
-            --version "${{ needs.preflight.outputs.version }}" \
-            --tag "${{ needs.preflight.outputs.tag }}" \
-            --release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.preflight.outputs.tag }}"
-
   finalize:
     name: Finalize release
     if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.release.result == 'success' && needs.preflight.outputs.release_channel == 'stable' }}
@@ -611,3 +585,60 @@ jobs:
           git add apps/server/package.json apps/desktop/package.json apps/web/package.json packages/contracts/package.json bun.lock
           git commit -m "chore(release): prepare $RELEASE_TAG"
           git push origin HEAD:main
+
+  announce_discord:
+    name: Announce release on Discord
+    if: |
+      always() && !cancelled() &&
+      needs.preflight.result == 'success' &&
+      needs.release.result == 'success' &&
+      (needs.finalize.result == 'success' || needs.finalize.result == 'skipped')
+    needs: [preflight, release, finalize]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Announce prerelease on Discord
+        if: needs.preflight.outputs.is_prerelease == 'true'
+        continue-on-error: true
+        env:
+          DISCORD_RELEASE_NIGHTLY_ROLE_ID: ${{ vars.DISCORD_RELEASE_NIGHTLY_ROLE_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          node scripts/notify-discord-release.ts prerelease \
+            --role-id "$DISCORD_RELEASE_NIGHTLY_ROLE_ID" \
+            --release-name "${{ needs.preflight.outputs.release_name }}" \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --tag "${{ needs.preflight.outputs.tag }}" \
+            --release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.preflight.outputs.tag }}"
+
+      - name: Announce latest release on Discord
+        if: needs.preflight.outputs.make_latest == 'true'
+        continue-on-error: true
+        env:
+          DISCORD_RELEASE_LATEST_ROLE_ID: ${{ vars.DISCORD_RELEASE_LATEST_ROLE_ID }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          node scripts/notify-discord-release.ts latest \
+            --role-id "$DISCORD_RELEASE_LATEST_ROLE_ID" \
+            --release-name "${{ needs.preflight.outputs.release_name }}" \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --tag "${{ needs.preflight.outputs.tag }}" \
+            --release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.preflight.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -508,6 +508,30 @@ jobs:
           fail_on_unmatched_files: true
           token: ${{ steps.app_token.outputs.token }}
 
+      - name: Announce prerelease on Discord
+        if: needs.preflight.outputs.is_prerelease == 'true'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          node scripts/notify-discord-release.ts prerelease \
+            --mention "@t3-code-nightly-announcements" \
+            --release-name "${{ needs.preflight.outputs.release_name }}" \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --tag "${{ needs.preflight.outputs.tag }}" \
+            --release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.preflight.outputs.tag }}"
+
+      - name: Announce latest release on Discord
+        if: needs.preflight.outputs.make_latest == 'true'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          node scripts/notify-discord-release.ts latest \
+            --mention "@t3-code-announcements" \
+            --release-name "${{ needs.preflight.outputs.release_name }}" \
+            --version "${{ needs.preflight.outputs.version }}" \
+            --tag "${{ needs.preflight.outputs.tag }}" \
+            --release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.preflight.outputs.tag }}"
+
   finalize:
     name: Finalize release
     if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.release.result == 'success' && needs.preflight.outputs.release_channel == 'stable' }}

--- a/scripts/notify-discord-release.test.ts
+++ b/scripts/notify-discord-release.test.ts
@@ -6,7 +6,7 @@ it("builds a prerelease Discord announcement for nightly subscribers", () => {
   assert.deepStrictEqual(
     buildDiscordReleaseAnnouncement({
       target: "prerelease",
-      mention: "@t3-code-nightly-announcements",
+      roleId: "111111111111111111",
       releaseName: "T3 Code Nightly 1.2.4-nightly.20260501.17 (abcdef123456)",
       version: "1.2.4-nightly.20260501.17",
       tag: "v1.2.4-nightly.20260501.17",
@@ -15,9 +15,9 @@ it("builds a prerelease Discord announcement for nightly subscribers", () => {
     }),
     {
       content:
-        "@t3-code-nightly-announcements Prerelease published: T3 Code Nightly 1.2.4-nightly.20260501.17 (abcdef123456)",
+        "<@&111111111111111111> Prerelease published: T3 Code Nightly 1.2.4-nightly.20260501.17 (abcdef123456)",
       allowed_mentions: {
-        parse: ["roles"],
+        roles: ["111111111111111111"],
       },
       embeds: [
         {
@@ -48,7 +48,7 @@ it("builds a latest Discord announcement for stable subscribers", () => {
   assert.deepStrictEqual(
     buildDiscordReleaseAnnouncement({
       target: "latest",
-      mention: "@t3-code-announcements",
+      roleId: "222222222222222222",
       releaseName: "T3 Code v1.2.3",
       version: "1.2.3",
       tag: "v1.2.3",
@@ -56,9 +56,9 @@ it("builds a latest Discord announcement for stable subscribers", () => {
       timestamp: "2026-05-01T01:41:00.000Z",
     }),
     {
-      content: "@t3-code-announcements Latest published: T3 Code v1.2.3",
+      content: "<@&222222222222222222> Latest published: T3 Code v1.2.3",
       allowed_mentions: {
-        parse: ["roles"],
+        roles: ["222222222222222222"],
       },
       embeds: [
         {

--- a/scripts/notify-discord-release.test.ts
+++ b/scripts/notify-discord-release.test.ts
@@ -1,0 +1,86 @@
+import { assert, it } from "@effect/vitest";
+
+import { buildDiscordReleaseAnnouncement } from "./notify-discord-release.ts";
+
+it("builds a prerelease Discord announcement for nightly subscribers", () => {
+  assert.deepStrictEqual(
+    buildDiscordReleaseAnnouncement({
+      target: "prerelease",
+      mention: "@t3-code-nightly-announcements",
+      releaseName: "T3 Code Nightly 1.2.4-nightly.20260501.17 (abcdef123456)",
+      version: "1.2.4-nightly.20260501.17",
+      tag: "v1.2.4-nightly.20260501.17",
+      releaseUrl: "https://github.com/t3dotgg/t3-code/releases/tag/v1.2.4-nightly.20260501.17",
+      timestamp: "2026-05-01T01:41:00.000Z",
+    }),
+    {
+      content:
+        "@t3-code-nightly-announcements Prerelease published: T3 Code Nightly 1.2.4-nightly.20260501.17 (abcdef123456)",
+      allowed_mentions: {
+        parse: ["roles"],
+      },
+      embeds: [
+        {
+          title: "T3 Code Nightly 1.2.4-nightly.20260501.17 (abcdef123456)",
+          url: "https://github.com/t3dotgg/t3-code/releases/tag/v1.2.4-nightly.20260501.17",
+          description: "A new T3 Code prerelease is available for nightly testers.",
+          color: 0x5865f2,
+          fields: [
+            {
+              name: "Version",
+              value: "1.2.4-nightly.20260501.17",
+              inline: true,
+            },
+            {
+              name: "Tag",
+              value: "v1.2.4-nightly.20260501.17",
+              inline: true,
+            },
+          ],
+          timestamp: "2026-05-01T01:41:00.000Z",
+        },
+      ],
+    },
+  );
+});
+
+it("builds a latest Discord announcement for stable subscribers", () => {
+  assert.deepStrictEqual(
+    buildDiscordReleaseAnnouncement({
+      target: "latest",
+      mention: "@t3-code-announcements",
+      releaseName: "T3 Code v1.2.3",
+      version: "1.2.3",
+      tag: "v1.2.3",
+      releaseUrl: "https://github.com/t3dotgg/t3-code/releases/tag/v1.2.3",
+      timestamp: "2026-05-01T01:41:00.000Z",
+    }),
+    {
+      content: "@t3-code-announcements Latest published: T3 Code v1.2.3",
+      allowed_mentions: {
+        parse: ["roles"],
+      },
+      embeds: [
+        {
+          title: "T3 Code v1.2.3",
+          url: "https://github.com/t3dotgg/t3-code/releases/tag/v1.2.3",
+          description: "A new T3 Code latest release is available.",
+          color: 0x2ecc71,
+          fields: [
+            {
+              name: "Version",
+              value: "1.2.3",
+              inline: true,
+            },
+            {
+              name: "Tag",
+              value: "v1.2.3",
+              inline: true,
+            },
+          ],
+          timestamp: "2026-05-01T01:41:00.000Z",
+        },
+      ],
+    },
+  );
+});

--- a/scripts/notify-discord-release.ts
+++ b/scripts/notify-discord-release.ts
@@ -4,7 +4,12 @@ import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Config, Data, Effect, Layer, Schema } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
-import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http";
 
 export type DiscordReleaseTarget = "prerelease" | "latest";
 
@@ -94,10 +99,17 @@ const postDiscordWebhook = Effect.fn("postDiscordWebhook")(function* (
   webhookUrl: string,
   payload: DiscordWebhookPayload,
 ) {
-  const httpClient = yield* HttpClient.HttpClient;
-  const response = yield* HttpClientRequest.post(webhookUrl).pipe(
+  const httpClient = (yield* HttpClient.HttpClient).pipe(
+    HttpClient.retryTransient({
+      retryOn: "errors-and-responses",
+      times: 3,
+    }),
+  );
+
+  yield* HttpClientRequest.post(webhookUrl).pipe(
     HttpClientRequest.bodyJson(payload),
     Effect.flatMap(httpClient.execute),
+    Effect.flatMap(HttpClientResponse.filterStatusOk),
     Effect.mapError(
       (cause) =>
         new DiscordReleaseAnnouncementError({
@@ -106,15 +118,6 @@ const postDiscordWebhook = Effect.fn("postDiscordWebhook")(function* (
         }),
     ),
   );
-
-  if (response.status < 200 || response.status >= 300) {
-    const body = yield* response.text.pipe(Effect.catch(() => Effect.succeed("")));
-    return yield* new DiscordReleaseAnnouncementError({
-      message: `Discord release announcement failed with HTTP ${response.status}${
-        body ? `: ${body}` : ""
-      }`,
-    });
-  }
 });
 
 const runtimeLayer = Layer.mergeAll(NodeServices.layer, FetchHttpClient.layer);

--- a/scripts/notify-discord-release.ts
+++ b/scripts/notify-discord-release.ts
@@ -2,7 +2,7 @@
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { Config, Effect, Schema } from "effect";
+import { Config, Data, Effect, Schema } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 
 export type DiscordReleaseTarget = "prerelease" | "latest";
@@ -36,9 +36,14 @@ interface DiscordWebhookPayload {
   }>;
 }
 
-const DiscordReleaseTargetSchema = Schema.Literal("prerelease", "latest");
+const DISCORD_RELEASE_TARGETS = ["prerelease", "latest"] as const;
 const WebUrlSchema = Schema.String.check(Schema.isPattern(/^https?:\/\/\S+$/));
 const DiscordWebhookUrl = Config.nonEmptyString("DISCORD_WEBHOOK_URL");
+
+class DiscordReleaseAnnouncementError extends Data.TaggedError("DiscordReleaseAnnouncementError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
 
 const targetLabels = {
   prerelease: "Prerelease",
@@ -96,26 +101,27 @@ const postDiscordWebhook = Effect.fn("postDiscordWebhook")(function* (
         },
         body: JSON.stringify(payload),
       }),
-    catch: (cause) => new Error(`Failed to post Discord release announcement: ${String(cause)}`),
+    catch: (cause) =>
+      new DiscordReleaseAnnouncementError({
+        message: "Failed to post Discord release announcement.",
+        cause,
+      }),
   });
 
   if (!response.ok) {
     const body = yield* Effect.promise(() => response.text().catch(() => ""));
-    return yield* Effect.fail(
-      new Error(
-        `Discord release announcement failed with HTTP ${response.status}${
-          body ? `: ${body}` : ""
-        }`,
-      ),
-    );
+    return yield* new DiscordReleaseAnnouncementError({
+      message: `Discord release announcement failed with HTTP ${response.status}${
+        body ? `: ${body}` : ""
+      }`,
+    });
   }
 });
 
 export const notifyDiscordReleaseCommand = Command.make(
   "notify-discord-release",
   {
-    target: Argument.string("target").pipe(
-      Argument.withSchema(DiscordReleaseTargetSchema),
+    target: Argument.choice("target", DISCORD_RELEASE_TARGETS).pipe(
       Argument.withDescription("Discord announcement target: prerelease or latest."),
     ),
     mention: Flag.string("mention").pipe(
@@ -140,22 +146,21 @@ export const notifyDiscordReleaseCommand = Command.make(
     ),
   },
   ({ target, mention, releaseName, version, tag, releaseUrl }) =>
-    DiscordWebhookUrl.pipe(
-      Effect.flatMap((webhookUrl) =>
-        postDiscordWebhook(
-          webhookUrl,
-          buildDiscordReleaseAnnouncement({
-            target,
-            mention,
-            releaseName,
-            version,
-            tag,
-            releaseUrl,
-            timestamp: new Date().toISOString(),
-          }),
-        ),
-      ),
-    ),
+    Effect.gen(function* () {
+      const webhookUrl = yield* DiscordWebhookUrl;
+      yield* postDiscordWebhook(
+        webhookUrl,
+        buildDiscordReleaseAnnouncement({
+          target,
+          mention,
+          releaseName,
+          version,
+          tag,
+          releaseUrl,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+    }),
 ).pipe(Command.withDescription("Post a T3 Code release announcement to Discord."));
 
 if (import.meta.main) {

--- a/scripts/notify-discord-release.ts
+++ b/scripts/notify-discord-release.ts
@@ -9,7 +9,7 @@ export type DiscordReleaseTarget = "prerelease" | "latest";
 
 interface DiscordReleaseAnnouncementOptions {
   readonly target: DiscordReleaseTarget;
-  readonly mention: string;
+  readonly roleId: string;
   readonly releaseName: string;
   readonly version: string;
   readonly tag: string;
@@ -20,7 +20,7 @@ interface DiscordReleaseAnnouncementOptions {
 interface DiscordWebhookPayload {
   readonly content: string;
   readonly allowed_mentions: {
-    readonly parse: ReadonlyArray<"roles">;
+    readonly roles: ReadonlyArray<string>;
   };
   readonly embeds: ReadonlyArray<{
     readonly title: string;
@@ -37,6 +37,7 @@ interface DiscordWebhookPayload {
 }
 
 const DISCORD_RELEASE_TARGETS = ["prerelease", "latest"] as const;
+const DiscordRoleIdSchema = Schema.String.check(Schema.isPattern(/^\d+$/));
 const WebUrlSchema = Schema.String.check(Schema.isPattern(/^https?:\/\/\S+$/));
 const DiscordWebhookUrl = Config.nonEmptyString("DISCORD_WEBHOOK_URL");
 
@@ -58,9 +59,9 @@ const targetColors = {
 export const buildDiscordReleaseAnnouncement = (
   options: DiscordReleaseAnnouncementOptions,
 ): DiscordWebhookPayload => ({
-  content: `${options.mention} ${targetLabels[options.target]} published: ${options.releaseName}`,
+  content: `<@&${options.roleId}> ${targetLabels[options.target]} published: ${options.releaseName}`,
   allowed_mentions: {
-    parse: ["roles"],
+    roles: [options.roleId],
   },
   embeds: [
     {
@@ -124,9 +125,9 @@ export const notifyDiscordReleaseCommand = Command.make(
     target: Argument.choice("target", DISCORD_RELEASE_TARGETS).pipe(
       Argument.withDescription("Discord announcement target: prerelease or latest."),
     ),
-    mention: Flag.string("mention").pipe(
-      Flag.withSchema(Schema.NonEmptyString),
-      Flag.withDescription("Discord mention text included at the start of the message."),
+    roleId: Flag.string("role-id").pipe(
+      Flag.withSchema(DiscordRoleIdSchema),
+      Flag.withDescription("Discord role ID to mention in the release announcement."),
     ),
     releaseName: Flag.string("release-name").pipe(
       Flag.withSchema(Schema.NonEmptyString),
@@ -145,14 +146,14 @@ export const notifyDiscordReleaseCommand = Command.make(
       Flag.withDescription("Public GitHub release URL."),
     ),
   },
-  ({ target, mention, releaseName, version, tag, releaseUrl }) =>
+  ({ target, roleId, releaseName, version, tag, releaseUrl }) =>
     Effect.gen(function* () {
       const webhookUrl = yield* DiscordWebhookUrl;
       yield* postDiscordWebhook(
         webhookUrl,
         buildDiscordReleaseAnnouncement({
           target,
-          mention,
+          roleId,
           releaseName,
           version,
           tag,

--- a/scripts/notify-discord-release.ts
+++ b/scripts/notify-discord-release.ts
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { Config, Effect, Schema } from "effect";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+
+export type DiscordReleaseTarget = "prerelease" | "latest";
+
+interface DiscordReleaseAnnouncementOptions {
+  readonly target: DiscordReleaseTarget;
+  readonly mention: string;
+  readonly releaseName: string;
+  readonly version: string;
+  readonly tag: string;
+  readonly releaseUrl: string;
+  readonly timestamp: string;
+}
+
+interface DiscordWebhookPayload {
+  readonly content: string;
+  readonly allowed_mentions: {
+    readonly parse: ReadonlyArray<"roles">;
+  };
+  readonly embeds: ReadonlyArray<{
+    readonly title: string;
+    readonly url: string;
+    readonly description: string;
+    readonly color: number;
+    readonly fields: ReadonlyArray<{
+      readonly name: string;
+      readonly value: string;
+      readonly inline: boolean;
+    }>;
+    readonly timestamp: string;
+  }>;
+}
+
+const DiscordReleaseTargetSchema = Schema.Literal("prerelease", "latest");
+const WebUrlSchema = Schema.String.check(Schema.isPattern(/^https?:\/\/\S+$/));
+const DiscordWebhookUrl = Config.nonEmptyString("DISCORD_WEBHOOK_URL");
+
+const targetLabels = {
+  prerelease: "Prerelease",
+  latest: "Latest",
+} as const satisfies Record<DiscordReleaseTarget, string>;
+
+const targetColors = {
+  prerelease: 0x5865f2,
+  latest: 0x2ecc71,
+} as const satisfies Record<DiscordReleaseTarget, number>;
+
+export const buildDiscordReleaseAnnouncement = (
+  options: DiscordReleaseAnnouncementOptions,
+): DiscordWebhookPayload => ({
+  content: `${options.mention} ${targetLabels[options.target]} published: ${options.releaseName}`,
+  allowed_mentions: {
+    parse: ["roles"],
+  },
+  embeds: [
+    {
+      title: options.releaseName,
+      url: options.releaseUrl,
+      description:
+        options.target === "prerelease"
+          ? "A new T3 Code prerelease is available for nightly testers."
+          : "A new T3 Code latest release is available.",
+      color: targetColors[options.target],
+      fields: [
+        {
+          name: "Version",
+          value: options.version,
+          inline: true,
+        },
+        {
+          name: "Tag",
+          value: options.tag,
+          inline: true,
+        },
+      ],
+      timestamp: options.timestamp,
+    },
+  ],
+});
+
+const postDiscordWebhook = Effect.fn("postDiscordWebhook")(function* (
+  webhookUrl: string,
+  payload: DiscordWebhookPayload,
+) {
+  const response = yield* Effect.tryPromise({
+    try: () =>
+      fetch(webhookUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      }),
+    catch: (cause) => new Error(`Failed to post Discord release announcement: ${String(cause)}`),
+  });
+
+  if (!response.ok) {
+    const body = yield* Effect.promise(() => response.text().catch(() => ""));
+    return yield* Effect.fail(
+      new Error(
+        `Discord release announcement failed with HTTP ${response.status}${
+          body ? `: ${body}` : ""
+        }`,
+      ),
+    );
+  }
+});
+
+export const notifyDiscordReleaseCommand = Command.make(
+  "notify-discord-release",
+  {
+    target: Argument.string("target").pipe(
+      Argument.withSchema(DiscordReleaseTargetSchema),
+      Argument.withDescription("Discord announcement target: prerelease or latest."),
+    ),
+    mention: Flag.string("mention").pipe(
+      Flag.withSchema(Schema.NonEmptyString),
+      Flag.withDescription("Discord mention text included at the start of the message."),
+    ),
+    releaseName: Flag.string("release-name").pipe(
+      Flag.withSchema(Schema.NonEmptyString),
+      Flag.withDescription("Human-readable release name."),
+    ),
+    version: Flag.string("version").pipe(
+      Flag.withSchema(Schema.NonEmptyString),
+      Flag.withDescription("Release version."),
+    ),
+    tag: Flag.string("tag").pipe(
+      Flag.withSchema(Schema.NonEmptyString),
+      Flag.withDescription("Git tag for the release."),
+    ),
+    releaseUrl: Flag.string("release-url").pipe(
+      Flag.withSchema(WebUrlSchema),
+      Flag.withDescription("Public GitHub release URL."),
+    ),
+  },
+  ({ target, mention, releaseName, version, tag, releaseUrl }) =>
+    DiscordWebhookUrl.pipe(
+      Effect.flatMap((webhookUrl) =>
+        postDiscordWebhook(
+          webhookUrl,
+          buildDiscordReleaseAnnouncement({
+            target,
+            mention,
+            releaseName,
+            version,
+            tag,
+            releaseUrl,
+            timestamp: new Date().toISOString(),
+          }),
+        ),
+      ),
+    ),
+).pipe(Command.withDescription("Post a T3 Code release announcement to Discord."));
+
+if (import.meta.main) {
+  Command.run(notifyDiscordReleaseCommand, { version: "0.0.0" }).pipe(
+    Effect.provide(NodeServices.layer),
+    NodeRuntime.runMain,
+  );
+}

--- a/scripts/notify-discord-release.ts
+++ b/scripts/notify-discord-release.ts
@@ -4,12 +4,7 @@ import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Config, Data, Effect, Layer, Schema } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
-import {
-  FetchHttpClient,
-  HttpClient,
-  HttpClientRequest,
-  HttpClientResponse,
-} from "effect/unstable/http";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 export type DiscordReleaseTarget = "prerelease" | "latest";
 
@@ -104,12 +99,12 @@ const postDiscordWebhook = Effect.fn("postDiscordWebhook")(function* (
       retryOn: "errors-and-responses",
       times: 3,
     }),
+    HttpClient.filterStatusOk,
   );
 
   yield* HttpClientRequest.post(webhookUrl).pipe(
     HttpClientRequest.bodyJson(payload),
     Effect.flatMap(httpClient.execute),
-    Effect.flatMap(HttpClientResponse.filterStatusOk),
     Effect.mapError(
       (cause) =>
         new DiscordReleaseAnnouncementError({

--- a/scripts/notify-discord-release.ts
+++ b/scripts/notify-discord-release.ts
@@ -2,8 +2,9 @@
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { Config, Data, Effect, Schema } from "effect";
+import { Config, Data, Effect, Layer, Schema } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 export type DiscordReleaseTarget = "prerelease" | "latest";
 
@@ -93,24 +94,21 @@ const postDiscordWebhook = Effect.fn("postDiscordWebhook")(function* (
   webhookUrl: string,
   payload: DiscordWebhookPayload,
 ) {
-  const response = yield* Effect.tryPromise({
-    try: () =>
-      fetch(webhookUrl, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify(payload),
-      }),
-    catch: (cause) =>
-      new DiscordReleaseAnnouncementError({
-        message: "Failed to post Discord release announcement.",
-        cause,
-      }),
-  });
+  const httpClient = yield* HttpClient.HttpClient;
+  const response = yield* HttpClientRequest.post(webhookUrl).pipe(
+    HttpClientRequest.bodyJson(payload),
+    Effect.flatMap(httpClient.execute),
+    Effect.mapError(
+      (cause) =>
+        new DiscordReleaseAnnouncementError({
+          message: "Failed to post Discord release announcement.",
+          cause,
+        }),
+    ),
+  );
 
-  if (!response.ok) {
-    const body = yield* Effect.promise(() => response.text().catch(() => ""));
+  if (response.status < 200 || response.status >= 300) {
+    const body = yield* response.text.pipe(Effect.catch(() => Effect.succeed("")));
     return yield* new DiscordReleaseAnnouncementError({
       message: `Discord release announcement failed with HTTP ${response.status}${
         body ? `: ${body}` : ""
@@ -118,6 +116,8 @@ const postDiscordWebhook = Effect.fn("postDiscordWebhook")(function* (
     });
   }
 });
+
+const runtimeLayer = Layer.mergeAll(NodeServices.layer, FetchHttpClient.layer);
 
 export const notifyDiscordReleaseCommand = Command.make(
   "notify-discord-release",
@@ -166,7 +166,7 @@ export const notifyDiscordReleaseCommand = Command.make(
 
 if (import.meta.main) {
   Command.run(notifyDiscordReleaseCommand, { version: "0.0.0" }).pipe(
-    Effect.provide(NodeServices.layer),
+    Effect.provide(runtimeLayer),
     NodeRuntime.runMain,
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

Adds a release notification script and calls it from a final Discord announcement job after GitHub Release publishing succeeds and any stable version bump finalization completes. Prereleases mention the role ID from `DISCORD_RELEASE_NIGHTLY_ROLE_ID`; latest releases mention the role ID from `DISCORD_RELEASE_LATEST_ROLE_ID`.

## Why

Release announcements should be pushed automatically to Discord, but Discord webhook failures should never block publishing artifacts, publishing the CLI, or committing stable version bumps.

## UI Changes

Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e99541b-fc2a-4ded-92cc-0cff8d9f87ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e99541b-fc2a-4ded-92cc-0cff8d9f87ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Discord release announcements to the release workflow
> - Adds [scripts/notify-discord-release.ts](https://github.com/pingdotgg/t3code/pull/2429/files#diff-8a20022b49201d57b8cdd36c484de30a0b4263519883392faf1e801d2f7e5041), a CLI script that posts a formatted Discord webhook message for prerelease (nightly) or latest (stable) releases, including an embed with version, tag, and release URL.
> - Adds an `announce_discord` job to [.github/workflows/release.yml](https://github.com/pingdotgg/t3code/pull/2429/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) that runs after a successful release and invokes the script with the appropriate role ID and metadata from workflow outputs.
> - The announcement step uses `continue-on-error: true`, so a failed Discord post does not fail the release workflow.
> - Role IDs and webhook URL are sourced from repository variables and secrets (`DISCORD_RELEASE_NIGHTLY_ROLE_ID`, `DISCORD_RELEASE_LATEST_ROLE_ID`, `DISCORD_WEBHOOK_URL`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b66728.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->