### PR TITLE
[codex] fix Discord release version flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -628,7 +628,7 @@ jobs:
           node scripts/notify-discord-release.ts prerelease \
             --role-id "$DISCORD_MENTION_ROLE_ID" \
             --release-name "${{ needs.preflight.outputs.release_name }}" \
-            --version "${{ needs.preflight.outputs.version }}" \
+            --release-version "${{ needs.preflight.outputs.version }}" \
             --tag "${{ needs.preflight.outputs.tag }}" \
             --release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.preflight.outputs.tag }}"
 
@@ -642,6 +642,6 @@ jobs:
           node scripts/notify-discord-release.ts latest \
             --role-id "$DISCORD_MENTION_ROLE_ID" \
             --release-name "${{ needs.preflight.outputs.release_name }}" \
-            --version "${{ needs.preflight.outputs.version }}" \
+            --release-version "${{ needs.preflight.outputs.version }}" \
             --tag "${{ needs.preflight.outputs.tag }}" \
             --release-url "https://github.com/${{ github.repository }}/releases/tag/${{ needs.preflight.outputs.tag }}"

--- a/scripts/notify-discord-release.ts
+++ b/scripts/notify-discord-release.ts
@@ -173,7 +173,7 @@ export const notifyDiscordReleaseCommand = Command.make(
       Flag.withSchema(Schema.NonEmptyString),
       Flag.withDescription("Human-readable release name."),
     ),
-    version: Flag.string("version").pipe(
+    releaseVersion: Flag.string("release-version").pipe(
       Flag.withSchema(Schema.NonEmptyString),
       Flag.withDescription("Release version."),
     ),
@@ -186,7 +186,7 @@ export const notifyDiscordReleaseCommand = Command.make(
       Flag.withDescription("Public GitHub release URL."),
     ),
   },
-  ({ target, roleId, releaseName, version, tag, releaseUrl }) =>
+  ({ target, roleId, releaseName, releaseVersion, tag, releaseUrl }) =>
     Effect.gen(function* () {
       yield* Effect.logInfo("discord release announcement starting").pipe(
         Effect.annotateLogs({
@@ -194,7 +194,7 @@ export const notifyDiscordReleaseCommand = Command.make(
           roleIdProvided: roleId.length > 0,
           roleIdLength: roleId.length,
           releaseName,
-          version,
+          version: releaseVersion,
           tag,
           releaseUrl,
         }),
@@ -205,7 +205,7 @@ export const notifyDiscordReleaseCommand = Command.make(
         target,
         roleId,
         releaseName,
-        version,
+        version: releaseVersion,
         tag,
         releaseUrl,
         timestamp: new Date().toISOString(),


### PR DESCRIPTION
## What changed

- Renamed the Discord release CLI option from `--version` to `--release-version`.
- Updated both release workflow Discord announcement steps to pass `--release-version`.

## Why

Effect CLI treats `--version` as a built-in global action flag. The release workflow was passing the release number through that flag, so the command printed the CLI version and exited before posting to Discord.

## Validation

- `bun fmt`
- `bun lint` (passes with existing warnings)
- `bun typecheck`
- `cd scripts && bun run test notify-discord-release.test.ts`
- Local smoke check confirmed `--release-version` reaches the webhook POST path while old `--version` still exits via the built-in version handler.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Discord release announcement CLI flag from `--version` to `--release-version`
> Renames the CLI flag in [`notify-discord-release.ts`](https://github.com/pingdotgg/t3code/pull/2449/files#diff-8a20022b49201d57b8cdd36c484de30a0b4263519883392faf1e801d2f7e5041) from `--version` to `--release-version` and updates the corresponding invocations in [`release.yml`](https://github.com/pingdotgg/t3code/pull/2449/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34) for both prerelease and latest release announcement steps. Risk: any external callers using `--version` will no longer be recognized by the script.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d6450b7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only renames a CLI flag and updates the release workflow invocation; impact is limited to Discord release announcements and could fail only if callers still use the old `--version` flag.
> 
> **Overview**
> Fixes Discord release announcements by renaming the notify script’s CLI option from `--version` to `--release-version` (to avoid the CLI’s built-in `--version` behavior) and wiring the new flag through logging/payload construction.
> 
> Updates the GitHub `release.yml` workflow’s prerelease and latest Discord announcement steps to pass `--release-version` so announcements post correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6450b7b8d6be07ef3bf92fd625bf0d79df71493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->