### PR TITLE
feat(desktop): add Cmd+Option+V shortcut to paste clipboard text as file attachment

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -85,6 +85,7 @@ const SET_THEME_CHANNEL = "desktop:set-theme";
 const CONTEXT_MENU_CHANNEL = "desktop:context-menu";
 const OPEN_EXTERNAL_CHANNEL = "desktop:open-external";
 const MENU_ACTION_CHANNEL = "desktop:menu-action";
+const PASTE_CLIPBOARD_AS_FILE_CHANNEL = "desktop:paste-clipboard-as-file";
 const UPDATE_STATE_CHANNEL = "desktop:update-state";
 const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 const UPDATE_SET_CHANNEL_CHANNEL = "desktop:update-set-channel";
@@ -1782,6 +1783,30 @@ function registerIpcHandlers(): void {
     } catch {
       return false;
     }
+  });
+
+  ipcMain.removeHandler(PASTE_CLIPBOARD_AS_FILE_CHANNEL);
+  ipcMain.handle(PASTE_CLIPBOARD_AS_FILE_CHANNEL, async () => {
+    const text = clipboard.readText();
+    if (!text) return null;
+
+    const now = new Date();
+    const timestamp = [
+      now.getFullYear(),
+      String(now.getMonth() + 1).padStart(2, "0"),
+      String(now.getDate()).padStart(2, "0"),
+      String(now.getHours()).padStart(2, "0"),
+      String(now.getMinutes()).padStart(2, "0"),
+      String(now.getSeconds()).padStart(2, "0"),
+      String(now.getMilliseconds()).padStart(3, "0"),
+    ].join("-");
+    const fileName = `pasted-${timestamp}.md`;
+
+    const pastedFilesDir = Path.join(app.getPath("userData"), "pasted-files");
+    FS.mkdirSync(pastedFilesDir, { recursive: true });
+    FS.writeFileSync(Path.join(pastedFilesDir, fileName), text, "utf-8");
+
+    return { fileName, text };
   });
 
   ipcMain.removeHandler(UPDATE_GET_STATE_CHANNEL);

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -24,6 +24,7 @@ const SET_SAVED_ENVIRONMENT_SECRET_CHANNEL = "desktop:set-saved-environment-secr
 const REMOVE_SAVED_ENVIRONMENT_SECRET_CHANNEL = "desktop:remove-saved-environment-secret";
 const GET_SERVER_EXPOSURE_STATE_CHANNEL = "desktop:get-server-exposure-state";
 const SET_SERVER_EXPOSURE_MODE_CHANNEL = "desktop:set-server-exposure-mode";
+const PASTE_CLIPBOARD_AS_FILE_CHANNEL = "desktop:paste-clipboard-as-file";
 
 contextBridge.exposeInMainWorld("desktopBridge", {
   getAppBranding: () => {
@@ -58,6 +59,7 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   setTheme: (theme) => ipcRenderer.invoke(SET_THEME_CHANNEL, theme),
   showContextMenu: (items, position) => ipcRenderer.invoke(CONTEXT_MENU_CHANNEL, items, position),
   openExternal: (url: string) => ipcRenderer.invoke(OPEN_EXTERNAL_CHANNEL, url),
+  pasteClipboardAsFile: () => ipcRenderer.invoke(PASTE_CLIPBOARD_AS_FILE_CHANNEL),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {
       if (typeof action !== "string") return;

--- a/apps/server/src/attachmentStore.ts
+++ b/apps/server/src/attachmentStore.ts
@@ -9,7 +9,7 @@ import {
 } from "./attachmentPaths.ts";
 import { inferImageExtension, SAFE_IMAGE_FILE_EXTENSIONS } from "./imageMime.ts";
 
-const ATTACHMENT_FILENAME_EXTENSIONS = [...SAFE_IMAGE_FILE_EXTENSIONS, ".bin"];
+const ATTACHMENT_FILENAME_EXTENSIONS = [...SAFE_IMAGE_FILE_EXTENSIONS, ".md", ".bin"];
 const ATTACHMENT_ID_THREAD_SEGMENT_MAX_CHARS = 80;
 const ATTACHMENT_ID_THREAD_SEGMENT_PATTERN = "[a-z0-9_]+(?:-[a-z0-9_]+)*";
 const ATTACHMENT_ID_UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
@@ -61,6 +61,9 @@ export function attachmentRelativePath(attachment: ChatAttachment): string {
         fileName: attachment.name,
       });
       return `${attachment.id}${extension}`;
+    }
+    case "text": {
+      return `${attachment.id}.md`;
     }
   }
 }

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -69,6 +69,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },
   { key: "mod+o", command: "editor.openFavorite" },
