### PR TITLE
Add ACP registry provider support

### DIFF
--- a/apps/server/src/provider/Drivers/AcpRegistryDriver.ts
+++ b/apps/server/src/provider/Drivers/AcpRegistryDriver.ts
@@ -1,0 +1,181 @@
+import {
+  AcpRegistrySettings,
+  ProviderDriverKind,
+  TextGenerationError,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { Effect, FileSystem, Path, Schema, Stream } from "effect";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { ServerConfig } from "../../config.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeCursorAdapter } from "../Layers/CursorAdapter.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import {
+  buildServerProvider,
+  providerModelsFromSettings,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+
+const DRIVER_KIND = ProviderDriverKind.make("acpRegistry");
+
+export type AcpRegistryDriverEnv =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | FileSystem.FileSystem
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig;
+
+const unsupportedTextGeneration = (operation: string) =>
+  Effect.fail(
+    new TextGenerationError({
+      operation,
+      detail: "Generic ACP providers do not support git text generation yet.",
+    }),
+  );
+
+const makeTextGeneration = () => ({
+  generateCommitMessage: () => unsupportedTextGeneration("generateCommitMessage"),
+  generatePrContent: () => unsupportedTextGeneration("generatePrContent"),
+  generateBranchName: () => unsupportedTextGeneration("generateBranchName"),
+  generateThreadTitle: () => unsupportedTextGeneration("generateThreadTitle"),
+});
+
+function withIdentity(input: {
+  readonly instanceId: ProviderInstance["instanceId"];
+  readonly displayName: string | undefined;
+  readonly accentColor: string | undefined;
+  readonly iconUrl: string | undefined;
+  readonly continuationGroupKey: string;
+}) {
+  return (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    ...(input.iconUrl ? { iconUrl: input.iconUrl } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+}
+
+function initialSnapshot(settings: AcpRegistrySettings): ServerProviderDraft {
+  const checkedAt = new Date().toISOString();
+  const command = settings.command.trim();
+  const enabled = settings.enabled && command.length > 0;
+  return buildServerProvider({
+    presentation: {
+      displayName: "ACP Registry",
+      badgeLabel: "ACP",
+      showInteractionModeToggle: true,
+    },
+    enabled,
+    checkedAt,
+    models: providerModelsFromSettings(
+      [{ slug: "default", name: "Default", isCustom: false, capabilities: null }],
+      DRIVER_KIND,
+      settings.customModels,
+      { optionDescriptors: [] },
+    ),
+    probe: {
+      installed: enabled,
+      version: null,
+      status: enabled ? "ready" : "warning",
+      auth: { status: "unknown" },
+      message: enabled ? "ACP provider configured." : "Configure a launch command to enable.",
+    },
+  });
+}
+
+export const AcpRegistryDriver: ProviderDriver<AcpRegistrySettings, AcpRegistryDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "ACP Registry",
+    supportsMultipleInstances: true,
+  },
+  configSchema: AcpRegistrySettings,
+  defaultConfig: (): AcpRegistrySettings => Schema.decodeSync(AcpRegistrySettings)({}),
+  create: ({ instanceId, displayName, accentColor, iconUrl, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const eventLoggers = yield* ProviderEventLoggers;
+      const effectiveConfig = { ...config, enabled: enabled && config.enabled };
+      const effectiveIconUrl = iconUrl ?? effectiveConfig.iconUrl;
+      const processEnv = {
+        ...effectiveConfig.env,
+        ...mergeProviderInstanceEnvironment(environment),
+      };
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stamp = withIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        iconUrl: effectiveIconUrl,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+
+      const adapter = yield* makeCursorAdapter(
+        {
+          enabled: effectiveConfig.enabled,
+          binaryPath: effectiveConfig.command || "acp",
+          apiEndpoint: "",
+          customModels: effectiveConfig.customModels,
+        },
+        {
+          provider: DRIVER_KIND,
+          instanceId,
+          environment: processEnv,
+          readyReason: "ACP session ready",
+          applyCursorModelOptions: false,
+          normalizeModel: (model) => model?.trim() || "default",
+          ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+          spawn: ({ cwd, environment: spawnEnv }) => ({
+            command: effectiveConfig.command.trim(),
+            args: effectiveConfig.args,
+            cwd,
+            ...(spawnEnv ? { env: spawnEnv } : {}),
+          }),
+        },
+      );
+
+      const snapshot = yield* makeManagedServerProvider<AcpRegistrySettings>({
+        getSettings: Effect.succeed(effectiveConfig),
+        streamSettings: Stream.never,
+        haveSettingsChanged: () => false,
+        initialSnapshot: (settings) => stamp(initialSnapshot(settings)),
+        checkProvider: Effect.succeed(stamp(initialSnapshot(effectiveConfig))),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build ACP Registry snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        iconUrl: effectiveIconUrl,
+        enabled: effectiveConfig.enabled,
+        snapshot,
+        adapter,
+        textGeneration: makeTextGeneration(),
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Drivers/AcpRegistryDriver.ts
+++ b/apps/server/src/provider/Drivers/AcpRegistryDriver.ts
@@ -126,8 +126,8 @@ export const AcpRegistryDriver: ProviderDriver<AcpRegistrySettings, AcpRegistryD
       const adapter = yield* makeGenericAcpAdapter(
         {
           enabled: effectiveConfig.enabled,
-          binaryPath: effectiveConfig.command || "acp",
-          customModels: effectiveConfig.customModels,
+          command: effectiveConfig.command || "acp",
+          args: effectiveConfig.args,
         },
         {
           provider: DRIVER_KIND,
@@ -135,12 +135,6 @@ export const AcpRegistryDriver: ProviderDriver<AcpRegistrySettings, AcpRegistryD
           environment: processEnv,
           readyReason: "ACP session ready",
           ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
-          spawn: ({ cwd, environment: spawnEnv }) => ({
-            command: effectiveConfig.command.trim(),
-            args: effectiveConfig.args,
-            cwd,
-            ...(spawnEnv ? { env: spawnEnv } : {}),
-          }),
         },
       );
 

--- a/apps/server/src/provider/Drivers/AcpRegistryDriver.ts
+++ b/apps/server/src/provider/Drivers/AcpRegistryDriver.ts
@@ -9,7 +9,7 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import { ServerConfig } from "../../config.ts";
 import { ProviderDriverError } from "../Errors.ts";
-import { makeCursorAdapter } from "../Layers/CursorAdapter.ts";
+import { makeGenericAcpAdapter } from "../Layers/GenericAcpAdapter.ts";
 import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
 import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
 import {
@@ -123,11 +123,10 @@ export const AcpRegistryDriver: ProviderDriver<AcpRegistrySettings, AcpRegistryD
         continuationGroupKey: continuationIdentity.continuationKey,
       });
 
-      const adapter = yield* makeCursorAdapter(
+      const adapter = yield* makeGenericAcpAdapter(
         {
           enabled: effectiveConfig.enabled,
           binaryPath: effectiveConfig.command || "acp",
-          apiEndpoint: "",
           customModels: effectiveConfig.customModels,
         },
         {
@@ -135,8 +134,6 @@ export const AcpRegistryDriver: ProviderDriver<AcpRegistrySettings, AcpRegistryD
           instanceId,
           environment: processEnv,
           readyReason: "ACP session ready",
-          applyCursorModelOptions: false,
-          normalizeModel: (model) => model?.trim() || "default",
           ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
           spawn: ({ cwd, environment: spawnEnv }) => ({
             command: effectiveConfig.command.trim(),

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -52,6 +52,7 @@ const withInstanceIdentity =
     readonly instanceId: ProviderInstance["instanceId"];
     readonly displayName: string | undefined;
     readonly accentColor: string | undefined;
+    readonly iconUrl: string | undefined;
     readonly continuationGroupKey: string;
   }) =>
   (snapshot: ServerProviderDraft): ServerProvider => ({
@@ -60,6 +61,7 @@ const withInstanceIdentity =
     driver: DRIVER_KIND,
     ...(input.displayName ? { displayName: input.displayName } : {}),
     ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    ...(input.iconUrl ? { iconUrl: input.iconUrl } : {}),
     continuation: { groupKey: input.continuationGroupKey },
   });
 
@@ -71,7 +73,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
   },
   configSchema: ClaudeSettings,
   defaultConfig: (): ClaudeSettings => Schema.decodeSync(ClaudeSettings)({}),
-  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+  create: ({ instanceId, displayName, accentColor, iconUrl, environment, enabled, config }) =>
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const path = yield* Path.Path;
@@ -87,6 +89,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         instanceId,
         displayName,
         accentColor,
+        iconUrl,
         continuationGroupKey,
       });
 
@@ -148,6 +151,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         },
         displayName,
         accentColor,
+        iconUrl,
         enabled,
         snapshot,
         adapter,

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -67,6 +67,7 @@ const withInstanceIdentity =
     readonly instanceId: ProviderInstance["instanceId"];
     readonly displayName: string | undefined;
     readonly accentColor: string | undefined;
+    readonly iconUrl: string | undefined;
     readonly continuationGroupKey: string;
   }) =>
   (snapshot: ServerProviderDraft): ServerProvider => ({
@@ -75,6 +76,7 @@ const withInstanceIdentity =
     driver: DRIVER_KIND,
     ...(input.displayName ? { displayName: input.displayName } : {}),
     ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    ...(input.iconUrl ? { iconUrl: input.iconUrl } : {}),
     continuation: { groupKey: input.continuationGroupKey },
   });
 
@@ -86,7 +88,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
   },
   configSchema: CodexSettings,
   defaultConfig: (): CodexSettings => Schema.decodeSync(CodexSettings)({}),
-  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+  create: ({ instanceId, displayName, accentColor, iconUrl, environment, enabled, config }) =>
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -97,6 +99,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         instanceId,
         displayName,
         accentColor,
+        iconUrl,
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       yield* materializeCodexShadowHome(homeLayout).pipe(
@@ -162,6 +165,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
         continuationIdentity,
         displayName,
         accentColor,
+        iconUrl,
         enabled,
         snapshot,
         adapter,

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -50,6 +50,7 @@ const withInstanceIdentity =
     readonly instanceId: ProviderInstance["instanceId"];
     readonly displayName: string | undefined;
     readonly accentColor: string | undefined;
+    readonly iconUrl: string | undefined;
     readonly continuationGroupKey: string;
   }) =>
   (snapshot: ServerProviderDraft): ServerProvider => ({
@@ -58,6 +59,7 @@ const withInstanceIdentity =
     driver: DRIVER_KIND,
     ...(input.displayName ? { displayName: input.displayName } : {}),
     ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    ...(input.iconUrl ? { iconUrl: input.iconUrl } : {}),
     continuation: { groupKey: input.continuationGroupKey },
   });
 
@@ -69,7 +71,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
   },
   configSchema: CursorSettings,
   defaultConfig: (): CursorSettings => Schema.decodeSync(CursorSettings)({}),
-  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+  create: ({ instanceId, displayName, accentColor, iconUrl, environment, enabled, config }) =>
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const fileSystem = yield* FileSystem.FileSystem;
@@ -84,6 +86,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         instanceId,
         displayName,
         accentColor,
+        iconUrl,
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies CursorSettings;
@@ -139,6 +142,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         continuationIdentity,
         displayName,
         accentColor,
+        iconUrl,
         enabled,
         snapshot,
         adapter,

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -51,6 +51,7 @@ const withInstanceIdentity =
     readonly instanceId: ProviderInstance["instanceId"];
     readonly displayName: string | undefined;
     readonly accentColor: string | undefined;
+    readonly iconUrl: string | undefined;
     readonly continuationGroupKey: string;
   }) =>
   (snapshot: ServerProviderDraft): ServerProvider => ({
@@ -59,6 +60,7 @@ const withInstanceIdentity =
     driver: DRIVER_KIND,
     ...(input.displayName ? { displayName: input.displayName } : {}),
     ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    ...(input.iconUrl ? { iconUrl: input.iconUrl } : {}),
     continuation: { groupKey: input.continuationGroupKey },
   });
 
@@ -70,7 +72,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
   },
   configSchema: OpenCodeSettings,
   defaultConfig: (): OpenCodeSettings => Schema.decodeSync(OpenCodeSettings)({}),
-  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+  create: ({ instanceId, displayName, accentColor, iconUrl, environment, enabled, config }) =>
     Effect.gen(function* () {
       const openCodeRuntime = yield* OpenCodeRuntime;
       const serverConfig = yield* ServerConfig;
@@ -84,6 +86,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         instanceId,
         displayName,
         accentColor,
+        iconUrl,
         continuationGroupKey: continuationIdentity.continuationKey,
       });
       const effectiveConfig = { ...config, enabled } satisfies OpenCodeSettings;
@@ -126,6 +129,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         continuationIdentity,
         displayName,
         accentColor,
+        iconUrl,
         enabled,
         snapshot,
         adapter,

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -65,6 +65,7 @@ import {
 } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggers } from "../acp/AcpNativeLogging.ts";
 import { applyCursorAcpModelSelection, makeCursorAcpRuntime } from "../acp/CursorAcpSupport.ts";
