### PR TITLE
Add Claude Code auto mode

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -348,6 +348,25 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
+  it.effect("uses auto permission mode for Claude auto runtime sessions", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "auto",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.permissionMode, "auto");
+      assert.equal(createInput?.options.allowDangerouslySkipPermissions, undefined);
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
   it.effect("forwards claude effort levels into query options", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
@@ -3000,6 +3019,7 @@ describe("ClaudeAdapterLive", () => {
     { runtimeMode: "full-access", expectedBase: "bypassPermissions" },
     { runtimeMode: "approval-required", expectedBase: "default" },
     { runtimeMode: "auto-accept-edits", expectedBase: "acceptEdits" },
+    { runtimeMode: "auto", expectedBase: "auto" as PermissionMode },
   ])(
     "restores $expectedBase permission mode after plan turn ($runtimeMode)",
     ({ runtimeMode, expectedBase }) => {

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2862,6 +2862,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const effectiveEffort = getEffectiveClaudeAgentEffort(effort);
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
+        auto: "auto" as PermissionMode,
         "full-access": "bypassPermissions",
       };
       const permissionMode = runtimeModeToPermission[input.runtimeMode];

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -122,6 +122,21 @@ describe("buildTurnStartParams", () => {
     });
   });
 
+  it("maps Claude auto runtime mode to workspace-write for Codex turns", () => {
+    const params = Effect.runSync(
+      buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "auto",
+        prompt: "Implement it",
+        model: "gpt-5.3-codex",
+        interactionMode: "default",
+      }),
+    );
+
+    assert.equal(params.approvalPolicy, "on-request");
+    assert.deepStrictEqual(params.sandboxPolicy, { type: "workspaceWrite" });
+  });
+
   it("omits collaboration mode when interaction mode is absent", () => {
     const params = Effect.runSync(
       buildTurnStartParams({

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -251,6 +251,7 @@ function runtimeModeToThreadConfig(input: RuntimeMode): {
         sandbox: "read-only",
       };
     case "auto-accept-edits":
+    case "auto":
       return {
         approvalPolicy: "on-request",
         sandbox: "workspace-write",
@@ -289,6 +290,7 @@ function runtimeModeToTurnSandboxPolicy(
         type: "readOnly",
       };
     case "auto-accept-edits":
+    case "auto":
       return {
         type: "workspaceWrite",
       };

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -93,6 +93,7 @@ import {
   LockIcon,
   LockOpenIcon,
   PenLineIcon,
+  ShieldCheckIcon,
   XIcon,
 } from "lucide-react";
 import { proposedPlanTitle } from "../../proposedPlan";
@@ -128,6 +129,11 @@ const runtimeModeConfig: Record<
     description: "Auto-approve edits, ask before other actions.",
     icon: PenLineIcon,
   },
+  auto: {
+    label: "Auto mode",
+    description: "Everything, with background safety checks.",
+    icon: ShieldCheckIcon,
+  },
   "full-access": {
     label: "Full access",
     description: "Allow commands and edits without prompts.",
@@ -136,6 +142,8 @@ const runtimeModeConfig: Record<
 };
 
 const runtimeModeOptions = Object.keys(runtimeModeConfig) as RuntimeMode[];
+const CLAUDE_RUNTIME_MODE_OPTIONS = runtimeModeOptions;
+const DEFAULT_RUNTIME_MODE_OPTIONS = runtimeModeOptions.filter((mode) => mode !== "auto");
 const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
 const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
 
@@ -171,6 +179,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
   showInteractionModeToggle: boolean;
   interactionMode: ProviderInteractionMode;
   runtimeMode: RuntimeMode;
+  runtimeModeOptions: ReadonlyArray<RuntimeMode>;
   showPlanToggle: boolean;
   planSidebarLabel: string;
   planSidebarOpen: boolean;
@@ -224,7 +233,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
           <SelectValue>{runtimeModeOption.label}</SelectValue>
         </SelectTrigger>
         <SelectPopup alignItemWithTrigger={false}>
-          {runtimeModeOptions.map((mode) => {
+          {props.runtimeModeOptions.map((mode) => {
             const option = runtimeModeConfig[mode];
             const OptionIcon = option.icon;
             return (
@@ -592,6 +601,17 @@ export const ChatComposer = memo(
         explicitSelectedInstanceId,
       ) ?? ProviderDriverKind.make("codex");
     const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
+    const selectedProviderSupportsAutoMode =
+      selectedProvider === ProviderDriverKind.make("claudeAgent");
+    const availableRuntimeModeOptions = selectedProviderSupportsAutoMode
+      ? CLAUDE_RUNTIME_MODE_OPTIONS
+      : DEFAULT_RUNTIME_MODE_OPTIONS;
+
+    useEffect(() => {
+      if (selectedProviderSupportsAutoMode || runtimeMode !== "auto") return;
+      handleRuntimeModeChange("auto-accept-edits");
+    }, [handleRuntimeModeChange, runtimeMode, selectedProviderSupportsAutoMode]);
+
     const lockedContinuationGroupKey = useMemo((): string | null => {
       if (!lockedProvider || !activeThread) return null;
       const lockedInstanceId =
@@ -2027,6 +2047,7 @@ export const ChatComposer = memo(
                       planSidebarLabel={planSidebarLabel}
                       planSidebarOpen={planSidebarOpen}
                       runtimeMode={runtimeMode}
+                      runtimeModeOptions={availableRuntimeModeOptions}
                       showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
                       traitsMenuContent={providerTraitsMenuContent}
                       onToggleInteractionMode={toggleInteractionMode}
@@ -2050,6 +2071,7 @@ export const ChatComposer = memo(
                         }
                         interactionMode={interactionMode}
                         runtimeMode={runtimeMode}
+                        runtimeModeOptions={availableRuntimeModeOptions}
                         showPlanToggle={showPlanSidebarToggle}
                         planSidebarLabel={planSidebarLabel}
                         planSidebarOpen={planSidebarOpen}

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
@@ -20,6 +20,11 @@ import { TraitsMenuContent } from "./TraitsPicker";
 import { useComposerDraftStore } from "../../composerDraftStore";
 
 const LOCAL_ENVIRONMENT_ID = EnvironmentId.make("environment-local");
+const DEFAULT_RUNTIME_MODE_OPTIONS = [
+  "approval-required",
+  "auto-accept-edits",
+  "full-access",
+] as const;
 
 function selectDescriptor(
   id: string,
@@ -140,6 +145,7 @@ async function mountMenu(props?: { modelSelection?: ModelSelection; prompt?: str
       planSidebarLabel="Plan"
       planSidebarOpen={false}
       runtimeMode="approval-required"
+      runtimeModeOptions={DEFAULT_RUNTIME_MODE_OPTIONS}
       showInteractionModeToggle
       traitsMenuContent={
         <TraitsMenuContent
@@ -302,6 +308,7 @@ describe("CompactComposerControlsMenu", () => {
         planSidebarLabel="Plan"
         planSidebarOpen={false}
         runtimeMode="approval-required"
+        runtimeModeOptions={DEFAULT_RUNTIME_MODE_OPTIONS}
         showInteractionModeToggle={false}
         onToggleInteractionMode={vi.fn()}
         onTogglePlanSidebar={vi.fn()}

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -18,6 +18,7 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
   planSidebarLabel: string;
   planSidebarOpen: boolean;
   runtimeMode: RuntimeMode;
+  runtimeModeOptions: ReadonlyArray<RuntimeMode>;
   showInteractionModeToggle: boolean;
   traitsMenuContent?: ReactNode;
   onToggleInteractionMode: () => void;
@@ -69,9 +70,17 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             props.onRuntimeModeChange(value as RuntimeMode);
           }}
         >
-          <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
-          <MenuRadioItem value="auto-accept-edits">Auto-accept edits</MenuRadioItem>
-          <MenuRadioItem value="full-access">Full access</MenuRadioItem>
+          {props.runtimeModeOptions.map((mode) => (
+            <MenuRadioItem key={mode} value={mode}>
+              {mode === "approval-required"
+                ? "Supervised"
+                : mode === "auto-accept-edits"
+                  ? "Auto-accept edits"
+                  : mode === "auto"
+                    ? "Auto mode"
+                    : "Full access"}
+            </MenuRadioItem>
+          ))}
         </MenuRadioGroup>
         {props.activePlan ? (
           <>

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -111,6 +111,7 @@ export type ModelSelection = typeof ModelSelection.Type;
 export const RuntimeMode = Schema.Literals([
   "approval-required",
   "auto-accept-edits",
+  "auto",
   "full-access",
 ]);
 export type RuntimeMode = typeof RuntimeMode.Type;


### PR DESCRIPTION
This PR adds support for Claude Code auto mode (https://code.claude.com/docs/en/permission-modes).

#2239

<img width="917" height="359" alt="image" src="https://github.com/user-attachments/assets/8e4a15a9-775b-4da9-adc1-ac453375831f" />


  ## Summary
  - Add a shared runtime mode for Claude Code Auto Mode
  - Map Claude sessions to SDK permissionMode: auto
  - Show Auto mode in composer access menus
  - Keep non-Claude providers on conservative workspace-write behavior

  ## Checks
  - bun fmt
  - bun lint
  - bun typecheck
  - bunx vitest run apps/server/src/provider/Layers/ClaudeAdapter.test.ts apps/server/src/
  provider/Layers/CodexSessionRuntime.test.ts


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `RuntimeMode` value that changes permission/sandbox mappings for Claude and Codex sessions; mistakes could unintentionally loosen or tighten execution permissions.
> 
> **Overview**
> Adds a new shared runtime mode, `auto`, to the contracts schema and wires it through server and web.
> 
> On the server, Claude sessions started with `runtimeMode: "auto"` now map to Claude SDK `permissionMode: "auto"` (without `allowDangerouslySkipPermissions`), and Claude plan-mode turns restore back to `auto` afterward; Codex treats `auto` the same as `auto-accept-edits` (workspace-write sandbox with on-request approvals).
> 
> Updates the chat composer access UI to expose an **Auto mode** option (including a new icon) and adds/extends tests to cover the new mode mappings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b7c88c3472947523621d221a24cb6a808526a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'auto' runtime mode for Claude Code sessions
> - Adds `'auto'` as a valid `RuntimeMode` in [orchestration.ts](https://github.com/pingdotgg/t3code/pull/2433/files#diff-eb3f1de358c2fd7cec5950215e475b915ad3dca9e4f3f7305e46c3277630d2af), mapping it to `permissionMode: 'auto'` in the Claude adapter and `approvalPolicy: 'on-request'` with `sandboxPolicy: { type: 'workspaceWrite' }` in the Codex runtime.
> - Shows 'Auto mode' with a `ShieldCheckIcon` in the composer's runtime mode selector, but only when the Claude provider is selected.
> - Automatically coerces `runtimeMode` from `'auto'` to `'auto-accept-edits'` when switching to a non-Claude provider.
> - Both `CompactComposerControlsMenu` and `ComposerFooterModeControls` now accept a `runtimeModeOptions` prop to render a dynamic list instead of a hardcoded set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e3e510.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->