+  { key: "mod+alt+v", command: "chat.pasteAsFile", when: "!terminalFocus" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({

--- a/apps/server/src/orchestration/Normalizer.ts
+++ b/apps/server/src/orchestration/Normalizer.ts
@@ -4,6 +4,7 @@ import {
   type OrchestrationCommand,
   OrchestrationDispatchCommandError,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
+  PROVIDER_SEND_TURN_MAX_TEXT_BYTES,
 } from "@t3tools/contracts";
 
 import { createAttachmentId, resolveAttachmentPath } from "../attachmentStore.ts";
@@ -72,16 +73,34 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
       (attachment) =>
         Effect.gen(function* () {
           const parsed = parseBase64DataUrl(attachment.dataUrl);
-          if (!parsed || !parsed.mimeType.startsWith("image/")) {
+          if (!parsed) {
+            return yield* new OrchestrationDispatchCommandError({
+              message: `Invalid attachment payload for '${attachment.name}'.`,
+            });
+          }
+
+          const isImage = attachment.type === "image";
+          const isText = attachment.type === "text";
+
+          if (isImage && !parsed.mimeType.startsWith("image/")) {
             return yield* new OrchestrationDispatchCommandError({
               message: `Invalid image attachment payload for '${attachment.name}'.`,
             });
           }
 
-          const bytes = Buffer.from(parsed.base64, "base64");
-          if (bytes.byteLength === 0 || bytes.byteLength > PROVIDER_SEND_TURN_MAX_IMAGE_BYTES) {
+          if (isText && !parsed.mimeType.startsWith("text/")) {
             return yield* new OrchestrationDispatchCommandError({
-              message: `Image attachment '${attachment.name}' is empty or too large.`,
+              message: `Invalid text attachment payload for '${attachment.name}'.`,
+            });
+          }
+
+          const bytes = Buffer.from(parsed.base64, "base64");
+          const maxBytes = isImage
+            ? PROVIDER_SEND_TURN_MAX_IMAGE_BYTES
+            : PROVIDER_SEND_TURN_MAX_TEXT_BYTES;
+          if (bytes.byteLength === 0 || bytes.byteLength > maxBytes) {
+            return yield* new OrchestrationDispatchCommandError({
+              message: `Attachment '${attachment.name}' is empty or too large.`,
             });
           }
 
@@ -93,7 +112,7 @@ export const normalizeDispatchCommand = (command: ClientOrchestrationCommand) =>
           }
 
           const persistedAttachment = {
-            type: "image" as const,
+            type: isText ? ("text" as const) : ("image" as const),
             id: attachmentId,
             name: attachment.name,
             mimeType: parsed.mimeType.toLowerCase(),

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -30,6 +30,7 @@ describe("deriveComposerSendState", () => {
     const state = deriveComposerSendState({
       prompt: "\uFFFC",
       imageCount: 0,
+      textFileCount: 0,
       terminalContexts: [
         {
           id: "ctx-expired",
@@ -54,6 +55,7 @@ describe("deriveComposerSendState", () => {
     const state = deriveComposerSendState({
       prompt: `yoo \uFFFC waddup`,
       imageCount: 0,
+      textFileCount: 0,
       terminalContexts: [
         {
           id: "ctx-expired",

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -183,6 +183,7 @@ export function cloneComposerImageForRetry(
 export function deriveComposerSendState(options: {
   prompt: string;
   imageCount: number;
+  textFileCount: number;
   terminalContexts: ReadonlyArray<TerminalContextDraft>;
 }): {
   trimmedPrompt: string;
@@ -199,7 +200,10 @@ export function deriveComposerSendState(options: {
     sendableTerminalContexts,
     expiredTerminalContextCount,
     hasSendableContent:
-      trimmedPrompt.length > 0 || options.imageCount > 0 || sendableTerminalContexts.length > 0,
+      trimmedPrompt.length > 0 ||
+      options.imageCount > 0 ||
+      options.textFileCount > 0 ||
+      sendableTerminalContexts.length > 0,
   };
 }
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -89,6 +89,7 @@ import {
   DEFAULT_RUNTIME_MODE,
   DEFAULT_THREAD_TERMINAL_ID,
   MAX_TERMINALS_PER_GROUP,
+  type ChatAttachment,
   type ChatMessage,
   type SessionPhase,
   type Thread,
@@ -127,9 +128,10 @@ import {
 import { buildDraftThreadRouteParams } from "../threadRoutes";
 import {
   type ComposerImageAttachment,
+  type ComposerTextFileAttachment,
   type DraftThreadEnvMode,
-  useComposerDraftStore,
   type DraftId,
+  useComposerDraftStore,
 } from "../composerDraftStore";
 import {
   appendTerminalContextsToPrompt,
@@ -183,6 +185,10 @@ import { RightPanelSheet } from "./RightPanelSheet";
 
 const IMAGE_ONLY_BOOTSTRAP_PROMPT =
   "[User attached one or more images without additional text. Respond using the conversation context and the attached image(s).]";
+const TEXT_FILE_BOOTSTRAP_PROMPT =
+  "[User attached one or more text files without additional text. Respond using the conversation context and the attached file(s).]";
+const MIXED_ATTACHMENT_BOOTSTRAP_PROMPT =
+  "[User attached images and text files without additional text. Respond using the conversation context and all attached files.]";
 const EMPTY_ACTIVITIES: OrchestrationThreadActivity[] = [];
 const EMPTY_PROPOSED_PLANS: Thread["proposedPlans"] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
@@ -637,6 +643,7 @@ export default function ChatView(props: ChatViewProps) {
   );
   const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
   const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
+  const addComposerDraftTextFile = useComposerDraftStore((store) => store.addTextFile);
   const setComposerDraftTerminalContexts = useComposerDraftStore(
     (store) => store.setTerminalContexts,
   );
@@ -663,6 +670,7 @@ export default function ChatView(props: ChatViewProps) {
   );
   const promptRef = useRef("");
   const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
+  const composerTextFilesRef = useRef<ComposerTextFileAttachment[]>([]);
   const composerTerminalContextsRef = useRef<TerminalContextDraft[]>([]);
   const localComposerRef = useRef<ChatComposerHandle | null>(null);
   const composerRef = useComposerHandleContext() ?? localComposerRef;
@@ -2410,6 +2418,7 @@ export default function ChatView(props: ChatViewProps) {
     if (!sendCtx) return;
     const {
       images: composerImages,
+      textFiles: composerTextFiles,
       terminalContexts: composerTerminalContexts,
       selectedProvider: ctxSelectedProvider,
       selectedModel: ctxSelectedModel,
@@ -2426,6 +2435,7 @@ export default function ChatView(props: ChatViewProps) {
     } = deriveComposerSendState({
       prompt: promptForSend,
       imageCount: composerImages.length,
+      textFileCount: composerTextFiles.length,
       terminalContexts: composerTerminalContexts,
     });
     if (showPlanFollowUpPrompt && activeProposedPlan) {
@@ -2443,7 +2453,9 @@ export default function ChatView(props: ChatViewProps) {
       return;
     }
     const standaloneSlashCommand =
-      composerImages.length === 0 && sendableComposerTerminalContexts.length === 0
+      composerImages.length === 0 &&
+      composerTextFiles.length === 0 &&
+      sendableComposerTerminalContexts.length === 0
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
@@ -2490,6 +2502,7 @@ export default function ChatView(props: ChatViewProps) {
     beginLocalDispatch({ preparingWorktree: Boolean(baseBranchForWorktree) });
 
     const composerImagesSnapshot = [...composerImages];
+    const composerTextFilesSnapshot = [...composerTextFiles];
     const composerTerminalContextsSnapshot = [...sendableComposerTerminalContexts];
     const messageTextForSend = appendTerminalContextsToPrompt(
       promptForSend,
@@ -2497,30 +2510,54 @@ export default function ChatView(props: ChatViewProps) {
     );
     const messageIdForSend = newMessageId();
     const messageCreatedAt = new Date().toISOString();
+    const bootstrapPrompt =
+      composerImages.length > 0 && composerTextFiles.length > 0
+        ? MIXED_ATTACHMENT_BOOTSTRAP_PROMPT
+        : composerImages.length > 0
+          ? IMAGE_ONLY_BOOTSTRAP_PROMPT
+          : composerTextFiles.length > 0
+            ? TEXT_FILE_BOOTSTRAP_PROMPT
+            : "";
     const outgoingMessageText = formatOutgoingPrompt({
       provider: ctxSelectedProvider,
       model: ctxSelectedModel,
       models: ctxSelectedProviderModels,
       effort: ctxSelectedPromptEffort,
-      text: messageTextForSend || IMAGE_ONLY_BOOTSTRAP_PROMPT,
+      text: messageTextForSend || bootstrapPrompt,
     });
-    const turnAttachmentsPromise = Promise.all(
-      composerImagesSnapshot.map(async (image) => ({
+    const turnAttachmentsPromise = Promise.all([
+      ...composerImagesSnapshot.map(async (image) => ({
         type: "image" as const,
         name: image.name,
         mimeType: image.mimeType,
         sizeBytes: image.sizeBytes,
         dataUrl: await readFileAsDataUrl(image.file),
       })),
-    );
-    const optimisticAttachments = composerImagesSnapshot.map((image) => ({
-      type: "image" as const,
-      id: image.id,
-      name: image.name,
-      mimeType: image.mimeType,
-      sizeBytes: image.sizeBytes,
-      previewUrl: image.previewUrl,
-    }));
+      ...composerTextFilesSnapshot.map(async (file) => ({
+        type: "text" as const,
+        name: file.name,
+        mimeType: file.mimeType,
+        sizeBytes: file.sizeBytes,
+        dataUrl: await readFileAsDataUrl(file.file),
+      })),
+    ]);
+    const optimisticAttachments: ChatAttachment[] = [
+      ...composerImagesSnapshot.map((image) => ({
+        type: "image" as const,
+        id: image.id,
+        name: image.name,
+        mimeType: image.mimeType,
+        sizeBytes: image.sizeBytes,
+        previewUrl: image.previewUrl,
+      })),
+      ...composerTextFilesSnapshot.map((file) => ({
+        type: "text" as const,
+        id: file.id,
+        name: file.name,
+        mimeType: file.mimeType,
+        sizeBytes: file.sizeBytes,
+      })),
+    ];
     // Scroll to the current end *before* adding the optimistic message.
     // This sets LegendList's internal isAtEnd=true so maintainScrollAtEnd
     // automatically pins to the new item when the data changes.
@@ -2535,7 +2572,7 @@ export default function ChatView(props: ChatViewProps) {
         id: messageIdForSend,
         role: "user",
         text: outgoingMessageText,
-        ...(optimisticAttachments.length > 0 ? { attachments: optimisticAttachments } : {}),
+        attachments: optimisticAttachments,
         createdAt: messageCreatedAt,
         streaming: false,
       },
@@ -2568,10 +2605,19 @@ export default function ChatView(props: ChatViewProps) {
           firstComposerImageName = firstComposerImage.name;
         }
       }
+      let firstComposerTextFileName: string | null = null;
+      if (composerTextFilesSnapshot.length > 0) {
+        const firstComposerTextFile = composerTextFilesSnapshot[0];
+        if (firstComposerTextFile) {
+          firstComposerTextFileName = firstComposerTextFile.name;
+        }
+      }
       let titleSeed = trimmed;
       if (!titleSeed) {
         if (firstComposerImageName) {
           titleSeed = `Image: ${firstComposerImageName}`;
+        } else if (firstComposerTextFileName) {
+          titleSeed = `File: ${firstComposerTextFileName}`;
         } else if (composerTerminalContextsSnapshot.length > 0) {
           titleSeed = formatTerminalContextLabel(composerTerminalContextsSnapshot[0]!);
         } else {
@@ -2659,6 +2705,7 @@ export default function ChatView(props: ChatViewProps) {
         !turnStartSucceeded &&
         promptRef.current.length === 0 &&
         composerImagesRef.current.length === 0 &&
+        composerTextFilesRef.current.length === 0 &&
         composerTerminalContextsRef.current.length === 0
       ) {
         setOptimisticUserMessages((existing) => {
@@ -2672,9 +2719,13 @@ export default function ChatView(props: ChatViewProps) {
         promptRef.current = promptForSend;
         const retryComposerImages = composerImagesSnapshot.map(cloneComposerImageForRetry);
         composerImagesRef.current = retryComposerImages;
+        composerTextFilesRef.current = [...composerTextFilesSnapshot];
         composerTerminalContextsRef.current = composerTerminalContextsSnapshot;
         setComposerDraftPrompt(composerDraftTarget, promptForSend);
         addComposerDraftImages(composerDraftTarget, retryComposerImages);
+        for (const textFile of composerTextFilesSnapshot) {
+          addComposerDraftTextFile(composerDraftTarget, textFile);
+        }
         setComposerDraftTerminalContexts(composerDraftTarget, composerTerminalContextsSnapshot);
         composerRef.current?.resetCursorState({
           cursor: collapseExpandedComposerCursor(promptForSend, promptForSend.length),
@@ -3427,6 +3478,7 @@ export default function ChatView(props: ChatViewProps) {
               gitCwd={gitCwd}
               promptRef={promptRef}
               composerImagesRef={composerImagesRef}
+              composerTextFilesRef={composerTextFilesRef}
               composerTerminalContextsRef={composerTerminalContextsRef}
               shouldAutoScrollRef={isAtEndRef}
               scheduleStickToBottom={scrollToEnd}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -43,12 +43,13 @@ import {
 } from "../../composer-logic";
 import { deriveComposerSendState, readFileAsDataUrl } from "../ChatView.logic";
 import {
-  type ComposerImageAttachment,
-  type DraftId,
-  type PersistedComposerImageAttachment,
   useComposerDraftStore,
   useComposerThreadDraft,
   useEffectiveComposerModelState,
+  type ComposerImageAttachment,
+  type ComposerTextFileAttachment,
+  type DraftId,
+  type PersistedComposerImageAttachment,
 } from "../../composerDraftStore";
 import {
   type TerminalContextDraft,
@@ -88,6 +89,7 @@ import { toastManager } from "../ui/toast";
 import {
   BotIcon,
   CircleAlertIcon,
+  FileIcon,
   ListTodoIcon,
   type LucideIcon,
   LockIcon,
@@ -342,10 +344,15 @@ export interface ChatComposerHandle {
   }) => void;
   /** Insert a terminal context from the terminal drawer. */
   addTerminalContext: (selection: TerminalContextSelection) => void;
+  /** Attach a text file to the composer. */
+  addTextFile: (textFile: ComposerTextFileAttachment) => void;
+  /** Remove a text file from the composer. */
+  removeTextFile: (fileId: string) => void;
   /** Get the current prompt/effort/model state for use in send. */
   getSendContext: () => {
     prompt: string;
     images: ComposerImageAttachment[];
+    textFiles: ComposerTextFileAttachment[];
     terminalContexts: TerminalContextDraft[];
     selectedPromptEffort: string | null;
     selectedModelOptionsForDispatch: unknown;
@@ -428,6 +435,7 @@ export interface ChatComposerProps {
   // Refs the parent needs kept in sync
   promptRef: React.MutableRefObject<string>;
   composerImagesRef: React.MutableRefObject<ComposerImageAttachment[]>;
+  composerTextFilesRef: React.MutableRefObject<ComposerTextFileAttachment[]>;
   composerTerminalContextsRef: React.MutableRefObject<TerminalContextDraft[]>;
 
   // Scroll
@@ -515,6 +523,7 @@ export const ChatComposer = memo(
       gitCwd,
       promptRef,
       composerImagesRef,
+      composerTextFilesRef,
       composerTerminalContextsRef,
       shouldAutoScrollRef,
       scheduleStickToBottom,
@@ -543,6 +552,7 @@ export const ChatComposer = memo(
     const composerDraft = useComposerThreadDraft(composerDraftTarget);
     const prompt = composerDraft.prompt;
     const composerImages = composerDraft.images;
+    const composerTextFiles = composerDraft.textFiles;
     const composerTerminalContexts = composerDraft.terminalContexts;
     const nonPersistedComposerImageIds = composerDraft.nonPersistedImageIds;
 
@@ -550,6 +560,8 @@ export const ChatComposer = memo(
     const addComposerDraftImage = useComposerDraftStore((store) => store.addImage);
     const addComposerDraftImages = useComposerDraftStore((store) => store.addImages);
     const removeComposerDraftImage = useComposerDraftStore((store) => store.removeImage);
+    const addComposerDraftTextFile = useComposerDraftStore((store) => store.addTextFile);
+    const removeComposerDraftTextFile = useComposerDraftStore((store) => store.removeTextFile);
     const insertComposerDraftTerminalContext = useComposerDraftStore(
       (store) => store.insertTerminalContext,
     );
@@ -795,9 +807,10 @@ export const ChatComposer = memo(
         deriveComposerSendState({
           prompt,
           imageCount: composerImages.length,
+          textFileCount: composerTextFiles.length,
           terminalContexts: composerTerminalContexts,
         }),
-      [composerImages.length, composerTerminalContexts, prompt],
+      [composerImages.length, composerTextFiles.length, composerTerminalContexts, prompt],
     );
 
     // ------------------------------------------------------------------
@@ -1087,6 +1100,10 @@ export const ChatComposer = memo(
     useEffect(() => {
       composerImagesRef.current = composerImages;
     }, [composerImages, composerImagesRef]);
+
+    useEffect(() => {
+      composerTextFilesRef.current = composerTextFiles;
+    }, [composerTextFiles, composerTextFilesRef]);
 
     useEffect(() => {
       composerTerminalContextsRef.current = composerTerminalContexts;
@@ -1731,6 +1748,12 @@ export const ChatComposer = memo(
               : null,
           );
         },
+        addTextFile: (textFile: ComposerTextFileAttachment) => {
+          addComposerDraftTextFile(composerDraftTarget, textFile);
+        },
+        removeTextFile: (fileId: string) => {
+          removeComposerDraftTextFile(composerDraftTarget, fileId);
+        },
         addTerminalContext: (selection: TerminalContextSelection) => {
           if (!activeThread) return;
           const snapshot = composerEditorRef.current?.readSnapshot() ?? {
@@ -1769,6 +1792,7 @@ export const ChatComposer = memo(
         getSendContext: () => ({
           prompt: promptRef.current,
           images: composerImagesRef.current,
+          textFiles: composerTextFilesRef.current,
           terminalContexts: composerTerminalContextsRef.current,
           selectedPromptEffort,
           selectedModelOptionsForDispatch,
@@ -1786,6 +1810,7 @@ export const ChatComposer = memo(
         insertComposerDraftTerminalContext,
         promptRef,
         composerImagesRef,
+        composerTextFilesRef,
         composerTerminalContextsRef,
         isComposerModelPickerOpen,
         readComposerSnapshot,
@@ -1795,6 +1820,8 @@ export const ChatComposer = memo(
         selectedPromptEffort,
         selectedProvider,
         selectedProviderModels,
+        addComposerDraftTextFile,
+        removeComposerDraftTextFile,
       ],
     );
 
@@ -1935,6 +1962,31 @@ export const ChatComposer = memo(
                           className="absolute right-1 top-1 bg-background/80 hover:bg-background/90"
                           onClick={() => removeComposerImage(image.id)}
                           aria-label={`Remove ${image.name}`}
+                        >
+                          <XIcon />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+              {!isComposerApprovalState &&
+                pendingUserInputs.length === 0 &&
+                composerTextFiles.length > 0 && (
+                  <div className="mb-3 flex flex-wrap gap-2">
+                    {composerTextFiles.map((file) => (
+                      <div
+                        key={file.id}
+                        className="flex items-center gap-1.5 rounded-lg border border-border/80 bg-background px-2.5 py-1 text-sm text-muted-foreground"
+                      >
+                        <FileIcon className="size-3.5 shrink-0" />
+                        <span className="max-w-40 truncate">{file.name}</span>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          className="size-4 p-0 text-muted-foreground/60 hover:text-foreground"
+                          onClick={() => removeComposerDraftTextFile(composerDraftTarget, file.id)}
+                          aria-label={`Remove ${file.name}`}
                         >
                           <XIcon />
                         </Button>

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
@@ -63,6 +63,7 @@ async function mountMenu(props?: { modelSelection?: ModelSelection; prompt?: str
       [threadKey]: {
         prompt: props?.prompt ?? "",
         images: [],
+        textFiles: [],
         nonPersistedImageIds: [],
         persistedAttachments: [],
         terminalContexts: [],

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -12,7 +12,7 @@ import {
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { deriveTimelineEntries, formatElapsed } from "../../session-logic";
-import { type TurnDiffSummary } from "../../types";
+import { type TurnDiffSummary, type ChatImageAttachment } from "../../types";
 import { summarizeTurnDiffStats } from "../../lib/turnDiffTree";
 import ChatMarkdown from "../ChatMarkdown";
 import {
@@ -300,7 +300,10 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
       {row.kind === "message" &&
         row.message.role === "user" &&
         (() => {
-          const userImages = row.message.attachments ?? [];
+          const userAttachments = row.message.attachments ?? [];
+          const userImages = userAttachments.filter(
+            (a): a is ChatImageAttachment => a.type === "image",
+          );
           const displayedUserMessage = deriveDisplayedUserMessageState(row.message.text);
           const terminalContexts = displayedUserMessage.contexts;
           const canRevertAgentWork = typeof row.revertTurnCount === "number";
@@ -309,37 +312,35 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
               <div className="group relative max-w-[80%] rounded-2xl rounded-br-sm border border-border bg-secondary px-4 py-3">
                 {userImages.length > 0 && (
                   <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
-                    {userImages.map(
-                      (image: NonNullable<TimelineMessage["attachments"]>[number]) => (
-                        <div
-                          key={image.id}
-                          className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
-                        >
-                          {image.previewUrl ? (
-                            <button
-                              type="button"
-                              className="h-full w-full cursor-zoom-in"
-                              aria-label={`Preview ${image.name}`}
-                              onClick={() => {
-                                const preview = buildExpandedImagePreview(userImages, image.id);
-                                if (!preview) return;
-                                ctx.onImageExpand(preview);
-                              }}
-                            >
-                              <img
-                                src={image.previewUrl}
-                                alt={image.name}
-                                className="block h-auto max-h-[220px] w-full object-cover"
-                              />
-                            </button>
-                          ) : (
-                            <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
-                              {image.name}
-                            </div>
-                          )}
-                        </div>
-                      ),
-                    )}
+                    {userImages.map((image) => (
+                      <div
+                        key={image.id}
+                        className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
+                      >
+                        {image.previewUrl ? (
+                          <button
+                            type="button"
+                            className="h-full w-full cursor-zoom-in"
+                            aria-label={`Preview ${image.name}`}
+                            onClick={() => {
+                              const preview = buildExpandedImagePreview(userImages, image.id);
+                              if (!preview) return;
+                              ctx.onImageExpand(preview);
+                            }}
+                          >
+                            <img
+                              src={image.previewUrl}
+                              alt={image.name}
+                              className="block h-auto max-h-[220px] w-full object-cover"
+                            />
+                          </button>
+                        ) : (
+                          <div className="flex min-h-[72px] items-center justify-center px-2 py-3 text-center text-[11px] text-muted-foreground/70">
+                            {image.name}
+                          </div>
+                        )}
+                      </div>
+                    ))}
                   </div>
                 )}
                 {(displayedUserMessage.visibleText.trim().length > 0 ||

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -328,6 +328,7 @@ const createDesktopBridgeStub = (overrides?: {
       .fn()
       .mockResolvedValue({ accepted: false, completed: false, state: idleUpdateState }),
     onUpdateState: () => () => {},
+    pasteClipboardAsFile: vi.fn().mockResolvedValue(null),
   };
 };
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -80,6 +80,15 @@ export interface ComposerImageAttachment extends Omit<ChatImageAttachment, "prev
   file: File;
 }
 
+export interface ComposerTextFileAttachment {
+  type: "text";
+  id: string;
+  name: string;
+  mimeType: string;
+  sizeBytes: number;
+  file: File;
+}
+
 const PersistedTerminalContextDraft = Schema.Struct({
   id: Schema.String,
   threadId: ThreadId,
@@ -212,6 +221,7 @@ const PersistedComposerDraftStoreStorage = Schema.Struct({
 export interface ComposerThreadDraftState {
   prompt: string;
   images: ComposerImageAttachment[];
+  textFiles: ComposerTextFileAttachment[];
   nonPersistedImageIds: string[];
   persistedAttachments: PersistedComposerImageAttachment[];
   terminalContexts: TerminalContextDraft[];
@@ -267,7 +277,7 @@ interface ProjectDraftSession extends DraftSessionState {
  * Raw `ThreadId` is intentionally excluded so callers cannot drop environment
  * identity for real threads.
  */
-type ComposerThreadTarget = ScopedThreadRef | DraftId;
+export type ComposerThreadTarget = ScopedThreadRef | DraftId;
 
 /**
  * Persisted store for composer content plus draft-session metadata.
@@ -385,6 +395,8 @@ interface ComposerDraftStoreState {
   addImage: (threadRef: ComposerThreadTarget, image: ComposerImageAttachment) => void;
   addImages: (threadRef: ComposerThreadTarget, images: ComposerImageAttachment[]) => void;
   removeImage: (threadRef: ComposerThreadTarget, imageId: string) => void;
+  addTextFile: (threadRef: ComposerThreadTarget, file: ComposerTextFileAttachment) => void;
+  removeTextFile: (threadRef: ComposerThreadTarget, fileId: string) => void;
   insertTerminalContext: (
     threadRef: ComposerThreadTarget,
     prompt: string,
@@ -465,10 +477,12 @@ const EMPTY_PERSISTED_DRAFT_STORE_STATE = Object.freeze<PersistedComposerDraftSt
 });
 
 const EMPTY_IMAGES: ComposerImageAttachment[] = [];
+const EMPTY_TEXT_FILES: ComposerTextFileAttachment[] = [];
 const EMPTY_IDS: string[] = [];
 const EMPTY_PERSISTED_ATTACHMENTS: PersistedComposerImageAttachment[] = [];
 const EMPTY_TERMINAL_CONTEXTS: TerminalContextDraft[] = [];
 Object.freeze(EMPTY_IMAGES);
+Object.freeze(EMPTY_TEXT_FILES);
 Object.freeze(EMPTY_IDS);
 Object.freeze(EMPTY_PERSISTED_ATTACHMENTS);
 const EMPTY_MODEL_SELECTION_BY_PROVIDER: Partial<Record<ProviderDriverKind, ModelSelection>> =
@@ -481,6 +495,7 @@ const EMPTY_COMPOSER_DRAFT_MODEL_STATE = Object.freeze<ComposerDraftModelState>(
 const EMPTY_THREAD_DRAFT = Object.freeze<ComposerThreadDraftState>({
   prompt: "",
   images: EMPTY_IMAGES,
+  textFiles: EMPTY_TEXT_FILES,
   nonPersistedImageIds: EMPTY_IDS,
   persistedAttachments: EMPTY_PERSISTED_ATTACHMENTS,
   terminalContexts: EMPTY_TERMINAL_CONTEXTS,
@@ -494,6 +509,7 @@ function createEmptyThreadDraft(): ComposerThreadDraftState {
   return {
     prompt: "",
     images: [],
+    textFiles: [],
     nonPersistedImageIds: [],
     persistedAttachments: [],
     terminalContexts: [],
@@ -565,6 +581,7 @@ function shouldRemoveDraft(draft: ComposerThreadDraftState): boolean {
   return (
     draft.prompt.length === 0 &&
     draft.images.length === 0 &&
+    draft.textFiles.length === 0 &&
     draft.persistedAttachments.length === 0 &&
     draft.terminalContexts.length === 0 &&
     Object.keys(draft.modelSelectionByProvider).length === 0 &&
@@ -1889,6 +1906,7 @@ function toHydratedThreadDraft(
   return {
     prompt: persistedDraft.prompt,
     images: hydrateImagesFromPersisted(persistedDraft.attachments),
+    textFiles: [],
     nonPersistedImageIds: [],
     persistedAttachments: [...persistedDraft.attachments],
     terminalContexts:
@@ -2676,6 +2694,54 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
             return { draftsByThreadKey: nextDraftsByThreadKey };
           });
         },
+        addTextFile: (threadRef, textFile) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
+          if (threadKey.length === 0) {
+            return;
+          }
+          set((state) => {
+            const existing = state.draftsByThreadKey[threadKey] ?? createEmptyThreadDraft();
+            if (existing.textFiles.some((f) => f.id === textFile.id)) {
+              return state;
+            }
+            return {
+              draftsByThreadKey: {
+                ...state.draftsByThreadKey,
+                [threadKey]: {
+                  ...existing,
+                  textFiles: [...existing.textFiles, textFile],
+                },
+              },
+            };
+          });
+        },
+        removeTextFile: (threadRef, fileId) => {
+          const threadKey = resolveComposerDraftKey(get(), threadRef) ?? "";
+          if (threadKey.length === 0) {
+            return;
+          }
+          const existing = get().draftsByThreadKey[threadKey];
+          if (!existing) {
+            return;
+          }
+          set((state) => {
+            const current = state.draftsByThreadKey[threadKey];
+            if (!current) {
+              return state;
+            }
+            const nextDraft: ComposerThreadDraftState = {
+              ...current,
+              textFiles: current.textFiles.filter((f) => f.id !== fileId),
+            };
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            if (shouldRemoveDraft(nextDraft)) {
+              delete nextDraftsByThreadKey[threadKey];
+            } else {
+              nextDraftsByThreadKey[threadKey] = nextDraft;
+            }
+            return { draftsByThreadKey: nextDraftsByThreadKey };
+          });
+        },
         insertTerminalContext: (threadRef, prompt, context, index) => {
           const threadKey = resolveComposerDraftKey(get(), threadRef);
           const threadId = resolveComposerThreadId(get(), threadRef);
@@ -2874,6 +2940,7 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               ...current,
               prompt: "",
               images: [],
+              textFiles: [],
               nonPersistedImageIds: [],
               persistedAttachments: [],
               terminalContexts: [],

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -203,6 +203,7 @@ function makeDesktopBridge(overrides: Partial<DesktopBridge> = {}): DesktopBridg
       throw new Error("installUpdate not implemented in test");
     },
     onUpdateState: () => () => undefined,
+    pasteClipboardAsFile: async () => null,
     ...overrides,
   };
 }

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,16 +1,19 @@
-import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
-import { useEffect } from "react";
+import { Outlet, createFileRoute, redirect, useParams } from "@tanstack/react-router";
+import { useEffect, useMemo } from "react";
 
 import { useCommandPaletteStore } from "../commandPaletteStore";
+import { useComposerDraftStore, type ComposerThreadTarget } from "../composerDraftStore";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import {
   startNewLocalThreadFromContext,
   startNewThreadFromContext,
 } from "../lib/chatThreadActions";
 import { isTerminalFocused } from "../lib/terminalFocus";
+import { randomUUID } from "../lib/utils";
 import { resolveShortcutCommand } from "../keybindings";
 import { selectThreadTerminalState, useTerminalStateStore } from "../terminalStateStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
+import { resolveThreadRouteTarget } from "../threadRoutes";
 import { resolveSidebarNewThreadEnvMode } from "~/components/Sidebar.logic";
 import { useSettings } from "~/hooks/useSettings";
 import { useServerKeybindings } from "~/rpc/serverState";
@@ -27,6 +30,8 @@ function ChatRouteGlobalShortcuts() {
       : false,
   );
   const appSettings = useSettings();
+  const params = useParams({ strict: false });
+  const routeTarget = useMemo(() => resolveThreadRouteTarget(params), [params]);
 
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
@@ -76,6 +81,29 @@ function ChatRouteGlobalShortcuts() {
           handleNewThread,
         });
       }
+
+      if (command === "chat.pasteAsFile") {
+        event.preventDefault();
+        event.stopPropagation();
+        const bridge = window.desktopBridge;
+        if (!bridge || !routeTarget) return;
+        void (async () => {
+          const result = await bridge.pasteClipboardAsFile();
+          if (!result) return;
+          const composerTarget: ComposerThreadTarget =
+            routeTarget.kind === "server" ? routeTarget.threadRef : routeTarget.draftId;
+          const blob = new Blob([result.text], { type: "text/markdown" });
+          const file = new File([blob], result.fileName, { type: "text/markdown" });
+          useComposerDraftStore.getState().addTextFile(composerTarget, {
+            type: "text",
+            id: randomUUID(),
+            name: result.fileName,
+            mimeType: "text/markdown",
+            sizeBytes: file.size,
+            file,
+          });
+        })();
+      }
     };
 
     window.addEventListener("keydown", onWindowKeyDown);
@@ -92,6 +120,7 @@ function ChatRouteGlobalShortcuts() {
     selectedThreadKeysSize,
     terminalOpen,
     appSettings.defaultThreadEnvMode,
+    routeTarget,
   ]);
 
   return null;

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -41,7 +41,15 @@ export interface ChatImageAttachment {
   previewUrl?: string;
 }
 
-export type ChatAttachment = ChatImageAttachment;
+export interface ChatTextFileAttachment {
+  type: "text";
+  id: string;
+  name: string;
+  mimeType: string;
+  sizeBytes: number;
+}
+
+export type ChatAttachment = ChatImageAttachment | ChatTextFileAttachment;
 
 export interface ChatMessage {
   id: MessageId;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -147,6 +147,11 @@ export interface PickFolderOptions {
   initialPath?: string | null;
 }
 
+export interface PasteClipboardAsFileResult {
+  fileName: string;
+  text: string;
+}
+
 export interface DesktopBridge {
   getAppBranding: () => DesktopAppBranding | null;
   getLocalEnvironmentBootstrap: () => DesktopEnvironmentBootstrap | null;
@@ -170,6 +175,7 @@ export interface DesktopBridge {
   ) => Promise<T | null>;
   openExternal: (url: string) => Promise<boolean>;
   onMenuAction: (listener: (action: string) => void) => () => void;
+  pasteClipboardAsFile: () => Promise<PasteClipboardAsFileResult | null>;
   getUpdateState: () => Promise<DesktopUpdateState>;
   setUpdateChannel: (channel: DesktopUpdateChannel) => Promise<DesktopUpdateState>;
   checkForUpdate: () => Promise<DesktopUpdateCheckResult>;

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -56,6 +56,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "commandPalette.toggle",
   "chat.new",
   "chat.newLocal",
+  "chat.pasteAsFile",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -135,6 +135,7 @@ export type ProviderUserInputAnswers = typeof ProviderUserInputAnswers.Type;
 export const PROVIDER_SEND_TURN_MAX_INPUT_CHARS = 120_000;
 export const PROVIDER_SEND_TURN_MAX_ATTACHMENTS = 8;
 export const PROVIDER_SEND_TURN_MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+export const PROVIDER_SEND_TURN_MAX_TEXT_BYTES = 512 * 1024;
 const PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS = 14_000_000;
 const CHAT_ATTACHMENT_ID_MAX_CHARS = 128;
 // Correlation id is command id by design in this model.
@@ -167,9 +168,28 @@ const UploadChatImageAttachment = Schema.Struct({
 });
 export type UploadChatImageAttachment = typeof UploadChatImageAttachment.Type;
 
-export const ChatAttachment = Schema.Union([ChatImageAttachment]);
+export const ChatTextAttachment = Schema.Struct({
+  type: Schema.Literal("text"),
+  id: ChatAttachmentId,
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100)),
+  sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_TEXT_BYTES)),
+});
+export type ChatTextAttachment = typeof ChatTextAttachment.Type;
+
+const UploadChatTextAttachment = Schema.Struct({
+  type: Schema.Literal("text"),
+  name: TrimmedNonEmptyString.check(Schema.isMaxLength(255)),
+  mimeType: TrimmedNonEmptyString.check(Schema.isMaxLength(100)),
+  sizeBytes: NonNegativeInt.check(Schema.isLessThanOrEqualTo(PROVIDER_SEND_TURN_MAX_TEXT_BYTES)),
+  dataUrl: TrimmedNonEmptyString.check(
+    Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_IMAGE_DATA_URL_CHARS),
+  ),
+});
+
+export const ChatAttachment = Schema.Union([ChatImageAttachment, ChatTextAttachment]);
 export type ChatAttachment = typeof ChatAttachment.Type;
-const UploadChatAttachment = Schema.Union([UploadChatImageAttachment]);
+const UploadChatAttachment = Schema.Union([UploadChatImageAttachment, UploadChatTextAttachment]);
 export type UploadChatAttachment = typeof UploadChatAttachment.Type;
 
 export const ProjectScriptIcon = Schema.Literals([


### PR DESCRIPTION
## Summary

Adds a new keyboard shortcut (`mod+alt+v` / `Cmd+Option+V`) that reads clipboard text, writes it to a `.md` file on disk, and attaches it to the current chat as a text file attachment. Normal paste (`Cmd+V`) remains unchanged.

## Files Changed

- **contracts/keybindings.ts** — Add `chat.pasteAsFile` command
- **server/keybindings.ts** — Default binding `mod+alt+v` → `chat.pasteAsFile`
- **contracts/orchestration.ts** — Add `ChatTextAttachment` (type: `"text"`) to attachment unions
- **server/attachmentStore.ts** — Support `.md` extension for text-type attachments
- **contracts/ipc.ts** — Add `PasteClipboardAsFileResult` + `pasteClipboardAsFile` to `DesktopBridge`
- **desktop/preload.ts** — Wire `pasteClipboardAsFile` IPC channel
- **desktop/main.ts** — New IPC handler reads clipboard via `clipboard.readText()` and writes to `userData/pasted-files/`
- **web/composerDraftStore.ts** — Add `ComposerTextFileAttachment`, `textFiles` draft state, `addTextFile`/`removeTextFile`
- **web/ChatComposer.tsx** — Render text file badges, sync ref, expose via imperative handle
- **web/ChatView.tsx** — Include text file attachments in `turnAttachmentsPromise` and optimistic message
- **web/routes/_chat.tsx** — Handle `chat.pasteAsFile` shortcut → desktop bridge → attach
- **web/types.ts** — Update local `ChatAttachment` to `ChatImageAttachment | ChatTextFileAttachment`
- **MessagesTimeline.tsx** — Filter attachments by type before accessing `previewUrl`

## Tests

- Updated test mocks for `DesktopBridge` in `localApi.test.ts` and `SettingsPanels.browser.tsx`
- Updated `deriveComposerSendState` call sites in `ChatView.logic.test.ts`

## Validation

- `bun fmt` ✓
- `bun lint` (0 errors) ✓
- `turbo run typecheck` (contracts, web, server) ✓
- `turbo run test` (105 files, 938 tests, all passing) ✓

Closes #2283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new attachment type (text) that flows through IPC, web composer state, and server persistence, plus writes clipboard contents to disk; mistakes could affect data validation, storage, or message sending behavior.
> 
> **Overview**
> Adds a new `chat.pasteAsFile` command (default `mod+alt+v`) that reads clipboard text in the Electron main process, writes it as a timestamped `.md` under `userData/pasted-files`, and returns it to the renderer via a new `DesktopBridge.pasteClipboardAsFile()` IPC API.
> 
> Extends chat attachments end-to-end to support *text file* attachments: web composer/draft store can add/remove and display attached text files, `ChatView` includes them in optimistic messages and send payloads (with updated bootstrap prompts/title seeding), and the server normalizer validates/persists text attachments with a 512KiB cap and `.md` storage path. UI rendering is adjusted to treat only `image` attachments as previewable images, and test/mocks are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 818b129e0d9a9e1a720c9357592c7fb7995ae732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cmd+Option+V shortcut to paste clipboard text as a markdown file attachment in chat
> - Adds a `chat.pasteAsFile` keybinding (`mod+alt+v`) that reads clipboard text via a new `desktopBridge.pasteClipboardAsFile()` IPC call, saves it as a timestamped `.md` file in `userData/pasted-files`, and attaches it to the active composer draft.
> - Introduces `ComposerTextFileAttachment` and `ChatTextFileAttachment` types, extending the composer draft store, send context, and orchestration contract to support `text` attachments alongside existing image attachments.
> - The orchestration normalizer validates text attachment MIME types and enforces a 512 KiB size limit (`PROVIDER_SEND_TURN_MAX_TEXT_BYTES`) separate from image limits.
> - The composer UI renders attached text files as a badge list with remove buttons; the timeline filters them out of image preview rendering.
> - Bootstrap prompts are selected based on whether the turn contains images, text files, or both.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de5cc65.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->