+import { makeGenericAcpRuntime } from "../acp/GenericAcpSupport.ts";
 import {
   CursorAskQuestionRequest,
   CursorCreatePlanRequest,
@@ -101,6 +102,9 @@ export interface CursorAdapterLiveOptions {
   };
   readonly normalizeModel?: (model: string | null | undefined) => string;
   readonly applyCursorModelOptions?: boolean;
+  readonly cursorExtensions?: boolean;
+  readonly authMethodId?: string | undefined;
+  readonly clientCapabilities?: EffectAcpSchema.InitializeRequest["clientCapabilities"];
   /**
    * Selections are honored when `modelSelection.instanceId` matches this value.
    * Defaults to the legacy built-in instance id (`cursor`).
@@ -338,6 +342,7 @@ export function makeCursorAdapter(
     const readyReason = options?.readyReason ?? "Cursor ACP session ready";
     const normalizeModel = options?.normalizeModel ?? resolveCursorAcpBaseModelId;
     const applyCursorModelOptions = options?.applyCursorModelOptions ?? true;
+    const cursorExtensions = options?.cursorExtensions ?? true;
     const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("cursor");
     const fileSystem = yield* FileSystem.FileSystem;
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
@@ -530,24 +535,53 @@ export function makeCursorAdapter(
             ? yield* options.resolveSettings
             : cursorSettings;
 
-          const acp = yield* makeCursorAcpRuntime({
-            cursorSettings: effectiveCursorSettings,
-            ...(options?.environment ? { environment: options.environment } : {}),
-            ...(options?.spawn
-              ? {
-                  spawn: options.spawn({
-                    settings: effectiveCursorSettings,
-                    cwd,
-                    ...(options.environment ? { environment: options.environment } : {}),
-                  }),
-                }
-              : {}),
-            childProcessSpawner,
-            cwd,
-            ...(resumeSessionId ? { resumeSessionId } : {}),
-            clientInfo: { name: "t3-code", version: "0.0.0" },
-            ...acpNativeLoggers,
-          }).pipe(
+          const spawn = options?.spawn
+            ? options.spawn({
+                settings: effectiveCursorSettings,
+                cwd,
+                ...(options.environment ? { environment: options.environment } : {}),
+              })
+            : undefined;
+          const acp = yield* (
+            cursorExtensions
+              ? makeCursorAcpRuntime({
+                  cursorSettings: effectiveCursorSettings,
+                  ...(options?.environment ? { environment: options.environment } : {}),
+                  ...(spawn ? { spawn } : {}),
+                  childProcessSpawner,
+                  cwd,
+                  ...(resumeSessionId ? { resumeSessionId } : {}),
+                  clientInfo: { name: "t3-code", version: "0.0.0" },
+                  ...acpNativeLoggers,
+                })
+              : makeGenericAcpRuntime({
+                  spawn:
+                    spawn ??
+                    (() => {
+                      const fallback = options?.spawn?.({
+                        settings: effectiveCursorSettings,
+                        cwd,
+                        ...(options.environment ? { environment: options.environment } : {}),
+                      });
+                      if (fallback) return fallback;
+                      return {
+                        command: effectiveCursorSettings.binaryPath,
+                        args: [],
+                        cwd,
+                        ...(options?.environment ? { env: options.environment } : {}),
+                      };
+                    })(),
+                  childProcessSpawner,
+                  cwd,
+                  ...(resumeSessionId ? { resumeSessionId } : {}),
+                  clientInfo: { name: "t3-code", version: "0.0.0" },
+                  ...(options?.authMethodId ? { authMethodId: options.authMethodId } : {}),
+                  ...(options?.clientCapabilities
+                    ? { clientCapabilities: options.clientCapabilities }
+                    : {}),
+                  ...acpNativeLoggers,
+                })
+          ).pipe(
             Effect.provideService(Scope.Scope, sessionScope),
             Effect.mapError(
               (cause) =>
@@ -560,92 +594,97 @@ export function makeCursorAdapter(
             ),
           );
           const started = yield* Effect.gen(function* () {
-            yield* acp.handleExtRequest("cursor/ask_question", CursorAskQuestionRequest, (params) =>
-              Effect.gen(function* () {
-                yield* logNative(
-                  input.threadId,
-                  "cursor/ask_question",
-                  params,
-                  "acp.cursor.extension",
-                );
-                const requestId = ApprovalRequestId.make(crypto.randomUUID());
-                const runtimeRequestId = RuntimeRequestId.make(requestId);
-                const answers = yield* Deferred.make<ProviderUserInputAnswers>();
-                pendingUserInputs.set(requestId, { answers });
-                yield* offerRuntimeEvent({
-                  type: "user-input.requested",
-                  ...(yield* makeEventStamp()),
-                  provider: providerKind,
-                  threadId: input.threadId,
-                  turnId: ctx?.activeTurnId,
-                  requestId: runtimeRequestId,
-                  payload: { questions: extractAskQuestions(params) },
-                  raw: {
-                    source: "acp.cursor.extension",
-                    method: "cursor/ask_question",
-                    payload: params,
-                  },
-                });
-                const resolved = yield* Deferred.await(answers);
-                pendingUserInputs.delete(requestId);
-                yield* offerRuntimeEvent({
-                  type: "user-input.resolved",
-                  ...(yield* makeEventStamp()),
-                  provider: providerKind,
-                  threadId: input.threadId,
-                  turnId: ctx?.activeTurnId,
-                  requestId: runtimeRequestId,
-                  payload: { answers: resolved },
-                });
-                return { answers: resolved };
-              }),
-            );
-            yield* acp.handleExtRequest("cursor/create_plan", CursorCreatePlanRequest, (params) =>
-              Effect.gen(function* () {
-                yield* logNative(
-                  input.threadId,
-                  "cursor/create_plan",
-                  params,
-                  "acp.cursor.extension",
-                );
-                yield* offerRuntimeEvent({
-                  type: "turn.proposed.completed",
-                  ...(yield* makeEventStamp()),
-                  provider: providerKind,
-                  threadId: input.threadId,
-                  turnId: ctx?.activeTurnId,
-                  payload: { planMarkdown: extractPlanMarkdown(params) },
-                  raw: {
-                    source: "acp.cursor.extension",
-                    method: "cursor/create_plan",
-                    payload: params,
-                  },
-                });
-                return { accepted: true } as const;
-              }),
-            );
-            yield* acp.handleExtNotification(
-              "cursor/update_todos",
-              CursorUpdateTodosRequest,
-              (params) =>
+            if (cursorExtensions) {
+              yield* acp.handleExtRequest(
+                "cursor/ask_question",
+                CursorAskQuestionRequest,
+                (params) =>
+                  Effect.gen(function* () {
+                    yield* logNative(
+                      input.threadId,
+                      "cursor/ask_question",
+                      params,
+                      "acp.cursor.extension",
+                    );
+                    const requestId = ApprovalRequestId.make(crypto.randomUUID());
+                    const runtimeRequestId = RuntimeRequestId.make(requestId);
+                    const answers = yield* Deferred.make<ProviderUserInputAnswers>();
+                    pendingUserInputs.set(requestId, { answers });
+                    yield* offerRuntimeEvent({
+                      type: "user-input.requested",
+                      ...(yield* makeEventStamp()),
+                      provider: providerKind,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      payload: { questions: extractAskQuestions(params) },
+                      raw: {
+                        source: "acp.cursor.extension",
+                        method: "cursor/ask_question",
+                        payload: params,
+                      },
+                    });
+                    const resolved = yield* Deferred.await(answers);
+                    pendingUserInputs.delete(requestId);
+                    yield* offerRuntimeEvent({
+                      type: "user-input.resolved",
+                      ...(yield* makeEventStamp()),
+                      provider: providerKind,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      payload: { answers: resolved },
+                    });
+                    return { answers: resolved };
+                  }),
+              );
+              yield* acp.handleExtRequest("cursor/create_plan", CursorCreatePlanRequest, (params) =>
                 Effect.gen(function* () {
                   yield* logNative(
                     input.threadId,
-                    "cursor/update_todos",
+                    "cursor/create_plan",
                     params,
                     "acp.cursor.extension",
                   );
-                  if (ctx) {
-                    yield* emitPlanUpdate(
-                      ctx,
-                      extractTodosAsPlan(params),
+                  yield* offerRuntimeEvent({
+                    type: "turn.proposed.completed",
+                    ...(yield* makeEventStamp()),
+                    provider: providerKind,
+                    threadId: input.threadId,
+                    turnId: ctx?.activeTurnId,
+                    payload: { planMarkdown: extractPlanMarkdown(params) },
+                    raw: {
+                      source: "acp.cursor.extension",
+                      method: "cursor/create_plan",
+                      payload: params,
+                    },
+                  });
+                  return { accepted: true } as const;
+                }),
+              );
+              yield* acp.handleExtNotification(
+                "cursor/update_todos",
+                CursorUpdateTodosRequest,
+                (params) =>
+                  Effect.gen(function* () {
+                    yield* logNative(
+                      input.threadId,
+                      "cursor/update_todos",
                       params,
                       "acp.cursor.extension",
-                      "cursor/update_todos",
                     );
-                  }
-                }),
-            );
+                    if (ctx) {
+                      yield* emitPlanUpdate(
+                        ctx,
+                        extractTodosAsPlan(params),
+                        params,
+                        "acp.cursor.extension",
+                        "cursor/update_todos",
+                      );
+                    }
+                  }),
+              );
+            }
             yield* acp.handleRequestPermission((params) =>
               Effect.gen(function* () {
                 yield* logNative(

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -65,7 +65,6 @@ import {
 } from "../acp/AcpRuntimeModel.ts";
 import { makeAcpNativeLoggers } from "../acp/AcpNativeLogging.ts";
 import { applyCursorAcpModelSelection, makeCursorAcpRuntime } from "../acp/CursorAcpSupport.ts";
-import { makeGenericAcpRuntime } from "../acp/GenericAcpSupport.ts";
 import {
   CursorAskQuestionRequest,
   CursorCreatePlanRequest,
@@ -88,23 +87,6 @@ export interface CursorAdapterLiveOptions {
   readonly environment?: NodeJS.ProcessEnv;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
-  readonly provider?: ProviderDriverKind;
-  readonly readyReason?: string;
-  readonly spawn?: (input: {
-    readonly settings: CursorSettings;
-    readonly cwd: string;
-    readonly environment?: NodeJS.ProcessEnv;
-  }) => {
-    readonly command: string;
-    readonly args: ReadonlyArray<string>;
-    readonly cwd?: string;
-    readonly env?: NodeJS.ProcessEnv;
-  };
-  readonly normalizeModel?: (model: string | null | undefined) => string;
-  readonly applyCursorModelOptions?: boolean;
-  readonly cursorExtensions?: boolean;
-  readonly authMethodId?: string | undefined;
-  readonly clientCapabilities?: EffectAcpSchema.InitializeRequest["clientCapabilities"];
   /**
    * Selections are honored when `modelSelection.instanceId` matches this value.
    * Defaults to the legacy built-in instance id (`cursor`).
@@ -262,8 +244,6 @@ function applyRequestedSessionConfiguration<E>(input: {
         readonly options?: ReadonlyArray<ProviderOptionSelection> | null | undefined;
       }
     | undefined;
-  readonly normalizeModel: (model: string | null | undefined) => string;
-  readonly applyCursorModelOptions: boolean;
   readonly mapError: (context: {
     readonly cause: import("effect-acp/errors").AcpError;
     readonly method: "session/set_config_option" | "session/set_mode";
@@ -271,30 +251,16 @@ function applyRequestedSessionConfiguration<E>(input: {
 }): Effect.Effect<void, E> {
   return Effect.gen(function* () {
     if (input.modelSelection) {
-      if (input.applyCursorModelOptions) {
-        yield* applyCursorAcpModelSelection({
-          runtime: input.runtime,
-          model: input.modelSelection.model,
-          selections: input.modelSelection.options,
-          mapError: ({ cause }) =>
-            input.mapError({
-              cause,
-              method: "session/set_config_option",
-            }),
-        });
-      } else {
-        const normalizedModel = input.normalizeModel(input.modelSelection.model);
-        if (normalizedModel !== "default") {
-          yield* input.runtime.setModel(normalizedModel).pipe(
-            Effect.mapError((cause) =>
-              input.mapError({
-                cause,
-                method: "session/set_config_option",
-              }),
-            ),
-          );
-        }
-      }
+      yield* applyCursorAcpModelSelection({
+        runtime: input.runtime,
+        model: input.modelSelection.model,
+        selections: input.modelSelection.options,
+        mapError: ({ cause }) =>
+          input.mapError({
+            cause,
+            method: "session/set_config_option",
+          }),
+      });
     }
 
     const requestedModeId = resolveRequestedModeId({
@@ -338,11 +304,6 @@ export function makeCursorAdapter(
   options?: CursorAdapterLiveOptions,
 ) {
   return Effect.gen(function* () {
-    const providerKind = options?.provider ?? PROVIDER;
-    const readyReason = options?.readyReason ?? "Cursor ACP session ready";
-    const normalizeModel = options?.normalizeModel ?? resolveCursorAcpBaseModelId;
-    const applyCursorModelOptions = options?.applyCursorModelOptions ?? true;
-    const cursorExtensions = options?.cursorExtensions ?? true;
     const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("cursor");
     const fileSystem = yield* FileSystem.FileSystem;
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
@@ -404,7 +365,7 @@ export function makeCursorAdapter(
             event: {
               id: crypto.randomUUID(),
               kind: "notification",
-              provider: providerKind,
+              provider: PROVIDER,
               createdAt: observedAt,
               method,
               threadId,
@@ -437,7 +398,7 @@ export function makeCursorAdapter(
         yield* offerRuntimeEvent(
           makeAcpPlanUpdatedEvent({
             stamp: yield* makeEventStamp(),
-            provider: providerKind,
+            provider: PROVIDER,
             threadId: ctx.threadId,
             turnId: ctx.activeTurnId,
             payload,
@@ -454,7 +415,7 @@ export function makeCursorAdapter(
       const ctx = sessions.get(threadId);
       if (!ctx || ctx.stopped) {
         return Effect.fail(
-          new ProviderAdapterSessionNotFoundError({ provider: providerKind, threadId }),
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
         );
       }
       return Effect.succeed(ctx);
@@ -474,7 +435,7 @@ export function makeCursorAdapter(
         yield* offerRuntimeEvent({
           type: "session.exited",
           ...(yield* makeEventStamp()),
-          provider: providerKind,
+          provider: PROVIDER,
           threadId: ctx.threadId,
           payload: { exitKind: "graceful" },
         });
@@ -484,16 +445,16 @@ export function makeCursorAdapter(
       withThreadLock(
         input.threadId,
         Effect.gen(function* () {
-          if (input.provider !== undefined && input.provider !== providerKind) {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
             return yield* new ProviderAdapterValidationError({
-              provider: providerKind,
+              provider: PROVIDER,
               operation: "startSession",
-              issue: `Expected provider '${providerKind}' but received '${input.provider}'.`,
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
             });
           }
           if (!input.cwd?.trim()) {
             return yield* new ProviderAdapterValidationError({
-              provider: providerKind,
+              provider: PROVIDER,
               operation: "startSession",
               issue: "cwd is required and must be non-empty.",
             });
@@ -519,7 +480,7 @@ export function makeCursorAdapter(
           const resumeSessionId = parseCursorResume(input.resumeCursor)?.sessionId;
           const acpNativeLoggers = makeAcpNativeLoggers({
             nativeEventLogger,
-            provider: providerKind,
+            provider: PROVIDER,
             threadId: input.threadId,
           });
 
@@ -535,58 +496,20 @@ export function makeCursorAdapter(
             ? yield* options.resolveSettings
             : cursorSettings;
 
-          const spawn = options?.spawn
-            ? options.spawn({
-                settings: effectiveCursorSettings,
-                cwd,
-                ...(options.environment ? { environment: options.environment } : {}),
-              })
-            : undefined;
-          const acp = yield* (
-            cursorExtensions
-              ? makeCursorAcpRuntime({
-                  cursorSettings: effectiveCursorSettings,
-                  ...(options?.environment ? { environment: options.environment } : {}),
-                  ...(spawn ? { spawn } : {}),
-                  childProcessSpawner,
-                  cwd,
-                  ...(resumeSessionId ? { resumeSessionId } : {}),
-                  clientInfo: { name: "t3-code", version: "0.0.0" },
-                  ...acpNativeLoggers,
-                })
-              : makeGenericAcpRuntime({
-                  spawn:
-                    spawn ??
-                    (() => {
-                      const fallback = options?.spawn?.({
-                        settings: effectiveCursorSettings,
-                        cwd,
-                        ...(options.environment ? { environment: options.environment } : {}),
-                      });
-                      if (fallback) return fallback;
-                      return {
-                        command: effectiveCursorSettings.binaryPath,
-                        args: [],
-                        cwd,
-                        ...(options?.environment ? { env: options.environment } : {}),
-                      };
-                    })(),
-                  childProcessSpawner,
-                  cwd,
-                  ...(resumeSessionId ? { resumeSessionId } : {}),
-                  clientInfo: { name: "t3-code", version: "0.0.0" },
-                  ...(options?.authMethodId ? { authMethodId: options.authMethodId } : {}),
-                  ...(options?.clientCapabilities
-                    ? { clientCapabilities: options.clientCapabilities }
-                    : {}),
-                  ...acpNativeLoggers,
-                })
-          ).pipe(
+          const acp = yield* makeCursorAcpRuntime({
+            cursorSettings: effectiveCursorSettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...acpNativeLoggers,
+          }).pipe(
             Effect.provideService(Scope.Scope, sessionScope),
             Effect.mapError(
               (cause) =>
                 new ProviderAdapterProcessError({
-                  provider: providerKind,
+                  provider: PROVIDER,
                   threadId: input.threadId,
                   detail: cause.message,
                   cause,
@@ -594,97 +517,92 @@ export function makeCursorAdapter(
             ),
           );
           const started = yield* Effect.gen(function* () {
-            if (cursorExtensions) {
-              yield* acp.handleExtRequest(
-                "cursor/ask_question",
-                CursorAskQuestionRequest,
-                (params) =>
-                  Effect.gen(function* () {
-                    yield* logNative(
-                      input.threadId,
-                      "cursor/ask_question",
-                      params,
-                      "acp.cursor.extension",
-                    );
-                    const requestId = ApprovalRequestId.make(crypto.randomUUID());
-                    const runtimeRequestId = RuntimeRequestId.make(requestId);
-                    const answers = yield* Deferred.make<ProviderUserInputAnswers>();
-                    pendingUserInputs.set(requestId, { answers });
-                    yield* offerRuntimeEvent({
-                      type: "user-input.requested",
-                      ...(yield* makeEventStamp()),
-                      provider: providerKind,
-                      threadId: input.threadId,
-                      turnId: ctx?.activeTurnId,
-                      requestId: runtimeRequestId,
-                      payload: { questions: extractAskQuestions(params) },
-                      raw: {
-                        source: "acp.cursor.extension",
-                        method: "cursor/ask_question",
-                        payload: params,
-                      },
-                    });
-                    const resolved = yield* Deferred.await(answers);
-                    pendingUserInputs.delete(requestId);
-                    yield* offerRuntimeEvent({
-                      type: "user-input.resolved",
-                      ...(yield* makeEventStamp()),
-                      provider: providerKind,
-                      threadId: input.threadId,
-                      turnId: ctx?.activeTurnId,
-                      requestId: runtimeRequestId,
-                      payload: { answers: resolved },
-                    });
-                    return { answers: resolved };
-                  }),
-              );
-              yield* acp.handleExtRequest("cursor/create_plan", CursorCreatePlanRequest, (params) =>
+            yield* acp.handleExtRequest("cursor/ask_question", CursorAskQuestionRequest, (params) =>
+              Effect.gen(function* () {
+                yield* logNative(
+                  input.threadId,
+                  "cursor/ask_question",
+                  params,
+                  "acp.cursor.extension",
+                );
+                const requestId = ApprovalRequestId.make(crypto.randomUUID());
+                const runtimeRequestId = RuntimeRequestId.make(requestId);
+                const answers = yield* Deferred.make<ProviderUserInputAnswers>();
+                pendingUserInputs.set(requestId, { answers });
+                yield* offerRuntimeEvent({
+                  type: "user-input.requested",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: ctx?.activeTurnId,
+                  requestId: runtimeRequestId,
+                  payload: { questions: extractAskQuestions(params) },
+                  raw: {
+                    source: "acp.cursor.extension",
+                    method: "cursor/ask_question",
+                    payload: params,
+                  },
+                });
+                const resolved = yield* Deferred.await(answers);
+                pendingUserInputs.delete(requestId);
+                yield* offerRuntimeEvent({
+                  type: "user-input.resolved",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: ctx?.activeTurnId,
+                  requestId: runtimeRequestId,
+                  payload: { answers: resolved },
+                });
+                return { answers: resolved };
+              }),
+            );
+            yield* acp.handleExtRequest("cursor/create_plan", CursorCreatePlanRequest, (params) =>
+              Effect.gen(function* () {
+                yield* logNative(
+                  input.threadId,
+                  "cursor/create_plan",
+                  params,
+                  "acp.cursor.extension",
+                );
+                yield* offerRuntimeEvent({
+                  type: "turn.proposed.completed",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: ctx?.activeTurnId,
+                  payload: { planMarkdown: extractPlanMarkdown(params) },
+                  raw: {
+                    source: "acp.cursor.extension",
+                    method: "cursor/create_plan",
+                    payload: params,
+                  },
+                });
+                return { accepted: true } as const;
+              }),
+            );
+            yield* acp.handleExtNotification(
+              "cursor/update_todos",
+              CursorUpdateTodosRequest,
+              (params) =>
                 Effect.gen(function* () {
                   yield* logNative(
                     input.threadId,
-                    "cursor/create_plan",
+                    "cursor/update_todos",
                     params,
                     "acp.cursor.extension",
                   );
-                  yield* offerRuntimeEvent({
-                    type: "turn.proposed.completed",
-                    ...(yield* makeEventStamp()),
-                    provider: providerKind,
-                    threadId: input.threadId,
-                    turnId: ctx?.activeTurnId,
-                    payload: { planMarkdown: extractPlanMarkdown(params) },
-                    raw: {
-                      source: "acp.cursor.extension",
-                      method: "cursor/create_plan",
-                      payload: params,
-                    },
-                  });
-                  return { accepted: true } as const;
-                }),
-              );
-              yield* acp.handleExtNotification(
-                "cursor/update_todos",
-                CursorUpdateTodosRequest,
-                (params) =>
-                  Effect.gen(function* () {
-                    yield* logNative(
-                      input.threadId,
-                      "cursor/update_todos",
+                  if (ctx) {
+                    yield* emitPlanUpdate(
+                      ctx,
+                      extractTodosAsPlan(params),
                       params,
                       "acp.cursor.extension",
+                      "cursor/update_todos",
                     );
-                    if (ctx) {
-                      yield* emitPlanUpdate(
-                        ctx,
-                        extractTodosAsPlan(params),
-                        params,
-                        "acp.cursor.extension",
-                        "cursor/update_todos",
-                      );
-                    }
-                  }),
-              );
-            }
+                  }
+                }),
+            );
             yield* acp.handleRequestPermission((params) =>
               Effect.gen(function* () {
                 yield* logNative(
@@ -715,7 +633,7 @@ export function makeCursorAdapter(
                 yield* offerRuntimeEvent(
                   makeAcpRequestOpenedEvent({
                     stamp: yield* makeEventStamp(),
-                    provider: providerKind,
+                    provider: PROVIDER,
                     threadId: input.threadId,
                     turnId: ctx?.activeTurnId,
                     requestId: runtimeRequestId,
@@ -732,7 +650,7 @@ export function makeCursorAdapter(
                 yield* offerRuntimeEvent(
                   makeAcpRequestResolvedEvent({
                     stamp: yield* makeEventStamp(),
-                    provider: providerKind,
+                    provider: PROVIDER,
                     threadId: input.threadId,
                     turnId: ctx?.activeTurnId,
                     requestId: runtimeRequestId,
@@ -754,7 +672,7 @@ export function makeCursorAdapter(
             return yield* acp.start();
           }).pipe(
             Effect.mapError((error) =>
-              mapAcpToAdapterError(providerKind, input.threadId, "session/start", error),
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
             ),
           );
 
@@ -763,15 +681,13 @@ export function makeCursorAdapter(
             runtimeMode: input.runtimeMode,
             interactionMode: undefined,
             modelSelection: cursorModelSelection,
-            normalizeModel,
-            applyCursorModelOptions,
             mapError: ({ cause, method }) =>
-              mapAcpToAdapterError(providerKind, input.threadId, method, cause),
+              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
           });
 
           const now = yield* nowIso;
           const session: ProviderSession = {
-            provider: providerKind,
+            provider: PROVIDER,
             providerInstanceId: boundInstanceId,
             status: "ready",
             runtimeMode: input.runtimeMode,
@@ -810,7 +726,7 @@ export function makeCursorAdapter(
                     yield* offerRuntimeEvent(
                       makeAcpAssistantItemEvent({
                         stamp: yield* makeEventStamp(),
-                        provider: providerKind,
+                        provider: PROVIDER,
                         threadId: ctx.threadId,
                         turnId: ctx.activeTurnId,
                         itemId: event.itemId,
@@ -822,7 +738,7 @@ export function makeCursorAdapter(
                     yield* offerRuntimeEvent(
                       makeAcpAssistantItemEvent({
                         stamp: yield* makeEventStamp(),
-                        provider: providerKind,
+                        provider: PROVIDER,
                         threadId: ctx.threadId,
                         turnId: ctx.activeTurnId,
                         itemId: event.itemId,
@@ -855,7 +771,7 @@ export function makeCursorAdapter(
                     yield* offerRuntimeEvent(
                       makeAcpToolCallEvent({
                         stamp: yield* makeEventStamp(),
-                        provider: providerKind,
+                        provider: PROVIDER,
                         threadId: ctx.threadId,
                         turnId: ctx.activeTurnId,
                         toolCall: event.toolCall,
@@ -873,7 +789,7 @@ export function makeCursorAdapter(
                     yield* offerRuntimeEvent(
                       makeAcpContentDeltaEvent({
                         stamp: yield* makeEventStamp(),
-                        provider: providerKind,
+                        provider: PROVIDER,
                         threadId: ctx.threadId,
                         turnId: ctx.activeTurnId,
                         ...(event.itemId ? { itemId: event.itemId } : {}),
@@ -894,21 +810,21 @@ export function makeCursorAdapter(
           yield* offerRuntimeEvent({
             type: "session.started",
             ...(yield* makeEventStamp()),
-            provider: providerKind,
+            provider: PROVIDER,
             threadId: input.threadId,
             payload: { resume: started.initializeResult },
           });
           yield* offerRuntimeEvent({
             type: "session.state.changed",
             ...(yield* makeEventStamp()),
-            provider: providerKind,
+            provider: PROVIDER,
             threadId: input.threadId,
-            payload: { state: "ready", reason: readyReason },
+            payload: { state: "ready", reason: "Cursor ACP session ready" },
           });
           yield* offerRuntimeEvent({
             type: "thread.started",
             ...(yield* makeEventStamp()),
-            provider: providerKind,
+            provider: PROVIDER,
             threadId: input.threadId,
             payload: { providerThreadId: started.sessionId },
           });
@@ -924,7 +840,7 @@ export function makeCursorAdapter(
         const turnModelSelection =
           input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
         const model = turnModelSelection?.model ?? ctx.session.model;
-        const resolvedModel = normalizeModel(model);
+        const resolvedModel = resolveCursorAcpBaseModelId(model);
         yield* applyRequestedSessionConfiguration({
           runtime: ctx.acp,
           runtimeMode: ctx.session.runtimeMode,
@@ -936,10 +852,8 @@ export function makeCursorAdapter(
                   model,
                   options: turnModelSelection?.options,
                 },
-          normalizeModel,
-          applyCursorModelOptions,
           mapError: ({ cause, method }) =>
-            mapAcpToAdapterError(providerKind, input.threadId, method, cause),
+            mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
         });
         ctx.activeTurnId = turnId;
         ctx.lastPlanFingerprint = undefined;
@@ -952,7 +866,7 @@ export function makeCursorAdapter(
         yield* offerRuntimeEvent({
           type: "turn.started",
           ...(yield* makeEventStamp()),
-          provider: providerKind,
+          provider: PROVIDER,
           threadId: input.threadId,
           turnId,
           payload: { model: resolvedModel },
@@ -970,7 +884,7 @@ export function makeCursorAdapter(
             });
             if (!attachmentPath) {
               return yield* new ProviderAdapterRequestError({
-                provider: providerKind,
+                provider: PROVIDER,
                 method: "session/prompt",
                 detail: `Invalid attachment id '${attachment.id}'.`,
               });
@@ -979,7 +893,7 @@ export function makeCursorAdapter(
               Effect.mapError(
                 (cause) =>
                   new ProviderAdapterRequestError({
-                    provider: providerKind,
+                    provider: PROVIDER,
                     method: "session/prompt",
                     detail: cause.message,
                     cause,
@@ -996,7 +910,7 @@ export function makeCursorAdapter(
 
         if (promptParts.length === 0) {
           return yield* new ProviderAdapterValidationError({
-            provider: providerKind,
+            provider: PROVIDER,
             operation: "sendTurn",
             issue: "Turn requires non-empty text or attachments.",
           });
@@ -1008,7 +922,7 @@ export function makeCursorAdapter(
           })
           .pipe(
             Effect.mapError((error) =>
-              mapAcpToAdapterError(providerKind, input.threadId, "session/prompt", error),
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
             ),
           );
 
@@ -1023,7 +937,7 @@ export function makeCursorAdapter(
         yield* offerRuntimeEvent({
           type: "turn.completed",
           ...(yield* makeEventStamp()),
-          provider: providerKind,
+          provider: PROVIDER,
           threadId: input.threadId,
           turnId,
           payload: {
@@ -1047,7 +961,7 @@ export function makeCursorAdapter(
         yield* Effect.ignore(
           ctx.acp.cancel.pipe(
             Effect.mapError((error) =>
-              mapAcpToAdapterError(providerKind, threadId, "session/cancel", error),
+              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
             ),
           ),
         );
@@ -1063,7 +977,7 @@ export function makeCursorAdapter(
         const pending = ctx.pendingApprovals.get(requestId);
         if (!pending) {
           return yield* new ProviderAdapterRequestError({
-            provider: providerKind,
+            provider: PROVIDER,
             method: "session/request_permission",
             detail: `Unknown pending approval request: ${requestId}`,
           });
@@ -1081,7 +995,7 @@ export function makeCursorAdapter(
         const pending = ctx.pendingUserInputs.get(requestId);
         if (!pending) {
           return yield* new ProviderAdapterRequestError({
-            provider: providerKind,
+            provider: PROVIDER,
             method: "cursor/ask_question",
             detail: `Unknown pending user-input request: ${requestId}`,
           });
@@ -1100,7 +1014,7 @@ export function makeCursorAdapter(
         const ctx = yield* requireSession(threadId);
         if (!Number.isInteger(numTurns) || numTurns < 1) {
           return yield* new ProviderAdapterValidationError({
-            provider: providerKind,
+            provider: PROVIDER,
             operation: "rollbackThread",
             issue: "numTurns must be an integer >= 1.",
           });
@@ -1141,7 +1055,7 @@ export function makeCursorAdapter(
     const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
 
     return {
-      provider: providerKind,
+      provider: PROVIDER,
       capabilities: { sessionModelSwitch: "in-session" },
       startSession,
       sendTurn,

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -87,6 +87,20 @@ export interface CursorAdapterLiveOptions {
   readonly environment?: NodeJS.ProcessEnv;
   readonly nativeEventLogPath?: string;
   readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly provider?: ProviderDriverKind;
+  readonly readyReason?: string;
+  readonly spawn?: (input: {
+    readonly settings: CursorSettings;
+    readonly cwd: string;
+    readonly environment?: NodeJS.ProcessEnv;
+  }) => {
+    readonly command: string;
+    readonly args: ReadonlyArray<string>;
+    readonly cwd?: string;
+    readonly env?: NodeJS.ProcessEnv;
+  };
+  readonly normalizeModel?: (model: string | null | undefined) => string;
+  readonly applyCursorModelOptions?: boolean;
   /**
    * Selections are honored when `modelSelection.instanceId` matches this value.
    * Defaults to the legacy built-in instance id (`cursor`).
@@ -244,6 +258,8 @@ function applyRequestedSessionConfiguration<E>(input: {
         readonly options?: ReadonlyArray<ProviderOptionSelection> | null | undefined;
       }
     | undefined;
+  readonly normalizeModel: (model: string | null | undefined) => string;
+  readonly applyCursorModelOptions: boolean;
   readonly mapError: (context: {
     readonly cause: import("effect-acp/errors").AcpError;
     readonly method: "session/set_config_option" | "session/set_mode";
@@ -251,16 +267,30 @@ function applyRequestedSessionConfiguration<E>(input: {
 }): Effect.Effect<void, E> {
   return Effect.gen(function* () {
     if (input.modelSelection) {
-      yield* applyCursorAcpModelSelection({
-        runtime: input.runtime,
-        model: input.modelSelection.model,
-        selections: input.modelSelection.options,
-        mapError: ({ cause }) =>
-          input.mapError({
-            cause,
-            method: "session/set_config_option",
-          }),
-      });
+      if (input.applyCursorModelOptions) {
+        yield* applyCursorAcpModelSelection({
+          runtime: input.runtime,
+          model: input.modelSelection.model,
+          selections: input.modelSelection.options,
+          mapError: ({ cause }) =>
+            input.mapError({
+              cause,
+              method: "session/set_config_option",
+            }),
+        });
+      } else {
+        const normalizedModel = input.normalizeModel(input.modelSelection.model);
+        if (normalizedModel !== "default") {
+          yield* input.runtime.setModel(normalizedModel).pipe(
+            Effect.mapError((cause) =>
+              input.mapError({
+                cause,
+                method: "session/set_config_option",
+              }),
+            ),
+          );
+        }
+      }
     }
 
     const requestedModeId = resolveRequestedModeId({
@@ -304,6 +334,10 @@ export function makeCursorAdapter(
   options?: CursorAdapterLiveOptions,
 ) {
   return Effect.gen(function* () {
+    const providerKind = options?.provider ?? PROVIDER;
+    const readyReason = options?.readyReason ?? "Cursor ACP session ready";
+    const normalizeModel = options?.normalizeModel ?? resolveCursorAcpBaseModelId;
+    const applyCursorModelOptions = options?.applyCursorModelOptions ?? true;
     const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("cursor");
     const fileSystem = yield* FileSystem.FileSystem;
     const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
@@ -365,7 +399,7 @@ export function makeCursorAdapter(
             event: {
               id: crypto.randomUUID(),
               kind: "notification",
-              provider: PROVIDER,
+              provider: providerKind,
               createdAt: observedAt,
               method,
               threadId,
@@ -398,7 +432,7 @@ export function makeCursorAdapter(
         yield* offerRuntimeEvent(
           makeAcpPlanUpdatedEvent({
             stamp: yield* makeEventStamp(),
-            provider: PROVIDER,
+            provider: providerKind,
             threadId: ctx.threadId,
             turnId: ctx.activeTurnId,
             payload,
@@ -415,7 +449,7 @@ export function makeCursorAdapter(
       const ctx = sessions.get(threadId);
       if (!ctx || ctx.stopped) {
         return Effect.fail(
-          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+          new ProviderAdapterSessionNotFoundError({ provider: providerKind, threadId }),
         );
       }
       return Effect.succeed(ctx);
@@ -435,7 +469,7 @@ export function makeCursorAdapter(
         yield* offerRuntimeEvent({
           type: "session.exited",
           ...(yield* makeEventStamp()),
-          provider: PROVIDER,
+          provider: providerKind,
           threadId: ctx.threadId,
           payload: { exitKind: "graceful" },
         });
@@ -445,16 +479,16 @@ export function makeCursorAdapter(
       withThreadLock(
         input.threadId,
         Effect.gen(function* () {
-          if (input.provider !== undefined && input.provider !== PROVIDER) {
+          if (input.provider !== undefined && input.provider !== providerKind) {
             return yield* new ProviderAdapterValidationError({
-              provider: PROVIDER,
+              provider: providerKind,
               operation: "startSession",
-              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+              issue: `Expected provider '${providerKind}' but received '${input.provider}'.`,
             });
           }
           if (!input.cwd?.trim()) {
             return yield* new ProviderAdapterValidationError({
-              provider: PROVIDER,
+              provider: providerKind,
               operation: "startSession",
               issue: "cwd is required and must be non-empty.",
             });
@@ -480,7 +514,7 @@ export function makeCursorAdapter(
           const resumeSessionId = parseCursorResume(input.resumeCursor)?.sessionId;
           const acpNativeLoggers = makeAcpNativeLoggers({
             nativeEventLogger,
-            provider: PROVIDER,
+            provider: providerKind,
             threadId: input.threadId,
           });
 
@@ -499,6 +533,15 @@ export function makeCursorAdapter(
           const acp = yield* makeCursorAcpRuntime({
             cursorSettings: effectiveCursorSettings,
             ...(options?.environment ? { environment: options.environment } : {}),
+            ...(options?.spawn
+              ? {
+                  spawn: options.spawn({
+                    settings: effectiveCursorSettings,
+                    cwd,
+                    ...(options.environment ? { environment: options.environment } : {}),
+                  }),
+                }
+              : {}),
             childProcessSpawner,
             cwd,
             ...(resumeSessionId ? { resumeSessionId } : {}),
@@ -509,7 +552,7 @@ export function makeCursorAdapter(
             Effect.mapError(
               (cause) =>
                 new ProviderAdapterProcessError({
-                  provider: PROVIDER,
+                  provider: providerKind,
                   threadId: input.threadId,
                   detail: cause.message,
                   cause,
@@ -532,7 +575,7 @@ export function makeCursorAdapter(
                 yield* offerRuntimeEvent({
                   type: "user-input.requested",
                   ...(yield* makeEventStamp()),
-                  provider: PROVIDER,
+                  provider: providerKind,
                   threadId: input.threadId,
                   turnId: ctx?.activeTurnId,
                   requestId: runtimeRequestId,
@@ -548,7 +591,7 @@ export function makeCursorAdapter(
                 yield* offerRuntimeEvent({
                   type: "user-input.resolved",
                   ...(yield* makeEventStamp()),
-                  provider: PROVIDER,
+                  provider: providerKind,
                   threadId: input.threadId,
                   turnId: ctx?.activeTurnId,
                   requestId: runtimeRequestId,
@@ -568,7 +611,7 @@ export function makeCursorAdapter(
                 yield* offerRuntimeEvent({
                   type: "turn.proposed.completed",
                   ...(yield* makeEventStamp()),
-                  provider: PROVIDER,
+                  provider: providerKind,
                   threadId: input.threadId,
                   turnId: ctx?.activeTurnId,
                   payload: { planMarkdown: extractPlanMarkdown(params) },
@@ -633,7 +676,7 @@ export function makeCursorAdapter(
                 yield* offerRuntimeEvent(
                   makeAcpRequestOpenedEvent({
                     stamp: yield* makeEventStamp(),
-                    provider: PROVIDER,
+                    provider: providerKind,
                     threadId: input.threadId,
                     turnId: ctx?.activeTurnId,
                     requestId: runtimeRequestId,
@@ -650,7 +693,7 @@ export function makeCursorAdapter(
                 yield* offerRuntimeEvent(
                   makeAcpRequestResolvedEvent({
                     stamp: yield* makeEventStamp(),
-                    provider: PROVIDER,
+                    provider: providerKind,
                     threadId: input.threadId,
                     turnId: ctx?.activeTurnId,
                     requestId: runtimeRequestId,
@@ -672,7 +715,7 @@ export function makeCursorAdapter(
             return yield* acp.start();
           }).pipe(
             Effect.mapError((error) =>
-              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+              mapAcpToAdapterError(providerKind, input.threadId, "session/start", error),
             ),
           );
 
@@ -681,13 +724,15 @@ export function makeCursorAdapter(
             runtimeMode: input.runtimeMode,
             interactionMode: undefined,
             modelSelection: cursorModelSelection,
+            normalizeModel,
+            applyCursorModelOptions,
             mapError: ({ cause, method }) =>
-              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+              mapAcpToAdapterError(providerKind, input.threadId, method, cause),
           });
 
           const now = yield* nowIso;
           const session: ProviderSession = {
-            provider: PROVIDER,
+            provider: providerKind,
             providerInstanceId: boundInstanceId,
             status: "ready",
             runtimeMode: input.runtimeMode,
@@ -726,7 +771,7 @@ export function makeCursorAdapter(
                     yield* offerRuntimeEvent(
                       makeAcpAssistantItemEvent({
                         stamp: yield* makeEventStamp(),
-                        provider: PROVIDER,
+                        provider: providerKind,
                         threadId: ctx.threadId,
                         turnId: ctx.activeTurnId,
                         itemId: event.itemId,
@@ -738,7 +783,7 @@ export function makeCursorAdapter(
                     yield* offerRuntimeEvent(
                       makeAcpAssistantItemEvent({
                         stamp: yield* makeEventStamp(),
-                        provider: PROVIDER,
+                        provider: providerKind,
                         threadId: ctx.threadId,
                         turnId: ctx.activeTurnId,
                         itemId: event.itemId,
@@ -771,7 +816,7 @@ export function makeCursorAdapter(
                     yield* offerRuntimeEvent(
                       makeAcpToolCallEvent({
                         stamp: yield* makeEventStamp(),
-                        provider: PROVIDER,
+                        provider: providerKind,
                         threadId: ctx.threadId,
                         turnId: ctx.activeTurnId,
                         toolCall: event.toolCall,
@@ -789,7 +834,7 @@ export function makeCursorAdapter(
                     yield* offerRuntimeEvent(
                       makeAcpContentDeltaEvent({
                         stamp: yield* makeEventStamp(),
-                        provider: PROVIDER,
+                        provider: providerKind,
                         threadId: ctx.threadId,
                         turnId: ctx.activeTurnId,
                         ...(event.itemId ? { itemId: event.itemId } : {}),
@@ -810,21 +855,21 @@ export function makeCursorAdapter(
           yield* offerRuntimeEvent({
             type: "session.started",
             ...(yield* makeEventStamp()),
-            provider: PROVIDER,
+            provider: providerKind,
             threadId: input.threadId,
             payload: { resume: started.initializeResult },
           });
           yield* offerRuntimeEvent({
             type: "session.state.changed",
             ...(yield* makeEventStamp()),
-            provider: PROVIDER,
+            provider: providerKind,
             threadId: input.threadId,
-            payload: { state: "ready", reason: "Cursor ACP session ready" },
+            payload: { state: "ready", reason: readyReason },
           });
           yield* offerRuntimeEvent({
             type: "thread.started",
             ...(yield* makeEventStamp()),
-            provider: PROVIDER,
+            provider: providerKind,
             threadId: input.threadId,
             payload: { providerThreadId: started.sessionId },
           });
@@ -840,7 +885,7 @@ export function makeCursorAdapter(
         const turnModelSelection =
           input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
         const model = turnModelSelection?.model ?? ctx.session.model;
-        const resolvedModel = resolveCursorAcpBaseModelId(model);
+        const resolvedModel = normalizeModel(model);
         yield* applyRequestedSessionConfiguration({
           runtime: ctx.acp,
           runtimeMode: ctx.session.runtimeMode,
@@ -852,8 +897,10 @@ export function makeCursorAdapter(
                   model,
                   options: turnModelSelection?.options,
                 },
+          normalizeModel,
+          applyCursorModelOptions,
           mapError: ({ cause, method }) =>
-            mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+            mapAcpToAdapterError(providerKind, input.threadId, method, cause),
         });
         ctx.activeTurnId = turnId;
         ctx.lastPlanFingerprint = undefined;
@@ -866,7 +913,7 @@ export function makeCursorAdapter(
         yield* offerRuntimeEvent({
           type: "turn.started",
           ...(yield* makeEventStamp()),
-          provider: PROVIDER,
+          provider: providerKind,
           threadId: input.threadId,
           turnId,
           payload: { model: resolvedModel },
@@ -884,7 +931,7 @@ export function makeCursorAdapter(
             });
             if (!attachmentPath) {
               return yield* new ProviderAdapterRequestError({
-                provider: PROVIDER,
+                provider: providerKind,
                 method: "session/prompt",
                 detail: `Invalid attachment id '${attachment.id}'.`,
               });
@@ -893,7 +940,7 @@ export function makeCursorAdapter(
               Effect.mapError(
                 (cause) =>
                   new ProviderAdapterRequestError({
-                    provider: PROVIDER,
+                    provider: providerKind,
                     method: "session/prompt",
                     detail: cause.message,
                     cause,
@@ -910,7 +957,7 @@ export function makeCursorAdapter(
 
         if (promptParts.length === 0) {
           return yield* new ProviderAdapterValidationError({
-            provider: PROVIDER,
+            provider: providerKind,
             operation: "sendTurn",
             issue: "Turn requires non-empty text or attachments.",
           });
@@ -922,7 +969,7 @@ export function makeCursorAdapter(
           })
           .pipe(
             Effect.mapError((error) =>
-              mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+              mapAcpToAdapterError(providerKind, input.threadId, "session/prompt", error),
             ),
           );
 
@@ -937,7 +984,7 @@ export function makeCursorAdapter(
         yield* offerRuntimeEvent({
           type: "turn.completed",
           ...(yield* makeEventStamp()),
-          provider: PROVIDER,
+          provider: providerKind,
           threadId: input.threadId,
           turnId,
           payload: {
@@ -961,7 +1008,7 @@ export function makeCursorAdapter(
         yield* Effect.ignore(
           ctx.acp.cancel.pipe(
             Effect.mapError((error) =>
-              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+              mapAcpToAdapterError(providerKind, threadId, "session/cancel", error),
             ),
           ),
         );
@@ -977,7 +1024,7 @@ export function makeCursorAdapter(
         const pending = ctx.pendingApprovals.get(requestId);
         if (!pending) {
           return yield* new ProviderAdapterRequestError({
-            provider: PROVIDER,
+            provider: providerKind,
             method: "session/request_permission",
             detail: `Unknown pending approval request: ${requestId}`,
           });
@@ -995,7 +1042,7 @@ export function makeCursorAdapter(
         const pending = ctx.pendingUserInputs.get(requestId);
         if (!pending) {
           return yield* new ProviderAdapterRequestError({
-            provider: PROVIDER,
+            provider: providerKind,
             method: "cursor/ask_question",
             detail: `Unknown pending user-input request: ${requestId}`,
           });
@@ -1014,7 +1061,7 @@ export function makeCursorAdapter(
         const ctx = yield* requireSession(threadId);
         if (!Number.isInteger(numTurns) || numTurns < 1) {
           return yield* new ProviderAdapterValidationError({
-            provider: PROVIDER,
+            provider: providerKind,
             operation: "rollbackThread",
             issue: "numTurns must be an integer >= 1.",
           });
@@ -1055,7 +1102,7 @@ export function makeCursorAdapter(
     const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
 
     return {
-      provider: PROVIDER,
+      provider: providerKind,
       capabilities: { sessionModelSwitch: "in-session" },
       startSession,
       sendTurn,

--- a/apps/server/src/provider/Layers/GenericAcpAdapter.ts
+++ b/apps/server/src/provider/Layers/GenericAcpAdapter.ts
@@ -737,7 +737,9 @@ export function makeGenericAcpAdapter(
       listSessions,
       hasSession,
       stopAll,
-      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+      get streamEvents() {
+        return Stream.fromPubSub(runtimeEventPubSub);
+      },
     } satisfies ProviderAdapterShape<ProviderAdapterError>;
   });
 }

--- a/apps/server/src/provider/Layers/GenericAcpAdapter.ts
+++ b/apps/server/src/provider/Layers/GenericAcpAdapter.ts
@@ -1,38 +1,743 @@
+import * as nodePath from "node:path";
+
 import {
-  type CursorSettings,
+  ApprovalRequestId,
+  type ProviderApprovalDecision,
   type ProviderDriverKind,
-  type ProviderInstanceId,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderUserInputAnswers,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+  EventId,
 } from "@t3tools/contracts";
+import {
+  DateTime,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  PubSub,
+  Random,
+  Scope,
+  Semaphore,
+  Stream,
+  SynchronizedRef,
+} from "effect";
+import { ChildProcessSpawner } from "effect/unstable/process";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
-import { makeCursorAdapter, type CursorAdapterLiveOptions } from "./CursorAdapter.ts";
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+  type ProviderAdapterError,
+} from "../Errors.ts";
+import { acpPermissionOutcome, mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import { type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { makeAcpNativeLoggers } from "../acp/AcpNativeLogging.ts";
+import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
+import { makeGenericAcpRuntime } from "../acp/GenericAcpSupport.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import { type ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
 
-type GenericAcpAdapterSettings = Pick<CursorSettings, "enabled" | "binaryPath" | "customModels">;
+const GENERIC_ACP_RESUME_VERSION = 1 as const;
 
-type GenericAcpAdapterOptions = Omit<
-  CursorAdapterLiveOptions,
-  "applyCursorModelOptions" | "authMethodId" | "clientCapabilities" | "cursorExtensions"
-> & {
+export interface GenericAcpAdapterSettings {
+  readonly enabled: boolean;
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+}
+
+export interface GenericAcpAdapterOptions {
   readonly provider: ProviderDriverKind;
-  readonly instanceId: typeof ProviderInstanceId.Type;
-  readonly authMethodId?: string | undefined;
+  readonly instanceId: ProviderSession["providerInstanceId"];
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly readyReason?: string;
   readonly clientCapabilities?: EffectAcpSchema.InitializeRequest["clientCapabilities"];
-};
+  readonly authMethodId?: string | undefined;
+  readonly normalizeModel?: (model: string | null | undefined) => string;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+}
+
+interface PendingUserInput {
+  readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
+}
+
+interface GenericAcpSessionContext {
+  readonly threadId: ThreadId;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntimeShape;
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
+  readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  activeTurnId: TurnId | undefined;
+  stopped: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseGenericResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== GENERIC_ACP_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+function settlePendingApprovalsAsCancelled(
+  pendingApprovals: ReadonlyMap<ApprovalRequestId, PendingApproval>,
+): Effect.Effect<void> {
+  return Effect.forEach(
+    pendingApprovals.values(),
+    (pending) => Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore),
+    { discard: true },
+  );
+}
+
+function settlePendingUserInputsAsEmptyAnswers(
+  pendingUserInputs: ReadonlyMap<ApprovalRequestId, PendingUserInput>,
+): Effect.Effect<void> {
+  return Effect.forEach(
+    pendingUserInputs.values(),
+    (pending) => Deferred.succeed(pending.answers, {}).pipe(Effect.ignore),
+    { discard: true },
+  );
+}
 
 export function makeGenericAcpAdapter(
   settings: GenericAcpAdapterSettings,
   options: GenericAcpAdapterOptions,
 ) {
-  return makeCursorAdapter(
-    {
-      ...settings,
-      apiEndpoint: "",
-    },
-    {
-      ...options,
-      applyCursorModelOptions: false,
-      cursorExtensions: false,
-      normalizeModel: options.normalizeModel ?? ((model) => model?.trim() || "default"),
-    },
-  );
+  return Effect.gen(function* () {
+    const providerKind = options.provider;
+    const readyReason = options.readyReason ?? "ACP session ready";
+    const normalizeModel = options.normalizeModel ?? ((model) => model?.trim() || "default");
+    const fileSystem = yield* FileSystem.FileSystem;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const nativeEventLogger =
+      options.nativeEventLogger ??
+      (options.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
+        : undefined);
+    const managedNativeEventLogger =
+      options.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+
+    const sessions = new Map<ThreadId, GenericAcpSessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const nextEventId = Effect.map(Random.nextUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing = current.get(threadId);
+        if (existing) return Effect.succeed([existing, current] as const);
+        return Semaphore.make(1).pipe(
+          Effect.map((semaphore) => {
+            const next = new Map(current);
+            next.set(threadId, semaphore);
+            return [semaphore, next] as const;
+          }),
+        );
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<GenericAcpSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: providerKind, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: GenericAcpSessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: providerKind,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: ProviderAdapterShape<ProviderAdapterError>["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== providerKind) {
+            return yield* new ProviderAdapterValidationError({
+              provider: providerKind,
+              operation: "startSession",
+              issue: `Expected provider '${providerKind}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: providerKind,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const command = settings.command.trim();
+          if (!settings.enabled || command.length === 0) {
+            return yield* new ProviderAdapterValidationError({
+              provider: providerKind,
+              operation: "startSession",
+              issue: "ACP command is not configured.",
+            });
+          }
+
+          const cwd = nodePath.resolve(input.cwd.trim());
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+          let ctx!: GenericAcpSessionContext;
+
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: providerKind,
+            threadId: input.threadId,
+          });
+          const resumeSessionId = parseGenericResume(input.resumeCursor)?.sessionId;
+          const acp = yield* makeGenericAcpRuntime({
+            spawn: {
+              command,
+              args: settings.args,
+              cwd,
+              ...(options.environment ? { env: options.environment } : {}),
+            },
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...(options.authMethodId ? { authMethodId: options.authMethodId } : {}),
+            ...(options.clientCapabilities
+              ? { clientCapabilities: options.clientCapabilities }
+              : {}),
+            ...acpNativeLoggers,
+          }).pipe(
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: providerKind,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+
+          const started = yield* Effect.gen(function* () {
+            yield* acp.handleRequestPermission((params) =>
+              Effect.gen(function* () {
+                if (input.runtimeMode === "full-access") {
+                  const autoApprovedOptionId =
+                    params.options.find((option) => option.kind === "allow_always")?.optionId ??
+                    params.options.find((option) => option.kind === "allow_once")?.optionId;
+                  if (typeof autoApprovedOptionId === "string" && autoApprovedOptionId.trim()) {
+                    return {
+                      outcome: {
+                        outcome: "selected" as const,
+                        optionId: autoApprovedOptionId.trim(),
+                      },
+                    };
+                  }
+                }
+                const permissionRequest = parsePermissionRequest(params);
+                const requestId = ApprovalRequestId.make(crypto.randomUUID());
+                const runtimeRequestId = RuntimeRequestId.make(requestId);
+                const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                pendingApprovals.set(requestId, { decision });
+                yield* offerRuntimeEvent(
+                  makeAcpRequestOpenedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: providerKind,
+                    threadId: input.threadId,
+                    turnId: ctx?.activeTurnId,
+                    requestId: runtimeRequestId,
+                    permissionRequest,
+                    detail: permissionRequest.detail ?? JSON.stringify(params).slice(0, 2000),
+                    args: params,
+                    source: "acp.jsonrpc",
+                    method: "session/request_permission",
+                    rawPayload: params,
+                  }),
+                );
+                const resolved = yield* Deferred.await(decision);
+                pendingApprovals.delete(requestId);
+                yield* offerRuntimeEvent(
+                  makeAcpRequestResolvedEvent({
+                    stamp: yield* makeEventStamp(),
+                    provider: providerKind,
+                    threadId: input.threadId,
+                    turnId: ctx?.activeTurnId,
+                    requestId: runtimeRequestId,
+                    permissionRequest,
+                    decision: resolved,
+                  }),
+                );
+                return {
+                  outcome:
+                    resolved === "cancel"
+                      ? ({ outcome: "cancelled" } as const)
+                      : {
+                          outcome: "selected" as const,
+                          optionId: acpPermissionOutcome(resolved),
+                        },
+                };
+              }),
+            );
+            return yield* acp.start();
+          }).pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(providerKind, input.threadId, "session/start", error),
+            ),
+          );
+
+          const initialModelSelection =
+            input.modelSelection?.instanceId === options.instanceId
+              ? input.modelSelection
+              : undefined;
+          if (initialModelSelection?.model) {
+            const model = normalizeModel(initialModelSelection.model);
+            if (model !== "default") {
+              yield* acp
+                .setModel(model)
+                .pipe(
+                  Effect.mapError((error) =>
+                    mapAcpToAdapterError(
+                      providerKind,
+                      input.threadId,
+                      "session/set_config_option",
+                      error,
+                    ),
+                  ),
+                );
+            }
+          }
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: providerKind,
+            providerInstanceId: options.instanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            model: initialModelSelection?.model,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: GENERIC_ACP_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          ctx = {
+            threadId: input.threadId,
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            pendingApprovals,
+            pendingUserInputs,
+            turns: [],
+            activeTurnId: undefined,
+            stopped: false,
+          };
+
+          const notificationFiber = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                switch (event._tag) {
+                  case "ModeChanged":
+                    return;
+                  case "AssistantItemStarted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: providerKind,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.started",
+                      }),
+                    );
+                    return;
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: providerKind,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* offerRuntimeEvent(
+                      makeAcpPlanUpdatedEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: providerKind,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        payload: event.payload,
+                        source: "acp.jsonrpc",
+                        method: "session/update",
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ToolCallUpdated":
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: providerKind,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: providerKind,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(Effect.forkChild);
+
+          ctx.notificationFiber = notificationFiber;
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: providerKind,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: providerKind,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: readyReason },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: providerKind,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: ProviderAdapterShape<ProviderAdapterError>["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(input.threadId);
+        const turnId = TurnId.make(crypto.randomUUID());
+        const turnModelSelection =
+          input.modelSelection?.instanceId === options.instanceId
+            ? input.modelSelection
+            : undefined;
+        const model = turnModelSelection?.model ?? ctx.session.model;
+        const resolvedModel = normalizeModel(model);
+        if (model !== undefined && resolvedModel !== "default") {
+          yield* ctx.acp
+            .setModel(resolvedModel)
+            .pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(
+                  providerKind,
+                  input.threadId,
+                  "session/set_config_option",
+                  error,
+                ),
+              ),
+            );
+        }
+
+        ctx.activeTurnId = turnId;
+        ctx.session = {
+          ...ctx.session,
+          activeTurnId: turnId,
+          updatedAt: yield* nowIso,
+        };
+
+        yield* offerRuntimeEvent({
+          type: "turn.started",
+          ...(yield* makeEventStamp()),
+          provider: providerKind,
+          threadId: input.threadId,
+          turnId,
+          payload: { model: resolvedModel },
+        });
+
+        const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
+        if (input.input?.trim()) {
+          promptParts.push({ type: "text", text: input.input.trim() });
+        }
+        if (input.attachments && input.attachments.length > 0) {
+          for (const attachment of input.attachments) {
+            const attachmentPath = resolveAttachmentPath({
+              attachmentsDir: serverConfig.attachmentsDir,
+              attachment,
+            });
+            if (!attachmentPath) {
+              return yield* new ProviderAdapterRequestError({
+                provider: providerKind,
+                method: "session/prompt",
+                detail: `Invalid attachment id '${attachment.id}'.`,
+              });
+            }
+            const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProviderAdapterRequestError({
+                    provider: providerKind,
+                    method: "session/prompt",
+                    detail: cause.message,
+                    cause,
+                  }),
+              ),
+            );
+            promptParts.push({
+              type: "image",
+              data: Buffer.from(bytes).toString("base64"),
+              mimeType: attachment.mimeType,
+            });
+          }
+        }
+
+        if (promptParts.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: providerKind,
+            operation: "sendTurn",
+            issue: "Turn requires non-empty text or attachments.",
+          });
+        }
+
+        const result = yield* ctx.acp
+          .prompt({ prompt: promptParts })
+          .pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(providerKind, input.threadId, "session/prompt", error),
+            ),
+          );
+
+        ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
+        ctx.session = {
+          ...ctx.session,
+          activeTurnId: turnId,
+          updatedAt: yield* nowIso,
+          model: resolvedModel,
+        };
+
+        yield* offerRuntimeEvent({
+          type: "turn.completed",
+          ...(yield* makeEventStamp()),
+          provider: providerKind,
+          threadId: input.threadId,
+          turnId,
+          payload: {
+            state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+            stopReason: result.stopReason ?? null,
+          },
+        });
+
+        return {
+          threadId: input.threadId,
+          turnId,
+          resumeCursor: ctx.session.resumeCursor,
+        };
+      });
+
+    const interruptTurn: ProviderAdapterShape<ProviderAdapterError>["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        yield* Effect.ignore(
+          ctx.acp.cancel.pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(providerKind, threadId, "session/cancel", error),
+            ),
+          ),
+        );
+      });
+
+    const respondToRequest: ProviderAdapterShape<ProviderAdapterError>["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: providerKind,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: ProviderAdapterShape<ProviderAdapterError>["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingUserInputs.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: providerKind,
+            method: "elicitation/create",
+            detail: `Unknown pending user-input request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.answers, answers);
+      });
+
+    const readThread: ProviderAdapterShape<ProviderAdapterError>["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: ProviderAdapterShape<ProviderAdapterError>["rollbackThread"] = (
+      threadId,
+      numTurns,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: providerKind,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        const nextLength = Math.max(0, ctx.turns.length - numTurns);
+        ctx.turns.splice(nextLength);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const stopSession: ProviderAdapterShape<ProviderAdapterError>["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions = () =>
+      Effect.sync(() => Array.from(sessions.values(), (ctx) => ({ ...ctx.session })));
+    const hasSession = (threadId: ThreadId) =>
+      Effect.sync(() => {
+        const ctx = sessions.get(threadId);
+        return ctx !== undefined && !ctx.stopped;
+      });
+    const stopAll = () => Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    return {
+      provider: providerKind,
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+    } satisfies ProviderAdapterShape<ProviderAdapterError>;
+  });
 }

--- a/apps/server/src/provider/Layers/GenericAcpAdapter.ts
+++ b/apps/server/src/provider/Layers/GenericAcpAdapter.ts
@@ -1,0 +1,38 @@
+import {
+  type CursorSettings,
+  type ProviderDriverKind,
+  type ProviderInstanceId,
+} from "@t3tools/contracts";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { makeCursorAdapter, type CursorAdapterLiveOptions } from "./CursorAdapter.ts";
+
+type GenericAcpAdapterSettings = Pick<CursorSettings, "enabled" | "binaryPath" | "customModels">;
+
+type GenericAcpAdapterOptions = Omit<
+  CursorAdapterLiveOptions,
+  "applyCursorModelOptions" | "authMethodId" | "clientCapabilities" | "cursorExtensions"
+> & {
+  readonly provider: ProviderDriverKind;
+  readonly instanceId: typeof ProviderInstanceId.Type;
+  readonly authMethodId?: string | undefined;
+  readonly clientCapabilities?: EffectAcpSchema.InitializeRequest["clientCapabilities"];
+};
+
+export function makeGenericAcpAdapter(
+  settings: GenericAcpAdapterSettings,
+  options: GenericAcpAdapterOptions,
+) {
+  return makeCursorAdapter(
+    {
+      ...settings,
+      apiEndpoint: "",
+    },
+    {
+      ...options,
+      applyCursorModelOptions: false,
+      cursorExtensions: false,
+      normalizeModel: options.normalizeModel ?? ((model) => model?.trim() || "default"),
+    },
+  );
+}

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -120,6 +120,7 @@ const buildEntry = <R>(input: {
           instanceId,
           displayName: entry.displayName,
           accentColor: entry.accentColor,
+          iconUrl: entry.iconUrl,
           reason: `Driver '${entry.driver}' is not registered in this build.`,
         }),
       };
@@ -142,6 +143,7 @@ const buildEntry = <R>(input: {
           instanceId,
           displayName: entry.displayName,
           accentColor: entry.accentColor,
+          iconUrl: entry.iconUrl,
           reason: `Invalid config for instance '${rawInstanceId}': ${detail}`,
         }),
       };
@@ -161,6 +163,7 @@ const buildEntry = <R>(input: {
         instanceId,
         displayName: entry.displayName,
         accentColor: entry.accentColor,
+        iconUrl: entry.iconUrl,
         environment: entry.environment ?? [],
         enabled: entry.enabled ?? decodedConfigEnabled(typedConfig) ?? true,
         config: typedConfig,
@@ -180,6 +183,7 @@ const buildEntry = <R>(input: {
           instanceId,
           displayName: entry.displayName,
           accentColor: entry.accentColor,
+          iconUrl: entry.iconUrl,
           reason: `Driver '${entry.driver}' failed to create instance: ${createResult.failure.detail}`,
         }),
       };

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -65,6 +65,7 @@ export interface ProviderInstance {
   readonly continuationIdentity: ProviderContinuationIdentity;
   readonly displayName: string | undefined;
   readonly accentColor?: string | undefined;
+  readonly iconUrl?: string | undefined;
   readonly enabled: boolean;
   readonly snapshot: ServerProviderShape;
   readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
@@ -96,6 +97,7 @@ export interface ProviderDriverCreateInput<Config> {
   readonly instanceId: ProviderInstanceId;
   readonly displayName: string | undefined;
   readonly accentColor?: string | undefined;
+  readonly iconUrl?: string | undefined;
   readonly environment: ProviderInstanceEnvironment;
   readonly enabled: boolean;
   readonly config: Config;

--- a/apps/server/src/provider/Services/AcpRegistryClient.ts
+++ b/apps/server/src/provider/Services/AcpRegistryClient.ts
@@ -1,0 +1,13 @@
+import { Schema } from "effect";
+
+export class AcpRegistryClientError extends Schema.TaggedErrorClass<AcpRegistryClientError>()(
+  "AcpRegistryClientError",
+  {
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {
+  override get message(): string {
+    return this.detail;
+  }
+}

--- a/apps/server/src/provider/acp/AcpRegistryBinaryInstaller.ts
+++ b/apps/server/src/provider/acp/AcpRegistryBinaryInstaller.ts
@@ -1,0 +1,432 @@
+import { Data, Effect, FileSystem, Path, Schema } from "effect";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+
+import {
+  type AcpRegistryAgent,
+  type AcpRegistryInstallBinaryResult,
+  type AcpRegistryListResult,
+} from "@t3tools/contracts";
+
+import { ServerConfig } from "../../config.ts";
+import { collectStreamAsString } from "../providerSnapshot.ts";
+
+const ACP_BINARY_INSTALLS_DIR = "acp_agents";
+const ACP_BINARY_MANIFEST_FILE = "install.json";
+
+type BinaryDistributionTarget = {
+  readonly archive: string;
+  readonly cmd: string;
+};
+
+class AcpRegistryBinaryInstallError extends Data.TaggedError("AcpRegistryBinaryInstallError")<{
+  readonly detail: string;
+  readonly cause?: unknown;
+}> {}
+
+const AcpBinaryInstallManifest = Schema.Struct({
+  layoutVersion: Schema.Literal(2),
+  agentId: Schema.String,
+  version: Schema.String,
+  platformKey: Schema.String,
+  command: Schema.String,
+  archiveUrl: Schema.String,
+});
+
+type AcpBinaryInstallManifest = typeof AcpBinaryInstallManifest.Type;
+
+function getAcpBinaryPlatformKey(): string {
+  const os = process.platform;
+  const cpu = process.arch;
+  const osKey =
+    os === "darwin" ? "darwin" : os === "win32" ? "windows" : os === "linux" ? "linux" : os;
+  const archKey = cpu === "arm64" ? "aarch64" : cpu === "x64" ? "x86_64" : cpu;
+  return `${osKey}-${archKey}`;
+}
+
+function getBinaryTarget(agent: AcpRegistryAgent): BinaryDistributionTarget | null {
+  const binary = agent.distribution.binary;
+  if (!binary || typeof binary !== "object" || globalThis.Array.isArray(binary)) return null;
+  const target = (binary as Record<string, unknown>)[getAcpBinaryPlatformKey()];
+  if (!target || typeof target !== "object" || globalThis.Array.isArray(target)) return null;
+  const record = target as Record<string, unknown>;
+  if (typeof record.archive !== "string" || typeof record.cmd !== "string") return null;
+  return { archive: record.archive, cmd: record.cmd };
+}
+
+function resolveHomeDirectory(): string {
+  return process.env.HOME ?? process.env.USERPROFILE ?? "";
+}
+
+function normalizeArchiveCommandPath(path: Path.Path, command: string): string {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    throw new Error("Registry binary command must not be empty.");
+  }
+  if (path.isAbsolute(trimmed)) {
+    throw new Error("Registry binary command must be a relative archive path.");
+  }
+  const withoutLeadingDot = trimmed.replace(/^(?:\.[/\\])+/u, "");
+  const parts = withoutLeadingDot
+    .split(/[/\\]+/u)
+    .filter((part) => part.length > 0 && part !== ".");
+  if (parts.length === 0 || parts.some((part) => part === "..")) {
+    throw new Error("Registry binary command resolves outside the archive.");
+  }
+  return path.join(...parts);
+}
+
+function resolveInstallRootFromBinaryPath(
+  path: Path.Path,
+  binaryPath: string,
+  commandRelativePath: string,
+): string {
+  const depth = commandRelativePath.split(/[/\\]+/u).filter((part) => part.length > 0).length;
+  let installRoot = binaryPath;
+  for (let index = 0; index < depth; index += 1) {
+    installRoot = path.dirname(installRoot);
+  }
+  return installRoot;
+}
+
+function resolveAcpBinaryInstallPath(
+  path: Path.Path,
+  config: { readonly stateDir: string },
+  agent: AcpRegistryAgent,
+) {
+  const commandPath = normalizeArchiveCommandPath(path, getBinaryTarget(agent)?.cmd ?? agent.id);
+  return path.join(config.stateDir, ACP_BINARY_INSTALLS_DIR, agent.id, agent.version, commandPath);
+}
+
+function expandUserPath(path: Path.Path, inputPath: string): string {
+  const home = resolveHomeDirectory();
+  if (!home) return inputPath;
+  if (inputPath === "~") return home;
+  if (inputPath.startsWith("~/") || inputPath.startsWith("~\\")) {
+    return path.join(home, inputPath.slice(2));
+  }
+  return inputPath;
+}
+
+function normalizeAcpBinaryInstallPath(path: Path.Path, inputPath: string): string {
+  const expanded = expandUserPath(path, inputPath.trim());
+  return path.isAbsolute(expanded) ? expanded : path.resolve(expanded);
+}
+
+function displayPath(path: Path.Path, inputPath: string): string {
+  const home = resolveHomeDirectory();
+  return home && (inputPath === home || inputPath.startsWith(`${home}${path.sep}`))
+    ? `~${inputPath.slice(home.length)}`
+    : inputPath;
+}
+
+function isPathInside(path: Path.Path, parent: string, child: string): boolean {
+  const relativePath = path.relative(parent, child);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
+function toBinaryInstallPreview(
+  path: Path.Path,
+  config: { readonly stateDir: string },
+  agent: AcpRegistryAgent,
+  target: BinaryDistributionTarget,
+) {
+  const defaultInstallPath = resolveAcpBinaryInstallPath(path, config, agent);
+  return {
+    archiveUrl: target.archive,
+    defaultInstallPath: displayPath(path, defaultInstallPath),
+    platformKey: getAcpBinaryPlatformKey(),
+    command: target.cmd,
+  };
+}
+
+function resolveAcpBinaryManifestPath(
+  path: Path.Path,
+  config: { readonly stateDir: string },
+  agent: AcpRegistryAgent,
+) {
+  return path.join(
+    path.dirname(resolveAcpBinaryInstallPath(path, config, agent)),
+    ACP_BINARY_MANIFEST_FILE,
+  );
+}
+
+const readAcpBinaryManifest = (config: { readonly stateDir: string }, agent: AcpRegistryAgent) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const manifestPath = resolveAcpBinaryManifestPath(path, config, agent);
+    const raw = yield* fs.readFileString(manifestPath).pipe(Effect.option);
+    if (raw._tag === "None") return null;
+    const json = yield* Effect.try({
+      try: () => JSON.parse(raw.value) as unknown,
+      catch: () => null,
+    });
+    if (json === null) return null;
+    const parsed = yield* Schema.decodeUnknownEffect(AcpBinaryInstallManifest)(json).pipe(
+      Effect.option,
+    );
+    if (parsed._tag === "None") return null;
+    const manifest = parsed.value;
+    if (
+      manifest.agentId === agent.id &&
+      manifest.version === agent.version &&
+      manifest.platformKey === getAcpBinaryPlatformKey() &&
+      (yield* fs.exists(manifest.command))
+    ) {
+      return manifest;
+    }
+    return null;
+  });
+
+const downloadFile = (url: string, destination: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const bytes = yield* Effect.tryPromise({
+      try: async () => {
+        const response = await fetch(url);
+        if (!response.ok) {
+          throw new Error(`Download failed with status ${response.status}`);
+        }
+        return new Uint8Array(await response.arrayBuffer());
+      },
+      catch: (cause) =>
+        new AcpRegistryBinaryInstallError({
+          detail: cause instanceof Error ? cause.message : String(cause),
+          cause,
+        }),
+    });
+    yield* fs.writeFile(destination, bytes);
+  });
+
+const runArchiveCommand = (command: string, args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const child = yield* spawner.spawn(ChildProcess.make(command, [...args]));
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [collectStreamAsString(child.stdout), collectStreamAsString(child.stderr), child.exitCode],
+      { concurrency: "unbounded" },
+    );
+    if (Number(exitCode) !== 0) {
+      return yield* Effect.fail(
+        new Error(
+          `Archive command '${command}' failed with exit code ${String(exitCode)}: ${
+            stderr || stdout
+          }`,
+        ),
+      );
+    }
+  }).pipe(Effect.scoped);
+
+const extractArchive = (archivePath: string, destinationDir: string) => {
+  if (archivePath.endsWith(".tar.gz") || archivePath.endsWith(".tgz")) {
+    return runArchiveCommand("tar", ["-xzf", archivePath, "-C", destinationDir]);
+  }
+  if (archivePath.endsWith(".zip")) {
+    if (process.platform === "win32") {
+      return runArchiveCommand("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        "Expand-Archive",
+        "-LiteralPath",
+        archivePath,
+        "-DestinationPath",
+        destinationDir,
+        "-Force",
+      ]);
+    }
+    return runArchiveCommand("unzip", ["-q", archivePath, "-d", destinationDir]);
+  }
+  return Effect.fail(new Error("Unsupported binary archive format."));
+};
+
+function toInstallError(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+const installAcpBinaryAgent = (input: {
+  readonly config: { readonly stateDir: string };
+  readonly agent: AcpRegistryAgent;
+  readonly installPath?: string | undefined;
+}) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const target = getBinaryTarget(input.agent);
+    if (!target) {
+      return yield* Effect.fail(
+        new Error(`No binary is available for ${getAcpBinaryPlatformKey()}.`),
+      );
+    }
+    const installPath = normalizeAcpBinaryInstallPath(
+      path,
+      input.installPath?.trim() || resolveAcpBinaryInstallPath(path, input.config, input.agent),
+    );
+    const commandPath = normalizeArchiveCommandPath(path, target.cmd);
+    const installRoot = resolveInstallRootFromBinaryPath(path, installPath, commandPath);
+    if (installRoot === path.dirname(installRoot)) {
+      return yield* Effect.fail(
+        new Error(`Binary path is too shallow for registry command '${target.cmd}'.`),
+      );
+    }
+    const manifestPath = resolveAcpBinaryManifestPath(path, input.config, input.agent);
+    const tempDir = yield* fs.makeTempDirectory({ prefix: "t3-acp-agent-" });
+    yield* Effect.addFinalizer(() =>
+      fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore),
+    );
+
+    const archivePath = path.join(
+      tempDir,
+      path.basename(new URL(target.archive).pathname) || "agent.archive",
+    );
+    const extractDir = path.join(tempDir, "extract");
+    yield* fs.makeDirectory(extractDir, { recursive: true });
+    yield* downloadFile(target.archive, archivePath);
+    yield* extractArchive(archivePath, extractDir);
+
+    const extractedCommand = path.resolve(extractDir, commandPath);
+    if (!isPathInside(path, extractDir, extractedCommand)) {
+      return yield* Effect.fail(new Error("Registry binary command resolves outside the archive."));
+    }
+    if (!(yield* fs.exists(extractedCommand))) {
+      return yield* Effect.fail(
+        new Error(`Installed archive did not contain expected command '${target.cmd}'.`),
+      );
+    }
+    yield* fs.makeDirectory(installRoot, { recursive: true });
+    yield* fs.copy(extractDir, installRoot, { overwrite: true });
+    if (!(yield* fs.exists(installPath))) {
+      yield* fs.makeDirectory(path.dirname(installPath), { recursive: true });
+      yield* fs.copyFile(extractedCommand, installPath);
+    }
+    if (process.platform !== "win32") {
+      yield* fs.chmod(installPath, 0o755);
+    }
+    const manifest: AcpBinaryInstallManifest = {
+      layoutVersion: 2,
+      agentId: input.agent.id,
+      version: input.agent.version,
+      platformKey: getAcpBinaryPlatformKey(),
+      command: installPath,
+      archiveUrl: target.archive,
+    };
+    yield* fs.makeDirectory(path.dirname(manifestPath), { recursive: true });
+    yield* fs.writeFileString(manifestPath, JSON.stringify(manifest, null, 2));
+    return { ...target, command: installPath };
+  }).pipe(Effect.scoped);
+
+export const toAcpLaunchSpec = (agent: AcpRegistryAgent) =>
+  Effect.gen(function* () {
+    const config = yield* ServerConfig;
+    const path = yield* Path.Path;
+    if (agent.distribution.npx) {
+      return {
+        supported: true as const,
+        distributionType: "npx" as const,
+        launch: {
+          command: "npx",
+          args: ["-y", agent.distribution.npx.package, ...(agent.distribution.npx.args ?? [])],
+          env: agent.distribution.npx.env ?? {},
+        },
+      };
+    }
+    if (agent.distribution.uvx) {
+      return {
+        supported: true as const,
+        distributionType: "uvx" as const,
+        launch: {
+          command: "uvx",
+          args: [agent.distribution.uvx.package, ...(agent.distribution.uvx.args ?? [])],
+          env: agent.distribution.uvx.env ?? {},
+        },
+      };
+    }
+    const manifest = yield* readAcpBinaryManifest(config, agent);
+    const target = getBinaryTarget(agent);
+    if (manifest) {
+      return {
+        supported: true as const,
+        distributionType: "binary" as const,
+        launch: {
+          command: manifest.command,
+          args: [],
+          env: {},
+        },
+        ...(target ? { binaryInstall: toBinaryInstallPreview(path, config, agent, target) } : {}),
+      };
+    }
+    return {
+      supported: false as const,
+      distributionType: "binaryUnsupported" as const,
+      launch: null,
+      ...(target ? { binaryInstall: toBinaryInstallPreview(path, config, agent, target) } : {}),
+    };
+  });
+
+export const listAcpRegistryAgents = (registry: {
+  readonly version: string;
+  readonly agents: ReadonlyArray<AcpRegistryAgent>;
+}) =>
+  Effect.gen(function* () {
+    const agents = yield* Effect.forEach(registry.agents, (agent) =>
+      toAcpLaunchSpec(agent).pipe(
+        Effect.map((resolved) => ({
+          agent,
+          supported: resolved.supported,
+          distributionType: resolved.distributionType,
+          launch: resolved.launch,
+          ...("binaryInstall" in resolved && resolved.binaryInstall
+            ? { binaryInstall: resolved.binaryInstall }
+            : {}),
+        })),
+      ),
+    );
+    return {
+      registryVersion: registry.version,
+      agents: agents.toSorted((left, right) => left.agent.name.localeCompare(right.agent.name)),
+    } satisfies AcpRegistryListResult;
+  });
+
+export const installAcpRegistryBinaryAgent = (input: {
+  readonly registry: {
+    readonly agents: ReadonlyArray<AcpRegistryAgent>;
+  };
+  readonly agentId: string;
+  readonly installPath?: string | undefined;
+}) =>
+  Effect.gen(function* () {
+    const config = yield* ServerConfig;
+    const path = yield* Path.Path;
+    const agent = input.registry.agents.find((entry) => entry.id === input.agentId);
+    if (!agent) {
+      return {
+        ok: false,
+        error: `No ACP registry agent found for '${input.agentId}'.`,
+      } satisfies AcpRegistryInstallBinaryResult;
+    }
+    const installed = yield* installAcpBinaryAgent({
+      config,
+      agent,
+      installPath: input.installPath,
+    });
+    return {
+      ok: true,
+      agent: {
+        agent,
+        supported: true,
+        distributionType: "binary",
+        binaryInstall: toBinaryInstallPreview(path, config, agent, installed),
+        launch: {
+          command: installed.command,
+          args: [],
+          env: {},
+        },
+      },
+    } satisfies AcpRegistryInstallBinaryResult;
+  }).pipe(
+    Effect.catch((cause: unknown) =>
+      Effect.succeed({
+        ok: false,
+        error: toInstallError(cause),
+      } satisfies AcpRegistryInstallBinaryResult),
+    ),
+  );

--- a/apps/server/src/provider/acp/AcpRegistryBinaryInstaller.ts
+++ b/apps/server/src/provider/acp/AcpRegistryBinaryInstaller.ts
@@ -57,104 +57,121 @@ function resolveHomeDirectory(): string {
   return process.env.HOME ?? process.env.USERPROFILE ?? "";
 }
 
-function normalizeArchiveCommandPath(path: Path.Path, command: string): string {
-  const trimmed = command.trim();
-  if (!trimmed) {
-    throw new Error("Registry binary command must not be empty.");
-  }
-  if (path.isAbsolute(trimmed)) {
-    throw new Error("Registry binary command must be a relative archive path.");
-  }
-  const withoutLeadingDot = trimmed.replace(/^(?:\.[/\\])+/u, "");
-  const parts = withoutLeadingDot
-    .split(/[/\\]+/u)
-    .filter((part) => part.length > 0 && part !== ".");
-  if (parts.length === 0 || parts.some((part) => part === "..")) {
-    throw new Error("Registry binary command resolves outside the archive.");
-  }
-  return path.join(...parts);
-}
+const normalizeArchiveCommandPath = (command: string) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const trimmed = command.trim();
+    if (!trimmed) {
+      return yield* Effect.fail(new Error("Registry binary command must not be empty."));
+    }
+    if (path.isAbsolute(trimmed)) {
+      return yield* Effect.fail(
+        new Error("Registry binary command must be a relative archive path."),
+      );
+    }
+    const withoutLeadingDot = trimmed.replace(/^(?:\.[/\\])+/u, "");
+    const parts = withoutLeadingDot
+      .split(/[/\\]+/u)
+      .filter((part) => part.length > 0 && part !== ".");
+    if (parts.length === 0 || parts.some((part) => part === "..")) {
+      return yield* Effect.fail(new Error("Registry binary command resolves outside the archive."));
+    }
+    return path.join(...parts);
+  });
 
-function resolveInstallRootFromBinaryPath(
-  path: Path.Path,
-  binaryPath: string,
-  commandRelativePath: string,
-): string {
-  const depth = commandRelativePath.split(/[/\\]+/u).filter((part) => part.length > 0).length;
-  let installRoot = binaryPath;
-  for (let index = 0; index < depth; index += 1) {
-    installRoot = path.dirname(installRoot);
-  }
-  return installRoot;
-}
+const resolveInstallRootFromBinaryPath = (binaryPath: string, commandRelativePath: string) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const depth = commandRelativePath.split(/[/\\]+/u).filter((part) => part.length > 0).length;
+    let installRoot = binaryPath;
+    for (let index = 0; index < depth; index += 1) {
+      installRoot = path.dirname(installRoot);
+    }
+    return installRoot;
+  });
 
-function resolveAcpBinaryInstallPath(
-  path: Path.Path,
+const resolveAcpBinaryInstallPath = (
   config: { readonly stateDir: string },
   agent: AcpRegistryAgent,
-) {
-  const commandPath = normalizeArchiveCommandPath(path, getBinaryTarget(agent)?.cmd ?? agent.id);
-  return path.join(config.stateDir, ACP_BINARY_INSTALLS_DIR, agent.id, agent.version, commandPath);
-}
+) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const commandPath = yield* normalizeArchiveCommandPath(getBinaryTarget(agent)?.cmd ?? agent.id);
+    return path.join(
+      config.stateDir,
+      ACP_BINARY_INSTALLS_DIR,
+      agent.id,
+      agent.version,
+      commandPath,
+    );
+  });
 
-function expandUserPath(path: Path.Path, inputPath: string): string {
-  const home = resolveHomeDirectory();
-  if (!home) return inputPath;
-  if (inputPath === "~") return home;
-  if (inputPath.startsWith("~/") || inputPath.startsWith("~\\")) {
-    return path.join(home, inputPath.slice(2));
-  }
-  return inputPath;
-}
+const expandUserPath = (inputPath: string) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const home = resolveHomeDirectory();
+    if (!home) return inputPath;
+    if (inputPath === "~") return home;
+    if (inputPath.startsWith("~/") || inputPath.startsWith("~\\")) {
+      return path.join(home, inputPath.slice(2));
+    }
+    return inputPath;
+  });
 
-function normalizeAcpBinaryInstallPath(path: Path.Path, inputPath: string): string {
-  const expanded = expandUserPath(path, inputPath.trim());
-  return path.isAbsolute(expanded) ? expanded : path.resolve(expanded);
-}
+const normalizeAcpBinaryInstallPath = (inputPath: string) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const expanded = yield* expandUserPath(inputPath.trim());
+    return path.isAbsolute(expanded) ? expanded : path.resolve(expanded);
+  });
 
-function displayPath(path: Path.Path, inputPath: string): string {
-  const home = resolveHomeDirectory();
-  return home && (inputPath === home || inputPath.startsWith(`${home}${path.sep}`))
-    ? `~${inputPath.slice(home.length)}`
-    : inputPath;
-}
+const displayPath = (inputPath: string) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const home = resolveHomeDirectory();
+    return home && (inputPath === home || inputPath.startsWith(`${home}${path.sep}`))
+      ? `~${inputPath.slice(home.length)}`
+      : inputPath;
+  });
 
-function isPathInside(path: Path.Path, parent: string, child: string): boolean {
-  const relativePath = path.relative(parent, child);
-  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
-}
+const isPathInside = (parent: string, child: string) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const relativePath = path.relative(parent, child);
+    return (
+      relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath))
+    );
+  });
 
-function toBinaryInstallPreview(
-  path: Path.Path,
+const toBinaryInstallPreview = (
   config: { readonly stateDir: string },
   agent: AcpRegistryAgent,
   target: BinaryDistributionTarget,
-) {
-  const defaultInstallPath = resolveAcpBinaryInstallPath(path, config, agent);
-  return {
-    archiveUrl: target.archive,
-    defaultInstallPath: displayPath(path, defaultInstallPath),
-    platformKey: getAcpBinaryPlatformKey(),
-    command: target.cmd,
-  };
-}
+) =>
+  Effect.gen(function* () {
+    const defaultInstallPath = yield* resolveAcpBinaryInstallPath(config, agent);
+    return {
+      archiveUrl: target.archive,
+      defaultInstallPath: yield* displayPath(defaultInstallPath),
+      platformKey: getAcpBinaryPlatformKey(),
+      command: target.cmd,
+    };
+  });
 
-function resolveAcpBinaryManifestPath(
-  path: Path.Path,
+const resolveAcpBinaryManifestPath = (
   config: { readonly stateDir: string },
   agent: AcpRegistryAgent,
-) {
-  return path.join(
-    path.dirname(resolveAcpBinaryInstallPath(path, config, agent)),
-    ACP_BINARY_MANIFEST_FILE,
-  );
-}
+) =>
+  Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const installPath = yield* resolveAcpBinaryInstallPath(config, agent);
+    return path.join(path.dirname(installPath), ACP_BINARY_MANIFEST_FILE);
+  });
 
 const readAcpBinaryManifest = (config: { readonly stateDir: string }, agent: AcpRegistryAgent) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const path = yield* Path.Path;
-    const manifestPath = resolveAcpBinaryManifestPath(path, config, agent);
+    const manifestPath = yield* resolveAcpBinaryManifestPath(config, agent);
     const raw = yield* fs.readFileString(manifestPath).pipe(Effect.option);
     if (raw._tag === "None") return null;
     const json = yield* Effect.try({
@@ -257,18 +274,18 @@ const installAcpBinaryAgent = (input: {
         new Error(`No binary is available for ${getAcpBinaryPlatformKey()}.`),
       );
     }
-    const installPath = normalizeAcpBinaryInstallPath(
-      path,
-      input.installPath?.trim() || resolveAcpBinaryInstallPath(path, input.config, input.agent),
+    const defaultInstallPath = yield* resolveAcpBinaryInstallPath(input.config, input.agent);
+    const installPath = yield* normalizeAcpBinaryInstallPath(
+      input.installPath?.trim() || defaultInstallPath,
     );
-    const commandPath = normalizeArchiveCommandPath(path, target.cmd);
-    const installRoot = resolveInstallRootFromBinaryPath(path, installPath, commandPath);
+    const commandPath = yield* normalizeArchiveCommandPath(target.cmd);
+    const installRoot = yield* resolveInstallRootFromBinaryPath(installPath, commandPath);
     if (installRoot === path.dirname(installRoot)) {
       return yield* Effect.fail(
         new Error(`Binary path is too shallow for registry command '${target.cmd}'.`),
       );
     }
-    const manifestPath = resolveAcpBinaryManifestPath(path, input.config, input.agent);
+    const manifestPath = yield* resolveAcpBinaryManifestPath(input.config, input.agent);
     const tempDir = yield* fs.makeTempDirectory({ prefix: "t3-acp-agent-" });
     yield* Effect.addFinalizer(() =>
       fs.remove(tempDir, { recursive: true, force: true }).pipe(Effect.ignore),
@@ -284,7 +301,7 @@ const installAcpBinaryAgent = (input: {
     yield* extractArchive(archivePath, extractDir);
 
     const extractedCommand = path.resolve(extractDir, commandPath);
-    if (!isPathInside(path, extractDir, extractedCommand)) {
+    if (!(yield* isPathInside(extractDir, extractedCommand))) {
       return yield* Effect.fail(new Error("Registry binary command resolves outside the archive."));
     }
     if (!(yield* fs.exists(extractedCommand))) {
@@ -317,7 +334,6 @@ const installAcpBinaryAgent = (input: {
 export const toAcpLaunchSpec = (agent: AcpRegistryAgent) =>
   Effect.gen(function* () {
     const config = yield* ServerConfig;
-    const path = yield* Path.Path;
     if (agent.distribution.npx) {
       return {
         supported: true as const,
@@ -351,14 +367,14 @@ export const toAcpLaunchSpec = (agent: AcpRegistryAgent) =>
           args: [],
           env: {},
         },
-        ...(target ? { binaryInstall: toBinaryInstallPreview(path, config, agent, target) } : {}),
+        ...(target ? { binaryInstall: yield* toBinaryInstallPreview(config, agent, target) } : {}),
       };
     }
     return {
       supported: false as const,
       distributionType: "binaryUnsupported" as const,
       launch: null,
-      ...(target ? { binaryInstall: toBinaryInstallPreview(path, config, agent, target) } : {}),
+      ...(target ? { binaryInstall: yield* toBinaryInstallPreview(config, agent, target) } : {}),
     };
   });
 
@@ -395,7 +411,6 @@ export const installAcpRegistryBinaryAgent = (input: {
 }) =>
   Effect.gen(function* () {
     const config = yield* ServerConfig;
-    const path = yield* Path.Path;
     const agent = input.registry.agents.find((entry) => entry.id === input.agentId);
     if (!agent) {
       return {
@@ -414,7 +429,7 @@ export const installAcpRegistryBinaryAgent = (input: {
         agent,
         supported: true,
         distributionType: "binary",
-        binaryInstall: toBinaryInstallPreview(path, config, agent, installed),
+        binaryInstall: yield* toBinaryInstallPreview(config, agent, installed),
         launch: {
           command: installed.command,
           args: [],

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -382,7 +382,7 @@ const makeAcpSessionRuntime = (
         | EffectAcpSchema.LoadSessionResponse
         | EffectAcpSchema.NewSessionResponse
         | EffectAcpSchema.ResumeSessionResponse;
-      if (options.resumeSessionId) {
+      if (options.resumeSessionId && initializeResult.agentCapabilities?.loadSession === true) {
         const loadPayload = {
           sessionId: options.resumeSessionId,
           cwd: options.cwd,

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -33,7 +33,7 @@ export interface AcpSessionRuntimeOptions {
     readonly name: string;
     readonly version: string;
   };
-  readonly authMethodId: string;
+  readonly authMethodId?: string;
   readonly requestLogger?: (event: AcpSessionRequestLogEvent) => Effect.Effect<void, never>;
   readonly protocolLogging?: {
     readonly logIncoming?: boolean;
@@ -365,15 +365,17 @@ const makeAcpSessionRuntime = (
         acp.agent.initialize(initializePayload),
       );
 
-      const authenticatePayload = {
-        methodId: options.authMethodId,
-      } satisfies EffectAcpSchema.AuthenticateRequest;
+      if (options.authMethodId) {
+        const authenticatePayload = {
+          methodId: options.authMethodId,
+        } satisfies EffectAcpSchema.AuthenticateRequest;
 
-      yield* runLoggedRequest(
-        "authenticate",
-        authenticatePayload,
-        acp.agent.authenticate(authenticatePayload),
-      );
+        yield* runLoggedRequest(
+          "authenticate",
+          authenticatePayload,
+          acp.agent.authenticate(authenticatePayload),
+        );
+      }
 
       let sessionId: string;
       let sessionSetupResult:

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -2,6 +2,7 @@ import { type CursorSettings, type ProviderOptionSelection } from "@t3tools/cont
 import { Effect, Layer, Scope } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import type * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
 
 import {
   CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
@@ -24,6 +25,9 @@ export interface CursorAcpRuntimeInput extends Omit<
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
   readonly cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined;
   readonly environment?: NodeJS.ProcessEnv;
+  readonly spawn?: AcpSpawnInput;
+  readonly authMethodId?: string;
+  readonly clientCapabilities?: EffectAcpSchema.InitializeRequest["clientCapabilities"];
 }
 
 export interface CursorAcpModelSelectionErrorContext {
@@ -55,9 +59,12 @@ export const makeCursorAcpRuntime = (
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
         ...input,
-        spawn: buildCursorAcpSpawnInput(input.cursorSettings, input.cwd, input.environment),
-        authMethodId: "cursor_login",
-        clientCapabilities: CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
+        spawn:
+          input.spawn ??
+          buildCursorAcpSpawnInput(input.cursorSettings, input.cwd, input.environment),
+        authMethodId: input.authMethodId ?? "cursor_login",
+        clientCapabilities:
+          input.clientCapabilities ?? CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
       }).pipe(
         Layer.provide(
           Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -2,7 +2,6 @@ import { type CursorSettings, type ProviderOptionSelection } from "@t3tools/cont
 import { Effect, Layer, Scope } from "effect";
 import { ChildProcessSpawner } from "effect/unstable/process";
 import type * as EffectAcpErrors from "effect-acp/errors";
-import type * as EffectAcpSchema from "effect-acp/schema";
 
 import {
   CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
@@ -25,9 +24,6 @@ export interface CursorAcpRuntimeInput extends Omit<
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
   readonly cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined;
   readonly environment?: NodeJS.ProcessEnv;
-  readonly spawn?: AcpSpawnInput;
-  readonly authMethodId?: string;
-  readonly clientCapabilities?: EffectAcpSchema.InitializeRequest["clientCapabilities"];
 }
 
 export interface CursorAcpModelSelectionErrorContext {
@@ -59,12 +55,9 @@ export const makeCursorAcpRuntime = (
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
         ...input,
-        spawn:
-          input.spawn ??
-          buildCursorAcpSpawnInput(input.cursorSettings, input.cwd, input.environment),
-        authMethodId: input.authMethodId ?? "cursor_login",
-        clientCapabilities:
-          input.clientCapabilities ?? CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
+        spawn: buildCursorAcpSpawnInput(input.cursorSettings, input.cwd, input.environment),
+        authMethodId: "cursor_login",
+        clientCapabilities: CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
       }).pipe(
         Layer.provide(
           Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),

--- a/apps/server/src/provider/acp/GenericAcpSupport.ts
+++ b/apps/server/src/provider/acp/GenericAcpSupport.ts
@@ -1,0 +1,29 @@
+import { Effect, Layer, Scope } from "effect";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import type * as EffectAcpErrors from "effect-acp/errors";
+
+import {
+  AcpSessionRuntime,
+  type AcpSessionRuntimeOptions,
+  type AcpSessionRuntimeShape,
+  type AcpSpawnInput,
+} from "./AcpSessionRuntime.ts";
+
+export interface GenericAcpRuntimeInput extends Omit<AcpSessionRuntimeOptions, "spawn"> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly spawn: AcpSpawnInput;
+}
+
+export const makeGenericAcpRuntime = (
+  input: GenericAcpRuntimeInput,
+): Effect.Effect<AcpSessionRuntimeShape, EffectAcpErrors.AcpError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer(input).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return yield* Effect.service(AcpSessionRuntime).pipe(Effect.provide(acpContext));
+  });

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -24,6 +24,7 @@ import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
+import { AcpRegistryDriver, type AcpRegistryDriverEnv } from "./Drivers/AcpRegistryDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
 /**
@@ -35,7 +36,8 @@ export type BuiltInDriversEnv =
   | ClaudeDriverEnv
   | CodexDriverEnv
   | CursorDriverEnv
-  | OpenCodeDriverEnv;
+  | OpenCodeDriverEnv
+  | AcpRegistryDriverEnv;
 
 /**
  * Ordered list of built-in drivers. Order matters only for tie-breaking in
@@ -47,4 +49,5 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   ClaudeDriver,
   CursorDriver,
   OpenCodeDriver,
+  AcpRegistryDriver,
 ];

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -33,6 +33,7 @@ export interface ProviderProbeResult {
 
 export interface ServerProviderPresentation {
   readonly displayName: string;
+  readonly iconUrl?: string | undefined;
   readonly badgeLabel?: string;
   readonly showInteractionModeToggle?: boolean;
 }
@@ -192,6 +193,7 @@ export function buildServerProvider(input: {
 }): ServerProviderDraft {
   return {
     displayName: input.presentation.displayName,
+    ...(input.presentation.iconUrl ? { iconUrl: input.presentation.iconUrl } : {}),
     ...(input.presentation.badgeLabel ? { badgeLabel: input.presentation.badgeLabel } : {}),
     ...(typeof input.presentation.showInteractionModeToggle === "boolean"
       ? { showInteractionModeToggle: input.presentation.showInteractionModeToggle }

--- a/apps/server/src/provider/unavailableProviderSnapshot.ts
+++ b/apps/server/src/provider/unavailableProviderSnapshot.ts
@@ -23,6 +23,7 @@ export interface UnavailableProviderSnapshotInput {
   readonly instanceId: ProviderInstanceId;
   readonly displayName?: string | undefined;
   readonly accentColor?: string | undefined;
+  readonly iconUrl?: string | undefined;
   readonly reason: string;
   /**
    * Optional override for `checkedAt`. Defaulted to `new Date()` so callers
@@ -62,6 +63,7 @@ export function buildUnavailableProviderSnapshot(
     ...base,
     instanceId: input.instanceId,
     ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    ...(input.iconUrl ? { iconUrl: input.iconUrl } : {}),
     driver:
       typeof input.driverKind === "string"
         ? ProviderDriverKind.make(input.driverKind)

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1,6 +1,28 @@
+import { execFile } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import {
+  access,
+  chmod,
+  copyFile,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { arch, homedir, platform, tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { promisify } from "node:util";
+
 import { Cause, Duration, Effect, Layer, Option, Queue, Ref, Schema, Stream } from "effect";
 import {
   type AuthAccessStreamEvent,
+  AcpRegistryIndex,
+  type AcpRegistryAgent,
+  type AcpRegistryInstallBinaryResult,
+  type AcpRegistryListResult,
   AuthSessionId,
   CommandId,
   EventId,
@@ -40,6 +62,7 @@ import {
   observeRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
 import { ProviderRegistry } from "./provider/Services/ProviderRegistry.ts";
+import { AcpRegistryClientError } from "./provider/Services/AcpRegistryClient.ts";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents.ts";
 import { ServerRuntimeStartup } from "./serverRuntimeStartup.ts";
 import { redactServerSettingsForClient, ServerSettingsService } from "./serverSettings.ts";
@@ -75,6 +98,8 @@ import {
 } from "./auth/Services/SessionCredentialService.ts";
 import { respondToAuthError } from "./auth/http.ts";
 
+const execFileAsync = promisify(execFile);
+
 function isThreadDetailEvent(event: OrchestrationEvent): event is Extract<
   OrchestrationEvent,
   {
@@ -98,6 +123,313 @@ function isThreadDetailEvent(event: OrchestrationEvent): event is Extract<
 }
 
 const PROVIDER_STATUS_DEBOUNCE_MS = 200;
+const ACP_BINARY_INSTALLS_DIR = "acp_agents";
+const ACP_BINARY_MANIFEST_FILE = "install.json";
+
+type BinaryDistributionTarget = {
+  readonly archive: string;
+  readonly cmd: string;
+};
+
+type AcpBinaryInstallManifest = {
+  readonly layoutVersion: 2;
+  readonly agentId: string;
+  readonly version: string;
+  readonly platformKey: string;
+  readonly command: string;
+  readonly archiveUrl: string;
+};
+
+function getAcpBinaryPlatformKey(): string {
+  const os = platform();
+  const cpu = arch();
+  const osKey =
+    os === "darwin" ? "darwin" : os === "win32" ? "windows" : os === "linux" ? "linux" : os;
+  const archKey = cpu === "arm64" ? "aarch64" : cpu === "x64" ? "x86_64" : cpu;
+  return `${osKey}-${archKey}`;
+}
+
+function getBinaryTarget(agent: AcpRegistryAgent): BinaryDistributionTarget | null {
+  const binary = agent.distribution.binary;
+  if (!binary || typeof binary !== "object" || globalThis.Array.isArray(binary)) return null;
+  const target = (binary as Record<string, unknown>)[getAcpBinaryPlatformKey()];
+  if (!target || typeof target !== "object" || globalThis.Array.isArray(target)) return null;
+  const record = target as Record<string, unknown>;
+  if (typeof record.archive !== "string" || typeof record.cmd !== "string") return null;
+  return { archive: record.archive, cmd: record.cmd };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeArchiveCommandPath(command: string): string {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    throw new Error("Registry binary command must not be empty.");
+  }
+  if (isAbsolute(trimmed)) {
+    throw new Error("Registry binary command must be a relative archive path.");
+  }
+  const withoutLeadingDot = trimmed.replace(/^(?:\.[/\\])+/u, "");
+  const parts = withoutLeadingDot
+    .split(/[/\\]+/u)
+    .filter((part) => part.length > 0 && part !== ".");
+  if (parts.length === 0 || parts.some((part) => part === "..")) {
+    throw new Error("Registry binary command resolves outside the archive.");
+  }
+  return join(...parts);
+}
+
+function resolveInstallRootFromBinaryPath(binaryPath: string, commandRelativePath: string): string {
+  const depth = commandRelativePath.split(/[/\\]+/u).filter((part) => part.length > 0).length;
+  let installRoot = binaryPath;
+  for (let index = 0; index < depth; index += 1) {
+    installRoot = dirname(installRoot);
+  }
+  return installRoot;
+}
+
+function resolveAcpBinaryInstallPath(
+  config: { readonly stateDir: string },
+  agent: AcpRegistryAgent,
+) {
+  const commandPath = normalizeArchiveCommandPath(getBinaryTarget(agent)?.cmd ?? agent.id);
+  return join(config.stateDir, ACP_BINARY_INSTALLS_DIR, agent.id, agent.version, commandPath);
+}
+
+function expandUserPath(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/") || path.startsWith("~\\")) return join(homedir(), path.slice(2));
+  return path;
+}
+
+function normalizeAcpBinaryInstallPath(path: string): string {
+  const expanded = expandUserPath(path.trim());
+  return isAbsolute(expanded) ? expanded : resolve(expanded);
+}
+
+function displayPath(path: string): string {
+  const home = homedir();
+  return path === home || path.startsWith(`${home}/`) || path.startsWith(`${home}\\`)
+    ? `~${path.slice(home.length)}`
+    : path;
+}
+
+function isPathInside(parent: string, child: string): boolean {
+  const relativePath = relative(parent, child);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+function toBinaryInstallPreview(
+  config: { readonly stateDir: string },
+  agent: AcpRegistryAgent,
+  target: BinaryDistributionTarget,
+) {
+  const defaultInstallPath = resolveAcpBinaryInstallPath(config, agent);
+  return {
+    archiveUrl: target.archive,
+    defaultInstallPath: displayPath(defaultInstallPath),
+    platformKey: getAcpBinaryPlatformKey(),
+    command: target.cmd,
+  };
+}
+
+function resolveAcpBinaryManifestPath(
+  config: { readonly stateDir: string },
+  agent: AcpRegistryAgent,
+) {
+  return join(dirname(resolveAcpBinaryInstallPath(config, agent)), ACP_BINARY_MANIFEST_FILE);
+}
+
+async function readAcpBinaryManifest(
+  config: { readonly stateDir: string },
+  agent: AcpRegistryAgent,
+): Promise<AcpBinaryInstallManifest | null> {
+  const manifestPath = resolveAcpBinaryManifestPath(config, agent);
+  try {
+    const raw = await readFile(manifestPath, "utf8");
+    const parsed = JSON.parse(raw) as Partial<AcpBinaryInstallManifest>;
+    if (
+      parsed.layoutVersion === 2 &&
+      parsed.agentId === agent.id &&
+      parsed.version === agent.version &&
+      parsed.platformKey === getAcpBinaryPlatformKey() &&
+      typeof parsed.command === "string" &&
+      (await fileExists(parsed.command))
+    ) {
+      return parsed as AcpBinaryInstallManifest;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function downloadFile(url: string, destination: string): Promise<void> {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed with status ${response.status}`);
+  }
+  await pipeline(response.body, createWriteStream(destination));
+}
+
+async function extractArchive(archivePath: string, destinationDir: string): Promise<void> {
+  if (archivePath.endsWith(".tar.gz") || archivePath.endsWith(".tgz")) {
+    await execFileAsync("tar", ["-xzf", archivePath, "-C", destinationDir]);
+    return;
+  }
+  if (archivePath.endsWith(".zip")) {
+    if (platform() === "win32") {
+      await execFileAsync("powershell.exe", [
+        "-NoProfile",
+        "-Command",
+        "Expand-Archive",
+        "-LiteralPath",
+        archivePath,
+        "-DestinationPath",
+        destinationDir,
+        "-Force",
+      ]);
+      return;
+    }
+    await execFileAsync("unzip", ["-q", archivePath, "-d", destinationDir]);
+    return;
+  }
+  throw new Error("Unsupported binary archive format.");
+}
+
+async function installAcpBinaryAgent(input: {
+  readonly config: { readonly stateDir: string };
+  readonly agent: AcpRegistryAgent;
+  readonly installPath?: string | undefined;
+}): Promise<BinaryDistributionTarget & { readonly command: string }> {
+  const target = getBinaryTarget(input.agent);
+  if (!target) {
+    throw new Error(`No binary is available for ${getAcpBinaryPlatformKey()}.`);
+  }
+  const installPath = normalizeAcpBinaryInstallPath(
+    input.installPath?.trim() || resolveAcpBinaryInstallPath(input.config, input.agent),
+  );
+  const commandPath = normalizeArchiveCommandPath(target.cmd);
+  const installRoot = resolveInstallRootFromBinaryPath(installPath, commandPath);
+  if (installRoot === dirname(installRoot)) {
+    throw new Error(`Binary path is too shallow for registry command '${target.cmd}'.`);
+  }
+  const manifestPath = resolveAcpBinaryManifestPath(input.config, input.agent);
+  const tempDir = await mkdtemp(join(tmpdir(), "t3-acp-agent-"));
+  try {
+    const archivePath = join(
+      tempDir,
+      basename(new URL(target.archive).pathname) || "agent.archive",
+    );
+    const extractDir = join(tempDir, "extract");
+    await mkdir(extractDir, { recursive: true });
+    await downloadFile(target.archive, archivePath);
+    await extractArchive(archivePath, extractDir);
+
+    const extractedCommand = resolve(extractDir, commandPath);
+    if (!isPathInside(extractDir, extractedCommand)) {
+      throw new Error(`Registry binary command resolves outside the archive.`);
+    }
+    if (!(await fileExists(extractedCommand))) {
+      throw new Error(`Installed archive did not contain expected command '${target.cmd}'.`);
+    }
+    await mkdir(installRoot, { recursive: true });
+    await cp(extractDir, installRoot, {
+      recursive: true,
+      force: true,
+      errorOnExist: false,
+    });
+    if (!(await fileExists(installPath))) {
+      await mkdir(dirname(installPath), { recursive: true });
+      await copyFile(extractedCommand, installPath);
+    }
+    if (platform() !== "win32") {
+      await chmod(installPath, 0o755);
+    }
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+  const manifest: AcpBinaryInstallManifest = {
+    layoutVersion: 2,
+    agentId: input.agent.id,
+    version: input.agent.version,
+    platformKey: getAcpBinaryPlatformKey(),
+    command: installPath,
+    archiveUrl: target.archive,
+  };
+  await mkdir(dirname(manifestPath), { recursive: true });
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+  return { ...target, command: installPath };
+}
+
+async function toAcpLaunchSpec(
+  agent: AcpRegistryAgent,
+  config: { readonly stateDir: string },
+): Promise<{
+  readonly supported: boolean;
+  readonly distributionType: "npx" | "uvx" | "binary" | "binaryUnsupported";
+  readonly launch: {
+    readonly command: string;
+    readonly args: readonly string[];
+    readonly env: Record<string, string>;
+  } | null;
+  readonly binaryInstall?: {
+    readonly archiveUrl: string;
+    readonly defaultInstallPath: string;
+    readonly platformKey: string;
+    readonly command: string;
+  };
+}> {
+  if (agent.distribution.npx) {
+    return {
+      supported: true as const,
+      distributionType: "npx" as const,
+      launch: {
+        command: "npx",
+        args: ["-y", agent.distribution.npx.package, ...(agent.distribution.npx.args ?? [])],
+        env: agent.distribution.npx.env ?? {},
+      },
+    };
+  }
+  if (agent.distribution.uvx) {
+    return {
+      supported: true as const,
+      distributionType: "uvx" as const,
+      launch: {
+        command: "uvx",
+        args: [agent.distribution.uvx.package, ...(agent.distribution.uvx.args ?? [])],
+        env: agent.distribution.uvx.env ?? {},
+      },
+    };
+  }
+  const manifest = await readAcpBinaryManifest(config, agent);
+  const target = getBinaryTarget(agent);
+  if (manifest) {
+    return {
+      supported: true as const,
+      distributionType: "binary" as const,
+      launch: {
+        command: manifest.command,
+        args: [],
+        env: {},
+      },
+      ...(target ? { binaryInstall: toBinaryInstallPreview(config, agent, target) } : {}),
+    };
+  }
+  return {
+    supported: false as const,
+    distributionType: "binaryUnsupported" as const,
+    launch: null,
+    ...(target ? { binaryInstall: toBinaryInstallPreview(config, agent, target) } : {}),
+  };
+}
 
 function toAuthAccessStreamEvent(
   change: BootstrapCredentialChange | SessionCredentialChange,
@@ -174,6 +506,110 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
           pairingLinks: serverAuth.listPairingLinks().pipe(Effect.orDie),
           clientSessions: serverAuth.listClientSessions(currentSessionId).pipe(Effect.orDie),
         });
+
+      const loadAcpRegistryIndex = serverSettings.getSettings.pipe(
+        Effect.flatMap((settings) =>
+          Effect.tryPromise({
+            try: async () => {
+              const response = await fetch(settings.providers.acpRegistry.registryUrl);
+              if (!response.ok) {
+                throw new Error(`Registry request failed with status ${response.status}`);
+              }
+              return response.json();
+            },
+            catch: (cause) =>
+              new AcpRegistryClientError({
+                detail: cause instanceof Error ? cause.message : String(cause),
+                cause,
+              }),
+          }),
+        ),
+        Effect.flatMap((raw) => Schema.decodeUnknownEffect(AcpRegistryIndex)(raw)),
+      );
+
+      const listAcpRegistry = Effect.all({
+        registry: loadAcpRegistryIndex,
+        config: Effect.succeed(config),
+      }).pipe(
+        Effect.flatMap(({ registry, config }) =>
+          Effect.tryPromise({
+            try: async (): Promise<AcpRegistryListResult> => ({
+              registryVersion: registry.version,
+              agents: (
+                await Promise.all(
+                  registry.agents.map(async (agent) => {
+                    const resolved = await toAcpLaunchSpec(agent, config);
+                    return {
+                      agent,
+                      supported: resolved.supported,
+                      distributionType: resolved.distributionType,
+                      launch: resolved.launch,
+                      ...(resolved.binaryInstall ? { binaryInstall: resolved.binaryInstall } : {}),
+                    };
+                  }),
+                )
+              ).toSorted((left, right) => left.agent.name.localeCompare(right.agent.name)),
+            }),
+            catch: (cause) =>
+              new AcpRegistryClientError({
+                detail: cause instanceof Error ? cause.message : String(cause),
+                cause,
+              }),
+          }),
+        ),
+      );
+
+      const installAcpRegistryBinary = (input: {
+        readonly agentId: string;
+        readonly installPath?: string | undefined;
+      }) =>
+        Effect.all({
+          registry: loadAcpRegistryIndex,
+          config: Effect.succeed(config),
+        }).pipe(
+          Effect.flatMap(({ registry, config }) =>
+            Effect.tryPromise({
+              try: async (): Promise<AcpRegistryInstallBinaryResult> => {
+                const agent = registry.agents.find((entry) => entry.id === input.agentId);
+                if (!agent) {
+                  return {
+                    ok: false,
+                    error: `No ACP registry agent found for '${input.agentId}'.`,
+                  };
+                }
+                const installed = await installAcpBinaryAgent({
+                  config,
+                  agent,
+                  installPath: input.installPath,
+                });
+                return {
+                  ok: true,
+                  agent: {
+                    agent,
+                    supported: true,
+                    distributionType: "binary",
+                    binaryInstall: toBinaryInstallPreview(config, agent, installed),
+                    launch: {
+                      command: installed.command,
+                      args: [],
+                      env: {},
+                    },
+                  },
+                };
+              },
+              catch: (cause): AcpRegistryInstallBinaryResult => ({
+                ok: false,
+                error: cause instanceof Error ? cause.message : String(cause),
+              }),
+            }),
+          ),
+          Effect.catch((cause: unknown) =>
+            Effect.succeed({
+              ok: false,
+              error: cause instanceof Error ? cause.message : String(cause),
+            } satisfies AcpRegistryInstallBinaryResult),
+          ),
+        );
 
       const appendSetupScriptActivity = (input: {
         readonly threadId: ThreadId;
@@ -803,6 +1239,32 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
           observeRpcEffect(
             WS_METHODS.serverDiscoverSourceControl,
             sourceControlDiscovery.discover,
+            {
+              "rpc.aggregate": "server",
+            },
+          ),
+        [WS_METHODS.serverListAcpRegistry]: (_input) =>
+          observeRpcEffect(
+            WS_METHODS.serverListAcpRegistry,
+            listAcpRegistry.pipe(
+              Effect.tapError((error) =>
+                Effect.logWarning("failed to list ACP registry agents", {
+                  error: error.message,
+                }),
+              ),
+              Effect.orElseSucceed(() => ({
+                registryVersion: "unavailable",
+                agents: [],
+              })),
+            ),
+            {
+              "rpc.aggregate": "server",
+            },
+          ),
+        [WS_METHODS.serverInstallAcpRegistryBinary]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverInstallAcpRegistryBinary,
+            installAcpRegistryBinary(input),
             {
               "rpc.aggregate": "server",
             },

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1,28 +1,7 @@
-import { execFile } from "node:child_process";
-import { createWriteStream } from "node:fs";
-import {
-  access,
-  chmod,
-  copyFile,
-  cp,
-  mkdir,
-  mkdtemp,
-  readFile,
-  rm,
-  writeFile,
-} from "node:fs/promises";
-import { arch, homedir, platform, tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { pipeline } from "node:stream/promises";
-import { promisify } from "node:util";
-
 import { Cause, Duration, Effect, Layer, Option, Queue, Ref, Schema, Stream } from "effect";
 import {
   type AuthAccessStreamEvent,
   AcpRegistryIndex,
-  type AcpRegistryAgent,
-  type AcpRegistryInstallBinaryResult,
-  type AcpRegistryListResult,
   AuthSessionId,
   CommandId,
   EventId,
@@ -97,8 +76,10 @@ import {
   type SessionCredentialChange,
 } from "./auth/Services/SessionCredentialService.ts";
 import { respondToAuthError } from "./auth/http.ts";
-
-const execFileAsync = promisify(execFile);
+import {
+  installAcpRegistryBinaryAgent,
+  listAcpRegistryAgents,
+} from "./provider/acp/AcpRegistryBinaryInstaller.ts";
 
 function isThreadDetailEvent(event: OrchestrationEvent): event is Extract<
   OrchestrationEvent,
@@ -123,313 +104,6 @@ function isThreadDetailEvent(event: OrchestrationEvent): event is Extract<
 }
 
 const PROVIDER_STATUS_DEBOUNCE_MS = 200;
-const ACP_BINARY_INSTALLS_DIR = "acp_agents";
-const ACP_BINARY_MANIFEST_FILE = "install.json";
-
-type BinaryDistributionTarget = {
-  readonly archive: string;
-  readonly cmd: string;
-};
-
-type AcpBinaryInstallManifest = {
-  readonly layoutVersion: 2;
-  readonly agentId: string;
-  readonly version: string;
-  readonly platformKey: string;
-  readonly command: string;
-  readonly archiveUrl: string;
-};
-
-function getAcpBinaryPlatformKey(): string {
-  const os = platform();
-  const cpu = arch();
-  const osKey =
-    os === "darwin" ? "darwin" : os === "win32" ? "windows" : os === "linux" ? "linux" : os;
-  const archKey = cpu === "arm64" ? "aarch64" : cpu === "x64" ? "x86_64" : cpu;
-  return `${osKey}-${archKey}`;
-}
-
-function getBinaryTarget(agent: AcpRegistryAgent): BinaryDistributionTarget | null {
-  const binary = agent.distribution.binary;
-  if (!binary || typeof binary !== "object" || globalThis.Array.isArray(binary)) return null;
-  const target = (binary as Record<string, unknown>)[getAcpBinaryPlatformKey()];
-  if (!target || typeof target !== "object" || globalThis.Array.isArray(target)) return null;
-  const record = target as Record<string, unknown>;
-  if (typeof record.archive !== "string" || typeof record.cmd !== "string") return null;
-  return { archive: record.archive, cmd: record.cmd };
-}
-
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function normalizeArchiveCommandPath(command: string): string {
-  const trimmed = command.trim();
-  if (!trimmed) {
-    throw new Error("Registry binary command must not be empty.");
-  }
-  if (isAbsolute(trimmed)) {
-    throw new Error("Registry binary command must be a relative archive path.");
-  }
-  const withoutLeadingDot = trimmed.replace(/^(?:\.[/\\])+/u, "");
-  const parts = withoutLeadingDot
-    .split(/[/\\]+/u)
-    .filter((part) => part.length > 0 && part !== ".");
-  if (parts.length === 0 || parts.some((part) => part === "..")) {
-    throw new Error("Registry binary command resolves outside the archive.");
-  }
-  return join(...parts);
-}
-
-function resolveInstallRootFromBinaryPath(binaryPath: string, commandRelativePath: string): string {
-  const depth = commandRelativePath.split(/[/\\]+/u).filter((part) => part.length > 0).length;
-  let installRoot = binaryPath;
-  for (let index = 0; index < depth; index += 1) {
-    installRoot = dirname(installRoot);
-  }
-  return installRoot;
-}
-
-function resolveAcpBinaryInstallPath(
-  config: { readonly stateDir: string },
-  agent: AcpRegistryAgent,
-) {
-  const commandPath = normalizeArchiveCommandPath(getBinaryTarget(agent)?.cmd ?? agent.id);
-  return join(config.stateDir, ACP_BINARY_INSTALLS_DIR, agent.id, agent.version, commandPath);
-}
-
-function expandUserPath(path: string): string {
-  if (path === "~") return homedir();
-  if (path.startsWith("~/") || path.startsWith("~\\")) return join(homedir(), path.slice(2));
-  return path;
-}
-
-function normalizeAcpBinaryInstallPath(path: string): string {
-  const expanded = expandUserPath(path.trim());
-  return isAbsolute(expanded) ? expanded : resolve(expanded);
-}
-
-function displayPath(path: string): string {
-  const home = homedir();
-  return path === home || path.startsWith(`${home}/`) || path.startsWith(`${home}\\`)
-    ? `~${path.slice(home.length)}`
-    : path;
-}
-
-function isPathInside(parent: string, child: string): boolean {
-  const relativePath = relative(parent, child);
-  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
-}
-
-function toBinaryInstallPreview(
-  config: { readonly stateDir: string },
-  agent: AcpRegistryAgent,
-  target: BinaryDistributionTarget,
-) {
-  const defaultInstallPath = resolveAcpBinaryInstallPath(config, agent);
-  return {
-    archiveUrl: target.archive,
-    defaultInstallPath: displayPath(defaultInstallPath),
-    platformKey: getAcpBinaryPlatformKey(),
-    command: target.cmd,
-  };
-}
-
-function resolveAcpBinaryManifestPath(
-  config: { readonly stateDir: string },
-  agent: AcpRegistryAgent,
-) {
-  return join(dirname(resolveAcpBinaryInstallPath(config, agent)), ACP_BINARY_MANIFEST_FILE);
-}
-
-async function readAcpBinaryManifest(
-  config: { readonly stateDir: string },
-  agent: AcpRegistryAgent,
-): Promise<AcpBinaryInstallManifest | null> {
-  const manifestPath = resolveAcpBinaryManifestPath(config, agent);
-  try {
-    const raw = await readFile(manifestPath, "utf8");
-    const parsed = JSON.parse(raw) as Partial<AcpBinaryInstallManifest>;
-    if (
-      parsed.layoutVersion === 2 &&
-      parsed.agentId === agent.id &&
-      parsed.version === agent.version &&
-      parsed.platformKey === getAcpBinaryPlatformKey() &&
-      typeof parsed.command === "string" &&
-      (await fileExists(parsed.command))
-    ) {
-      return parsed as AcpBinaryInstallManifest;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-async function downloadFile(url: string, destination: string): Promise<void> {
-  const response = await fetch(url);
-  if (!response.ok || !response.body) {
-    throw new Error(`Download failed with status ${response.status}`);
-  }
-  await pipeline(response.body, createWriteStream(destination));
-}
-
-async function extractArchive(archivePath: string, destinationDir: string): Promise<void> {
-  if (archivePath.endsWith(".tar.gz") || archivePath.endsWith(".tgz")) {
-    await execFileAsync("tar", ["-xzf", archivePath, "-C", destinationDir]);
-    return;
-  }
-  if (archivePath.endsWith(".zip")) {
-    if (platform() === "win32") {
-      await execFileAsync("powershell.exe", [
-        "-NoProfile",
-        "-Command",
-        "Expand-Archive",
-        "-LiteralPath",
-        archivePath,
-        "-DestinationPath",
-        destinationDir,
-        "-Force",
-      ]);
-      return;
-    }
-    await execFileAsync("unzip", ["-q", archivePath, "-d", destinationDir]);
-    return;
-  }
-  throw new Error("Unsupported binary archive format.");
-}
-
-async function installAcpBinaryAgent(input: {
-  readonly config: { readonly stateDir: string };
-  readonly agent: AcpRegistryAgent;
-  readonly installPath?: string | undefined;
-}): Promise<BinaryDistributionTarget & { readonly command: string }> {
-  const target = getBinaryTarget(input.agent);
-  if (!target) {
-    throw new Error(`No binary is available for ${getAcpBinaryPlatformKey()}.`);
-  }
-  const installPath = normalizeAcpBinaryInstallPath(
-    input.installPath?.trim() || resolveAcpBinaryInstallPath(input.config, input.agent),
-  );
-  const commandPath = normalizeArchiveCommandPath(target.cmd);
-  const installRoot = resolveInstallRootFromBinaryPath(installPath, commandPath);
-  if (installRoot === dirname(installRoot)) {
-    throw new Error(`Binary path is too shallow for registry command '${target.cmd}'.`);
-  }
-  const manifestPath = resolveAcpBinaryManifestPath(input.config, input.agent);
-  const tempDir = await mkdtemp(join(tmpdir(), "t3-acp-agent-"));
-  try {
-    const archivePath = join(
-      tempDir,
-      basename(new URL(target.archive).pathname) || "agent.archive",
-    );
-    const extractDir = join(tempDir, "extract");
-    await mkdir(extractDir, { recursive: true });
-    await downloadFile(target.archive, archivePath);
-    await extractArchive(archivePath, extractDir);
-
-    const extractedCommand = resolve(extractDir, commandPath);
-    if (!isPathInside(extractDir, extractedCommand)) {
-      throw new Error(`Registry binary command resolves outside the archive.`);
-    }
-    if (!(await fileExists(extractedCommand))) {
-      throw new Error(`Installed archive did not contain expected command '${target.cmd}'.`);
-    }
-    await mkdir(installRoot, { recursive: true });
-    await cp(extractDir, installRoot, {
-      recursive: true,
-      force: true,
-      errorOnExist: false,
-    });
-    if (!(await fileExists(installPath))) {
-      await mkdir(dirname(installPath), { recursive: true });
-      await copyFile(extractedCommand, installPath);
-    }
-    if (platform() !== "win32") {
-      await chmod(installPath, 0o755);
-    }
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-  const manifest: AcpBinaryInstallManifest = {
-    layoutVersion: 2,
-    agentId: input.agent.id,
-    version: input.agent.version,
-    platformKey: getAcpBinaryPlatformKey(),
-    command: installPath,
-    archiveUrl: target.archive,
-  };
-  await mkdir(dirname(manifestPath), { recursive: true });
-  await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
-  return { ...target, command: installPath };
-}
-
-async function toAcpLaunchSpec(
-  agent: AcpRegistryAgent,
-  config: { readonly stateDir: string },
-): Promise<{
-  readonly supported: boolean;
-  readonly distributionType: "npx" | "uvx" | "binary" | "binaryUnsupported";
-  readonly launch: {
-    readonly command: string;
-    readonly args: readonly string[];
-    readonly env: Record<string, string>;
-  } | null;
-  readonly binaryInstall?: {
-    readonly archiveUrl: string;
-    readonly defaultInstallPath: string;
-    readonly platformKey: string;
-    readonly command: string;
-  };
-}> {
-  if (agent.distribution.npx) {
-    return {
-      supported: true as const,
-      distributionType: "npx" as const,
-      launch: {
-        command: "npx",
-        args: ["-y", agent.distribution.npx.package, ...(agent.distribution.npx.args ?? [])],
-        env: agent.distribution.npx.env ?? {},
-      },
-    };
-  }
-  if (agent.distribution.uvx) {
-    return {
-      supported: true as const,
-      distributionType: "uvx" as const,
-      launch: {
-        command: "uvx",
-        args: [agent.distribution.uvx.package, ...(agent.distribution.uvx.args ?? [])],
-        env: agent.distribution.uvx.env ?? {},
-      },
-    };
-  }
-  const manifest = await readAcpBinaryManifest(config, agent);
-  const target = getBinaryTarget(agent);
-  if (manifest) {
-    return {
-      supported: true as const,
-      distributionType: "binary" as const,
-      launch: {
-        command: manifest.command,
-        args: [],
-        env: {},
-      },
-      ...(target ? { binaryInstall: toBinaryInstallPreview(config, agent, target) } : {}),
-    };
-  }
-  return {
-    supported: false as const,
-    distributionType: "binaryUnsupported" as const,
-    launch: null,
-    ...(target ? { binaryInstall: toBinaryInstallPreview(config, agent, target) } : {}),
-  };
-}
 
 function toAuthAccessStreamEvent(
   change: BootstrapCredentialChange | SessionCredentialChange,
@@ -527,35 +201,14 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         Effect.flatMap((raw) => Schema.decodeUnknownEffect(AcpRegistryIndex)(raw)),
       );
 
-      const listAcpRegistry = Effect.all({
-        registry: loadAcpRegistryIndex,
-        config: Effect.succeed(config),
-      }).pipe(
-        Effect.flatMap(({ registry, config }) =>
-          Effect.tryPromise({
-            try: async (): Promise<AcpRegistryListResult> => ({
-              registryVersion: registry.version,
-              agents: (
-                await Promise.all(
-                  registry.agents.map(async (agent) => {
-                    const resolved = await toAcpLaunchSpec(agent, config);
-                    return {
-                      agent,
-                      supported: resolved.supported,
-                      distributionType: resolved.distributionType,
-                      launch: resolved.launch,
-                      ...(resolved.binaryInstall ? { binaryInstall: resolved.binaryInstall } : {}),
-                    };
-                  }),
-                )
-              ).toSorted((left, right) => left.agent.name.localeCompare(right.agent.name)),
+      const listAcpRegistry = loadAcpRegistryIndex.pipe(
+        Effect.flatMap((registry) => listAcpRegistryAgents(registry)),
+        Effect.mapError(
+          (cause) =>
+            new AcpRegistryClientError({
+              detail: cause instanceof Error ? cause.message : String(cause),
+              cause,
             }),
-            catch: (cause) =>
-              new AcpRegistryClientError({
-                detail: cause instanceof Error ? cause.message : String(cause),
-                cause,
-              }),
-          }),
         ),
       );
 
@@ -563,51 +216,19 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         readonly agentId: string;
         readonly installPath?: string | undefined;
       }) =>
-        Effect.all({
-          registry: loadAcpRegistryIndex,
-          config: Effect.succeed(config),
-        }).pipe(
-          Effect.flatMap(({ registry, config }) =>
-            Effect.tryPromise({
-              try: async (): Promise<AcpRegistryInstallBinaryResult> => {
-                const agent = registry.agents.find((entry) => entry.id === input.agentId);
-                if (!agent) {
-                  return {
-                    ok: false,
-                    error: `No ACP registry agent found for '${input.agentId}'.`,
-                  };
-                }
-                const installed = await installAcpBinaryAgent({
-                  config,
-                  agent,
-                  installPath: input.installPath,
-                });
-                return {
-                  ok: true,
-                  agent: {
-                    agent,
-                    supported: true,
-                    distributionType: "binary",
-                    binaryInstall: toBinaryInstallPreview(config, agent, installed),
-                    launch: {
-                      command: installed.command,
-                      args: [],
-                      env: {},
-                    },
-                  },
-                };
-              },
-              catch: (cause): AcpRegistryInstallBinaryResult => ({
-                ok: false,
-                error: cause instanceof Error ? cause.message : String(cause),
-              }),
+        loadAcpRegistryIndex.pipe(
+          Effect.flatMap((registry) =>
+            installAcpRegistryBinaryAgent({
+              registry,
+              agentId: input.agentId,
+              installPath: input.installPath,
             }),
           ),
           Effect.catch((cause: unknown) =>
             Effect.succeed({
               ok: false,
               error: cause instanceof Error ? cause.message : String(cause),
-            } satisfies AcpRegistryInstallBinaryResult),
+            }),
           ),
         );
 

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -103,6 +103,7 @@ function createBaseServerConfig(): ServerConfig {
         model: "gpt-5.4-mini",
       },
       providers: {
+        ...DEFAULT_SERVER_SETTINGS.providers,
         codex: {
           enabled: true,
           binaryPath: "",

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -99,6 +99,7 @@ import { proposedPlanTitle } from "../../proposedPlan";
 import { getProviderInteractionModeToggle } from "../../providerModels";
 import {
   deriveProviderInstanceEntries,
+  isModelPickerProviderInstanceEntry,
   resolveProviderDriverKindForInstanceSelection,
   sortProviderInstanceEntries,
   type ProviderInstanceEntry,
@@ -595,7 +596,12 @@ export const ChatComposer = memo(
     // configured instance (default built-in + any custom `providerInstances.*`),
     // sorted default-first per driver kind for a stable picker order.
     const providerInstanceEntries = useMemo<ReadonlyArray<ProviderInstanceEntry>>(
-      () => sortProviderInstanceEntries(deriveProviderInstanceEntries(providerStatuses)),
+      () =>
+        sortProviderInstanceEntries(
+          deriveProviderInstanceEntries(providerStatuses).filter(
+            isModelPickerProviderInstanceEntry,
+          ),
+        ),
       [providerStatuses],
     );
     const selectedProviderByThreadId = composerDraft.activeProvider ?? null;

--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -5,8 +5,8 @@ import {
   getDisplayModelName,
   getTriggerDisplayModelLabel,
   type ModelEsque,
-  PROVIDER_ICON_BY_PROVIDER,
 } from "./providerIconUtils";
+import { ProviderInstanceIcon } from "./ProviderInstanceIcon";
 import { ComboboxItem } from "../ui/combobox";
 import { Kbd } from "../ui/kbd";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -26,6 +26,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
    */
   providerDisplayName: string;
   providerAccentColor?: string | undefined;
+  providerIconUrl?: string | undefined;
   isFavorite: boolean;
   showProvider: boolean;
   preferShortName?: boolean;
@@ -34,7 +35,6 @@ export const ModelListRow = memo(function ModelListRow(props: {
   jumpLabel?: string | null;
   onToggleFavorite: () => void;
 }) {
-  const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[props.driverKind] ?? null;
   const providerLabel = props.model.subProvider
     ? `${props.providerDisplayName} · ${props.model.subProvider}`
     : props.providerDisplayName;
@@ -104,7 +104,13 @@ export const ModelListRow = memo(function ModelListRow(props: {
         </div>
         {props.showProvider && (
           <div className="flex items-center gap-1 mt-0.5">
-            {ProviderIcon ? <ProviderIcon className="size-3 shrink-0" /> : null}
+            <ProviderInstanceIcon
+              driverKind={props.driverKind}
+              displayName={props.providerDisplayName}
+              iconUrl={props.providerIconUrl}
+              className="size-3"
+              iconClassName="size-3 text-muted-foreground/70"
+            />
             {props.providerAccentColor ? (
               <span
                 className="size-1.5 shrink-0 rounded-full"

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -11,7 +11,8 @@ import { ModelPickerSidebar } from "./ModelPickerSidebar";
 import { isModelPickerNewModel } from "./modelPickerModelHighlights";
 import { buildModelPickerSearchText, scoreModelPickerSearch } from "./modelPickerSearch";
 import { Combobox, ComboboxEmpty, ComboboxInput, ComboboxList } from "../ui/combobox";
-import { ModelEsque, PROVIDER_ICON_BY_PROVIDER } from "./providerIconUtils";
+import { ModelEsque } from "./providerIconUtils";
+import { ProviderInstanceIcon } from "./ProviderInstanceIcon";
 import {
   modelPickerJumpCommandForIndex,
   modelPickerJumpIndexFromCommand,
@@ -33,6 +34,7 @@ type ModelPickerItem = {
   driverKind: ProviderDriverKind;
   instanceDisplayName: string;
   instanceAccentColor?: string | undefined;
+  instanceIconUrl?: string | undefined;
   continuationGroupKey?: string | undefined;
 };
 
@@ -202,6 +204,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
           driverKind: entry.driverKind,
           instanceDisplayName: entry.displayName,
           ...(entry.accentColor ? { instanceAccentColor: entry.accentColor } : {}),
+          ...(entry.iconUrl ? { instanceIconUrl: entry.iconUrl } : {}),
           ...(entry.continuationGroupKey
             ? { continuationGroupKey: entry.continuationGroupKey }
             : {}),
@@ -363,18 +366,16 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     [favorites, updateSettings],
   );
 
-  const LockedProviderIcon =
-    isLocked && props.lockedProvider ? PROVIDER_ICON_BY_PROVIDER[props.lockedProvider] : null;
   // Header label for locked mode. Use the active instance's displayName
   // when the lock narrows to exactly one instance (so "Codex Personal"
   // shows instead of the generic driver label); fall back to the first
   // matching entry otherwise.
-  const lockedHeaderLabel = useMemo(() => {
+  const lockedHeaderEntry = useMemo(() => {
     if (!isLocked || !props.lockedProvider) return null;
     const matches = instanceEntries.filter((entry) => matchesLockedProvider(entry));
     if (matches.length === 0) return null;
     const active = matches.find((entry) => entry.instanceId === props.activeInstanceId);
-    return (active ?? matches[0])?.displayName ?? null;
+    return active ?? matches[0] ?? null;
   }, [
     isLocked,
     matchesLockedProvider,
@@ -524,12 +525,18 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
         )}
       >
         {/* Locked provider header (only shown in locked mode) */}
-        {isLocked && !showLockedInstanceSidebar && LockedProviderIcon && lockedHeaderLabel && (
+        {isLocked && !showLockedInstanceSidebar && lockedHeaderEntry ? (
           <div className="flex items-center gap-2 px-4 py-3 border-b">
-            <LockedProviderIcon className="size-5 shrink-0" />
-            <span className="font-medium text-sm">{lockedHeaderLabel}</span>
+            <ProviderInstanceIcon
+              driverKind={lockedHeaderEntry.driverKind}
+              displayName={lockedHeaderEntry.displayName}
+              iconUrl={lockedHeaderEntry.iconUrl}
+              className="size-5"
+              iconClassName="size-5"
+            />
+            <span className="font-medium text-sm">{lockedHeaderEntry.displayName}</span>
           </div>
-        )}
+        ) : null}
 
         {/* Sidebar (only in unlocked mode) */}
         {showSidebar && (
@@ -626,6 +633,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
                       driverKind={model.driverKind}
                       providerDisplayName={model.instanceDisplayName}
                       providerAccentColor={model.instanceAccentColor}
+                      providerIconUrl={model.instanceIconUrl}
                       isFavorite={favoritesSet.has(modelKey)}
                       showProvider={!isLocked || showLockedInstanceSidebar}
                       preferShortName={!isLocked}

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -158,6 +158,7 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
                 driverKind={entry.driverKind}
                 displayName={entry.displayName}
                 accentColor={entry.accentColor}
+                iconUrl={entry.iconUrl}
                 showBadge={showInstanceBadge}
                 className="size-6"
                 iconClassName="size-5"

--- a/apps/web/src/components/chat/ProviderInstanceIcon.tsx
+++ b/apps/web/src/components/chat/ProviderInstanceIcon.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, memo } from "react";
+import { type CSSProperties, memo, useEffect, useState } from "react";
 import { type ProviderDriverKind } from "@t3tools/contracts";
 
 import { PROVIDER_ICON_BY_PROVIDER } from "./providerIconUtils";
@@ -18,6 +18,7 @@ export const ProviderInstanceIcon = memo(function ProviderInstanceIcon(props: {
   driverKind: ProviderDriverKind;
   displayName: string;
   accentColor?: string | undefined;
+  iconUrl?: string | undefined;
   showBadge?: boolean;
   className?: string;
   iconClassName?: string;
@@ -25,9 +26,16 @@ export const ProviderInstanceIcon = memo(function ProviderInstanceIcon(props: {
   statusDotClassName?: string;
 }) {
   const Icon = PROVIDER_ICON_BY_PROVIDER[props.driverKind] ?? null;
+  const [imageFailed, setImageFailed] = useState(false);
+  const customIconUrl = props.iconUrl?.trim();
+  const showCustomIcon = Boolean(customIconUrl) && !imageFailed;
   const accentStyle = props.accentColor
     ? ({ "--provider-accent": props.accentColor } as CSSProperties)
     : undefined;
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [customIconUrl]);
 
   return (
     <span
@@ -38,7 +46,18 @@ export const ProviderInstanceIcon = memo(function ProviderInstanceIcon(props: {
       style={accentStyle}
       data-provider-accent-color={props.accentColor}
     >
-      {Icon ? (
+      {showCustomIcon ? (
+        <img
+          src={customIconUrl}
+          alt=""
+          className={cn(
+            "size-5 shrink-0 rounded-sm object-contain dark:invert",
+            props.iconClassName,
+          )}
+          onError={() => setImageFailed(true)}
+          draggable={false}
+        />
+      ) : Icon ? (
         <Icon className={cn("size-5 shrink-0", props.iconClassName)} aria-hidden />
       ) : (
         <span className={cn("text-[10px] font-semibold leading-none", props.iconClassName)}>

--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -129,6 +129,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
               driverKind={activeEntry.driverKind}
               displayName={activeEntry.displayName}
               accentColor={activeEntry.accentColor}
+              iconUrl={activeEntry.iconUrl}
               showBadge={showInstanceBadge}
               className={showInstanceBadge ? "size-5" : "size-4"}
               iconClassName={cn("size-4", props.activeProviderIconClassName)}

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,5 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ACPRegistryIcon, ClaudeAI, CursorIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -7,6 +7,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("claudeAgent")]: ClaudeAI,
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
+  [ProviderDriverKind.make("acpRegistry")]: ACPRegistryIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -1,19 +1,42 @@
 "use client";
 
-import { CheckIcon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  Loader2Icon,
+  PlusIcon,
+  RefreshCwIcon,
+  SearchIcon,
+  XIcon,
+} from "lucide-react";
 import { Radio as RadioPrimitive } from "@base-ui/react/radio";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  ProviderInstanceId,
   ProviderDriverKind,
+  ProviderInstanceId,
   type ProviderInstanceConfig,
+  type ProviderInstanceEnvironmentVariable,
+  type ResolvedRegistryAcpAgent,
 } from "@t3tools/contracts";
+import { normalizeSearchQuery, scoreQueryMatch } from "@t3tools/shared/searchRanking";
 
 import { useSettings, useUpdateSettings } from "../../hooks/useSettings";
+import { ensureLocalApi } from "../../localApi";
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
+import { AnimatedHeight } from "../AnimatedHeight";
+import { Gemini, GithubCopilotIcon, PiAgentIcon, type Icon } from "../Icons";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { ACPRegistryIcon, Gemini, GithubCopilotIcon, PiAgentIcon, type Icon } from "../Icons";
 import {
   Dialog,
   DialogDescription,
@@ -22,13 +45,12 @@ import {
   DialogPopup,
   DialogTitle,
 } from "../ui/dialog";
-import { Badge } from "../ui/badge";
 import { Input } from "../ui/input";
 import { RadioGroup } from "../ui/radio-group";
+import { ScrollArea } from "../ui/scroll-area";
 import { toastManager } from "../ui/toast";
 import { DRIVER_OPTION_BY_VALUE, DRIVER_OPTIONS } from "./providerDriverMeta";
-import { ProviderSettingsForm, deriveProviderSettingsFields } from "./ProviderSettingsForm";
-import { AnimatedHeight } from "../AnimatedHeight";
+import { deriveProviderSettingsFields, ProviderSettingsForm } from "./ProviderSettingsForm";
 
 const PROVIDER_ACCENT_SWATCHES = [
   "#2563eb",
@@ -39,13 +61,6 @@ const PROVIDER_ACCENT_SWATCHES = [
   "#0891b2",
 ] as const;
 
-/**
- * Normalize a user-provided label into a slug suffix for the instance id.
- * The full id is formed by prefixing the driver slug — e.g. label "Work" on
- * driver "codex" becomes `codex_work`. Output is trimmed to 48 chars so the
- * final composed id stays under the 64-char slug cap enforced by
- * `ProviderInstanceId` in `@t3tools/contracts`.
- */
 function slugifyLabel(value: string): string {
   return value
     .trim()
@@ -61,9 +76,13 @@ function deriveInstanceId(driver: ProviderDriverKind, label: string): string {
 }
 
 const INSTANCE_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 const DEFAULT_DRIVER_KIND = ProviderDriverKind.make("codex");
+const ACP_REGISTRY_DRIVER_KIND = ProviderDriverKind.make("acpRegistry");
 const DEFAULT_DRIVER_OPTION = DRIVER_OPTIONS[0]!;
 const EMPTY_CONFIG_DRAFT: Record<string, unknown> = {};
+const MANUAL_ACP_REGISTRY_OPTION = "__manual__";
+
 interface ComingSoonDriverOption {
   readonly value: ProviderDriverKind;
   readonly label: string;
@@ -82,22 +101,19 @@ const COMING_SOON_DRIVER_OPTIONS: readonly ComingSoonDriverOption[] = [
     icon: Gemini,
   },
   {
-    value: ProviderDriverKind.make("acpRegistry"),
-    label: "ACP Registry",
-    icon: ACPRegistryIcon,
-  },
-  {
     value: ProviderDriverKind.make("piAgent"),
     label: "Pi Agent",
     icon: PiAgentIcon,
   },
 ];
 
-/**
- * Validate an instance id against the same slug rules the server applies in
- * `ProviderInstanceId` (see `packages/contracts/src/providerInstance.ts`).
- * Returns a user-facing error string, or `null` if valid.
- */
+let environmentVariableDraftId = 0;
+const nextEnvironmentVariableDraftId = () => `add-provider-env-${environmentVariableDraftId++}`;
+
+type EnvironmentVariableDraft = ProviderInstanceEnvironmentVariable & {
+  readonly id: string;
+};
+
 function validateInstanceId(id: string, existing: ReadonlySet<string>): string | null {
   if (id.length === 0) return "Instance ID is required.";
   if (id.length > 64) return "Instance ID must be 64 characters or fewer.";
@@ -107,6 +123,99 @@ function validateInstanceId(id: string, existing: ReadonlySet<string>): string |
   if (existing.has(id)) return `An instance named '${id}' already exists.`;
   return null;
 }
+
+function envRecordToVariables(
+  env: Record<string, string> | null | undefined,
+): ReadonlyArray<EnvironmentVariableDraft> {
+  return Object.entries(env ?? {})
+    .filter(([name]) => ENVIRONMENT_VARIABLE_NAME_PATTERN.test(name))
+    .map(([name, value]) => ({
+      id: nextEnvironmentVariableDraftId(),
+      name,
+      value,
+      sensitive: false,
+    }));
+}
+
+function emptyEnvironmentVariable(): EnvironmentVariableDraft {
+  return {
+    id: nextEnvironmentVariableDraftId(),
+    name: "",
+    value: "",
+    sensitive: true,
+  };
+}
+
+function acpDistributionLabel(entry: ResolvedRegistryAcpAgent): string {
+  switch (entry.distributionType) {
+    case "npx":
+      return "npx";
+    case "uvx":
+      return "uvx";
+    case "binary":
+      return "Installed";
+    case "binaryUnsupported":
+      return "Binary";
+    case "manual":
+      return "Manual";
+  }
+}
+
+function acpRegistryAgentSearchFields(entry: ResolvedRegistryAcpAgent): readonly string[] {
+  return [
+    entry.agent.name,
+    entry.agent.id,
+    entry.agent.description,
+    entry.agent.repository,
+    entry.agent.website,
+    entry.distributionType,
+    entry.launch?.command,
+    ...(entry.launch?.args ?? []),
+  ]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .map((value) => normalizeSearchQuery(value));
+}
+
+function scoreAcpRegistryAgentSearch(entry: ResolvedRegistryAcpAgent, query: string): number | null {
+  const tokens = normalizeSearchQuery(query)
+    .split(/\s+/u)
+    .filter((token) => token.length > 0);
+  if (tokens.length === 0) return 0;
+
+  const fields = acpRegistryAgentSearchFields(entry);
+  let score = 0;
+  for (const token of tokens) {
+    const tokenScores = fields
+      .map((field, index) =>
+        scoreQueryMatch({
+          value: field,
+          query: token,
+          exactBase: index * 10,
+          prefixBase: index * 10 + 2,
+          boundaryBase: index * 10 + 4,
+          includesBase: index * 10 + 6,
+          ...(token.length >= 3 ? { fuzzyBase: index * 10 + 100 } : {}),
+        }),
+      )
+      .filter((fieldScore): fieldScore is number => fieldScore !== null);
+    if (tokenScores.length === 0) return null;
+    score += Math.min(...tokenScores);
+  }
+  return score;
+}
+
+type AcpRegistryState =
+  | { readonly status: "idle" | "loading"; readonly agents: readonly ResolvedRegistryAcpAgent[] }
+  | {
+      readonly status: "loaded";
+      readonly registryVersion: string;
+      readonly agents: readonly ResolvedRegistryAcpAgent[];
+    }
+  | {
+      readonly status: "error";
+      readonly agents: readonly ResolvedRegistryAcpAgent[];
+      readonly error: string;
+    };
 
 interface AddProviderInstanceDialogProps {
   open: boolean;
@@ -120,41 +229,62 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
   const [wizardStep, setWizardStep] = useState(0);
   const [driver, setDriver] = useState<ProviderDriverKind>(DEFAULT_DRIVER_KIND);
   const [label, setLabel] = useState("");
+  const [labelDirty, setLabelDirty] = useState(false);
   const [accentColor, setAccentColor] = useState<string>("");
   const [instanceId, setInstanceId] = useState("");
   const [instanceIdDirty, setInstanceIdDirty] = useState(false);
-  // Driver-specific config drafts keyed by driver so toggling between drivers
-  // during the same dialog session does not lose in-progress input.
   const [configByDriver, setConfigByDriver] = useState<Record<string, Record<string, unknown>>>({});
-  // Errors are suppressed until the user has tried to submit once. After that
-  // they update live so fixing the problem clears the message in place.
+  const [environmentVariables, setEnvironmentVariables] = useState<
+    ReadonlyArray<EnvironmentVariableDraft>
+  >([]);
+  const [acpRegistryState, setAcpRegistryState] = useState<AcpRegistryState>({
+    status: "idle",
+    agents: [],
+  });
+  const [acpRegistrySearch, setAcpRegistrySearch] = useState("");
+  const [selectedAcpRegistryAgentId, setSelectedAcpRegistryAgentId] = useState(
+    MANUAL_ACP_REGISTRY_OPTION,
+  );
+  const [installingAcpAgentId, setInstallingAcpAgentId] = useState<string | null>(null);
+  const [installConfirmAgent, setInstallConfirmAgent] = useState<ResolvedRegistryAcpAgent | null>(
+    null,
+  );
+  const [installPath, setInstallPath] = useState("");
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
 
   const existingIds = useMemo(
     () => new Set(Object.keys(settings.providerInstances ?? {})),
     [settings.providerInstances],
   );
+  const isAcpRegistryDriver = driver === ACP_REGISTRY_DRIVER_KIND;
 
-  // Reset the form every time the dialog opens so each creation starts
-  // from a clean slate.
   useEffect(() => {
     if (!open) return;
     setDriver(DEFAULT_DRIVER_KIND);
     setLabel("");
+    setLabelDirty(false);
     setAccentColor("");
     setInstanceId("");
     setWizardStep(0);
     setInstanceIdDirty(false);
     setConfigByDriver({});
+    setEnvironmentVariables([]);
+    setAcpRegistrySearch("");
+    setSelectedAcpRegistryAgentId(MANUAL_ACP_REGISTRY_OPTION);
+    setInstallingAcpAgentId(null);
+    setInstallConfirmAgent(null);
+    setInstallPath("");
     setHasAttemptedSubmit(false);
   }, [open]);
 
-  // Auto-derive the instance id from driver + label until the user types
-  // in the Instance ID field directly (after which they own its value).
   useEffect(() => {
     if (instanceIdDirty) return;
     setInstanceId(deriveInstanceId(driver, label));
   }, [driver, label, instanceIdDirty]);
+
+  useEffect(() => {
+    setWizardStep((step) => Math.min(step, isAcpRegistryDriver ? 3 : 2));
+  }, [isAcpRegistryDriver]);
 
   const driverOption = DRIVER_OPTION_BY_VALUE[driver] ?? DEFAULT_DRIVER_OPTION;
   const driverSettingsFields = useMemo(
@@ -164,8 +294,71 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
   const instanceIdError = validateInstanceId(instanceId, existingIds);
   const showInstanceIdError = hasAttemptedSubmit && instanceIdError !== null;
   const previewLabel = label.trim() || `${driverOption.label} Workspace`;
-  const wizardSteps = ["Driver", "Identity", "Config"] as const;
-  const wizardStepSummaries = [driverOption.label, previewLabel, null] as const;
+  const wizardSteps = isAcpRegistryDriver
+    ? (["Driver", "Registry", "Identity", "Config"] as const)
+    : (["Driver", "Identity", "Config"] as const);
+  const registryStepIndex = isAcpRegistryDriver ? 1 : -1;
+  const identityStepIndex = isAcpRegistryDriver ? 2 : 1;
+  const configStepIndex = wizardSteps.length - 1;
+  const selectedAcpRegistryAgent = useMemo(
+    () =>
+      acpRegistryState.agents.find((entry) => entry.agent.id === selectedAcpRegistryAgentId) ??
+      null,
+    [acpRegistryState.agents, selectedAcpRegistryAgentId],
+  );
+  const selectedAcpRegistryAgentNeedsInstall =
+    selectedAcpRegistryAgent?.distributionType === "binaryUnsupported" &&
+    Boolean(selectedAcpRegistryAgent.binaryInstall);
+  const installingConfirmAgent =
+    installConfirmAgent !== null && installingAcpAgentId === installConfirmAgent.agent.id;
+  const wizardStepSummaries = [
+    driverOption.label,
+    ...(isAcpRegistryDriver
+      ? [
+          selectedAcpRegistryAgent
+            ? selectedAcpRegistryAgent.agent.name
+            : selectedAcpRegistryAgentId === MANUAL_ACP_REGISTRY_OPTION
+              ? "Manual"
+              : null,
+        ]
+      : []),
+    previewLabel,
+    null,
+  ] as const;
+  const filteredAcpRegistryAgents = useMemo(() => {
+    const query = acpRegistrySearch.trim();
+    if (!query) return acpRegistryState.agents;
+    return acpRegistryState.agents
+      .map((entry) => ({ entry, score: scoreAcpRegistryAgentSearch(entry, query) }))
+      .filter((result): result is { entry: ResolvedRegistryAcpAgent; score: number } => {
+        return result.score !== null;
+      })
+      .toSorted((left, right) => left.score - right.score || left.entry.agent.name.localeCompare(right.entry.agent.name))
+      .map((result) => result.entry);
+  }, [acpRegistrySearch, acpRegistryState.agents]);
+
+  const loadAcpRegistry = useCallback(async () => {
+    setAcpRegistryState((current) => ({ status: "loading", agents: current.agents }));
+    try {
+      const result = await ensureLocalApi().server.listAcpRegistry();
+      setAcpRegistryState({
+        status: "loaded",
+        registryVersion: result.registryVersion,
+        agents: result.agents,
+      });
+    } catch (error) {
+      setAcpRegistryState((current) => ({
+        status: "error",
+        agents: current.agents,
+        error: error instanceof Error ? error.message : "Registry request failed.",
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open || !isAcpRegistryDriver || acpRegistryState.status !== "idle") return;
+    void loadAcpRegistry();
+  }, [acpRegistryState.status, isAcpRegistryDriver, loadAcpRegistry, open]);
 
   const configDraft = configByDriver[driver] ?? EMPTY_CONFIG_DRAFT;
   const setConfigDraft = useCallback(
@@ -183,25 +376,162 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
     [driver],
   );
 
+  const applyAcpRegistryAgent = useCallback(
+    (entry: ResolvedRegistryAcpAgent) => {
+      const launch = entry.launch;
+      if (!launch) return;
+      setSelectedAcpRegistryAgentId(entry.agent.id);
+      setConfigByDriver((existing) => ({
+        ...existing,
+        [ACP_REGISTRY_DRIVER_KIND]: {
+          ...(existing[ACP_REGISTRY_DRIVER_KIND] ?? {}),
+          command: launch.command,
+          args: launch.args,
+          env: launch.env,
+          iconUrl: entry.agent.icon ?? "",
+          registryAgentId: entry.agent.id,
+          importedVersion: entry.agent.version,
+          distributionType: entry.distributionType,
+        },
+      }));
+      setEnvironmentVariables(envRecordToVariables(launch.env));
+      if (!labelDirty) {
+        setLabel(entry.agent.name);
+      }
+      if (!instanceIdDirty) {
+        setInstanceId(deriveInstanceId(ACP_REGISTRY_DRIVER_KIND, entry.agent.name));
+      }
+    },
+    [instanceIdDirty, labelDirty],
+  );
+
+  const selectInstallableAcpRegistryAgent = useCallback(
+    (entry: ResolvedRegistryAcpAgent) => {
+      setSelectedAcpRegistryAgentId(entry.agent.id);
+      setInstallPath(entry.binaryInstall?.defaultInstallPath ?? "");
+      setEnvironmentVariables([]);
+      if (!labelDirty) {
+        setLabel(entry.agent.name);
+      }
+      if (!instanceIdDirty) {
+        setInstanceId(deriveInstanceId(ACP_REGISTRY_DRIVER_KIND, entry.agent.name));
+      }
+    },
+    [instanceIdDirty, labelDirty],
+  );
+
+  const selectManualAcpRegistryAgent = useCallback(() => {
+    setSelectedAcpRegistryAgentId(MANUAL_ACP_REGISTRY_OPTION);
+    setEnvironmentVariables([]);
+  }, []);
+
+  const handleInstallAcpRegistryAgent = useCallback(async () => {
+    const entry = installConfirmAgent;
+    if (!entry) return;
+    setInstallingAcpAgentId(entry.agent.id);
+    try {
+      const trimmedInstallPath = installPath.trim();
+      const result = await ensureLocalApi().server.installAcpRegistryBinary({
+        agentId: entry.agent.id,
+        ...(trimmedInstallPath ? { installPath: trimmedInstallPath } : {}),
+      });
+      if (!result.ok || !result.agent) {
+        throw new Error(result.error ?? "Install failed.");
+      }
+      setAcpRegistryState((current) => ({
+        ...current,
+        agents: current.agents.map((candidate) =>
+          candidate.agent.id === result.agent?.agent.id ? result.agent : candidate,
+        ),
+      }));
+      applyAcpRegistryAgent(result.agent);
+      setInstallConfirmAgent(null);
+      setWizardStep(identityStepIndex);
+      toastManager.add({
+        type: "success",
+        title: "ACP agent installed",
+        description: `${entry.agent.name} is ready to use.`,
+      });
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Could not install ACP agent",
+        description: error instanceof Error ? error.message : "Install failed.",
+      });
+    } finally {
+      setInstallingAcpAgentId(null);
+    }
+  }, [applyAcpRegistryAgent, identityStepIndex, installConfirmAgent, installPath]);
+
+  const handleAdvanceWizard = useCallback(() => {
+    if (wizardStep === registryStepIndex && selectedAcpRegistryAgentNeedsInstall) {
+      setInstallPath(selectedAcpRegistryAgent?.binaryInstall?.defaultInstallPath ?? "");
+      setInstallConfirmAgent(selectedAcpRegistryAgent);
+      return;
+    }
+    setWizardStep((step) => Math.min(configStepIndex, step + 1));
+  }, [
+    configStepIndex,
+    registryStepIndex,
+    selectedAcpRegistryAgent,
+    selectedAcpRegistryAgentNeedsInstall,
+    wizardStep,
+  ]);
+
+  const updateEnvironmentVariable = useCallback(
+    (
+      index: number,
+      patch: Partial<Pick<EnvironmentVariableDraft, "name" | "value" | "sensitive">>,
+    ) => {
+      setEnvironmentVariables((existing) =>
+        existing.map((variable, variableIndex) =>
+          variableIndex === index ? { ...variable, ...patch } : variable,
+        ),
+      );
+    },
+    [],
+  );
+
+  const removeEnvironmentVariable = useCallback((index: number) => {
+    setEnvironmentVariables((existing) =>
+      existing.filter((_variable, variableIndex) => variableIndex !== index),
+    );
+  }, []);
+
   const handleSave = useCallback(() => {
     setHasAttemptedSubmit(true);
     if (instanceIdError !== null) return;
 
-    const config = configByDriver[driver] ?? {};
+    const config: Record<string, unknown> = { ...(configByDriver[driver] ?? {}) };
+    if (driver === ACP_REGISTRY_DRIVER_KIND && selectedAcpRegistryAgent) {
+      config.registryAgentId = selectedAcpRegistryAgent.agent.id;
+      config.importedVersion = selectedAcpRegistryAgent.agent.version;
+      config.distributionType = selectedAcpRegistryAgent.distributionType;
+      if (selectedAcpRegistryAgent.agent.icon) {
+        config.iconUrl = selectedAcpRegistryAgent.agent.icon;
+      }
+    }
     const hasConfig = Object.keys(config).length > 0;
     const normalizedAccentColor = normalizeProviderAccentColor(accentColor);
+    const cleanedEnvironment = environmentVariables
+      .map((variable) => ({
+        value: variable.value,
+        sensitive: variable.sensitive,
+        name: variable.name.trim(),
+      }))
+      .filter((variable) => ENVIRONMENT_VARIABLE_NAME_PATTERN.test(variable.name));
 
     const nextInstance: ProviderInstanceConfig = {
       driver,
       enabled: true,
       ...(label.trim().length > 0 ? { displayName: label.trim() } : {}),
       ...(normalizedAccentColor ? { accentColor: normalizedAccentColor } : {}),
+      ...(cleanedEnvironment.length > 0 ? { environment: cleanedEnvironment } : {}),
+      ...(selectedAcpRegistryAgent?.agent.icon
+        ? { iconUrl: selectedAcpRegistryAgent.agent.icon }
+        : {}),
       ...(hasConfig ? { config } : {}),
     };
-    // `ProviderInstanceId.make` revalidates the slug; we've already checked
-    // it via `validateInstanceId`, but going through the brand constructor
-    // keeps the type boundary honest and guards against any future drift in
-    // the slug rules.
     const brandedId = ProviderInstanceId.make(instanceId);
     const nextMap = {
       ...settings.providerInstances,
@@ -223,269 +553,546 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
       });
     }
   }, [
+    accentColor,
+    configByDriver,
     driver,
     driverOption,
-    configByDriver,
+    environmentVariables,
     instanceId,
     instanceIdError,
     label,
-    accentColor,
     onOpenChange,
+    selectedAcpRegistryAgent,
     settings.providerInstances,
     updateSettings,
   ]);
 
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogPopup className="max-w-xl overflow-hidden">
-        <div className="flex min-h-0 flex-col overflow-hidden border-foreground/10 bg-background shadow-2xl">
-          <DialogHeader className="border-b border-border/70 bg-background">
-            <DialogTitle>Add provider instance</DialogTitle>
-            <DialogDescription>
-              Configure an additional provider instance — for example, a second Codex install
-              pointed at a different workspace.
-            </DialogDescription>
-            <div className="grid grid-cols-3 gap-2">
-              {wizardSteps.map((step, index) => (
-                <button
-                  key={step}
-                  type="button"
-                  className={cn(
-                    "grid min-w-0 grid-cols-[1rem_minmax(0,1fr)] gap-x-2 rounded-lg border px-3 py-2 text-left",
-                    index === wizardStep
-                      ? "border-primary bg-primary/10 ring-1 ring-primary/25"
-                      : index < wizardStep
-                        ? "border-border bg-background"
-                        : "border-border bg-muted/40",
-                  )}
-                  onClick={() => setWizardStep(index)}
-                >
-                  <span
-                    className={cn(
-                      "row-span-2 mt-0.5 grid size-4 place-items-center rounded-full border",
-                      index < wizardStep
-                        ? "border-primary bg-primary text-primary-foreground"
-                        : index === wizardStep
-                          ? "border-primary bg-background"
-                          : "border-muted-foreground/35 bg-background",
-                    )}
-                    aria-hidden
-                  >
-                    {index < wizardStep ? <CheckIcon className="size-3" /> : null}
-                  </span>
-                  <span className="text-[10px] font-medium uppercase text-muted-foreground">
-                    Step {index + 1}
-                  </span>
-                  <span className="truncate text-xs font-semibold text-foreground">
-                    {step}
-                    {index < wizardStep && wizardStepSummaries[index]
-                      ? `: ${wizardStepSummaries[index]}`
-                      : ""}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </DialogHeader>
-
-          <div
-            data-slot="dialog-panel"
-            className="space-y-4 border-b border-border/70 bg-muted/20 px-6 py-5"
-          >
-            <AnimatedHeight>
-              <div className={cn("grid gap-2", wizardStep !== 0 && "hidden")}>
-                <span
-                  id="add-instance-driver-label"
-                  className="text-xs font-medium text-foreground"
-                >
-                  Driver
-                </span>
-                <RadioGroup
-                  value={driver}
-                  onValueChange={(value) => setDriver(ProviderDriverKind.make(value))}
-                  aria-labelledby="add-instance-driver-label"
-                  className="grid grid-cols-2 gap-2.5"
-                >
-                  {DRIVER_OPTIONS.map((option) => {
-                    const IconComponent = option.icon;
-                    const isSelected = option.value === driver;
-                    return (
-                      <RadioPrimitive.Root
-                        key={option.value}
-                        value={option.value}
-                        className={cn(
-                          "relative flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-3 text-left outline-none transition-[background-color,border-color,box-shadow]",
-                          "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
-                          isSelected
-                            ? "border-primary bg-background shadow-sm ring-2 ring-primary/35"
-                            : "border-border bg-background hover:border-foreground/20 hover:bg-muted/50",
-                        )}
-                      >
-                        <IconComponent className="size-5 shrink-0" aria-hidden />
-                        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                          {option.label}
-                        </span>
-                        {option.badgeLabel ? (
-                          <Badge variant="warning" size="sm">
-                            {option.badgeLabel}
-                          </Badge>
-                        ) : null}
-                      </RadioPrimitive.Root>
-                    );
-                  })}
-                  {COMING_SOON_DRIVER_OPTIONS.map((option) => {
-                    const IconComponent = option.icon;
-                    return (
-                      <RadioPrimitive.Root
-                        key={option.value}
-                        value={option.value}
-                        disabled
-                        className={cn(
-                          "relative flex cursor-not-allowed items-center gap-3 rounded-lg border border-border bg-background px-3 py-3 text-left opacity-55 outline-none",
-                        )}
-                      >
-                        <IconComponent
-                          className="size-5 shrink-0 text-muted-foreground"
-                          aria-hidden
-                        />
-                        <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
-                          {option.label}
-                        </span>
-                        <Badge variant="warning" size="sm">
-                          Coming Soon
-                        </Badge>
-                      </RadioPrimitive.Root>
-                    );
-                  })}
-                </RadioGroup>
-              </div>
-
-              <label className={cn("grid gap-2", wizardStep !== 1 && "hidden")}>
-                <span className="text-xs font-medium text-foreground">Label</span>
+  const renderEnvironmentVariables = () => (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-xs font-medium text-foreground">Environment variables</span>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1.5 px-2 text-xs"
+          onClick={() =>
+            setEnvironmentVariables((existing) => [...existing, emptyEnvironmentVariable()])
+          }
+        >
+          <PlusIcon className="size-3" />
+          Add
+        </Button>
+      </div>
+      {environmentVariables.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Add variables to pass API keys, base URLs, or other per-instance CLI settings.
+        </p>
+      ) : (
+        <div className="grid gap-2">
+          {environmentVariables.map((variable, index) => {
+            const name = variable.name.trim();
+            const nameInvalid = name.length > 0 && !ENVIRONMENT_VARIABLE_NAME_PATTERN.test(name);
+            return (
+              <div
+                key={variable.id}
+                className="grid gap-2 rounded-md border border-border/70 bg-muted/20 p-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_auto_auto] sm:items-center"
+              >
                 <Input
-                  className="bg-background"
-                  placeholder="e.g. Work"
-                  value={label}
-                  onChange={(event) => setLabel(event.target.value)}
+                  value={variable.name}
+                  onChange={(event) =>
+                    updateEnvironmentVariable(index, { name: event.target.value })
+                  }
+                  placeholder="VARIABLE_NAME"
+                  spellCheck={false}
+                  aria-label={`Environment variable name ${index + 1}`}
+                  className={cn("bg-background", nameInvalid && "border-destructive")}
                 />
-                <span className="text-[11px] text-muted-foreground">
-                  Shown in the provider list. Optional.
-                </span>
-              </label>
-
-              <label className={cn("grid gap-2", wizardStep !== 1 && "hidden")}>
-                <span className="text-xs font-medium text-foreground">Instance ID</span>
                 <Input
+                  value={variable.value}
+                  onChange={(event) =>
+                    updateEnvironmentVariable(index, { value: event.target.value })
+                  }
+                  type={variable.sensitive ? "password" : undefined}
+                  autoComplete="off"
+                  placeholder="Value"
+                  spellCheck={false}
+                  aria-label={`Environment variable value ${index + 1}`}
                   className="bg-background"
-                  placeholder={`${driver}_work`}
-                  value={instanceId}
-                  onChange={(event) => {
-                    setInstanceIdDirty(true);
-                    setInstanceId(event.target.value);
-                  }}
-                  aria-invalid={showInstanceIdError}
                 />
-                {showInstanceIdError ? (
-                  <span className="text-[11px] text-destructive">{instanceIdError}</span>
-                ) : (
-                  <span className="text-[11px] text-muted-foreground">
-                    Routing key used by threads and sessions. Letters, digits, '-', or '_'.
-                  </span>
-                )}
-              </label>
-
-              <div className={cn("grid gap-2", wizardStep !== 1 && "hidden")}>
-                <span className="text-xs font-medium text-foreground">Accent color</span>
-                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <label className="inline-flex h-8 items-center gap-2 text-xs text-muted-foreground">
                   <input
-                    type="color"
-                    value={normalizeProviderAccentColor(accentColor) ?? PROVIDER_ACCENT_SWATCHES[0]}
-                    onChange={(event) => setAccentColor(event.target.value)}
-                    aria-label="Provider instance accent color"
-                    className="h-8 w-10 cursor-pointer rounded-xl border border-input bg-background p-0.5"
+                    type="checkbox"
+                    className="size-3.5"
+                    checked={variable.sensitive}
+                    onChange={(event) =>
+                      updateEnvironmentVariable(index, {
+                        sensitive: event.currentTarget.checked,
+                      })
+                    }
                   />
-                  <div className="flex flex-wrap gap-1.5">
-                    {PROVIDER_ACCENT_SWATCHES.map((swatch) => {
-                      const selected = accentColor.toLowerCase() === swatch;
+                  Sensitive
+                </label>
+                <Button
+                  type="button"
+                  size="icon-sm"
+                  variant="ghost"
+                  className="size-8 justify-self-start text-muted-foreground hover:text-destructive sm:justify-self-end"
+                  onClick={() => removeEnvironmentVariable(index)}
+                  aria-label={`Remove environment variable ${variable.name || index + 1}`}
+                >
+                  <XIcon className="size-3.5" />
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <span className="text-xs text-muted-foreground">
+        Sensitive values are stored separately and are not returned to the app after saving.
+      </span>
+    </div>
+  );
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogPopup className="max-w-xl overflow-hidden">
+          <div className="flex min-h-0 flex-col overflow-hidden border-foreground/10 bg-background shadow-2xl">
+            <DialogHeader className="border-b border-border/70 bg-background">
+              <DialogTitle>Add provider instance</DialogTitle>
+              <DialogDescription>
+                Configure an additional provider instance — for example, a second Codex install
+                pointed at a different workspace.
+              </DialogDescription>
+              <div
+                className="grid gap-2"
+                style={{ gridTemplateColumns: `repeat(${wizardSteps.length}, minmax(0, 1fr))` }}
+              >
+                {wizardSteps.map((step, index) => (
+                  <button
+                    key={step}
+                    type="button"
+                    className={cn(
+                      "grid min-w-0 grid-cols-[1rem_minmax(0,1fr)] gap-x-2 rounded-lg border px-3 py-2 text-left transition",
+                      index === wizardStep
+                        ? "border-primary bg-primary/10 ring-1 ring-primary/25"
+                        : index < wizardStep
+                          ? "border-border bg-background"
+                          : "border-border bg-muted/40",
+                    )}
+                    onClick={() => setWizardStep(index)}
+                  >
+                    <span
+                      className={cn(
+                        "row-span-2 mt-0.5 grid size-4 place-items-center rounded-full border",
+                        index < wizardStep
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : index === wizardStep
+                            ? "border-primary bg-background"
+                            : "border-muted-foreground/35 bg-background",
+                      )}
+                      aria-hidden
+                    >
+                      {index < wizardStep ? <CheckIcon className="size-3" /> : null}
+                    </span>
+                    <span className="text-[10px] font-medium uppercase text-muted-foreground">
+                      Step {index + 1}
+                    </span>
+                    <span className="truncate text-xs font-semibold text-foreground">
+                      {step}
+                      {index < wizardStep && wizardStepSummaries[index]
+                        ? `: ${wizardStepSummaries[index]}`
+                        : ""}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </DialogHeader>
+
+            <div
+              data-slot="dialog-panel"
+              className="space-y-4 border-b border-border/70 bg-muted/20 px-6 py-5"
+            >
+              <AnimatedHeight>
+                <div className={cn("grid gap-2", wizardStep !== 0 && "hidden")}>
+                  <span
+                    id="add-instance-driver-label"
+                    className="text-xs font-medium text-foreground"
+                  >
+                    Driver
+                  </span>
+                  <RadioGroup
+                    value={driver}
+                    onValueChange={(value) => setDriver(ProviderDriverKind.make(value))}
+                    aria-labelledby="add-instance-driver-label"
+                    className="grid grid-cols-2 gap-2.5"
+                  >
+                    {DRIVER_OPTIONS.map((option) => {
+                      const IconComponent = option.icon;
+                      const isSelected = option.value === driver;
                       return (
-                        <button
-                          key={swatch}
-                          type="button"
+                        <RadioPrimitive.Root
+                          key={option.value}
+                          value={option.value}
                           className={cn(
-                            "size-6 cursor-pointer rounded-full border transition",
-                            selected
-                              ? "scale-110 border-foreground ring-2 ring-ring ring-offset-1 ring-offset-background"
-                              : "border-black/10 hover:scale-105 dark:border-white/20",
+                            "relative flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-3 text-left outline-none transition-[background-color,border-color,box-shadow]",
+                            "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                            isSelected
+                              ? "border-primary bg-background shadow-sm ring-2 ring-primary/35"
+                              : "border-border bg-background hover:border-foreground/20 hover:bg-muted/50",
                           )}
-                          style={{ backgroundColor: swatch }}
-                          onClick={() => setAccentColor(swatch)}
-                          aria-label={`Use ${swatch} accent`}
-                        />
+                        >
+                          <IconComponent className="size-5 shrink-0" aria-hidden />
+                          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                            {option.label}
+                          </span>
+                          {option.badgeLabel ? (
+                            <Badge variant="warning" size="sm">
+                              {option.badgeLabel}
+                            </Badge>
+                          ) : null}
+                        </RadioPrimitive.Root>
+                      );
+                    })}
+                    {COMING_SOON_DRIVER_OPTIONS.map((option) => {
+                      const IconComponent = option.icon;
+                      return (
+                        <RadioPrimitive.Root
+                          key={option.value}
+                          value={option.value}
+                          disabled
+                          className="relative flex cursor-not-allowed items-center gap-3 rounded-lg border border-border bg-background px-3 py-3 text-left opacity-55 outline-none"
+                        >
+                          <IconComponent
+                            className="size-5 shrink-0 text-muted-foreground"
+                            aria-hidden
+                          />
+                          <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                            {option.label}
+                          </span>
+                          <Badge variant="warning" size="sm">
+                            Coming Soon
+                          </Badge>
+                        </RadioPrimitive.Root>
+                      );
+                    })}
+                  </RadioGroup>
+                </div>
+
+                <div className={cn("grid gap-3", wizardStep !== registryStepIndex && "hidden")}>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <div className="relative min-w-0 flex-1">
+                      <SearchIcon
+                        className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+                        aria-hidden
+                      />
+                      <Input
+                        className="bg-background pl-8"
+                        placeholder="Search ACP agents..."
+                        value={acpRegistrySearch}
+                        onChange={(event) => setAcpRegistrySearch(event.target.value)}
+                        spellCheck={false}
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="outline"
+                      className="size-9"
+                      onClick={() => void loadAcpRegistry()}
+                      aria-label="Refresh ACP registry"
+                      disabled={acpRegistryState.status === "loading"}
+                    >
+                      {acpRegistryState.status === "loading" ? (
+                        <Loader2Icon className="size-4 animate-spin" />
+                      ) : (
+                        <RefreshCwIcon className="size-4" />
+                      )}
+                    </Button>
+                  </div>
+
+                  {acpRegistryState.status === "error" ? (
+                    <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                      {acpRegistryState.error}
+                    </div>
+                  ) : null}
+
+                  <div className="max-h-72 space-y-2 overflow-y-auto pr-1">
+                    <button
+                      type="button"
+                      className={cn(
+                        "w-full rounded-lg border px-3 py-2.5 text-left transition",
+                        selectedAcpRegistryAgentId === MANUAL_ACP_REGISTRY_OPTION
+                          ? "border-primary bg-background ring-2 ring-primary/25"
+                          : "border-border bg-background hover:border-foreground/20 hover:bg-muted/50",
+                      )}
+                      onClick={selectManualAcpRegistryAgent}
+                    >
+                      <div className="text-sm font-medium text-foreground">Manual ACP agent</div>
+                      <div className="mt-0.5 text-xs text-muted-foreground">
+                        Enter a launch command yourself on the next step.
+                      </div>
+                    </button>
+
+                    {filteredAcpRegistryAgents.map((entry) => {
+                      const isSelected = selectedAcpRegistryAgentId === entry.agent.id;
+                      const canInstall =
+                        entry.distributionType === "binaryUnsupported" && entry.binaryInstall;
+                      const selectable = Boolean(canInstall || (entry.supported && entry.launch));
+                      const unavailable = !selectable;
+                      return (
+                        <div
+                          key={entry.agent.id}
+                          role={selectable ? "button" : undefined}
+                          tabIndex={selectable ? 0 : undefined}
+                          className={cn(
+                            "w-full rounded-lg border px-3 py-2.5 text-left transition",
+                            isSelected
+                              ? "border-primary bg-background ring-2 ring-primary/25"
+                              : "border-border bg-background hover:border-foreground/20 hover:bg-muted/50",
+                            unavailable &&
+                              "cursor-not-allowed opacity-50 hover:border-border hover:bg-background",
+                          )}
+                          onClick={() => {
+                            if (canInstall) {
+                              selectInstallableAcpRegistryAgent(entry);
+                            } else if (entry.supported && entry.launch) {
+                              applyAcpRegistryAgent(entry);
+                            }
+                          }}
+                          onKeyDown={(event) => {
+                            if (!selectable || (event.key !== "Enter" && event.key !== " ")) {
+                              return;
+                            }
+                            event.preventDefault();
+                            if (canInstall) {
+                              selectInstallableAcpRegistryAgent(entry);
+                            } else {
+                              applyAcpRegistryAgent(entry);
+                            }
+                          }}
+                        >
+                          <div className="flex min-w-0 items-center gap-2">
+                            {entry.agent.icon ? (
+                              <img
+                                src={entry.agent.icon}
+                                alt=""
+                                className="size-5 shrink-0 rounded-sm object-contain dark:invert"
+                                draggable={false}
+                              />
+                            ) : null}
+                            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                              {entry.agent.name}
+                            </span>
+                            <Badge variant="outline" size="sm">
+                              {entry.agent.version}
+                            </Badge>
+                            <Badge variant={entry.supported ? "secondary" : "warning"} size="sm">
+                              {acpDistributionLabel(entry)}
+                            </Badge>
+                          </div>
+                          <div className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                            {entry.agent.description}
+                          </div>
+                        </div>
                       );
                     })}
                   </div>
-                  {accentColor ? (
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      className="h-7 px-2 text-xs text-muted-foreground"
-                      onClick={() => setAccentColor("")}
-                    >
-                      Clear
-                    </Button>
-                  ) : null}
                 </div>
-                <span className="text-[11px] text-muted-foreground">
-                  Optional marker shown in the picker.
-                </span>
-              </div>
 
-              {driverSettingsFields.length > 0 ? (
-                <div className={cn("grid gap-4", wizardStep !== 2 && "hidden")}>
-                  <ProviderSettingsForm
-                    definition={driverOption}
-                    value={configDraft}
-                    idPrefix={`add-provider-${driver}`}
-                    variant="dialog"
-                    onChange={setConfigDraft}
+                <label className={cn("grid gap-2", wizardStep !== identityStepIndex && "hidden")}>
+                  <span className="text-xs font-medium text-foreground">Label</span>
+                  <Input
+                    className="bg-background"
+                    placeholder="e.g. Work"
+                    value={label}
+                    onChange={(event) => {
+                      setLabelDirty(true);
+                      setLabel(event.target.value);
+                    }}
                   />
-                </div>
-              ) : wizardStep === 2 ? (
-                <div className="grid gap-2">
-                  <p className="text-sm text-muted-foreground">
-                    This driver has no required configuration. You can add the instance now.
-                  </p>
-                </div>
-              ) : null}
-            </AnimatedHeight>
-          </div>
+                  <span className="text-[11px] text-muted-foreground">
+                    Shown in the provider list. Optional.
+                  </span>
+                </label>
 
-          <DialogFooter className="border-t bg-background">
+                <label className={cn("grid gap-2", wizardStep !== identityStepIndex && "hidden")}>
+                  <span className="text-xs font-medium text-foreground">Instance ID</span>
+                  <Input
+                    className="bg-background"
+                    placeholder={`${driver}_work`}
+                    value={instanceId}
+                    onChange={(event) => {
+                      setInstanceIdDirty(true);
+                      setInstanceId(event.target.value);
+                    }}
+                    aria-invalid={showInstanceIdError}
+                  />
+                  {showInstanceIdError ? (
+                    <span className="text-[11px] text-destructive">{instanceIdError}</span>
+                  ) : (
+                    <span className="text-[11px] text-muted-foreground">
+                      Routing key used by threads and sessions. Letters, digits, '-', or '_'.
+                    </span>
+                  )}
+                </label>
+
+                <div className={cn("grid gap-2", wizardStep !== identityStepIndex && "hidden")}>
+                  <span className="text-xs font-medium text-foreground">Accent color</span>
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <input
+                      type="color"
+                      value={
+                        normalizeProviderAccentColor(accentColor) ?? PROVIDER_ACCENT_SWATCHES[0]
+                      }
+                      onChange={(event) => setAccentColor(event.target.value)}
+                      aria-label="Provider instance accent color"
+                      className="h-8 w-10 cursor-pointer rounded-xl border border-input bg-background p-0.5"
+                    />
+                    <div className="flex flex-wrap gap-1.5">
+                      {PROVIDER_ACCENT_SWATCHES.map((swatch) => {
+                        const selected = accentColor.toLowerCase() === swatch;
+                        return (
+                          <button
+                            key={swatch}
+                            type="button"
+                            className={cn(
+                              "size-6 cursor-pointer rounded-full border transition",
+                              selected
+                                ? "scale-110 border-foreground ring-2 ring-ring ring-offset-1 ring-offset-background"
+                                : "border-black/10 hover:scale-105 dark:border-white/20",
+                            )}
+                            style={{ backgroundColor: swatch }}
+                            onClick={() => setAccentColor(swatch)}
+                            aria-label={`Use ${swatch} accent`}
+                          />
+                        );
+                      })}
+                    </div>
+                    {accentColor ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 px-2 text-xs text-muted-foreground"
+                        onClick={() => setAccentColor("")}
+                      >
+                        Clear
+                      </Button>
+                    ) : null}
+                  </div>
+                  <span className="text-[11px] text-muted-foreground">
+                    Optional marker shown in the picker.
+                  </span>
+                </div>
+
+                <div className={cn("grid gap-4", wizardStep !== configStepIndex && "hidden")}>
+                  {driverSettingsFields.length > 0 ? (
+                    <ProviderSettingsForm
+                      definition={driverOption}
+                      value={configDraft}
+                      idPrefix={`add-provider-${driver}`}
+                      variant="dialog"
+                      onChange={setConfigDraft}
+                    />
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      This driver has no required configuration. You can add the instance now.
+                    </p>
+                  )}
+                  {renderEnvironmentVariables()}
+                </div>
+              </AnimatedHeight>
+            </div>
+
+            <DialogFooter className="border-t bg-background">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  if (wizardStep === 0) {
+                    onOpenChange(false);
+                    return;
+                  }
+                  setWizardStep((step) => Math.max(0, step - 1));
+                }}
+              >
+                {wizardStep === 0 ? "Cancel" : "Back"}
+              </Button>
+              {wizardStep < wizardSteps.length - 1 ? (
+                <Button size="sm" onClick={handleAdvanceWizard}>
+                  {wizardStep === registryStepIndex && selectedAcpRegistryAgentNeedsInstall
+                    ? "Install"
+                    : "Next"}
+                </Button>
+              ) : (
+                <Button size="sm" onClick={handleSave}>
+                  Add instance
+                </Button>
+              )}
+            </DialogFooter>
+          </div>
+        </DialogPopup>
+      </Dialog>
+      <AlertDialog
+        open={installConfirmAgent !== null}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && !installingConfirmAgent) setInstallConfirmAgent(null);
+        }}
+      >
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Install {installConfirmAgent?.agent.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              T3 Code will download and extract this agent binary from the archive URL published in
+              the ACP registry. The registry does not currently provide checksums or signatures, so
+              only install agents from publishers you trust.
+            </AlertDialogDescription>
+            {installConfirmAgent?.binaryInstall ? (
+              <div className="grid gap-3 pt-2 text-left">
+                <div className="grid gap-1.5">
+                  <span className="text-xs font-medium text-foreground">Download URL</span>
+                  <ScrollArea
+                    hideScrollbars
+                    scrollFade
+                    className="h-[34px] min-w-0 rounded-md border bg-background"
+                  >
+                    <div className="w-max select-all py-2 pr-2.5 pl-2.5 font-mono text-[11px] text-muted-foreground whitespace-nowrap">
+                      {installConfirmAgent.binaryInstall.archiveUrl}
+                    </div>
+                  </ScrollArea>
+                </div>
+                <div className="flex items-center justify-center text-muted-foreground">
+                  <ArrowRightIcon className="size-4 rotate-90 sm:rotate-0" />
+                </div>
+                <label className="grid gap-1.5">
+                  <span className="text-xs font-medium text-foreground">Binary path</span>
+                  <Input
+                    value={installPath}
+                    onChange={(event) => setInstallPath(event.target.value)}
+                    spellCheck={false}
+                    className="bg-background font-mono text-xs"
+                    placeholder={installConfirmAgent.binaryInstall.defaultInstallPath}
+                  />
+                </label>
+              </div>
+            ) : null}
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" disabled={installingConfirmAgent} />}>
+              Cancel
+            </AlertDialogClose>
             <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                if (wizardStep === 0) {
-                  onOpenChange(false);
-                  return;
-                }
-                setWizardStep((step) => Math.max(0, step - 1));
-              }}
+              disabled={installingConfirmAgent}
+              onClick={() => void handleInstallAcpRegistryAgent()}
             >
-              {wizardStep === 0 ? "Cancel" : "Back"}
+              {installingConfirmAgent ? <Loader2Icon className="mr-1 size-3 animate-spin" /> : null}
+              Install
             </Button>
-            {wizardStep < wizardSteps.length - 1 ? (
-              <Button size="sm" onClick={() => setWizardStep((step) => Math.min(2, step + 1))}>
-                Next
-              </Button>
-            ) : (
-              <Button size="sm" onClick={handleSave}>
-                Add instance
-              </Button>
-            )}
-          </DialogFooter>
-        </div>
-      </DialogPopup>
-    </Dialog>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
   );
 }

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -124,6 +124,71 @@ function validateInstanceId(id: string, existing: ReadonlySet<string>): string |
   return null;
 }
 
+function acpRegistryAgentSearchFields(entry: ResolvedRegistryAcpAgent): string[] {
+  return [
+    entry.agent.name,
+    entry.agent.id,
+    entry.agent.description,
+    entry.agent.repository,
+    entry.agent.website,
+    entry.distributionType,
+    entry.launch?.command,
+    ...(entry.launch?.args ?? []),
+  ]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .map((value) => normalizeSearchQuery(value));
+}
+
+function acpRegistryAgentSearchText(entry: ResolvedRegistryAcpAgent): string {
+  return acpRegistryAgentSearchFields(entry).join(" ");
+}
+
+function scoreAcpRegistryAgentSearchToken(
+  field: string,
+  token: string,
+  fieldBase: number,
+): number | null {
+  return scoreQueryMatch({
+    value: field,
+    query: token,
+    exactBase: fieldBase,
+    prefixBase: fieldBase + 2,
+    boundaryBase: fieldBase + 4,
+    includesBase: fieldBase + 6,
+    ...(token.length >= 3 ? { fuzzyBase: fieldBase + 100 } : {}),
+  });
+}
+
+function scoreAcpRegistryAgentSearch(
+  entry: ResolvedRegistryAcpAgent,
+  query: string,
+): number | null {
+  const tokens = normalizeSearchQuery(query)
+    .split(/\s+/u)
+    .filter((token) => token.length > 0);
+
+  if (tokens.length === 0) {
+    return 0;
+  }
+
+  const fields = acpRegistryAgentSearchFields(entry);
+  const combinedField = acpRegistryAgentSearchText(entry);
+  let score = 0;
+
+  for (const token of tokens) {
+    const tokenScores = [...fields, combinedField]
+      .map((field, index) => scoreAcpRegistryAgentSearchToken(field, token, index * 10))
+      .filter((fieldScore): fieldScore is number => fieldScore !== null);
+
+    if (tokenScores.length === 0) {
+      return null;
+    }
+
+    score += Math.min(...tokenScores);
+  }
+
+  return score;
+}
 function envRecordToVariables(
   env: Record<string, string> | null | undefined,
 ): ReadonlyArray<EnvironmentVariableDraft> {
@@ -159,49 +224,6 @@ function acpDistributionLabel(entry: ResolvedRegistryAcpAgent): string {
     case "manual":
       return "Manual";
   }
-}
-
-function acpRegistryAgentSearchFields(entry: ResolvedRegistryAcpAgent): readonly string[] {
-  return [
-    entry.agent.name,
-    entry.agent.id,
-    entry.agent.description,
-    entry.agent.repository,
-    entry.agent.website,
-    entry.distributionType,
-    entry.launch?.command,
-    ...(entry.launch?.args ?? []),
-  ]
-    .filter((value): value is string => typeof value === "string" && value.length > 0)
-    .map((value) => normalizeSearchQuery(value));
-}
-
-function scoreAcpRegistryAgentSearch(entry: ResolvedRegistryAcpAgent, query: string): number | null {
-  const tokens = normalizeSearchQuery(query)
-    .split(/\s+/u)
-    .filter((token) => token.length > 0);
-  if (tokens.length === 0) return 0;
-
-  const fields = acpRegistryAgentSearchFields(entry);
-  let score = 0;
-  for (const token of tokens) {
-    const tokenScores = fields
-      .map((field, index) =>
-        scoreQueryMatch({
-          value: field,
-          query: token,
-          exactBase: index * 10,
-          prefixBase: index * 10 + 2,
-          boundaryBase: index * 10 + 4,
-          includesBase: index * 10 + 6,
-          ...(token.length >= 3 ? { fuzzyBase: index * 10 + 100 } : {}),
-        }),
-      )
-      .filter((fieldScore): fieldScore is number => fieldScore !== null);
-    if (tokenScores.length === 0) return null;
-    score += Math.min(...tokenScores);
-  }
-  return score;
 }
 
 type AcpRegistryState =
@@ -327,14 +349,29 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
   ] as const;
   const filteredAcpRegistryAgents = useMemo(() => {
     const query = acpRegistrySearch.trim();
-    if (!query) return acpRegistryState.agents;
-    return acpRegistryState.agents
-      .map((entry) => ({ entry, score: scoreAcpRegistryAgentSearch(entry, query) }))
-      .filter((result): result is { entry: ResolvedRegistryAcpAgent; score: number } => {
-        return result.score !== null;
+    const agents = acpRegistryState.agents;
+    if (!query) return agents;
+    return agents
+      .map((entry) => ({
+        entry,
+        score: scoreAcpRegistryAgentSearch(entry, query),
+        tieBreaker: acpRegistryAgentSearchText(entry),
+      }))
+      .filter(
+        (
+          rankedAgent,
+        ): rankedAgent is {
+          entry: ResolvedRegistryAcpAgent;
+          score: number;
+          tieBreaker: string;
+        } => rankedAgent.score !== null,
+      )
+      .toSorted((left, right) => {
+        const scoreDelta = left.score - right.score;
+        if (scoreDelta !== 0) return scoreDelta;
+        return left.tieBreaker.localeCompare(right.tieBreaker);
       })
-      .toSorted((left, right) => left.score - right.score || left.entry.agent.name.localeCompare(right.entry.agent.name))
-      .map((result) => result.entry);
+      .map((rankedAgent) => rankedAgent.entry);
   }, [acpRegistrySearch, acpRegistryState.agents]);
 
   const loadAcpRegistry = useCallback(async () => {
@@ -384,7 +421,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
       setConfigByDriver((existing) => ({
         ...existing,
         [ACP_REGISTRY_DRIVER_KIND]: {
-          ...(existing[ACP_REGISTRY_DRIVER_KIND] ?? {}),
+          ...existing[ACP_REGISTRY_DRIVER_KIND],
           command: launch.command,
           args: launch.args,
           env: launch.env,
@@ -502,7 +539,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
     setHasAttemptedSubmit(true);
     if (instanceIdError !== null) return;
 
-    const config: Record<string, unknown> = { ...(configByDriver[driver] ?? {}) };
+    const config: Record<string, unknown> = { ...configByDriver[driver] };
     if (driver === ACP_REGISTRY_DRIVER_KIND && selectedAcpRegistryAgent) {
       config.registryAgentId = selectedAcpRegistryAgent.agent.id;
       config.importedVersion = selectedAcpRegistryAgent.agent.version;
@@ -1080,7 +1117,9 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
             ) : null}
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogClose render={<Button variant="outline" disabled={installingConfirmAgent} />}>
+            <AlertDialogClose
+              render={<Button variant="outline" disabled={installingConfirmAgent} />}
+            >
               Cancel
             </AlertDialogClose>
             <Button

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -546,6 +546,7 @@ export function ProviderInstanceCard({
                   driverKind={driverKind}
                   displayName={displayName}
                   accentColor={accentColor}
+                  iconUrl={instance.iconUrl ?? liveProvider?.iconUrl}
                   showBadge={Boolean(accentColor)}
                   statusDotClassName={statusStyle.dot}
                   className="size-5"

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -38,6 +38,7 @@ import {
 } from "../../modelSelection";
 import {
   deriveProviderInstanceEntries,
+  isModelPickerProviderInstanceEntry,
   sortProviderInstanceEntries,
 } from "../../providerInstances";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
@@ -514,7 +515,7 @@ export function GeneralSettingsPanel() {
   const textGenModel = textGenerationModelSelection.model;
   const textGenModelOptions = textGenerationModelSelection.options;
   const gitModelInstanceEntries = sortProviderInstanceEntries(
-    deriveProviderInstanceEntries(serverProviders),
+    deriveProviderInstanceEntries(serverProviders).filter(isModelPickerProviderInstanceEntry),
   );
   const textGenInstanceEntry = gitModelInstanceEntries.find(
     (entry) => entry.instanceId === textGenInstanceId,

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -1,4 +1,5 @@
 import {
+  AcpRegistrySettings,
   ClaudeSettings,
   CodexSettings,
   CursorSettings,
@@ -6,7 +7,7 @@ import {
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type { Schema } from "effect";
-import { ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ACPRegistryIcon, ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -58,6 +59,12 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("acpRegistry"),
+    label: "ACP Registry",
+    icon: ACPRegistryIcon,
+    settingsSchema: AcpRegistrySettings,
   },
 ];
 

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -139,6 +139,14 @@ function createBrowserLocalApi(rpcClient?: WsRpcClient): LocalApi {
         rpcClient
           ? rpcClient.server.discoverSourceControl()
           : Promise.reject(unavailableLocalBackendError()),
+      listAcpRegistry: () =>
+        rpcClient
+          ? rpcClient.server.listAcpRegistry()
+          : Promise.reject(unavailableLocalBackendError()),
+      installAcpRegistryBinary: (input) =>
+        rpcClient
+          ? rpcClient.server.installAcpRegistryBinary(input)
+          : Promise.reject(unavailableLocalBackendError()),
     },
   };
 }

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -20,7 +20,11 @@ import {
   resolveSelectableProvider,
 } from "./providerModels";
 import { ModelEsque } from "./components/chat/providerIconUtils";
-import { type ProviderInstanceEntry, deriveProviderInstanceEntries } from "./providerInstances";
+import {
+  type ProviderInstanceEntry,
+  deriveProviderInstanceEntries,
+  isModelPickerProviderInstanceEntry,
+} from "./providerInstances";
 import { sortModelsForProviderInstance } from "./modelOrdering";
 
 const MAX_CUSTOM_MODEL_COUNT = 32;
@@ -238,9 +242,9 @@ export function resolveAppModelSelectionForInstance(
   providers: ReadonlyArray<ServerProvider>,
   selectedModel: string | null | undefined,
 ): string | null {
-  const entry = deriveProviderInstanceEntries(providers).find(
-    (candidate) => candidate.instanceId === instanceId,
-  );
+  const entry = deriveProviderInstanceEntries(providers)
+    .filter(isModelPickerProviderInstanceEntry)
+    .find((candidate) => candidate.instanceId === instanceId);
   if (!entry) return null;
   const options = getAppModelOptionsForInstance(settings, entry);
   return (
@@ -263,7 +267,9 @@ export function getCustomModelOptionsByInstance(
   _selectedModel?: string | null,
 ): ReadonlyMap<ProviderInstanceId, ReadonlyArray<ModelEsque>> {
   const out = new Map<ProviderInstanceId, ReadonlyArray<ModelEsque>>();
-  for (const entry of deriveProviderInstanceEntries(providers)) {
+  for (const entry of deriveProviderInstanceEntries(providers).filter(
+    isModelPickerProviderInstanceEntry,
+  )) {
     out.set(entry.instanceId, getAppModelOptionsForInstance(settings, entry));
   }
   return out;
@@ -277,7 +283,9 @@ export function resolveAppModelSelectionState(
     instanceId: DEFAULT_TEXT_GENERATION_INSTANCE_ID,
     model: DEFAULT_GIT_TEXT_GENERATION_MODEL,
   };
-  const entries = deriveProviderInstanceEntries(providers);
+  const entries = deriveProviderInstanceEntries(providers).filter(
+    isModelPickerProviderInstanceEntry,
+  );
   const selectedEntry = entries.find(
     (entry) => entry.instanceId === selection.instanceId && entry.enabled && entry.isAvailable,
   );

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -2,6 +2,7 @@ import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3
 import { describe, expect, it } from "vitest";
 import {
   deriveProviderInstanceEntries,
+  isModelPickerProviderInstanceEntry,
   resolveSelectableProviderInstance,
   resolveProviderDriverKindForInstanceSelection,
 } from "./providerInstances";
@@ -41,6 +42,25 @@ describe("deriveProviderInstanceEntries", () => {
     expect(entry?.instanceId).toBe("codex_personal");
     expect(entry?.driverKind).toBe("codex");
     expect(entry?.isDefault).toBe(false);
+  });
+});
+
+describe("isModelPickerProviderInstanceEntry", () => {
+  it("hides the default ACP Registry catalog while keeping imported ACP agents", () => {
+    const entries = deriveProviderInstanceEntries([
+      provider({
+        provider: ProviderDriverKind.make("acpRegistry"),
+        instanceId: "acpRegistry",
+        displayName: "ACP Registry",
+      }),
+      provider({
+        provider: ProviderDriverKind.make("acpRegistry"),
+        instanceId: "acpRegistry_auggie_cli",
+        displayName: "Auggie CLI",
+      }),
+    ]);
+
+    expect(entries.map(isModelPickerProviderInstanceEntry)).toEqual([false, true]);
   });
 });
 

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -24,6 +24,8 @@ import {
 
 import { formatProviderDriverKindLabel } from "./providerModels";
 
+const ACP_REGISTRY_DRIVER_KIND = "acpRegistry";
+
 /**
  * UI-facing projection of one configured provider instance. Carries the
  * snapshot verbatim for callers that need server-side fields we don't
@@ -35,6 +37,7 @@ export interface ProviderInstanceEntry {
   readonly driverKind: ProviderDriverKind;
   readonly displayName: string;
   readonly accentColor?: string | undefined;
+  readonly iconUrl?: string | undefined;
   readonly continuationGroupKey?: string | undefined;
   readonly enabled: boolean;
   readonly installed: boolean;
@@ -140,6 +143,7 @@ export function deriveProviderInstanceEntries(
       driverKind,
       displayName,
       accentColor: normalizeProviderAccentColor(snapshot.accentColor),
+      ...(snapshot.iconUrl ? { iconUrl: snapshot.iconUrl } : {}),
       continuationGroupKey: snapshot.continuation?.groupKey,
       enabled: snapshot.enabled,
       installed: snapshot.installed,
@@ -182,6 +186,15 @@ export function sortProviderInstanceEntries(
     sorted.push(...defaults, ...customs);
   }
   return sorted;
+}
+
+/**
+ * The ACP Registry default slot is a catalog/import surface, not an agent
+ * users should chat with. Registry-created provider instances share the same
+ * driver kind, but have their own non-default ids and remain selectable.
+ */
+export function isModelPickerProviderInstanceEntry(entry: ProviderInstanceEntry): boolean {
+  return !(entry.driverKind === ACP_REGISTRY_DRIVER_KIND && entry.isDefault);
 }
 
 /**

--- a/apps/web/src/rpc/wsRpcClient.ts
+++ b/apps/web/src/rpc/wsRpcClient.ts
@@ -127,6 +127,10 @@ export interface WsRpcClient {
     readonly discoverSourceControl: RpcUnaryNoArgMethod<
       typeof WS_METHODS.serverDiscoverSourceControl
     >;
+    readonly listAcpRegistry: RpcUnaryNoArgMethod<typeof WS_METHODS.serverListAcpRegistry>;
+    readonly installAcpRegistryBinary: RpcUnaryMethod<
+      typeof WS_METHODS.serverInstallAcpRegistryBinary
+    >;
     readonly subscribeConfig: RpcStreamMethod<typeof WS_METHODS.subscribeServerConfig>;
     readonly subscribeLifecycle: RpcStreamMethod<typeof WS_METHODS.subscribeServerLifecycle>;
     readonly subscribeAuthAccess: RpcStreamMethod<typeof WS_METHODS.subscribeAuthAccess>;
@@ -241,6 +245,10 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
         transport.request((client) => client[WS_METHODS.serverUpdateSettings]({ patch })),
       discoverSourceControl: () =>
         transport.request((client) => client[WS_METHODS.serverDiscoverSourceControl]({})),
+      listAcpRegistry: () =>
+        transport.request((client) => client[WS_METHODS.serverListAcpRegistry]({})),
+      installAcpRegistryBinary: (input) =>
+        transport.request((client) => client[WS_METHODS.serverInstallAcpRegistryBinary](input)),
       subscribeConfig: (listener, options) =>
         transport.subscribe((client) => client[WS_METHODS.subscribeServerConfig]({}), listener, {
           ...options,

--- a/packages/contracts/src/acp.ts
+++ b/packages/contracts/src/acp.ts
@@ -1,0 +1,104 @@
+import { Effect, Schema } from "effect";
+import { IsoDateTime, TrimmedNonEmptyString } from "./baseSchemas.ts";
+
+export const AcpDistributionType = Schema.Literals([
+  "manual",
+  "npx",
+  "uvx",
+  "binary",
+  "binaryUnsupported",
+]);
+export type AcpDistributionType = typeof AcpDistributionType.Type;
+
+export const AcpLaunchSpec = Schema.Struct({
+  command: TrimmedNonEmptyString,
+  args: Schema.Array(TrimmedNonEmptyString).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  env: Schema.Record(Schema.String, Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
+});
+export type AcpLaunchSpec = typeof AcpLaunchSpec.Type;
+
+export const AcpRegistryAgent = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  name: TrimmedNonEmptyString,
+  version: TrimmedNonEmptyString,
+  description: TrimmedNonEmptyString,
+  repository: Schema.optional(TrimmedNonEmptyString),
+  website: Schema.optional(TrimmedNonEmptyString),
+  authors: Schema.optional(Schema.Array(TrimmedNonEmptyString)),
+  license: Schema.optional(TrimmedNonEmptyString),
+  icon: Schema.optional(TrimmedNonEmptyString),
+  distribution: Schema.Struct({
+    npx: Schema.optional(
+      Schema.Struct({
+        package: TrimmedNonEmptyString,
+        args: Schema.optional(Schema.Array(TrimmedNonEmptyString)),
+        env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+      }),
+    ),
+    uvx: Schema.optional(
+      Schema.Struct({
+        package: TrimmedNonEmptyString,
+        args: Schema.optional(Schema.Array(TrimmedNonEmptyString)),
+        env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+      }),
+    ),
+    binary: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  }),
+});
+export type AcpRegistryAgent = typeof AcpRegistryAgent.Type;
+
+export const AcpRegistryIndex = Schema.Struct({
+  version: TrimmedNonEmptyString,
+  agents: Schema.Array(AcpRegistryAgent),
+});
+export type AcpRegistryIndex = typeof AcpRegistryIndex.Type;
+
+export const ResolvedRegistryAcpAgent = Schema.Struct({
+  agent: AcpRegistryAgent,
+  supported: Schema.Boolean,
+  distributionType: AcpDistributionType,
+  launch: Schema.NullOr(AcpLaunchSpec),
+  binaryInstall: Schema.optional(
+    Schema.Struct({
+      archiveUrl: TrimmedNonEmptyString,
+      defaultInstallPath: TrimmedNonEmptyString,
+      platformKey: TrimmedNonEmptyString,
+      command: TrimmedNonEmptyString,
+    }),
+  ),
+});
+export type ResolvedRegistryAcpAgent = typeof ResolvedRegistryAcpAgent.Type;
+
+export const AcpRegistryListResult = Schema.Struct({
+  registryVersion: TrimmedNonEmptyString,
+  agents: Schema.Array(ResolvedRegistryAcpAgent),
+});
+export type AcpRegistryListResult = typeof AcpRegistryListResult.Type;
+
+export const AcpRegistryInstallBinaryInput = Schema.Struct({
+  agentId: TrimmedNonEmptyString,
+  installPath: Schema.optional(TrimmedNonEmptyString),
+});
+export type AcpRegistryInstallBinaryInput = typeof AcpRegistryInstallBinaryInput.Type;
+
+export const AcpRegistryInstallBinaryResult = Schema.Struct({
+  ok: Schema.Boolean,
+  agent: Schema.optional(ResolvedRegistryAcpAgent),
+  error: Schema.optional(TrimmedNonEmptyString),
+});
+export type AcpRegistryInstallBinaryResult = typeof AcpRegistryInstallBinaryResult.Type;
+
+export const ServerAcpAgentStatus = Schema.Struct({
+  agentServerId: TrimmedNonEmptyString,
+  enabled: Schema.Boolean,
+  installed: Schema.Boolean,
+  status: Schema.Literals(["ready", "warning", "error", "disabled"]),
+  authStatus: Schema.Literals(["authenticated", "unauthenticated", "unknown"]),
+  checkedAt: IsoDateTime,
+  displayName: TrimmedNonEmptyString,
+  message: Schema.optional(TrimmedNonEmptyString),
+  version: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type ServerAcpAgentStatus = typeof ServerAcpAgentStatus.Type;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7,6 +7,7 @@ export * from "./terminal.ts";
 export * from "./provider.ts";
 export * from "./providerInstance.ts";
 export * from "./providerRuntime.ts";
+export * from "./acp.ts";
 export * from "./model.ts";
 export * from "./keybindings.ts";
 export * from "./server.ts";

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -18,6 +18,11 @@ import type {
   VcsStatusResult,
   VcsCreateRefResult,
 } from "./git.ts";
+import type {
+  AcpRegistryInstallBinaryInput,
+  AcpRegistryInstallBinaryResult,
+  AcpRegistryListResult,
+} from "./acp.ts";
 import type { FilesystemBrowseInput, FilesystemBrowseResult } from "./filesystem.ts";
 import type {
   ProjectSearchEntriesInput,
@@ -300,6 +305,10 @@ export interface LocalApi {
     getSettings: () => Promise<ServerSettings>;
     updateSettings: (patch: ServerSettingsPatch) => Promise<ServerSettings>;
     discoverSourceControl: () => Promise<SourceControlDiscoveryResult>;
+    listAcpRegistry: () => Promise<AcpRegistryListResult>;
+    installAcpRegistryBinary: (
+      input: AcpRegistryInstallBinaryInput,
+    ) => Promise<AcpRegistryInstallBinaryResult>;
   };
 }
 

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -129,6 +129,7 @@ const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const ACP_REGISTRY_DRIVER_KIND = ProviderDriverKind.make("acpRegistry");
 
 export const DEFAULT_MODEL = "gpt-5.4";
 export const DEFAULT_GIT_TEXT_GENERATION_MODEL = "gpt-5.4-mini";
@@ -138,6 +139,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CLAUDE_DRIVER_KIND]: "claude-sonnet-4-6",
   [CURSOR_DRIVER_KIND]: "auto",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ACP_REGISTRY_DRIVER_KIND]: "default",
 };
 
 /** Per-provider text generation model defaults. */
@@ -148,6 +150,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ACP_REGISTRY_DRIVER_KIND]: "default",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -189,6 +192,7 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [ACP_REGISTRY_DRIVER_KIND]: {},
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -198,4 +202,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CLAUDE_DRIVER_KIND]: "Claude",
   [CURSOR_DRIVER_KIND]: "Cursor",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [ACP_REGISTRY_DRIVER_KIND]: "ACP Registry",
 };

--- a/packages/contracts/src/providerInstance.ts
+++ b/packages/contracts/src/providerInstance.ts
@@ -124,6 +124,7 @@ export const ProviderInstanceConfig = Schema.Struct({
   driver: ProviderDriverKind,
   displayName: Schema.optional(TrimmedNonEmptyString),
   accentColor: Schema.optional(TrimmedNonEmptyString),
+  iconUrl: Schema.optional(TrimmedNonEmptyString),
   environment: Schema.optionalKey(ProviderInstanceEnvironment),
   enabled: Schema.optionalKey(Schema.Boolean),
   config: Schema.optionalKey(Schema.Unknown),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -5,6 +5,11 @@ import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
 import { OpenError, OpenInEditorInput } from "./editor.ts";
 import { AuthAccessStreamEvent } from "./auth.ts";
 import {
+  AcpRegistryInstallBinaryInput,
+  AcpRegistryInstallBinaryResult,
+  AcpRegistryListResult,
+} from "./acp.ts";
+import {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
   FilesystemBrowseError,
@@ -133,6 +138,8 @@ export const WS_METHODS = {
   serverGetSettings: "server.getSettings",
   serverUpdateSettings: "server.updateSettings",
   serverDiscoverSourceControl: "server.discoverSourceControl",
+  serverListAcpRegistry: "server.listAcpRegistry",
+  serverInstallAcpRegistryBinary: "server.installAcpRegistryBinary",
 
   // Source control methods
   sourceControlLookupRepository: "sourceControl.lookupRepository",
@@ -188,6 +195,19 @@ export const WsServerDiscoverSourceControlRpc = Rpc.make(WS_METHODS.serverDiscov
   payload: Schema.Struct({}),
   success: SourceControlDiscoveryResult,
 });
+
+export const WsServerListAcpRegistryRpc = Rpc.make(WS_METHODS.serverListAcpRegistry, {
+  payload: Schema.Struct({}),
+  success: AcpRegistryListResult,
+});
+
+export const WsServerInstallAcpRegistryBinaryRpc = Rpc.make(
+  WS_METHODS.serverInstallAcpRegistryBinary,
+  {
+    payload: AcpRegistryInstallBinaryInput,
+    success: AcpRegistryInstallBinaryResult,
+  },
+);
 
 export const WsSourceControlLookupRepositoryRpc = Rpc.make(
   WS_METHODS.sourceControlLookupRepository,
@@ -419,6 +439,8 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerGetSettingsRpc,
   WsServerUpdateSettingsRpc,
   WsServerDiscoverSourceControlRpc,
+  WsServerListAcpRegistryRpc,
+  WsServerInstallAcpRegistryBinaryRpc,
   WsSourceControlLookupRepositoryRpc,
   WsSourceControlCloneRepositoryRpc,
   WsSourceControlPublishRepositoryRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -118,6 +118,7 @@ export const ServerProvider = Schema.Struct({
   driver: ProviderDriverKind,
   displayName: Schema.optional(TrimmedNonEmptyString),
   accentColor: Schema.optional(TrimmedNonEmptyString),
+  iconUrl: Schema.optional(TrimmedNonEmptyString),
   badgeLabel: Schema.optional(TrimmedNonEmptyString),
   continuation: Schema.optional(ServerProviderContinuation),
   showInteractionModeToggle: Schema.optional(Schema.Boolean),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -313,6 +313,26 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const AcpRegistrySettings = Schema.Struct({
+  enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  registryUrl: TrimmedString.pipe(
+    Schema.withDecodingDefault(
+      Effect.succeed("https://cdn.agentclientprotocol.com/registry/v1/latest/registry.json"),
+    ),
+  ),
+  command: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  args: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  env: Schema.Record(Schema.String, Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
+  iconUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  registryAgentId: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  importedVersion: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  distributionType: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+});
+export type AcpRegistrySettings = typeof AcpRegistrySettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -345,6 +365,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    acpRegistry: AcpRegistrySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -420,6 +441,19 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const AcpRegistrySettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  registryUrl: Schema.optionalKey(Schema.String),
+  command: Schema.optionalKey(Schema.String),
+  args: Schema.optionalKey(Schema.Array(Schema.String)),
+  env: Schema.optionalKey(Schema.Record(Schema.String, Schema.String)),
+  iconUrl: Schema.optionalKey(Schema.String),
+  registryAgentId: Schema.optionalKey(Schema.String),
+  importedVersion: Schema.optionalKey(Schema.String),
+  distributionType: Schema.optionalKey(Schema.String),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
@@ -438,6 +472,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      acpRegistry: Schema.optionalKey(AcpRegistrySettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual


### PR DESCRIPTION
## Summary
- Adds a new `ACP Registry` provider driver backed by the ACP registry flow, including session startup and model selection handling.
- Extends provider instance metadata to carry `iconUrl` through server snapshot construction and driver creation.
- Updates the Cursor ACP adapter to support provider-specific event labeling, custom spawn behavior, model normalization, and optional Cursor model option handling.
- Expands the web UI and shared contracts so ACP registry instances can be created, displayed, and selected consistently across settings and model pickers.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces a new provider driver that spawns external ACP agent processes and adds server RPCs that download/extract/install binaries from remote registry URLs, expanding the attack surface and potential platform-specific failure modes.
> 
> **Overview**
> Adds first-class **ACP Registry** support end-to-end: a new `AcpRegistryDriver` (multi-instance) built on the existing ACP/Cursor session adapter, plus contracts/settings updates to persist ACP registry configuration and defaults.
> 
> Extends provider instance/snapshot metadata to carry `iconUrl` through the server registry, unavailable snapshots, and UI rendering, and updates several drivers to accept/pass through `iconUrl`.
> 
> Generalizes `makeCursorAdapter` so it can be reused by non-Cursor ACP providers (custom `provider` kind, spawn command/args/env, model normalization, optional Cursor-specific model-option application, and customizable “ready” reason).
> 
> Adds server websocket RPCs `server.listAcpRegistry` and `server.installAcpRegistryBinary` that fetch the ACP registry index and optionally download/extract an agent binary into the server state dir, and updates the web UI wizard/model pickers to browse registry agents, install binaries, and create ACP registry-backed provider instances (including env var editing and hiding the default ACP registry catalog entry from model selection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46fc8ff3f21fb4ff69b880867b177b0282b72b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ACP Registry provider support with binary install and model picker integration
> - Introduces a new `acpRegistry` provider driver that spawns a configured command as an ACP agent, registers it as a built-in driver, and exposes it in settings with configurable `command` and `args` fields.
> - Adds two WS RPC endpoints (`server.listAcpRegistry` and `server.installAcpRegistryBinary`) so the client can browse a remote registry index, resolve per-platform launch specs, and install binary agents.
> - Extends the Add Provider Instance dialog with a Registry step: users can search, select, or install ACP agents; selecting an agent populates command, args, env vars, and icon; env vars can be marked sensitive and are validated before save.
> - Adds `isModelPickerProviderInstanceEntry` to exclude the default ACP Registry catalog instance from model selection while keeping explicitly imported agents visible.
> - Propagates optional `iconUrl` through provider snapshots, `ProviderInstanceConfig`, driver create inputs, and UI components (`ProviderInstanceIcon`, `ModelListRow`, `ModelPickerContent`, etc.) with image-load fallback to glyph or initials.
> - Risk: `args` fields in existing provider instance configs are now stored and parsed as `string[]`; any code reading `args` as a plain string will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 121f70b. 5 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->