### PR TITLE
feat(codex): add reasoning off option

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -35,7 +35,7 @@ export interface CodexAppServerProviderSnapshot {
 }
 
 const REASONING_EFFORT_LABELS: Record<CodexSchema.V2ModelListResponse__ReasoningEffort, string> = {
-  none: "None",
+  none: "Off",
   minimal: "Minimal",
   low: "Low",
   medium: "Medium",
@@ -84,7 +84,14 @@ function codexAccountEmail(account: CodexSchema.V2GetAccountResponse["account"])
 function mapCodexModelCapabilities(
   model: CodexSchema.V2ModelListResponse__Model,
 ): ModelCapabilities {
-  const reasoningOptions = model.supportedReasoningEfforts.map(({ reasoningEffort }) =>
+  const supportedReasoningEfforts = model.supportedReasoningEfforts.map(
+    ({ reasoningEffort }) => reasoningEffort,
+  );
+  const reasoningEfforts: ReadonlyArray<CodexSchema.V2ModelListResponse__ReasoningEffort> =
+    supportedReasoningEfforts.length === 0 || supportedReasoningEfforts.includes("none")
+      ? supportedReasoningEfforts
+      : ["none", ...supportedReasoningEfforts];
+  const reasoningOptions = reasoningEfforts.map((reasoningEffort) =>
     reasoningEffort === model.defaultReasoningEffort
       ? {
           id: reasoningEffort,


### PR DESCRIPTION
## What Changed

Adds an `Off` option to the Codex reasoning picker for reasoning-capable models when the Codex app-server model list does not advertise the `none` effort.

The underlying protocol value remains `none`; only the UI label is shown as `Off`.

## Why

The Codex app-server schema accepts `reasoning_effort: "none"`, and t3code already forwards selected reasoning effort values. This makes the existing picker able to disable reasoning without adding new UI or changing dispatch behavior.

## UI Changes

This changes the Codex reasoning picker options by showing `Off`.

<img width="345" height="329" alt="image" src="https://github.com/user-attachments/assets/251e9e2d-bd1a-470e-acb1-f46c1f2f7992" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect how reasoning-effort options are labeled and populated for Codex models, without altering request/dispatch semantics.
> 
> **Overview**
> Updates the Codex model capability mapping to always offer a reasoning-disable option by injecting the `none` effort when a model advertises reasoning efforts but omits it.
> 
> Renames the `none` reasoning effort label from **"None"** to **"Off"**, while keeping the underlying protocol value as `none` and preserving default selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 662a1eb104ef5420740fe16114aba03bec84de93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Off' reasoning effort option to Codex model capabilities
> - Renames the `none` reasoning effort label from `'None'` to `'Off'` in `REASONING_EFFORT_LABELS`.
> - Updates `mapCodexModelCapabilities` in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/2448/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) to always inject a `none` effort option when a model exposes at least one reasoning effort but omits `none`.
> - The default option continues to be derived from `model.defaultReasoningEffort`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 662a1eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->