### PR TITLE
Diff panel: per-thread state and full-width toggle

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -37,14 +37,14 @@ import { truncate } from "@t3tools/shared/String";
 import { nextTerminalId, resolveTerminalSessionLabel } from "@t3tools/shared/terminalLabels";
 import { Debouncer } from "@tanstack/react-pacer";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useNavigate } from "@tanstack/react-router";
 import { useShallow } from "zustand/react/shallow";
 import { useVcsStatus } from "~/lib/vcsStatusState";
 import { usePrimaryEnvironmentId } from "../environments/primary";
 import { readEnvironmentApi } from "../environmentApi";
 import { isElectron } from "../env";
 import { readLocalApi } from "../localApi";
-import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import { stripDiffSearchParams } from "../diffRouteSearch";
 import {
   collapseExpandedComposerCursor,
   parseStandaloneComposerSlashCommand,
@@ -799,10 +799,6 @@ export default function ChatView(props: ChatViewProps) {
   const timestampFormat = settings.timestampFormat;
   const autoOpenPlanSidebar = settings.autoOpenPlanSidebar;
   const navigate = useNavigate();
-  const rawSearch = useSearch({
-    strict: false,
-    select: (params) => parseDiffRouteSearch(params),
-  });
   const { resolvedTheme } = useTheme();
   // Granular store selectors — avoid subscribing to prompt changes.
   const composerRuntimeMode = useComposerDraftStore(
@@ -967,7 +963,6 @@ export default function ChatView(props: ChatViewProps) {
     composerInteractionMode ?? activeThread?.interactionMode ?? DEFAULT_INTERACTION_MODE;
   const isLocalDraftThread = !isServerThread && localDraftThread !== undefined;
   const canCheckoutPullRequestIntoThread = isLocalDraftThread;
-  const diffOpen = rawSearch.diff === "1";
   const activeThreadId = activeThread?.id ?? null;
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: activeThread?.environmentId ?? null,
@@ -999,6 +994,10 @@ export default function ChatView(props: ChatViewProps) {
     [activeThread],
   );
   const activeThreadKey = activeThreadRef ? scopedThreadKey(activeThreadRef) : null;
+  const diffOpen = useUiStateStore((store) =>
+    activeThreadKey ? store.threadDiffOpenById[activeThreadKey] === true : false,
+  );
+  const setThreadDiffOpen = useUiStateStore((store) => store.setThreadDiffOpen);
 
   useEffect(() => {
     if (!activeThreadRef) {
@@ -1902,25 +1901,14 @@ export default function ChatView(props: ChatViewProps) {
     [keybindings, nonTerminalShortcutLabelOptions],
   );
   const onToggleDiff = useCallback(() => {
-    if (!isServerThread) {
+    if (!isServerThread || !activeThreadKey) {
       return;
     }
     if (!diffOpen) {
       onDiffPanelOpen?.();
     }
-    void navigate({
-      to: "/$environmentId/$threadId",
-      params: {
-        environmentId,
-        threadId,
-      },
-      replace: true,
-      search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
-        return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
-      },
-    });
-  }, [diffOpen, environmentId, isServerThread, navigate, onDiffPanelOpen, threadId]);
+    setThreadDiffOpen(activeThreadKey, !diffOpen);
+  }, [activeThreadKey, diffOpen, isServerThread, onDiffPanelOpen, setThreadDiffOpen]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -3681,10 +3669,11 @@ export default function ChatView(props: ChatViewProps) {
   }, []);
   const onOpenTurnDiff = useCallback(
     (turnId: TurnId, filePath?: string) => {
-      if (!isServerThread) {
+      if (!isServerThread || !activeThreadKey) {
         return;
       }
       onDiffPanelOpen?.();
+      setThreadDiffOpen(activeThreadKey, true);
       void navigate({
         to: "/$environmentId/$threadId",
         params: {
@@ -3694,12 +3683,20 @@ export default function ChatView(props: ChatViewProps) {
         search: (previous) => {
           const rest = stripDiffSearchParams(previous);
           return filePath
-            ? { ...rest, diff: "1", diffTurnId: turnId, diffFilePath: filePath }
-            : { ...rest, diff: "1", diffTurnId: turnId };
+            ? { ...rest, diffTurnId: turnId, diffFilePath: filePath }
+            : { ...rest, diffTurnId: turnId };
         },
       });
     },
-    [environmentId, isServerThread, navigate, onDiffPanelOpen, threadId],
+    [
+      activeThreadKey,
+      environmentId,
+      isServerThread,
+      navigate,
+      onDiffPanelOpen,
+      setThreadDiffOpen,
+      threadId,
+    ],
   );
   // Both the Map and the revert handler are read from refs at call-time so
   // the callback reference is fully stable and never busts context identity.

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -1,11 +1,13 @@
 import { FileDiff, Virtualizer } from "@pierre/diffs/react";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { scopeThreadRef } from "@t3tools/client-runtime";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime";
 import type { TurnId } from "@t3tools/contracts";
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  ChevronsLeftRightIcon,
+  ChevronsRightLeftIcon,
   Columns2Icon,
   PilcrowIcon,
   Rows3Icon,
@@ -36,6 +38,7 @@ import {
 } from "../lib/diffRendering";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { selectProjectByRef, useStore } from "../store";
+import { useUiStateStore } from "../uiStateStore";
 import { createThreadSelectorByRef } from "../storeSelectors";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { useSettings } from "../hooks/useSettings";
@@ -43,7 +46,6 @@ import { formatShortTimestamp } from "../timestampFormat";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
-type DiffRenderMode = "stacked" | "split";
 type DiffThemeType = "light" | "dark";
 
 const DIFF_PANEL_UNSAFE_CSS = `
@@ -120,15 +122,24 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const navigate = useNavigate();
   const { resolvedTheme } = useTheme();
   const settings = useSettings();
-  const [diffRenderMode, setDiffRenderMode] = useState<DiffRenderMode>("stacked");
-  const [diffWordWrap, setDiffWordWrap] = useState(settings.diffWordWrap);
-  const [diffIgnoreWhitespace, setDiffIgnoreWhitespace] = useState(settings.diffIgnoreWhitespace);
-  const [collapsedDiffFileKeys, setCollapsedDiffFileKeys] = useState<ReadonlySet<string>>(
-    () => new Set(),
+  const diffRenderMode = useUiStateStore((store) => store.diffRenderMode);
+  const setDiffRenderMode = useUiStateStore((store) => store.setDiffRenderMode);
+  // diffWordWrap / diffIgnoreWhitespace use an override pattern: the store
+  // holds the user's in-session toggle (or `undefined` for "no override")
+  // and we fall back to the settings.* default on first render. This avoids
+  // a render-vs-effect race that would otherwise dispatch the first
+  // checkpoint diff query with the store's hardcoded default before any
+  // hydration effect catches up.
+  const diffWordWrapOverride = useUiStateStore((store) => store.diffWordWrapOverride);
+  const setDiffWordWrap = useUiStateStore((store) => store.setDiffWordWrap);
+  const diffWordWrap = diffWordWrapOverride ?? settings.diffWordWrap;
+  const diffIgnoreWhitespaceOverride = useUiStateStore(
+    (store) => store.diffIgnoreWhitespaceOverride,
   );
+  const setDiffIgnoreWhitespace = useUiStateStore((store) => store.setDiffIgnoreWhitespace);
+  const diffIgnoreWhitespace = diffIgnoreWhitespaceOverride ?? settings.diffIgnoreWhitespace;
   const patchViewportRef = useRef<HTMLDivElement>(null);
   const turnStripRef = useRef<HTMLDivElement>(null);
-  const previousDiffOpenRef = useRef(false);
   const [canScrollTurnStripLeft, setCanScrollTurnStripLeft] = useState(false);
   const [canScrollTurnStripRight, setCanScrollTurnStripRight] = useState(false);
   const routeThreadRef = useParams({
@@ -136,11 +147,32 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     select: (params) => resolveThreadRouteRef(params),
   });
   const diffSearch = useSearch({ strict: false, select: (search) => parseDiffRouteSearch(search) });
-  const diffOpen = diffSearch.diff === "1";
   const activeThreadId = routeThreadRef?.threadId ?? null;
   const activeThread = useStore(
     useMemo(() => createThreadSelectorByRef(routeThreadRef), [routeThreadRef]),
   );
+  const activeThreadKey = useMemo(
+    () => (routeThreadRef ? scopedThreadKey(routeThreadRef) : null),
+    [routeThreadRef],
+  );
+  const diffFullWidth = useUiStateStore((store) =>
+    activeThreadKey ? store.threadDiffFullWidthById[activeThreadKey] === true : false,
+  );
+  const setThreadDiffFullWidth = useUiStateStore((store) => store.setThreadDiffFullWidth);
+  const [collapsedDiffFileKeys, setCollapsedDiffFileKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const toggleDiffFileCollapsed = useCallback((fileKey: string) => {
+    setCollapsedDiffFileKeys((current) => {
+      const next = new Set(current);
+      if (next.has(fileKey)) {
+        next.delete(fileKey);
+      } else {
+        next.add(fileKey);
+      }
+      return next;
+    });
+  }, []);
   const activeProjectId = activeThread?.projectId ?? null;
   const activeProject = useStore((store) =>
     activeThread && activeProjectId
@@ -262,26 +294,19 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     );
   }, [renderablePatch]);
 
+  // Drop collapsed-file keys for files that are no longer in the current
+  // patch so the set doesn't keep growing forever as turns come and go.
   useEffect(() => {
     if (renderableFiles.length === 0) {
       setCollapsedDiffFileKeys((current) => (current.size === 0 ? current : new Set()));
       return;
     }
-
     const visibleFileKeys = new Set(renderableFiles.map(buildFileDiffRenderKey));
     setCollapsedDiffFileKeys((current) => {
       const next = new Set([...current].filter((fileKey) => visibleFileKeys.has(fileKey)));
       return next.size === current.size ? current : next;
     });
   }, [renderableFiles]);
-
-  useEffect(() => {
-    if (diffOpen && !previousDiffOpenRef.current) {
-      setDiffWordWrap(settings.diffWordWrap);
-      setDiffIgnoreWhitespace(settings.diffIgnoreWhitespace);
-    }
-    previousDiffOpenRef.current = diffOpen;
-  }, [diffOpen, settings.diffIgnoreWhitespace, settings.diffWordWrap]);
 
   useEffect(() => {
     if (!selectedFilePath || !patchViewportRef.current) {
@@ -304,17 +329,6 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
     },
     [activeCwd],
   );
-  const toggleDiffFileCollapsed = useCallback((fileKey: string) => {
-    setCollapsedDiffFileKeys((current) => {
-      const next = new Set(current);
-      if (next.has(fileKey)) {
-        next.delete(fileKey);
-      } else {
-        next.add(fileKey);
-      }
-      return next;
-    });
-  }, []);
 
   const selectTurn = (turnId: TurnId) => {
     if (!activeThread) return;
@@ -323,7 +337,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1", diffTurnId: turnId };
+        return { ...rest, diffTurnId: turnId };
       },
     });
   };
@@ -333,10 +347,13 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
       to: "/$environmentId/$threadId",
       params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
       search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
+        return stripDiffSearchParams(previous);
       },
     });
+  };
+  const toggleDiffFullWidth = () => {
+    if (!activeThreadKey) return;
+    setThreadDiffFullWidth(activeThreadKey, !diffFullWidth);
   };
   const updateTurnStripScrollState = useCallback(() => {
     const element = turnStripRef.current;
@@ -536,6 +553,26 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
         >
           <PilcrowIcon className="size-3" />
         </Toggle>
+        {mode !== "sheet" ? (
+          <Toggle
+            aria-label={
+              diffFullWidth ? "Restore split pane diff view" : "Expand diff view to full width"
+            }
+            title={diffFullWidth ? "Restore split pane" : "Expand to full width"}
+            variant="outline"
+            size="xs"
+            pressed={diffFullWidth}
+            onPressedChange={() => {
+              toggleDiffFullWidth();
+            }}
+          >
+            {diffFullWidth ? (
+              <ChevronsRightLeftIcon className="size-3" />
+            ) : (
+              <ChevronsLeftRightIcon className="size-3" />
+            )}
+          </Toggle>
+        ) : null}
       </div>
     </>
   );

--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -3,72 +3,46 @@ import { describe, expect, it } from "vitest";
 import { parseDiffRouteSearch } from "./diffRouteSearch";
 
 describe("parseDiffRouteSearch", () => {
-  it("parses valid diff search values", () => {
+  it("parses turn and file selection values", () => {
     const parsed = parseDiffRouteSearch({
-      diff: "1",
       diffTurnId: "turn-1",
       diffFilePath: "src/app.ts",
     });
 
     expect(parsed).toEqual({
-      diff: "1",
       diffTurnId: "turn-1",
       diffFilePath: "src/app.ts",
     });
   });
 
-  it("treats numeric and boolean diff toggles as open", () => {
-    expect(
-      parseDiffRouteSearch({
-        diff: 1,
-        diffTurnId: "turn-1",
-      }),
-    ).toEqual({
+  it("ignores legacy 'diff' open/closed flag", () => {
+    // The diff panel open/closed state moved to the UI store. Old URLs that
+    // still carry ?diff=1 must not surface as anything in the parsed search.
+    const parsed = parseDiffRouteSearch({
       diff: "1",
       diffTurnId: "turn-1",
     });
 
-    expect(
-      parseDiffRouteSearch({
-        diff: true,
-        diffTurnId: "turn-1",
-      }),
-    ).toEqual({
-      diff: "1",
+    expect(parsed).toEqual({
       diffTurnId: "turn-1",
     });
+    expect("diff" in parsed).toBe(false);
   });
 
-  it("drops turn and file values when diff is closed", () => {
+  it("drops file value when turn is not selected", () => {
     const parsed = parseDiffRouteSearch({
-      diff: "0",
-      diffTurnId: "turn-1",
       diffFilePath: "src/app.ts",
     });
 
     expect(parsed).toEqual({});
   });
 
-  it("drops file value when turn is not selected", () => {
-    const parsed = parseDiffRouteSearch({
-      diff: "1",
-      diffFilePath: "src/app.ts",
-    });
-
-    expect(parsed).toEqual({
-      diff: "1",
-    });
-  });
-
   it("normalizes whitespace-only values", () => {
     const parsed = parseDiffRouteSearch({
-      diff: "1",
       diffTurnId: "  ",
       diffFilePath: "  ",
     });
 
-    expect(parsed).toEqual({
-      diff: "1",
-    });
+    expect(parsed).toEqual({});
   });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -1,13 +1,8 @@
 import { TurnId } from "@t3tools/contracts";
 
 export interface DiffRouteSearch {
-  diff?: "1" | undefined;
   diffTurnId?: TurnId | undefined;
   diffFilePath?: string | undefined;
-}
-
-function isDiffOpenValue(value: unknown): boolean {
-  return value === "1" || value === 1 || value === true;
 }
 
 function normalizeSearchString(value: unknown): string | undefined {
@@ -21,18 +16,19 @@ function normalizeSearchString(value: unknown): string | undefined {
 export function stripDiffSearchParams<T extends Record<string, unknown>>(
   params: T,
 ): Omit<T, "diff" | "diffTurnId" | "diffFilePath"> {
+  // "diff" is intentionally still listed here so any legacy URLs with the old
+  // open/closed flag are stripped on first interaction; the panel state now
+  // lives in the UI store, scoped per thread.
   const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, ...rest } = params;
   return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
 }
 
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
-  const diff = isDiffOpenValue(search.diff) ? "1" : undefined;
-  const diffTurnIdRaw = diff ? normalizeSearchString(search.diffTurnId) : undefined;
+  const diffTurnIdRaw = normalizeSearchString(search.diffTurnId);
   const diffTurnId = diffTurnIdRaw ? TurnId.make(diffTurnIdRaw) : undefined;
-  const diffFilePath = diff && diffTurnId ? normalizeSearchString(search.diffFilePath) : undefined;
+  const diffFilePath = diffTurnId ? normalizeSearchString(search.diffFilePath) : undefined;
 
   return {
-    ...(diff ? { diff } : {}),
     ...(diffTurnId ? { diffTurnId } : {}),
     ...(diffFilePath ? { diffFilePath } : {}),
   };

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -1,4 +1,5 @@
-import { createFileRoute, retainSearchParams, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { scopedThreadKey } from "@t3tools/client-runtime";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
 
 import ChatView from "../components/ChatView";
@@ -11,18 +12,16 @@ import {
   type DiffPanelMode,
 } from "../components/DiffPanelShell";
 import { finalizePromotedDraftThreadByRef, useComposerDraftStore } from "../composerDraftStore";
-import {
-  type DiffRouteSearch,
-  parseDiffRouteSearch,
-  stripDiffSearchParams,
-} from "../diffRouteSearch";
+import { parseDiffRouteSearch } from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import { selectEnvironmentState, selectThreadExistsByRef, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
-import { resolveThreadRouteRef, buildThreadRouteParams } from "../threadRoutes";
+import { resolveThreadRouteRef } from "../threadRoutes";
+import { useUiStateStore } from "../uiStateStore";
 import { RightPanelSheet } from "../components/RightPanelSheet";
 import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
+import { cn } from "~/lib/utils";
 
 const DiffPanel = lazy(() => import("../components/DiffPanel"));
 const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
@@ -167,52 +166,66 @@ function ChatThreadRouteView() {
   const routeThreadExists = threadExists || draftThreadExists;
   const serverThreadStarted = threadHasStarted(serverThread);
   const environmentHasAnyThreads = environmentHasServerThreads || environmentHasDraftThreads;
-  const diffOpen = search.diff === "1";
+  const activeThreadKey = useMemo(
+    () => (threadRef ? scopedThreadKey(threadRef) : null),
+    [threadRef],
+  );
+  const diffOpen = useUiStateStore((store) =>
+    activeThreadKey ? store.threadDiffOpenById[activeThreadKey] === true : false,
+  );
+  const threadDiffFullWidth = useUiStateStore((store) =>
+    activeThreadKey ? store.threadDiffFullWidthById[activeThreadKey] === true : false,
+  );
+  const setThreadDiffOpen = useUiStateStore((store) => store.setThreadDiffOpen);
+  const diffFullWidth = diffOpen && threadDiffFullWidth;
   const shouldUseDiffSheet = useMediaQuery(RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY);
-  const currentThreadKey = threadRef ? `${threadRef.environmentId}:${threadRef.threadId}` : null;
   const [diffPanelMountState, setDiffPanelMountState] = useState(() => ({
-    threadKey: currentThreadKey,
+    threadKey: activeThreadKey,
     hasOpenedDiff: diffOpen,
   }));
   const hasOpenedDiff =
-    diffPanelMountState.threadKey === currentThreadKey
+    diffPanelMountState.threadKey === activeThreadKey
       ? diffPanelMountState.hasOpenedDiff
       : diffOpen;
   const markDiffOpened = useCallback(() => {
     setDiffPanelMountState((previous) => {
-      if (previous.threadKey === currentThreadKey && previous.hasOpenedDiff) {
+      if (previous.threadKey === activeThreadKey && previous.hasOpenedDiff) {
         return previous;
       }
       return {
-        threadKey: currentThreadKey,
+        threadKey: activeThreadKey,
         hasOpenedDiff: true,
       };
     });
-  }, [currentThreadKey]);
+  }, [activeThreadKey]);
   const closeDiff = useCallback(() => {
-    if (!threadRef) {
+    if (!activeThreadKey) {
       return;
     }
-    void navigate({
-      to: "/$environmentId/$threadId",
-      params: buildThreadRouteParams(threadRef),
-      search: { diff: undefined },
-    });
-  }, [navigate, threadRef]);
+    setThreadDiffOpen(activeThreadKey, false);
+  }, [activeThreadKey, setThreadDiffOpen]);
   const openDiff = useCallback(() => {
-    if (!threadRef) {
+    if (!activeThreadKey) {
       return;
     }
     markDiffOpened();
-    void navigate({
-      to: "/$environmentId/$threadId",
-      params: buildThreadRouteParams(threadRef),
-      search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
-      },
-    });
-  }, [markDiffOpened, navigate, threadRef]);
+    setThreadDiffOpen(activeThreadKey, true);
+  }, [activeThreadKey, markDiffOpened, setThreadDiffOpen]);
+
+  // Shared / bookmarked / browser-history links keep diffTurnId in the URL.
+  // When such a link loads on a thread whose diff panel state is closed
+  // (e.g. first visit, or no persisted preference), auto-open the panel so
+  // the link actually reveals the diff it points at. The deps key off the
+  // turn id so manually closing the panel afterwards is respected — it
+  // only reopens when the user navigates to a different turn link.
+  const diffTurnIdInSearch = search.diffTurnId ?? null;
+  useEffect(() => {
+    if (!activeThreadKey || !diffTurnIdInSearch) {
+      return;
+    }
+    markDiffOpened();
+    setThreadDiffOpen(activeThreadKey, true);
+  }, [activeThreadKey, diffTurnIdInSearch, markDiffOpened, setThreadDiffOpen]);
 
   useEffect(() => {
     if (!threadRef || !bootstrapComplete) {
@@ -240,7 +253,12 @@ function ChatThreadRouteView() {
   if (!shouldUseDiffSheet) {
     return (
       <>
-        <SidebarInset className="h-svh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground md:h-dvh">
+        <SidebarInset
+          className={cn(
+            "h-svh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground md:h-dvh",
+            diffFullWidth && "hidden",
+          )}
+        >
           <ChatView
             environmentId={threadRef.environmentId}
             threadId={threadRef.threadId}
@@ -249,12 +267,18 @@ function ChatThreadRouteView() {
             routeKind="server"
           />
         </SidebarInset>
-        <DiffPanelInlineSidebar
-          diffOpen={diffOpen}
-          onCloseDiff={closeDiff}
-          onOpenDiff={openDiff}
-          renderDiffContent={shouldRenderDiffContent}
-        />
+        {diffFullWidth ? (
+          <SidebarInset className="h-svh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground md:h-dvh">
+            {shouldRenderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
+          </SidebarInset>
+        ) : (
+          <DiffPanelInlineSidebar
+            diffOpen={diffOpen}
+            onCloseDiff={closeDiff}
+            onOpenDiff={openDiff}
+            renderDiffContent={shouldRenderDiffContent}
+          />
+        )}
       </>
     );
   }
@@ -278,8 +302,5 @@ function ChatThreadRouteView() {
 
 export const Route = createFileRoute("/_chat/$environmentId/$threadId")({
   validateSearch: (search) => parseDiffRouteSearch(search),
-  search: {
-    middlewares: [retainSearchParams<DiffRouteSearch>(["diff"])],
-  },
   component: ChatThreadRouteView,
 });

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -11,8 +11,13 @@ import {
   persistState,
   reorderProjects,
   setDefaultAdvertisedEndpointKey,
+  setDiffIgnoreWhitespace,
+  setDiffRenderMode,
+  setDiffWordWrap,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
+  setThreadDiffFullWidth,
+  setThreadDiffOpen,
   syncProjects,
   syncThreads,
   type UiState,
@@ -25,6 +30,11 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
     defaultAdvertisedEndpointKey: null,
+    threadDiffFullWidthById: {},
+    threadDiffOpenById: {},
+    diffRenderMode: "stacked",
+    diffWordWrapOverride: undefined,
+    diffIgnoreWhitespaceOverride: undefined,
     ...overrides,
   };
 }
@@ -352,6 +362,14 @@ describe("uiStateStore pure functions", () => {
           "turn-2": false,
         },
       },
+      threadDiffFullWidthById: {
+        [thread1]: true,
+        [thread2]: true,
+      },
+      threadDiffOpenById: {
+        [thread1]: true,
+        [thread2]: true,
+      },
     });
 
     const next = syncThreads(initialState, [{ key: thread1 }]);
@@ -363,6 +381,12 @@ describe("uiStateStore pure functions", () => {
       [thread1]: {
         "turn-1": false,
       },
+    });
+    expect(next.threadDiffFullWidthById).toEqual({
+      [thread1]: true,
+    });
+    expect(next.threadDiffOpenById).toEqual({
+      [thread1]: true,
     });
   });
 
@@ -408,12 +432,20 @@ describe("uiStateStore pure functions", () => {
           "turn-1": false,
         },
       },
+      threadDiffFullWidthById: {
+        [thread1]: true,
+      },
+      threadDiffOpenById: {
+        [thread1]: true,
+      },
     });
 
     const next = clearThreadUi(initialState, thread1);
 
     expect(next.threadLastVisitedAtById).toEqual({});
     expect(next.threadChangedFilesExpandedById).toEqual({});
+    expect(next.threadDiffFullWidthById).toEqual({});
+    expect(next.threadDiffOpenById).toEqual({});
   });
 
   it("setThreadChangedFilesExpanded stores collapsed turns per thread", () => {
@@ -443,6 +475,161 @@ describe("uiStateStore pure functions", () => {
 
     expect(next.threadChangedFilesExpandedById).toEqual({});
   });
+
+  it("setThreadDiffFullWidth stores full-width preference per thread", () => {
+    const threadKey = "env-1:thread-1";
+    const initialState = makeUiState();
+
+    const next = setThreadDiffFullWidth(initialState, threadKey, true);
+
+    expect(next.threadDiffFullWidthById).toEqual({
+      [threadKey]: true,
+    });
+  });
+
+  it("setThreadDiffFullWidth removes the thread entry when collapsing back to split", () => {
+    const threadKey = "env-1:thread-1";
+    const initialState = makeUiState({
+      threadDiffFullWidthById: {
+        [threadKey]: true,
+      },
+    });
+
+    const next = setThreadDiffFullWidth(initialState, threadKey, false);
+
+    expect(next.threadDiffFullWidthById).toEqual({});
+  });
+
+  it("setThreadDiffFullWidth is a no-op when value is unchanged", () => {
+    const threadKey = "env-1:thread-1";
+    const initialState = makeUiState({
+      threadDiffFullWidthById: {
+        [threadKey]: true,
+      },
+    });
+
+    const next = setThreadDiffFullWidth(initialState, threadKey, true);
+
+    expect(next).toBe(initialState);
+  });
+
+  it("setThreadDiffFullWidth keeps each thread's preference independent", () => {
+    const threadA = "env-1:thread-A";
+    const threadB = "env-1:thread-B";
+
+    let state = makeUiState();
+    state = setThreadDiffFullWidth(state, threadA, true);
+    state = setThreadDiffFullWidth(state, threadB, true);
+    state = setThreadDiffFullWidth(state, threadA, false);
+
+    expect(state.threadDiffFullWidthById).toEqual({
+      [threadB]: true,
+    });
+  });
+
+  it("setDiffRenderMode updates the render mode", () => {
+    const initialState = makeUiState();
+
+    const next = setDiffRenderMode(initialState, "split");
+
+    expect(next.diffRenderMode).toBe("split");
+  });
+
+  it("setDiffRenderMode is a no-op when value is unchanged", () => {
+    const initialState = makeUiState({ diffRenderMode: "split" });
+
+    const next = setDiffRenderMode(initialState, "split");
+
+    expect(next).toBe(initialState);
+  });
+
+  it("setDiffWordWrap records the user's override", () => {
+    const initialState = makeUiState();
+
+    const next = setDiffWordWrap(initialState, true);
+
+    expect(next.diffWordWrapOverride).toBe(true);
+  });
+
+  it("setDiffWordWrap records an explicit off override distinct from the unset default", () => {
+    // Before any user toggle the override is undefined and the panel reads
+    // settings.diffWordWrap. After the user explicitly turns wrap off the
+    // override must be `false` (not `undefined`) so the settings default
+    // never re-flips it back on for the rest of the session.
+    const initialState = makeUiState();
+
+    const next = setDiffWordWrap(initialState, false);
+
+    expect(next.diffWordWrapOverride).toBe(false);
+  });
+
+  it("setDiffIgnoreWhitespace records the user's override", () => {
+    const initialState = makeUiState();
+
+    const next = setDiffIgnoreWhitespace(initialState, true);
+
+    expect(next.diffIgnoreWhitespaceOverride).toBe(true);
+  });
+
+  it("setDiffIgnoreWhitespace is a no-op when override is unchanged", () => {
+    const initialState = makeUiState({ diffIgnoreWhitespaceOverride: true });
+
+    const next = setDiffIgnoreWhitespace(initialState, true);
+
+    expect(next).toBe(initialState);
+  });
+
+  it("setThreadDiffOpen stores open state per thread", () => {
+    const threadKey = "env-1:thread-1";
+    const initialState = makeUiState();
+
+    const next = setThreadDiffOpen(initialState, threadKey, true);
+
+    expect(next.threadDiffOpenById).toEqual({
+      [threadKey]: true,
+    });
+  });
+
+  it("setThreadDiffOpen removes the thread entry when closing", () => {
+    const threadKey = "env-1:thread-1";
+    const initialState = makeUiState({
+      threadDiffOpenById: {
+        [threadKey]: true,
+      },
+    });
+
+    const next = setThreadDiffOpen(initialState, threadKey, false);
+
+    expect(next.threadDiffOpenById).toEqual({});
+  });
+
+  it("setThreadDiffOpen is a no-op when value is unchanged", () => {
+    const threadKey = "env-1:thread-1";
+    const initialState = makeUiState({
+      threadDiffOpenById: {
+        [threadKey]: true,
+      },
+    });
+
+    const next = setThreadDiffOpen(initialState, threadKey, true);
+
+    expect(next).toBe(initialState);
+  });
+
+  it("setThreadDiffOpen keeps each thread's open state independent", () => {
+    const threadA = "env-1:thread-A";
+    const threadB = "env-1:thread-B";
+
+    let state = makeUiState();
+    state = setThreadDiffOpen(state, threadA, true);
+    state = setThreadDiffOpen(state, threadB, true);
+    state = setThreadDiffOpen(state, threadA, false);
+
+    expect(state.threadDiffOpenById).toEqual({
+      [threadB]: true,
+    });
+  });
+
 });
 
 function createLocalStorageStub(): Storage {
@@ -577,6 +764,43 @@ describe("uiStateStore persistence round-trip", () => {
       localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
     ) as PersistedUiState;
     expect(persisted.defaultAdvertisedEndpointKey).toBe("desktop-core:lan:http");
+  });
+
+  it("persists per-thread diff full-width preferences", () => {
+    const threadKey = "env-1:thread-1";
+    const otherThreadKey = "env-1:thread-2";
+
+    let state = makeUiState();
+    state = setThreadDiffFullWidth(state, threadKey, true);
+    // Setting and unsetting another thread should not leak into persisted state.
+    state = setThreadDiffFullWidth(state, otherThreadKey, true);
+    state = setThreadDiffFullWidth(state, otherThreadKey, false);
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    expect(persisted.threadDiffFullWidthById).toEqual({
+      [threadKey]: true,
+    });
+  });
+
+  it("persists per-thread diff open state", () => {
+    const threadA = "env-1:thread-A";
+    const threadB = "env-1:thread-B";
+
+    let state = makeUiState();
+    state = setThreadDiffOpen(state, threadA, true);
+    state = setThreadDiffOpen(state, threadB, true);
+    state = setThreadDiffOpen(state, threadB, false);
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    expect(persisted.threadDiffOpenById).toEqual({
+      [threadA]: true,
+    });
   });
 
   it("preserves expand state across restart when project's logical key changes", () => {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -21,6 +21,8 @@ export interface PersistedUiState {
   projectOrderCwds?: string[];
   defaultAdvertisedEndpointKey?: string | null;
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
+  threadDiffFullWidthById?: Record<string, boolean>;
+  threadDiffOpenById?: Record<string, boolean>;
 }
 
 export interface UiProjectState {
@@ -31,13 +33,33 @@ export interface UiProjectState {
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
+  threadDiffFullWidthById: Record<string, boolean>;
+  threadDiffOpenById: Record<string, boolean>;
 }
 
 export interface UiEndpointState {
   defaultAdvertisedEndpointKey: string | null;
 }
 
-export interface UiState extends UiProjectState, UiThreadState, UiEndpointState {}
+export type DiffRenderMode = "stacked" | "split";
+
+export interface UiDiffViewState {
+  diffRenderMode: DiffRenderMode;
+  // Session-scoped overrides for the diff toolbar toggles. `undefined` means
+  // "no override — follow the corresponding settings.* default". Storing
+  // overrides instead of materialized booleans avoids a render-vs-effect
+  // initial-state mismatch (queries that read these values on first paint
+  // would otherwise fire with the store's hardcoded default and refetch
+  // once a hydration effect catches up to the user's settings).
+  diffWordWrapOverride: boolean | undefined;
+  diffIgnoreWhitespaceOverride: boolean | undefined;
+}
+
+export interface UiState
+  extends UiProjectState,
+    UiThreadState,
+    UiEndpointState,
+    UiDiffViewState {}
 
 export interface SyncProjectInput {
   /** Physical project key (env + cwd). Used for manual sort order. */
@@ -58,6 +80,11 @@ const initialState: UiState = {
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
   defaultAdvertisedEndpointKey: null,
+  threadDiffFullWidthById: {},
+  threadDiffOpenById: {},
+  diffRenderMode: "stacked",
+  diffWordWrapOverride: undefined,
+  diffIgnoreWhitespaceOverride: undefined,
 };
 
 const persistedCollapsedProjectCwds = new Set<string>();
@@ -103,10 +130,27 @@ function readPersistedState(): UiState {
       threadChangedFilesExpandedById: sanitizePersistedThreadChangedFilesExpanded(
         parsed.threadChangedFilesExpandedById,
       ),
+      threadDiffFullWidthById: sanitizePersistedThreadBooleanMap(parsed.threadDiffFullWidthById),
+      threadDiffOpenById: sanitizePersistedThreadBooleanMap(parsed.threadDiffOpenById),
     };
   } catch {
     return initialState;
   }
+}
+
+function sanitizePersistedThreadBooleanMap(
+  value: Record<string, boolean> | undefined,
+): Record<string, boolean> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+  const next: Record<string, boolean> = {};
+  for (const [threadId, flag] of Object.entries(value)) {
+    if (threadId && flag === true) {
+      next[threadId] = true;
+    }
+  }
+  return next;
 }
 
 function sanitizePersistedThreadChangedFilesExpanded(
@@ -187,6 +231,12 @@ export function persistState(state: UiState): void {
         return Object.keys(nextTurns).length > 0 ? [[threadId, nextTurns]] : [];
       }),
     );
+    const threadDiffFullWidthById = Object.fromEntries(
+      Object.entries(state.threadDiffFullWidthById).filter(([, fullWidth]) => fullWidth === true),
+    );
+    const threadDiffOpenById = Object.fromEntries(
+      Object.entries(state.threadDiffOpenById).filter(([, open]) => open === true),
+    );
     window.localStorage.setItem(
       PERSISTED_STATE_KEY,
       JSON.stringify({
@@ -195,6 +245,8 @@ export function persistState(state: UiState): void {
         projectOrderCwds,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpandedById,
+        threadDiffFullWidthById,
+        threadDiffOpenById,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -427,12 +479,24 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
       retainedThreadIds.has(threadId),
     ),
   );
+  const nextThreadDiffFullWidthById = Object.fromEntries(
+    Object.entries(state.threadDiffFullWidthById).filter(([threadId]) =>
+      retainedThreadIds.has(threadId),
+    ),
+  );
+  const nextThreadDiffOpenById = Object.fromEntries(
+    Object.entries(state.threadDiffOpenById).filter(([threadId]) =>
+      retainedThreadIds.has(threadId),
+    ),
+  );
   if (
     recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById) &&
     nestedBooleanRecordsEqual(
       state.threadChangedFilesExpandedById,
       nextThreadChangedFilesExpandedById,
-    )
+    ) &&
+    recordsEqual(state.threadDiffFullWidthById, nextThreadDiffFullWidthById) &&
+    recordsEqual(state.threadDiffOpenById, nextThreadDiffOpenById)
   ) {
     return state;
   }
@@ -440,6 +504,8 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
     threadChangedFilesExpandedById: nextThreadChangedFilesExpandedById,
+    threadDiffFullWidthById: nextThreadDiffFullWidthById,
+    threadDiffOpenById: nextThreadDiffOpenById,
   };
 }
 
@@ -492,17 +558,30 @@ export function markThreadUnread(
 export function clearThreadUi(state: UiState, threadId: string): UiState {
   const hasVisitedState = threadId in state.threadLastVisitedAtById;
   const hasChangedFilesState = threadId in state.threadChangedFilesExpandedById;
-  if (!hasVisitedState && !hasChangedFilesState) {
+  const hasDiffFullWidthState = threadId in state.threadDiffFullWidthById;
+  const hasDiffOpenState = threadId in state.threadDiffOpenById;
+  if (
+    !hasVisitedState &&
+    !hasChangedFilesState &&
+    !hasDiffFullWidthState &&
+    !hasDiffOpenState
+  ) {
     return state;
   }
   const nextThreadLastVisitedAtById = { ...state.threadLastVisitedAtById };
   const nextThreadChangedFilesExpandedById = { ...state.threadChangedFilesExpandedById };
+  const nextThreadDiffFullWidthById = { ...state.threadDiffFullWidthById };
+  const nextThreadDiffOpenById = { ...state.threadDiffOpenById };
   delete nextThreadLastVisitedAtById[threadId];
   delete nextThreadChangedFilesExpandedById[threadId];
+  delete nextThreadDiffFullWidthById[threadId];
+  delete nextThreadDiffOpenById[threadId];
   return {
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
     threadChangedFilesExpandedById: nextThreadChangedFilesExpandedById,
+    threadDiffFullWidthById: nextThreadDiffFullWidthById,
+    threadDiffOpenById: nextThreadDiffOpenById,
   };
 }
 
@@ -563,6 +642,65 @@ export function setDefaultAdvertisedEndpointKey(state: UiState, key: string | nu
   return {
     ...state,
     defaultAdvertisedEndpointKey: nextKey,
+  };
+}
+
+export function setDiffRenderMode(state: UiState, mode: DiffRenderMode): UiState {
+  if (state.diffRenderMode === mode) {
+    return state;
+  }
+  return { ...state, diffRenderMode: mode };
+}
+
+export function setDiffWordWrap(state: UiState, wrap: boolean): UiState {
+  if (state.diffWordWrapOverride === wrap) {
+    return state;
+  }
+  return { ...state, diffWordWrapOverride: wrap };
+}
+
+export function setDiffIgnoreWhitespace(state: UiState, ignore: boolean): UiState {
+  if (state.diffIgnoreWhitespaceOverride === ignore) {
+    return state;
+  }
+  return { ...state, diffIgnoreWhitespaceOverride: ignore };
+}
+
+export function setThreadDiffFullWidth(
+  state: UiState,
+  threadKey: string,
+  fullWidth: boolean,
+): UiState {
+  const current = state.threadDiffFullWidthById[threadKey] === true;
+  if (current === fullWidth) {
+    return state;
+  }
+  const next = { ...state.threadDiffFullWidthById };
+  if (fullWidth) {
+    next[threadKey] = true;
+  } else {
+    delete next[threadKey];
+  }
+  return {
+    ...state,
+    threadDiffFullWidthById: next,
+  };
+}
+
+export function setThreadDiffOpen(state: UiState, threadKey: string, open: boolean): UiState {
+  const current = state.threadDiffOpenById[threadKey] === true;
+  if (current === open) {
+    return state;
+  }
+  const next = { ...state.threadDiffOpenById };
+  if (open) {
+    next[threadKey] = true;
+  } else {
+    delete next[threadKey];
+  }
+  return {
+    ...state,
+    threadDiffOpenById: next,
   };
 }
 
@@ -641,6 +779,11 @@ interface UiStateStore extends UiState {
   clearThreadUi: (threadId: string) => void;
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
+  setThreadDiffFullWidth: (threadKey: string, fullWidth: boolean) => void;
+  setThreadDiffOpen: (threadKey: string, open: boolean) => void;
+  setDiffRenderMode: (mode: DiffRenderMode) => void;
+  setDiffWordWrap: (wrap: boolean) => void;
+  setDiffIgnoreWhitespace: (ignore: boolean) => void;
   toggleProject: (projectId: string) => void;
   setProjectExpanded: (projectId: string, expanded: boolean) => void;
   reorderProjects: (
@@ -662,6 +805,12 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setThreadChangedFilesExpanded(state, threadId, turnId, expanded)),
   setDefaultAdvertisedEndpointKey: (key) =>
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
+  setThreadDiffFullWidth: (threadKey, fullWidth) =>
+    set((state) => setThreadDiffFullWidth(state, threadKey, fullWidth)),
+  setThreadDiffOpen: (threadKey, open) => set((state) => setThreadDiffOpen(state, threadKey, open)),
+  setDiffRenderMode: (mode) => set((state) => setDiffRenderMode(state, mode)),
+  setDiffWordWrap: (wrap) => set((state) => setDiffWordWrap(state, wrap)),
+  setDiffIgnoreWhitespace: (ignore) => set((state) => setDiffIgnoreWhitespace(state, ignore)),
   toggleProject: (projectId) => set((state) => toggleProject(state, projectId)),
   setProjectExpanded: (projectId, expanded) =>
     set((state) => setProjectExpanded(state, projectId, expanded)),


### PR DESCRIPTION
## Summary

- Move diff-panel UI state out of URL search params / component-local state into the Zustand UI store, with per-thread scoping where it makes sense (panel open, full-width) and global session scope where it doesn't (render mode, line wrap, ignore whitespace)
- Add a **full-width** toggle to the diff toolbar that hides the chat column and lets the diff fill the content area; the toggle is per-thread, so one thread can be expanded while another is split

## State scoping

| Field | Scope | Persisted | Notes |
| --- | --- | --- | --- |
| `threadDiffOpenById` | per-thread | yes | replaces `?diff=1` in the URL |
| `threadDiffFullWidthById` | per-thread | yes | drives the new toolbar toggle |
| `diffRenderMode` | global session | no | survives the full-width remount |
| `diffWordWrapOverride` | global session | no | `undefined` falls back to `settings.diffWordWrap` |
| `diffIgnoreWhitespaceOverride` | global session | no | `undefined` falls back to `settings.diffIgnoreWhitespace` |

The wrap and ignore-whitespace fields use an **override pattern** (`undefined` ⇒ "no override — follow the settings default"). Storing overrides instead of materialized booleans means the very first checkpoint diff query reads the correct value on first paint without a render-vs-effect race — no wasted refetch, no flash.

`?diff=1` is removed from `DiffRouteSearch`. Legacy URLs that still carry it parse cleanly and are ignored. `diffTurnId` and `diffFilePath` remain in the URL since they identify a specific selection. A route-level effect watches `search.diffTurnId` and auto-opens the panel when one is present, so shared / bookmarked / browser-history turn links still reveal the diff they point at.

## What's NOT in this PR

Per-file collapse (chevron in each FileDiff header) is upstream's pre-existing `useState<ReadonlySet<string>>` from #2502. It's intentionally **not** lifted to per-thread storage in this PR. Side effect: file collapse state resets when the user toggles full-width (since the panel remounts). Acceptable trade-off for now; can be revisited if it becomes annoying.

## Test plan

- [ ] Open diff in thread A; confirm thread B opens with its own (closed) state
- [ ] Toggle full-width in A; navigate to B; B is split-pane; navigate back to A; A is still full-width
- [ ] Toggle stacked → split in A; expand/collapse the panel; selection survives the remount
- [ ] First paint of the diff panel fires only one checkpoint diff query (no settings-default vs store-default refetch)
- [ ] Open a thread URL that carries `?diffTurnId=...` (e.g. by copying the URL while a turn is selected, then visiting it in a fresh tab); the diff panel auto-opens with that turn selected
- [ ] Reload the page; per-thread `open` and `full-width` preferences are restored from localStorage; wrap / ignore-whitespace fall back to the user's settings defaults
- [ ] `vitest run` (apps/web) and `tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move diff panel open/full-width state to per-thread UI store and add full-width toggle
> - Diff open/closed state is now stored per thread in `uiStateStore` instead of the URL `?diff` param; toggling no longer modifies the address bar.
> - Adds a per-thread full-width mode in inline layout: when active, the chat pane is hidden and the diff panel expands to fill the viewport, toggled via a new button in the diff toolbar.
> - `diffRenderMode`, `diffWordWrap`, and `diffIgnoreWhitespace` preferences are now session-scoped via the store, persisting across panel mounts.
> - Visiting a URL with `diffTurnId` auto-opens the diff panel for that thread if it is currently closed.
> - The `diff` field is removed from `DiffRouteSearch`; `diffTurnId` and `diffFilePath` parse independently without it. `stripDiffSearchParams` still clears legacy `diff` values.
> - Behavioral Change: existing bookmarks or shared URLs containing `?diff=1` will no longer open the diff panel automatically; only `diffTurnId` triggers auto-open.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8abc5d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->