### PR TITLE
Preserve language in generated thread titles

### DIFF
--- a/apps/server/src/git/Prompts.test.ts
+++ b/apps/server/src/git/Prompts.test.ts
@@ -115,6 +115,14 @@ describe("buildThreadTitlePrompt", () => {
     expect(result.prompt).not.toContain("Attachment metadata:");
   });
 
+  it("instructs title generation to preserve the user's language", () => {
+    const result = buildThreadTitlePrompt({
+      message: "Investigate inconsistent generated chat title language",
+    });
+
+    expect(result.prompt).toContain("Use the user's language; do not translate.");
+  });
+
   it("includes attachment metadata when attachments are provided", () => {
     const result = buildThreadTitlePrompt({
       message: "Name this thread from the screenshot",

--- a/apps/server/src/git/Prompts.ts
+++ b/apps/server/src/git/Prompts.ts
@@ -188,6 +188,7 @@ export function buildThreadTitlePrompt(input: ThreadTitlePromptInput) {
     rules: [
       "Title should summarize the user's request, not restate it verbatim.",
       "Keep it short and specific (3-8 words).",
+      "Use the user's language; do not translate.",
       "Avoid quotes, filler, prefixes, and trailing punctuation.",
       "If images are attached, use them as primary context for visual/UI issues.",
     ],


### PR DESCRIPTION
## What Changed

Updated the thread title generation prompt to preserve the user's language.

Added prompt coverage to ensure the instruction stays present.

## Why

Thread titles are generated from the user's first message, but the prompt did not specify which language to use. As a result, titles for non-English requests could be generated inconsistently in either the user's language or English.

Keeping the instruction in the prompt is the smallest fix because title generation already happens there, and this avoids adding language detection or UI-side special cases.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

## Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b0c28dac-d5e5-4177-8545-564cfb0ccac4" />

## After
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/09eb9103-5967-4484-8454-e72243b6c267" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the LLM prompt text for thread title generation and adds a unit test to prevent regressions; no auth, data handling, or control-flow changes.
> 
> **Overview**
> Thread title generation now explicitly instructs the model to **use the user’s language and not translate** by adding a new rule to `buildThreadTitlePrompt`.
> 
> Adds a focused test in `Prompts.test.ts` to assert the language-preservation instruction remains present in the generated prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eef0c435dd2b5eade745960b274757603553009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve user language in generated thread titles
> Adds the rule "Use the user's language; do not translate." to the `buildThreadTitlePrompt` function in [Prompts.ts](https://github.com/pingdotgg/t3code/pull/2446/files#diff-6306703f0635b0f5c498ff05c08d8946df5f39bbfd497ac0f83d0dfc965fba71), preventing the model from translating thread titles into another language.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8eef0c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->