### PR TITLE
Optimize release workflow job execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   check_changes:
     name: Check for changes since last nightly
     if: github.event_name == 'schedule'
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
@@ -376,13 +376,16 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --filter=t3 --filter=@t3tools/web --filter=@t3tools/scripts
 
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
 
+      - name: Build web package
+        run: bun --filter=@t3tools/web run build
+
       - name: Build CLI package
-        run: bun run build --filter=@t3tools/web --filter=t3
+        run: bun --filter=t3 run build
 
       - name: Publish CLI package
         run: node apps/server/scripts/cli.ts publish --tag "${{ needs.preflight.outputs.cli_dist_tag }}" --app-version "${{ needs.preflight.outputs.version }}" --verbose
@@ -391,7 +394,7 @@ jobs:
     name: Publish GitHub Release
     needs: [preflight, build, publish_cli]
     if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' && needs.build.result == 'success' && needs.publish_cli.result == 'success' }}
-    runs-on: ubuntu-24.04 # blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - id: app_token
@@ -418,7 +421,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --filter=@t3tools/scripts
 
       - name: Download all desktop artifacts
         uses: actions/download-artifact@v8
@@ -552,7 +555,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --filter=@t3tools/scripts
 
       - id: update_versions
         name: Update version strings
@@ -562,7 +565,7 @@ jobs:
 
       - name: Format package.json files
         if: steps.update_versions.outputs.changed == 'true'
-        run: bunx oxfmt apps/server/package.json apps/desktop/package.json apps/web/package.json packages/contracts/package.json
+        run: bunx oxfmt@0.40.0 apps/server/package.json apps/desktop/package.json apps/web/package.json packages/contracts/package.json
 
       - name: Refresh lockfile
         if: steps.update_versions.outputs.changed == 'true'
@@ -594,7 +597,7 @@ jobs:
       needs.release.result == 'success' &&
       (needs.finalize.result == 'success' || needs.finalize.result == 'skipped')
     needs: [preflight, release, finalize]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -613,7 +616,7 @@ jobs:
           node-version-file: package.json
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bun install --frozen-lockfile --filter=@t3tools/scripts
 
       - name: Announce prerelease on Discord
         if: needs.preflight.outputs.is_prerelease == 'true'


### PR DESCRIPTION
## Summary
- Move selected release workflow jobs onto Blacksmith runners to reduce execution time.
- Narrow `bun install` scope in release-related jobs to only the packages they need.
- Split the release build into explicit web and CLI build steps.
- Pin `oxfmt` to `0.40.0` for deterministic formatting during version updates.

## Testing
- Not run (workflow-only change).
- Verified the diff updates only `.github/workflows/release.yml`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow-only changes but they modify the release pipeline (runner selection, install/build steps), so a misconfiguration could break publishing or produce incomplete artifacts.
> 
> **Overview**
> Optimizes the `release.yml` GitHub Actions workflow to reduce runtime by moving additional jobs (`check_changes`, `release`, `announce_discord`) onto Blacksmith runners.
> 
> Scopes several `bun install` steps to only the required workspaces via `--filter` (notably release/finalize/announce and CLI publishing), and splits publishing builds into explicit `@t3tools/web` and `t3` build steps.
> 
> Pins `oxfmt` to `0.40.0` during the finalize version-bump formatting step for deterministic output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96790d9f7c05c6ea7092d94f75048688465749cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize release workflow job execution with scoped installs and dedicated build steps
> - Switches `check_changes`, `release`, and `announce_discord` jobs to the `blacksmith-8vcpu-ubuntu-2404` runner.
> - Scopes `bun install` to only the relevant workspace filters in each job, reducing install overhead.
> - Splits the web and CLI builds in `check_changes` into separate steps, building `@t3tools/web` first, then `t3` independently.
> - Pins `oxfmt` to version `0.40.0` in the `finalize` job to avoid unpinned version drift.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96790d9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->